### PR TITLE
feat(ml-framework-core-ts): EmbeddingOp lookup-table (v1.3 / Phase A.3)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 ## Unreleased
 
+### Added — v1.3.0: EmbeddingOp lookup-table (Phase A.3)
+
+PR #3 of 7 in **Phase A**.  Adds the embedding-layer op — the one
+op that gates almost every NLP model.  Without it, you can't take
+discrete token IDs as input; with it, the road to attention layers
+(and from there, transformer architectures) is open.
+
+#### What works now
+
+```ts
+// Vocab of 10k tokens, each embedded into a 128-D vector.
+const weight = Tensor.zeros(10000, 128);   // learnable lookup table
+weight.requiresGrad = true;
+
+// A batch of 4 sequences, each 32 tokens long.
+const tokens = new Tensor([...], { shape: [4, 32] });   // integer values in [0, 10000)
+
+// Look up each token's embedding.  Output shape: [4, 32, 128].
+const x = weight.embedding(tokens);
+
+// During training: gradients flow back into `weight` via SCATTER-ADD.
+// Repeated tokens (the common case in real text) accumulate correctly.
+loss.backward();
+console.log(weight.grad!.shape);   // → [10000, 128]
+```
+
+#### Implementation notes
+
+- **`EmbeddingOp`** (`src/ops.ts`): standard forward — for each flat
+  index `i` in `indices`, copy `weight[indices[i], :]` into `out[i, :]`.
+  Output shape = `[...indices.shape, embedding_dim]`.  Indices values
+  are `Math.trunc`'d at lookup time and validated against `[0,
+  vocab_size)` — out-of-range throws a clear `RangeError`.
+- **Scatter-add backward** is THE correctness property of an embedding
+  layer.  When the same vocab index appears multiple times in the
+  input (which is the case for nearly every real sentence — common
+  words repeat), the gradient at that weight row must be the SUM of
+  the per-occurrence grad slices.  A naive "set weight[idx, :] = grad
+  slice" silently drops all but the last occurrence's contribution
+  and trains to garbage.  We use `+=` (accumulate into a zero-init
+  buffer) to do this correctly.  The test suite has an explicit
+  "REPEATED indices accumulate" test that fails loud if you ever
+  break this.
+- **Indices are a Tensor, not a `number[]`** — consistency with the
+  rest of the framework and makes `indices.shape` the prefix of the
+  output shape without a separate parameter.  Cells are f32 (only
+  dtype we support) but get truncated to int at lookup time.
+- **Indices receive no gradient** — `backward` returns `null` for the
+  indices parent.  Even if the user erroneously sets
+  `indices.requiresGrad = true`, the autograd walker handles the
+  `null` gracefully without crashing.
+- **`Tensor.embedding(indices)`** convenience method: `weight.embedding(tokens)`
+  reads naturally and matches the PyTorch `F.embedding(tokens, weight)`
+  signature (with self-as-weight for fluent chaining).
+
+#### Tests
+
+- 12 new vitest cases (`tests/embedding.test.ts`):
+  - 3 forward-shape cases (1-D indices, 2-D indices, scalar indices)
+  - 2 backward correctness (shape + the killer "repeated indices" sum)
+  - 1 backward with explicit non-ones gradient
+  - 1 indices-grad-is-null
+  - 4 validation cases (non-2-D weight, negative idx, idx ≥ vocab, boundary OK)
+  - 1 fluent-method parity
+- **206 tests pass.**  Up from 194 in v1.2.
+
+#### What this unlocks
+
+Embedding is the last big op needed before attention.  With `matmul`
+batched (v1.2), `softmax` (v1.0), and `embedding` (v1.3), the core
+operations for an attention layer are all in place.  Phase A.4 adds
+LayerNorm + BatchNorm + Dropout (the "normalize and regularize"
+trifecta every transformer uses); A.7 wires up safetensors so we
+can load any HF checkpoint's weights.
+
 ### Added — v1.2.0: N-D batched MatMul + higher-rank Transpose (Phase A.2)
 
 PR #2 of 7 in **Phase A** — v1.0 had a 2-D-only `MatMul` and a

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Complete PyTorch-shaped TypeScript ML framework on the Rust matrix-cpu engine.  Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and backward.  Small tensors use a pure-TypeScript fast path; tensors of 10k+ cells auto-dispatch through @coding-adventures/matrix-rust-napi to the Rust matrix-cpu executor for SIMD-accelerated f32 math.  End-to-end MLP training verified by the test suite.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/index.ts
+++ b/code/packages/typescript/ml-framework-core/src/index.ts
@@ -56,6 +56,7 @@ export {
   SoftmaxOp,
   SumOp,
   MeanOp,
+  EmbeddingOp,
   BroadcastOp,
   DISPATCH_THRESHOLD,
   packF32Hex,

--- a/code/packages/typescript/ml-framework-core/src/ops.ts
+++ b/code/packages/typescript/ml-framework-core/src/ops.ts
@@ -968,3 +968,126 @@ export class MeanOp extends Function {
     return [new Tensor(new Array(numel).fill(g), { shape: inputShape.slice() })];
   }
 }
+
+// ────────── Embedding — lookup table (Phase A.3) ──────────
+//
+// Standard NN embedding layer.  Given a learnable weight matrix of shape
+// (vocab_size, embedding_dim) and an integer-valued indices tensor of
+// arbitrary shape `S`, looks up each index's row and produces an output
+// of shape `[...S, embedding_dim]`.
+//
+// ## Why indices are a Tensor (of integers) and not number[]
+//
+// Two reasons:
+//   1. Consistency — everything else in the framework is a Tensor.  An
+//      embedding lookup naturally chains: tokens → embedding → linear → ...
+//   2. Shape: `indices.shape` IS the prefix of the output shape.  Carrying
+//      shape on the Tensor saves a separate `indicesShape` argument.
+//
+// Indices values are still cast to int at lookup time (we use Math.trunc
+// on each f32 cell).  This matches PyTorch's de-facto "you pass a Long
+// tensor" convention but works within our f32-only storage model.
+//
+// ## Backward = scatter-add
+//
+// This is the MOST IMPORTANT correctness property of an embedding layer.
+// When the same vocabulary index appears multiple times in `indices`
+// (which is the common case — most sentences have repeated tokens), the
+// gradient at that weight row is the SUM of grad slices from every
+// occurrence.  A naive "set weight[idx, :] = grad slice" would drop all
+// but the last occurrence's contribution.  We use += (accumulate) into
+// the grad-weight buffer to avoid that bug.
+//
+// Indices receive no gradient (they're not differentiable; return null).
+//
+// ## What this unlocks
+//
+// Any NLP model that takes token IDs as input — i.e. essentially every
+// transformer ever published.  v1.3 with Embedding is the last big op
+// missing before we can start expressing attention layers (matmul + softmax
+// + embedding all in place).
+
+export class EmbeddingOp extends Function {
+  forward(...inputs: unknown[]): Tensor {
+    const weight = inputs[0] as Tensor;
+    const indices = inputs[1] as Tensor;
+
+    if (weight.ndim !== 2) {
+      throw new RangeError(
+        `embedding weight must be 2-D (vocab_size, embedding_dim); got shape [${weight.shape.join(", ")}]`,
+      );
+    }
+    const [vocabSize, embDim] = weight.shape as [number, number];
+
+    // Materialize a Int32Array view of the indices so range-checks and
+    // lookups are integer-clean.  We use Math.trunc to convert (round
+    // toward zero), then validate range.
+    const numIndices = indices.numel;
+    const idx = new Int32Array(numIndices);
+    for (let i = 0; i < numIndices; i++) {
+      const v = Math.trunc(indices.data[i]!);
+      if (v < 0 || v >= vocabSize) {
+        throw new RangeError(
+          `embedding index ${indices.data[i]} at position ${i} out of range ` +
+            `[0, ${vocabSize}); embedding weight has ${vocabSize} rows`,
+        );
+      }
+      idx[i] = v;
+    }
+
+    // Output shape: indices.shape ++ [embedding_dim].  Special case:
+    // scalar indices (shape []) yields shape [embedding_dim].
+    const outShape = [...indices.shape, embDim];
+    const out = new Float32Array(numIndices * embDim);
+    for (let i = 0; i < numIndices; i++) {
+      const row = idx[i]!;
+      const srcStart = row * embDim;
+      const dstStart = i * embDim;
+      for (let d = 0; d < embDim; d++) {
+        out[dstStart + d] = weight.data[srcStart + d]!;
+      }
+    }
+
+    this.savedForBackward.weightShape = weight.shape.slice();
+    this.savedForBackward.indicesShape = indices.shape.slice();
+    this.savedForBackward.idx = idx;
+    this.savedForBackward.vocabSize = vocabSize;
+    this.savedForBackward.embDim = embDim;
+
+    return new Tensor(Array.from(out), { shape: outShape });
+  }
+
+  // Backward = scatter-add into a zeros-initialized grad-weight.
+  //
+  // grad shape: [...indices.shape, embedding_dim]
+  // → flatten the leading dims to numIndices and treat as
+  //   (numIndices, embedding_dim).
+  // For each i in 0..numIndices:
+  //   gradWeight[idx[i], :] += grad[i, :]
+  //
+  // The += (not =) is the scatter-add — repeated indices accumulate.
+  //
+  // Indices receive null (not differentiable).
+  backward(grad: Tensor): (Tensor | null)[] {
+    const idx = this.savedForBackward.idx as Int32Array;
+    const vocabSize = this.savedForBackward.vocabSize as number;
+    const embDim = this.savedForBackward.embDim as number;
+    const weightShape = this.savedForBackward.weightShape as number[];
+    const numIndices = idx.length;
+
+    const gradWeight = new Float32Array(vocabSize * embDim); // zero-init
+    for (let i = 0; i < numIndices; i++) {
+      const row = idx[i]!;
+      const srcStart = i * embDim;
+      const dstStart = row * embDim;
+      for (let d = 0; d < embDim; d++) {
+        gradWeight[dstStart + d]! += grad.data[srcStart + d]!;
+      }
+    }
+
+    return [
+      new Tensor(Array.from(gradWeight), { shape: weightShape }),
+      null,
+    ];
+  }
+}

--- a/code/packages/typescript/ml-framework-core/src/tensor.ts
+++ b/code/packages/typescript/ml-framework-core/src/tensor.ts
@@ -59,6 +59,7 @@ import {
   SoftmaxOp,
   SumOp,
   MeanOp,
+  EmbeddingOp,
 } from "./ops.js";
 
 export type Dtype = "f32";
@@ -474,6 +475,19 @@ export class Tensor {
 
   matmul(other: Tensor): Tensor {
     return MatMulOp.apply(this, other);
+  }
+
+  /**
+   * Embedding lookup.  `this` is the weight matrix (vocab_size, embedding_dim);
+   * `indices` is a Tensor of integer-valued cells (any shape) giving rows to
+   * fetch.  Output shape: `[...indices.shape, embedding_dim]`.
+   *
+   * Convention matches `torch.nn.functional.embedding(input, weight)` but
+   * with self-as-weight for fluent chaining: `weight.embedding(tokenIds)`.
+   * Gradients flow into `this` via scatter-add (repeated indices sum).
+   */
+  embedding(indices: Tensor): Tensor {
+    return EmbeddingOp.apply(this, indices);
   }
 
   relu(): Tensor {

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "1.2.0" as const;
+export const VERSION = "1.3.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/embedding.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/embedding.test.ts
@@ -1,0 +1,181 @@
+/**
+ * embedding.test.ts — EmbeddingOp lookup-table coverage.
+ *
+ * Added in v1.3 (Phase A.3).  Exercises:
+ *   - Forward shape: (vocab, dim) + indices (B,) → (B, dim);
+ *                    (vocab, dim) + indices (B, S) → (B, S, dim).
+ *   - Forward numerical correctness on hand-computed lookups.
+ *   - Backward shape: grad-weight always has weight shape.
+ *   - Backward scatter-add for REPEATED indices (the key correctness
+ *     test — naive set-not-sum would silently lose gradients).
+ *   - Out-of-range index validation (negative + ≥ vocab_size).
+ *   - Tensor.embedding() fluent convenience method.
+ *
+ * Why the scatter-add test matters: nearly every real-world input has
+ * repeated tokens.  A buggy embedding that overwrites instead of
+ * accumulates passes the shape tests but trains to garbage on real
+ * data.  The test below catches that class of bug directly.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor, EmbeddingOp } from "../src/index.js";
+
+describe("EmbeddingOp — forward shapes", () => {
+  it("(10, 4) weight + (3,) indices → (3, 4) output", () => {
+    const weight = new Tensor(
+      Array.from({ length: 10 * 4 }, (_, i) => i),
+      { shape: [10, 4] },
+    );
+    const indices = new Tensor([0, 2, 9]);
+    const out = EmbeddingOp.apply(weight, indices);
+    expect(out.shape).toEqual([3, 4]);
+    // Row 0 = [0,1,2,3], row 2 = [8,9,10,11], row 9 = [36,37,38,39].
+    expect(out.toArray()).toEqual([0, 1, 2, 3, 8, 9, 10, 11, 36, 37, 38, 39]);
+  });
+
+  it("(10, 4) weight + (2, 5) indices → (2, 5, 4) output", () => {
+    const weight = new Tensor(
+      Array.from({ length: 10 * 4 }, (_, i) => i),
+      { shape: [10, 4] },
+    );
+    const indices = new Tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], { shape: [2, 5] });
+    const out = EmbeddingOp.apply(weight, indices);
+    expect(out.shape).toEqual([2, 5, 4]);
+    // Position (0, 0) = row 0 = [0,1,2,3]; position (1, 4) = row 9 = [36,37,38,39].
+    expect(out.toArray().slice(0, 4)).toEqual([0, 1, 2, 3]);
+    expect(out.toArray().slice(-4)).toEqual([36, 37, 38, 39]);
+  });
+
+  it("(vocab=5, dim=3) + scalar indices (shape []) → shape [3]", () => {
+    const weight = new Tensor(
+      Array.from({ length: 5 * 3 }, (_, i) => i),
+      { shape: [5, 3] },
+    );
+    const indices = new Tensor([2], { shape: [] }); // 0-D
+    const out = EmbeddingOp.apply(weight, indices);
+    expect(out.shape).toEqual([3]);
+    // Row 2 = [6, 7, 8].
+    expect(out.toArray()).toEqual([6, 7, 8]);
+  });
+});
+
+describe("EmbeddingOp — backward", () => {
+  it("grad-weight shape matches weight shape", () => {
+    const weight = new Tensor(
+      Array.from({ length: 8 * 5 }, (_, i) => i * 0.1),
+      { shape: [8, 5] },
+    );
+    weight.requiresGrad = true;
+    const indices = new Tensor([0, 3, 7]);
+    const out = EmbeddingOp.apply(weight, indices);
+    out.backward();
+    expect(weight.grad?.shape).toEqual([8, 5]);
+  });
+
+  it("scatter-add: REPEATED indices accumulate gradients (does NOT overwrite)", () => {
+    // The killer correctness test.  weight (5, 2), indices [1, 1, 3].
+    // Output shape (3, 2).  Default backward seeds grad with ones — shape (3, 2).
+    // Expected grad-weight:
+    //   row 0: [0, 0]          ← no index pointed here
+    //   row 1: [2, 2]          ← TWO occurrences (positions 0 and 1) each contributing [1, 1]
+    //   row 2: [0, 0]
+    //   row 3: [1, 1]          ← one occurrence (position 2) contributing [1, 1]
+    //   row 4: [0, 0]
+    const weight = new Tensor(
+      Array.from({ length: 5 * 2 }, () => 0),
+      { shape: [5, 2] },
+    );
+    weight.requiresGrad = true;
+    const indices = new Tensor([1, 1, 3]);
+    const out = EmbeddingOp.apply(weight, indices);
+    out.backward(); // ones seed of shape (3, 2)
+    expect(weight.grad?.shape).toEqual([5, 2]);
+    expect(Array.from(weight.grad!.data)).toEqual([
+      0, 0,    // row 0
+      2, 2,    // row 1: 2 contributions
+      0, 0,    // row 2
+      1, 1,    // row 3
+      0, 0,    // row 4
+    ]);
+  });
+
+  it("scatter-add with explicit non-ones gradient", () => {
+    // weight (4, 2), indices [0, 0, 2] with grad = [[1,2],[3,4],[5,6]].
+    // Expected grad-weight:
+    //   row 0: [1+3, 2+4] = [4, 6]
+    //   row 1: [0, 0]
+    //   row 2: [5, 6]
+    //   row 3: [0, 0]
+    const weight = new Tensor(
+      Array.from({ length: 4 * 2 }, () => 0),
+      { shape: [4, 2] },
+    );
+    weight.requiresGrad = true;
+    const indices = new Tensor([0, 0, 2]);
+    const out = EmbeddingOp.apply(weight, indices);
+    const customGrad = new Tensor([1, 2, 3, 4, 5, 6], { shape: [3, 2] });
+    out.backward(customGrad);
+    expect(Array.from(weight.grad!.data)).toEqual([
+      4, 6,
+      0, 0,
+      5, 6,
+      0, 0,
+    ]);
+  });
+
+  it("indices receive no gradient (parent grad is null)", () => {
+    // Both tensors are parents of the op, but indices is non-differentiable.
+    // Verify that flagging indices with requiresGrad doesn't trigger a backward
+    // crash — backward simply returns null for that parent.
+    const weight = new Tensor([0, 0, 0, 0, 0, 0], { shape: [3, 2] });
+    weight.requiresGrad = true;
+    const indices = new Tensor([0, 1]);
+    indices.requiresGrad = true; // user error, but should not crash
+    const out = EmbeddingOp.apply(weight, indices);
+    expect(() => out.backward()).not.toThrow();
+    expect(indices.grad).toBeNull();
+    expect(weight.grad?.shape).toEqual([3, 2]);
+  });
+});
+
+describe("EmbeddingOp — validation", () => {
+  it("rejects non-2-D weight", () => {
+    expect(() =>
+      EmbeddingOp.apply(new Tensor([1, 2, 3]), new Tensor([0])),
+    ).toThrow(RangeError);
+    expect(() =>
+      EmbeddingOp.apply(Tensor.zeros(2, 3, 4), new Tensor([0])),
+    ).toThrow(RangeError);
+  });
+
+  it("rejects negative index", () => {
+    const weight = Tensor.zeros(5, 3);
+    expect(() => EmbeddingOp.apply(weight, new Tensor([0, -1]))).toThrow(RangeError);
+  });
+
+  it("rejects index >= vocab_size", () => {
+    const weight = Tensor.zeros(5, 3);
+    expect(() => EmbeddingOp.apply(weight, new Tensor([5]))).toThrow(RangeError);
+    expect(() => EmbeddingOp.apply(weight, new Tensor([100]))).toThrow(RangeError);
+  });
+
+  it("accepts boundary indices 0 and vocab_size - 1", () => {
+    const weight = Tensor.zeros(5, 3);
+    expect(() => EmbeddingOp.apply(weight, new Tensor([0]))).not.toThrow();
+    expect(() => EmbeddingOp.apply(weight, new Tensor([4]))).not.toThrow();
+  });
+});
+
+describe("Tensor.embedding() fluent method", () => {
+  it("weight.embedding(indices) matches EmbeddingOp.apply(weight, indices)", () => {
+    const weight = new Tensor(
+      Array.from({ length: 4 * 2 }, (_, i) => i),
+      { shape: [4, 2] },
+    );
+    const indices = new Tensor([0, 2, 3]);
+    const a = weight.embedding(indices);
+    const b = EmbeddingOp.apply(weight, indices);
+    expect(a.shape).toEqual(b.shape);
+    expect(a.toArray()).toEqual(b.toArray());
+  });
+});


### PR DESCRIPTION
## Summary

**Phase A.3 of 7** in the TypeScript ml-framework expansion.

- New **`EmbeddingOp`** Function (`src/ops.ts`): standard lookup-table op. Weight `(vocab_size, embedding_dim)` + indices Tensor of any shape → output `[...indices.shape, embedding_dim]`.
- **Scatter-add backward** — the critical correctness property. When the same vocab index appears multiple times in `indices` (the common case for real text), gradients accumulate at that weight row instead of overwriting. A test explicitly verifies this with repeated indices.
- Index validation: out-of-range throws `RangeError`; NaN coerces safely to 0 via `Int32Array`; bounds check is robust against `Infinity`/`-Infinity` and large floats (security review enumerated edge cases — all safe).
- Indices receive no gradient (returns `null` from backward; autograd walker handles cleanly).
- **`Tensor.embedding(indices)`** fluent convenience method.
- Bumps to **v1.3.0**.

## Why now

Embedding is the last big op needed before attention. With batched `matmul` (v1.2), `softmax` (v1.0), and now `embedding`, the core operations of an attention layer are all in place. The runway is now clear for A.4 (LayerNorm/BatchNorm/Dropout) and from there to actual transformer architectures.

## Test plan

- [x] 206 vitest cases pass (194 → 206; +12 new in `tests/embedding.test.ts`)
  - 3 forward shape cases (1-D / 2-D / scalar indices)
  - 1 backward shape check
  - 1 **scatter-add for repeated indices** (the killer correctness test)
  - 1 backward with explicit non-ones grad
  - 1 indices-grad-is-null
  - 4 validation cases (non-2-D weight, negative, ≥ vocab, boundary OK)
  - 1 fluent-method parity
- [x] `tsc --noEmit` clean
- [x] Security review passed (no findings; NaN/Infinity edge cases verified safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)