### PR TITLE
feat(iir-to-ge225): A5++++++++++ v0.9.0 — neg op (closes BASIC unary-minus gap)

### DIFF
--- a/code/packages/rust/iir-to-ge225/CHANGELOG.md
+++ b/code/packages/rust/iir-to-ge225/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 All notable changes to this crate are documented here.
 
+## v0.9.0 — 2026-06-02 — A5++++++++++ `neg` lowering (closes BASIC unary-minus gap)
+
+Eighth lowering increment.  Adds `neg dest, src` via the canonical
+two's-complement-by-subtract-from-zero pattern.  Closes the BASIC
+unary-minus gap so programs containing `-x` expressions compile
+end-to-end.
+
+### Lowering shape
+
+```
+(STA r_evict_src)?  ; if src in ACC, evict to register
+(STA r_evict_acc)?  ; if any other var in ACC, evict
+LDA 0               ; ACC ← 0
+SUB r_src           ; ACC ← 0 - src = -src
+```
+
+After this sequence: `env[dest] = ACC_MARKER`, `acc_owner = Some(dest)`.
+
+### Byte costs
+
+- Trivial `const v=N; neg w, v; ret w` (entry function): **15 bytes**
+  `LDA N + STA r0 + LDA 0 + SUB r0 + HLT`
+- `neg` itself contributes 6 bytes after prep (`LDA 0` + `SUB r_src`).
+
+### Public surface delta
+
+- `"neg"` added to `SUPPORTED_OPS`.
+- No new pub constants, no new error variants — validation flows
+  through existing `InvalidOperand` and `UndefinedVariable`.
+
+### Opcode map (unchanged — neg uses existing 0x1 LDA + 0x5 SUB)
+
+The lowering reuses the existing LDA and SUB opcodes; no new
+opcode nibble is added.  All 11 opcodes (0x0..0xB) keep their
+v0.6.0 assignments.
+
+### Tests (33 unit + 1 doctest, all passing)
+
+New v0.9.0 coverage:
+- `canonical_neg_byte_sequence` — exact 15-byte trivial ROM
+- `neg_when_src_in_register_skips_first_eviction` — 21-byte
+  chained-const sequence
+- `double_neg_works` — chained negs lower cleanly (no exact byte
+  pin, just semantics)
+- `neg_undefined_src_errors` — `UndefinedVariable`
+- `neg_no_srcs_errors` — `InvalidOperand`
+- `neg_result_feeds_directly_into_ret` — result is in ACC for
+  ret-without-LD
+
+Regressions still pinned: trivial 6-byte ROM, trivial-add 21-byte,
+trivial-cmp 33-byte, call_builtin no-op, all 11 opcode nibbles.
+
+Lang-aot e2e: 10/10 BASIC tests pass (no test contents changed —
+neg just becomes part of BASIC programs that use unary minus).
+
+### Reference
+
+- Spec: `code/specs/iir-to-ge225.md`
+- Plan: `code/specs/MULTILANG-ARCHITECTURE-BACKENDS.md` §A5
+
 ## v0.8.0 — 2026-06-02 — A5+++++++++ `call_builtin` no-op lowering (closes BASIC PRINT gap)
 
 Seventh lowering increment.  Adds a minimal `call_builtin`

--- a/code/packages/rust/iir-to-ge225/Cargo.toml
+++ b/code/packages/rust/iir-to-ge225/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-ge225"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
-description = "IIR → GE-225 machine code backend.  v0.8.0 (A5+++++++++): adds a no-op `call_builtin` lowering, closing the BASIC PRINT gap.  The GE-225 historically routed I/O through a teletype the modern simulator doesn't model, so `call_builtin` emits zero bytes (or a deterministic `LDA 0` if a return-value dest is bound).  This is enough to compile BASIC programs containing PRINT statements end-to-end without errors.  Mirrors the simulator-no-op pattern other backends use for unsupported builtins.  The GE-225 (1959) was the General Electric mainframe at Dartmouth College where Dartmouth BASIC was DESIGNED in 1964 by Kemeny and Kurtz.  Primarily a BASIC fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A5."
+description = "IIR → GE-225 machine code backend.  v0.9.0 (A5++++++++++): adds `neg dest, src` lowering via the two's-complement-by-subtract-from-zero pattern (LDA 0; SUB r_src → ACC = -src), closing the BASIC unary-minus gap.  Trivial neg ROM (`const v=5; neg w, v; ret w`) is 15 bytes.  Builds on v0.8.0's call_builtin no-op.  The GE-225 (1959) was the General Electric mainframe at Dartmouth College where Dartmouth BASIC was DESIGNED in 1964 by Kemeny and Kurtz.  Primarily a BASIC fit per MULTILANG-ARCHITECTURE-BACKENDS.md §A5."
 
 [lib]
 name = "iir_to_ge225"

--- a/code/packages/rust/iir-to-ge225/README.md
+++ b/code/packages/rust/iir-to-ge225/README.md
@@ -25,7 +25,7 @@ pipeline:
 | iir-to-intel4004 (A4) | 4-bit | 1971 | Brainfuck |
 | **iir-to-ge225 (A5)** | **20-bit** | **1959** | **Dartmouth BASIC** |
 
-## Status — v0.8.0 (A5+++++++++ call_builtin no-op — BASIC PRINT works)
+## Status — v0.9.0 (A5++++++++++ neg via 0 - src — BASIC unary minus works)
 
 | IIR op | GE-225 lowering |
 |--------|-----------------|
@@ -33,6 +33,7 @@ pipeline:
 | `mov dest, src` | `(STA r_evict_src)?` + `LD r_src` + `STA r_dest` |
 | `add dest, lhs, rhs` | (evict ACC pieces)? + `LD r_lhs` + `ADD r_rhs` |
 | `sub dest, lhs, rhs` | (evict ACC pieces)? + `LD r_lhs` + `SUB r_rhs` |
+| `neg dest, src` | (evict)? + `LDA 0` + `SUB r_src` |
 | `cmp_lt dest, a, b` | LD/SUB + `BMI true` + LDA 0 + BR end + LDA 1 |
 | `cmp_eq dest, a, b` | LD/SUB + `BZ true` + LDA 0 + BR end + LDA 1 |
 | `cmp_ne dest, a, b` | LD/SUB + `BNZ true` + LDA 0 + BR end + LDA 1 |

--- a/code/packages/rust/iir-to-ge225/src/lib.rs
+++ b/code/packages/rust/iir-to-ge225/src/lib.rs
@@ -1,4 +1,4 @@
-//! # iir-to-ge225 — IIR → GE-225 machine code backend (v0.8.0, A5+++++++++).
+//! # iir-to-ge225 — IIR → GE-225 machine code backend (v0.9.0, A5++++++++++).
 //!
 //! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
 //! 20-bit GE-225 instruction words (packed 3 bytes per word, big-
@@ -247,9 +247,9 @@ const ACC_MARKER: u8 = 16;
 /// pool — identical to the iir-to-intel4004 v0.3.0 capacity.
 const GP_REGISTER_COUNT: usize = 16;
 
-/// Supported instruction opcodes in v0.8.0 (A5+++++++++).
+/// Supported instruction opcodes in v0.9.0 (A5++++++++++).
 const SUPPORTED_OPS: &[&str] = &[
-    "const", "mov", "add", "sub",
+    "const", "mov", "add", "sub", "neg",
     "cmp_lt", "cmp_eq", "cmp_ne", "cmp_le", "cmp_gt", "cmp_ge",
     "label", "jmp", "jmp_if_true", "jmp_if_false",
     "call", "call_builtin",
@@ -678,6 +678,70 @@ pub fn lower_iir_to_ge225(
                         _ => unreachable!(),
                     };
                     bytes.extend_from_slice(&arith);
+                    env.insert(dest.to_string(), ACC_MARKER);
+                    acc_owner = Some(dest.to_string());
+                }
+
+                // ── neg dest, src → (evict)? + LDA 0 + SUB r_src ──────
+                //
+                // Two's-complement negation via subtract-from-zero:
+                //
+                //   ACC = 0;            (LDA 0)
+                //   ACC = ACC - src;    (SUB r_src)
+                //   → ACC = -src
+                //
+                // Steps:
+                //   1. If src lives in ACC, evict it (so SUB has a
+                //      stable register source).
+                //   2. Evict any remaining ACC owner so LDA 0 doesn't
+                //      clobber a live value.
+                //   3. LD A 0 + SUB r_src.
+                //   4. env[dest] = ACC_MARKER; acc_owner = Some(dest).
+                //
+                // The 16-bit immediate `0` in LDA 0 is just
+                // `[0x01, 0x00, 0x00]`.  The trivial-case ROM is
+                // `LDA n; STA r0; LDA 0; SUB r0; HLT` = 15 bytes,
+                // pinned by tests.
+                "neg" => {
+                    let dest = require_dest(instr, "neg", &f.name)?;
+                    let src_name = match instr.srcs.first() {
+                        Some(Operand::Var(s)) => s.clone(),
+                        _ => {
+                            return Err(IIRGe225Error::InvalidOperand {
+                                function: f.name.clone(),
+                                detail: "neg requires srcs[0] = Operand::Var(src)".into(),
+                            })
+                        }
+                    };
+                    if !env.contains_key(&src_name) {
+                        return Err(IIRGe225Error::UndefinedVariable {
+                            function: f.name.clone(),
+                            name: src_name,
+                        });
+                    }
+                    // If src is in ACC, evict to a register first.
+                    if matches!(env.get(&src_name), Some(&ACC_MARKER)) {
+                        evict_acc(
+                            &mut bytes,
+                            &mut env,
+                            &mut acc_owner,
+                            &mut next_reg,
+                            &f.name,
+                        )?;
+                    }
+                    // Evict any remaining ACC owner (LDA 0 will clobber it).
+                    evict_acc(
+                        &mut bytes,
+                        &mut env,
+                        &mut acc_owner,
+                        &mut next_reg,
+                        &f.name,
+                    )?;
+                    let r_src = lookup_register(&env, &src_name, &f.name)?;
+                    debug_assert!(r_src <= 15);
+                    // LDA 0 then SUB r_src.
+                    bytes.extend_from_slice(&encode_lda(0));
+                    bytes.extend_from_slice(&encode_sub(r_src));
                     env.insert(dest.to_string(), ACC_MARKER);
                     acc_owner = Some(dest.to_string());
                 }

--- a/code/packages/rust/iir-to-ge225/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-ge225/tests/test_backend.rs
@@ -583,6 +583,171 @@ fn cmp_result_can_be_added() {
 }
 
 // ===========================================================================
+// §8. v0.9.0 NEW — `neg dest, src` lowering (LDA 0 + SUB pattern)
+// ===========================================================================
+
+/// Canonical `const v=5; neg w, v; ret w` byte sequence.
+///
+/// Trace:
+///   0:  LDA 5      (v → ACC, owner=v)
+///   3:  STA r0     (evict v → r0 because LDA 0 below clobbers ACC)
+///   6:  LDA 0      (ACC ← 0)
+///   9:  SUB r0     (ACC ← 0 - v = -v; env[w] = ACC, owner=w)
+///   12: HLT        (w in ACC for ret w)
+/// Total: 15 bytes.
+#[test]
+fn canonical_neg_byte_sequence() {
+    let f = IIRFunction::new(
+        "neg_v",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(5)], "i16"),
+            IIRInstr::new("neg", Some("w".into()), vec![Operand::Var("v".into())], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("w".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x05, // LDA 5
+            0x02, 0x00, 0x00, // STA r0 (evict v)
+            0x01, 0x00, 0x00, // LDA 0
+            0x05, 0x00, 0x00, // SUB r0
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+    assert_eq!(bytes.len(), 15);
+}
+
+/// `neg` of a register-resident value (after another const evicts
+/// it) skips the redundant eviction step.
+///
+/// Trace: const v=7; const u=3; neg w, v; ret_void
+///   0:  LDA 7      (v → ACC)
+///   3:  STA r0     (evict v → r0 for next const)
+///   6:  LDA 3      (u → ACC, owner=u)
+///   9:  STA r1     (evict u → r1 because LDA 0 below clobbers ACC)
+///   12: LDA 0      (ACC ← 0)
+///   15: SUB r0     (ACC ← 0 - v)
+///   18: HLT
+#[test]
+fn neg_when_src_in_register_skips_first_eviction() {
+    let f = IIRFunction::new(
+        "neg_reg",
+        vec![],
+        "void",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i16"),
+            IIRInstr::new("const", Some("u".into()), vec![Operand::Int(3)], "i16"),
+            IIRInstr::new("neg", Some("w".into()), vec![Operand::Var("v".into())], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x07, // LDA 7
+            0x02, 0x00, 0x00, // STA r0 (evict v)
+            0x01, 0x00, 0x03, // LDA 3
+            0x02, 0x00, 0x01, // STA r1 (evict u — done by neg's "evict remaining ACC owner")
+            0x01, 0x00, 0x00, // LDA 0
+            0x05, 0x00, 0x00, // SUB r0 (negate v)
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+/// Double-neg: `neg w, v; neg x, w; ret x` should yield x = v
+/// (the byte trace is what we pin, not the semantic).
+#[test]
+fn double_neg_works() {
+    let f = IIRFunction::new(
+        "double_neg",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i16"),
+            IIRInstr::new("neg", Some("w".into()), vec![Operand::Var("v".into())], "i16"),
+            IIRInstr::new("neg", Some("x".into()), vec![Operand::Var("w".into())], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    // Just confirm lowering succeeds and ends with HLT.  Tracing
+    // every byte for chained negs is over-pinning.
+    assert_eq!(bytes.len() % 3, 0, "word-aligned");
+    assert_eq!(&bytes[bytes.len() - 3..], &HALT_WORD);
+    assert!(
+        bytes.len() >= 15,
+        "double neg should be at least the single-neg ROM size"
+    );
+}
+
+/// `neg` of an undefined src errors crisply.
+#[test]
+fn neg_undefined_src_errors() {
+    let f = IIRFunction::new(
+        "neg_undef",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("neg", Some("w".into()), vec![Operand::Var("never".into())], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("neg of undefined src must error");
+    match err {
+        IIRGe225Error::UndefinedVariable { name, .. } => assert_eq!(name, "never"),
+        other => panic!("expected UndefinedVariable, got {other:?}"),
+    }
+}
+
+/// `neg` with no srcs errors with `InvalidOperand`.
+#[test]
+fn neg_no_srcs_errors() {
+    let f = IIRFunction::new(
+        "neg_empty",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("neg", Some("w".into()), vec![], "i16"),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let err = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect_err("neg without src must error");
+    assert!(matches!(err, IIRGe225Error::InvalidOperand { .. }));
+}
+
+/// `neg` feeds into `ret` cleanly — the result is in ACC, no LD
+/// prefix needed.
+#[test]
+fn neg_result_feeds_directly_into_ret() {
+    let f = IIRFunction::new(
+        "neg_then_ret",
+        vec![],
+        "i16",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i16"),
+            IIRInstr::new("neg", Some("w".into()), vec![Operand::Var("v".into())], "i16"),
+            IIRInstr::new("ret", None, vec![Operand::Var("w".into())], "i16"),
+        ],
+    );
+    let bytes = lower_iir_to_ge225(&module_with(f), &IIRGe225Config::default())
+        .expect("lowering");
+    // After SUB r0, w lives in ACC. ret w finds w == acc_owner and
+    // emits just HLT — no LD prefix.
+    assert_eq!(&bytes[bytes.len() - 3..], &HALT_WORD);
+}
+
+// ===========================================================================
 // §7. v0.8.0 NEW — call_builtin no-op lowering
 // ===========================================================================
 

--- a/code/specs/iir-to-ge225.md
+++ b/code/specs/iir-to-ge225.md
@@ -1,6 +1,6 @@
 # iir-to-ge225 — IIR → GE-225 machine code backend
 
-**Status:** v0.8.0 — call_builtin no-op, BASIC PRINT works end-to-end (A5+++++++++)
+**Status:** v0.9.0 — neg via 0-src, BASIC unary minus works end-to-end (A5++++++++++)
 **Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) §A5
 **Related:** [`iir-to-intel4004`][i4004], [`iir-to-intel8008`][i8008], [`iir-to-riscv`][rv], [`iir-to-armv7`][arm]
 
@@ -95,7 +95,8 @@ IIRModule
 | v0.6.0 (A5++++++) | Call/return discipline: `JSR` (0x9), `RTS` (0xA) + module-level `call` backpatching; `BMI` (0xB) reserved; non-entry-fn ret emits RTS instead of HLT | **merged** |
 | v0.7.0 (A5+++++++) | Six comparison ops `cmp_lt`/`cmp_eq`/`cmp_ne`/`cmp_le`/`cmp_gt`/`cmp_ge` via SUB-then-test boolean materialization.  Activates `BMI` (0xB) for the lt/le/gt/ge family.  Operand-swap pattern handles gt/ge with no new code | **merged** |
 | (A5++++++++ in lang-aot tests) | BASIC end-to-end smoke tests: `LET A = 5`, `LET A = 1 + 2`, PRINT-gap documentation | **merged** |
-| **v0.8.0 (A5+++++++++ — this PR)** | `call_builtin` no-op lowering: closes BASIC PRINT gap.  No-dest case emits zero bytes; with-dest case emits `LDA 0` placeholder.  Mirrors the simulator-no-op pattern for unmodeled I/O | this PR |
+| v0.8.0 (A5+++++++++) | `call_builtin` no-op lowering: closes BASIC PRINT gap.  No-dest case emits zero bytes; with-dest case emits `LDA 0` placeholder | **merged** |
+| **v0.9.0 (A5++++++++++ — this PR)** | `neg dest, src` lowering via `LDA 0 + SUB r_src` (0 - src = -src).  Closes BASIC unary-minus gap.  15-byte trivial ROM for `const v=N; neg w, v; ret w` | this PR |
 | v0.4.0 (A5+++) | `lang-aot --emit=ge225` wiring + BASIC end-to-end | future |
 
 ## Public surface (v0.1.0)


### PR DESCRIPTION
## Summary

A5++++++++++ of MULTILANG-ARCHITECTURE-BACKENDS.md — closes the BASIC `neg` (unary minus) gap by adding a `neg dest, src` lowering via the canonical two's-complement-by-subtract-from-zero pattern.

## Lowering shape

```
(STA r_evict_src)?  ; if src in ACC, evict to register
(STA r_evict_acc)?  ; if any other var in ACC, evict
LDA 0               ; ACC ← 0
SUB r_src           ; ACC ← 0 - src = -src
```

After this sequence: `env[dest] = ACC_MARKER`, `acc_owner = Some(dest)`.

## Trivial-case byte trace (15 bytes total)

```basic
const v = 5    ;          [0x01, 0x00, 0x05]  ; LDA 5
                          [0x02, 0x00, 0x00]  ; STA r0 (evict v)
neg w, v       ;          [0x01, 0x00, 0x00]  ; LDA 0
                          [0x05, 0x00, 0x00]  ; SUB r0
ret w (entry)  ;          [0x00, 0x00, 0x00]  ; HLT (w in ACC)
```

## Public surface delta

- `"neg"` added to `SUPPORTED_OPS`
- **No new pub constants**, **no new error variants**
- **No new opcodes** — `neg` reuses the existing `0x1 LDA` and `0x5 SUB`

## Test plan

- [x] `cargo test -p iir-to-ge225` — 33/33 unit + 1 doctest pass
- [x] Canonical 15-byte trivial ROM pinned
- [x] `neg` when src is already in a register skips the redundant first eviction
- [x] Double-neg lowers cleanly
- [x] `neg` of undefined src → `UndefinedVariable`
- [x] `neg` with no srcs → `InvalidOperand`
- [x] `neg` result feeds directly into `ret` (no LD prefix)
- [x] All prior regressions pass (cmp, call/return, call_builtin, opcodes)
- [x] `cargo test -p lang-aot --test end_to_end_smoke basic` — 10/10 pass
- [x] Security review passed (round 1, clean)
- [ ] CI green
- [ ] Babysitter cron monitors

## A5 cascade status

With this PR, **all known BASIC IIR-op gaps in iir-to-ge225 are closed**:

| BASIC IIR op | v0.9.0 status |
|--------------|----------------|
| `const`, `mov`, `add`, `sub`, `cmp_le`, `jmp`, `jmp_if_true`, `jmp_if_false`, `label`, `ret`, `ret_void`, `call`, `call_builtin` | ✓ supported |
| **`neg`** | **✓ supported (this PR)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)