### PR TITLE
feat(logic-engine): kickback + counterfactual + source-disagreement (0.6.0) — closes ADJ46 awkwardness catalogue

### DIFF
--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.2.0] - 2026-06-02
+
+### Added
+
+- New `uncertain { e1, e2, ... } for <conclusion>` statement,
+  lowering to `logic_engine::UncertaintyMarker`. Accepts the
+  standard `source`/`locator`/`trust` annotations.
+- New lexer tokens: `KwUncertain`, `LBrace`, `RBrace`.
+- 2 new parser tests (basic + annotated forms), 1 new lower test
+  (`uncertain_statement_produces_voi_report_on_aggregation`
+  confirms end-to-end: surface syntax compiles, runs through
+  `SearchMode::LRAggregate`, and produces a non-empty
+  `uncertainties` vector with the right VOI logit range).
+
+Total tests: 29 (was 26 in 0.1.0).
+
+### ADJ46 awkwardness items dissolved by 0.2.0
+
+- **A5** (uncertainty markers) — fully addressed at the surface
+  layer. The IR pipeline can now hand off "no clear precipitator"
+  as a structured `uncertain { … } for …` clause, and the engine
+  surfaces it back to the user as a VOI report.
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -49,6 +49,16 @@ pub enum Statement {
     Observe { term: Term },
     /// `? <conclusion>` — query the engine for the posterior.
     Query { conclusion: Term },
+    /// `uncertain { <e1>, <e2>, ... } for <conclusion>` — annotate
+    /// the conclusion with a domain of candidate evidence terms,
+    /// none of which has been observed. The LR aggregator surfaces
+    /// a VOI report listing what each value would contribute.
+    /// Dissolves ADJ46 awkwardness item A5.
+    Uncertain {
+        domain: Vec<Term>,
+        conclusion: Term,
+        annotations: Vec<Annotation>,
+    },
 }
 
 /// Per-statement annotation. Multiple annotations per statement

--- a/code/packages/rust/adj-lang/src/lexer.rs
+++ b/code/packages/rust/adj-lang/src/lexer.rs
@@ -41,6 +41,11 @@ pub enum TokenKind {
     KwWhen,
     KwAnd,
     KwObserve,
+    /// ADJ47-D: `uncertain {a, b, c} for conclusion` — annotates a
+    /// conclusion with a domain of candidate evidence values none of
+    /// which has been observed. The LR aggregator surfaces a VOI
+    /// report listing what each value would contribute if learned.
+    KwUncertain,
     KwSource,
     KwTrust,
     KwLocator,
@@ -52,6 +57,10 @@ pub enum TokenKind {
     // Punctuation
     LParen,
     RParen,
+    /// `{` — opens the domain set in `uncertain {…}`.
+    LBrace,
+    /// `}` — closes the domain set.
+    RBrace,
     Comma,
     Question,
     // Literals
@@ -104,6 +113,16 @@ pub fn lex(src: &str) -> Result<Vec<Token>, LexError> {
             }
             ')' => {
                 tokens.push(Token { kind: TokenKind::RParen, line, col });
+                chars.next();
+                col += 1;
+            }
+            '{' => {
+                tokens.push(Token { kind: TokenKind::LBrace, line, col });
+                chars.next();
+                col += 1;
+            }
+            '}' => {
+                tokens.push(Token { kind: TokenKind::RBrace, line, col });
                 chars.next();
                 col += 1;
             }
@@ -240,6 +259,7 @@ fn keyword_or_ident(s: &str) -> TokenKind {
         "when" => TokenKind::KwWhen,
         "and" => TokenKind::KwAnd,
         "observe" => TokenKind::KwObserve,
+        "uncertain" => TokenKind::KwUncertain,
         "source" => TokenKind::KwSource,
         "trust" => TokenKind::KwTrust,
         "locator" => TokenKind::KwLocator,

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -22,7 +22,7 @@
 use logic_core::{atom as core_atom, compound, Term as CoreTerm};
 use logic_engine::{
     ContributionClause, Fact, JointContributionClause, KbError, KnowledgeBase, PriorClause,
-    Provenance, TrustTier,
+    Provenance, TrustTier, UncertaintyMarker,
 };
 
 use crate::ast::{Annotation, Program, Statement, Term as AstTerm, TrustTierName};
@@ -99,6 +99,19 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             }
             Statement::Query { conclusion } => {
                 queries.push(lower_term(conclusion));
+            }
+            Statement::Uncertain {
+                domain,
+                conclusion,
+                annotations,
+            } => {
+                let prov = annotations_to_provenance(annotations)?;
+                let marker = UncertaintyMarker::new(
+                    lower_term(conclusion),
+                    domain.iter().map(lower_term).collect(),
+                )
+                .with_provenance(prov);
+                kb.add_uncertainty_marker(marker);
             }
         }
     }
@@ -285,6 +298,49 @@ mod tests {
         let src = "observe pmh(hypertension)";
         let lowered = compile(src).unwrap();
         assert_eq!(lowered.queries.len(), 0);
+    }
+
+    #[test]
+    fn uncertain_statement_produces_voi_report_on_aggregation() {
+        // The ACS rulebook with a `uncertain {…}` clause for the
+        // precipitator, no precipitator observation. The aggregator
+        // should return a VOI report listing the three candidate
+        // values and the maximum log-odds swing knowing one of
+        // them would produce.
+        let src = r#"
+            prior 0.10 for acs
+
+            contributes 1.5 from pmh(hypertension) to acs
+            contributes 2.5 from precipitator(exertional) to acs
+            contributes 0.6 from precipitator(rest) to acs
+            contributes 0.8 from precipitator(positional) to acs
+
+            observe pmh(hypertension)
+
+            uncertain { precipitator(exertional),
+                        precipitator(rest),
+                        precipitator(positional) } for acs
+              source "patient did not specify"
+
+            ? acs
+        "#;
+        let lowered = compile(src).unwrap();
+        let query = &lowered.queries[0];
+        let result = search(query, &lowered.kb, SearchMode::LRAggregate);
+        match result {
+            SearchResult::LRAggregateResult { uncertainties, .. } => {
+                assert_eq!(uncertainties.len(), 1);
+                let report = &uncertainties[0];
+                assert_eq!(report.domain.len(), 3);
+                // VOI = ln(2.5) - ln(0.6) ≈ 1.4271
+                assert!(
+                    (report.voi_logit_range - (2.5_f64.ln() - 0.6_f64.ln())).abs() < 1e-9,
+                    "got VOI {}",
+                    report.voi_logit_range
+                );
+            }
+            other => panic!("expected LRAggregateResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/code/packages/rust/adj-lang/src/parser.rs
+++ b/code/packages/rust/adj-lang/src/parser.rs
@@ -133,11 +133,12 @@ impl<'a> Parser<'a> {
             TokenKind::KwContributes => self.parse_contributes(),
             TokenKind::KwInteracts => self.parse_interacts(),
             TokenKind::KwObserve => self.parse_observe(),
+            TokenKind::KwUncertain => self.parse_uncertain(),
             TokenKind::Question => self.parse_query(),
             other => {
                 let t = self.peek();
                 Err(ParseError::Expected {
-                    expected: "statement keyword (prior, contributes, interacts, observe, ?)"
+                    expected: "statement keyword (prior, contributes, interacts, observe, uncertain, ?)"
                         .into(),
                     found: format!("{other:?}"),
                     line: t.line,
@@ -211,6 +212,25 @@ impl<'a> Parser<'a> {
         self.expect(|k| matches!(k, TokenKind::Question), "`?`")?;
         let conclusion = self.parse_term()?;
         Ok(Statement::Query { conclusion })
+    }
+
+    fn parse_uncertain(&mut self) -> Result<Statement, ParseError> {
+        self.expect(|k| matches!(k, TokenKind::KwUncertain), "`uncertain`")?;
+        self.expect(|k| matches!(k, TokenKind::LBrace), "`{`")?;
+        let mut domain = vec![self.parse_term()?];
+        while matches!(self.peek().kind, TokenKind::Comma) {
+            self.advance();
+            domain.push(self.parse_term()?);
+        }
+        self.expect(|k| matches!(k, TokenKind::RBrace), "`}`")?;
+        self.expect(|k| matches!(k, TokenKind::KwFor), "`for`")?;
+        let conclusion = self.parse_term()?;
+        let annotations = self.parse_annotations()?;
+        Ok(Statement::Uncertain {
+            domain,
+            conclusion,
+            annotations,
+        })
     }
 
     fn parse_number(&mut self) -> Result<f64, ParseError> {
@@ -484,6 +504,36 @@ mod tests {
         let p = parse_src(src).unwrap();
         // 1 prior + 6 contributes + 1 interacts + 6 observes + 1 query = 15
         assert_eq!(p.statements.len(), 15);
+    }
+
+    #[test]
+    fn parses_uncertain_with_domain_set() {
+        let src = "uncertain { precipitator(exertional), precipitator(rest), precipitator(positional) } for acs";
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Uncertain {
+                domain, conclusion, ..
+            } => {
+                assert_eq!(domain.len(), 3);
+                assert!(matches!(conclusion, Term::Atom(n) if n == "acs"));
+            }
+            other => panic!("expected Uncertain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_uncertain_with_source_annotation() {
+        let src = r#"
+            uncertain { a, b } for c
+              source "patient declined to answer"
+        "#;
+        let p = parse_src(src).unwrap();
+        match &p.statements[0] {
+            Statement::Uncertain { annotations, .. } => {
+                assert_eq!(annotations.len(), 1);
+            }
+            other => panic!("expected Uncertain, got {other:?}"),
+        }
     }
 
     #[test]

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-06-02
+
+### Added
+
+- `UncertaintyMarker` clause type + `UncertaintyMarkerId`. Attached
+  to a conclusion with a `domain: Vec<Term>` of candidate evidence
+  terms. Represents "the IR pipeline knows the conclusion is the
+  target of an LR query, and knows the patient (or source) did not
+  specify one of these candidate values."
+- `UncertaintyReport` — the user-facing VOI summary the engine
+  emits when a marker's domain is entirely unobserved. Contains the
+  domain, the log-odds delta each value would have contributed if
+  observed, and a v0.1 VOI proxy (`voi_logit_range` = max − min of
+  the deltas). The framework's user-facing layer can rank these to
+  produce "if you can determine X, the posterior could swing by up
+  to Y" guidance.
+- `LRAggregateResult.uncertainties: Vec<UncertaintyReport>` +
+  `SearchResult::LRAggregateResult { ..., uncertainties }`.
+- `KnowledgeBase::add_uncertainty_marker` /
+  `uncertainty_markers_for`. Markers do not promote a query to
+  LR-aggregation — they're only meaningful relative to contribution
+  clauses already on the conclusion.
+- 3 new integration tests in `tests/test_lr_aggregation.rs`:
+  uncertainty report with no observation shows full domain + VOI,
+  one-domain-observation suppresses the report, marker over a
+  domain with no matching contributions has zero VOI but still
+  appears in the report.
+
+Total tests: 62 (was 59 in 0.4.0).
+
+### ADJ46 awkwardness items dissolved by 0.5.0
+
+- **A5** — uncertainty markers at the engine layer.
+  `add_uncertainty_marker` + `UncertaintyReport` give the IR
+  pipeline a way to losslessly hand off "the patient said nothing
+  about X over this domain" to the executor, and give the audit
+  reader a concrete VOI signal to act on.
+
+### Scope notes
+
+- VOI is the v0.1 proxy (max − min over candidate log-odds deltas)
+  — not the formal Bayesian decision-theoretic VOI. A richer
+  treatment that combines the candidate deltas with the prior over
+  the domain (and with the user's decision threshold, if any) is a
+  follow-up.
+- Still pending: A7 (kickback variant), A8 (counterfactuals), A9
+  (multi-source aggregation), and the surface-layer half of A5
+  (the `uncertain { ... } for ...` keyword — that ships in
+  `adj-lang` 0.2.0 simultaneously).
+
 ## [0.4.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-06-02
+
+### Added
+
+- `counterfactual(query, kb, &[Term])` — clones the KB, adds the
+  given Facts as Certain, and reruns `lr_aggregate`. Lets the
+  caller answer "what would the posterior be if X were true?"
+  without disturbing the original KB. Cloning the whole KB makes
+  the contract obvious; cost is linear and small.
+- `LRAggregateResult::suggest_kickback(decision_threshold)` —
+  computes a worst-case / best-case posterior band by reducing
+  each active uncertainty marker to its min/max contribution,
+  summing the shifts independently across markers, and applying
+  to the current `posterior_logit`. Returns `Some(KickbackReport)`
+  iff the band straddles `decision_threshold`. Includes
+  `recommended_resolutions` sorted by individual VOI.
+- `source_disagreements(kb, conclusion)` /
+  `source_disagreements_with_threshold(kb, conclusion, min_spread)`
+  — scans contributions on `conclusion`, groups by `evidence_term`,
+  flags groups where the `logit_delta`s have spread > threshold.
+  Per-source records include the clause id and provenance so the
+  audit reader can render "AHA 2021 says LR=2.5; ESC 2023 says
+  LR=4.0; sources disagree by 0.47 logits."
+- New types: `KickbackReport`, `SourceDisagreementReport`,
+  `SourceLogitDelta`.
+- `KnowledgeBase: Clone`.
+- 7 new tests covering counterfactual upward shift, KB
+  non-mutation invariant, kickback firing inside the band, no
+  kickback outside the band, source-disagreement detection on two
+  conflicting sources, no-disagreement when only one source, and
+  no-disagreement when sources agree.
+
+Total tests: 69 (was 62 in 0.5.0).
+
+### ADJ46 awkwardness items dissolved by 0.6.0
+
+- **A7** (no kickback search variant) — addressed via
+  `suggest_kickback` method on the result rather than a separate
+  search mode. Lower-friction API and the same diagnostic power.
+- **A8** (counterfactuals require KB clone + rerun) — `counterfactual`
+  function does the clone + rerun once, atomically; caller's KB
+  is invariant.
+- **A9** (source-disagreement aggregation) — detector +
+  per-source records surface conflicting LRs from the rulebook.
+
+### Status of the original 10 ADJ46 awkwardness items
+
+| Item | Status |
+|---|---|
+| A1 (LR magnitudes) | ✅ 0.3.0 |
+| A2 (provenance) | ✅ 0.4.0 |
+| A3 (prior) | ✅ 0.3.0 |
+| A4 (joint contributions syntax) | ✅ 0.1.0 (adj-lang) |
+| A5 (uncertainty markers) | ✅ 0.5.0 |
+| A6 (WMC vs LR) | ✅ 0.3.0 |
+| A7 (kickback) | ✅ 0.6.0 |
+| A8 (counterfactuals) | ✅ 0.6.0 |
+| A9 (source disagreement) | ✅ 0.6.0 |
+| A10 (surface syntax) | ✅ 0.1.0 (adj-lang) |
+
+All ten items dissolved as of logic-engine 0.6.0 +
+adj-lang 0.2.0.
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -45,7 +45,8 @@ use logic_core::{LogicVar, Substitution, Term, unify};
 pub use enumerate::enumerate_all;
 pub use lr_aggregate::{
     lr_aggregate, sigmoid, ContributionClause, JointContributionClause, KbError,
-    LRAggregateResult, LrAggregateWarning, PriorClause,
+    LRAggregateResult, LrAggregateWarning, PriorClause, UncertaintyMarker,
+    UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 pub use provenance::{Provenance, TrustTier};
@@ -79,6 +80,20 @@ pub struct ContributionClauseId(pub u64);
 /// Stable identifier for a [`JointContributionClause`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct JointContributionClauseId(pub u64);
+
+/// Stable identifier for an
+/// [`UncertaintyMarker`](crate::lr_aggregate::UncertaintyMarker).
+///
+/// LP19e + ADJ47-D: uncertainty markers are the engine-layer
+/// representation of "the patient (or the source) did not specify
+/// this value, but we know the domain it ranges over." The
+/// LR-aggregation result surfaces an
+/// [`UncertaintyReport`](crate::lr_aggregate::UncertaintyReport) for
+/// every active marker whose domain has zero observed members — so
+/// the audit reader can see *what would shift the answer* without
+/// having to look it up themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct UncertaintyMarkerId(pub u64);
 
 /// Probability annotation on a clause.
 ///
@@ -242,11 +257,18 @@ pub struct KnowledgeBase {
     priors: Vec<PriorClause>,
     contributions: Vec<ContributionClause>,
     joint_contributions: Vec<JointContributionClause>,
+    /// LP19e + ADJ47-D: uncertainty markers attached to conclusions.
+    /// Each marker carries a domain of candidate evidence terms; if
+    /// none of them is observed, the aggregator emits an
+    /// [`UncertaintyReport`] in the result so the audit reader sees
+    /// what's missing.
+    uncertainty_markers: Vec<UncertaintyMarker>,
     next_fact_id: u64,
     next_rule_id: u64,
     next_prior_id: u64,
     next_contribution_id: u64,
     next_joint_contribution_id: u64,
+    next_uncertainty_marker_id: u64,
 }
 
 impl KnowledgeBase {
@@ -392,7 +414,10 @@ impl KnowledgeBase {
 
     /// True iff at least one contribution (single or joint) names
     /// `conclusion`. This is the discriminator that `AutoDetect` uses
-    /// to route to LR aggregation rather than SLD / WMC.
+    /// to route to LR aggregation rather than SLD / WMC. Uncertainty
+    /// markers alone do not promote a query to LR-aggregation —
+    /// they're meaningful only relative to contribution clauses,
+    /// because they describe domain gaps inside an LR-shape query.
     pub fn participates_in_lr_aggregation(&self, conclusion: &Term) -> bool {
         self.contributions
             .iter()
@@ -401,6 +426,27 @@ impl KnowledgeBase {
                 .joint_contributions
                 .iter()
                 .any(|c| &c.conclusion == conclusion)
+    }
+
+    /// Insert an [`UncertaintyMarker`], assigning a fresh
+    /// [`UncertaintyMarkerId`].
+    pub fn add_uncertainty_marker(
+        &mut self,
+        mut marker: UncertaintyMarker,
+    ) -> UncertaintyMarkerId {
+        let id = UncertaintyMarkerId(self.next_uncertainty_marker_id);
+        self.next_uncertainty_marker_id += 1;
+        marker.id = id;
+        self.uncertainty_markers.push(marker);
+        id
+    }
+
+    /// Iterate the uncertainty markers attached to `conclusion`.
+    pub fn uncertainty_markers_for(&self, conclusion: &Term) -> Vec<&UncertaintyMarker> {
+        self.uncertainty_markers
+            .iter()
+            .filter(|m| &m.conclusion == conclusion)
+            .collect()
     }
 
     /// LP19e "observation gate." If `evidence_term` is asserted in
@@ -484,6 +530,10 @@ pub enum SearchResult {
         posterior: f64,
         posterior_logit: f64,
         warnings: Vec<LrAggregateWarning>,
+        /// Active uncertainty reports — one per
+        /// [`UncertaintyMarker`] on the query whose domain is
+        /// entirely unobserved. Empty in the common case.
+        uncertainties: Vec<UncertaintyReport>,
     },
 }
 
@@ -526,6 +576,7 @@ pub fn search(query: &Term, kb: &KnowledgeBase, mode: SearchMode) -> SearchResul
                 posterior: result.posterior,
                 posterior_logit: result.posterior_logit,
                 warnings: result.warnings,
+                uncertainties: result.uncertainties,
             }
         }
         // AutoDetect was rewritten above.

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -44,9 +44,10 @@ use logic_core::{LogicVar, Substitution, Term, unify};
 
 pub use enumerate::enumerate_all;
 pub use lr_aggregate::{
-    lr_aggregate, sigmoid, ContributionClause, JointContributionClause, KbError,
-    LRAggregateResult, LrAggregateWarning, PriorClause, UncertaintyMarker,
-    UncertaintyReport,
+    counterfactual, lr_aggregate, sigmoid, source_disagreements,
+    source_disagreements_with_threshold, ContributionClause, JointContributionClause, KbError,
+    KickbackReport, LRAggregateResult, LrAggregateWarning, PriorClause,
+    SourceDisagreementReport, SourceLogitDelta, UncertaintyMarker, UncertaintyReport,
 };
 pub use proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 pub use provenance::{Provenance, TrustTier};
@@ -243,7 +244,11 @@ impl ClauseIndex {
 /// SLD-resolution / WMC paths ignore these and the LR-aggregation
 /// path ignores `facts` and `rules` except via the `observed_evidence`
 /// query — the two inference shapes coexist without interference.
-#[derive(Debug, Default)]
+///
+/// **Cloneable** (ADJ47-E): so counterfactual queries can be served
+/// by cloning the KB, mutating the clone, and rerunning aggregation
+/// without disturbing the caller's KB.
+#[derive(Debug, Default, Clone)]
 pub struct KnowledgeBase {
     facts: HashMap<ClauseIndex, Vec<Fact>>,
     rules: HashMap<ClauseIndex, Vec<Rule>>,

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -38,7 +38,7 @@ use logic_core::{Substitution, Term};
 
 use crate::{
     ContributionClauseId, FactId, JointContributionClauseId, KnowledgeBase, PriorClauseId,
-    Provenance,
+    Provenance, UncertaintyMarkerId,
 };
 use crate::proof_dag::{DerivationOrigin, Proof, ProofDAG, ProofStep};
 
@@ -215,6 +215,79 @@ impl JointContributionClause {
 }
 
 // ---------------------------------------------------------------------------
+// Uncertainty markers — ADJ47-D, addresses ADJ46 awkwardness A5
+// ---------------------------------------------------------------------------
+
+/// An explicit "we don't know which value of X applies here" annotation.
+///
+/// Dissolves ADJ46 awkwardness item **A5**. When a patient case
+/// says "no clear precipitator," the IR pipeline lowers it to an
+/// `UncertaintyMarker` whose `domain` is the candidate precipitator
+/// terms. The aggregator detects markers whose domain is entirely
+/// unobserved and emits an [`UncertaintyReport`] in the result, so
+/// the framework's user-facing output can say "if you can determine
+/// the precipitator, the posterior could shift by up to X."
+///
+/// This is the engine-layer enabler of VOI (ADJ18). The full VOI
+/// computation lives in [`LRAggregateResult::uncertainties`], which
+/// the user-facing layer can rank, render, or act on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UncertaintyMarker {
+    pub id: UncertaintyMarkerId,
+    pub conclusion: Term,
+    /// Candidate evidence terms. Treated as mutually exclusive in
+    /// v0.1: the aggregator computes the maximum log-odds swing
+    /// across the domain, not the expected posterior under a prior
+    /// over the domain. Richer treatment is a follow-up.
+    pub domain: Vec<Term>,
+    pub provenance: Provenance,
+}
+
+impl UncertaintyMarker {
+    pub fn new(conclusion: Term, domain: Vec<Term>) -> Self {
+        Self {
+            id: UncertaintyMarkerId(u64::MAX),
+            conclusion,
+            domain,
+            provenance: Provenance::unattributed(),
+        }
+    }
+
+    pub fn with_provenance(mut self, provenance: Provenance) -> Self {
+        self.provenance = provenance;
+        self
+    }
+}
+
+/// A user-facing report on an active uncertainty in the
+/// LR-aggregation result.
+///
+/// Active means: the marker's domain has zero observed evidence
+/// terms in the KB, so the aggregator skipped every related
+/// contribution. The report tells the audit reader what each domain
+/// value would have contributed if observed, plus the VOI summary
+/// — the log-odds range that resolving the uncertainty could
+/// produce.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UncertaintyReport {
+    pub marker_id: UncertaintyMarkerId,
+    pub conclusion: Term,
+    pub domain: Vec<Term>,
+    /// One entry per domain term, in `domain` order. The f64 is the
+    /// log(LR) that would be added to the running log-odds if that
+    /// particular value were observed. `0.0` when no
+    /// [`ContributionClause`] names the (conclusion, value) pair —
+    /// i.e. the rulebook covers the uncertainty marker but not the
+    /// individual value, which is a modeller signal worth surfacing.
+    pub if_observed_logit_delta: Vec<f64>,
+    /// `max(if_observed_logit_delta) - min(if_observed_logit_delta)`.
+    /// The simple v0.1 VOI proxy: "knowing this value could swing
+    /// the running log-odds by up to this much." Higher is more
+    /// informative.
+    pub voi_logit_range: f64,
+}
+
+// ---------------------------------------------------------------------------
 // KB-construction error type
 // ---------------------------------------------------------------------------
 
@@ -274,6 +347,11 @@ pub struct LRAggregateResult {
     /// branch — e.g. "no prior declared," "no contributions active,"
     /// "a contribution with LR=1.0 was silently a no-op."
     pub warnings: Vec<LrAggregateWarning>,
+    /// Active uncertainty reports. One entry per
+    /// [`UncertaintyMarker`] on the query whose domain has zero
+    /// observed evidence — exactly the markers worth showing the
+    /// user as "if you can determine this, the answer would shift."
+    pub uncertainties: Vec<UncertaintyReport>,
 }
 
 /// Conditions worth surfacing to the audit trail without hard-failing
@@ -401,7 +479,52 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
         });
     }
 
-    // Step 4: package the proof.
+    // Step 4: uncertainty reports — for every marker on `query`
+    // whose domain has zero observed evidence, build a report
+    // listing what each domain value would contribute.
+    let mut uncertainties: Vec<UncertaintyReport> = Vec::new();
+    for marker in kb.uncertainty_markers_for(query) {
+        let any_observed = marker
+            .domain
+            .iter()
+            .any(|ev| kb.observed_evidence(ev).is_some());
+        if any_observed {
+            // The marker is "resolved" — one of its domain values
+            // was observed; the aggregator already counted that
+            // contribution above, so no report.
+            continue;
+        }
+        let deltas: Vec<f64> = marker
+            .domain
+            .iter()
+            .map(|ev| {
+                // Find the ContributionClause(s) for (query, ev) and
+                // sum their logit_delta; 0.0 if no clause names this
+                // pair.
+                kb.contributions_for(query)
+                    .iter()
+                    .filter(|c| &c.evidence_term == ev)
+                    .map(|c| c.logit_delta)
+                    .sum::<f64>()
+            })
+            .collect();
+        let voi = if deltas.is_empty() {
+            0.0
+        } else {
+            let max = deltas.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let min = deltas.iter().copied().fold(f64::INFINITY, f64::min);
+            max - min
+        };
+        uncertainties.push(UncertaintyReport {
+            marker_id: marker.id,
+            conclusion: marker.conclusion.clone(),
+            domain: marker.domain.clone(),
+            if_observed_logit_delta: deltas,
+            voi_logit_range: voi,
+        });
+    }
+
+    // Step 5: package the proof.
     via_facts.sort();
     via_facts.dedup();
     let posterior = sigmoid(running_logit);
@@ -420,6 +543,7 @@ pub fn lr_aggregate(query: &Term, kb: &KnowledgeBase) -> LRAggregateResult {
         posterior,
         posterior_logit: running_logit,
         warnings,
+        uncertainties,
     }
 }
 

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -354,6 +354,222 @@ pub struct LRAggregateResult {
     pub uncertainties: Vec<UncertaintyReport>,
 }
 
+// ---------------------------------------------------------------------------
+// Kickback — ADJ47-E, addresses ADJ46 awkwardness A7
+// ---------------------------------------------------------------------------
+
+/// Summary of why and how the framework would recommend the user
+/// resolve some uncertainty before committing to the posterior.
+///
+/// Surfaces only when the *plausible posterior range* induced by the
+/// current uncertainties straddles a decision threshold. Built so
+/// the user-facing layer (an EMR widget, a brief-review tool, a
+/// deal-room dashboard) can render "the system isn't confident; here
+/// are the things to resolve" without having to recompute the band
+/// itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KickbackReport {
+    pub posterior: f64,
+    pub posterior_logit: f64,
+    /// Worst-case posterior assuming every uncertainty resolves
+    /// in the direction that *lowers* the conclusion's probability.
+    pub posterior_lo: f64,
+    /// Best-case posterior assuming every uncertainty resolves
+    /// in the direction that *raises* the conclusion's probability.
+    pub posterior_hi: f64,
+    /// The decision threshold the band straddles.
+    pub decision_threshold: f64,
+    /// Recommend the user resolve these markers, ranked by
+    /// individual VOI (largest range first).
+    pub recommended_resolutions: Vec<UncertaintyMarkerId>,
+}
+
+// ---------------------------------------------------------------------------
+// Source disagreement — ADJ47-E, addresses ADJ46 awkwardness A9
+// ---------------------------------------------------------------------------
+
+/// A flag that two or more `ContributionClause`s with the same
+/// `(conclusion, evidence_term)` have substantially different
+/// `logit_delta` values — i.e. the rulebook's sources disagree
+/// about the LR for this piece of evidence.
+///
+/// Useful for the audit layer to surface "AHA 2021 says LR=2.5 for
+/// this finding; ESC 2023 says LR=4.0 — your posterior is sensitive
+/// to which authority you trust" without the user having to mine
+/// the rulebook by hand.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceDisagreementReport {
+    pub conclusion: Term,
+    pub evidence_term: Term,
+    /// Per-source records in clause-insertion order.
+    pub source_logit_deltas: Vec<SourceLogitDelta>,
+    /// `max(deltas) - min(deltas)`. Larger means the sources
+    /// disagree more.
+    pub disagreement_logit_range: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceLogitDelta {
+    pub clause_id: ContributionClauseId,
+    pub logit_delta: f64,
+    pub provenance: Provenance,
+}
+
+impl LRAggregateResult {
+    /// Suggest a kickback to the user if the posterior, accounting
+    /// for active [`UncertaintyReport`]s, could end up on either side
+    /// of `decision_threshold`.
+    ///
+    /// Returns `None` when:
+    /// - no uncertainties are active (posterior is robust by
+    ///   construction), or
+    /// - the worst-case and best-case posterior both lie on the
+    ///   *same* side of `decision_threshold` (the answer doesn't
+    ///   depend on resolving any uncertainty).
+    ///
+    /// Returns `Some(KickbackReport)` when the band straddles the
+    /// threshold — that's when the framework's recommended action
+    /// is to escalate rather than commit.
+    pub fn suggest_kickback(&self, decision_threshold: f64) -> Option<KickbackReport> {
+        if self.uncertainties.is_empty() {
+            return None;
+        }
+        // Sum of "if-observed" worst-case and best-case shifts the
+        // current log-odds would receive from resolving every
+        // uncertainty simultaneously. This is a *bounding* analysis
+        // (each marker independently optimized) — it does not assume
+        // the resolutions are jointly achievable, so the band is a
+        // conservative outer envelope on the true plausible posterior.
+        let mut lo_shift = 0.0;
+        let mut hi_shift = 0.0;
+        for u in &self.uncertainties {
+            if u.if_observed_logit_delta.is_empty() {
+                continue;
+            }
+            let mn = u
+                .if_observed_logit_delta
+                .iter()
+                .copied()
+                .fold(f64::INFINITY, f64::min);
+            let mx = u
+                .if_observed_logit_delta
+                .iter()
+                .copied()
+                .fold(f64::NEG_INFINITY, f64::max);
+            lo_shift += mn;
+            hi_shift += mx;
+        }
+        let posterior_lo = sigmoid(self.posterior_logit + lo_shift);
+        let posterior_hi = sigmoid(self.posterior_logit + hi_shift);
+        if posterior_lo <= decision_threshold && decision_threshold <= posterior_hi {
+            // Rank markers by their individual VOI (largest first).
+            let mut ranked: Vec<&UncertaintyReport> = self.uncertainties.iter().collect();
+            ranked.sort_by(|a, b| {
+                b.voi_logit_range
+                    .partial_cmp(&a.voi_logit_range)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            Some(KickbackReport {
+                posterior: self.posterior,
+                posterior_logit: self.posterior_logit,
+                posterior_lo,
+                posterior_hi,
+                decision_threshold,
+                recommended_resolutions: ranked.into_iter().map(|u| u.marker_id).collect(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Counterfactual — ADJ47-E, addresses ADJ46 awkwardness A8
+// ---------------------------------------------------------------------------
+
+/// Rerun [`lr_aggregate`] on a copy of `kb` with `assumed_facts`
+/// added as Certain Facts. Used to answer "what would the posterior
+/// be if X were true?" without disturbing the caller's KB.
+///
+/// The implementation clones the KB, inserts each assumed fact, and
+/// reruns aggregation. Linear in KB size + assumed_facts.len(); fine
+/// at current scale, and the clone semantics is the right contract
+/// — the caller's KB is unchanged.
+pub fn counterfactual(
+    query: &Term,
+    kb: &KnowledgeBase,
+    assumed_facts: &[Term],
+) -> LRAggregateResult {
+    let mut perturbed = kb.clone();
+    for fact in assumed_facts {
+        perturbed.add_fact(crate::Fact::certain(fact.clone()));
+    }
+    lr_aggregate(query, &perturbed)
+}
+
+/// Walk a KB's contributions for `conclusion`, group by
+/// `evidence_term`, and report every group whose members have a
+/// non-zero spread in `logit_delta`. Threshold parameter is the
+/// minimum spread (in absolute log-odds) to surface; the default
+/// in `kb_source_disagreements` is `1e-9` — i.e. any non-trivial
+/// floating-point difference.
+pub fn source_disagreements_with_threshold(
+    kb: &KnowledgeBase,
+    conclusion: &Term,
+    min_spread: f64,
+) -> Vec<SourceDisagreementReport> {
+    let contributions = kb.contributions_for(conclusion);
+    // Group by evidence_term (linear scan, small per-conclusion lists).
+    let mut groups: Vec<(Term, Vec<SourceLogitDelta>)> = Vec::new();
+    for c in &contributions {
+        let entry = groups.iter_mut().find(|(t, _)| t == &c.evidence_term);
+        let record = SourceLogitDelta {
+            clause_id: c.id,
+            logit_delta: c.logit_delta,
+            provenance: c.provenance.clone(),
+        };
+        match entry {
+            Some((_, list)) => list.push(record),
+            None => groups.push((c.evidence_term.clone(), vec![record])),
+        }
+    }
+    let mut out = Vec::new();
+    for (evidence_term, deltas) in groups {
+        if deltas.len() < 2 {
+            continue;
+        }
+        let max = deltas
+            .iter()
+            .map(|d| d.logit_delta)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let min = deltas
+            .iter()
+            .map(|d| d.logit_delta)
+            .fold(f64::INFINITY, f64::min);
+        let range = max - min;
+        if range > min_spread {
+            out.push(SourceDisagreementReport {
+                conclusion: conclusion.clone(),
+                evidence_term,
+                source_logit_deltas: deltas,
+                disagreement_logit_range: range,
+            });
+        }
+    }
+    out
+}
+
+/// Convenience wrapper over [`source_disagreements_with_threshold`]
+/// with `min_spread = 1e-9`. Surfaces every group of two or more
+/// `ContributionClause`s on the same `(conclusion, evidence)` whose
+/// `logit_delta`s are not bit-for-bit equal.
+pub fn source_disagreements(
+    kb: &KnowledgeBase,
+    conclusion: &Term,
+) -> Vec<SourceDisagreementReport> {
+    source_disagreements_with_threshold(kb, conclusion, 1e-9)
+}
+
 /// Conditions worth surfacing to the audit trail without hard-failing
 /// the query. These mirror the LP19e §"Edge cases" enumeration.
 #[derive(Debug, Clone, PartialEq)]

--- a/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
+++ b/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
@@ -5,8 +5,9 @@
 
 use logic_core::{atom, compound, Term};
 use logic_engine::{
-    search, ContributionClause, Fact, JointContributionClause, KnowledgeBase, LrAggregateWarning,
-    PriorClause, Provenance, SearchMode, SearchResult, TrustTier, UncertaintyMarker,
+    counterfactual, search, source_disagreements, ContributionClause, Fact,
+    JointContributionClause, KnowledgeBase, LrAggregateWarning, PriorClause, Provenance,
+    SearchMode, SearchResult, TrustTier, UncertaintyMarker,
 };
 
 fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
@@ -477,6 +478,208 @@ fn uncertainty_marker_with_no_matching_contributions_has_zero_voi() {
     } else {
         panic!("expected LRAggregateResult");
     }
+}
+
+#[test]
+fn counterfactual_assuming_precipitator_exertional_raises_posterior() {
+    // Baseline ACS posterior is ~0.281 with no precipitator info.
+    // Knowing the precipitator was exertional adds log(2.5) to the
+    // log-odds, so the counterfactual posterior should be higher.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+
+    let baseline = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let baseline_p = match baseline {
+        SearchResult::LRAggregateResult { posterior, .. } => posterior,
+        _ => panic!(),
+    };
+
+    let counter = counterfactual(
+        &atom("acs"),
+        &kb,
+        &[compound("precipitator", vec![atom("exertional")])],
+    );
+
+    assert!(
+        counter.posterior > baseline_p,
+        "exertional precipitator should raise posterior; baseline={baseline_p}, counter={}",
+        counter.posterior
+    );
+    // logit(0.281) + ln(2.5) → sigmoid ≈ 0.494
+    assert!(
+        (counter.posterior - 0.494).abs() < 0.01,
+        "expected ~0.494, got {}",
+        counter.posterior
+    );
+}
+
+#[test]
+fn counterfactual_does_not_mutate_the_caller_kb() {
+    // After running counterfactual, the original KB must be
+    // unchanged — the precipitator fact must not leak back.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    let _ = counterfactual(
+        &atom("acs"),
+        &kb,
+        &[compound("precipitator", vec![atom("exertional")])],
+    );
+    // Re-run aggregation: same as before, no precipitator fact.
+    let after = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let after_p = match after {
+        SearchResult::LRAggregateResult { posterior, .. } => posterior,
+        _ => panic!(),
+    };
+    assert!(
+        (after_p - 0.281).abs() < 0.005,
+        "baseline posterior should be unchanged; got {after_p}"
+    );
+}
+
+#[test]
+fn kickback_suggested_when_uncertainty_band_straddles_decision_threshold() {
+    // Patient case with no precipitator → posterior ~0.281, with
+    // VOI ranging from log(0.6) to log(2.5). At threshold 0.30, the
+    // band ~[0.19, 0.49] straddles the threshold → kickback should
+    // suggest.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("acs"),
+        vec![
+            compound("precipitator", vec![atom("exertional")]),
+            compound("precipitator", vec![atom("rest")]),
+            compound("precipitator", vec![atom("positional")]),
+        ],
+    ));
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let lr = match result {
+        SearchResult::LRAggregateResult {
+            dag,
+            posterior,
+            posterior_logit,
+            warnings,
+            uncertainties,
+        } => logic_engine::LRAggregateResult {
+            dag,
+            posterior,
+            posterior_logit,
+            warnings,
+            uncertainties,
+        },
+        _ => panic!(),
+    };
+    let kb_back = lr.suggest_kickback(0.30);
+    assert!(kb_back.is_some(), "expected kickback at threshold 0.30");
+    let k = kb_back.unwrap();
+    assert!(k.posterior_lo < 0.30);
+    assert!(k.posterior_hi > 0.30);
+    assert_eq!(k.recommended_resolutions.len(), 1);
+}
+
+#[test]
+fn no_kickback_when_uncertainty_band_lies_on_one_side_of_threshold() {
+    // Same setup but with a threshold of 0.05 — well below the
+    // band — kickback should NOT trigger because every resolution
+    // would still leave the posterior above the threshold.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("acs"),
+        vec![
+            compound("precipitator", vec![atom("exertional")]),
+            compound("precipitator", vec![atom("rest")]),
+            compound("precipitator", vec![atom("positional")]),
+        ],
+    ));
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let lr = match result {
+        SearchResult::LRAggregateResult {
+            dag,
+            posterior,
+            posterior_logit,
+            warnings,
+            uncertainties,
+        } => logic_engine::LRAggregateResult {
+            dag,
+            posterior,
+            posterior_logit,
+            warnings,
+            uncertainties,
+        },
+        _ => panic!(),
+    };
+    assert!(lr.suggest_kickback(0.05).is_none());
+}
+
+#[test]
+fn source_disagreement_detected_when_two_contributions_disagree() {
+    // Same evidence, two ContributionClauses with different LRs —
+    // simulates AHA saying LR=2.5, ESC saying LR=4.0 for the same
+    // finding. The detector should flag them.
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("acs"), 0.10))
+        .unwrap();
+    kb.add_contribution(
+        ContributionClause::from_lr(
+            atom("acs"),
+            compound("symptom", vec![atom("pressure")]),
+            2.5,
+        )
+        .with_provenance(Provenance::cited("AHA 2021")),
+    );
+    kb.add_contribution(
+        ContributionClause::from_lr(
+            atom("acs"),
+            compound("symptom", vec![atom("pressure")]),
+            4.0,
+        )
+        .with_provenance(Provenance::cited("ESC 2023")),
+    );
+    let reports = source_disagreements(&kb, &atom("acs"));
+    assert_eq!(reports.len(), 1);
+    let r = &reports[0];
+    assert_eq!(r.evidence_term, compound("symptom", vec![atom("pressure")]));
+    assert_eq!(r.source_logit_deltas.len(), 2);
+    // disagreement range = ln(4.0) - ln(2.5) ≈ 0.47
+    assert!(
+        (r.disagreement_logit_range - (4.0_f64.ln() - 2.5_f64.ln())).abs() < 1e-9,
+        "got {}",
+        r.disagreement_logit_range
+    );
+}
+
+#[test]
+fn no_disagreement_reported_when_only_one_source() {
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("acs"), 0.10))
+        .unwrap();
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("acs"),
+        compound("symptom", vec![atom("pressure")]),
+        2.5,
+    ));
+    assert!(source_disagreements(&kb, &atom("acs")).is_empty());
+}
+
+#[test]
+fn no_disagreement_reported_when_sources_agree() {
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("acs"), 0.10))
+        .unwrap();
+    // Two ContributionClauses with the same LR — even though they
+    // share an evidence term, they don't *disagree*. No report.
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("acs"),
+        compound("symptom", vec![atom("pressure")]),
+        2.5,
+    ));
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("acs"),
+        compound("symptom", vec![atom("pressure")]),
+        2.5,
+    ));
+    assert!(source_disagreements(&kb, &atom("acs")).is_empty());
 }
 
 #[test]

--- a/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
+++ b/code/packages/rust/logic-engine/tests/test_lr_aggregation.rs
@@ -6,7 +6,7 @@
 use logic_core::{atom, compound, Term};
 use logic_engine::{
     search, ContributionClause, Fact, JointContributionClause, KnowledgeBase, LrAggregateWarning,
-    PriorClause, Provenance, SearchMode, SearchResult, TrustTier,
+    PriorClause, Provenance, SearchMode, SearchResult, TrustTier, UncertaintyMarker,
 };
 
 fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
@@ -350,6 +350,133 @@ fn unattributed_provenance_is_the_default() {
     let prior = kb.prior_for(&atom("acs")).unwrap();
     assert_eq!(prior.provenance, Provenance::unattributed());
     assert_eq!(prior.provenance.trust_tier, TrustTier::Unattributed);
+}
+
+#[test]
+fn uncertainty_marker_with_no_observed_domain_value_produces_report() {
+    // Build the ACS rulebook (without the precipitator observations)
+    // and attach an UncertaintyMarker stating that the patient did
+    // not specify their precipitator. The LR aggregator should:
+    //   1. Skip all precipitator contributions (no observation).
+    //   2. Emit an UncertaintyReport listing the candidate values
+    //      and the log-odds delta each would contribute.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_uncertainty_marker(
+        UncertaintyMarker::new(
+            atom("acs"),
+            vec![
+                compound("precipitator", vec![atom("exertional")]),
+                compound("precipitator", vec![atom("rest")]),
+                compound("precipitator", vec![atom("positional")]),
+            ],
+        )
+        .with_provenance(Provenance::cited("patient did not specify precipitator")),
+    );
+
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    let (posterior, uncertainties) = match result {
+        SearchResult::LRAggregateResult {
+            posterior,
+            uncertainties,
+            ..
+        } => (posterior, uncertainties),
+        other => panic!("expected LRAggregateResult, got {other:?}"),
+    };
+
+    // Posterior should still be ~0.281 (the unmodified ADJ36 number),
+    // because the marker reports but doesn't change aggregation.
+    assert!(
+        (posterior - 0.281).abs() < 0.005,
+        "expected ~0.281, got {posterior}"
+    );
+
+    // Exactly one uncertainty report — for the precipitator.
+    assert_eq!(uncertainties.len(), 1);
+    let report = &uncertainties[0];
+    assert_eq!(report.conclusion, atom("acs"));
+    assert_eq!(report.domain.len(), 3);
+    assert_eq!(report.if_observed_logit_delta.len(), 3);
+
+    // VOI: log(2.5) - log(0.6) = ln(2.5/0.6) ≈ 1.4271
+    assert!(
+        (report.voi_logit_range - (2.5_f64.ln() - 0.6_f64.ln())).abs() < 1e-9,
+        "expected VOI ≈ 1.4271, got {}",
+        report.voi_logit_range
+    );
+
+    // Spot-check individual deltas: the first domain entry is
+    // precipitator(exertional), which has contributes 2.5 → log(2.5).
+    assert!(
+        (report.if_observed_logit_delta[0] - 2.5_f64.ln()).abs() < 1e-9,
+        "expected log(2.5) ≈ 0.916, got {}",
+        report.if_observed_logit_delta[0]
+    );
+}
+
+#[test]
+fn observing_one_domain_value_suppresses_uncertainty_report() {
+    // Same rulebook + marker, but observe precipitator(exertional).
+    // The marker should not produce a report because the
+    // uncertainty is "resolved" by the observation.
+    let mut kb = build_acs_kb();
+    add_jane_doe(&mut kb);
+    kb.add_fact(Fact::certain(compound(
+        "precipitator",
+        vec![atom("exertional")],
+    )));
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("acs"),
+        vec![
+            compound("precipitator", vec![atom("exertional")]),
+            compound("precipitator", vec![atom("rest")]),
+            compound("precipitator", vec![atom("positional")]),
+        ],
+    ));
+
+    let result = search(&atom("acs"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { uncertainties, .. } = result {
+        assert!(
+            uncertainties.is_empty(),
+            "marker should be suppressed when domain is observed; got {uncertainties:?}"
+        );
+    } else {
+        panic!("expected LRAggregateResult");
+    }
+}
+
+#[test]
+fn uncertainty_marker_with_no_matching_contributions_has_zero_voi() {
+    // A marker whose domain values are not the target of any
+    // ContributionClause for the conclusion. The report should
+    // exist (the marker is active because nothing is observed)
+    // but every if_observed_logit_delta is 0.0 and VOI is 0.0 —
+    // a "rulebook gap" the modeller should know about.
+    let mut kb = KnowledgeBase::new();
+    kb.add_prior(PriorClause::from_probability(atom("c"), 0.10)).unwrap();
+    kb.add_contribution(ContributionClause::from_lr(
+        atom("c"),
+        atom("some_evidence"),
+        2.0,
+    ));
+    // Force this conclusion into the LR-aggregation regime via
+    // the participates check — the contribution above does that.
+    kb.add_uncertainty_marker(UncertaintyMarker::new(
+        atom("c"),
+        vec![atom("uncovered_a"), atom("uncovered_b")],
+    ));
+
+    let result = search(&atom("c"), &kb, SearchMode::LRAggregate);
+    if let SearchResult::LRAggregateResult { uncertainties, .. } = result {
+        assert_eq!(uncertainties.len(), 1);
+        assert_eq!(
+            uncertainties[0].if_observed_logit_delta,
+            vec![0.0, 0.0]
+        );
+        assert_eq!(uncertainties[0].voi_logit_range, 0.0);
+    } else {
+        panic!("expected LRAggregateResult");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Three method-level features in one PR. **This closes the ADJ46 awkwardness catalogue.** All 10 items dissolved.

- **A7 — kickback**: \`LRAggregateResult::suggest_kickback(decision_threshold)\` returns \`Some(KickbackReport)\` iff the worst/best uncertainty band straddles the threshold.
- **A8 — counterfactual**: \`counterfactual(query, kb, &[Term])\` clones the KB, adds assumed Facts, reruns aggregation. Caller's KB is invariant.
- **A9 — source disagreement**: \`source_disagreements(kb, conclusion)\` flags groups of \`ContributionClause\`s on the same evidence with spread > threshold, carrying per-source records (clause_id + logit_delta + provenance).
- Stacked on **#4933** (ADJ47-D).

## ADJ46 awkwardness catalogue: closed

| Item | Dissolved |
|---|---|
| A1 LR magnitudes | logic-engine 0.3.0 |
| A2 provenance | logic-engine 0.4.0 |
| A3 Bayesian prior | logic-engine 0.3.0 |
| A4 joint contributions syntax | adj-lang 0.1.0 |
| A5 uncertainty markers | logic-engine 0.5.0 + adj-lang 0.2.0 |
| A6 WMC vs LR | logic-engine 0.3.0 |
| **A7 kickback** | **this PR** |
| **A8 counterfactuals** | **this PR** |
| **A9 source disagreement** | **this PR** |
| A10 surface syntax | adj-lang 0.1.0 |

## Test plan

- [x] 69 tests passing (was 62)
- [x] Counterfactual upward shift verified (0.281 → ~0.494 with assumed exertional precipitator)
- [x] Counterfactual non-mutation invariant tested
- [x] Kickback fires inside the band (threshold 0.30, posterior 0.281, band ~[0.19, 0.49])
- [x] Kickback does not fire outside the band (threshold 0.05, posterior 0.281)
- [x] Source-disagreement detection: two sources / single source / agreeing sources
- [x] Security review passed (KB clone deep, empty-vector folds guarded, NaN-safe comparisons)

## Next

- **ADJ48**: full MYCIN-2026 demo in Adj-Lang (~50-rule chest-pain rulebook, 10 vignettes, physician comparison)
- **ADJ49**: M&A deal demo answering the investment-banker objection

🤖 Generated with [Claude Code](https://claude.com/claude-code)