### PR TITLE
feat(ml-framework-core-ts): NumPy-style broadcasting (Phase A.1 — v1.1.0)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 ## Unreleased
 
+### Added — v1.1.0: NumPy-style broadcasting (Phase A.1)
+
+PR #1 of 7 in **Phase A** — broadening the op vocabulary toward
+realistic models.  v1.0 only accepted same-shape inputs to binary ops;
+v1.1 brings NumPy/PyTorch-style broadcasting.
+
+#### What works now
+
+```ts
+// Bias + (batch, features) — previously had to materialize bias as
+// (batch, features) yourself; now broadcasts automatically.
+const bias = new Tensor([0.1, 0.2, 0.3]);          // (3,)
+const x = new Tensor([[1, 2, 3], [4, 5, 6]]);     // (2, 3)
+const y = x.add(bias);                              // → (2, 3)
+
+// Outer product: (3, 1) * (1, 4) → (3, 4)
+const a = new Tensor([[1], [2], [3]]);
+const b = new Tensor([[10, 20, 30, 40]]);
+const c = a.mul(b);                                 // (3, 4)
+
+// Gradient flow is correct: gradients are unbroadcast back to the
+// ORIGINAL input shapes (stretched dims are summed out).
+bias.requiresGrad = true;
+y.backward();
+console.log(bias.grad!.shape);                      // → [3], NOT [2, 3]
+```
+
+#### New module: `src/broadcasting.ts`
+
+Three pure helpers (no Tensor allocation cost):
+
+- `broadcastShapes(a, b)` — pure shape math; returns the broadcast
+  shape or throws RangeError on incompatibility.  Follows NumPy rules:
+  right-align, pad shorter with 1s on the left, each dim must be equal
+  or one must be 1.
+- `broadcastDataTo(data, fromShape, toShape)` — materializes a fresh
+  Float32Array in `toShape` layout by stretching size-1 dims.  Used by
+  binary ops to align inputs before elementwise math.
+- `unbroadcastDataTo(data, fromShape, toShape)` — inverse for backward:
+  sums the gradient along stretched dims.  Used by binary op backward.
+
+#### Updated ops (Add / Sub / Mul / Div)
+
+- `forward()` now calls `broadcastShapes` and broadcasts inputs to the
+  common output shape via `broadcastDataTo` before doing elementwise
+  math.  Same-shape fast path is preserved (no extra alloc when
+  shapes already match).
+- `backward()` saves the broadcast and original shapes; gradients are
+  unbroadcast back to each parent's original shape using
+  `unbroadcastDataTo`.
+
+  Critical insight: when broadcasting stretches a size-1 dim to size N
+  in the forward output, the corresponding backward must SUM that dim's
+  gradient back into a single cell.  Concretely: `bias (3,)` added to
+  `x (B, 3)` → `bias.grad` is the column sums of the (B, 3) gradient,
+  shape `(3,)` — not the (B, 3) gradient itself.
+
+#### New op: `BroadcastOp`
+
+Explicit broadcasting as an autograd Function.  Most callers don't
+need this — binary ops broadcast implicitly — but for code that wants
+to express "promote this bias once" rather than relying on every
+downstream op:
+
+```ts
+import { BroadcastOp } from "@coding-adventures/ml-framework-core";
+
+const expanded = BroadcastOp.apply(bias, [batch, features]);
+// expanded.shape === [batch, features]
+// On backward, gradient sums back to bias's original shape.
+```
+
+#### Tests added (31 vitest cases, 179 total)
+
+- `broadcastShapes` (8): identical shapes, scalar broadcast, (3,) +
+  (2, 3), (5, 1, 3) + (2, 3), (1, 4) + (3, 4), outer-product layout,
+  incompatibility detection, zero-sized dims
+- `broadcastDataTo` (6): identity copy, row replication, column
+  replication, outer-product materialization, incompatible target
+- `unbroadcastDataTo` (5): identity, sum along axis 0, sum along axis
+  1, row-sum to single column, 3-D leading-axis sum
+- Binary ops with broadcasting (5): Add/Sub/Mul/Div with various
+  broadcast patterns, incompatibility errors
+- Binary op backward unbroadcasts (3): bias-gradient column-sum,
+  outer-product backward gradients, sign correctness for Sub
+- `BroadcastOp` (4): forward broadcast, backward gradient summing,
+  explicit seed grad, chaining through binary ops
+
+Existing 148 tests continue to pass — no regressions.
+
+Total: 179 tests, 0 failures.
+
+#### What's next in Phase A
+
+- **A.2** — N-D batched MatMul + Transpose for rank ≥ 3 (foundation
+  for attention)
+- **A.3** — `Embedding` op (lookup table, the first transformer op)
+- **A.4** — `LayerNorm` + `BatchNorm` + `Dropout`
+- **A.5** — `Conv2D` + `MaxPool2D` via im2col
+- **A.6** — Adam optimizer + `Linear` / `Sequential` layer abstractions
+- **A.7** — safetensors read/write (first Hugging Face interop)
+
+After A.7: load a tiny transformer checkpoint from HF Hub, run
+inference on it, fine-tune it, save the result — all in TypeScript.
+
 ### Added — v1.0.0: complete TypeScript ML framework on the Rust matrix-cpu engine
 
 PR #5 of 5 (FINAL) in the JS/TS pilot.  v1.0.0 marks the completion of

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Complete PyTorch-shaped TypeScript ML framework on the Rust matrix-cpu engine.  Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and backward.  Small tensors use a pure-TypeScript fast path; tensors of 10k+ cells auto-dispatch through @coding-adventures/matrix-rust-napi to the Rust matrix-cpu executor for SIMD-accelerated f32 math.  End-to-end MLP training verified by the test suite.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/broadcasting.ts
+++ b/code/packages/typescript/ml-framework-core/src/broadcasting.ts
@@ -1,0 +1,286 @@
+/**
+ * # broadcasting.ts — NumPy-style broadcasting for Tensor
+ *
+ * **NumPy broadcasting rules** (which PyTorch, JAX, TF all follow):
+ *
+ *   1. Right-align the two shapes.  Pad the shorter one on the LEFT
+ *      with 1s until both have the same rank.
+ *   2. For each dim, the sizes must EITHER be equal, OR one must be 1
+ *      (which then "stretches" to match the other), OR one must be
+ *      missing (handled by step 1 padding).
+ *   3. The broadcast output shape is the max along each dim.
+ *
+ * Examples:
+ *
+ *   (3,)        + (2, 3)     → (2, 3)        # (3,) → (1, 3) → stretched on axis 0
+ *   (5, 1, 3)   + (2, 3)     → (5, 2, 3)     # (2, 3) → (1, 2, 3); axis 1 stretches
+ *   (1, 4)      + (3, 4)     → (3, 4)        # axis 0 stretches
+ *   (2, 3)      + (3, 2)     → ERROR          # dim 0 mismatch (2 vs 3)
+ *
+ * ## What lives here
+ *
+ * - `broadcastShapes(a, b)` — pure shape math; returns the broadcast
+ *   shape or throws.
+ * - `broadcastDataTo(data, fromShape, toShape)` — given a Float32Array
+ *   in `fromShape` layout, materialize a Float32Array in `toShape`
+ *   layout.  Used by `BroadcastOp.forward`.
+ * - `unbroadcastDataTo(data, fromShape, toShape)` — the INVERSE for
+ *   backward: given a gradient in `fromShape` layout, sum it back down
+ *   to `toShape`.  Used by `BroadcastOp.backward`.
+ *
+ * ## Why these are pure helpers (not Tensor methods)
+ *
+ * Broadcasting is graph-aware in the forward path — a `BroadcastOp`
+ * autograd Function uses these helpers and attaches its own backward.
+ * Keeping the helpers pure (input: typed arrays + shape arrays;
+ * output: typed arrays) means the dispatch logic in `ops.ts` can call
+ * them without paying a Tensor allocation cost when it just needs the
+ * raw bytes.
+ */
+
+/**
+ * Compute the broadcast shape for two input shapes.  Returns the broadcast
+ * shape on success, throws RangeError on incompatibility.
+ *
+ * Implements steps 1-3 from the file header.
+ */
+export function broadcastShapes(
+  a: readonly number[],
+  b: readonly number[],
+): number[] {
+  // Step 1: right-align by walking from the end.  We don't actually need
+  // to create padded arrays — we can just index `a[a.length - 1 - i]`
+  // and treat missing entries as 1.
+  const ndim = Math.max(a.length, b.length);
+  const out = new Array<number>(ndim);
+
+  for (let i = 0; i < ndim; i++) {
+    const aDim = i < a.length ? a[a.length - 1 - i]! : 1;
+    const bDim = i < b.length ? b[b.length - 1 - i]! : 1;
+
+    // Step 2: each dim must match exactly OR one must be 1.
+    if (aDim !== bDim && aDim !== 1 && bDim !== 1) {
+      throw new RangeError(
+        `cannot broadcast shapes [${a.join(", ")}] and [${b.join(", ")}]: ` +
+          `dim ${ndim - 1 - i} (size ${aDim} vs ${bDim}) is neither equal nor 1`,
+      );
+    }
+
+    // Step 3: output dim is the max (the non-1 one wins).
+    out[ndim - 1 - i] = Math.max(aDim, bDim);
+  }
+  return out;
+}
+
+/**
+ * Materialize a broadcasted view as a fresh Float32Array.
+ *
+ * Given input data laid out in `fromShape`, produce a new array laid out
+ * in `toShape` where any dim that was 1 (or implicitly 1 via left-padding)
+ * gets "stretched" by repeating along that axis.
+ *
+ * ## Implementation: strided iteration
+ *
+ * The trick is computing the source index for each destination index.
+ * For each output position `(i_0, i_1, ..., i_{D-1})`:
+ *
+ *   - Pad the source shape on the left with 1s to match `toShape`.
+ *   - For each axis where source dim is 1, FORCE the source index to 0
+ *     (that's the "stretch" — every output position along that axis
+ *     reads from the same source row).
+ *   - For other axes, use the destination index directly.
+ *   - Convert the source multi-index to a flat offset using the source
+ *     strides (computed from `fromShape`, not `toShape`).
+ *
+ * This is O(numel(toShape)) — one source read per output cell.  No
+ * intermediate allocation other than the output buffer.
+ *
+ * @throws RangeError if `fromShape` cannot broadcast to `toShape`.
+ */
+export function broadcastDataTo(
+  data: Float32Array,
+  fromShape: readonly number[],
+  toShape: readonly number[],
+): Float32Array {
+  // Fast path: shapes already match → just copy.
+  if (shapesEqual(fromShape, toShape)) {
+    const out = new Float32Array(data.length);
+    out.set(data);
+    return out;
+  }
+
+  // Validate that this broadcast is actually possible.  We call
+  // broadcastShapes for its side-effect (the error message); the
+  // computed shape MUST equal toShape if valid.
+  const computed = broadcastShapes(fromShape, toShape);
+  if (!shapesEqual(computed, toShape)) {
+    throw new RangeError(
+      `broadcastDataTo: [${fromShape.join(", ")}] broadcasts to [${computed.join(", ")}], ` +
+        `not the requested [${toShape.join(", ")}]`,
+    );
+  }
+
+  // Left-pad fromShape with 1s to match toShape's rank.
+  const padded = leftPadShape(fromShape, toShape.length);
+
+  // Source strides over the PADDED source shape.  stride[i] = product of
+  // padded[i+1..].  This is the standard row-major stride formula.
+  const srcStrides = computeStrides(padded);
+
+  // numel of the output.
+  const dstNumel = toShape.reduce((acc, d) => acc * d, 1);
+
+  const out = new Float32Array(dstNumel);
+
+  // Walk every output flat index, compute the corresponding source flat
+  // index, and copy.
+  //
+  // Destination strides aren't precomputed — we unravel `dstFlat` on the
+  // fly using a divmod walk.  Equivalent and avoids a second strides
+  // array allocation.
+  for (let dstFlat = 0; dstFlat < dstNumel; dstFlat++) {
+    let remaining = dstFlat;
+    let srcFlat = 0;
+
+    // Walk axes left-to-right (most-significant first), peeling off the
+    // dst multi-index digit by digit.
+    for (let axis = 0; axis < toShape.length; axis++) {
+      // dst[axis] = remaining / (product of toShape[axis+1..]); but
+      // since we're walking left-to-right and need that denominator,
+      // it's easier to use the precomputed source strides which carry
+      // the same products from the SOURCE side.  Cleaner approach:
+      // compute the dst stride for this axis once per iteration.
+      let dstStrideThisAxis = 1;
+      for (let j = axis + 1; j < toShape.length; j++) {
+        dstStrideThisAxis *= toShape[j]!;
+      }
+      const dstIdx = Math.floor(remaining / dstStrideThisAxis);
+      remaining -= dstIdx * dstStrideThisAxis;
+
+      // For the source: if the padded source dim is 1, this axis is
+      // being stretched — force the source index to 0.  Otherwise use
+      // the destination index (they must match since we validated the
+      // broadcast).
+      const srcIdx = padded[axis] === 1 ? 0 : dstIdx;
+      srcFlat += srcIdx * srcStrides[axis]!;
+    }
+    out[dstFlat] = data[srcFlat]!;
+  }
+  return out;
+}
+
+/**
+ * Inverse of `broadcastDataTo`.  Given a gradient in `fromShape` layout
+ * (which is the broadcast output shape), sum it back down to `toShape`
+ * (the original input shape pre-broadcast).
+ *
+ * ## Why summing?
+ *
+ * Broadcasting takes one cell and "copies" it to N output positions.
+ * In autograd, every output gradient flows back to the same input cell,
+ * so the input gradient is the SUM of all the output gradients at the
+ * positions where that input cell was used.
+ *
+ * For dims that were stretched (source dim 1 → target dim N), sum along
+ * that axis.  For dims that were padded on the left (added by the rule),
+ * sum that whole axis out (the input had no such axis at all).
+ *
+ * @throws RangeError if `toShape` cannot have broadcast to `fromShape`.
+ */
+export function unbroadcastDataTo(
+  data: Float32Array,
+  fromShape: readonly number[],
+  toShape: readonly number[],
+): Float32Array {
+  // Fast path: shapes already match → just copy.
+  if (shapesEqual(fromShape, toShape)) {
+    const out = new Float32Array(data.length);
+    out.set(data);
+    return out;
+  }
+
+  // Validate that toShape could broadcast to fromShape (the inverse
+  // direction).
+  const computed = broadcastShapes(fromShape, toShape);
+  if (!shapesEqual(computed, fromShape)) {
+    throw new RangeError(
+      `unbroadcastDataTo: [${toShape.join(", ")}] cannot broadcast to [${fromShape.join(", ")}]`,
+    );
+  }
+
+  // Left-pad toShape to fromShape's rank.  Axes where padded == 1 but
+  // fromShape > 1 are stretched dims → sum along them.  Axes where
+  // toShape had no entry at all (the left-padded ones) are also reduced.
+  const padded = leftPadShape(toShape, fromShape.length);
+  const srcStrides = computeStrides(fromShape);
+
+  // We'll accumulate into a Float32Array of size numel(padded), which
+  // equals numel(toShape).  Then return that buffer directly — its
+  // shape IS toShape (post-pad-removal is a no-op for the data; the
+  // caller already knows the shape).
+  const dstNumel = padded.reduce((acc, d) => acc * d, 1);
+  const out = new Float32Array(dstNumel);
+
+  // Walk every SOURCE flat index, compute the corresponding dst index,
+  // and accumulate.
+  const srcNumel = fromShape.reduce((acc, d) => acc * d, 1);
+  for (let srcFlat = 0; srcFlat < srcNumel; srcFlat++) {
+    // Unravel srcFlat into a multi-index over fromShape.
+    let remaining = srcFlat;
+    let dstFlat = 0;
+    let dstStrideProd = 1;
+    // We need the dst strides over padded.  Compute on the fly: walk
+    // axes right-to-left, accumulating the stride product, and at the
+    // same time peel digits off srcFlat by dividing by srcStrides.
+    //
+    // Cleaner: compute dst strides up front.
+    const dstStrides = computeStrides(padded);
+    for (let axis = 0; axis < fromShape.length; axis++) {
+      const srcIdx = Math.floor(remaining / srcStrides[axis]!);
+      remaining -= srcIdx * srcStrides[axis]!;
+      // If padded[axis] == 1, this axis is being summed — clamp dst idx to 0.
+      const dstIdx = padded[axis] === 1 ? 0 : srcIdx;
+      dstFlat += dstIdx * dstStrides[axis]!;
+    }
+    // Silence the "dstStrideProd unused" — leftover from earlier algo iteration.
+    void dstStrideProd;
+    out[dstFlat]! += data[srcFlat]!;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function shapesEqual(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Right-align `shape` to `targetRank` by left-padding with 1s.
+ * Returns a new array; doesn't mutate the input.
+ */
+function leftPadShape(shape: readonly number[], targetRank: number): number[] {
+  if (shape.length >= targetRank) return shape.slice();
+  const padding = new Array<number>(targetRank - shape.length).fill(1);
+  return [...padding, ...shape];
+}
+
+/**
+ * Row-major strides: `stride[i] = product(shape[i+1..])`.
+ * `stride[ndim - 1]` is always 1.  Empty shape returns `[]`.
+ */
+function computeStrides(shape: readonly number[]): number[] {
+  const strides = new Array<number>(shape.length);
+  let acc = 1;
+  for (let i = shape.length - 1; i >= 0; i--) {
+    strides[i] = acc;
+    acc *= shape[i]!;
+  }
+  return strides;
+}

--- a/code/packages/typescript/ml-framework-core/src/index.ts
+++ b/code/packages/typescript/ml-framework-core/src/index.ts
@@ -56,9 +56,13 @@ export {
   SoftmaxOp,
   SumOp,
   MeanOp,
+  BroadcastOp,
   DISPATCH_THRESHOLD,
   packF32Hex,
   unpackF32Hex,
   runEnvelope,
+  broadcastShapes,
+  broadcastDataTo,
+  unbroadcastDataTo,
 } from "./ops.js";
 export { VERSION } from "./version.js";

--- a/code/packages/typescript/ml-framework-core/src/ops.ts
+++ b/code/packages/typescript/ml-framework-core/src/ops.ts
@@ -51,6 +51,11 @@
 
 import { Tensor } from "./tensor.js";
 import { Function } from "./autograd.js";
+import {
+  broadcastShapes,
+  broadcastDataTo,
+  unbroadcastDataTo,
+} from "./broadcasting.js";
 
 // ===========================================================================
 // Module-level helpers: hex packing, threshold, envelope dispatcher.
@@ -250,19 +255,36 @@ function binaryElementwise(
   b: Tensor,
   tsOp: (x: number, y: number) => number,
 ): Tensor {
-  if (!shapesEqual(a.shape, b.shape)) {
-    throw new RangeError(
-      `shape mismatch for ${kind}: [${a.shape.join(", ")}] vs [${b.shape.join(", ")}]`,
-    );
+  // Broadcast first.  If shapes already match this is a near-free copy.
+  // For shape-mismatched inputs we materialize broadcasted views in
+  // pure TS; the dispatched Rust path then sees same-shape inputs.
+  //
+  // Materializing the broadcast (vs. a strided view) costs memory but
+  // keeps the matrix-cpu wire format unchanged — matrix-cpu doesn't
+  // understand broadcasted views.
+  const outShape = broadcastShapes(a.shape, b.shape);
+  const aB =
+    a.shape.length === outShape.length && shapesEqual(a.shape, outShape)
+      ? a
+      : new Tensor(Array.from(broadcastDataTo(a.data, a.shape, outShape)), {
+          shape: outShape.slice(),
+        });
+  const bB =
+    b.shape.length === outShape.length && shapesEqual(b.shape, outShape)
+      ? b
+      : new Tensor(Array.from(broadcastDataTo(b.data, b.shape, outShape)), {
+          shape: outShape.slice(),
+        });
+
+  const numel = aB.numel;
+  if (numel >= DISPATCH_THRESHOLD) {
+    const envelope = binaryElementwiseEnvelope(kind, aB, bB);
+    const out = runEnvelope(envelope, numel);
+    return new Tensor(Array.from(out), { shape: outShape.slice() });
   }
-  if (a.numel >= DISPATCH_THRESHOLD) {
-    const envelope = binaryElementwiseEnvelope(kind, a, b);
-    const out = runEnvelope(envelope, a.numel);
-    return new Tensor(Array.from(out), { shape: a.shape.slice() });
-  }
-  const out = new Array(a.numel);
-  for (let i = 0; i < a.numel; i++) out[i] = tsOp(a.data[i]!, b.data[i]!);
-  return new Tensor(out, { shape: a.shape.slice() });
+  const out = new Array(numel);
+  for (let i = 0; i < numel; i++) out[i] = tsOp(aB.data[i]!, bB.data[i]!);
+  return new Tensor(out, { shape: outShape.slice() });
 }
 
 function unaryElementwise(
@@ -281,6 +303,45 @@ function unaryElementwise(
 }
 
 // ===========================================================================
+// BroadcastOp — explicit broadcasting as a first-class autograd op
+// ===========================================================================
+//
+// Most callers don't need this — the binary ops broadcast internally.
+// But for ML code that wants to express "promote this (out_dim,) bias
+// vector to (batch, out_dim) once" rather than relying on implicit
+// broadcasting in every downstream op, `BroadcastOp.apply(t, newShape)`
+// makes that intent explicit.
+//
+// forward: broadcast `data` from `t.shape` to `newShape`.
+// backward: sum the incoming gradient back from `newShape` to `t.shape`
+//           — that's `unbroadcastDataTo`.
+
+export class BroadcastOp extends Function {
+  forward(...inputs: unknown[]): Tensor {
+    const t = inputs[0] as Tensor;
+    const newShape = inputs[1] as number[];
+    this.savedForBackward.inputShape = t.shape.slice();
+    this.savedForBackward.outShape = newShape.slice();
+    const out = broadcastDataTo(t.data, t.shape, newShape);
+    return new Tensor(Array.from(out), { shape: newShape.slice() });
+  }
+  backward(grad: Tensor): (Tensor | null)[] {
+    const inputShape = this.savedForBackward.inputShape as number[];
+    // Only one Tensor parent (newShape is a number[], filtered out by
+    // Function.apply since it isn't a Tensor); return a 1-element Array.
+    return [
+      tensorFromBuf(
+        unbroadcastDataTo(grad.data, grad.shape, inputShape),
+        inputShape,
+      ),
+    ];
+  }
+}
+
+// Re-export the pure helpers so power users can call them directly.
+export { broadcastShapes, broadcastDataTo, unbroadcastDataTo };
+
+// ===========================================================================
 // The 15 differentiable ops — forward + backward.
 //
 // Backward formulas mirror Python autograd.py / Ruby PR #7 exactly.  All
@@ -292,31 +353,59 @@ function unaryElementwise(
 
 // ────────── Binary elementwise: Add / Sub / Mul / Div ──────────
 
+// ─── Broadcast-aware helpers for backward ────────────────────────────────
+//
+// With broadcasting, the forward output has the broadcast shape `C`
+// while parent inputs have shapes `A` and `B` (where A, B broadcast to C).
+// Backward receives `grad` of shape `C` and must return gradients of
+// shapes `A` and `B` — which means summing along the axes that got
+// stretched by broadcasting.  `unbroadcastDataTo` handles exactly that.
+
+/** Wrap a Float32Array into a Tensor with the given shape. */
+function tensorFromBuf(buf: Float32Array, shape: readonly number[]): Tensor {
+  return new Tensor(Array.from(buf), { shape: shape.slice() });
+}
+
 export class AddOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return binaryElementwise("Add", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x + y);
+    const a = inputs[0] as Tensor;
+    const b = inputs[1] as Tensor;
+    // Save parent shapes so backward can unbroadcast back to them.
+    this.savedForBackward.aShape = a.shape.slice();
+    this.savedForBackward.bShape = b.shape.slice();
+    return binaryElementwise("Add", a, b, (x, y) => x + y);
   }
-  // d/dx (x + y) = 1, d/dy (x + y) = 1.  Pass-through to both parents.
-  // Build fresh Tensors so each parent gets its own copy.
+  // d/dx (x + y) = 1, d/dy (x + y) = 1.  Gradient passes through, then
+  // unbroadcast to each parent's original shape.
   backward(grad: Tensor): (Tensor | null)[] {
-    const g = Array.from(grad.data);
+    const aShape = this.savedForBackward.aShape as number[];
+    const bShape = this.savedForBackward.bShape as number[];
     return [
-      new Tensor(g.slice(), { shape: grad.shape.slice() }),
-      new Tensor(g.slice(), { shape: grad.shape.slice() }),
+      tensorFromBuf(unbroadcastDataTo(grad.data, grad.shape, aShape), aShape),
+      tensorFromBuf(unbroadcastDataTo(grad.data, grad.shape, bShape), bShape),
     ];
   }
 }
 
 export class SubOp extends Function {
   forward(...inputs: unknown[]): Tensor {
-    return binaryElementwise("Sub", inputs[0] as Tensor, inputs[1] as Tensor, (x, y) => x - y);
+    const a = inputs[0] as Tensor;
+    const b = inputs[1] as Tensor;
+    this.savedForBackward.aShape = a.shape.slice();
+    this.savedForBackward.bShape = b.shape.slice();
+    return binaryElementwise("Sub", a, b, (x, y) => x - y);
   }
-  // d/dx (x - y) = 1, d/dy (x - y) = -1.
+  // d/dx (x - y) = 1, d/dy (x - y) = -1.  Unbroadcast after applying sign.
   backward(grad: Tensor): (Tensor | null)[] {
-    const g = Array.from(grad.data);
+    const aShape = this.savedForBackward.aShape as number[];
+    const bShape = this.savedForBackward.bShape as number[];
+    // Negate first (on the broadcast shape), then unbroadcast.  Order
+    // doesn't matter for negation but conceptually mirrors the chain rule.
+    const negGrad = new Float32Array(grad.data.length);
+    for (let i = 0; i < grad.data.length; i++) negGrad[i] = -grad.data[i]!;
     return [
-      new Tensor(g.slice(), { shape: grad.shape.slice() }),
-      new Tensor(g.map((v) => -v), { shape: grad.shape.slice() }),
+      tensorFromBuf(unbroadcastDataTo(grad.data, grad.shape, aShape), aShape),
+      tensorFromBuf(unbroadcastDataTo(negGrad, grad.shape, bShape), bShape),
     ];
   }
 }
@@ -325,24 +414,38 @@ export class MulOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
     const b = inputs[1] as Tensor;
-    this.savedForBackward.a = a;
-    this.savedForBackward.b = b;
+    // Save the BROADCASTED versions of a and b so backward's chain-rule
+    // multiply works on the same shape as `grad` (which has the
+    // broadcast output shape).  We can't naively save the originals
+    // because their shapes may differ from grad.shape.
+    const outShape = broadcastShapes(a.shape, b.shape);
+    const aB = broadcastDataTo(a.data, a.shape, outShape);
+    const bB = broadcastDataTo(b.data, b.shape, outShape);
+    this.savedForBackward.aB = aB;
+    this.savedForBackward.bB = bB;
+    this.savedForBackward.aShape = a.shape.slice();
+    this.savedForBackward.bShape = b.shape.slice();
+    this.savedForBackward.outShape = outShape;
     return binaryElementwise("Mul", a, b, (x, y) => x * y);
   }
-  // d/dx (x*y) = y, d/dy (x*y) = x.  Element-wise chain rule.
+  // d/dx (x*y) = y, d/dy (x*y) = x.  Element-wise on the broadcast shape,
+  // then unbroadcast to each parent's original shape.
   backward(grad: Tensor): (Tensor | null)[] {
-    const a = this.savedForBackward.a as Tensor;
-    const b = this.savedForBackward.b as Tensor;
-    const gData = grad.data;
-    const outA = new Array(a.numel);
-    const outB = new Array(b.numel);
-    for (let i = 0; i < a.numel; i++) {
-      outA[i] = gData[i]! * b.data[i]!;
-      outB[i] = gData[i]! * a.data[i]!;
+    const aB = this.savedForBackward.aB as Float32Array;
+    const bB = this.savedForBackward.bB as Float32Array;
+    const aShape = this.savedForBackward.aShape as number[];
+    const bShape = this.savedForBackward.bShape as number[];
+    const outShape = this.savedForBackward.outShape as number[];
+    const numel = aB.length;
+    const gradABig = new Float32Array(numel);
+    const gradBBig = new Float32Array(numel);
+    for (let i = 0; i < numel; i++) {
+      gradABig[i] = grad.data[i]! * bB[i]!;
+      gradBBig[i] = grad.data[i]! * aB[i]!;
     }
     return [
-      new Tensor(outA, { shape: a.shape.slice() }),
-      new Tensor(outB, { shape: b.shape.slice() }),
+      tensorFromBuf(unbroadcastDataTo(gradABig, outShape, aShape), aShape),
+      tensorFromBuf(unbroadcastDataTo(gradBBig, outShape, bShape), bShape),
     ];
   }
 }
@@ -351,25 +454,35 @@ export class DivOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
     const b = inputs[1] as Tensor;
-    this.savedForBackward.a = a;
-    this.savedForBackward.b = b;
+    const outShape = broadcastShapes(a.shape, b.shape);
+    const aB = broadcastDataTo(a.data, a.shape, outShape);
+    const bB = broadcastDataTo(b.data, b.shape, outShape);
+    this.savedForBackward.aB = aB;
+    this.savedForBackward.bB = bB;
+    this.savedForBackward.aShape = a.shape.slice();
+    this.savedForBackward.bShape = b.shape.slice();
+    this.savedForBackward.outShape = outShape;
     return binaryElementwise("Div", a, b, (x, y) => x / y);
   }
-  // d/dx (x/y) = 1/y, d/dy (x/y) = -x/y².  Standard quotient rule.
+  // d/dx (x/y) = 1/y, d/dy (x/y) = -x/y².  Quotient rule on broadcast
+  // shape, then unbroadcast.
   backward(grad: Tensor): (Tensor | null)[] {
-    const a = this.savedForBackward.a as Tensor;
-    const b = this.savedForBackward.b as Tensor;
-    const gData = grad.data;
-    const outA = new Array(a.numel);
-    const outB = new Array(b.numel);
-    for (let i = 0; i < a.numel; i++) {
-      const bv = b.data[i]!;
-      outA[i] = gData[i]! / bv;
-      outB[i] = -gData[i]! * a.data[i]! / (bv * bv);
+    const aB = this.savedForBackward.aB as Float32Array;
+    const bB = this.savedForBackward.bB as Float32Array;
+    const aShape = this.savedForBackward.aShape as number[];
+    const bShape = this.savedForBackward.bShape as number[];
+    const outShape = this.savedForBackward.outShape as number[];
+    const numel = aB.length;
+    const gradABig = new Float32Array(numel);
+    const gradBBig = new Float32Array(numel);
+    for (let i = 0; i < numel; i++) {
+      const bv = bB[i]!;
+      gradABig[i] = grad.data[i]! / bv;
+      gradBBig[i] = -grad.data[i]! * aB[i]! / (bv * bv);
     }
     return [
-      new Tensor(outA, { shape: a.shape.slice() }),
-      new Tensor(outB, { shape: b.shape.slice() }),
+      tensorFromBuf(unbroadcastDataTo(gradABig, outShape, aShape), aShape),
+      tensorFromBuf(unbroadcastDataTo(gradBBig, outShape, bShape), bShape),
     ];
   }
 }

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "1.0.0" as const;
+export const VERSION = "1.1.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/broadcasting.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/broadcasting.test.ts
@@ -1,0 +1,269 @@
+/**
+ * broadcasting.test.ts — coverage for the Phase A.1 broadcasting layer.
+ * ============================================================================
+ *
+ * Three layers of testing:
+ *
+ *   1. **Helpers in isolation** — `broadcastShapes`, `broadcastDataTo`,
+ *      `unbroadcastDataTo` against hand-computed expected outputs.
+ *
+ *   2. **Binary ops** — the existing Add/Sub/Mul/Div now accept
+ *      mismatched-but-broadcastable shapes; verify forward results
+ *      and backward gradient correctness (gradients must be the
+ *      shape of the ORIGINAL input, with broadcast-stretched dims
+ *      summed out).
+ *
+ *   3. **`BroadcastOp`** — explicit broadcast as an autograd op,
+ *      forward + backward.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  Tensor,
+  AddOp,
+  SubOp,
+  MulOp,
+  DivOp,
+  BroadcastOp,
+  broadcastShapes,
+  broadcastDataTo,
+  unbroadcastDataTo,
+} from "../src/index.js";
+
+describe("broadcastShapes — shape math only", () => {
+  it("identical shapes pass through unchanged", () => {
+    expect(broadcastShapes([2, 3], [2, 3])).toEqual([2, 3]);
+  });
+
+  it("scalar broadcasts to any shape (vector)", () => {
+    expect(broadcastShapes([], [4])).toEqual([4]);
+    expect(broadcastShapes([4], [])).toEqual([4]);
+  });
+
+  it("(3,) and (2, 3) → (2, 3)", () => {
+    expect(broadcastShapes([3], [2, 3])).toEqual([2, 3]);
+    expect(broadcastShapes([2, 3], [3])).toEqual([2, 3]);
+  });
+
+  it("(5, 1, 3) and (2, 3) → (5, 2, 3)", () => {
+    expect(broadcastShapes([5, 1, 3], [2, 3])).toEqual([5, 2, 3]);
+  });
+
+  it("(1, 4) and (3, 4) → (3, 4)", () => {
+    expect(broadcastShapes([1, 4], [3, 4])).toEqual([3, 4]);
+  });
+
+  it("(3, 1) and (1, 4) → (3, 4)  (outer-product style)", () => {
+    expect(broadcastShapes([3, 1], [1, 4])).toEqual([3, 4]);
+  });
+
+  it("incompatible shapes throw RangeError", () => {
+    expect(() => broadcastShapes([2, 3], [3, 2])).toThrow(RangeError);
+    expect(() => broadcastShapes([2, 3], [4])).toThrow(RangeError);
+    expect(() => broadcastShapes([2, 3, 4], [5, 4])).toThrow(RangeError);
+  });
+
+  it("matching zero-sized dims pass through", () => {
+    expect(broadcastShapes([0, 3], [0, 3])).toEqual([0, 3]);
+  });
+});
+
+describe("broadcastDataTo — materialize a broadcasted Float32Array", () => {
+  it("identical shapes: just copies (defensive, owns its memory)", () => {
+    const data = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const out = broadcastDataTo(data, [2, 3], [2, 3]);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(out).not.toBe(data); // fresh allocation
+  });
+
+  it("(3,) → (2, 3) replicates the row", () => {
+    const out = broadcastDataTo(new Float32Array([10, 20, 30]), [3], [2, 3]);
+    expect(Array.from(out)).toEqual([10, 20, 30, 10, 20, 30]);
+  });
+
+  it("(2, 1) → (2, 3) replicates each row 3 times", () => {
+    const out = broadcastDataTo(new Float32Array([1, 2]), [2, 1], [2, 3]);
+    expect(Array.from(out)).toEqual([1, 1, 1, 2, 2, 2]);
+  });
+
+  it("(1, 3) → (2, 3) replicates the single row", () => {
+    const out = broadcastDataTo(new Float32Array([10, 20, 30]), [1, 3], [2, 3]);
+    expect(Array.from(out)).toEqual([10, 20, 30, 10, 20, 30]);
+  });
+
+  it("(3, 1) and (1, 4) → (3, 4)  (outer-product layout)", () => {
+    // left input: shape (3, 1), values [a, b, c]
+    const a = broadcastDataTo(new Float32Array([1, 2, 3]), [3, 1], [3, 4]);
+    // Should produce: row 0 all 1s, row 1 all 2s, row 2 all 3s
+    expect(Array.from(a)).toEqual([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3]);
+
+    // right input: shape (1, 4), values [w, x, y, z]
+    const b = broadcastDataTo(new Float32Array([10, 20, 30, 40]), [1, 4], [3, 4]);
+    // Should produce: same row repeated 3 times
+    expect(Array.from(b)).toEqual([10, 20, 30, 40, 10, 20, 30, 40, 10, 20, 30, 40]);
+  });
+
+  it("rejects incompatible target shape", () => {
+    expect(() => broadcastDataTo(new Float32Array([1, 2, 3]), [3], [4])).toThrow(RangeError);
+  });
+});
+
+describe("unbroadcastDataTo — sum gradient back to original shape", () => {
+  it("identical shapes: just copies", () => {
+    const data = new Float32Array([1, 2, 3, 4]);
+    const out = unbroadcastDataTo(data, [2, 2], [2, 2]);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("(2, 3) → (3,) sums along axis 0", () => {
+    //  [[1, 2, 3],
+    //   [4, 5, 6]]
+    // sums along axis 0 → [5, 7, 9]
+    const out = unbroadcastDataTo(new Float32Array([1, 2, 3, 4, 5, 6]), [2, 3], [3]);
+    expect(Array.from(out)).toEqual([5, 7, 9]);
+  });
+
+  it("(2, 3) → (2, 1) sums along axis 1", () => {
+    //  [[1, 2, 3], [4, 5, 6]]  → row sums [6, 15], shape (2, 1)
+    const out = unbroadcastDataTo(new Float32Array([1, 2, 3, 4, 5, 6]), [2, 3], [2, 1]);
+    expect(Array.from(out)).toEqual([6, 15]);
+  });
+
+  it("(3, 4) → (3, 1) sums each row to 1 column", () => {
+    // input is row-major (3, 4):
+    //  [[1, 2, 3, 4],
+    //   [5, 6, 7, 8],
+    //   [9, 10, 11, 12]]
+    // row sums → [10, 26, 42]
+    const out = unbroadcastDataTo(
+      new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+      [3, 4],
+      [3, 1],
+    );
+    expect(Array.from(out)).toEqual([10, 26, 42]);
+  });
+
+  it("(5, 2, 3) → (2, 3) sums the leading axis", () => {
+    // 30 elements; sums of slabs [0..6), [6..12), [12..18), [18..24), [24..30)
+    const data = new Float32Array(30);
+    for (let i = 0; i < 30; i++) data[i] = i + 1;
+    const out = unbroadcastDataTo(data, [5, 2, 3], [2, 3]);
+    // For each (i, j), sum over k of data[k*6 + i*3 + j]
+    // k=0..4: i=0,j=0 → 1+7+13+19+25 = 65; i=0,j=1 → 2+8+14+20+26=70; etc.
+    expect(Array.from(out)).toEqual([65, 70, 75, 80, 85, 90]);
+  });
+});
+
+describe("Binary ops accept broadcastable shapes", () => {
+  it("Add: (2, 3) + (3,) broadcasts correctly", () => {
+    const a = new Tensor([[1, 2, 3], [4, 5, 6]]);
+    const b = new Tensor([10, 20, 30]);
+    const c = AddOp.apply(a, b);
+    expect(c.shape).toEqual([2, 3]);
+    expect(c.toArray()).toEqual([11, 22, 33, 14, 25, 36]);
+  });
+
+  it("Sub: (2, 1) - (1, 3) broadcasts to (2, 3)", () => {
+    const a = new Tensor([[10], [20]]); // (2, 1)
+    const b = new Tensor([[1, 2, 3]]);   // (1, 3)
+    const c = SubOp.apply(a, b);
+    expect(c.shape).toEqual([2, 3]);
+    expect(c.toArray()).toEqual([9, 8, 7, 19, 18, 17]);
+  });
+
+  it("Mul: (3, 1) * (1, 4) is an outer product", () => {
+    const a = new Tensor([[1], [2], [3]]); // (3, 1)
+    const b = new Tensor([[10, 20, 30, 40]]); // (1, 4)
+    const c = MulOp.apply(a, b);
+    expect(c.shape).toEqual([3, 4]);
+    expect(c.toArray()).toEqual([10, 20, 30, 40, 20, 40, 60, 80, 30, 60, 90, 120]);
+  });
+
+  it("Div: (2, 3) / (3,) broadcasts correctly", () => {
+    const a = new Tensor([[10, 20, 30], [40, 50, 60]]);
+    const b = new Tensor([1, 2, 3]);
+    const c = DivOp.apply(a, b);
+    expect(c.shape).toEqual([2, 3]);
+    expect(c.toArray()).toEqual([10, 10, 10, 40, 25, 20]);
+  });
+
+  it("incompatible shapes still throw", () => {
+    expect(() => AddOp.apply(new Tensor([[1, 2, 3]]), new Tensor([[1, 2]]))).toThrow(RangeError);
+  });
+});
+
+describe("Binary op backward unbroadcasts gradient to original input shape", () => {
+  it("Add (2, 3) + (3,) backward: bias grad is summed along batch axis", () => {
+    const a = new Tensor([[1, 2, 3], [4, 5, 6]]); a.requiresGrad = true;
+    const b = new Tensor([10, 20, 30]); b.requiresGrad = true;
+    AddOp.apply(a, b).backward();
+    // d/dA = ones(2, 3); d/dB = sum(ones, axis=0) = (2, 2, 2)
+    expect(a.grad!.shape).toEqual([2, 3]);
+    expect(a.grad!.toArray()).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(b.grad!.shape).toEqual([3]);
+    expect(b.grad!.toArray()).toEqual([2, 2, 2]);
+  });
+
+  it("Mul (2, 1) * (1, 3) outer-product backward", () => {
+    const a = new Tensor([[2], [3]]); a.requiresGrad = true;        // (2, 1)
+    const b = new Tensor([[10, 20, 30]]); b.requiresGrad = true;    // (1, 3)
+    MulOp.apply(a, b).backward();
+    // d/dA on broadcast shape = b broadcast → sum along axis 1 → (2, 1):
+    //   row 0: 10+20+30 = 60; row 1: same = 60
+    expect(a.grad!.shape).toEqual([2, 1]);
+    expect(a.grad!.toArray()).toEqual([60, 60]);
+    // d/dB on broadcast shape = a broadcast → sum along axis 0 → (1, 3):
+    //   col 0: 2+3 = 5; col 1: same; col 2: same
+    expect(b.grad!.shape).toEqual([1, 3]);
+    expect(b.grad!.toArray()).toEqual([5, 5, 5]);
+  });
+
+  it("Sub (3,) - (2, 3) backward signs are correct", () => {
+    const a = new Tensor([1, 2, 3]); a.requiresGrad = true;
+    const b = new Tensor([[10, 20, 30], [40, 50, 60]]); b.requiresGrad = true;
+    SubOp.apply(a, b).backward();
+    // dL/dA = ones(2, 3) → unbroadcast to (3,) = sum along axis 0 = (2, 2, 2)
+    expect(a.grad!.toArray()).toEqual([2, 2, 2]);
+    // dL/dB = -ones(2, 3) → already (2, 3), no unbroadcasting
+    expect(b.grad!.toArray()).toEqual([-1, -1, -1, -1, -1, -1]);
+  });
+});
+
+describe("BroadcastOp — explicit broadcast as autograd op", () => {
+  it("forward broadcasts (3,) → (2, 3)", () => {
+    const x = new Tensor([10, 20, 30]);
+    const y = BroadcastOp.apply(x, [2, 3]);
+    expect(y.shape).toEqual([2, 3]);
+    expect(y.toArray()).toEqual([10, 20, 30, 10, 20, 30]);
+  });
+
+  it("backward sums gradient back to input shape", () => {
+    const x = new Tensor([10, 20, 30]); x.requiresGrad = true;
+    const y = BroadcastOp.apply(x, [2, 3]);
+    y.backward();
+    // gradient with default seed = ones(2, 3); sum along axis 0 → (2, 2, 2)
+    expect(x.grad!.shape).toEqual([3]);
+    expect(x.grad!.toArray()).toEqual([2, 2, 2]);
+  });
+
+  it("backward with explicit seed grad respects the gradient values", () => {
+    const x = new Tensor([1, 2]); x.requiresGrad = true;     // (2,)
+    const y = BroadcastOp.apply(x, [3, 2]);                  // (3, 2)
+    // seed grad = [[1, 10], [100, 1000], [10000, 100000]]
+    const seed = new Tensor([[1, 10], [100, 1000], [10000, 100000]]);
+    y.backward(seed);
+    // x.grad = column sums of seed = [10101, 101010]
+    expect(x.grad!.toArray()).toEqual([10101, 101010]);
+  });
+
+  it("can chain through binary ops naturally", () => {
+    // y = broadcast(bias, (2, 3)) + x
+    const bias = new Tensor([0.5, 0.5, 0.5]); bias.requiresGrad = true;
+    const x = new Tensor([[1, 2, 3], [4, 5, 6]]);
+    const b = BroadcastOp.apply(bias, [2, 3]);
+    const y = AddOp.apply(b, x);
+    y.backward();
+    // dL/dBias = sum(ones(2, 3), axis=0) = (2, 2, 2)
+    expect(bias.grad!.toArray()).toEqual([2, 2, 2]);
+  });
+});


### PR DESCRIPTION
## Summary

PR #1 of 7 in **Phase A** — broadening the op vocabulary toward realistic models. v1.0 only accepted same-shape inputs to binary ops; v1.1 brings NumPy/PyTorch-style broadcasting.

## What this unlocks

The killer pattern for any non-trivial model — `pred + bias` where bias is `(out_dim,)` and pred is `(batch, out_dim)`:

\`\`\`ts
const bias = new Tensor([0.1, 0.2, 0.3]);          // (3,)
const x = new Tensor([[1, 2, 3], [4, 5, 6]]);     // (2, 3)
const y = x.add(bias);                              // → (2, 3)

bias.requiresGrad = true;
y.backward();
console.log(bias.grad!.shape);                      // → [3], NOT [2, 3]
\`\`\`

Critical: gradients are **unbroadcast** back to each parent's original shape — stretched dims get summed. Without this, you can't train any model with a bias term.

## What's new

- **`src/broadcasting.ts`** (NEW): three pure helpers — `broadcastShapes`, `broadcastDataTo`, `unbroadcastDataTo`
- **`Add` / `Sub` / `Mul` / `Div`**: forward broadcasts inputs; backward unbroadcasts gradients back to original parent shapes
- **`BroadcastOp`**: explicit broadcast as an autograd Function for code that wants to express \"promote bias once\"

## Architecture

- Fast path preserved (same-shape inputs pay zero broadcast cost)
- Helpers are pure (Float32Array in / Float32Array out) — no Tensor alloc overhead
- MulOp/DivOp save the broadcasted versions of a/b for the chain-rule multiply; Add/Sub only save shapes

## Test plan

- [x] \`npx tsc --noEmit\`: 0 errors
- [x] All 5 test files pass: 179/179 (61 tensor + 18 autograd + 67 ops + 2 end-to-end + 31 NEW broadcasting)
- [x] Security review passed
- [ ] CI: build (ubuntu/macos/windows) — pending
- [ ] CI: CodeQL js-ts Analyze — pending

## What's next in Phase A

| PR | Title |
|----|-------|
| A.2 | N-D batched MatMul + Transpose for rank ≥ 3 |
| A.3 | Embedding op (lookup table) |
| A.4 | LayerNorm + BatchNorm + Dropout |
| A.5 | Conv2D + MaxPool2D via im2col |
| A.6 | Adam optimizer + Linear/Sequential |
| A.7 | safetensors read/write (first HF interop) |

After A.7: load a tiny transformer checkpoint from HF Hub, run inference, fine-tune, save the result — all in TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)