### PR TITLE
feat(iir-to-ge225): A5+ v0.2.0 — const → LDA n + ret → HLT

### DIFF
--- a/code/packages/rust/iir-to-ge225/CHANGELOG.md
+++ b/code/packages/rust/iir-to-ge225/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 All notable changes to this crate are documented here.
 
+## v0.2.0 — 2026-06-02 — A5+ first real lowering
+
+First lowering increment after the A5 skeleton.  Adds:
+
+| IIR op | GE-225 lowering |
+|--------|-----------------|
+| `const dest, Int(n)` (16-bit signed/unsigned) | `LDA n` — 20-bit word: opcode nibble `0x1` + 16-bit immediate, packed `[0x01, hi, lo]` |
+| `const dest, Bool(b)` | `LDA 0` or `LDA 1` |
+| `ret <var>` | `HLT` (the all-zeros 20-bit word) — but only if `<var>` is the current ACC owner |
+| `ret_void` | `HLT` |
+
+### Added
+
+- `pub const LDA_OPCODE_NIBBLE: u8 = 0x1` — the GE-225 `LDA` opcode
+  nibble, lives in the low 4 bits of byte 0 in the 3-byte word
+  packing.
+- `IIRGe225Error::UndefinedVariable { function, name }` — fired
+  when `ret <var>` references a var that is either never bound or
+  no longer the current accumulator owner.  v0.2.0 has only the
+  accumulator; multi-register liveness arrives in A5++.
+- Real per-function lowering with accumulator tracking:
+  `env: HashMap<String, u8>` (single sentinel `ACC_MARKER = 16`
+  in v0.2.0) and `acc_owner: Option<String>`.  Mirrors the
+  iir-to-intel4004 v0.2.0 → v0.3.0 progression.
+
+### Acceptance test
+
+The trivial-case ROM (`const v = N; ret v`) is always 6 bytes —
+3 for `LDA N` + 3 for `HLT` — regardless of `N`.  Pinned by the
+`trivial_rom_is_six_bytes` test across N ∈ {0, 1, 42, 255, 256,
+32767, -1, -32768}.
+
+### Word format pinned by this PR
+
+```
+byte 0: 0000 OOOO   (top 4 bits zero + 4-bit opcode nibble)
+byte 1: IIII IIII   (high 8 bits of the 16-bit immediate)
+byte 2: IIII IIII   (low  8 bits of the 16-bit immediate)
+```
+
+Opcodes used in v0.2.0: `0x0` (HLT), `0x1` (LDA).  Future opcodes
+will populate `0x2..0xF`.
+
+### Tests
+
+21 unit + 1 doctest passing.  New coverage:
+- LDA opcode nibble pinned.
+- `const N; ret v` for N ∈ {0, 5}: exact byte sequence.
+- max positive (32767), min negative (-32768), and -1: two's
+  complement reinterpretation.
+- 16-bit overflow (65536) errors with `InvalidOperand`.
+- `Bool(true)` / `Bool(false)` lower to `LDA 1` / `LDA 0`.
+- `ret_void`-only function: 3-byte HLT.
+- Trivial-case 6-byte ROM size pinned across 8 value points.
+- Multi-const where ret targets the current ACC owner: works.
+- `ret` of a stale ACC owner: `UndefinedVariable`.
+- `ret` of a never-defined variable: `UndefinedVariable`.
+- `mov` (unsupported in v0.2.0): `UnsupportedOp { op: "mov" }`.
+
+### Reference
+
+- Spec: `code/specs/iir-to-ge225.md`
+- Plan: `code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md` §A5
+- Mirrors iir-to-intel4004 v0.2.0 (A4+) exactly in spirit.
+
 ## v0.1.0 — 2026-06-02 — A5 skeleton
 
 Initial release.  Establishes the IIR → GE-225 backend's public

--- a/code/packages/rust/iir-to-ge225/Cargo.toml
+++ b/code/packages/rust/iir-to-ge225/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-ge225"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "IIR → GE-225 machine code backend — lowers IIRModule to a Vec<u8> of encoded 20-bit GE-225 instruction words (packed 3 bytes per word, big-endian, top 4 bits zero).  v0.1.0 (A5): crate skeleton that lowers any module to a single HLT (the all-zeros 20-bit word, packed as [0x00, 0x00, 0x00]).  Real lowering (LDA/ADD/SUB/BR family) lands in A5+ through A5++.  The GE-225 (1959) was the General Electric mainframe at Dartmouth College where Dartmouth BASIC was DESIGNED in 1964 by Kemeny and Kurtz — BASIC's defaults still bear the imprint of this 20-bit machine.  Primarily a BASIC fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A5."
+description = "IIR → GE-225 machine code backend — lowers IIRModule to a Vec<u8> of encoded 20-bit GE-225 instruction words (packed 3 bytes per word, big-endian, top 4 bits zero).  v0.2.0 (A5+): first real lowering — `const dest, Int(n)` (16-bit signed/unsigned) → `LDA n` (opcode 0x1 + 16-bit immediate), `ret <var>` / `ret_void` → `HLT` (the all-zeros 20-bit word).  Single-accumulator first slice: most recent `const` owns ACC; multi-register allocation arrives in A5++.  The GE-225 (1959) was the General Electric mainframe at Dartmouth College where Dartmouth BASIC was DESIGNED in 1964 by Kemeny and Kurtz.  Primarily a BASIC fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A5."
 
 [lib]
 name = "iir_to_ge225"

--- a/code/packages/rust/iir-to-ge225/README.md
+++ b/code/packages/rust/iir-to-ge225/README.md
@@ -25,23 +25,33 @@ pipeline:
 | iir-to-intel4004 (A4) | 4-bit | 1971 | Brainfuck |
 | **iir-to-ge225 (A5)** | **20-bit** | **1959** | **Dartmouth BASIC** |
 
-## Status — v0.1.0 (A5 skeleton)
+## Status — v0.2.0 (A5+ first real lowering)
 
-Any module lowers to a single canonical halt sentinel — the
-**all-zeros 20-bit HLT word**, packed as `[0x00, 0x00, 0x00]`.
+| IIR op | GE-225 lowering |
+|--------|-----------------|
+| `const dest, Int(n)` (16-bit signed/unsigned) | `LDA n` — `[0x01, hi, lo]` |
+| `const dest, Bool(b)` | `LDA 0` / `LDA 1` |
+| `ret <var>` | `HLT` (if `<var>` is the current ACC owner; else `UndefinedVariable`) |
+| `ret_void` | `HLT` |
 
-Real instruction lowering arrives in v0.2.0+ (A5+).
+Accumulator-only first slice — most recent `const` owns the ACC.
+Multi-register allocation, arithmetic, and branches arrive in A5++.
 
 ## Quick start
 
 ```rust
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_ge225::{validate_for_ge225, lower_iir_to_ge225, IIRGe225Config};
 
+// const v=5; ret v
+let f = IIRFunction::new("five", vec![], "i16", vec![
+    IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "i16"),
+    IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i16"),
+]);
 let module = IIRModule {
     name: "demo".into(),
-    functions: vec![],
-    entry_point: None,
+    functions: vec![f],
+    entry_point: Some("five".into()),
     language: "demo".into(),
     exports: vec![],
     imports: vec![],
@@ -51,8 +61,8 @@ assert!(validate_for_ge225(&module).is_empty());
 
 let bytes = lower_iir_to_ge225(&module, &IIRGe225Config::default())
     .expect("lowering should succeed");
-// HLT = all-zeros 20-bit word, packed as 3 bytes.
-assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+// LDA 5 + HLT = 6 bytes.
+assert_eq!(bytes, vec![0x01, 0x00, 0x05, 0x00, 0x00, 0x00]);
 ```
 
 ## Word packing

--- a/code/packages/rust/iir-to-ge225/src/lib.rs
+++ b/code/packages/rust/iir-to-ge225/src/lib.rs
@@ -1,4 +1,4 @@
-//! # iir-to-ge225 — IIR → GE-225 machine code backend (v0.1.0 skeleton).
+//! # iir-to-ge225 — IIR → GE-225 machine code backend (v0.2.0, A5+).
 //!
 //! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
 //! 20-bit GE-225 instruction words (packed 3 bytes per word, big-
@@ -13,67 +13,78 @@
 //! defaults in ways still visible 60 years later.
 //!
 //! In this codebase the GE-225 is primarily a **BASIC fit** per
-//! MULTILANG-ARCHITECTURE-BACKENDS.md §A5.  Compiling BASIC source
-//! to GE-225 bytes is a small piece of computing history made
-//! queryable through the LANG VM pipeline.
+//! MULTILANG-ARCHITECTURE-BACKENDS.md §A5.
 //!
-//! Adding the GE-225 gives the LANG VM matrix its fifth and most
-//! exotic architecture backend:
+//! ## Scope of v0.2.0 (A5+ — first real lowering)
 //!
-//! | | RV32I (A1) | 8008 (A2) | ARMv7 (A3) | 4004 (A4) | **GE-225 (A5)** |
-//! |---|---|---|---|---|---|
-//! | Width | 32-bit | 8-bit | 32-bit | 4-bit | **20-bit** |
-//! | Year shipped | 2015 | 1972 | 2005 | 1971 | **1959** |
-//! | Style | Modern RISC | Accumulator CISC | RISC + cond | Tiny MCS-4 | **Mainframe accumulator** |
-//! | LANG VM fit | Generic | Oct's native | Phone-class | Brainfuck | **BASIC's birthplace** |
+//! | IIR op | GE-225 lowering |
+//! |--------|-----------------|
+//! | `const dest, Int(n)` (16-bit signed) | `LDA n` (20-bit word, opcode 0x1, 16-bit imm) |
+//! | `const dest, Bool(b)` | `LDA 0` or `LDA 1` |
+//! | `ret <var>` | `HLT` (20-bit zero word) — real RET needs A5++ |
+//! | `ret_void` | `HLT` |
 //!
-//! ## Scope of v0.1.0 (A5)
+//! ### Accumulator-only first slice
 //!
-//! This release is a **skeleton**: any IIR module lowers to a
-//! single `HLT` — the all-zeros 20-bit word, packed as
-//! `[0x00, 0x00, 0x00]`.  No instruction selection yet; that
-//! arrives in A5+ and beyond.
+//! Every `const` loads into the accumulator.  The GE-225's
+//! arithmetic unit is accumulator-anchored, so this is the natural
+//! starting point.  Multi-register allocation arrives in A5++
+//! alongside arithmetic; for now, the most recent `const` overwrites
+//! whatever ACC held before.  `ret <var>` requires `var` to be the
+//! current ACC owner — otherwise the value isn't reachable and we
+//! return `UndefinedVariable`.
 //!
-//! ## Why `Vec<u8>` output for a 20-bit-word machine?
+//! ### Why `ret` → HLT for now?
 //!
-//! - **Cross-backend uniformity.**  Every other backend emits
-//!   `Vec<u8>` or a `Vec<u32>` that's trivially flattened to bytes.
-//!   Bytes round-trip through every host filesystem without
-//!   alignment surprises.
-//! - **3-byte word packing.**  Each 20-bit GE-225 word is emitted
-//!   as 3 bytes (24 bits total), big-endian, with the top 4 bits
-//!   of byte 0 always zero.  This wastes 4 bits per word (~17 %
-//!   overhead) but means a downstream simulator can read 3 bytes,
-//!   mask off the top 4 bits, and recover the original 20-bit
-//!   word.
+//! A real return on the GE-225 would unwind via the SBR (Save
+//! Branch Register) discipline that JSR (Jump SubRoutine) sets up.
+//! Without proper call/return support (which lands in A5++), we
+//! cannot synthesise a meaningful `BR <saved>` — there's no saved
+//! address.  Emitting `HLT` (the all-zeros word) gives every
+//! GE-225 simulator a clean, deterministic stopping point in the
+//! meantime.
 //!
-//! ## The halt sentinel — all-zeros HLT
+//! ### Empty-module contract
 //!
-//! The GE-225's `HLT` instruction is the all-zeros 20-bit word.
-//! Emitted at the start of a program ROM, this halts the machine.
+//! Preserves v0.1.0's behaviour for the canonical "fn main() {}"
+//! minimal case: any module with no functions emits the bare
+//! `HALT_WORD` so the simulator halts deterministically.  Once at
+//! least one function is lowered, the halt sentinel terminates the
+//! last function's instruction stream.
+//!
+//! ## Word packing (recap from v0.1.0)
+//!
+//! Each 20-bit GE-225 word → 3 bytes (24 bits), big-endian, with
+//! the top 4 bits of byte 0 always zero (since 20 bits < 24 bits):
 //!
 //! ```text
-//! 20-bit word: 0000_0000_0000_0000_0000
-//!    ↓ packed into 3 big-endian bytes
-//! [0x00, 0x00, 0x00]
+//! byte 0: 0000 OOOO   (top 4 bits zero + 4-bit opcode nibble)
+//! byte 1: IIII IIII   (high 8 bits of the 16-bit immediate / address)
+//! byte 2: IIII IIII   (low  8 bits of the 16-bit immediate / address)
 //! ```
 //!
-//! This is the documented HLT encoding in the GE-225 reference
-//! manual.  Alternative halt idioms (e.g. unconditional branch to
-//! self, `BR $.` in mnemonics) would also work but produce less
-//! visually obvious bytes; the all-zeros HLT is preferred for
-//! skeleton purposes.
+//! v0.2.0 uses two opcode nibbles:
+//!
+//! * `0x0` — `HLT` (all-zeros word).
+//! * `0x1` — `LDA n` (load accumulator with 16-bit signed immediate).
+//!
+//! Future slices add `0x2` (`ADD`), `0x3` (`SUB`), `0x4` (`BR`), etc.
 //!
 //! ## Quick start
 //!
 //! ```
-//! use interpreter_ir::IIRModule;
+//! use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 //! use iir_to_ge225::{validate_for_ge225, lower_iir_to_ge225, IIRGe225Config};
 //!
+//! // const v=5; ret v
+//! let f = IIRFunction::new("five", vec![], "i16", vec![
+//!     IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "i16"),
+//!     IIRInstr::new("ret",   None,             vec![Operand::Var("v".into())], "i16"),
+//! ]);
 //! let module = IIRModule {
 //!     name: "demo".into(),
-//!     functions: vec![],
-//!     entry_point: None,
+//!     functions: vec![f],
+//!     entry_point: Some("five".into()),
 //!     language: "demo".into(),
 //!     exports: vec![],
 //!     imports: vec![],
@@ -83,11 +94,12 @@
 //!
 //! let bytes = lower_iir_to_ge225(&module, &IIRGe225Config::default())
 //!     .expect("lowering should succeed");
-//! // HLT = all-zeros 20-bit word, packed as 3 bytes.
-//! assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+//! // LDA 5 = [0x01, 0x00, 0x05]  ;  HLT = [0x00, 0x00, 0x00]
+//! assert_eq!(bytes, vec![0x01, 0x00, 0x05, 0x00, 0x00, 0x00]);
 //! ```
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRModule, Operand};
+use std::collections::HashMap;
 use std::fmt;
 
 // ===========================================================================
@@ -117,20 +129,43 @@ use std::fmt;
 /// ```
 ///
 /// For HLT (word = 0x00000): every bit is zero, so all 3 bytes are
-/// `0x00`.  Subsequent slices that emit non-zero words use the
-/// same big-endian packing.
-///
-/// ## Why HLT over branch-to-self?
-///
-/// | Candidate | Pros | Cons |
-/// |-----------|------|------|
-/// | All-zeros HLT (this) | Documented in the GE-225 reference manual; bytes are unambiguous | None for skeleton purposes |
-/// | `BR $.` (branch to self) | Pure single-word idiom | Encoded as a non-zero opcode; doesn't visually distinguish "halt" from arbitrary branch |
-/// | Unimplemented opcode | Forces a trap | GE-225 reaction to unused opcodes wasn't formally specified — implementation-defined |
-///
-/// The all-zeros HLT is the canonical and historically attested
-/// choice.
+/// `0x00`.
 pub const HALT_WORD: [u8; 3] = [0x00, 0x00, 0x00];
+
+/// GE-225 `LDA` opcode nibble — `0x1`.  Load accumulator with a
+/// 16-bit signed immediate.
+///
+/// The opcode occupies the low 4 bits of byte 0 (= bits 19..16 of
+/// the 20-bit word).  The 16-bit immediate fills bytes 1 + 2,
+/// big-endian.
+///
+/// Example: `LDA 5`:
+/// ```text
+/// byte 0: 0000 0001 = 0x01   (top 4 bits zero + LDA opcode nibble)
+/// byte 1: 0000 0000 = 0x00   (high byte of 16-bit imm = 0)
+/// byte 2: 0000 0101 = 0x05   (low  byte of 16-bit imm = 5)
+/// ```
+///
+/// The GE-225's accumulator is 20 bits wide on real silicon, but
+/// our `LDA n` immediate is restricted to 16 bits ([-32768, 32767]
+/// signed, or [0, 65535] unsigned, both interpreted via two's
+/// complement in the low 16 bits of the word).  Wider values must
+/// be built up via `LDA hi; ROTL 16; ADD lo` patterns in A5++.
+pub const LDA_OPCODE_NIBBLE: u8 = 0x1;
+
+/// Sentinel `env` value meaning "this var currently lives in the
+/// accumulator (ACC)".  Distinct from any register index that
+/// future slices will use.
+const ACC_MARKER: u8 = 16;
+
+/// Supported instruction opcodes in v0.2.0 (A5+).
+///
+/// * `const dest, Int(n)` / `const dest, Bool(b)` lowers to a
+///   single `LDA n` word with `dest` taking over the accumulator.
+/// * `ret <var>` requires `var` to be the current ACC owner; emits
+///   `HLT` (real RET via SBR discipline lands in A5++).
+/// * `ret_void` just emits `HLT`.
+const SUPPORTED_OPS: &[&str] = &["const", "ret", "ret_void"];
 
 // ===========================================================================
 // IIRGe225Config
@@ -173,14 +208,18 @@ impl Default for IIRGe225Config {
 pub enum IIRGe225Error {
     /// The module failed pre-flight validation.
     ValidationFailed(Vec<String>),
-    /// An IIR opcode not yet supported by this backend.  v0.1.0
-    /// doesn't lower any instructions, so a non-empty function body
-    /// would surface this in a future version.
+    /// An IIR opcode not yet supported by this backend.
     UnsupportedOp { function: String, op: String },
     /// A type hint that does not map to any GE-225 representation.
     UnsupportedType { function: String, type_hint: String },
-    /// An operand has an unexpected shape.
+    /// An operand has an unexpected shape, or an `Int` immediate
+    /// falls outside the 16-bit signed range `[-32768, 32767]`.
     InvalidOperand { function: String, detail: String },
+    /// A variable was returned (via `ret`) without ever being bound
+    /// by a `const`, or it's no longer the current accumulator
+    /// owner.  v0.2.0 only tracks ACC; multi-register liveness
+    /// arrives in A5++.
+    UndefinedVariable { function: String, name: String },
 }
 
 impl fmt::Display for IIRGe225Error {
@@ -198,6 +237,14 @@ impl fmt::Display for IIRGe225Error {
             Self::InvalidOperand { function, detail } => {
                 write!(f, "invalid operand in function {function:?}: {detail}")
             }
+            Self::UndefinedVariable { function, name } => {
+                write!(
+                    f,
+                    "variable {name:?} is not in the GE-225 accumulator in \
+                     function {function:?} (v0.2.0 tracks only ACC; \
+                     multi-register liveness arrives in A5++)"
+                )
+            }
         }
     }
 }
@@ -210,10 +257,9 @@ impl std::error::Error for IIRGe225Error {}
 
 /// Pre-flight validation for IIR → GE-225 lowering.
 ///
-/// **v0.1.0 stub**: always returns an empty `Vec` — there are no
-/// validation rules yet because no instructions are lowered.  Future
-/// versions will add rules as opcodes come online (see
-/// `MULTILANG-ARCHITECTURE-BACKENDS.md` §A5).
+/// **v0.2.0 stub**: always returns an empty `Vec` — per-instruction
+/// validation happens during `lower_iir_to_ge225` itself.  Future
+/// versions may move structural checks here.
 ///
 /// Mirrors the shape of the other IIR backends' `validate_for_*` so
 /// callers can switch backends without changing their pre-flight
@@ -229,11 +275,8 @@ pub fn validate_for_ge225(_module: &IIRModule) -> Vec<String> {
 /// Lower an [`IIRModule`] to a `Vec<u8>` of GE-225 opcode bytes
 /// (20-bit words packed 3 bytes each, big-endian).
 ///
-/// **v0.1.0 scope**: emits the canonical 3-byte HLT sentinel
-/// `[0x00, 0x00, 0x00]` regardless of the input.  This is the
-/// smallest "valid GE-225 program" we can produce — enough to load
-/// into a simulator, step once, and confirm the CPU halts.  Real
-/// lowering arrives in v0.2.0+ (A5+).
+/// **v0.2.0 scope (A5+)**: see the module-level docs for the per-op
+/// lowering table.
 pub fn lower_iir_to_ge225(
     module: &IIRModule,
     _cfg: &IIRGe225Config,
@@ -242,5 +285,187 @@ pub fn lower_iir_to_ge225(
     if !errors.is_empty() {
         return Err(IIRGe225Error::ValidationFailed(errors));
     }
-    Ok(HALT_WORD.to_vec())
+
+    // Trivial empty-module contract — preserves v0.1.0 callable
+    // behaviour for the canonical "fn main() {}" minimal case.
+    if module.functions.is_empty() {
+        return Ok(HALT_WORD.to_vec());
+    }
+
+    let mut bytes = Vec::new();
+    for f in &module.functions {
+        // ── Per-function accumulator state ────────────────────────────
+        //
+        // The GE-225's ALU is accumulator-anchored: arithmetic and
+        // immediate loads all flow through the 20-bit ACC.  We
+        // maintain two pieces of state:
+        //
+        //   env: HashMap<String, u8>
+        //     var name → location.  In v0.2.0 every entry is
+        //     `ACC_MARKER` (= 16) since we don't yet allocate GP
+        //     registers.  Future slices will use 0..15 for real
+        //     registers, mirroring the iir-to-intel4004 v0.3.0
+        //     ACC-first allocator.
+        //
+        //   acc_owner: Option<String>
+        //     Which var (if any) currently owns ACC.  Each new
+        //     `const` clobbers ACC, becoming the new owner.  `ret`
+        //     requires its src to be the current owner — otherwise
+        //     the value is unreachable in v0.2.0 (it's been
+        //     overwritten by a later const).
+        let mut env: HashMap<String, u8> = HashMap::new();
+        let mut acc_owner: Option<String> = None;
+
+        for instr in &f.instructions {
+            if !SUPPORTED_OPS.contains(&instr.op.as_str()) {
+                return Err(IIRGe225Error::UnsupportedOp {
+                    function: f.name.clone(),
+                    op: instr.op.clone(),
+                });
+            }
+            match instr.op.as_str() {
+                // ── const dest, Int(n) → LDA n ────────────────────────
+                //
+                // 20-bit word layout: bits 19..16 = LDA opcode (0x1),
+                // bits 15..0 = the 16-bit two's-complement immediate.
+                // Packed big-endian into 3 bytes per v0.1.0's
+                // convention.
+                "const" => {
+                    let dest = require_dest(instr, "const", &f.name)?;
+                    let imm16 = encode_immediate_16(instr.srcs.first(), &f.name)?;
+                    bytes.extend_from_slice(&encode_lda(imm16));
+                    env.insert(dest.to_string(), ACC_MARKER);
+                    acc_owner = Some(dest.to_string());
+                }
+
+                // ── ret <var>: require var == acc_owner; emit HLT ─────
+                //
+                // v0.2.0 has no LD register-source instruction yet;
+                // every value lives in ACC and gets overwritten by
+                // the next `const`.  So `ret v` requires v to still
+                // be the current ACC owner.  This is restrictive but
+                // correct — the alternative (silently producing wrong
+                // code) is worse.  A5++ adds register allocation and
+                // lifts this restriction.
+                "ret" => {
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => {
+                            return Err(IIRGe225Error::InvalidOperand {
+                                function: f.name.clone(),
+                                detail: "ret srcs[0] must be Var".into(),
+                            })
+                        }
+                    };
+                    let _ = env.get(&src_name).ok_or_else(|| {
+                        IIRGe225Error::UndefinedVariable {
+                            function: f.name.clone(),
+                            name: src_name.clone(),
+                        }
+                    })?;
+                    if acc_owner.as_deref() != Some(src_name.as_str()) {
+                        return Err(IIRGe225Error::UndefinedVariable {
+                            function: f.name.clone(),
+                            name: src_name,
+                        });
+                    }
+                    bytes.extend_from_slice(&HALT_WORD);
+                }
+
+                // ── ret_void: just HLT ────────────────────────────────
+                "ret_void" => {
+                    bytes.extend_from_slice(&HALT_WORD);
+                }
+
+                _ => unreachable!("SUPPORTED_OPS guard above prevents this"),
+            }
+        }
+    }
+
+    // Defensive — if every function was empty, fall back to
+    // HALT_WORD so the output remains a valid halting program.
+    if bytes.is_empty() {
+        bytes.extend_from_slice(&HALT_WORD);
+    }
+
+    Ok(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Per-instruction helpers
+// ---------------------------------------------------------------------------
+
+fn require_dest<'a>(
+    instr: &'a interpreter_ir::IIRInstr,
+    op: &str,
+    fn_name: &str,
+) -> Result<&'a str, IIRGe225Error> {
+    instr
+        .dest
+        .as_deref()
+        .ok_or_else(|| IIRGe225Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: format!("{op} requires a dest"),
+        })
+}
+
+/// Encode an `LDA n` 20-bit word as 3 bytes, big-endian.
+///
+/// Layout:
+/// ```text
+/// byte 0: 0000 0001  (top 4 bits zero + LDA opcode nibble 0x1)
+/// byte 1: high 8 bits of the 16-bit immediate
+/// byte 2: low  8 bits of the 16-bit immediate
+/// ```
+fn encode_lda(imm16: u16) -> [u8; 3] {
+    [
+        LDA_OPCODE_NIBBLE,
+        ((imm16 >> 8) & 0xFF) as u8,
+        (imm16 & 0xFF) as u8,
+    ]
+}
+
+/// Decode and range-check a `const` immediate operand into a 16-bit
+/// value (two's-complement reinterpretation for negatives).
+///
+/// * `Int(n)` with `n` in `[-32768, 32767]` → `n as i16 as u16`.
+/// * `Bool(true)` → 1, `Bool(false)` → 0.
+/// * Out-of-range or non-numeric → `InvalidOperand`.
+///
+/// The 16-bit ceiling reflects the v0.2.0 instruction format (4-bit
+/// opcode + 16-bit immediate fills the 20-bit word).  Future slices
+/// can synthesise wider values via `LDA hi; SHL 16; ADD lo` chains.
+fn encode_immediate_16(op: Option<&Operand>, fn_name: &str) -> Result<u16, IIRGe225Error> {
+    let n: i64 = match op {
+        Some(Operand::Int(n)) => *n,
+        Some(Operand::Bool(b)) => {
+            if *b {
+                1
+            } else {
+                0
+            }
+        }
+        _ => {
+            return Err(IIRGe225Error::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "const srcs[0] must be Int or Bool".into(),
+            })
+        }
+    };
+    // Accept both signed-16 and unsigned-16 ranges; both reinterpret
+    // cleanly via two's complement into the same 16 bits.
+    if (-32768..=32767).contains(&n) {
+        Ok((n as i16) as u16)
+    } else if (32768..=65535).contains(&n) {
+        Ok(n as u16)
+    } else {
+        Err(IIRGe225Error::InvalidOperand {
+            function: fn_name.to_string(),
+            detail: format!(
+                "const {n} exceeds 16-bit immediate range ([-32768, 65535]); \
+                 the GE-225 v0.2.0 LDA immediate is 16 bits wide — wider \
+                 values must be built up via LDA-shift-ADD chains in A5++"
+            ),
+        })
+    }
 }

--- a/code/packages/rust/iir-to-ge225/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-ge225/tests/test_backend.rs
@@ -1,25 +1,29 @@
-// Tests for iir-to-ge225 v0.1.0 (A5 skeleton).
+// Tests for iir-to-ge225 v0.2.0 (A5+ — first real lowering).
 //
-// Mirrors the iir-to-intel4004 v0.1.0 test set 1-for-1: every assertion
-// pins a guarantee made in the spec (code/specs/iir-to-ge225.md).
+// Mirrors iir-to-intel4004 v0.2.0's test set 1-for-1 in spirit:
+// every assertion pins a guarantee made in the spec
+// (code/specs/iir-to-ge225.md).
 //
-// Why 1-for-1 mirroring across the architecture-backend crates?
-// Consistency across iir-to-{riscv, intel8008, armv7, intel4004, ge225}
-// makes it cheap for a reviewer to scan a new backend's tests and confirm
-// "yes, this covers the same surface area as its siblings".  Divergence
-// has to be deliberate.
+// Coverage:
+//   §1 — validator stub
+//   §2 — HLT shape + constant pinning (regression from v0.1.0)
+//   §3 — Config defaults
+//   §4 — Error Display
+//   §5 — A5+: const → LDA, ret → HLT (the new behaviour)
 
-use interpreter_ir::IIRModule;
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use iir_to_ge225::{
     lower_iir_to_ge225, validate_for_ge225, IIRGe225Config, IIRGe225Error, HALT_WORD,
+    LDA_OPCODE_NIBBLE,
 };
 
-// Helper: build an empty IIRModule.  The v0.1.0 backend ignores the
-// contents entirely, but the constructor surface is non-trivial enough
-// that hand-writing the literal in every test would be noise.
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 fn empty_module() -> IIRModule {
     IIRModule {
-        name: "test_module".into(),
+        name: "demo".into(),
         functions: vec![],
         entry_point: None,
         language: "test".into(),
@@ -28,67 +32,79 @@ fn empty_module() -> IIRModule {
     }
 }
 
+fn module_with(f: IIRFunction) -> IIRModule {
+    let entry = f.name.clone();
+    IIRModule {
+        name: "test".into(),
+        functions: vec![f],
+        entry_point: Some(entry),
+        language: "test".into(),
+        exports: vec![],
+        imports: vec![],
+    }
+}
+
+// ===========================================================================
+// §1. Validator stub
+// ===========================================================================
+
 #[test]
 fn validate_returns_empty_for_empty_module() {
-    // v0.1.0 stub: validator returns no errors for any module.
-    let module = empty_module();
-    assert!(validate_for_ge225(&module).is_empty());
+    assert!(validate_for_ge225(&empty_module()).is_empty());
 }
 
-#[test]
-fn lower_emits_exactly_three_bytes() {
-    // Shape check: one 20-bit word, packed as 3 bytes.
-    let module = empty_module();
-    let cfg = IIRGe225Config::default();
-    let bytes = lower_iir_to_ge225(&module, &cfg).expect("lowering should succeed");
-    assert_eq!(bytes.len(), 3, "v0.1.0 emits exactly one 3-byte word");
-}
+// ===========================================================================
+// §2. v0.1.0 HLT contract (regression — empty module still halts)
+// ===========================================================================
 
 #[test]
-fn lower_emits_the_canonical_halt_word() {
-    // The acceptance criterion of A5 v0.1.0: the output is the all-zeros
-    // 20-bit HLT word, packed as [0x00, 0x00, 0x00].
-    let module = empty_module();
-    let cfg = IIRGe225Config::default();
-    let bytes = lower_iir_to_ge225(&module, &cfg).expect("lowering should succeed");
+fn empty_module_still_emits_the_canonical_halt_word() {
+    let bytes = lower_iir_to_ge225(&empty_module(), &IIRGe225Config::default())
+        .expect("lowering");
     assert_eq!(
         bytes,
         vec![0x00, 0x00, 0x00],
-        "v0.1.0 emits the canonical HLT sentinel"
+        "v0.2.0 preserves v0.1.0's empty-module contract"
     );
 }
 
 #[test]
 fn halt_word_constant_pinned_to_zeros() {
-    // Guard the public constant against accidental edits.
     assert_eq!(HALT_WORD, [0x00, 0x00, 0x00]);
 }
 
 #[test]
+fn lda_opcode_nibble_pinned_to_0x1() {
+    // LDA opcode lives in the low 4 bits of byte 0 of the 3-byte
+    // word packing; high 4 bits of byte 0 are always zero.
+    assert_eq!(LDA_OPCODE_NIBBLE, 0x1);
+}
+
+// ===========================================================================
+// §3. Config defaults
+// ===========================================================================
+
+#[test]
 fn default_config_has_nonempty_module_name() {
-    // A default-constructed config should produce something non-empty so
-    // downstream consumers can use it as a filename/symbol hint without
-    // null checks.
-    let cfg = IIRGe225Config::default();
-    assert!(!cfg.module_name.is_empty());
+    assert!(!IIRGe225Config::default().module_name.is_empty());
 }
 
 #[test]
 fn new_sets_module_name() {
-    // Builder contract: IIRGe225Config::new(s) stores s verbatim.
-    let cfg = IIRGe225Config::new("my_module");
-    assert_eq!(cfg.module_name, "my_module");
+    assert_eq!(IIRGe225Config::new("custom").module_name, "custom");
 }
+
+// ===========================================================================
+// §4. Error Display
+// ===========================================================================
 
 #[test]
 fn errors_display_without_panic() {
-    // Smoke: every IIRGe225Error variant has a Display impl that produces
-    // a non-empty string.  Catches missing match arms in Display.
     let errs = vec![
-        IIRGe225Error::ValidationFailed(vec!["x".into(), "y".into()]),
+        IIRGe225Error::ValidationFailed(vec!["x".into()]),
         IIRGe225Error::UnsupportedOp {
             function: "f".into(),
-            op: "weird_op".into(),
+            op: "weird".into(),
         },
         IIRGe225Error::UnsupportedType {
             function: "f".into(),
@@ -96,11 +112,318 @@ fn errors_display_without_panic() {
         },
         IIRGe225Error::InvalidOperand {
             function: "f".into(),
-            detail: "expected Int".into(),
+            detail: "bad".into(),
+        },
+        IIRGe225Error::UndefinedVariable {
+            function: "f".into(),
+            name: "v".into(),
         },
     ];
     for err in errs {
-        let s = format!("{err}");
-        assert!(!s.is_empty(), "Display produced empty string for {err:?}");
+        assert!(!format!("{err}").is_empty());
+    }
+}
+
+// ===========================================================================
+// §5. A5+ — `const` lowers to `LDA n`; `ret` → HLT
+// ===========================================================================
+//
+// Every `const` loads its 16-bit immediate into ACC via a single
+// 3-byte LDA word: [0x01, hi, lo].  `ret` requires its src to be
+// the current ACC owner and emits HLT.  `ret_void` just emits HLT.
+//
+// The trivial-case ROM (`const v=N; ret v`) is always 6 bytes — 3
+// for LDA, 3 for HLT — regardless of N.
+
+#[test]
+fn const_5_then_ret_lowers_to_lda_5_then_halt() {
+    // const v=5; ret v
+    //   LDA 5 = [0x01, 0x00, 0x05]
+    //   HLT   = [0x00, 0x00, 0x00]
+    let f = IIRFunction::new(
+        "five",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![0x01, 0x00, 0x05, 0x00, 0x00, 0x00],
+        "expected LDA 5 + HLT; got: {bytes:02x?}"
+    );
+}
+
+#[test]
+fn const_0_then_ret_emits_lda_zero() {
+    // const v=0; ret v → LDA 0 + HLT
+    let f = IIRFunction::new(
+        "zero",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0)], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![0x01, 0x00, 0x00, 0x00, 0x00, 0x00],
+        "LDA 0 byte 0 still has the LDA opcode nibble visible"
+    );
+}
+
+#[test]
+fn const_max_positive_16bit_emits_correct_bytes() {
+    // const v=32767 (max i16); ret_void
+    //   LDA 0x7FFF = [0x01, 0x7F, 0xFF]
+    let f = IIRFunction::new(
+        "max",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(32767)], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x7F, 0xFF, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn const_min_negative_16bit_emits_correct_bytes() {
+    // const v=-32768 (min i16); ret_void
+    //   -32768 → 0x8000 via two's complement
+    //   LDA 0x8000 = [0x01, 0x80, 0x00]
+    let f = IIRFunction::new(
+        "min",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-32768)], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x80, 0x00, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn const_negative_one_uses_twos_complement() {
+    // const v=-1 → 0xFFFF; LDA = [0x01, 0xFF, 0xFF]
+    let f = IIRFunction::new(
+        "minus_one",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(-1)], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0xFF, 0xFF, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn const_bool_true_emits_lda_one() {
+    let f = IIRFunction::new(
+        "btrue",
+        vec![],
+        "bool",
+        vec![
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Bool(true)], "bool"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x00, 0x01, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn const_bool_false_emits_lda_zero() {
+    let f = IIRFunction::new(
+        "bfalse",
+        vec![],
+        "bool",
+        vec![
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Bool(false)], "bool"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x00, 0x00, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn const_out_of_range_errors() {
+    // 65536 doesn't fit in 16 bits — must error, not silently truncate.
+    let f = IIRFunction::new(
+        "too_big",
+        vec![],
+        "i32",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(65536)], "i32"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("65536 must overflow the 16-bit immediate");
+    match err {
+        IIRGe225Error::InvalidOperand { detail, .. } => {
+            assert!(
+                detail.contains("16-bit"),
+                "error should mention the 16-bit ceiling: {detail}"
+            );
+        }
+        other => panic!("expected InvalidOperand, got {other:?}"),
+    }
+}
+
+#[test]
+fn ret_void_only_emits_just_halt() {
+    // No const at all — ret_void alone → 3 bytes HLT.
+    let f = IIRFunction::new(
+        "noop",
+        vec![],
+        "void",
+        vec![IIRInstr::new("ret_void", None, vec![], "void")],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn trivial_rom_is_six_bytes() {
+    // The canonical `const v=N; ret v` trivial-case ROM size: 3 bytes
+    // LDA + 3 bytes HLT = 6 bytes total, regardless of N.  Pinning this
+    // shape catches accidental regressions in the per-instruction byte
+    // count.
+    for &n in &[0i64, 1, 42, 255, 256, 32767, -1, -32768] {
+        let f = IIRFunction::new(
+            "trivial",
+            vec![],
+            "i16",
+            vec![
+                IIRInstr::new("const", Some("v".into()), vec![Operand::Int(n)], "i16"),
+                IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i16"),
+            ],
+        );
+        let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+            .expect("lowering");
+        assert_eq!(
+            bytes.len(),
+            6,
+            "trivial ROM for n={n} should be 6 bytes; got: {bytes:02x?}"
+        );
+        // First 3 bytes must be the LDA word; last 3 must be HLT.
+        assert_eq!(bytes[0], 0x01, "byte 0 must be LDA opcode for n={n}");
+        assert_eq!(&bytes[3..], &HALT_WORD, "tail must be HLT for n={n}");
+    }
+}
+
+#[test]
+fn multiple_consts_then_ret_of_current_acc_works() {
+    // const a=1; const b=2; ret b
+    //   LDA 1 + LDA 2 + HLT = 9 bytes
+    // b is the current ACC owner; ret b is fine.
+    let f = IIRFunction::new(
+        "two_consts",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "i16"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("b".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x01, // LDA 1
+            0x01, 0x00, 0x02, // LDA 2
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+#[test]
+fn ret_of_stale_acc_owner_errors_in_v0_2_0() {
+    // const a=1; const b=2; ret a
+    //   `a` was overwritten by `b`; v0.2.0 has no register file to
+    //   recover the value, so this must error (rather than silently
+    //   producing wrong code that returns 2 when the IR says return a).
+    //   A5++ will lift this restriction by allocating real GP
+    //   registers, mirroring the iir-to-intel4004 v0.3.0 transition.
+    let f = IIRFunction::new(
+        "stale",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "i16"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(2)], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "i16"),
+        ],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("ret of stale ACC owner must error");
+    match err {
+        IIRGe225Error::UndefinedVariable { name, .. } => {
+            assert_eq!(name, "a");
+        }
+        other => panic!("expected UndefinedVariable, got {other:?}"),
+    }
+}
+
+#[test]
+fn ret_of_completely_undefined_variable_errors() {
+    // No `const` at all — `ret v` references an unbound var.
+    let f = IIRFunction::new(
+        "unbound",
+        vec![],
+        "i16",
+        vec![IIRInstr::new(
+            "ret",
+            None,
+            vec![Operand::Var("never_defined".into())],
+            "i16",
+        )],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("ret of unbound var must error");
+    assert!(matches!(err, IIRGe225Error::UndefinedVariable { .. }));
+}
+
+#[test]
+fn unsupported_op_errors_with_op_name() {
+    // `mov` isn't in v0.2.0's SUPPORTED_OPS — must error explicitly.
+    let f = IIRFunction::new(
+        "with_mov",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(1)], "i16"),
+            IIRInstr::new("mov", Some("b".into()), vec![Operand::Var("a".into())], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("mov is not yet supported");
+    match err {
+        IIRGe225Error::UnsupportedOp { op, .. } => assert_eq!(op, "mov"),
+        other => panic!("expected UnsupportedOp, got {other:?}"),
     }
 }

--- a/code/specs/iir-to-ge225.md
+++ b/code/specs/iir-to-ge225.md
@@ -1,6 +1,6 @@
 # iir-to-ge225 — IIR → GE-225 machine code backend
 
-**Status:** v0.1.0 — skeleton (A5)
+**Status:** v0.2.0 — first real lowering (A5+)
 **Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A5
 **Related:** [`iir-to-intel4004`][i4004], [`iir-to-intel8008`][i8008], [`iir-to-riscv`][rv], [`iir-to-armv7`][arm]
 
@@ -86,9 +86,9 @@ IIRModule
 
 | Version | Scope | Status |
 |---------|-------|--------|
-| **v0.1.0 (A5 — this PR)** | crate skeleton: any module → single `HLT` (`0x00000`, packed `[0x00, 0x00, 0x00]`) | this PR |
-| v0.2.0 (A5+) | `const dest, Int(n)` → `LDA n` (load accumulator immediate, 16-bit n) + `ret`/`ret_void` → HLT | future |
-| v0.3.0 (A5++) | Accumulator-based arithmetic (`ADD`, `SUB`) + branch family (`BR`, `BMI`, `BNZ`) | future |
+| v0.1.0 (A5) | crate skeleton: any module → single `HLT` (`0x00000`, packed `[0x00, 0x00, 0x00]`) | **merged** |
+| **v0.2.0 (A5+ — this PR)** | `const dest, Int(n)` → `LDA n` (load accumulator immediate, 16-bit signed/unsigned) + `ret`/`ret_void` → HLT.  Single-ACC liveness model; multi-register allocation deferred. | this PR |
+| v0.3.0 (A5++) | ACC-first GP register allocator + `mov` + accumulator-based arithmetic (`ADD`, `SUB`) + branch family (`BR`, `BMI`, `BNZ`) | future |
 | v0.4.0 (A5+++) | `lang-aot --emit=ge225` wiring + BASIC end-to-end | future |
 
 ## Public surface (v0.1.0)
@@ -113,22 +113,47 @@ pub fn lower_iir_to_ge225(
 ) -> Result<Vec<u8>, IIRGe225Error>;
 
 pub const HALT_WORD: [u8; 3] = [0x00, 0x00, 0x00];
+pub const LDA_OPCODE_NIBBLE: u8 = 0x1;  // v0.2.0
 ```
 
-## Non-goals (v0.1.0)
+## Word format
 
-* No instruction lowering — deferred to A5+.
+```
+byte 0: 0000 OOOO   (top 4 bits zero + 4-bit opcode nibble)
+byte 1: IIII IIII   (high 8 bits of the 16-bit immediate)
+byte 2: IIII IIII   (low  8 bits of the 16-bit immediate)
+```
+
+Opcodes assigned so far: `0x0` (HLT), `0x1` (LDA).  Future slices
+take `0x2..0xF`.
+
+## Non-goals (v0.2.0)
+
+* No multi-register allocation — deferred to A5++ (mirrors the
+  iir-to-intel4004 v0.2.0 → v0.3.0 jump).
+* No arithmetic (`ADD`, `SUB`) — A5++.
+* No conditional branches — A5++.
 * No `lang-aot --emit=ge225` wiring — deferred to A5+++.
 * No external assembler / linker integration.
-* No 4-bit-per-word truncation in middle words (we always pack
-  3 bytes per word in v0.1.0).
 
-## Tests (v0.1.0)
+## Tests (v0.2.0 — 21 unit + 1 doctest)
 
 * `validate_returns_empty_for_empty_module` — stub validator behaves.
-* `lower_emits_exactly_three_bytes` — output shape (one 20-bit word).
-* `lower_emits_the_canonical_halt_word` — exact `[0x00, 0x00, 0x00]`.
-* `halt_word_constant_pinned_to_zeros` — guards the constant.
-* `default_config_has_nonempty_module_name` — config invariant.
-* `new_sets_module_name` — builder contract.
-* `errors_display_without_panic` — error formatting smoke.
+* `empty_module_still_emits_the_canonical_halt_word` — v0.1.0 contract preserved.
+* `halt_word_constant_pinned_to_zeros` — `HALT_WORD` constant.
+* `lda_opcode_nibble_pinned_to_0x1` — `LDA_OPCODE_NIBBLE` constant.
+* `default_config_has_nonempty_module_name` / `new_sets_module_name` — config invariants.
+* `errors_display_without_panic` — Display covers all 5 error variants.
+* `const_5_then_ret_lowers_to_lda_5_then_halt` — canonical 6-byte ROM.
+* `const_0_then_ret_emits_lda_zero` — LDA 0 byte 0 visibly has opcode nibble.
+* `const_max_positive_16bit_emits_correct_bytes` — n=32767 packed correctly.
+* `const_min_negative_16bit_emits_correct_bytes` — n=-32768 → 0x8000.
+* `const_negative_one_uses_twos_complement` — n=-1 → 0xFFFF.
+* `const_bool_true_emits_lda_one` / `const_bool_false_emits_lda_zero`.
+* `const_out_of_range_errors` — 65536 → `InvalidOperand`.
+* `ret_void_only_emits_just_halt` — 3-byte HLT.
+* `trivial_rom_is_six_bytes` — 6-byte invariant across 8 N values.
+* `multiple_consts_then_ret_of_current_acc_works` — `LDA; LDA; HLT` = 9 bytes.
+* `ret_of_stale_acc_owner_errors_in_v0_2_0` — `UndefinedVariable`.
+* `ret_of_completely_undefined_variable_errors` — `UndefinedVariable`.
+* `unsupported_op_errors_with_op_name` — `mov` → `UnsupportedOp`.


### PR DESCRIPTION
## Summary

A5+ of MULTILANG-ARCHITECTURE-BACKENDS.md — the first real lowering for the GE-225 backend.  Mirrors `iir-to-intel4004` v0.2.0 (A4+).

| IIR op | GE-225 lowering |
|--------|-----------------|
| `const dest, Int(n)` (16-bit signed/unsigned) | `LDA n` — `[0x01, hi, lo]` |
| `const dest, Bool(b)` | `LDA 0` / `LDA 1` |
| `ret <var>` | `HLT` (requires `<var>` to be current ACC owner) |
| `ret_void` | `HLT` |

### Word format pinned

```
byte 0: 0000 OOOO   (top 4 bits zero + 4-bit opcode nibble)
byte 1: IIII IIII   (high 8 bits of 16-bit immediate)
byte 2: IIII IIII   (low  8 bits of 16-bit immediate)
```

Opcodes assigned so far: `0x0` (HLT), `0x1` (LDA). Reserves `0x2..0xF` for future ADD/SUB/BR/JSR/etc.

### Accumulator-only liveness

`env: HashMap<String, u8>` (all entries = `ACC_MARKER = 16` in v0.2.0); `acc_owner: Option<String>` tracks the most-recent-const owner. `ret <var>` requires `var == acc_owner`; else `UndefinedVariable`. A5++ will lift this with a real GP register allocator.

### Trivial-case ROM invariant

`const v=N; ret v` → **6 bytes** (3 LDA + 3 HLT) for all N in [-32768, 65535]. Pinned across 8 N values.

### What's NOT in this PR

- No GP register allocator / `mov` — A5++
- No arithmetic (`ADD`/`SUB`) — A5++
- No control flow (`BR`/`BMI`/`BNZ`) — A5++
- No `lang-aot --emit=ge225` wiring — A5+++

## Test plan

- [x] `cargo test -p iir-to-ge225` — 21/21 + 1 doctest pass
- [x] Trivial-case ROM size 6 bytes pinned across {0, 1, 42, 255, 256, 32767, -1, -32768}
- [x] Max positive (32767), min negative (-32768), -1, Bool: two's-complement reinterpretation
- [x] 65536 → `InvalidOperand`
- [x] Stale ACC owner ret → `UndefinedVariable`
- [x] `mov` → `UnsupportedOp { op: \"mov\" }`
- [x] Security review passed (round 1, clean)
- [ ] CI green
- [ ] Babysitter cron monitors → kicks off A5++ on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)