### PR TITLE
feat(logic-engine, adj-lang): uncertainty markers + VOI — dissolves ADJ46 A5

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- New `uncertain { e1, e2, ... } for <conclusion>` statement,
+  lowering to `logic_engine::UncertaintyMarker`. Accepts the
+  standard `source`/`locator`/`trust` annotations.
+- New lexer tokens: `KwUncertain`, `LBrace`, `RBrace`.
+- 2 new parser tests (basic + annotated forms), 1 new lower test
+  (`uncertain_statement_produces_voi_report_on_aggregation`
+  confirms end-to-end: surface syntax compiles, runs through
+  `SearchMode::LRAggregate`, and produces a non-empty
+  `uncertainties` vector with the right VOI logit range).
+
+Total tests: 29 (was 26 in 0.1.0).
+
+### ADJ46 awkwardness items dissolved by 0.2.0
+
+- **A5** (uncertainty markers) — fully addressed at the surface
+  layer. The IR pipeline can now hand off "no clear precipitator"
+  as a structured `uncertain { … } for …` clause, and the engine
+  surfaces it back to the user as a VOI report.
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -49,6 +49,16 @@ pub enum Statement {
     Observe { term: Term },
     /// `? <conclusion>` — query the engine for the posterior.
     Query { conclusion: Term },
+    /// `uncertain { <e1>, <e2>, ... } for <conclusion>` — annotate
+    /// the conclusion with a domain of candidate evidence terms,
+    /// none of which has been observed. The LR aggregator surfaces
+    /// a VOI report listing what each value would contribute.
+    /// Dissolves ADJ46 awkwardness item A5.
+    Uncertain {
+        domain: Vec<Term>,
+        conclusion: Term,
+        annotations: Vec<Annotation>,
+    },
 }
 
 /// Per-statement annotation. Multiple annotations per statement

--- a/code/packages/rust/adj-lang/src/lexer.rs
+++ b/code/packages/rust/adj-lang/src/lexer.rs
@@ -41,6 +41,11 @@ pub enum TokenKind {
     KwWhen,
     KwAnd,
     KwObserve,
+    /// ADJ47-D: `uncertain {a, b, c} for conclusion` — annotates a
+    /// conclusion with a domain of candidate evidence values none of
+    /// which has been observed. The LR aggregator surfaces a VOI
+    /// report listing what each value would contribute if learned.
+    KwUncertain,
     KwSource,
     KwTrust,
     KwLocator,
@@ -52,6 +57,10 @@ pub enum TokenKind {
     // Punctuation
     LParen,
     RParen,
+    /// `{` — opens the domain set in `uncertain {…}`.
+    LBrace,
+    /// `}` — closes the domain set.
+    RBrace,
     Comma,
     Question,
     // Literals
@@ -104,6 +113,16 @@ pub fn lex(src: &str) -> Result<Vec<Token>, LexError> {
             }
             ')' => {
                 tokens.push(Token { kind: TokenKind::RParen, line, col });
+                chars.next();
+                col += 1;
+            }
+            '{' => {
+                tokens.push(Token { kind: TokenKind::LBrace, line, col });
+                chars.next();
+                col += 1;
+            }
+            '}' => {
+                tokens.push(Token { kind: TokenKind::RBrace, line, col });
                 chars.next();
                 col += 1;
             }
@@ -240,6 +259,7 @@ fn keyword_or_ident(s: &str) -> TokenKind {
         "when" => TokenKind::KwWhen,
         "and" => TokenKind::KwAnd,
         "observe" => TokenKind::KwObserve,
+        "uncertain" => TokenKind::KwUncertain,
         "source" => TokenKind::KwSource,
         "trust" => TokenKind::KwTrust,
         "locator" => TokenKind::KwLocator,

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -22,7 +22,7 @@
 use logic_core::{atom as core_atom, compound, Term as CoreTerm};
 use logic_engine::{
     ContributionClause, Fact, JointContributionClause, KbError, KnowledgeBase, PriorClause,
-    Provenance, TrustTier,
+    Provenance, TrustTier, UncertaintyMarker,
 };
 
 use crate::ast::{Annotation, Program, Statement, Term as AstTerm, TrustTierName};
@@ -99,6 +99,19 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             }
             Statement::Query { conclusion } => {
                 queries.push(lower_term(conclusion));
+            }
+            Statement::Uncertain {
+                domain,
+                conclusion,
+                annotations,
+            } => {
+                let prov = annotations_to_provenance(annotations)?;
+                let marker = UncertaintyMarker::new(
+                    lower_term(conclusion),
+                    domain.iter().map(lower_term).collect(),
+                )
+                .with_provenance(prov);
+                kb.add_uncertainty_marker(marker);
             }
         }
     }
@@ -285,6 +298,49 @@ mod tests {
         let src = "observe pmh(hypertension)";
         let lowered = compile(src).unwrap();
         assert_eq!(lowered.queries.len(), 0);
+    }
+
+    #[test]
+    fn uncertain_statement_produces_voi_report_on_aggregation() {
+        // The ACS rulebook with a `uncertain {…}` clause for the
+        // precipitator, no precipitator observation. The aggregator
+        // should return a VOI report listing the three candidate
+        // values and the maximum log-odds swing knowing one of
+        // them would produce.
+        let src = r#"
+            prior 0.10 for acs
+
+            contributes 1.5 from pmh(hypertension) to acs
+            contributes 2.5 from precipitator(exertional) to acs
+            contributes 0.6 from precipitator(rest) to acs
+            contributes 0.8 from precipitator(positional) to acs
+
+            observe pmh(hypertension)
+
+            uncertain { precipitator(exertional),
+                        precipitator(rest),
+                        precipitator(positional) } for acs
+              source "patient did not specify"
+
+            ? acs
+        "#;
+        let lowered = compile(src).unwrap();
+        let query = &lowered.queries[0];
+        let result = search(query, &lowered.kb, SearchMode::LRAggregate);
+        match result {
+            SearchResult::LRAggregateResult { uncertainties, .. } => {
+                assert_eq!(uncertainties.len(), 1);
+                let report = &uncertainties[0];
+                assert_eq!(report.domain.len(), 3);
+                // VOI = ln(2.5) - ln(0.6) ≈ 1.4271
+                assert!(
+                    (report.voi_logit_range - (2.5_f64.ln() - 0.6_f64.ln())).abs() < 1e-9,
+                    "got VOI {}",
+                    report.voi_logit_range
+                );
+            }
+            other => panic!("expected LRAggregateResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/code/packages/rust/adj-lang/src/parser.rs
+++ b/code/packages/rust/adj-lang/src/parser.rs
@@ -133,11 +133,12 @@ impl<'a> Parser<'a> {
             TokenKind::KwContributes => self.parse_contributes(),
             TokenKind::KwInteracts => self.parse_interacts(),
             TokenKind::KwObserve => self.parse_observe(),
+            TokenKind::KwUncertain => self.parse_uncertain(),
             TokenKind::Question => self.parse_query(),
             other => {
                 let t = self.peek();
                 Err(ParseError::Expected {
-                    expected: "statement keyword (prior, contributes, interacts, observe, ?)"
+                    expected: "statement keyword (prior, contributes, interacts, observe, uncertain, ?)"
                         .into(),
                     found: format!("{other:?}"),
                     line: t.line,
@@ -211,6 +212,25 @@ impl<'a> Parser<'a> {
         self.expect(|k| matches!(k, TokenKind::Question), "`?`")?;
         let conclusion = self.parse_term()?;
         Ok(Statement::Query { conclusion })
+    }
+
+    fn parse_uncertain(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::KwUncertain), "`uncertain`")?;
+        self.expect(|k| matches!(k, TokenKind::LBrace), "`{`")?;
+        let mut domain = vec![self.parse_term()?];
+        while matches!(self.peek().kind, TokenKind::Comma) {
+            self.advance();
+            domain.push(self.parse_term()?);
+        }
+        self.expect(|k| matches!(k, TokenKind::RBrace), "`}`")?;
+        self.expect(|k| matches!(k, TokenKind::KwFor), "`for`")?;
+        let conclusion = self.parse_term()?;
+        let annotations = self.parse_annotations()?;
+        Ok(Statement::Uncertain {
+            domain,
+            conclusion,
+            annotations,
+        })
     }
 
     fn parse_number(&mut self) -> Result<f64, ParseError> {
@@ -484,6 +504,36 @@ mod tests {
         let p = parse_src(src).unwrap();
         // 1 prior + 6 contributes + 1 interacts + 6 observes + 1 query = 15
         assert_eq!(p.statements.len(), 15);
+    }
+
+    #[test]
+    fn parses_uncertain_with_domain_set() {
+        let src = "uncertain { precipitator(exertional), precipitator(rest), precipitator(positional) } for acs";
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Uncertain {
+                domain, conclusion, ..
+            } => {
+                assert_eq!(domain.len(), 3);
+                assert!(matches!(conclusion, Term::Atom(n) if n == "acs"));
+            }
+            other => panic!("expected Uncertain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_uncertain_with_source_annotation() {
+        let src = r#"
+            uncertain { a, b } for c
+              source "patient declined to answer"
+        "#;
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Uncertain { annotations, .. } => {
+                assert_eq!(annotations.len(), 1);
+            }
+            other => panic!("expected Uncertain, got {other:?}"),
+        }
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-06-02
+
+### Added
+
+- `UncertaintyMarker` clause type + `UncertaintyMarkerId`. Attached
+  to a conclusion with a `domain: Vec<Term>` of candidate evidence
+  terms. Represents "the IR pipeline knows the conclusion is the
+  target of an LR query, and knows the patient (or source) did not
+  specify one of these candidate values."
+- `UncertaintyReport` — the user-facing VOI summary the engine
+  emits when a marker's domain is entirely unobserved. Contains the
+  domain, the log-odds delta each value would have contributed if
+  observed, and a v0.1 VOI proxy (`voi_logit_range` = max − min of
+  the deltas). The framework's user-facing layer can rank these to
+  produce "if you can determine X, the posterior could swing by up
+  to Y" guidance.
+- `LRAggregateResult.uncertainties: Vec<UncertaintyReport>` +
+  `SearchResult::LRAggregateResult { ..., uncertainties }`.
+- `KnowledgeBase::add_uncertainty_marker` /
+  `uncertainty_markers_for`. Markers do not promote a query to
+  LR-aggregation — they're only meaningful relative to contribution
+  clauses already on the conclusion.
+- 3 new integration tests in `tests/test_lr_aggregation.rs`:
+  uncertainty report with no observation shows full domain + VOI,
+  one-domain-observation suppresses the report, marker over a
+  domain with no matching contributions has zero VOI but still
+  appears in the report.
+
+Total tests: 62 (was 59 in 0.4.0).
+
+### ADJ46 awkwardness items dissolved by 0.5.0
+
+- **A5** — uncertainty markers at the engine layer.
+  `add_uncertainty_marker` + `UncertaintyReport` give the IR
+  pipeline a way to losslessly hand off "the patient said nothing
+  about X over this domain" to the executor, and give the audit
+  reader a concrete VOI signal to act on.
+
+### Scope notes
+
+- VOI is the v0.1 proxy (max − min over candidate log-odds deltas)
+  — not the formal Bayesian decision-theoretic VOI. A richer
+  treatment that combines the candidate deltas with the prior over
+  the domain (and with the user's decision threshold, if any) is a
+  follow-up.
+- Still pending: A7 (kickback variant), A8 (counterfactuals), A9
+  (multi-source aggregation), and the surface-layer half of A5
+  (the `uncertain { ... } for ...` keyword — that ships in
+  `adj-lang` 0.2.0 simultaneously).
+
 ## [0.4.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -45,7 +45,8 @@ use logic_core::{LogicVar, Substitution, Term, unify};
 pub use enumerate::enumerate_all;
 pub use lr_aggregate::{
     lr_aggregate, sigmoid, ContributionClause, JointContributionClause, KbError,
-    LRAggregateResult, LrAggregateWarning, PriorClause,
+    LRAggregateResult, LrAggregateWarning, PriorClause, UncertaintyMarker,
+    UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 pub use provenance::{Provenance, TrustTier};
@@ -79,6 +80,20 @@ pub struct ContributionClauseId(pub u64);
 /// Stable identifier for a [`JointContributionClause`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct JointContributionClauseId(pub u64);
+
+/// Stable identifier for an
+/// [`UncertaintyMarker`](crate::lr_aggregate::UncertaintyMarker).
+///
+/// LP19e + ADJ47-D: uncertainty markers are the engine-layer
+/// representation of "the patient (or the source) did not specify
+/// this value, but we know the domain it ranges over." The
+/// LR-aggregation result surfaces an
+/// [`UncertaintyReport`](crate::lr_aggregate::UncertaintyReport) for
+/// every active marker whose domain has zero observed members — so
+/// the audit reader can see *what would shift the answer* without
+/// having to look it up themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct UncertaintyMarkerId(pub u64);
 
 /// Probability annotation on a clause.
 ///
@@ -242,11 +257,18 @@ pub struct KnowledgeBase {
     priors: Vec<PriorClause>,
     contributions: Vec<ContributionClause>,
     joint_contributions: Vec<JointContributionClause>,
+    /// LP19e + ADJ47-D: uncertainty markers attached to conclusions.
+    /// Each marker carries a domain of candidate evidence terms; if
+    /// none of them is observed, the aggregator emits an
+    /// [`UncertaintyReport`] in the result so the audit reader sees
+    /// what's missing.
+    uncertainty_markers: Vec<UncertaintyMarker>,
     next_fact_id: u64,
     next_rule_id: u64,
     next_prior_id: u64,
     next_contribution_id: u64,
     next_joint_contribution_id: u64,
+    next_uncertainty_marker_id: u64,
 }
 
 impl KnowledgeBase {
@@ -392,7 +414,10 @@ impl KnowledgeBase {
 
     /// True iff at least one contribution (single or joint) names
     /// `conclusion`. This is the discriminator that `AutoDetect` uses
-    /// to route to LR aggregation rather than SLD / WMC.
+    /// to route to LR aggregation rather than SLD / WMC. Uncertainty
+    /// markers alone do not promote a query to LR-aggregation —
+    /// they're meaningful only relative to contribution clauses,
+    /// because they describe domain gaps inside an LR-shape query.
     pub fn participates_in_lr_aggregation(&self, conclusion: &Term) -> bool {
         self.contributions
             .iter()
@@ -401,6 +426,27 @@ impl KnowledgeBase {
                 .joint_contributions
                 .iter()
                 .any(|c| &c.conclusion == conclusion)
+    }
+
+    /// Insert an [`UncertaintyMarker`], assigning a fresh
+    /// [`UncertaintyMarkerId`].
+    pub fn add_uncertainty_marker(
+        &mut self,
+        mut marker: UncertaintyMarker,
+    ) -> UncertaintyMarkerId {
+        let id = UncertaintyMarkerId(self.next_uncertainty_marker_id);
+        self.next_uncertainty_marker_id += 1;
+        marker.id = id;
+        self.uncertainty_markers.push(marker);
+        id
+    }
+
+    /// Iterate the uncertainty markers attached to `conclusion`.
+    pub fn uncertainty_markers_for(&self, conclusion: &Term) -> Vec<&UncertaintyMarker> {
+        self.uncertainty_markers
+            .iter()
+            .filter(|m| &m.conclusion == conclusion)
+            .collect()
     }
 
     /// LP19e "observation gate." If `evidence_term` is asserted in
@@ -484,6 +530,10 @@ pub enum SearchResult {
         posterior: f64,
         posterior_logit: f64,
         warnings: Vec<LrAggregateWarning>,
+        /// Active uncertainty reports — one per
+        /// [`UncertaintyMarker`] on the query whose domain is
+        /// entirely unobserved. Empty in the common case.
+        uncertainties: Vec<UncertaintyReport>,
     },
 }
 
@@ -526,6 +576,7 @@ pub fn search(query: &Term, kb: &KnowledgeBase, mode: SearchMode) -> SearchResul
                 posterior: result.posterior,
                 posterior_logit: result.posterior_logit,
                 warnings: result.warnings,
+                uncertainties: result.uncertainties,
             }
         }
         // AutoDetect was rewritten above.

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -38,7 +38,7 @@ use logic_core::{Substitution, Term};
 
 use crate::{
     ContributionClauseId, FactId, JointContributionClauseId, KnowledgeBase, PriorClauseId,
-    Provenance,
+    Provenance, UncertaintyMarkerId,
 };
 use crate::proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 
@@ -215,6 +215,79 @@ impl JointContributionClause {
 }
 
 // ---------------------------------------------------------------------------
+// Uncertainty markers — ADJ47-D, addresses ADJ46 awkwardness A5
+// ---------------------------------------------------------------------------
+
+/// An explicit "we don't know which value of X applies here" annotation.
+///
+/// Dissolves ADJ46 awkwardness item **A5**. When a patient case
+/// says "no clear precipitator," the IR pipeline lowers it to an
+/// `UncertaintyMarker` whose `domain` is the candidate precipitator
+/// terms. The aggregator detects markers whose domain is entirely
+/// unobserved and emits an [`UncertaintyReport`] in the result, so
+/// the framework's user-facing output can say "if you can determine
+/// the precipitator, the posterior could shift by up to X."
+///
+/// This is the engine-layer enabler of VOI (ADJ18). The full VOI
+/// computation lives in [`LRAggregateResult::uncertainties`], which
+/// the user-facing layer can rank, render, or act on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UncertaintyMarker {
+    pub id: UncertaintyMarkerId,
+    pub conclusion: Term,
+    /// Candidate evidence terms. Treated as mutually exclusive in
+    /// v0.1: the aggregator computes the maximum log-odds swing
+    /// across the domain, not the expected posterior under a prior
+    /// over the domain. Richer treatment is a follow-up.
+    pub domain: Vec<Term>,
+    pub provenance: Provenance,
+}
+
+impl UncertaintyMarker {
+    pub fn new(conclusion: Term, domain: Vec<Term>) -> Self {
+        Self {
+            id: UncertaintyMarkerId(u64::MAX),
+            conclusion,
+            domain,
+            provenance: Provenance::unattributed(),
+        }
+    }
+
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = provenance;
+        self
+    }
+}
+
+/// A user-facing report on an active uncertainty in the
+/// LR-aggregation result.
+///
+/// Active means: the marker's domain has zero observed evidence
+/// terms in the KB, so the aggregator skipped every related
+/// contribution. The report tells the audit reader what each domain
+/// value would have contributed if observed, plus the VOI summary
+/// — the log-odds range that resolving the uncertainty could
+/// produce.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UncertaintyReport {
+    pub marker_id: UncertaintyMarkerId,
+    pub conclusion: Term,
+    pub domain: Vec<Term>,
+    /// One entry per domain term, in `domain` order. The f64 is the
+    /// log(LR) that would be added to the running log-odds if that
+    /// particular value were observed. `0.0` when no
+    /// [`ContributionClause`] names the (conclusion, value) pair —
+    /// i.e. the rulebook covers the uncertainty marker but not the
+    /// individual value, which is a modeller signal worth surfacing.
+    pub if_observed_logit_delta: Vec<f64>,
+    /// `max(if_observed_logit_delta) - min(if_observed_logit_delta)`.
+    /// The simple v0.1 VOI proxy: "knowing this value could swing
+    /// the running log-odds by up to this much." Higher is more
+    /// informative.
+    pub voi_logit_range: f64,
+}
+
+// ---------------------------------------------------------------------------
 // KB-construction error type
 // ---------------------------------------------------------------------------
 
@@ -274,6 +347,11 @@ pub struct LRAggregateResult {
     /// branch — e.g. "no prior declared," "no contributions active,"
     /// "a contribution with LR=1.0 was silently a no-op."
     pub warnings: Vec<LrAggregateWarning>,
+    /// Active uncertainty reports. One entry per
+    /// [`UncertaintyMarker`] on the query whose domain has zero
+    /// observed evidence — exactly the markers worth showing the
+    /// user as "if you can determine this, the answer would shift."
+    pub uncertainties: Vec<UncertaintyReport>,
 }
 
 /// Conditions worth surfacing to the audit trail without hard-failing
@@ -401,7 +479,52 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
         });
     }
 
-    // Step 4: package the proof.
+    // Step 4: uncertainty reports — for every marker on `query`
+    // whose domain has zero observed evidence, build a report
+    // listing what each domain value would contribute.
+    let mut uncertainties: Vec<UncertaintyReport> = Vec::new();
+    for marker in kb.uncertainty_markers_for(query) {
+        let any_observed = marker
+            .domain
+            .iter()
+            .any(|ev| kb.observed_evidence(ev).is_some());
+        if any_observed {
+            // The marker is "resolved" — one of its domain values
+            // was observed; the aggregator already counted that
+            // contribution above, so no report.
+            continue;
+        }
+        let deltas: Vec<f64> = marker
+            .domain
+            .iter()
+            .map(|ev| {
+                // Find the ContributionClause(s) for (query, ev) and
+                // sum their logit_delta; 0.0 if no clause names this
+                // pair.
+                kb.contributions_for(query)
+                    .iter()
+                    .filter(|c| &c.evidence_term == ev)
+                    .map(|c| c.logit_delta)
+                    .sum::<f64>()
+            })
+            .collect();
+        let voi = if deltas.is_empty() {
+            0.0
+        } else {
+            let max = deltas.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let min = deltas.iter().copied().fold(f64::INFINITY, f64::min);
+            max - min
+        };
+        uncertainties.push(UncertaintyReport {
+            marker_id: marker.id,
+            conclusion: marker.conclusion.clone(),
+            domain: marker.domain.clone(),
+            if_observed_logit_delta: deltas,
+            voi_logit_range: voi,
+        });
+    }
+
+    // Step 5: package the proof.
     via_facts.sort();
     via_facts.dedup();
     let posterior = sigmoid(running_logit);
@@ -420,6 +543,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
         posterior,
         posterior_logit: running_logit,
         warnings,
+        uncertainties,
     }
 }
 

--- a/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
+++ b/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
@@ -6,7 +6,7 @@
 use logic_core::{atom, compound, Term};
 use logic_engine::{
     search, ContributionClause, Fact, JointContributionClause, KnowledgeBase, LrAggregateWarning,
-    PriorClause, Provenance, SearchMode, SearchResult, TrustTier,
+    PriorClause, Provenance, SearchMode, SearchResult, TrustTier, UncertaintyMarker,
 };
 
 fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
@@ -350,6 +350,133 @@ fn unattributed_provenance_is_the_default() {
     let prior = kb.prior_for(&atom("acs")).unwrap();
     assert_eq!(prior.provenance, Provenance::unattributed());
     assert_eq!(prior.provenance.trust_tier, TrustTier::Unattributed);
+}
+
+#[test]
+fn uncertainty_marker_with_no_observed_domain_value_produces_report() {
+    // Build the ACS rulebook (without the precipitator observations)
+    // and attach an UncertaintyMarker stating that the patient did
+    // not specify their precipitator. The LR aggregator should:
+    //   1. Skip all precipitator contributions (no observation).
+    //   2. Emit an UncertaintyReport listing the candidate values
+    //      and the log-odds delta each would contribute.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_uncertainty_marker(
+        UncertaintyMarker::new(
+            atom("acs"),
+            vec![
+                compound("precipitator", vec![atom("exertional")]),
+                compound("precipitator", vec![atom("rest")]),
+                compound("precipitator", vec![atom("positional")]),
+            ],
+        )
+        .with_provenance(Provenance::cited("patient did not specify precipitator")),
+    );
+
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let (posterior, uncertainties) = match result {
+        SearchResult::LRAggregateResult {
+            posterior,
+            uncertainties,
+            ..
+        } => (posterior, uncertainties),
+        other => panic!("expected LRAggregateResult, got {other:?}"),
+    };
+
+    // Posterior should still be ~0.281 (the unmodified ADJ36 number),
+    // because the marker reports but doesn't change aggregation.
+    assert!(
+        (posterior - 0.281).abs() < 0.005,
+        "expected ~0.281, got {posterior}"
+    );
+
+    // Exactly one uncertainty report — for the precipitator.
+    assert_eq!(uncertainties.len(), 1);
+    let report = &uncertainties[0];
+    assert_eq!(report.conclusion, atom("acs"));
+    assert_eq!(report.domain.len(), 3);
+    assert_eq!(report.if_observed_logit_delta.len(), 3);
+
+    // VOI: log(2.5) - log(0.6) = ln(2.5/0.6) ≈ 1.4271
+    assert!(
+        (report.voi_logit_range - (2.5_f64.ln() - 0.6_f64.ln())).abs() < 1e-9,
+        "expected VOI ≈ 1.4271, got {}",
+        report.voi_logit_range
+    );
+
+    // Spot-check individual deltas: the first domain entry is
+    // precipitator(exertional), which has contributes 2.5 → log(2.5).
+    assert!(
+        (report.if_observed_logit_delta[0] - 2.5_f64.ln()).abs() < 1e-9,
+        "expected log(2.5) ≈ 0.916, got {}",
+        report.if_observed_logit_delta[0]
+    );
+}
+
+#[test]
+fn observing_one_domain_value_suppresses_uncertainty_report() {
+    // Same rulebook + marker, but observe precipitator(exertional).
+    // The marker should not produce a report because the
+    // uncertainty is "resolved" by the observation.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_fact(Fact::certain(compound(
+        "precipitator",
+        vec![atom("exertional")],
+    )));
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("acs"),
+        vec![
+            compound("precipitator", vec![atom("exertional")]),
+            compound("precipitator", vec![atom("rest")]),
+            compound("precipitator", vec![atom("positional")]),
+        ],
+    ));
+
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { uncertainties, .. } = result {
+        assert!(
+            uncertainties.is_empty(),
+            "marker should be suppressed when domain is observed; got {uncertainties:?}"
+        );
+    } else {
+        panic!("expected LRAggregateResult");
+    }
+}
+
+#[test]
+fn uncertainty_marker_with_no_matching_contributions_has_zero_voi() {
+    // A marker whose domain values are not the target of any
+    // ContributionClause for the conclusion. The report should
+    // exist (the marker is active because nothing is observed)
+    // but every if_observed_logit_delta is 0.0 and VOI is 0.0 —
+    // a "rulebook gap" the modeller should know about.
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("c"), 0.10)).unwrap();
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("c"),
+        atom("some_evidence"),
+        2.0,
+    ));
+    // Force this conclusion into the LR-aggregation regime via
+    // the participates check — the contribution above does that.
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("c"),
+        vec![atom("uncovered_a"), atom("uncovered_b")],
+    ));
+
+    let result = search(&atom("c"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { uncertainties, .. } = result {
+        assert_eq!(uncertainties.len(), 1);
+        assert_eq!(
+            uncertainties[0].if_observed_logit_delta,
+            vec![0.0, 0.0]
+        );
+        assert_eq!(uncertainties[0].voi_logit_range, 0.0);
+    } else {
+        panic!("expected LRAggregateResult");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Engine** (logic-engine 0.5.0): \`UncertaintyMarker\` + \`UncertaintyReport\` + KB methods. The aggregator now surfaces VOI per active marker.
- **Surface** (adj-lang 0.2.0): \`uncertain { e1, e2, ... } for <conclusion>\` statement with optional annotations.
- **Headline**: ACS rulebook with \`uncertain { precipitator(exertional), precipitator(rest), precipitator(positional) } for acs\` runs end-to-end and reports VOI = ln(2.5/0.6) ≈ 1.43 logits — \"knowing the precipitator could swing the log-odds by up to 1.43.\"
- Stacked on **#4932** (ADJ47-C).

## ADJ46 awkwardness items dissolved

- **A5** (uncertainty markers) — fully addressed at both layers.

## Status of the original 10 items

| Item | Status |
|---|---|
| A1, A2, A3, A4, A5, A6, A10 | ✅ dissolved |
| A7 (kickback), A8 (counterfactual), A9 (multi-source) | next in ADJ47-E |

## Test plan

- [x] logic-engine: 62 tests (was 59)
- [x] adj-lang: 29 tests (was 26)
- [x] Headline test runs the ACS rulebook with an uncertain block end-to-end and confirms voi_logit_range matches the expected ln(2.5/0.6)
- [x] Security review passed (parse_term depth guard still in place for uncertain bodies, empty-deltas case explicitly handled to avoid NaN propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)