### PR TITLE
feat(adj-lang): surface DSL (0.1.0) — dissolves ADJ46 A4, A10

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "adj-lang",
     "aarch64-backend",
     "aarch64-encoder",
     "x86_64-encoder",

--- a/code/packages/rust/adj-lang/BUILD
+++ b/code/packages/rust/adj-lang/BUILD
@@ -1,0 +1,12 @@
+load("code/packages/starlark/library-rules/rust_library.star", "rust_library")
+
+_targets = [
+    rust_library(
+        name = "adj-lang",
+        srcs = ["src/**/*.rs", "tests/**/*.rs"],
+        deps = [
+            "//code/packages/rust/logic-core:logic-core",
+            "//code/packages/rust/logic-engine:logic-engine",
+        ],
+    ),
+]

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## [0.1.0] - 2026-06-02
+
+### Added
+
+- Initial release. Hand-written lexer + recursive-descent parser +
+  lowering pass for the v0.1 surface syntax described in `README.md`.
+- Grammar covers: `prior`, `contributes`, `interacts`, `observe`,
+  `?`-prefix queries; `source`/`locator`/`trust` annotations;
+  identifiers, compound terms with multi-arg arity, line comments,
+  string literals with backslash escapes.
+- Lowering produces a `LoweredProgram { kb, queries }` where `kb` is
+  populated with `Fact`, `PriorClause`, `ContributionClause`, and
+  `JointContributionClause` entries ready for
+  `logic_engine::search`.
+- Lowerer enforces: at most one `prior` per conclusion, at most one
+  `source`/`locator`/`trust` annotation per statement.
+- Default trust tier when a `source` annotation is present but no
+  `trust` is given is `Authoritative`. When neither is given, the
+  tier is `Unattributed`.
+- 24 tests across lexer (9), parser (8), and lower (6+1 headline).
+- **Headline test**:
+  `lowers_full_acs_rulebook_and_reproduces_adj36_posterior` compiles
+  the ACS rulebook end-to-end (parse + lower + search via
+  `SearchMode::LRAggregate`) and reproduces ADJ36's 28.1% posterior.
+
+### ADJ46 awkwardness items dissolved
+
+- **A4** — `interacts` is syntactically distinct from `contributes`,
+  so the proof DAG can name the interaction term explicitly.
+- **A10** — the rulebook surface is now a domain-expert-readable
+  DSL, not hand-written Rust.
+
+### Not yet shipped
+
+- A5 (uncertainty markers), A7 (kickback variant), A8 (counterfactual
+  queries), A9 (multi-source aggregation). Each is a small additive
+  grammar extension; the parser is structured so each new clause kind
+  adds one arm to `parser::parse_statement` and one variant to the
+  lowerer.

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "adj-lang"
+version = "0.1.0"
+edition = "2021"
+description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
+
+[dependencies]
+logic-core = { path = "../logic-core" }
+logic-engine = { path = "../logic-engine" }

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -1,0 +1,141 @@
+# adj-lang (Rust)
+
+Surface-syntax frontend for the adjudication framework. Lexes,
+parses, and lowers a small domain-expert-readable rulebook DSL into
+a `logic-engine` `KnowledgeBase`.
+
+## What this is
+
+Adj-Lang is the language layer of the adjudication framework. Its
+v0.1 grammar covers the five clause kinds the LP19e LR-aggregation
+engine exposes:
+
+- `prior <p> for <conclusion>` — Bayesian baseline.
+- `contributes <lr> from <evidence> to <conclusion>` — atomic LR.
+- `interacts <lr> when <e1> and <e2> [and ...] for <conclusion>` —
+  joint-evidence interaction term.
+- `observe <term>` — assert a Certain Fact.
+- `? <conclusion>` — query the engine.
+
+Every clause can carry annotations:
+
+- `source "<text>"` — citation string.
+- `locator "<text>"` — page / section / paragraph within the source.
+- `trust <tier>` — one of `consensus | authoritative | empirical |
+  inferred | unattributed`.
+
+## The ACS rulebook in Adj-Lang
+
+```adj
+% chest-pain ACS risk rulebook (ADJ36)
+
+prior 0.10 for acs
+  source "Pope JH et al., NEJM 1995;342(16):1163-70"
+
+contributes 1.5 from pmh(hypertension) to acs
+  source "HEART Score; Six AJ et al., Neth Heart J 2008"
+  trust empirical
+
+contributes 1.8 from pmh(smoker) to acs
+  source "HEART Score; Six AJ et al., Neth Heart J 2008"
+  trust empirical
+
+contributes 2.5 from symptom_quality(pressure_like) to acs
+  source "Panju AA et al., JAMA 1998;280(14):1256-63"
+
+contributes 2.0 from associated_symptom(diaphoresis) to acs
+  source "Panju AA et al., JAMA 1998"
+
+contributes 0.5 from vital_signs(within_normal_limits) to acs
+  source "Panju 1998"
+
+contributes 0.4 from denied(ecg_acute_st_changes) to acs
+  source "Pope 1995"
+
+interacts 1.3 when symptom_quality(pressure_like)
+               and associated_symptom(diaphoresis)
+               for acs
+  source "[empirical] synergy"
+  trust empirical
+
+% The case — Jane Doe vignette from ADJ36
+observe pmh(hypertension)
+observe pmh(smoker)
+observe symptom_quality(pressure_like)
+observe associated_symptom(diaphoresis)
+observe vital_signs(within_normal_limits)
+observe denied(ecg_acute_st_changes)
+
+? acs
+```
+
+Compared to the hand-written Rust encoding in ADJ46
+(`code/specs/data/adj46/src/main.rs`, ~390 LOC), the Adj-Lang
+source above is ~30 lines of readable English. The ACS rulebook is
+no longer addressed to the engine; it's addressed to the ED
+physician who wrote it.
+
+## How it fits
+
+```
+   adj-lang source
+        │ [lex] → [parse] → [lower]
+        ▼
+   logic-engine::KnowledgeBase     ← (this crate's output)
+        │ [search, SearchMode::LRAggregate]
+        ▼
+   posterior + proof DAG + warnings
+```
+
+## API at a glance
+
+```rust
+use adj_lang::compile;
+use logic_engine::{search, SearchMode, SearchResult};
+
+let lowered = compile(source_text)?;
+for query in &lowered.queries {
+    match search(query, &lowered.kb, SearchMode::LRAggregate) {
+        SearchResult::LRAggregateResult { posterior, dag, .. } => {
+            println!("P({query:?}) = {posterior:.3}");
+            // dag.proofs[0].steps enumerates the prior + every
+            // active contribution, with provenance reachable via
+            // step.origin's clause_id.
+        }
+        _ => unreachable!(),
+    }
+}
+```
+
+## What v0.1 covers — and what's deferred
+
+Adj-Lang dissolves ADJ46 awkwardness items **A4** (joint
+contributions syntactically distinct from atomic, via the `interacts`
+keyword) and **A10** (rulebook surface is hand-written Rust).
+
+Not yet covered (all language-layer follow-ups):
+
+- **A5** — uncertainty markers (`uncertain X over {a,b,c}`).
+- **A7** — kickback as a query-result variant.
+- **A8** — counterfactual queries (`? acs given pmh(htn)=true`).
+- **A9** — source-disagreement aggregation (multiple `via "<source>"`
+  clauses per `(conclusion, evidence)`).
+
+These are small additive extensions of the grammar; each adds one or
+two arms to `parser::parse_statement` and one new variant to the
+lowering pass.
+
+## Tests
+
+24 unit tests across `lexer`, `parser`, and `lower`. Headline test:
+`lowers_full_acs_rulebook_and_reproduces_adj36_posterior` — the ACS
+program above compiles, runs through `SearchMode::LRAggregate`, and
+reproduces ADJ36's 28.1% posterior end-to-end through the production
+engine.
+
+## See also
+
+- [ADJ46 — awkwardness catalogue](../../../specs/ADJ46-acs-rulebook-on-logic-engine-toolchain-shakedown.md)
+- [LP19e — LR aggregation spec](../../../specs/LP19e-likelihood-ratio-aggregation.md)
+- [logic-engine](../logic-engine/README.md) — the inference layer
+  Adj-Lang lowers to.

--- a/code/packages/rust/adj-lang/required_capabilities.json
+++ b/code/packages/rust/adj-lang/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/adj-lang",
+  "capabilities": [],
+  "justification": "Pure computation. Lexes and parses source text in memory, produces an AST, lowers to a logic-engine KnowledgeBase. No filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -1,0 +1,82 @@
+//! # AST — what the parser produces and the lowerer consumes.
+//!
+//! Deliberately small and shape-preserving with the surface syntax.
+//! Each statement variant maps 1:1 to an LP19e clause kind plus
+//! [`Statement::Observe`] (Fact) and [`Statement::Query`] (run a
+//! query at the end). Annotations are gathered into a `Vec` and
+//! interpreted at lowering time — that keeps the parser simple
+//! (one annotation = one rule) while still letting the lowerer
+//! enforce ordering / multiplicity invariants.
+
+/// A Term in the surface language: either an atom or a compound
+/// term. The lowerer converts these to `logic_core::Term`s.
+///
+/// Mirrors a small subset of Prolog term shape — sufficient for
+/// medical / legal / financial rulebooks where every term is either
+/// a flat label (`acs`) or a single-arg predicate (`pmh(hypertension)`).
+/// Multi-arg compounds are supported syntactically but rarely used.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Term {
+    Atom(String),
+    Compound { functor: String, args: Vec<Term> },
+}
+
+/// One source line in an Adj-Lang program.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Statement {
+    /// `prior <probability> for <conclusion>` (+ annotations).
+    Prior {
+        probability: f64,
+        conclusion: Term,
+        annotations: Vec<Annotation>,
+    },
+    /// `contributes <lr> from <evidence> to <conclusion>` (+ annotations).
+    Contributes {
+        lr: f64,
+        evidence: Term,
+        conclusion: Term,
+        annotations: Vec<Annotation>,
+    },
+    /// `interacts <lr> when <evidence> and <evidence> [and ...] for
+    /// <conclusion>` (+ annotations).
+    Interacts {
+        lr: f64,
+        evidence_set: Vec<Term>,
+        conclusion: Term,
+        annotations: Vec<Annotation>,
+    },
+    /// `observe <term>` — assert a Certain Fact.
+    Observe { term: Term },
+    /// `? <conclusion>` — query the engine for the posterior.
+    Query { conclusion: Term },
+}
+
+/// Per-statement annotation. Multiple annotations per statement
+/// permitted; the lowerer collapses them onto the clause's
+/// [`logic_engine::Provenance`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum Annotation {
+    /// `source "<text>"` — sets `Provenance::source`.
+    Source(String),
+    /// `locator "<text>"` — sets `Provenance::locator`.
+    Locator(String),
+    /// `trust <tier>` — sets `Provenance::trust_tier`.
+    Trust(TrustTierName),
+}
+
+/// Surface name for a trust tier — keywords in the language map
+/// 1:1 to [`logic_engine::TrustTier`] variants.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TrustTierName {
+    Consensus,
+    Authoritative,
+    Empirical,
+    Inferred,
+    Unattributed,
+}
+
+/// A complete program: a sequence of statements.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Program {
+    pub statements: Vec<Statement>,
+}

--- a/code/packages/rust/adj-lang/src/lexer.rs
+++ b/code/packages/rust/adj-lang/src/lexer.rs
@@ -1,0 +1,371 @@
+//! # Lexer — source text → token stream.
+//!
+//! Hand-written tokenizer. The token set is small enough (under 20
+//! kinds) that a generated lexer would buy us little — and writing
+//! it by hand lets the diagnostic surface (line + column on every
+//! error) stay simple.
+//!
+//! ## Token kinds
+//!
+//! - **Keywords**: `prior`, `for`, `contributes`, `from`, `to`,
+//!   `interacts`, `when`, `and`, `observe`, `source`, `trust`,
+//!   `locator`, `consensus`, `authoritative`, `empirical`,
+//!   `inferred`, `unattributed`.
+//! - **Punctuation**: `(`, `)`, `,`, `?`.
+//! - **Literals**: numbers (`0.10`, `1.5`, `2`), quoted strings
+//!   (`"…"` with backslash escapes for `"` and `\`).
+//! - **Identifiers**: lowercase letter or underscore followed by
+//!   letters / digits / underscores. Identifiers shadow keywords
+//!   only when not in keyword position — see the parser; the lexer
+//!   does keyword recognition eagerly.
+//! - **Trivia**: whitespace (skipped), `%` line comments (skipped to
+//!   end of line), newlines (significant only for diagnostic spans;
+//!   the parser is whitespace-insensitive otherwise).
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub line: usize,
+    pub col: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenKind {
+    // Keywords
+    KwPrior,
+    KwFor,
+    KwContributes,
+    KwFrom,
+    KwTo,
+    KwInteracts,
+    KwWhen,
+    KwAnd,
+    KwObserve,
+    KwSource,
+    KwTrust,
+    KwLocator,
+    KwConsensus,
+    KwAuthoritative,
+    KwEmpirical,
+    KwInferred,
+    KwUnattributed,
+    // Punctuation
+    LParen,
+    RParen,
+    Comma,
+    Question,
+    // Literals
+    Number(f64),
+    String(String),
+    // Identifiers
+    Ident(String),
+    // End of input
+    Eof,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LexError {
+    UnterminatedString { line: usize, col: usize },
+    InvalidNumber { lexeme: String, line: usize, col: usize },
+    UnknownCharacter { ch: char, line: usize, col: usize },
+}
+
+pub fn lex(src: &str) -> Result<Vec<Token>, LexError> {
+    let mut tokens = Vec::new();
+    let mut chars = src.chars().peekable();
+    let mut line = 1usize;
+    let mut col = 1usize;
+
+    while let Some(&c) = chars.peek() {
+        match c {
+            ' ' | '\t' | '\r' => {
+                chars.next();
+                col += 1;
+            }
+            '\n' => {
+                chars.next();
+                line += 1;
+                col = 1;
+            }
+            '%' => {
+                // Line comment to EOL.
+                while let Some(&nc) = chars.peek() {
+                    if nc == '\n' {
+                        break;
+                    }
+                    chars.next();
+                    col += 1;
+                }
+            }
+            '(' => {
+                tokens.push(Token { kind: TokenKind::LParen, line, col });
+                chars.next();
+                col += 1;
+            }
+            ')' => {
+                tokens.push(Token { kind: TokenKind::RParen, line, col });
+                chars.next();
+                col += 1;
+            }
+            ',' => {
+                tokens.push(Token { kind: TokenKind::Comma, line, col });
+                chars.next();
+                col += 1;
+            }
+            '?' => {
+                tokens.push(Token { kind: TokenKind::Question, line, col });
+                chars.next();
+                col += 1;
+            }
+            '"' => {
+                let start_line = line;
+                let start_col = col;
+                chars.next();
+                col += 1;
+                let mut s = String::new();
+                let mut terminated = false;
+                while let Some(&nc) = chars.peek() {
+                    match nc {
+                        '"' => {
+                            chars.next();
+                            col += 1;
+                            terminated = true;
+                            break;
+                        }
+                        '\\' => {
+                            chars.next();
+                            col += 1;
+                            if let Some(&esc) = chars.peek() {
+                                match esc {
+                                    '"' => { s.push('"'); chars.next(); col += 1; }
+                                    '\\' => { s.push('\\'); chars.next(); col += 1; }
+                                    'n' => { s.push('\n'); chars.next(); col += 1; }
+                                    other => {
+                                        // Unknown escape — keep verbatim.
+                                        s.push('\\');
+                                        s.push(other);
+                                        chars.next();
+                                        col += 1;
+                                    }
+                                }
+                            }
+                        }
+                        '\n' => {
+                            chars.next();
+                            line += 1;
+                            col = 1;
+                            s.push('\n');
+                        }
+                        other => {
+                            s.push(other);
+                            chars.next();
+                            col += 1;
+                        }
+                    }
+                }
+                if !terminated {
+                    return Err(LexError::UnterminatedString {
+                        line: start_line,
+                        col: start_col,
+                    });
+                }
+                tokens.push(Token {
+                    kind: TokenKind::String(s),
+                    line: start_line,
+                    col: start_col,
+                });
+            }
+            d if d.is_ascii_digit() || d == '-' => {
+                let start_line = line;
+                let start_col = col;
+                let mut s = String::new();
+                if d == '-' {
+                    s.push('-');
+                    chars.next();
+                    col += 1;
+                }
+                while let Some(&nc) = chars.peek() {
+                    if nc.is_ascii_digit() || nc == '.' {
+                        s.push(nc);
+                        chars.next();
+                        col += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let n = s.parse::<f64>().map_err(|_| LexError::InvalidNumber {
+                    lexeme: s.clone(),
+                    line: start_line,
+                    col: start_col,
+                })?;
+                tokens.push(Token {
+                    kind: TokenKind::Number(n),
+                    line: start_line,
+                    col: start_col,
+                });
+            }
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                let start_line = line;
+                let start_col = col;
+                let mut s = String::new();
+                while let Some(&nc) = chars.peek() {
+                    if nc.is_ascii_alphanumeric() || nc == '_' {
+                        s.push(nc);
+                        chars.next();
+                        col += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let kind = keyword_or_ident(&s);
+                tokens.push(Token { kind, line: start_line, col: start_col });
+            }
+            other => {
+                return Err(LexError::UnknownCharacter { ch: other, line, col });
+            }
+        }
+    }
+    tokens.push(Token { kind: TokenKind::Eof, line, col });
+    Ok(tokens)
+}
+
+fn keyword_or_ident(s: &str) -> TokenKind {
+    match s {
+        "prior" => TokenKind::KwPrior,
+        "for" => TokenKind::KwFor,
+        "contributes" => TokenKind::KwContributes,
+        "from" => TokenKind::KwFrom,
+        "to" => TokenKind::KwTo,
+        "interacts" => TokenKind::KwInteracts,
+        "when" => TokenKind::KwWhen,
+        "and" => TokenKind::KwAnd,
+        "observe" => TokenKind::KwObserve,
+        "source" => TokenKind::KwSource,
+        "trust" => TokenKind::KwTrust,
+        "locator" => TokenKind::KwLocator,
+        "consensus" => TokenKind::KwConsensus,
+        "authoritative" => TokenKind::KwAuthoritative,
+        "empirical" => TokenKind::KwEmpirical,
+        "inferred" => TokenKind::KwInferred,
+        "unattributed" => TokenKind::KwUnattributed,
+        other => TokenKind::Ident(other.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(tokens: &[Token]) -> Vec<TokenKind> {
+        tokens.iter().map(|t| t.kind.clone()).collect()
+    }
+
+    #[test]
+    fn lexes_simple_prior_statement() {
+        let src = "prior 0.10 for acs";
+        let toks = lex(src).unwrap();
+        assert_eq!(
+            kinds(&toks),
+            vec![
+                TokenKind::KwPrior,
+                TokenKind::Number(0.10),
+                TokenKind::KwFor,
+                TokenKind::Ident("acs".into()),
+                TokenKind::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_compound_term_with_args() {
+        let src = "pmh(hypertension)";
+        let toks = lex(src).unwrap();
+        assert_eq!(
+            kinds(&toks),
+            vec![
+                TokenKind::Ident("pmh".into()),
+                TokenKind::LParen,
+                TokenKind::Ident("hypertension".into()),
+                TokenKind::RParen,
+                TokenKind::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn lexes_string_with_escaped_quote() {
+        // Use a heavier-quoted raw string so we can include both
+        // `\"` escapes and a real closing quote in the source we
+        // pass to the lexer.
+        let src = r##"source "Pope JH \"et al.\"""##;
+        let toks = lex(src).unwrap();
+        match &toks[1].kind {
+            TokenKind::String(s) => assert_eq!(s, r#"Pope JH "et al.""#),
+            other => panic!("expected string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skips_line_comments() {
+        let src = "% this is a comment\nprior 0.10 for acs";
+        let toks = lex(src).unwrap();
+        assert!(matches!(toks[0].kind, TokenKind::KwPrior));
+        assert_eq!(toks[0].line, 2);
+    }
+
+    #[test]
+    fn lexes_query_question_mark() {
+        let src = "? acs";
+        let toks = lex(src).unwrap();
+        assert_eq!(
+            kinds(&toks),
+            vec![
+                TokenKind::Question,
+                TokenKind::Ident("acs".into()),
+                TokenKind::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn unterminated_string_is_an_error() {
+        let src = r#"source "missing quote"#;
+        assert!(matches!(lex(src), Err(LexError::UnterminatedString { .. })));
+    }
+
+    #[test]
+    fn unknown_character_is_an_error() {
+        let src = "prior $0.10 for acs";
+        let err = lex(src).unwrap_err();
+        assert!(matches!(err, LexError::UnknownCharacter { ch: '$', .. }));
+    }
+
+    #[test]
+    fn lexes_all_trust_tier_keywords() {
+        let src = "consensus authoritative empirical inferred unattributed";
+        let toks = lex(src).unwrap();
+        assert_eq!(
+            kinds(&toks)[..5],
+            [
+                TokenKind::KwConsensus,
+                TokenKind::KwAuthoritative,
+                TokenKind::KwEmpirical,
+                TokenKind::KwInferred,
+                TokenKind::KwUnattributed,
+            ]
+        );
+    }
+
+    #[test]
+    fn line_and_column_diagnostics_work_across_newlines() {
+        let src = "prior 0.10 for acs\ncontributes 1.5";
+        let toks = lex(src).unwrap();
+        let contrib = toks.iter().find(|t| matches!(t.kind, TokenKind::KwContributes)).unwrap();
+        assert_eq!(contrib.line, 2);
+        assert_eq!(contrib.col, 1);
+    }
+}

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -1,0 +1,89 @@
+//! # adj-lang — surface syntax for the adjudication framework
+//!
+//! A small probabilistic-logic DSL whose programs lower directly to
+//! a `logic-engine` [`KnowledgeBase`]. Designed to be readable by a
+//! domain expert (ED physician, M&A lawyer, security researcher,
+//! investigative journalist) without a Rust compiler in scope.
+//!
+//! Dissolves ADJ46 awkwardness items
+//! [A10](../../../specs/data/adj46/AWKWARDNESS.md) (rulebook surface
+//! is hand-written Rust) and A4 (joint contributions look like
+//! ordinary multi-body rules) by making each clause kind a distinct
+//! keyword.
+//!
+//! ## Surface syntax (v0.1)
+//!
+//! ```adj
+//! % comments start with %
+//!
+//! prior 0.10 for acs
+//!   source "Pope JH et al., NEJM 1995;342(16):1163-70"
+//!
+//! contributes 1.5 from pmh(hypertension) to acs
+//!   source "HEART Score; Six AJ et al., 2008"
+//!   trust empirical
+//!
+//! interacts 1.3 when symptom_quality(pressure_like)
+//!                and associated_symptom(diaphoresis)
+//!                for acs
+//!   source "[empirical] synergy"
+//!
+//! observe pmh(hypertension)
+//! observe symptom_quality(pressure_like)
+//!
+//! ? acs   % query
+//! ```
+//!
+//! ## Pipeline
+//!
+//! `source text → [lexer] → tokens → [parser] → AST → [lower] →
+//! (KnowledgeBase, queries)`
+//!
+//! The KB is then handed to [`logic_engine::search`] in
+//! `SearchMode::LRAggregate` (or any other mode the caller wants).
+//!
+//! ## What v0.1 does NOT cover
+//!
+//! - **Uncertainty markers** (ADJ46 A5) — `uncertain X over {a,b,c}`
+//!   is reserved syntax but not yet lowered. ADJ47-D.
+//! - **Counterfactual queries** (A8) — `? acs given pmh(htn)=true`.
+//!   ADJ47-D.
+//! - **Source disagreement aggregation** (A9) — `contributes 1.5
+//!   ... via "AHA 2021"` with multiple `via` clauses per
+//!   (conclusion, evidence). ADJ47-D.
+//! - **Kickback** (A7) — surfaces as an engine-layer search-result
+//!   variant, not a surface keyword. Cross-cutting work.
+//!
+//! Each of these is a small additive change to the grammar; the
+//! current parser is structured so adding a statement kind is a
+//! single new arm of [`parser::parse_statement`].
+
+pub mod ast;
+pub mod lexer;
+pub mod lower;
+pub mod parser;
+
+pub use ast::{Annotation, Program, Statement, Term as AstTerm};
+pub use lexer::{lex, LexError, Token, TokenKind};
+pub use lower::{lower, LowerError, LoweredProgram};
+pub use parser::{parse, ParseError};
+
+/// Top-level convenience: source text → lowered program (KB + queries).
+///
+/// Returns the first error encountered in either the lexer or the
+/// parser if anything fails. Mainly for tests and the
+/// `examples/`-style invocation; production callers will typically
+/// split into [`lex`], [`parse`], and [`lower`] so they can route
+/// errors to their own diagnostic surface.
+pub fn compile(src: &str) -> Result<LoweredProgram, CompileError> {
+    let tokens = lex(src).map_err(CompileError::Lex)?;
+    let program = parse(&tokens).map_err(CompileError::Parse)?;
+    lower(&program).map_err(CompileError::Lower)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompileError {
+    Lex(LexError),
+    Parse(ParseError),
+    Lower(LowerError),
+}

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1,0 +1,304 @@
+//! # Lowering — AST → KnowledgeBase + queries.
+//!
+//! Translates the AST produced by [`crate::parser`] into a
+//! `logic-engine` [`KnowledgeBase`] populated with [`Fact`],
+//! [`PriorClause`], [`ContributionClause`], and
+//! [`JointContributionClause`] entries. Queries appear in the
+//! returned [`LoweredProgram::queries`] vector in source order; the
+//! caller decides whether to run them via
+//! [`logic_engine::search`] and what to do with the results.
+//!
+//! ## What the lowerer enforces beyond the parser
+//!
+//! - At most one `prior` per conclusion. Two priors for the same
+//!   atom is a [`LowerError::DuplicatePrior`] (mirroring the
+//!   engine's `KbError::ConflictingPriors`, but caught at lowering
+//!   time so the diagnostic carries surface line/col).
+//! - All three trust-tier names map to the engine's
+//!   [`logic_engine::TrustTier`] variants.
+//! - `source` may appear at most once per statement; multiple
+//!   `source` annotations are a [`LowerError::DuplicateAnnotation`].
+
+use logic_core::{atom as core_atom, compound, Term as CoreTerm};
+use logic_engine::{
+    ContributionClause, Fact, JointContributionClause, KbError, KnowledgeBase, PriorClause,
+    Provenance, TrustTier,
+};
+
+use crate::ast::{Annotation, Program, Statement, Term as AstTerm, TrustTierName};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LowerError {
+    DuplicatePrior { conclusion_name: String },
+    DuplicateAnnotation { name: &'static str },
+    EngineRejected { detail: String },
+}
+
+/// The result of lowering — a populated KB and any queries to run.
+#[derive(Debug)]
+pub struct LoweredProgram {
+    pub kb: KnowledgeBase,
+    pub queries: Vec<CoreTerm>,
+}
+
+/// Lower an [`ast::Program`] to a populated KB + queries.
+pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
+    let mut kb = KnowledgeBase::new();
+    let mut queries = Vec::new();
+
+    for stmt in &program.statements {
+        match stmt {
+            Statement::Prior {
+                probability,
+                conclusion,
+                annotations,
+            } => {
+                let prov = annotations_to_provenance(annotations)?;
+                let clause = PriorClause::from_probability(lower_term(conclusion), *probability)
+                    .with_provenance(prov);
+                kb.add_prior(clause).map_err(|e| match e {
+                    KbError::ConflictingPriors { conclusion, .. } => {
+                        LowerError::DuplicatePrior {
+                            conclusion_name: format!("{conclusion:?}"),
+                        }
+                    }
+                })?;
+            }
+            Statement::Contributes {
+                lr,
+                evidence,
+                conclusion,
+                annotations,
+            } => {
+                let prov = annotations_to_provenance(annotations)?;
+                let clause = ContributionClause::from_lr(
+                    lower_term(conclusion),
+                    lower_term(evidence),
+                    *lr,
+                )
+                .with_provenance(prov);
+                kb.add_contribution(clause);
+            }
+            Statement::Interacts {
+                lr,
+                evidence_set,
+                conclusion,
+                annotations,
+            } => {
+                let prov = annotations_to_provenance(annotations)?;
+                let clause = JointContributionClause::from_lr(
+                    lower_term(conclusion),
+                    evidence_set.iter().map(lower_term).collect(),
+                    *lr,
+                )
+                .with_provenance(prov);
+                kb.add_joint_contribution(clause);
+            }
+            Statement::Observe { term } => {
+                kb.add_fact(Fact::certain(lower_term(term)));
+            }
+            Statement::Query { conclusion } => {
+                queries.push(lower_term(conclusion));
+            }
+        }
+    }
+
+    Ok(LoweredProgram { kb, queries })
+}
+
+fn lower_term(t: &AstTerm) -> CoreTerm {
+    match t {
+        AstTerm::Atom(name) => core_atom(name),
+        AstTerm::Compound { functor, args } => {
+            compound(functor, args.iter().map(lower_term).collect())
+        }
+    }
+}
+
+fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, LowerError> {
+    let mut source: Option<String> = None;
+    let mut locator: Option<String> = None;
+    let mut trust: Option<TrustTier> = None;
+
+    for a in annotations {
+        match a {
+            Annotation::Source(s) => {
+                if source.is_some() {
+                    return Err(LowerError::DuplicateAnnotation { name: "source" });
+                }
+                source = Some(s.clone());
+            }
+            Annotation::Locator(s) => {
+                if locator.is_some() {
+                    return Err(LowerError::DuplicateAnnotation { name: "locator" });
+                }
+                locator = Some(s.clone());
+            }
+            Annotation::Trust(name) => {
+                if trust.is_some() {
+                    return Err(LowerError::DuplicateAnnotation { name: "trust" });
+                }
+                trust = Some(match name {
+                    TrustTierName::Consensus => TrustTier::Consensus,
+                    TrustTierName::Authoritative => TrustTier::Authoritative,
+                    TrustTierName::Empirical => TrustTier::Empirical,
+                    TrustTierName::Inferred => TrustTier::Inferred,
+                    TrustTierName::Unattributed => TrustTier::Unattributed,
+                });
+            }
+        }
+    }
+
+    // If a source is present but no trust tier was specified, default
+    // to Authoritative — the common case for cited rulebooks.
+    // Otherwise (no source, no tier), default to Unattributed.
+    let trust_tier = trust.unwrap_or_else(|| {
+        if source.is_some() {
+            TrustTier::Authoritative
+        } else {
+            TrustTier::Unattributed
+        }
+    });
+
+    Ok(Provenance::new(
+        source.unwrap_or_default(),
+        locator,
+        trust_tier,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile;
+    use logic_engine::{search, SearchMode, SearchResult};
+
+    #[test]
+    fn lowers_full_acs_rulebook_and_reproduces_adj36_posterior() {
+        let src = r#"
+            prior 0.10 for acs
+              source "Pope JH et al., NEJM 1995;342(16):1163-70"
+
+            contributes 1.5 from pmh(hypertension) to acs
+              source "HEART Score; Six AJ et al., Neth Heart J 2008"
+              trust empirical
+
+            contributes 1.8 from pmh(smoker) to acs
+              source "HEART Score; Six AJ et al., Neth Heart J 2008"
+              trust empirical
+
+            contributes 2.5 from symptom_quality(pressure_like) to acs
+              source "Panju AA et al., JAMA 1998;280(14):1256-63"
+
+            contributes 2.0 from associated_symptom(diaphoresis) to acs
+              source "Panju AA et al., JAMA 1998"
+
+            contributes 0.5 from vital_signs(within_normal_limits) to acs
+              source "Panju AA et al., JAMA 1998"
+
+            contributes 0.4 from denied(ecg_acute_st_changes) to acs
+              source "Pope JH et al., NEJM 1995"
+
+            interacts 1.3 when symptom_quality(pressure_like)
+                           and associated_symptom(diaphoresis)
+                           for acs
+              source "[empirical] synergy"
+              trust empirical
+
+            observe pmh(hypertension)
+            observe pmh(smoker)
+            observe symptom_quality(pressure_like)
+            observe associated_symptom(diaphoresis)
+            observe vital_signs(within_normal_limits)
+            observe denied(ecg_acute_st_changes)
+
+            ? acs
+        "#;
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.queries.len(), 1);
+        let query = &lowered.queries[0];
+        let result = search(query, &lowered.kb, SearchMode::LRAggregate);
+        match result {
+            SearchResult::LRAggregateResult { posterior, .. } => {
+                assert!(
+                    (posterior - 0.281).abs() < 0.005,
+                    "expected ≈0.281, got {posterior}"
+                );
+            }
+            other => panic!("expected LRAggregateResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_prior_is_rejected() {
+        let src = r#"
+            prior 0.10 for acs
+            prior 0.20 for acs
+        "#;
+        let err = compile(src).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::CompileError::Lower(LowerError::DuplicatePrior { .. })
+        ));
+    }
+
+    #[test]
+    fn duplicate_source_annotation_is_rejected() {
+        let src = r#"
+            contributes 1.5 from pmh(htn) to acs
+              source "first"
+              source "second"
+        "#;
+        let err = compile(src).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::CompileError::Lower(LowerError::DuplicateAnnotation { name: "source" })
+        ));
+    }
+
+    #[test]
+    fn source_without_trust_defaults_to_authoritative() {
+        let src = r#"
+            contributes 1.5 from x to y
+              source "some paper"
+        "#;
+        let lowered = compile(src).unwrap();
+        let contribs = lowered.kb.contributions_for(&core_atom("y"));
+        assert_eq!(contribs.len(), 1);
+        assert_eq!(contribs[0].provenance.trust_tier, TrustTier::Authoritative);
+    }
+
+    #[test]
+    fn no_source_and_no_trust_defaults_to_unattributed() {
+        let src = "contributes 1.5 from x to y";
+        let lowered = compile(src).unwrap();
+        let contribs = lowered.kb.contributions_for(&core_atom("y"));
+        assert_eq!(contribs[0].provenance.trust_tier, TrustTier::Unattributed);
+    }
+
+    #[test]
+    fn observe_without_query_still_compiles() {
+        let src = "observe pmh(hypertension)";
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.queries.len(), 0);
+    }
+
+    #[test]
+    fn locator_annotation_is_carried_through() {
+        let src = r#"
+            contributes 1.5 from x to y
+              source "guideline"
+              locator "§3.2"
+        "#;
+        let lowered = compile(src).unwrap();
+        let contribs = lowered.kb.contributions_for(&core_atom("y"));
+        assert_eq!(
+            contribs[0].provenance.locator.as_deref(),
+            Some("§3.2")
+        );
+    }
+}

--- a/code/packages/rust/adj-lang/src/parser.rs
+++ b/code/packages/rust/adj-lang/src/parser.rs
@@ -1,0 +1,535 @@
+//! # Parser — token stream → AST.
+//!
+//! Hand-written recursive descent. Each grammar production maps to
+//! one function; lookahead is at most one token via [`Parser::peek`].
+//!
+//! ## Grammar (v0.1)
+//!
+//! ```text
+//! program     := statement*
+//! statement   := prior_decl | contrib_decl | interact_decl
+//!              | observe_decl | query_decl
+//!
+//! prior_decl  := 'prior' NUMBER 'for' term annotation*
+//! contrib_decl:= 'contributes' NUMBER 'from' term 'to' term annotation*
+//! interact_decl := 'interacts' NUMBER 'when' term ('and' term)+ 'for' term annotation*
+//! observe_decl:= 'observe' term
+//! query_decl  := '?' term
+//!
+//! annotation  := 'source' STRING
+//!              | 'locator' STRING
+//!              | 'trust' trust_tier
+//!
+//! trust_tier  := 'consensus' | 'authoritative' | 'empirical'
+//!              | 'inferred' | 'unattributed'
+//!
+//! term        := IDENT
+//!              | IDENT '(' term (',' term)* ')'
+//! ```
+
+use crate::ast::{Annotation, Program, Statement, Term, TrustTierName};
+use crate::lexer::{Token, TokenKind};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParseError {
+    /// We expected one of `expected` but found `found` at the given
+    /// source position. Includes a string description of the
+    /// production context so the error message points the reader at
+    /// the right grammar rule.
+    Expected {
+        expected: String,
+        found: String,
+        line: usize,
+        col: usize,
+    },
+    /// `interacts` requires at least two evidence terms joined by
+    /// `and`. With one or zero, the modeller probably meant
+    /// `contributes` — flag explicitly so the diagnostic is helpful.
+    InteractNeedsAtLeastTwoEvidence { line: usize, col: usize },
+    /// A compound term was nested deeper than [`MAX_TERM_DEPTH`].
+    ///
+    /// This bound exists to prevent untrusted input from producing
+    /// stack-overflow DoS via `f(f(f(...)))`-style nesting. Real
+    /// rulebook terms in clinical / legal / financial domains never
+    /// approach this depth — single-argument `pmh(hypertension)`
+    /// covers the bulk of real usage; depths above ~10 indicate a
+    /// modeller error or an adversarial input.
+    TooDeeplyNested { depth: usize, line: usize, col: usize },
+    UnexpectedEof,
+}
+
+/// Maximum depth of nested compound terms the parser accepts.
+///
+/// Chosen as a sane upper bound: rulebooks in practice nest 1-2
+/// levels (`pmh(hypertension)`, occasionally
+/// `relation(a, compound(b, c))`); 256 leaves three orders of
+/// magnitude of headroom before any plausible legitimate input is
+/// rejected, while bounding adversarial recursion well within a
+/// typical 2-8 MB stack budget. Each `parse_term` frame is a few
+/// hundred bytes; 256 × ~512 bytes ≈ 128 KB.
+pub const MAX_TERM_DEPTH: usize = 256;
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    pos: usize,
+    /// Current nesting depth inside `parse_term`. Tracked to bound
+    /// recursion at [`MAX_TERM_DEPTH`] so adversarial input cannot
+    /// stack-overflow the process.
+    term_depth: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(tokens: &'a [Token]) -> Self {
+        Self {
+            tokens,
+            pos: 0,
+            term_depth: 0,
+        }
+    }
+
+    fn peek(&self) -> &Token {
+        &self.tokens[self.pos]
+    }
+
+    fn advance(&mut self) -> &Token {
+        let t = &self.tokens[self.pos];
+        if self.pos < self.tokens.len() - 1 {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn expect(&mut self, kind_match: impl Fn(&TokenKind) -> bool, expected: &str)
+        -> Result<&Token, ParseError>
+    {
+        let t = self.peek();
+        if kind_match(&t.kind) {
+            Ok(self.advance())
+        } else {
+            Err(ParseError::Expected {
+                expected: expected.into(),
+                found: format!("{:?}", t.kind),
+                line: t.line,
+                col: t.col,
+            })
+        }
+    }
+
+    fn at_eof(&self) -> bool {
+        matches!(self.peek().kind, TokenKind::Eof)
+    }
+
+    fn parse_program(&mut self) -> Result<Program, ParseError> {
+        let mut statements = Vec::new();
+        while !self.at_eof() {
+            statements.push(self.parse_statement()?);
+        }
+        Ok(Program { statements })
+    }
+
+    fn parse_statement(&mut self) -> Result<Statement, ParseError> {
+        match &self.peek().kind {
+            TokenKind::KwPrior => self.parse_prior(),
+            TokenKind::KwContributes => self.parse_contributes(),
+            TokenKind::KwInteracts => self.parse_interacts(),
+            TokenKind::KwObserve => self.parse_observe(),
+            TokenKind::Question => self.parse_query(),
+            other => {
+                let t = self.peek();
+                Err(ParseError::Expected {
+                    expected: "statement keyword (prior, contributes, interacts, observe, ?)"
+                        .into(),
+                    found: format!("{other:?}"),
+                    line: t.line,
+                    col: t.col,
+                })
+            }
+        }
+    }
+
+    fn parse_prior(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::KwPrior), "`prior`")?;
+        let probability = self.parse_number()?;
+        self.expect(|k| matches!(k, TokenKind::KwFor), "`for`")?;
+        let conclusion = self.parse_term()?;
+        let annotations = self.parse_annotations()?;
+        Ok(Statement::Prior {
+            probability,
+            conclusion,
+            annotations,
+        })
+    }
+
+    fn parse_contributes(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::KwContributes), "`contributes`")?;
+        let lr = self.parse_number()?;
+        self.expect(|k| matches!(k, TokenKind::KwFrom), "`from`")?;
+        let evidence = self.parse_term()?;
+        self.expect(|k| matches!(k, TokenKind::KwTo), "`to`")?;
+        let conclusion = self.parse_term()?;
+        let annotations = self.parse_annotations()?;
+        Ok(Statement::Contributes {
+            lr,
+            evidence,
+            conclusion,
+            annotations,
+        })
+    }
+
+    fn parse_interacts(&mut self) -> Result<Statement, ParseError> {
+        let interact_tok = self.expect(|k| matches!(k, TokenKind::KwInteracts), "`interacts`")?;
+        let line = interact_tok.line;
+        let col = interact_tok.col;
+        let lr = self.parse_number()?;
+        self.expect(|k| matches!(k, TokenKind::KwWhen), "`when`")?;
+        let mut evidence_set = vec![self.parse_term()?];
+        while matches!(self.peek().kind, TokenKind::KwAnd) {
+            self.advance();
+            evidence_set.push(self.parse_term()?);
+        }
+        if evidence_set.len() < 2 {
+            return Err(ParseError::InteractNeedsAtLeastTwoEvidence { line, col });
+        }
+        self.expect(|k| matches!(k, TokenKind::KwFor), "`for`")?;
+        let conclusion = self.parse_term()?;
+        let annotations = self.parse_annotations()?;
+        Ok(Statement::Interacts {
+            lr,
+            evidence_set,
+            conclusion,
+            annotations,
+        })
+    }
+
+    fn parse_observe(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::KwObserve), "`observe`")?;
+        let term = self.parse_term()?;
+        Ok(Statement::Observe { term })
+    }
+
+    fn parse_query(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::Question), "`?`")?;
+        let conclusion = self.parse_term()?;
+        Ok(Statement::Query { conclusion })
+    }
+
+    fn parse_number(&mut self) -> Result<f64, ParseError> {
+        let t = self.peek().clone();
+        match t.kind {
+            TokenKind::Number(n) => {
+                self.advance();
+                Ok(n)
+            }
+            other => Err(ParseError::Expected {
+                expected: "number".into(),
+                found: format!("{other:?}"),
+                line: t.line,
+                col: t.col,
+            }),
+        }
+    }
+
+    fn parse_term(&mut self) -> Result<Term, ParseError> {
+        // Depth guard: prevent adversarial nested compounds
+        // (`f(f(f(...)))`) from overflowing the stack. Increment on
+        // entry, decrement on every exit path (both Ok and Err). The
+        // manual increment/decrement avoids a Drop-based RAII guard
+        // because we need access to `&mut self` for the recursive
+        // call anyway.
+        self.term_depth += 1;
+        if self.term_depth > MAX_TERM_DEPTH {
+            let t = self.peek();
+            let err = ParseError::TooDeeplyNested {
+                depth: self.term_depth,
+                line: t.line,
+                col: t.col,
+            };
+            self.term_depth -= 1;
+            return Err(err);
+        }
+        let result = self.parse_term_inner();
+        self.term_depth -= 1;
+        result
+    }
+
+    /// Body of `parse_term` — separated so the entry/exit depth
+    /// management can wrap a single `?`-using inner function.
+    fn parse_term_inner(&mut self) -> Result<Term, ParseError> {
+        let t = self.peek().clone();
+        let name = match t.kind {
+            TokenKind::Ident(ref s) => s.clone(),
+            other => {
+                return Err(ParseError::Expected {
+                    expected: "term identifier".into(),
+                    found: format!("{other:?}"),
+                    line: t.line,
+                    col: t.col,
+                });
+            }
+        };
+        self.advance();
+        if matches!(self.peek().kind, TokenKind::LParen) {
+            self.advance();
+            let mut args = vec![self.parse_term()?];
+            while matches!(self.peek().kind, TokenKind::Comma) {
+                self.advance();
+                args.push(self.parse_term()?);
+            }
+            self.expect(|k| matches!(k, TokenKind::RParen), "`)`")?;
+            Ok(Term::Compound { functor: name, args })
+        } else {
+            Ok(Term::Atom(name))
+        }
+    }
+
+    fn parse_annotations(&mut self) -> Result<Vec<Annotation>, ParseError> {
+        let mut out = Vec::new();
+        loop {
+            match &self.peek().kind {
+                TokenKind::KwSource => {
+                    self.advance();
+                    let s = self.parse_string()?;
+                    out.push(Annotation::Source(s));
+                }
+                TokenKind::KwLocator => {
+                    self.advance();
+                    let s = self.parse_string()?;
+                    out.push(Annotation::Locator(s));
+                }
+                TokenKind::KwTrust => {
+                    self.advance();
+                    let tier = self.parse_trust_tier()?;
+                    out.push(Annotation::Trust(tier));
+                }
+                _ => break,
+            }
+        }
+        Ok(out)
+    }
+
+    fn parse_string(&mut self) -> Result<String, ParseError> {
+        let t = self.peek().clone();
+        match t.kind {
+            TokenKind::String(s) => {
+                self.advance();
+                Ok(s)
+            }
+            other => Err(ParseError::Expected {
+                expected: "string literal".into(),
+                found: format!("{other:?}"),
+                line: t.line,
+                col: t.col,
+            }),
+        }
+    }
+
+    fn parse_trust_tier(&mut self) -> Result<TrustTierName, ParseError> {
+        let t = self.peek().clone();
+        let tier = match t.kind {
+            TokenKind::KwConsensus => TrustTierName::Consensus,
+            TokenKind::KwAuthoritative => TrustTierName::Authoritative,
+            TokenKind::KwEmpirical => TrustTierName::Empirical,
+            TokenKind::KwInferred => TrustTierName::Inferred,
+            TokenKind::KwUnattributed => TrustTierName::Unattributed,
+            other => {
+                return Err(ParseError::Expected {
+                    expected: "trust tier (consensus / authoritative / empirical / inferred / unattributed)"
+                        .into(),
+                    found: format!("{other:?}"),
+                    line: t.line,
+                    col: t.col,
+                });
+            }
+        };
+        self.advance();
+        Ok(tier)
+    }
+}
+
+pub fn parse(tokens: &[Token]) -> Result<Program, ParseError> {
+    if tokens.is_empty() {
+        return Err(ParseError::UnexpectedEof);
+    }
+    Parser::new(tokens).parse_program()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::lex;
+
+    fn parse_src(src: &str) -> Result<Program, ParseError> {
+        let tokens = lex(src).unwrap();
+        parse(&tokens)
+    }
+
+    #[test]
+    fn parses_minimal_prior() {
+        let p = parse_src("prior 0.10 for acs").unwrap();
+        assert_eq!(p.statements.len(), 1);
+        assert!(matches!(
+            p.statements[0],
+            Statement::Prior { probability, .. } if probability == 0.10
+        ));
+    }
+
+    #[test]
+    fn parses_contributes_with_annotations() {
+        let src = r#"
+            contributes 1.5 from pmh(hypertension) to acs
+              source "HEART Score"
+              trust empirical
+        "#;
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Contributes { lr, evidence, conclusion, annotations } => {
+                assert_eq!(*lr, 1.5);
+                assert!(matches!(evidence, Term::Compound { functor, .. } if functor == "pmh"));
+                assert!(matches!(conclusion, Term::Atom(n) if n == "acs"));
+                assert_eq!(annotations.len(), 2);
+                assert!(matches!(annotations[0], Annotation::Source(_)));
+                assert!(matches!(annotations[1], Annotation::Trust(TrustTierName::Empirical)));
+            }
+            other => panic!("expected Contributes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_interacts_with_two_evidence_terms() {
+        let src = "interacts 1.3 when symptom_quality(pressure_like) and associated_symptom(diaphoresis) for acs";
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Interacts { evidence_set, .. } => {
+                assert_eq!(evidence_set.len(), 2);
+            }
+            other => panic!("expected Interacts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interacts_with_single_evidence_is_an_error() {
+        let src = "interacts 1.3 when pmh(htn) for acs";
+        let err = parse_src(src).unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::InteractNeedsAtLeastTwoEvidence { .. }
+        ));
+    }
+
+    #[test]
+    fn parses_observe_and_query() {
+        let src = "observe pmh(hypertension)\n? acs";
+        let p = parse_src(src).unwrap();
+        assert!(matches!(p.statements[0], Statement::Observe { .. }));
+        assert!(matches!(p.statements[1], Statement::Query { .. }));
+    }
+
+    #[test]
+    fn parses_multi_arg_compound_terms() {
+        let src = "observe relation(a, b, c)";
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Observe { term: Term::Compound { args, .. } } => {
+                assert_eq!(args.len(), 3);
+            }
+            other => panic!("expected compound term, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_full_acs_rulebook() {
+        // The smoke test for the language: the ACS rulebook from
+        // ADJ36 parses cleanly.
+        let src = r#"
+            prior 0.10 for acs
+              source "Pope JH et al., NEJM 1995"
+
+            contributes 1.5 from pmh(hypertension) to acs
+              source "HEART Score; Six 2008"
+              trust empirical
+
+            contributes 1.8 from pmh(smoker) to acs
+              source "HEART Score; Six 2008"
+
+            contributes 2.5 from symptom_quality(pressure_like) to acs
+              source "Panju AA et al., JAMA 1998"
+
+            contributes 2.0 from associated_symptom(diaphoresis) to acs
+              source "Panju AA et al., JAMA 1998"
+
+            contributes 0.5 from vital_signs(within_normal_limits) to acs
+              source "Panju 1998"
+
+            contributes 0.4 from denied(ecg_acute_st_changes) to acs
+              source "Pope 1995"
+
+            interacts 1.3 when symptom_quality(pressure_like)
+                           and associated_symptom(diaphoresis)
+                           for acs
+              source "[empirical] synergy"
+
+            observe pmh(hypertension)
+            observe pmh(smoker)
+            observe symptom_quality(pressure_like)
+            observe associated_symptom(diaphoresis)
+            observe vital_signs(within_normal_limits)
+            observe denied(ecg_acute_st_changes)
+
+            ? acs
+        "#;
+        let p = parse_src(src).unwrap();
+        // 1 prior + 6 contributes + 1 interacts + 6 observes + 1 query = 15
+        assert_eq!(p.statements.len(), 15);
+    }
+
+    #[test]
+    fn deeply_nested_compound_term_is_rejected_with_too_deeply_nested_error() {
+        // Build a synthetic source with MAX_TERM_DEPTH + 10 layers
+        // of f(f(...)) nesting. The parser should reject it
+        // gracefully instead of stack-overflowing.
+        let depth = MAX_TERM_DEPTH + 10;
+        let mut src = String::from("observe ");
+        for _ in 0..depth {
+            src.push_str("f(");
+        }
+        src.push('x');
+        for _ in 0..depth {
+            src.push(')');
+        }
+        let err = parse_src(&src).unwrap_err();
+        assert!(
+            matches!(err, ParseError::TooDeeplyNested { .. }),
+            "expected TooDeeplyNested, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn nesting_up_to_the_limit_is_still_accepted() {
+        // Just under the limit must still parse.
+        let depth = MAX_TERM_DEPTH - 1;
+        let mut src = String::from("observe ");
+        for _ in 0..depth {
+            src.push_str("f(");
+        }
+        src.push('x');
+        for _ in 0..depth {
+            src.push(')');
+        }
+        assert!(parse_src(&src).is_ok());
+    }
+
+    #[test]
+    fn missing_for_after_prior_is_an_error() {
+        let err = parse_src("prior 0.10 acs").unwrap_err();
+        match err {
+            ParseError::Expected { expected, .. } => {
+                assert!(expected.contains("for"));
+            }
+            other => panic!("expected Expected(for), got {other:?}"),
+        }
+    }
+}

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-06-02
+
+### Added
+
+- `provenance` module: `Provenance { source, locator, trust_tier }`
+  + `TrustTier { Consensus, Authoritative, Empirical, Inferred,
+  Unattributed }`. Designed so the common case is a one-liner —
+  `Provenance::cited("AHA 2021 §3.2")` — while still carrying enough
+  structure that an audit reader can sort or filter across clauses
+  by trust tier.
+- `PriorClause`, `ContributionClause`, `JointContributionClause`
+  each grow a `provenance: Provenance` field plus a
+  builder-style `.with_provenance(...)` method. Default is
+  `Provenance::unattributed()` so existing pre-ADJ47-B code
+  continues to construct clauses without any source-of-truth
+  ambiguity.
+- 5 new inline unit tests in `provenance.rs` covering trust-tier
+  ordering, locator builder-style threading, and the default.
+- 2 new integration tests in `tests/test_lr_aggregation.rs`:
+  `provenance_is_recoverable_from_kb_after_aggregation` (the
+  contract: clauses carry citations and the audit reader recovers
+  them via the clause id from the proof DAG, no side-table) and
+  `unattributed_provenance_is_the_default` (legacy compatibility).
+
+Total tests: 59 (was 52 in 0.3.0).
+
+### ADJ46 awkwardness items dissolved by 0.4.0
+
+- **A2** (provenance is not a clause field) — fully addressed.
+  Clauses now carry citations; the proof DAG references them by
+  clause id; no side-table required.
+
+### Scope notes
+
+What 0.4.0 still does NOT ship: A4 (joint as syntactically
+distinct from atomic in the *surface* syntax — semantically the
+engine already distinguishes them), A5 (uncertainty markers), A7
+(kickback search variant), A8 (counterfactuals), A9 (source-
+disagreement aggregation, though `Provenance` is the prerequisite
+data structure), A10 (surface syntax) — all language-layer.
+
 ## [0.3.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -35,6 +35,7 @@
 pub mod enumerate;
 pub mod lr_aggregate;
 pub mod proof_dag;
+pub mod provenance;
 pub mod wmc;
 
 use std::collections::HashMap;
@@ -47,6 +48,7 @@ pub use lr_aggregate::{
     LRAggregateResult, LrAggregateWarning, PriorClause,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
+pub use provenance::{Provenance, TrustTier};
 pub use wmc::weighted_model_count;
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -38,6 +38,7 @@ use logic_core::{Substitution, Term};
 
 use crate::{
     ContributionClauseId, FactId, JointContributionClauseId, KnowledgeBase, PriorClauseId,
+    Provenance,
 };
 use crate::proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 
@@ -65,13 +66,18 @@ pub struct PriorClause {
     pub id: PriorClauseId,
     pub conclusion: Term,
     pub prior_logit: f64,
+    /// LP19e + ADJ47-B: citation for this prior. Default is
+    /// [`Provenance::unattributed`] when constructed via
+    /// `PriorClause::new` / `from_probability`; use
+    /// [`PriorClause::with_provenance`] to attach a citation.
+    pub provenance: Provenance,
 }
 
 impl PriorClause {
-    /// Construct a prior with an explicit log-odds value. The `id` is
-    /// a sentinel `PriorClauseId(u64::MAX)` that
-    /// [`KnowledgeBase::add_prior`] overwrites on insert. This mirrors
-    /// the `Fact::certain` / `Rule::certain` pattern in
+    /// Construct a prior with an explicit log-odds value, no
+    /// provenance. The `id` is a sentinel `PriorClauseId(u64::MAX)`
+    /// that [`KnowledgeBase::add_prior`] overwrites on insert. This
+    /// mirrors the `Fact::certain` / `Rule::certain` pattern in
     /// [`crate::lib`] so that all clause types behave identically at
     /// construction time.
     pub fn new(conclusion: Term, prior_logit: f64) -> Self {
@@ -79,6 +85,7 @@ impl PriorClause {
             id: PriorClauseId(u64::MAX),
             conclusion,
             prior_logit,
+            provenance: Provenance::unattributed(),
         }
     }
 
@@ -92,6 +99,21 @@ impl PriorClause {
             "PriorClause::from_probability requires p ∈ (0.0, 1.0); got {p}"
         );
         Self::new(conclusion, (p / (1.0 - p)).ln())
+    }
+
+    /// Builder-style: attach a citation. Returns a new value with
+    /// `provenance` set, leaving the original unchanged.
+    ///
+    /// Idiomatic usage:
+    /// ```ignore
+    /// kb.add_prior(
+    ///     PriorClause::from_probability(atom("acs"), 0.10)
+    ///         .with_provenance(Provenance::cited("Pope JH et al., NEJM 1995;342(16):1163-70"))
+    /// )?;
+    /// ```
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = provenance;
+        self
     }
 }
 
@@ -109,16 +131,20 @@ pub struct ContributionClause {
     pub conclusion: Term,
     pub evidence_term: Term,
     pub logit_delta: f64,
+    /// LP19e + ADJ47-B: citation for this contribution.
+    pub provenance: Provenance,
 }
 
 impl ContributionClause {
-    /// Construct a contribution with an explicit log(LR) value.
+    /// Construct a contribution with an explicit log(LR) value and
+    /// unattributed provenance.
     pub fn new(conclusion: Term, evidence_term: Term, logit_delta: f64) -> Self {
         Self {
             id: ContributionClauseId(u64::MAX),
             conclusion,
             evidence_term,
             logit_delta,
+            provenance: Provenance::unattributed(),
         }
     }
 
@@ -131,6 +157,12 @@ impl ContributionClause {
             "ContributionClause::from_lr requires lr > 0.0; got {lr}"
         );
         Self::new(conclusion, evidence_term, lr.ln())
+    }
+
+    /// Builder-style: attach a citation.
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = provenance;
+        self
     }
 }
 
@@ -148,16 +180,20 @@ pub struct JointContributionClause {
     pub conclusion: Term,
     pub evidence_set: Vec<Term>,
     pub joint_logit_delta: f64,
+    /// LP19e + ADJ47-B: citation for this joint contribution.
+    pub provenance: Provenance,
 }
 
 impl JointContributionClause {
-    /// Construct a joint contribution with explicit log(joint LR).
+    /// Construct a joint contribution with explicit log(joint LR)
+    /// and unattributed provenance.
     pub fn new(conclusion: Term, evidence_set: Vec<Term>, joint_logit_delta: f64) -> Self {
         Self {
             id: JointContributionClauseId(u64::MAX),
             conclusion,
             evidence_set,
             joint_logit_delta,
+            provenance: Provenance::unattributed(),
         }
     }
 
@@ -169,6 +205,12 @@ impl JointContributionClause {
             "JointContributionClause::from_lr requires joint_lr > 0.0; got {joint_lr}"
         );
         Self::new(conclusion, evidence_set, joint_lr.ln())
+    }
+
+    /// Builder-style: attach a citation.
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = provenance;
+        self
     }
 }
 

--- a/code/packages/rust/logic-engine/src/provenance.rs
+++ b/code/packages/rust/logic-engine/src/provenance.rs
@@ -1,0 +1,180 @@
+//! # Provenance — first-class citations for every clause.
+//!
+//! Addresses ADJ46 awkwardness item **A2**: "Provenance is not a
+//! clause field." Each prior, contribution, and joint contribution
+//! now carries a [`Provenance`] value that names the authority the
+//! clause is grounded in. The proof DAG threads this through every
+//! step's [`crate::DerivationOrigin`] so an audit-trail consumer can
+//! print, for every contribution that fired, the exact citation it
+//! came from — without consulting a side-table.
+//!
+//! The shape is intentionally small. ADJ44's recursive-rulebook
+//! derivation produces a richer object; this is the minimum the
+//! engine needs to be able to *cite* a clause back to its origin.
+//! Richer provenance (recursion depth, derivation tree, content-match
+//! verification status) lives at the rulebook-acquisition layer and
+//! is referenced from here by `source` + `locator`.
+
+/// Citation + trust signal for a single clause.
+///
+/// Designed so the common case is a one-liner — `Provenance::cited("AHA 2021
+/// chest-pain guideline §3.2")` — while still carrying enough
+/// structure that an audit reader can sort, filter, and aggregate
+/// across clauses by trust tier.
+///
+/// `Provenance::unattributed()` is the explicit sentinel for "this
+/// clause has no citation." It is preserved as a value rather than
+/// `None` so the audit trail can distinguish "no one bothered to
+/// attribute" from "the modeller explicitly committed to a fact
+/// without external grounding" at proof-display time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Provenance {
+    /// Human-readable citation. Typically a journal reference, a
+    /// guideline name + year, a statute, a clinical trial id, etc.
+    /// Empty string only when `trust_tier == TrustTier::Unattributed`.
+    pub source: String,
+    /// Optional locator within the source — page, section, paragraph,
+    /// figure number, court-opinion page-line.
+    pub locator: Option<String>,
+    /// How much weight a reviewer should place on this clause.
+    pub trust_tier: TrustTier,
+}
+
+/// A coarse trust-tier rank. The variants are ordered from highest
+/// (consensus across multiple authoritative sources) to lowest
+/// (modeller intuition with no external grounding).
+///
+/// `Eq + Ord` is derived deliberately: tools that aggregate proofs
+/// can sort by trust tier without re-implementing the ordering, and
+/// the order in the source determines the order — `Consensus <
+/// Authoritative < Empirical < Inferred < Unattributed` by `PartialOrd`,
+/// which corresponds to "more trustworthy is smaller" so a min-tier
+/// reduction picks the strongest provenance in a proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum TrustTier {
+    /// Multi-society / cross-authority consensus. E.g. AHA + ESC
+    /// + ACC agreeing on a treatment recommendation.
+    Consensus,
+    /// Single authoritative source — a guideline, a statute, a
+    /// peer-reviewed meta-analysis. The "default reasonable" tier
+    /// for most clauses.
+    Authoritative,
+    /// Cohort study, case series, retrospective analysis. Lower
+    /// power than `Authoritative` but still empirically grounded.
+    Empirical,
+    /// Derived by an LLM or by a knowledge engineer from training
+    /// data, not from an external citation. ADJ44's recursive
+    /// rulebook derivation marks rules at this tier when no
+    /// external authority has been resolved.
+    Inferred,
+    /// No citation. The clause is asserted by the modeller without
+    /// external grounding. Distinct from "citation not yet
+    /// recorded" — the modeller explicitly committed to no source.
+    Unattributed,
+}
+
+impl Provenance {
+    /// Construct a `Provenance` with all three fields explicit.
+    pub fn new(
+        source: impl Into<String>,
+        locator: Option<String>,
+        trust_tier: TrustTier,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            locator,
+            trust_tier,
+        }
+    }
+
+    /// The common case: a single-line citation at
+    /// [`TrustTier::Authoritative`]. Used for the bulk of
+    /// guideline-derived clauses.
+    pub fn cited(source: impl Into<String>) -> Self {
+        Self::new(source, None, TrustTier::Authoritative)
+    }
+
+    /// A citation at consensus tier.
+    pub fn consensus(source: impl Into<String>) -> Self {
+        Self::new(source, None, TrustTier::Consensus)
+    }
+
+    /// Empirical observation; the bulk of LR magnitudes in the
+    /// HEART-score / Panju 1998 literature land here.
+    pub fn empirical(source: impl Into<String>) -> Self {
+        Self::new(source, None, TrustTier::Empirical)
+    }
+
+    /// No external grounding. Use this when adapting a rulebook
+    /// from a non-citing source or when the modeller is explicitly
+    /// committing to a fact on their own authority.
+    pub fn unattributed() -> Self {
+        Self::new(String::new(), None, TrustTier::Unattributed)
+    }
+
+    /// Convenience: attach a locator to an existing provenance.
+    /// Returns a new value, leaves the receiver unchanged.
+    pub fn with_locator(mut self, locator: impl Into<String>) -> Self {
+        self.locator = Some(locator.into());
+        self
+    }
+}
+
+impl Default for Provenance {
+    /// The default is [`Provenance::unattributed`], not a panic.
+    /// Defaulting to "no citation" is the right behaviour for tests
+    /// and small examples where citing every clause would be noise;
+    /// real rulebooks should set this explicitly via the constructor.
+    fn default() -> Self {
+        Self::unattributed()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cited_lands_at_authoritative_tier() {
+        let p = Provenance::cited("AHA 2021 chest-pain guideline");
+        assert_eq!(p.trust_tier, TrustTier::Authoritative);
+        assert!(p.locator.is_none());
+        assert_eq!(p.source, "AHA 2021 chest-pain guideline");
+    }
+
+    #[test]
+    fn unattributed_has_empty_source() {
+        let p = Provenance::unattributed();
+        assert_eq!(p.trust_tier, TrustTier::Unattributed);
+        assert!(p.source.is_empty());
+    }
+
+    #[test]
+    fn trust_tier_ord_puts_consensus_lowest_value() {
+        // "Lower variant => stronger trust" is the convention so
+        // that min(...) over a proof's contributions picks the
+        // strongest provenance in evidence.
+        assert!(TrustTier::Consensus < TrustTier::Authoritative);
+        assert!(TrustTier::Authoritative < TrustTier::Empirical);
+        assert!(TrustTier::Empirical < TrustTier::Inferred);
+        assert!(TrustTier::Inferred < TrustTier::Unattributed);
+    }
+
+    #[test]
+    fn with_locator_threads_immutably() {
+        let p = Provenance::cited("ACOG bulletin").with_locator("§4.2");
+        assert_eq!(p.locator.as_deref(), Some("§4.2"));
+        // Original `cited` still has no locator if reused:
+        let q = Provenance::cited("ACOG bulletin");
+        assert!(q.locator.is_none());
+    }
+
+    #[test]
+    fn default_is_unattributed() {
+        assert_eq!(Provenance::default(), Provenance::unattributed());
+    }
+}

--- a/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
+++ b/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
@@ -6,7 +6,7 @@
 use logic_core::{atom, compound, Term};
 use logic_engine::{
     search, ContributionClause, Fact, JointContributionClause, KnowledgeBase, LrAggregateWarning,
-    PriorClause, SearchMode, SearchResult,
+    PriorClause, Provenance, SearchMode, SearchResult, TrustTier,
 };
 
 fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
@@ -274,6 +274,82 @@ fn term_equality_on_compounds_works_for_contribution_lookup() {
     } else {
         panic!("expected LRAggregateResult");
     }
+}
+
+#[test]
+fn provenance_is_recoverable_from_kb_after_aggregation() {
+    // Build a tiny rulebook with citations on every clause, run LR
+    // aggregation, and confirm that for every step in the proof we
+    // can recover the citation by joining the step's clause id back
+    // to the KB. This is the ADJ47-B contract: clauses carry
+    // provenance, and the audit reader recovers it without a
+    // side-table.
+    use logic_engine::DerivationOrigin;
+
+    let mut kb = KnowledgeBase::new();
+    let prior_id = kb
+        .add_prior(
+            PriorClause::from_probability(atom("acs"), 0.10)
+                .with_provenance(Provenance::cited(
+                    "Pope JH et al., NEJM 1995;342(16):1163-70",
+                )),
+        )
+        .unwrap();
+    let contrib_id = kb.add_contribution(
+        ContributionClause::from_lr(
+            atom("acs"),
+            compound("pmh", vec![atom("hypertension")]),
+            1.5,
+        )
+        .with_provenance(
+            Provenance::empirical("HEART Score; Six AJ et al., Neth Heart J 2008;16(6):191-6")
+                .with_locator("Table 2"),
+        ),
+    );
+    kb.add_fact(Fact::certain(compound("pmh", vec![atom("hypertension")])));
+
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let dag = if let SearchResult::LRAggregateResult { dag, .. } = result {
+        dag
+    } else {
+        panic!("expected LRAggregateResult")
+    };
+    let proof = &dag.proofs[0];
+
+    // For each step, recover the provenance via the clause id.
+    for step in &proof.steps {
+        match &step.origin {
+            DerivationOrigin::FromPrior { clause_id, .. } => {
+                assert_eq!(*clause_id, prior_id);
+                let p = kb.prior_for(&atom("acs")).unwrap();
+                assert_eq!(p.provenance.trust_tier, TrustTier::Authoritative);
+                assert_eq!(p.provenance.source, "Pope JH et al., NEJM 1995;342(16):1163-70");
+            }
+            DerivationOrigin::FromContribution { clause_id, .. } => {
+                assert_eq!(*clause_id, contrib_id);
+                let contribs = kb.contributions_for(&atom("acs"));
+                let c = contribs.iter().find(|c| c.id == contrib_id).unwrap();
+                assert_eq!(c.provenance.trust_tier, TrustTier::Empirical);
+                assert!(c.provenance.source.contains("HEART"));
+                assert_eq!(c.provenance.locator.as_deref(), Some("Table 2"));
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn unattributed_provenance_is_the_default() {
+    // Clauses constructed without `.with_provenance(...)` should
+    // round-trip with Provenance::unattributed(). This is the
+    // legacy-compatible behaviour: pre-ADJ47-B code that doesn't
+    // know about provenance keeps working.
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("acs"), 0.10))
+        .unwrap();
+    let prior = kb.prior_for(&atom("acs")).unwrap();
+    assert_eq!(prior.provenance, Provenance::unattributed());
+    assert_eq!(prior.provenance.trust_tier, TrustTier::Unattributed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **New crate \`adj-lang\`**: hand-written lexer + recursive-descent parser + AST + lowering pass for a probabilistic-logic rulebook DSL. Compiles directly to a \`logic-engine\` \`KnowledgeBase\`.
- The ACS rulebook is now ~30 lines of readable English instead of ~390 lines of Rust (ADJ46 baseline).
- 26 tests, all green. Headline: \`lowers_full_acs_rulebook_and_reproduces_adj36_posterior\` compiles + searches + reproduces ADJ36's 28.1% posterior end-to-end.
- Stacked on **#4928** (ADJ47-B).

## Surface syntax (v0.1)

\`\`\`adj
prior 0.10 for acs
  source \"Pope JH et al., NEJM 1995\"

contributes 1.5 from pmh(hypertension) to acs
  source \"HEART Score; Six 2008\"
  trust empirical

interacts 1.3 when symptom_quality(pressure_like)
               and associated_symptom(diaphoresis)
               for acs

observe pmh(hypertension)
? acs
\`\`\`

## Awkwardness dissolved

| | |
|---|---|
| **A4** | \`interacts\` syntactically distinct from \`contributes\` |
| **A10** | rulebook surface is no longer hand-written Rust |

## Security

Initial security review flagged a HIGH-severity stack-overflow DoS in \`parse_term\` (unbounded recursion on \`f(f(f(...)))\`-style adversarial input). Fixed: depth counter (cap \`MAX_TERM_DEPTH = 256\`) with rejection test \`deeply_nested_compound_term_is_rejected_with_too_deeply_nested_error\` and acceptance test \`nesting_up_to_the_limit_is_still_accepted\`. Re-reviewed; clean.

## Test plan

- [x] \`cargo build -p adj-lang\` clean
- [x] \`cargo test -p adj-lang\` — 26 tests passing
- [x] Workspace integration: \`code/packages/rust/Cargo.toml\` lists \`adj-lang\` in \`members\`
- [x] BUILD file + required_capabilities.json present per repo convention
- [x] Security review: passed after depth-guard fix

## Next

- **ADJ47-D**: uncertainty markers (A5) — the most impactful remaining language item.
- **ADJ47-E**: kickback (A7), counterfactuals (A8), source disagreement (A9).
- **ADJ48**: full MYCIN-2026 demo in Adj-Lang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)