### PR TITLE
feat(ml-framework-core-ts): N-D batched MatMul + higher-rank Transpose (v1.2 / Phase A.2)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 ## Unreleased
 
+### Added — v1.2.0: N-D batched MatMul + higher-rank Transpose (Phase A.2)
+
+PR #2 of 7 in **Phase A** — v1.0 had a 2-D-only `MatMul` and a
+2-D-only `transpose`; ML code with batches (attention, batched matmul
+in MLPs over sequences, etc.) couldn't express what it needed without
+manually reshaping.  v1.2 fixes both.
+
+#### What works now
+
+```ts
+// Batched matmul: (B, M, K) @ (B, K, N) → (B, M, N)
+const a = Tensor.zeros(8, 3, 4);      // 8 batches of (3, 4)
+const b = Tensor.zeros(8, 4, 5);      // 8 batches of (4, 5)
+a.matmul(b).shape;                    // → [8, 3, 5]
+
+// Broadcast right operand: (B, M, K) @ (K, N) → (B, M, N)
+const w = Tensor.zeros(4, 5);         // shared weight matrix
+a.matmul(w).shape;                    // → [8, 3, 5]; gradient on `w` sums across batch
+
+// Multi-batch broadcasting: (B1, 1, M, K) @ (1, B2, K, N) → (B1, B2, M, N)
+const x = Tensor.zeros(2, 1, 3, 4);
+const y = Tensor.zeros(1, 5, 4, 6);
+x.matmul(y).shape;                    // → [2, 5, 3, 6]
+
+// N-D transpose with arbitrary perm
+const t = Tensor.zeros(2, 3, 4, 5);
+t.transpose(2, 0, 3, 1).shape;        // → [4, 2, 5, 3]
+```
+
+#### Implementation notes
+
+- **`MatMulOp`** (`src/ops.ts`): the 2-D fast path is unchanged
+  (identical bytes/numerical output as v1.0; the Rust dispatch path
+  still triggers at `numel ≥ 10_000`).  For rank ≥ 3 on either input,
+  the op splits each tensor into a "batch portion" (all dims except
+  the trailing two) and a "matrix portion".  Batch portions broadcast
+  via the existing `broadcastShapes`/`broadcastDataTo` helpers from
+  Phase A.1; the matrix portion stays untouched (broadcasting matrix
+  dims is not what batched matmul means).  Then a per-slice 2-D matmul
+  loop reuses the existing `_matmulNaive` helper.
+- **Backward** for batched matmul applies the same per-slice formulas
+  (`dL/dA_slice = grad_slice @ B_slice^T`, `dL/dB_slice = A_slice^T @
+  grad_slice`), then `unbroadcastDataTo` flows gradients back to each
+  parent's original shape — so a shared/broadcast operand (e.g. a
+  per-layer weight matrix used across a batch) receives a properly
+  summed gradient.
+- **`Tensor.transpose`** (`src/tensor.ts`): 2-D fast path preserved.
+  For rank ≥ 3, generic strided index math: walk every output flat
+  index, decompose into output coordinates, map to input coordinates
+  via the inverse permutation, look up the source value.  O(numel).
+  Pure TS — no Rust dispatch yet (matrix-cpu would need a generic
+  Transpose op; deferred).
+- Rust dispatch is intentionally limited to the original 2-D MatMul
+  path for now.  A future PR can add a `BatchMatMul` op to matrix-ir
+  and lift the per-slice loop into Rust SIMD — for now, the TS path
+  is correct and fast at the parameter sizes ML training uses.
+
+#### Tests
+
+- 15 new vitest cases (`tests/batched-matmul.test.ts` + extended
+  transpose coverage in `tests/tensor.test.ts`).
+- Covers all five supported batched-matmul shape patterns, shape
+  validation (rank < 2 rejected, inner-dim mismatch rejected,
+  incompatible batch dims rejected), backward gradient correctness
+  for the broadcast cases, plus N-D transpose forward + roundtrip.
+- The existing v1.0 2-D matmul + 2-D transpose tests still pass
+  bit-identically.
+- **194 tests pass.**  Up from 179 in v1.1.
+
+#### Why this matters for the bigger picture
+
+Batched matmul + N-D transpose are the two ops you need before
+implementing anything attention-shaped (Q, K, V tensors are
+typically rank-3 or rank-4; computing `Q @ K^T` for attention
+requires both batched matmul and a higher-rank transpose).  This PR
+clears the runway for Phase A.3 (Embedding) and the eventual
+transformer architectures.
+
 ### Added — v1.1.0: NumPy-style broadcasting (Phase A.1)
 
 PR #1 of 7 in **Phase A** — broadening the op vocabulary toward

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Complete PyTorch-shaped TypeScript ML framework on the Rust matrix-cpu engine.  Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and backward.  Small tensors use a pure-TypeScript fast path; tensors of 10k+ cells auto-dispatch through @coding-adventures/matrix-rust-napi to the Rust matrix-cpu executor for SIMD-accelerated f32 math.  End-to-end MLP training verified by the test suite.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/ops.ts
+++ b/code/packages/typescript/ml-framework-core/src/ops.ts
@@ -563,58 +563,196 @@ export class PowOp extends Function {
   }
 }
 
-// ────────── MatMul (2-D only) ──────────
+// ────────── MatMul — N-D batched ──────────
+//
+// Supported shapes (rank ≥ 2 on both sides):
+//   * 2-D × 2-D                                           (M, K) @ (K, N) → (M, N)
+//   * batched same rank                       (B…, M, K) @ (B…, K, N) → (B…, M, N)
+//   * broadcast right operand                 (B…, M, K) @       (K, N) → (B…, M, N)
+//   * broadcast left operand                        (M, K) @ (B…, K, N) → (B…, M, N)
+//   * batch-dim broadcasting                  (B1, 1, M, K) @ (1, B2, K, N) → (B1, B2, M, N)
+//
+// Algorithm: split each input into a "batch portion" (all dims except
+// the last two) and a "matrix portion" (the trailing two).  Broadcast
+// the batch portions to a common shape via the existing broadcasting
+// machinery, then loop a single 2-D matmul per batch index.  The
+// matrix dims themselves are NEVER broadcast — that's not what batched
+// matmul means.
+//
+// Backward uses the same per-slice 2-D formulas (dL/dA_slice = grad_slice @
+// B_slice^T, dL/dB_slice = A_slice^T @ grad_slice), then unbroadcasts the
+// batch dims back to each parent's original shape so gradients flow to
+// shared/broadcast operands correctly.
+//
+// Rust dispatch is intentionally limited to the pure 2-D case for now —
+// matrix-cpu's MatMul kernel is 2-D, and pumping a thousand small matmuls
+// through the JSON/FFI roundtrip would be slower than the TS loop.  A
+// future PR can lift batched matmul to Rust by adding a BatchMatMul op
+// to matrix-ir, but for v1.2 the per-slice TS path is correct + fast
+// enough at the parameter sizes ML training uses.
 
 export class MatMulOp extends Function {
   forward(...inputs: unknown[]): Tensor {
     const a = inputs[0] as Tensor;
     const b = inputs[1] as Tensor;
-    if (a.ndim !== 2 || b.ndim !== 2) {
-      throw new RangeError(`matmul requires 2-D tensors, got ndim ${a.ndim} and ${b.ndim}`);
+    if (a.ndim < 2 || b.ndim < 2) {
+      throw new RangeError(
+        `matmul requires rank ≥ 2 on both inputs, got ndim ${a.ndim} and ${b.ndim}`,
+      );
     }
-    const [m, k1] = a.shape as [number, number];
-    const [k2, n] = b.shape as [number, number];
+    const aMat = a.shape.slice(-2) as [number, number];
+    const bMat = b.shape.slice(-2) as [number, number];
+    const [m, k1] = aMat;
+    const [k2, n] = bMat;
     if (k1 !== k2) {
-      throw new RangeError(`matmul shape mismatch: [${a.shape.join(", ")}] @ [${b.shape.join(", ")}]`);
+      throw new RangeError(
+        `matmul inner-dim mismatch: [${a.shape.join(", ")}] @ [${b.shape.join(", ")}] ` +
+          `(trailing dims must match: ${k1} vs ${k2})`,
+      );
     }
 
-    this.savedForBackward.a = a;
-    this.savedForBackward.b = b;
+    // Pure 2-D fast path — keeps the Rust dispatch and the v1.0 codepath
+    // bit-identical when both operands are exactly 2-D.
+    if (a.ndim === 2 && b.ndim === 2) {
+      this.savedForBackward.a = a;
+      this.savedForBackward.b = b;
+      this.savedForBackward.batchShape = [] as number[];
+      this.savedForBackward.aShape = a.shape.slice();
+      this.savedForBackward.bShape = b.shape.slice();
+      this.savedForBackward.batched = false;
 
-    if (a.numel >= DISPATCH_THRESHOLD || b.numel >= DISPATCH_THRESHOLD) {
-      const envelope = matmulEnvelope(a, b);
-      const out = runEnvelope(envelope, m * n);
-      return new Tensor(Array.from(out), { shape: [m, n] });
+      if (a.numel >= DISPATCH_THRESHOLD || b.numel >= DISPATCH_THRESHOLD) {
+        const envelope = matmulEnvelope(a, b);
+        const out = runEnvelope(envelope, m * n);
+        return new Tensor(Array.from(out), { shape: [m, n] });
+      }
+
+      return new Tensor(MatMulOp._matmulNaive(a.data, b.data, m, k1, n), {
+        shape: [m, n],
+      });
     }
 
-    return new Tensor(MatMulOp._matmulNaive(a.data, b.data, m, k1, n), { shape: [m, n] });
+    // ── N-D batched path ──
+    //
+    // Broadcast the batch dims (everything except the trailing two) to
+    // a common shape.  Then concatenate that with the per-side matrix
+    // dims to form the broadcast shape used by the per-batch loop.
+    const aBatch = a.shape.slice(0, -2);
+    const bBatch = b.shape.slice(0, -2);
+    const outBatch = broadcastShapes(aBatch, bBatch);
+    const batchSize = outBatch.reduce((acc, d) => acc * d, 1);
+
+    const aFullShape = [...outBatch, m, k1];
+    const bFullShape = [...outBatch, k1, n];
+
+    // Materialize the broadcasted batch portion.  Matching shapes are
+    // a near-free copy in `broadcastDataTo` (its fast path also handles
+    // the no-stretch case).
+    const aBuf = broadcastDataTo(a.data, a.shape, aFullShape);
+    const bBuf = broadcastDataTo(b.data, b.shape, bFullShape);
+
+    const outShape = [...outBatch, m, n];
+    const out = new Float32Array(batchSize * m * n);
+    const aStride = m * k1;
+    const bStride = k1 * n;
+    const oStride = m * n;
+    for (let batch = 0; batch < batchSize; batch++) {
+      const aSlice = aBuf.subarray(batch * aStride, (batch + 1) * aStride);
+      const bSlice = bBuf.subarray(batch * bStride, (batch + 1) * bStride);
+      const cSlice = MatMulOp._matmulNaive(aSlice, bSlice, m, k1, n);
+      for (let i = 0; i < oStride; i++) out[batch * oStride + i] = cSlice[i]!;
+    }
+
+    // Save broadcasted buffers — backward needs them at the broadcast
+    // shape to compute per-slice grads, then unbroadcasts back to the
+    // original parent shapes.
+    this.savedForBackward.aBuf = aBuf;
+    this.savedForBackward.bBuf = bBuf;
+    this.savedForBackward.aShape = a.shape.slice();
+    this.savedForBackward.bShape = b.shape.slice();
+    this.savedForBackward.aFullShape = aFullShape;
+    this.savedForBackward.bFullShape = bFullShape;
+    this.savedForBackward.outBatch = outBatch;
+    this.savedForBackward.m = m;
+    this.savedForBackward.k = k1;
+    this.savedForBackward.n = n;
+    this.savedForBackward.batched = true;
+
+    return new Tensor(Array.from(out), { shape: outShape });
   }
 
-  // Backward for C = A @ B (2-D):
-  //   dL/dA = grad @ B^T
-  //   dL/dB = A^T @ grad
-  // Use internal helpers (not MatMulOp.apply) so backward stays a leaf
-  // math operation — no extra autograd subgraph.
+  // Backward for C = A @ B:
+  //   dL/dA = grad @ B^T           (per batch slice)
+  //   dL/dB = A^T @ grad           (per batch slice)
+  //
+  // 2-D: identical to v1.0.  N-D batched: loop over batch slices,
+  // accumulate into broadcast-shaped grads, then unbroadcast back to
+  // each parent's original shape (so a broadcast operand receives a
+  // properly summed gradient).
   backward(grad: Tensor): (Tensor | null)[] {
-    const a = this.savedForBackward.a as Tensor;
-    const b = this.savedForBackward.b as Tensor;
-    const [m, k] = a.shape as [number, number];
-    const [, n] = b.shape as [number, number];
+    if (!this.savedForBackward.batched) {
+      const a = this.savedForBackward.a as Tensor;
+      const b = this.savedForBackward.b as Tensor;
+      const [m, k] = a.shape as [number, number];
+      const [, n] = b.shape as [number, number];
 
-    const bT = MatMulOp._transpose2D(b.data, k, n);             // (n, k)
-    const gradAData = MatMulOp._matmulNaive(grad.data, bT, m, n, k);  // (m, k)
+      const bT = MatMulOp._transpose2D(b.data, k, n);                  // (n, k)
+      const gradAData = MatMulOp._matmulNaive(grad.data, bT, m, n, k); // (m, k)
+      const aT = MatMulOp._transpose2D(a.data, m, k);                  // (k, m)
+      const gradBData = MatMulOp._matmulNaive(aT, grad.data, k, m, n); // (k, n)
 
-    const aT = MatMulOp._transpose2D(a.data, m, k);             // (k, m)
-    const gradBData = MatMulOp._matmulNaive(aT, grad.data, k, m, n);  // (k, n)
+      return [
+        new Tensor(gradAData, { shape: [m, k] }),
+        new Tensor(gradBData, { shape: [k, n] }),
+      ];
+    }
+
+    const aBuf = this.savedForBackward.aBuf as Float32Array;
+    const bBuf = this.savedForBackward.bBuf as Float32Array;
+    const aShape = this.savedForBackward.aShape as number[];
+    const bShape = this.savedForBackward.bShape as number[];
+    const aFullShape = this.savedForBackward.aFullShape as number[];
+    const bFullShape = this.savedForBackward.bFullShape as number[];
+    const outBatch = this.savedForBackward.outBatch as number[];
+    const m = this.savedForBackward.m as number;
+    const k = this.savedForBackward.k as number;
+    const n = this.savedForBackward.n as number;
+    const batchSize = outBatch.reduce((acc, d) => acc * d, 1);
+
+    const gradABig = new Float32Array(batchSize * m * k);
+    const gradBBig = new Float32Array(batchSize * k * n);
+    const aStride = m * k;
+    const bStride = k * n;
+    const gStride = m * n;
+
+    for (let batch = 0; batch < batchSize; batch++) {
+      const aSlice = aBuf.subarray(batch * aStride, (batch + 1) * aStride);
+      const bSlice = bBuf.subarray(batch * bStride, (batch + 1) * bStride);
+      const gSlice = grad.data.subarray(batch * gStride, (batch + 1) * gStride);
+
+      const bT = MatMulOp._transpose2D(bSlice, k, n);                 // (n, k)
+      const gA = MatMulOp._matmulNaive(gSlice, bT, m, n, k);          // (m, k)
+      for (let i = 0; i < aStride; i++) gradABig[batch * aStride + i] = gA[i]!;
+
+      const aT = MatMulOp._transpose2D(aSlice, m, k);                 // (k, m)
+      const gB = MatMulOp._matmulNaive(aT, gSlice, k, m, n);          // (k, n)
+      for (let i = 0; i < bStride; i++) gradBBig[batch * bStride + i] = gB[i]!;
+    }
 
     return [
-      new Tensor(gradAData, { shape: [m, k] }),
-      new Tensor(gradBData, { shape: [k, n] }),
+      tensorFromBuf(unbroadcastDataTo(gradABig, aFullShape, aShape), aShape),
+      tensorFromBuf(unbroadcastDataTo(gradBBig, bFullShape, bShape), bShape),
     ];
   }
 
   /** O(m*k*n) naive matmul on raw Float32Array data. */
-  static _matmulNaive(aData: ArrayLike<number>, bData: ArrayLike<number>, m: number, k: number, n: number): number[] {
+  static _matmulNaive(
+    aData: ArrayLike<number>,
+    bData: ArrayLike<number>,
+    m: number,
+    k: number,
+    n: number,
+  ): number[] {
     const out = new Array(m * n).fill(0);
     for (let i = 0; i < m; i++) {
       for (let j = 0; j < n; j++) {

--- a/code/packages/typescript/ml-framework-core/src/tensor.ts
+++ b/code/packages/typescript/ml-framework-core/src/tensor.ts
@@ -296,8 +296,19 @@ export class Tensor {
   }
 
   /**
-   * Transpose.  2-D only in v0.1 (higher-rank perm transpose needs generic
-   * strided index math; deferred to a later PR when there's actual demand).
+   * Transpose.  Generic N-D perm transpose.
+   *
+   * - `t.transpose()` with no args: only valid for 2-D, swaps the two dims.
+   * - `t.transpose(p0, p1, ...)`: reorders dims so `out.shape[i] = in.shape[perm[i]]`.
+   *
+   * Matches NumPy's `np.transpose(a, axes=...)` semantics.  Used by
+   * higher-rank ML code (e.g. swapping (batch, seq, features) ↔
+   * (batch, features, seq) for attention-style ops).
+   *
+   * For rank ≥ 3 we walk the output index space and, for each output
+   * coordinate, compute the matching input coordinate via the inverse
+   * permutation: if `outCoord[i] = inCoord[perm[i]]`, then
+   * `inCoord[perm[i]] = outCoord[i]`.  Pure strided index math, O(numel).
    */
   transpose(...perm: number[]): Tensor {
     if (perm.length === 0) {
@@ -319,18 +330,66 @@ export class Tensor {
       }
     }
 
-    if (this.ndim !== 2) {
-      throw new Error(`transpose on rank-${this.ndim} tensors not yet implemented (v0.1: 2-D only)`);
+    // 2-D fast path — same code as v1.0, here so 2-D doesn't pay the
+    // generic per-index loop overhead.
+    if (this.ndim === 2) {
+      const [rows, cols] = this.shape as [number, number];
+      const out = new Float32Array(rows * cols);
+      // perm could be [0,1] (identity) or [1,0] (swap).
+      if (perm[0] === 0 && perm[1] === 1) {
+        out.set(this.data);
+        return new Tensor(Array.from(out), { shape: [rows, cols] });
+      }
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          out[c * rows + r] = this.data[r * cols + c]!;
+        }
+      }
+      return new Tensor(Array.from(out), { shape: [cols, rows] });
     }
 
-    const [rows, cols] = this.shape as [number, number];
-    const out = new Float32Array(rows * cols);
-    for (let r = 0; r < rows; r++) {
-      for (let c = 0; c < cols; c++) {
-        out[c * rows + r] = this.data[r * cols + c]!;
+    // ── Generic N-D path ──
+    const ndim = this.ndim;
+    const inShape = this.shape;
+    const outShape = perm.map((p) => inShape[p]!);
+
+    // Row-major strides: stride[i] = product of shape[i+1..].
+    const inStrides = new Array<number>(ndim);
+    const outStrides = new Array<number>(ndim);
+    {
+      let s = 1;
+      for (let i = ndim - 1; i >= 0; i--) {
+        inStrides[i] = s;
+        s *= inShape[i]!;
+      }
+      s = 1;
+      for (let i = ndim - 1; i >= 0; i--) {
+        outStrides[i] = s;
+        s *= outShape[i]!;
       }
     }
-    return new Tensor(Array.from(out), { shape: [cols, rows] });
+
+    const numel = this.numel;
+    const out = new Float32Array(numel);
+    const outCoords = new Array<number>(ndim).fill(0);
+    const inCoords = new Array<number>(ndim).fill(0);
+
+    for (let outIdx = 0; outIdx < numel; outIdx++) {
+      // Decompose outIdx into outCoords (row-major).
+      let rem = outIdx;
+      for (let i = 0; i < ndim; i++) {
+        outCoords[i] = Math.floor(rem / outStrides[i]!);
+        rem -= outCoords[i]! * outStrides[i]!;
+      }
+      // Map: out axis i corresponds to in axis perm[i].
+      for (let i = 0; i < ndim; i++) {
+        inCoords[perm[i]!] = outCoords[i]!;
+      }
+      let srcIdx = 0;
+      for (let i = 0; i < ndim; i++) srcIdx += inCoords[i]! * inStrides[i]!;
+      out[outIdx] = this.data[srcIdx]!;
+    }
+    return new Tensor(Array.from(out), { shape: outShape });
   }
 
   /** Drop size-1 dimensions.  With no axis, drops all of them. */

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "1.1.0" as const;
+export const VERSION = "1.2.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/batched-matmul.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/batched-matmul.test.ts
@@ -1,0 +1,199 @@
+/**
+ * batched-matmul.test.ts — N-D batched MatMul forward + backward.
+ *
+ * Added in v1.2 (Phase A.2).  Exercises:
+ *  - Forward: equal-batch, broadcast-right, broadcast-left, multi-batch,
+ *    multi-batch with broadcasting.
+ *  - Numerical correctness against hand-computed reference values.
+ *  - Backward: per-batch slice formulas, and gradient unbroadcast to the
+ *    original (broadcast) parent shape so shared operands get summed grads.
+ *  - Shape validation: rank ≥ 2 enforced, inner-dim mismatch rejected,
+ *    incompatible batch shapes rejected.
+ *
+ * Reference for hand-computed values: numpy.matmul on identical inputs.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor, MatMulOp } from "../src/index.js";
+
+/** Helper: build a 2-D tensor by enumerating rows × cols starting from `start`. */
+function make2D(rows: number, cols: number, start: number = 0): Tensor {
+  return new Tensor(
+    Array.from({ length: rows * cols }, (_, i) => start + i),
+    { shape: [rows, cols] },
+  );
+}
+
+/** Build a tensor and flip `requiresGrad` — Tensor options don't accept it. */
+function withGrad(data: number[], shape: number[]): Tensor {
+  const t = new Tensor(data, { shape });
+  t.requiresGrad = true;
+  return t;
+}
+
+describe("Batched MatMul — forward shapes", () => {
+  it("(B, M, K) @ (B, K, N) → (B, M, N)  equal batch", () => {
+    // Batch 2 of (2, 3) @ (3, 4) → (2, 2, 4).
+    const a = new Tensor(Array.from({ length: 2 * 2 * 3 }, (_, i) => i), {
+      shape: [2, 2, 3],
+    });
+    const b = new Tensor(Array.from({ length: 2 * 3 * 4 }, (_, i) => i), {
+      shape: [2, 3, 4],
+    });
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([2, 2, 4]);
+
+    // Hand-check batch 0: a_b0 = [[0,1,2],[3,4,5]],  b_b0 = [[0,1,2,3],[4,5,6,7],[8,9,10,11]].
+    //   row 0 col 0 = 0*0 + 1*4 + 2*8 = 20
+    //   row 0 col 3 = 0*3 + 1*7 + 2*11 = 29
+    //   row 1 col 0 = 3*0 + 4*4 + 5*8 = 56
+    //   row 1 col 3 = 3*3 + 4*7 + 5*11 = 92
+    const flat = out.toArray();
+    expect(flat[0]).toBe(20);
+    expect(flat[3]).toBe(29);
+    expect(flat[4]).toBe(56);
+    expect(flat[7]).toBe(92);
+
+    // Batch 1: a_b1 starts at 6, b_b1 starts at 12.
+    //   a_b1 = [[6,7,8],[9,10,11]], b_b1 = [[12,13,14,15],[16,17,18,19],[20,21,22,23]]
+    //   row 0 col 0 = 6*12 + 7*16 + 8*20 = 72 + 112 + 160 = 344
+    expect(flat[8]).toBe(344);
+  });
+
+  it("(B, M, K) @ (K, N) → (B, M, N)  broadcasts right operand", () => {
+    // Batch 3 on the left; single matrix on the right.
+    const a = new Tensor(Array.from({ length: 3 * 2 * 2 }, (_, i) => i), {
+      shape: [3, 2, 2],
+    });
+    const b = make2D(2, 2); // [[0,1],[2,3]]
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([3, 2, 2]);
+
+    // Batch 0: [[0,1],[2,3]] @ [[0,1],[2,3]] = [[2, 3], [6, 11]]
+    expect(out.toArray().slice(0, 4)).toEqual([2, 3, 6, 11]);
+  });
+
+  it("(M, K) @ (B, K, N) → (B, M, N)  broadcasts left operand", () => {
+    const a = make2D(2, 2); // [[0,1],[2,3]]
+    const b = new Tensor(Array.from({ length: 3 * 2 * 2 }, (_, i) => i), {
+      shape: [3, 2, 2],
+    });
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([3, 2, 2]);
+
+    // Batch 0: [[0,1],[2,3]] @ [[0,1],[2,3]] = [[2,3],[6,11]]
+    expect(out.toArray().slice(0, 4)).toEqual([2, 3, 6, 11]);
+  });
+
+  it("(B1, B2, M, K) @ (B1, B2, K, N) → (B1, B2, M, N)  multi-batch", () => {
+    const a = new Tensor(
+      Array.from({ length: 2 * 3 * 2 * 2 }, (_, i) => i),
+      { shape: [2, 3, 2, 2] },
+    );
+    const b = new Tensor(
+      Array.from({ length: 2 * 3 * 2 * 2 }, (_, i) => i),
+      { shape: [2, 3, 2, 2] },
+    );
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([2, 3, 2, 2]);
+    // First slice (b1=0, b2=0): [[0,1],[2,3]] @ [[0,1],[2,3]] = [[2,3],[6,11]]
+    expect(out.toArray().slice(0, 4)).toEqual([2, 3, 6, 11]);
+  });
+
+  it("(B1, 1, M, K) @ (1, B2, K, N) → (B1, B2, M, N)  multi-batch broadcast", () => {
+    // B1 = 2 (left-only), B2 = 3 (right-only).
+    const a = new Tensor(Array.from({ length: 2 * 1 * 2 * 2 }, (_, i) => i), {
+      shape: [2, 1, 2, 2],
+    });
+    const b = new Tensor(Array.from({ length: 1 * 3 * 2 * 2 }, (_, i) => i), {
+      shape: [1, 3, 2, 2],
+    });
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([2, 3, 2, 2]);
+    // (b1=0, b2=0): a slice = [[0,1],[2,3]], b slice = [[0,1],[2,3]] → [[2,3],[6,11]]
+    expect(out.toArray().slice(0, 4)).toEqual([2, 3, 6, 11]);
+  });
+});
+
+describe("Batched MatMul — shape validation", () => {
+  it("rejects mismatched inner dim", () => {
+    expect(() =>
+      MatMulOp.apply(Tensor.zeros(2, 3, 4), Tensor.zeros(2, 5, 6)),
+    ).toThrow(RangeError);
+  });
+
+  it("rejects incompatible batch shapes", () => {
+    // (2, M, K) @ (3, K, N): batch dims 2 vs 3 can't broadcast.
+    expect(() =>
+      MatMulOp.apply(Tensor.zeros(2, 2, 3), Tensor.zeros(3, 3, 2)),
+    ).toThrow(RangeError);
+  });
+});
+
+describe("Batched MatMul — backward gradient correctness", () => {
+  it("equal-batch backward returns per-slice grads of correct shape", () => {
+    const a = withGrad(
+      Array.from({ length: 2 * 2 * 3 }, (_, i) => i + 1),
+      [2, 2, 3],
+    );
+    const b = withGrad(
+      Array.from({ length: 2 * 3 * 2 }, (_, i) => i + 1),
+      [2, 3, 2],
+    );
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([2, 2, 2]);
+    out.backward();
+    expect(a.grad?.shape).toEqual([2, 2, 3]);
+    expect(b.grad?.shape).toEqual([2, 3, 2]);
+  });
+
+  it("broadcast-right backward sums grad across batch back to (K, N)", () => {
+    // (B, M, K) @ (K, N) — shared (K, N) operand should receive sum of per-slice grads.
+    const a = withGrad(Array.from({ length: 3 * 2 * 2 }, () => 1), [3, 2, 2]);
+    const b = withGrad([1, 0, 0, 1], [2, 2]);
+    const out = MatMulOp.apply(a, b);
+    out.backward(); // ones-grad of shape (3, 2, 2)
+    expect(a.grad?.shape).toEqual([3, 2, 2]);
+    expect(b.grad?.shape).toEqual([2, 2]);
+    // For each batch slice, dL/dB_slice = A_slice^T @ grad_slice.
+    // A_slice = ones(2,2), grad_slice = ones(2,2) → A^T @ grad = [[2,2],[2,2]].
+    // Sum over 3 batch slices → [[6,6],[6,6]].
+    expect(Array.from(b.grad!.data)).toEqual([6, 6, 6, 6]);
+  });
+
+  it("broadcast-left backward sums grad across batch back to (M, K)", () => {
+    const a = withGrad([1, 0, 0, 1], [2, 2]);
+    const b = withGrad(Array.from({ length: 3 * 2 * 2 }, () => 1), [3, 2, 2]);
+    const out = MatMulOp.apply(a, b);
+    out.backward();
+    expect(a.grad?.shape).toEqual([2, 2]);
+    expect(b.grad?.shape).toEqual([3, 2, 2]);
+    // dL/dA_slice = grad_slice @ B_slice^T.  B_slice = ones, grad_slice = ones → [[2,2],[2,2]].
+    // Summed over 3 slices → [[6,6],[6,6]].
+    expect(Array.from(a.grad!.data)).toEqual([6, 6, 6, 6]);
+  });
+});
+
+describe("Batched MatMul — 2-D still works (no regression)", () => {
+  it("2-D matmul matches the v1.0 baseline exactly", () => {
+    const a = new Tensor([[1, 2], [3, 4]]);
+    const b = new Tensor([[5, 6], [7, 8]]);
+    const out = MatMulOp.apply(a, b);
+    expect(out.shape).toEqual([2, 2]);
+    expect(out.toArray()).toEqual([19, 22, 43, 50]);
+  });
+
+  it("2-D matmul backward matches the v1.0 baseline", () => {
+    const a = new Tensor([[1, 2], [3, 4]]);
+    a.requiresGrad = true;
+    const b = new Tensor([[5, 6], [7, 8]]);
+    b.requiresGrad = true;
+    const out = MatMulOp.apply(a, b);
+    out.backward();
+    expect(a.grad?.shape).toEqual([2, 2]);
+    expect(b.grad?.shape).toEqual([2, 2]);
+    // grad ones(2,2).  dL/dA = ones @ B^T = [[11, 15], [11, 15]]; dL/dB = A^T @ ones = [[4, 4], [6, 6]].
+    expect(Array.from(a.grad!.data)).toEqual([11, 15, 11, 15]);
+    expect(Array.from(b.grad!.data)).toEqual([4, 4, 6, 6]);
+  });
+});

--- a/code/packages/typescript/ml-framework-core/tests/ops.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/ops.test.ts
@@ -109,8 +109,10 @@ describe("ForwardSmall — every op pure-TS path", () => {
     expect(out.shape).toEqual([2, 2]);
     expect(out.toArray()).toEqual([19, 22, 43, 50]);
   });
-  it("MatMul rejects non-2-D", () => {
+  it("MatMul rejects rank < 2 on either input", () => {
     expect(() => MatMulOp.apply(new Tensor([1, 2, 3]), new Tensor([[1, 2], [3, 4]])))
+      .toThrow(RangeError);
+    expect(() => MatMulOp.apply(new Tensor([[1, 2], [3, 4]]), new Tensor([1, 2])))
       .toThrow(RangeError);
   });
   it("MatMul rejects inner-dim mismatch", () => {

--- a/code/packages/typescript/ml-framework-core/tests/tensor.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/tensor.test.ts
@@ -202,9 +202,51 @@ describe("Tensor — shape ops", () => {
     expect(() => t.transpose(0, 1, 2)).toThrow(RangeError);
   });
 
-  it("transpose on higher-rank tensors is not yet implemented", () => {
-    const t = Tensor.zeros(2, 2, 2);
-    expect(() => t.transpose(2, 1, 0)).toThrow();
+  it("transpose 3-D reverses all dims", () => {
+    // shape (2, 3, 4) with values 0..23 → perm (2, 1, 0) gives shape (4, 3, 2)
+    const data = Array.from({ length: 24 }, (_, i) => i);
+    const t = new Tensor(data, { shape: [2, 3, 4] });
+    const u = t.transpose(2, 1, 0);
+    expect(u.shape).toEqual([4, 3, 2]);
+    // out[i, j, k] = in[k, j, i].  Spot-check a few:
+    //   out[0, 0, 0] = in[0, 0, 0] = 0
+    //   out[3, 2, 1] = in[1, 2, 3] = 1*12 + 2*4 + 3 = 23
+    //   out[1, 0, 1] = in[1, 0, 1] = 1*12 + 0*4 + 1 = 13
+    const flat = u.toArray();
+    // out stride is (3*2, 2, 1) = (6, 2, 1)
+    expect(flat[0 * 6 + 0 * 2 + 0]).toBe(0);
+    expect(flat[3 * 6 + 2 * 2 + 1]).toBe(23);
+    expect(flat[1 * 6 + 0 * 2 + 1]).toBe(13);
+  });
+
+  it("transpose 3-D with arbitrary perm", () => {
+    // (2, 3, 4) → perm (1, 2, 0) gives (3, 4, 2): out[a, b, c] = in[c, a, b]
+    const data = Array.from({ length: 24 }, (_, i) => i);
+    const t = new Tensor(data, { shape: [2, 3, 4] });
+    const u = t.transpose(1, 2, 0);
+    expect(u.shape).toEqual([3, 4, 2]);
+    // out stride (4*2, 2, 1) = (8, 2, 1); in stride (3*4, 4, 1) = (12, 4, 1)
+    const flat = u.toArray();
+    // out[2, 3, 1] = in[1, 2, 3] = 12 + 8 + 3 = 23 → at out index 2*8+3*2+1 = 23
+    expect(flat[2 * 8 + 3 * 2 + 1]).toBe(23);
+    // out[0, 0, 1] = in[1, 0, 0] = 12 → at out index 1
+    expect(flat[1]).toBe(12);
+  });
+
+  it("transpose 4-D round-trip with inverse perm is the identity", () => {
+    const data = Array.from({ length: 2 * 3 * 4 * 5 }, (_, i) => i);
+    const t = new Tensor(data, { shape: [2, 3, 4, 5] });
+    // perm (2, 0, 3, 1); inverse satisfies inv[perm[i]] = i → inv = (1, 3, 0, 2)
+    const u = t.transpose(2, 0, 3, 1);
+    expect(u.shape).toEqual([4, 2, 5, 3]);
+    const back = u.transpose(1, 3, 0, 2);
+    expect(back.shape).toEqual([2, 3, 4, 5]);
+    expect(back.toArray()).toEqual(t.toArray());
+  });
+
+  it("transpose with identity perm is the identity", () => {
+    const t = new Tensor(Array.from({ length: 24 }, (_, i) => i), { shape: [2, 3, 4] });
+    expect(t.transpose(0, 1, 2).toArray()).toEqual(t.toArray());
   });
 
   it("squeeze with no arg drops all size-1 dims", () => {


### PR DESCRIPTION
## Summary

**Phase A.2 of 7** in the TypeScript ml-framework expansion toward "constantly training models locally."

- Extends `MatMulOp` from 2-D-only to **N-D batched matmul** (5 supported shape patterns: equal-batch, broadcast-right, broadcast-left, multi-batch, multi-batch with broadcasting).
- Extends `Tensor.transpose` from 2-D-only to **generic N-D perm transpose** via strided index math.
- Backward for batched matmul correctly unbroadcasts gradients to each parent's original shape, so shared/broadcast operands receive properly summed grads.
- 2-D fast path preserved bit-identically (incl. Rust dispatch at `numel ≥ 10_000`).
- Bumps to **v1.2.0**.

## Why now

These two ops are prerequisites for anything attention-shaped: Q, K, V tensors are typically rank-3 or rank-4, and computing `Q @ K^T` requires both batched matmul and a higher-rank transpose. This clears the runway for Phase A.3 (Embedding), eventually transformer architectures, and HF safetensors interop in A.7.

## Test plan

- [x] Pre-existing 194 vitest cases all pass (179 before + 15 new in this PR)
  - 5 batched-matmul forward shape patterns
  - 2 shape-validation cases (rank < 2, incompatible batch shapes)
  - 3 backward gradient-correctness cases
  - 2 2-D regression cases
  - 3 N-D transpose cases (full reverse, arbitrary perm, 4-D roundtrip, identity)
- [x] `tsc --noEmit` clean
- [x] Security review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)