### PR TITLE
Track browser form object descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1616,6 +1616,7 @@ pub struct BrowserForm {
     pub selects: Vec<BrowserFormSelect>,
     pub outputs: Vec<BrowserFormOutput>,
     pub measurements: Vec<BrowserFormMeasurement>,
+    pub object_controls: Vec<BrowserFormObject>,
     pub successful_controls: Vec<BrowserFormSuccessfulControl>,
     pub validation_controls: Vec<BrowserFormValidationControl>,
     pub buttons: Vec<BrowserFormButton>,
@@ -1716,6 +1717,29 @@ pub struct BrowserFormMeasurement {
     pub optimum: Option<String>,
     pub indeterminate: bool,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormObject {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub data: Option<String>,
+    pub resolved_data: Option<String>,
+    pub type_hint: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub usemap: Option<String>,
+    pub fallback_text: String,
+    pub params: Vec<BrowserFormObjectParam>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormObjectParam {
+    pub name: Option<String>,
+    pub value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11516,6 +11540,10 @@ fn is_browser_form_control_element(name: &str) -> bool {
     matches!(name, "button" | "input" | "output" | "select" | "textarea")
 }
 
+fn is_browser_form_grouped_element(name: &str) -> bool {
+    is_browser_form_control_element(name) || name == "object"
+}
+
 fn is_browser_form_measurement_element(name: &str) -> bool {
     matches!(name, "meter" | "progress")
 }
@@ -12866,6 +12894,71 @@ fn collect_form_measurements_for_form(
     measurements
 }
 
+fn collect_form_objects_for_form(
+    body_root: &[Node],
+    target_form: &Element,
+    id_texts: &[(String, String)],
+    base_href: Option<&str>,
+) -> Vec<BrowserFormObject> {
+    let mut objects = Vec::new();
+    collect_form_objects_for_form_into(
+        body_root,
+        &mut objects,
+        id_texts,
+        base_href,
+        target_form as *const Element,
+        target_form.attribute("id"),
+        None,
+    );
+    objects
+}
+
+fn collect_form_objects_for_form_into(
+    nodes: &[Node],
+    objects: &mut Vec<BrowserFormObject>,
+    id_texts: &[(String, String)],
+    base_href: Option<&str>,
+    target_form: *const Element,
+    target_form_id: Option<&str>,
+    current_form: Option<*const Element>,
+) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        let element_form = if element.name == "form" {
+            Some(element as *const Element)
+        } else {
+            current_form
+        };
+
+        if element.name == "object" {
+            let form_owner = browser_form_owner(element);
+            let associated_with_target = match form_owner.as_deref() {
+                Some(owner) => target_form_id.is_some_and(|form_id| form_id == owner),
+                None => current_form.is_some_and(|form| form == target_form),
+            };
+
+            if associated_with_target {
+                objects.push(browser_form_object(element, id_texts, base_href));
+            }
+        }
+
+        for child in &element.children {
+            collect_form_objects_for_form_into(
+                std::slice::from_ref(child),
+                objects,
+                id_texts,
+                base_href,
+                target_form,
+                target_form_id,
+                element_form,
+            );
+        }
+    }
+}
+
 fn collect_form_measurements_for_form_into(
     nodes: &[Node],
     measurements: &mut Vec<BrowserFormMeasurement>,
@@ -13011,6 +13104,7 @@ fn browser_form(
     let controls = collect_form_controls_for_form(body_root, element, labels, id_texts, base_href);
     let fieldsets = collect_form_fieldsets_for_form(body_root, element, element.attribute("id"));
     let measurements = collect_form_measurements_for_form(body_root, element, labels, id_texts);
+    let object_controls = collect_form_objects_for_form(body_root, element, id_texts, base_href);
     let form_labels = collect_form_labels_for_form(
         body_root,
         element,
@@ -13089,6 +13183,7 @@ fn browser_form(
         selects,
         outputs,
         measurements,
+        object_controls,
         successful_controls,
         validation_controls,
         buttons,
@@ -13346,7 +13441,7 @@ fn collect_fieldset_control_attribute_values(
             continue;
         };
 
-        if is_browser_form_control_element(&child_element.name)
+        if is_browser_form_grouped_element(&child_element.name)
             && child_element
                 .attribute("form")
                 .is_none_or(|form| target_form_id.is_some_and(|id| id == form))
@@ -13509,6 +13604,47 @@ fn browser_form_measurement(
         value,
         text: visible_text_for_nodes(&element.children),
     }
+}
+
+fn browser_form_object(
+    element: &Element,
+    id_texts: &[(String, String)],
+    base_href: Option<&str>,
+) -> BrowserFormObject {
+    let data = element.attribute("data").map(ToOwned::to_owned);
+    BrowserFormObject {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        name: element.attribute("name").map(ToOwned::to_owned),
+        form_owner: browser_form_owner(element),
+        accessible_name: browser_accessible_name(element, "object", &[], id_texts),
+        accessible_description: browser_accessible_description(element, id_texts),
+        resolved_data: data
+            .as_deref()
+            .and_then(|data| resolve_browser_url(data, base_href)),
+        data,
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        usemap: element.attribute("usemap").map(ToOwned::to_owned),
+        fallback_text: visible_text_for_nodes(&element.children),
+        params: browser_form_object_params(element),
+    }
+}
+
+fn browser_form_object_params(element: &Element) -> Vec<BrowserFormObjectParam> {
+    element
+        .children
+        .iter()
+        .filter_map(|child| {
+            let Node::Element(child_element) = child else {
+                return None;
+            };
+            (child_element.name == "param").then(|| BrowserFormObjectParam {
+                name: child_element.attribute("name").map(ToOwned::to_owned),
+                value: child_element.attribute("value").map(ToOwned::to_owned),
+            })
+        })
+        .collect()
 }
 
 fn browser_form_selects(controls: &[BrowserFormControl]) -> Vec<BrowserFormSelect> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,13 +3,14 @@ use coding_adventures_html_parser::{
     BrowserDatalistOption, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
     BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
     BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormOutput,
-    BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
+    BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -730,6 +731,8 @@ struct ExpectedForm {
     #[serde(default)]
     measurements: Vec<ExpectedFormMeasurement>,
     #[serde(default)]
+    object_controls: Vec<ExpectedFormObject>,
+    #[serde(default)]
     successful_controls: Vec<ExpectedFormSuccessfulControl>,
     #[serde(default)]
     validation_controls: Vec<ExpectedFormValidationControl>,
@@ -892,6 +895,44 @@ struct ExpectedFormMeasurement {
     #[serde(default)]
     indeterminate: bool,
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormObject {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    data: Option<String>,
+    #[serde(default)]
+    resolved_data: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    usemap: Option<String>,
+    #[serde(default)]
+    fallback_text: String,
+    #[serde(default)]
+    params: Vec<ExpectedFormObjectParam>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormObjectParam {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1635,6 +1676,82 @@ fn browser_form_output_descriptor_metadata_tracks_for_references_and_labels() {
     assert_eq!(external.for_control_names, vec!["sum"]);
     assert_eq!(external.for_control_types, vec!["output"]);
     assert_eq!(external.value.as_deref(), Some("External"));
+}
+
+#[test]
+fn browser_form_object_descriptor_metadata_tracks_embedded_controls_and_params() {
+    let document = parse_browser_document(
+        "<base href=\"https://example.test/media/\">\
+         <form id=player>\
+         <p id=movie-help>Legacy plugin fallback</p>\
+         <fieldset id=plugins><legend>Plugins</legend>\
+         <object id=movie name=movie data=movie.swf type=\"application/x-shockwave-flash\" \
+             width=400 height=300 usemap=#movie-map aria-label=\"Movie plugin\" aria-describedby=movie-help>\
+             <param name=autoplay value=false><param name=quality value=high>Fallback player\
+         </object>\
+         </fieldset>\
+         <input id=token name=token value=ok>\
+         </form>\
+         <object id=external name=external form=player data=/external.bin type=\"application/octet-stream\" aria-label=External>External fallback</object>\
+         <object id=outside name=outside data=outside.bin>Outside fallback</object>",
+    )
+    .expect("form object descriptor fixture should parse");
+
+    let form = document
+        .forms
+        .first()
+        .expect("player form should be summarized");
+
+    let object_ids: Vec<&str> = form
+        .object_controls
+        .iter()
+        .filter_map(|object| object.id.as_deref())
+        .collect();
+    assert_eq!(object_ids, vec!["movie", "external"]);
+
+    let movie = &form.object_controls[0];
+    assert_eq!(movie.name.as_deref(), Some("movie"));
+    assert_eq!(movie.accessible_name.as_deref(), Some("Movie plugin"));
+    assert_eq!(
+        movie.accessible_description.as_deref(),
+        Some("Legacy plugin fallback")
+    );
+    assert_eq!(movie.data.as_deref(), Some("movie.swf"));
+    assert_eq!(
+        movie.resolved_data.as_deref(),
+        Some("https://example.test/media/movie.swf")
+    );
+    assert_eq!(
+        movie.type_hint.as_deref(),
+        Some("application/x-shockwave-flash")
+    );
+    assert_eq!(movie.width.as_deref(), Some("400"));
+    assert_eq!(movie.height.as_deref(), Some("300"));
+    assert_eq!(movie.usemap.as_deref(), Some("#movie-map"));
+    assert_eq!(movie.fallback_text, "Fallback player");
+    assert_eq!(movie.params.len(), 2);
+    assert_eq!(movie.params[0].name.as_deref(), Some("autoplay"));
+    assert_eq!(movie.params[0].value.as_deref(), Some("false"));
+    assert_eq!(movie.params[1].name.as_deref(), Some("quality"));
+    assert_eq!(movie.params[1].value.as_deref(), Some("high"));
+
+    let external = &form.object_controls[1];
+    assert_eq!(external.form_owner.as_deref(), Some("player"));
+    assert_eq!(external.name.as_deref(), Some("external"));
+    assert_eq!(external.accessible_name.as_deref(), Some("External"));
+    assert_eq!(
+        external.resolved_data.as_deref(),
+        Some("https://example.test/external.bin")
+    );
+
+    assert_eq!(form.fieldsets[0].control_ids, vec!["movie"]);
+    assert_eq!(form.fieldsets[0].control_names, vec!["movie"]);
+    assert_eq!(form.controls.len(), 1);
+    assert_eq!(form.controls[0].id.as_deref(), Some("token"));
+    assert_eq!(form.successful_controls.len(), 1);
+    assert_eq!(form.successful_controls[0].name, "token");
+    assert_eq!(form.validation_controls.len(), 1);
+    assert_eq!(form.validation_controls[0].id.as_deref(), Some("token"));
 }
 
 #[test]
@@ -3087,6 +3204,11 @@ impl ExpectedForm {
                 .into_iter()
                 .map(ExpectedFormMeasurement::into_browser_form_measurement)
                 .collect(),
+            object_controls: self
+                .object_controls
+                .into_iter()
+                .map(ExpectedFormObject::into_browser_form_object)
+                .collect(),
             successful_controls: self
                 .successful_controls
                 .into_iter()
@@ -3232,6 +3354,39 @@ impl ExpectedFormMeasurement {
             optimum: self.optimum,
             indeterminate: self.indeterminate,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedFormObject {
+    fn into_browser_form_object(self) -> BrowserFormObject {
+        BrowserFormObject {
+            id: self.id,
+            name: self.name,
+            form_owner: self.form_owner,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            data: self.data,
+            resolved_data: self.resolved_data,
+            type_hint: self.type_hint,
+            width: self.width,
+            height: self.height,
+            usemap: self.usemap,
+            fallback_text: self.fallback_text,
+            params: self
+                .params
+                .into_iter()
+                .map(ExpectedFormObjectParam::into_browser_form_object_param)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedFormObjectParam {
+    fn into_browser_form_object_param(self) -> BrowserFormObjectParam {
+        BrowserFormObjectParam {
+            name: self.name,
+            value: self.value,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -856,6 +856,95 @@
       }
     },
     {
+      "id": "form-object-descriptor-page",
+      "description": "Browser document form summaries include form-associated object descriptors, object params, fieldset membership, and embedded resource metadata without treating objects as ordinary submitted controls.",
+      "input": "<base href=\"https://example.test/media/\"><form id=player><p id=movie-help>Legacy plugin fallback</p><fieldset id=plugins><legend>Plugins</legend><object id=movie name=movie data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300 usemap=#movie-map aria-label=\"Movie plugin\" aria-describedby=movie-help><param name=autoplay value=false><param name=quality value=high>Fallback player</object></fieldset><input id=token name=token value=ok></form><object id=external name=external form=player data=/external.bin type=\"application/octet-stream\" aria-label=External>External fallback</object><object id=outside name=outside data=outside.bin>Outside fallback</object>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/media/",
+        "base_target": null,
+        "body_text": "Legacy plugin fallback Plugins Fallback player External fallback Outside fallback",
+        "metas": [],
+        "resources": [
+          { "kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "rel": null, "type_hint": "application/x-shockwave-flash", "media": null, "title": null, "width": "400", "height": "300", "async_script": false, "defer_script": false },
+          { "kind": "object", "url": "/external.bin", "resolved_url": "https://example.test/external.bin", "rel": null, "type_hint": "application/octet-stream", "media": null, "title": null, "async_script": false, "defer_script": false },
+          { "kind": "object", "url": "outside.bin", "resolved_url": "https://example.test/media/outside.bin", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
+        ],
+        "anchors": [
+          { "id": "player", "name": null, "text": "Legacy plugin fallback Plugins Fallback player" },
+          { "id": "movie-help", "name": null, "text": "Legacy plugin fallback" },
+          { "id": "plugins", "name": null, "text": "Plugins Fallback player" },
+          { "id": "movie", "name": null, "text": "Fallback player" },
+          { "id": "token", "name": null, "text": "" },
+          { "id": "external", "name": null, "text": "External fallback" },
+          { "id": "outside", "name": null, "text": "Outside fallback" }
+        ],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "embedded_contexts": [
+          { "element": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "fallback_text": "Fallback player" },
+          { "element": "object", "url": "/external.bin", "resolved_url": "https://example.test/external.bin", "type_hint": "application/octet-stream", "fallback_text": "External fallback" },
+          { "element": "object", "url": "outside.bin", "resolved_url": "https://example.test/media/outside.bin", "fallback_text": "Outside fallback" }
+        ],
+        "forms": [
+          {
+            "id": "player",
+            "action": null,
+            "resolved_action": null,
+            "method": "get",
+            "enctype": null,
+            "target": null,
+            "fieldsets": [
+              { "id": "plugins", "legend": "Plugins", "control_ids": ["movie"], "control_names": ["movie"] }
+            ],
+            "object_controls": [
+              {
+                "id": "movie",
+                "name": "movie",
+                "accessible_name": "Movie plugin",
+                "accessible_description": "Legacy plugin fallback",
+                "data": "movie.swf",
+                "resolved_data": "https://example.test/media/movie.swf",
+                "type_hint": "application/x-shockwave-flash",
+                "width": "400",
+                "height": "300",
+                "usemap": "#movie-map",
+                "fallback_text": "Fallback player",
+                "params": [
+                  { "name": "autoplay", "value": "false" },
+                  { "name": "quality", "value": "high" }
+                ]
+              },
+              {
+                "id": "external",
+                "name": "external",
+                "form_owner": "player",
+                "accessible_name": "External",
+                "data": "/external.bin",
+                "resolved_data": "https://example.test/external.bin",
+                "type_hint": "application/octet-stream",
+                "fallback_text": "External fallback"
+              }
+            ],
+            "successful_controls": [
+              { "id": "token", "control_type": "text", "name": "token", "submission_values": ["ok"] }
+            ],
+            "validation_controls": [
+              { "id": "token", "control_type": "text", "name": "token", "will_validate": true }
+            ],
+            "text_entries": [
+              { "id": "token", "control_type": "text", "name": "token", "value": "ok", "text": "", "disabled": false, "will_validate": true }
+            ],
+            "controls": [
+              { "id": "token", "control_type": "text", "name": "token", "value": "ok", "successful": true, "submission_values": ["ok"], "disabled": false, "will_validate": true, "checked": false, "text": "", "options": [] }
+            ]
+          }
+        ],
+        "tables": []
+      }
+    },
+    {
       "id": "component-template-page",
       "description": "Browser document summaries expose inert template content, declarative shadow root metadata, and component hydration targets.",
       "input": "<body><template id=card-template data-template=card shadowrootmode=open shadowrootdelegatesfocus shadowrootclonable shadowrootserializable><article part=frame><slot name=title>Untitled</slot><slot>Body</slot></article></template><product-card id=card data-controller=product data-state=ready part=host exportparts=\"header:title, chart\"><span slot=title data-field=name part=title>Widget</span><canvas id=chart width=300 height=150 data-renderer=canvas part=chart>Chart fallback</canvas><button is=fancy-button data-action=save part=action>Save</button><slot name=footer part=footer>Fallback footer</slot></product-card>",


### PR DESCRIPTION
## Summary
- add form-level object_controls descriptors for form-associated `<object>` elements
- track object data URL resolution, type/layout/usemap metadata, fallback text, and direct `<param>` entries
- include object membership in fieldset grouping while keeping objects out of ordinary controls, successful controls, and validation buckets

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_form_object_descriptor_metadata_tracks_embedded_controls_and_params
- cargo test -p coding-adventures-html-parser browser_form_
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser