### PR TITLE
feat(iir-to-ge225): A5 skeleton — IIR → GE-225 backend (Dartmouth BASIC's birthplace)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -658,6 +658,7 @@ members = [
     "iir-to-intel8008",
     "iir-to-armv7",
     "iir-to-intel4004",
+    "iir-to-ge225",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/iir-to-ge225/BUILD
+++ b/code/packages/rust/iir-to-ge225/BUILD
@@ -1,0 +1,1 @@
+cargo test -p iir-to-ge225

--- a/code/packages/rust/iir-to-ge225/CHANGELOG.md
+++ b/code/packages/rust/iir-to-ge225/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog — iir-to-ge225
+
+All notable changes to this crate are documented here.
+
+## v0.1.0 — 2026-06-02 — A5 skeleton
+
+Initial release.  Establishes the IIR → GE-225 backend's public
+surface as the fifth architecture-backend slot (after iir-to-riscv,
+iir-to-intel8008, iir-to-armv7, iir-to-intel4004) — and the most
+exotic by a wide margin (20-bit words, mainframe accumulator model,
+1959 silicon).
+
+### Added
+
+- `IIRGe225Config` — module-name-carrying config (reserved for
+  future symbol-table / `.bin` header use).
+- `IIRGe225Error` — backend-side error type with four variants:
+  `ValidationFailed`, `UnsupportedOp`, `UnsupportedType`,
+  `InvalidOperand`.  Mirrors the iir-to-intel4004 / iir-to-armv7 /
+  iir-to-intel8008 / iir-to-riscv error surface so callers can
+  pattern-match identically across backends.
+- `validate_for_ge225(&IIRModule) -> Vec<String>` — stub validator
+  (always returns `[]` in v0.1.0).
+- `lower_iir_to_ge225(&IIRModule, &IIRGe225Config) -> Result<Vec<u8>,
+  IIRGe225Error>` — lowering entry point.  Currently emits the
+  3-byte canonical HLT sentinel regardless of input.
+- `pub const HALT_WORD: [u8; 3] = [0x00, 0x00, 0x00]` — the all-zeros
+  20-bit GE-225 HLT word, packed big-endian.  Documented choice
+  (vs branch-to-self / unimplemented-opcode) recorded in the spec
+  and the constant's doc comment.
+
+### Why the all-zeros HLT halt sentinel?
+
+The GE-225's `HLT` instruction is the all-zeros 20-bit word.
+Emitted at the start of program ROM, it halts the machine
+deterministically — recognized by every GE-225 simulator and the
+historical silicon.  Alternative halt idioms (branch-to-self) would
+work but produce less visually obvious bytes.
+
+### Word packing
+
+GE-225 words are 20 bits; we pack each into 3 bytes (24 bits),
+big-endian, with the top 4 bits of byte 0 always zero.  A downstream
+simulator reads 3 bytes per instruction, masks off the top 4 bits,
+and recovers the original 20-bit word.
+
+### Scope notes
+
+- No instruction lowering — deferred to v0.2.0 (A5+).
+- No `lang-aot --emit=ge225` wiring — deferred to A5+++.
+- No external assembler / linker integration.
+
+### Tests
+
+7 tests covering: empty-module validation, output shape, exact
+halt bytes, `HALT_WORD` constant pinning, default-config invariant,
+`IIRGe225Config::new` builder contract, and Display smoke for all
+four `IIRGe225Error` variants.
+
+### Reference
+
+- Spec: `code/specs/iir-to-ge225.md`
+- Plan: `code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md` §A5

--- a/code/packages/rust/iir-to-ge225/Cargo.toml
+++ b/code/packages/rust/iir-to-ge225/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "iir-to-ge225"
+version = "0.1.0"
+edition = "2021"
+description = "IIR → GE-225 machine code backend — lowers IIRModule to a Vec<u8> of encoded 20-bit GE-225 instruction words (packed 3 bytes per word, big-endian, top 4 bits zero).  v0.1.0 (A5): crate skeleton that lowers any module to a single HLT (the all-zeros 20-bit word, packed as [0x00, 0x00, 0x00]).  Real lowering (LDA/ADD/SUB/BR family) lands in A5+ through A5++.  The GE-225 (1959) was the General Electric mainframe at Dartmouth College where Dartmouth BASIC was DESIGNED in 1964 by Kemeny and Kurtz — BASIC's defaults still bear the imprint of this 20-bit machine.  Primarily a BASIC fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A5."
+
+[lib]
+name = "iir_to_ge225"
+path = "src/lib.rs"
+
+[dependencies]
+interpreter-ir = { path = "../interpreter-ir" }
+
+[[test]]
+name = "test_backend"
+path = "tests/test_backend.rs"

--- a/code/packages/rust/iir-to-ge225/README.md
+++ b/code/packages/rust/iir-to-ge225/README.md
@@ -1,0 +1,77 @@
+# iir-to-ge225
+
+IIR → GE-225 machine code backend.
+
+Lowers an `interpreter_ir::IIRModule` to a `Vec<u8>` of encoded
+20-bit GE-225 instruction words (packed 3 bytes per word, big-endian,
+with the top 4 bits of byte 0 zero).
+
+## What's this for?
+
+The **GE-225** (1959) was the General Electric mainframe at Dartmouth
+College where **John Kemeny and Thomas Kurtz designed Dartmouth BASIC
+in 1964**. BASIC ran on this very machine — and BASIC's defaults
+(line numbers, 1-indexed arrays, single-letter variables) still bear
+the imprint of this 20-bit, accumulator-based mainframe.
+
+This crate is the **fifth architecture backend** in the LANG VM
+pipeline:
+
+| | Width | Year | Primary fit |
+|---|---|---|---|
+| iir-to-riscv (A1) | 32-bit | 2015 | generic |
+| iir-to-intel8008 (A2) | 8-bit | 1972 | Oct |
+| iir-to-armv7 (A3) | 32-bit | 2005 | phone-class targets |
+| iir-to-intel4004 (A4) | 4-bit | 1971 | Brainfuck |
+| **iir-to-ge225 (A5)** | **20-bit** | **1959** | **Dartmouth BASIC** |
+
+## Status — v0.1.0 (A5 skeleton)
+
+Any module lowers to a single canonical halt sentinel — the
+**all-zeros 20-bit HLT word**, packed as `[0x00, 0x00, 0x00]`.
+
+Real instruction lowering arrives in v0.2.0+ (A5+).
+
+## Quick start
+
+```rust
+use interpreter_ir::IIRModule;
+use iir_to_ge225::{validate_for_ge225, lower_iir_to_ge225, IIRGe225Config};
+
+let module = IIRModule {
+    name: "demo".into(),
+    functions: vec![],
+    entry_point: None,
+    language: "demo".into(),
+    exports: vec![],
+    imports: vec![],
+};
+
+assert!(validate_for_ge225(&module).is_empty());
+
+let bytes = lower_iir_to_ge225(&module, &IIRGe225Config::default())
+    .expect("lowering should succeed");
+// HLT = all-zeros 20-bit word, packed as 3 bytes.
+assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+```
+
+## Word packing
+
+Each 20-bit GE-225 word is emitted as 3 bytes (24 bits), big-endian,
+with the top 4 bits of byte 0 always zero:
+
+```text
+byte 0: 0000 BBBB   (top 4 bits zero + bits 19..16 of word)
+byte 1: BBBB BBBB   (bits 15..8 of word)
+byte 2: BBBB BBBB   (bits 7..0 of word)
+```
+
+A downstream simulator reads 3 bytes per instruction, masks off the
+top 4 bits, and recovers the original 20-bit word.
+
+## See also
+
+- Spec: `code/specs/iir-to-ge225.md`
+- Plan: `code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md` §A5
+- Sister crates: `iir-to-riscv`, `iir-to-intel8008`, `iir-to-armv7`,
+  `iir-to-intel4004`

--- a/code/packages/rust/iir-to-ge225/src/lib.rs
+++ b/code/packages/rust/iir-to-ge225/src/lib.rs
@@ -1,0 +1,246 @@
+//! # iir-to-ge225 — IIR → GE-225 machine code backend (v0.1.0 skeleton).
+//!
+//! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
+//! 20-bit GE-225 instruction words (packed 3 bytes per word, big-
+//! endian, with the top 4 bits of byte 0 always zero).
+//!
+//! ## Why a GE-225 backend?
+//!
+//! The **GE-225** (1959) was the General Electric mainframe at
+//! Dartmouth College where **John Kemeny and Thomas Kurtz designed
+//! Dartmouth BASIC in 1964**.  BASIC ran on this very machine — the
+//! 1.7 µs cycle time and 20-bit word size shaped the language's
+//! defaults in ways still visible 60 years later.
+//!
+//! In this codebase the GE-225 is primarily a **BASIC fit** per
+//! MULTILANG-ARCHITECTURE-BACKENDS.md §A5.  Compiling BASIC source
+//! to GE-225 bytes is a small piece of computing history made
+//! queryable through the LANG VM pipeline.
+//!
+//! Adding the GE-225 gives the LANG VM matrix its fifth and most
+//! exotic architecture backend:
+//!
+//! | | RV32I (A1) | 8008 (A2) | ARMv7 (A3) | 4004 (A4) | **GE-225 (A5)** |
+//! |---|---|---|---|---|---|
+//! | Width | 32-bit | 8-bit | 32-bit | 4-bit | **20-bit** |
+//! | Year shipped | 2015 | 1972 | 2005 | 1971 | **1959** |
+//! | Style | Modern RISC | Accumulator CISC | RISC + cond | Tiny MCS-4 | **Mainframe accumulator** |
+//! | LANG VM fit | Generic | Oct's native | Phone-class | Brainfuck | **BASIC's birthplace** |
+//!
+//! ## Scope of v0.1.0 (A5)
+//!
+//! This release is a **skeleton**: any IIR module lowers to a
+//! single `HLT` — the all-zeros 20-bit word, packed as
+//! `[0x00, 0x00, 0x00]`.  No instruction selection yet; that
+//! arrives in A5+ and beyond.
+//!
+//! ## Why `Vec<u8>` output for a 20-bit-word machine?
+//!
+//! - **Cross-backend uniformity.**  Every other backend emits
+//!   `Vec<u8>` or a `Vec<u32>` that's trivially flattened to bytes.
+//!   Bytes round-trip through every host filesystem without
+//!   alignment surprises.
+//! - **3-byte word packing.**  Each 20-bit GE-225 word is emitted
+//!   as 3 bytes (24 bits total), big-endian, with the top 4 bits
+//!   of byte 0 always zero.  This wastes 4 bits per word (~17 %
+//!   overhead) but means a downstream simulator can read 3 bytes,
+//!   mask off the top 4 bits, and recover the original 20-bit
+//!   word.
+//!
+//! ## The halt sentinel — all-zeros HLT
+//!
+//! The GE-225's `HLT` instruction is the all-zeros 20-bit word.
+//! Emitted at the start of a program ROM, this halts the machine.
+//!
+//! ```text
+//! 20-bit word: 0000_0000_0000_0000_0000
+//!    ↓ packed into 3 big-endian bytes
+//! [0x00, 0x00, 0x00]
+//! ```
+//!
+//! This is the documented HLT encoding in the GE-225 reference
+//! manual.  Alternative halt idioms (e.g. unconditional branch to
+//! self, `BR $.` in mnemonics) would also work but produce less
+//! visually obvious bytes; the all-zeros HLT is preferred for
+//! skeleton purposes.
+//!
+//! ## Quick start
+//!
+//! ```
+//! use interpreter_ir::IIRModule;
+//! use iir_to_ge225::{validate_for_ge225, lower_iir_to_ge225, IIRGe225Config};
+//!
+//! let module = IIRModule {
+//!     name: "demo".into(),
+//!     functions: vec![],
+//!     entry_point: None,
+//!     language: "demo".into(),
+//!     exports: vec![],
+//!     imports: vec![],
+//! };
+//!
+//! assert!(validate_for_ge225(&module).is_empty());
+//!
+//! let bytes = lower_iir_to_ge225(&module, &IIRGe225Config::default())
+//!     .expect("lowering should succeed");
+//! // HLT = all-zeros 20-bit word, packed as 3 bytes.
+//! assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+//! ```
+
+use interpreter_ir::IIRModule;
+use std::fmt;
+
+// ===========================================================================
+// GE-225 opcode constants
+// ===========================================================================
+
+/// Canonical "halt" sentinel for the GE-225 — three bytes:
+/// `[0x00, 0x00, 0x00]` (= the all-zeros 20-bit HLT word, packed
+/// big-endian with the top 4 bits of byte 0 zero).
+///
+/// The GE-225 reference manual documents the all-zeros 20-bit word
+/// as the `HLT` instruction.  When emitted at the start of program
+/// memory, this halts the machine deterministically — every GE-225
+/// simulator and the historical silicon recognises this pattern as
+/// "stop".
+///
+/// ## Word packing
+///
+/// GE-225 instructions are 20 bits wide.  We pack each word into 3
+/// bytes, big-endian, with the top 4 bits of byte 0 always zero
+/// (since 20 bits < 24 bits in 3 bytes):
+///
+/// ```text
+/// byte 0: 0000 BBBB   (top 4 bits zero + bits 19..16 of word)
+/// byte 1: BBBB BBBB   (bits 15..8 of word)
+/// byte 2: BBBB BBBB   (bits 7..0 of word)
+/// ```
+///
+/// For HLT (word = 0x00000): every bit is zero, so all 3 bytes are
+/// `0x00`.  Subsequent slices that emit non-zero words use the
+/// same big-endian packing.
+///
+/// ## Why HLT over branch-to-self?
+///
+/// | Candidate | Pros | Cons |
+/// |-----------|------|------|
+/// | All-zeros HLT (this) | Documented in the GE-225 reference manual; bytes are unambiguous | None for skeleton purposes |
+/// | `BR $.` (branch to self) | Pure single-word idiom | Encoded as a non-zero opcode; doesn't visually distinguish "halt" from arbitrary branch |
+/// | Unimplemented opcode | Forces a trap | GE-225 reaction to unused opcodes wasn't formally specified — implementation-defined |
+///
+/// The all-zeros HLT is the canonical and historically attested
+/// choice.
+pub const HALT_WORD: [u8; 3] = [0x00, 0x00, 0x00];
+
+// ===========================================================================
+// IIRGe225Config
+// ===========================================================================
+
+/// Configuration for the IIR → GE-225 lowering pass.
+///
+/// Currently only the module name is configurable, reserved for
+/// future symbol-table / memory-image emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IIRGe225Config {
+    /// Module name — reserved for future symbol-table / `.bin`
+    /// header use.
+    pub module_name: String,
+}
+
+impl IIRGe225Config {
+    /// Build a config with a custom module name.
+    pub fn new(module_name: impl Into<String>) -> Self {
+        Self {
+            module_name: module_name.into(),
+        }
+    }
+}
+
+impl Default for IIRGe225Config {
+    fn default() -> Self {
+        Self {
+            module_name: "iir_module".into(),
+        }
+    }
+}
+
+// ===========================================================================
+// IIRGe225Error
+// ===========================================================================
+
+/// Errors that can occur during IIR → GE-225 lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IIRGe225Error {
+    /// The module failed pre-flight validation.
+    ValidationFailed(Vec<String>),
+    /// An IIR opcode not yet supported by this backend.  v0.1.0
+    /// doesn't lower any instructions, so a non-empty function body
+    /// would surface this in a future version.
+    UnsupportedOp { function: String, op: String },
+    /// A type hint that does not map to any GE-225 representation.
+    UnsupportedType { function: String, type_hint: String },
+    /// An operand has an unexpected shape.
+    InvalidOperand { function: String, detail: String },
+}
+
+impl fmt::Display for IIRGe225Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ValidationFailed(errs) => {
+                write!(f, "validation failed:\n  {}", errs.join("\n  "))
+            }
+            Self::UnsupportedOp { function, op } => {
+                write!(f, "unsupported op in function {function:?}: {op}")
+            }
+            Self::UnsupportedType { function, type_hint } => {
+                write!(f, "unsupported type in function {function:?}: {type_hint}")
+            }
+            Self::InvalidOperand { function, detail } => {
+                write!(f, "invalid operand in function {function:?}: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IIRGe225Error {}
+
+// ===========================================================================
+// validate_for_ge225
+// ===========================================================================
+
+/// Pre-flight validation for IIR → GE-225 lowering.
+///
+/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
+/// validation rules yet because no instructions are lowered.  Future
+/// versions will add rules as opcodes come online (see
+/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A5).
+///
+/// Mirrors the shape of the other IIR backends' `validate_for_*` so
+/// callers can switch backends without changing their pre-flight
+/// logic.
+pub fn validate_for_ge225(_module: &IIRModule) -> Vec<String> {
+    Vec::new()
+}
+
+// ===========================================================================
+// lower_iir_to_ge225
+// ===========================================================================
+
+/// Lower an [`IIRModule`] to a `Vec<u8>` of GE-225 opcode bytes
+/// (20-bit words packed 3 bytes each, big-endian).
+///
+/// **v0.1.0 scope**: emits the canonical 3-byte HLT sentinel
+/// `[0x00, 0x00, 0x00]` regardless of the input.  This is the
+/// smallest "valid GE-225 program" we can produce — enough to load
+/// into a simulator, step once, and confirm the CPU halts.  Real
+/// lowering arrives in v0.2.0+ (A5+).
+pub fn lower_iir_to_ge225(
+    module: &IIRModule,
+    _cfg: &IIRGe225Config,
+) -> Result<Vec<u8>, IIRGe225Error> {
+    let errors = validate_for_ge225(module);
+    if !errors.is_empty() {
+        return Err(IIRGe225Error::ValidationFailed(errors));
+    }
+    Ok(HALT_WORD.to_vec())
+}

--- a/code/packages/rust/iir-to-ge225/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-ge225/tests/test_backend.rs
@@ -1,0 +1,106 @@
+// Tests for iir-to-ge225 v0.1.0 (A5 skeleton).
+//
+// Mirrors the iir-to-intel4004 v0.1.0 test set 1-for-1: every assertion
+// pins a guarantee made in the spec (code/specs/iir-to-ge225.md).
+//
+// Why 1-for-1 mirroring across the architecture-backend crates?
+// Consistency across iir-to-{riscv, intel8008, armv7, intel4004, ge225}
+// makes it cheap for a reviewer to scan a new backend's tests and confirm
+// "yes, this covers the same surface area as its siblings".  Divergence
+// has to be deliberate.
+
+use interpreter_ir::IIRModule;
+use iir_to_ge225::{
+    lower_iir_to_ge225, validate_for_ge225, IIRGe225Config, IIRGe225Error, HALT_WORD,
+};
+
+// Helper: build an empty IIRModule.  The v0.1.0 backend ignores the
+// contents entirely, but the constructor surface is non-trivial enough
+// that hand-writing the literal in every test would be noise.
+fn empty_module() -> IIRModule {
+    IIRModule {
+        name: "test_module".into(),
+        functions: vec![],
+        entry_point: None,
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+#[test]
+fn validate_returns_empty_for_empty_module() {
+    // v0.1.0 stub: validator returns no errors for any module.
+    let module = empty_module();
+    assert!(validate_for_ge225(&module).is_empty());
+}
+
+#[test]
+fn lower_emits_exactly_three_bytes() {
+    // Shape check: one 20-bit word, packed as 3 bytes.
+    let module = empty_module();
+    let cfg = IIRGe225Config::default();
+    let bytes = lower_iir_to_ge225(&module, &cfg).expect("lowering should succeed");
+    assert_eq!(bytes.len(), 3, "v0.1.0 emits exactly one 3-byte word");
+}
+
+#[test]
+fn lower_emits_the_canonical_halt_word() {
+    // The acceptance criterion of A5 v0.1.0: the output is the all-zeros
+    // 20-bit HLT word, packed as [0x00, 0x00, 0x00].
+    let module = empty_module();
+    let cfg = IIRGe225Config::default();
+    let bytes = lower_iir_to_ge225(&module, &cfg).expect("lowering should succeed");
+    assert_eq!(
+        bytes,
+        vec![0x00, 0x00, 0x00],
+        "v0.1.0 emits the canonical HLT sentinel"
+    );
+}
+
+#[test]
+fn halt_word_constant_pinned_to_zeros() {
+    // Guard the public constant against accidental edits.
+    assert_eq!(HALT_WORD, [0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn default_config_has_nonempty_module_name() {
+    // A default-constructed config should produce something non-empty so
+    // downstream consumers can use it as a filename/symbol hint without
+    // null checks.
+    let cfg = IIRGe225Config::default();
+    assert!(!cfg.module_name.is_empty());
+}
+
+#[test]
+fn new_sets_module_name() {
+    // Builder contract: IIRGe225Config::new(s) stores s verbatim.
+    let cfg = IIRGe225Config::new("my_module");
+    assert_eq!(cfg.module_name, "my_module");
+}
+
+#[test]
+fn errors_display_without_panic() {
+    // Smoke: every IIRGe225Error variant has a Display impl that produces
+    // a non-empty string.  Catches missing match arms in Display.
+    let errs = vec![
+        IIRGe225Error::ValidationFailed(vec!["x".into(), "y".into()]),
+        IIRGe225Error::UnsupportedOp {
+            function: "f".into(),
+            op: "weird_op".into(),
+        },
+        IIRGe225Error::UnsupportedType {
+            function: "f".into(),
+            type_hint: "Quaternion".into(),
+        },
+        IIRGe225Error::InvalidOperand {
+            function: "f".into(),
+            detail: "expected Int".into(),
+        },
+    ];
+    for err in errs {
+        let s = format!("{err}");
+        assert!(!s.is_empty(), "Display produced empty string for {err:?}");
+    }
+}

--- a/code/specs/iir-to-ge225.md
+++ b/code/specs/iir-to-ge225.md
@@ -1,0 +1,134 @@
+# iir-to-ge225 — IIR → GE-225 machine code backend
+
+**Status:** v0.1.0 — skeleton (A5)
+**Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A5
+**Related:** [`iir-to-intel4004`][i4004], [`iir-to-intel8008`][i8008], [`iir-to-riscv`][rv], [`iir-to-armv7`][arm]
+
+[i4004]: ../packages/rust/iir-to-intel4004/
+[i8008]: ../packages/rust/iir-to-intel8008/
+[rv]: ../packages/rust/iir-to-riscv/
+[arm]: ../packages/rust/iir-to-armv7/
+
+## Why a new crate?
+
+The **GE-225** (1959) was the General Electric mainframe at
+Dartmouth College where **John Kemeny and Thomas Kurtz designed
+Dartmouth BASIC in 1964**.  BASIC ran on this very machine — the
+1.7 microsecond cycle time and 20-bit word size shaped the
+language's defaults in ways still visible 60 years later.
+
+In this codebase the GE-225 is primarily a **BASIC fit** per
+MULTILANG-ARCHITECTURE-BACKENDS.md §A5.  Compiling BASIC source
+to GE-225 bytes is a small piece of computing history made
+queryable through the LANG VM pipeline.
+
+Adding the GE-225 gives us:
+
+1. **Historical fidelity for Dartmouth BASIC.**  BASIC programs
+   round-trip to the silicon they were designed for.
+2. **A fifth architecture backend** alongside RV32I (A1), Intel
+   8008 (A2), ARMv7 (A3), and Intel 4004 (A4).  The five span
+   width / age / programming-model diversity:
+   - RV32I: 32-bit clean RISC (modern).
+   - Intel 8008: 8-bit accumulator CISC (Oct's native, 1972).
+   - ARMv7: 32-bit RISC + cond-prefix (phone-class, 2005).
+   - Intel 4004: 4-bit accumulator (world's first commercial μP, 1971).
+   - **GE-225**: 20-bit mainframe (Dartmouth BASIC's birthplace, 1959).
+
+3. **Stress-tests the IIR's neutrality across the most exotic
+   target** in the lane: 20-bit words don't fit cleanly in
+   bytes, and the GE-225's accumulator + magnetic-drum-style
+   memory model is unlike anything else.
+
+## Why `Vec<u8>` output for a 20-bit-word machine?
+
+* **Cross-backend uniformity.**  Every other backend emits
+  `Vec<u8>` (Intel 8008, Intel 4004) or a `Vec<u32>` that's
+  trivially flattened to bytes by `lang-aot` (RV32I, ARMv7).
+  Bytes round-trip through every host filesystem without
+  alignment surprises.
+* **3-byte word packing.**  Each 20-bit GE-225 word is emitted
+  as 3 bytes (24 bits total) with the top 4 bits zero,
+  big-endian-style.  This wastes 4 bits per word (~17 % overhead)
+  but means a downstream simulator can read 3 bytes, mask off
+  the top 4 bits, and have the original 20-bit word.
+
+## The halt sentinel — all-zeros HLT
+
+The GE-225's `HLT` instruction is the all-zeros 20-bit word.
+Emitted at the start of a program ROM, this immediately halts
+the machine.
+
+```text
+20-bit word: 0000_0000_0000_0000_0000
+   ↓ packed into 3 big-endian bytes (top 4 bits of byte 0 are zero)
+[0x00, 0x00, 0x00]
+```
+
+This is the documented HLT encoding in the GE-225 reference
+manual.  Alternative halt idioms (e.g. unconditional branch to
+self, `BR $.` in mnemonics) would also work but produce less
+visually obvious bytes; the all-zeros HLT is preferred for
+skeleton purposes.
+
+## Pipeline
+
+```text
+IIRModule
+  → validate_for_ge225()      pre-flight, returns Vec<String>
+  → lower_iir_to_ge225()      returns Vec<u8> (20-bit words packed 3 bytes each)
+  → (optional)
+      • a GE-225 simulator (mostly historical now, but a few exist)
+      • write to .bin + custom emulator
+```
+
+## Scope by version
+
+| Version | Scope | Status |
+|---------|-------|--------|
+| **v0.1.0 (A5 — this PR)** | crate skeleton: any module → single `HLT` (`0x00000`, packed `[0x00, 0x00, 0x00]`) | this PR |
+| v0.2.0 (A5+) | `const dest, Int(n)` → `LDA n` (load accumulator immediate, 16-bit n) + `ret`/`ret_void` → HLT | future |
+| v0.3.0 (A5++) | Accumulator-based arithmetic (`ADD`, `SUB`) + branch family (`BR`, `BMI`, `BNZ`) | future |
+| v0.4.0 (A5+++) | `lang-aot --emit=ge225` wiring + BASIC end-to-end | future |
+
+## Public surface (v0.1.0)
+
+```rust
+pub struct IIRGe225Config { pub module_name: String }
+impl IIRGe225Config {
+    pub fn new(module_name: impl Into<String>) -> Self;
+}
+
+pub enum IIRGe225Error {
+    ValidationFailed(Vec<String>),
+    UnsupportedOp     { function: String, op: String },
+    UnsupportedType   { function: String, type_hint: String },
+    InvalidOperand    { function: String, detail: String },
+}
+
+pub fn validate_for_ge225(module: &IIRModule) -> Vec<String>;
+pub fn lower_iir_to_ge225(
+    module: &IIRModule,
+    cfg: &IIRGe225Config,
+) -> Result<Vec<u8>, IIRGe225Error>;
+
+pub const HALT_WORD: [u8; 3] = [0x00, 0x00, 0x00];
+```
+
+## Non-goals (v0.1.0)
+
+* No instruction lowering — deferred to A5+.
+* No `lang-aot --emit=ge225` wiring — deferred to A5+++.
+* No external assembler / linker integration.
+* No 4-bit-per-word truncation in middle words (we always pack
+  3 bytes per word in v0.1.0).
+
+## Tests (v0.1.0)
+
+* `validate_returns_empty_for_empty_module` — stub validator behaves.
+* `lower_emits_exactly_three_bytes` — output shape (one 20-bit word).
+* `lower_emits_the_canonical_halt_word` — exact `[0x00, 0x00, 0x00]`.
+* `halt_word_constant_pinned_to_zeros` — guards the constant.
+* `default_config_has_nonempty_module_name` — config invariant.
+* `new_sets_module_name` — builder contract.
+* `errors_display_without_panic` — error formatting smoke.


### PR DESCRIPTION
## Summary

A5 of MULTILANG-ARCHITECTURE-BACKENDS.md — the **fifth** and most exotic architecture backend in the LANG VM matrix:

| | Width | Year | Primary fit |
|---|---|---|---|
| iir-to-riscv (A1) | 32-bit | 2015 | generic |
| iir-to-intel8008 (A2) | 8-bit | 1972 | Oct |
| iir-to-armv7 (A3) | 32-bit | 2005 | phone-class |
| iir-to-intel4004 (A4) | 4-bit | 1971 | Brainfuck |
| **iir-to-ge225 (A5, this PR)** | **20-bit** | **1959** | **Dartmouth BASIC** |

The **GE-225** (1959) is the General Electric mainframe at Dartmouth College where Kemeny and Kurtz **designed Dartmouth BASIC in 1964**. BASIC was literally born on this machine.

## What v0.1.0 (this PR) does

- Crate skeleton mirroring `iir-to-intel4004` v0.1.0's surface area 1-for-1: `IIRGe225Config`, `IIRGe225Error`, `validate_for_ge225`, `lower_iir_to_ge225`.
- Any module lowers to the canonical 3-byte halt sentinel — the all-zeros 20-bit HLT word packed as `[0x00, 0x00, 0x00]` (big-endian, 3 bytes per 20-bit word, top 4 bits zero).
- 7 unit tests + 1 doctest, all passing.

## Word packing convention

Each 20-bit GE-225 word → 3 bytes (24 bits), big-endian, with the top 4 bits of byte 0 always zero. Downstream simulators read 3 bytes, mask off the top 4 bits, and recover the original 20-bit word. Keeps the `Vec<u8>` output shape uniform with the 8008 and 4004 backends.

## Why the all-zeros HLT?

The GE-225 reference manual documents the all-zeros 20-bit word as the `HLT` instruction. Self-documenting bytes; recognised by every GE-225 simulator and the historical silicon. Alternative halt idioms (branch-to-self) work but produce less visually obvious bytes.

## What's NOT in this PR

- No instruction lowering (deferred to A5+: `const Int(n)` → `LDA n` + `ret` → HLT).
- No `lang-aot --emit=ge225` wiring (deferred to A5+++).
- No external assembler / linker integration.

## Test plan

- [x] `cargo test -p iir-to-ge225` — 7/7 pass + 1 doctest pass
- [x] Workspace `Cargo.toml` updated with `iir-to-ge225` member
- [x] Spec `code/specs/iir-to-ge225.md` committed first
- [x] Security review passed (round 1, clean)
- [ ] CI green
- [ ] Babysitter cron monitors → kicks off A5+ on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)