### PR TITLE
feat(ml-framework-core-ts): Adam optimizer + Linear/Sequential (v1.6 / Phase A.6)

### DIFF
--- a/code/packages/typescript/ml-framework-core/CHANGELOG.md
+++ b/code/packages/typescript/ml-framework-core/CHANGELOG.md
@@ -2,6 +2,111 @@
 
 ## Unreleased
 
+### Added — v1.6.0: Adam optimizer + Linear / Sequential / Module (Phase A.6)
+
+PR #6 of 7 in **Phase A** — turns the framework from "a bag of ops"
+into something you can call `Sequential(...).forward(x)` on, then
+hand the parameters to an optimizer.  Last step before HF interop
+in A.7.
+
+#### What works now
+
+```ts
+import { Tensor, Sequential, Linear, Fn, Adam } from "@coding-adventures/ml-framework-core";
+
+// Build a 3-layer MLP: 784 → 256 → 64 → 10
+const model = new Sequential(
+  new Linear(784, 256),
+  new Fn(x => x.relu()),
+  new Linear(256, 64),
+  new Fn(x => x.relu()),
+  new Linear(64, 10),
+);
+
+const opt = new Adam(model.parameters(), 1e-3);
+
+// Standard training loop.
+for (const [xBatch, yTrue] of dataset) {
+  const logits = model.forward(xBatch);
+  const loss = computeLoss(logits, yTrue);
+  opt.zeroGrad();
+  loss.backward();
+  opt.step();
+}
+```
+
+#### Implementation notes
+
+- **`src/optim.ts`** — `Optimizer` abstract base + `SGD` + `Adam`.
+  Optimizers hold references to the parameter Tensors and mutate
+  `param.data` in place during `step()` (PyTorch convention — TS's
+  `readonly` on the `data` field prevents buffer reassignment but
+  allows element writes, which is exactly what we want).  `zeroGrad`
+  sets `param.grad = null` (matches the framework's existing
+  "allocate-on-first-contribution / accumulate-via-add" semantics
+  in `backwardImpl`).
+- **`Adam`** maintains per-parameter `m` (first-moment) and `v`
+  (second-moment) `Float32Array` buffers and a step counter `t`.
+  Bias-corrected via `m̂ = m / (1 - β1^t)` and `v̂ = v / (1 - β2^t)` —
+  verified by an explicit test that the magnitude of the first
+  step is `≈ lr` (NOT `lr*(1-β1)` which would be the uncorrected
+  naive form).  Defaults match PyTorch: `lr=1e-3, betas=(0.9,
+  0.999), eps=1e-8`.
+- **`src/nn.ts`** — `Module` abstract base + `Linear` + `Sequential`
+  + `Fn` (function-wrapper for dropping activations into a
+  `Sequential`).  Each Module exposes `parameters(): Tensor[]`
+  (used by optimizers) and `forward(x): Tensor`.
+- **`Linear` weight orientation: `(inFeatures, outFeatures)`**, NOT
+  PyTorch's `(outFeatures, inFeatures)`.  Reason: our
+  `Tensor.transpose()` is currently a non-autograd shape op
+  (gradients don't flow back through it), so doing `x @ W.T` would
+  silently drop the gradient on `W`.  Keeping weight in `(in, out)`
+  means forward is a clean `x.matmul(weight)` with no transpose
+  needed.  When a future PR adds a proper `TransposeOp` we can
+  optionally flip the convention to match PyTorch state-dicts
+  exactly.  Documented in `nn.ts`.
+- **Xavier-uniform init** for Linear weights: `U(-L, L)` with
+  `L = √(6 / (in + out))`.  Matches PyTorch's default and keeps
+  activations roughly unit-variance through a stack of layers,
+  which is critical for training stability.  Bias zero-init.
+- **`Sequential`** stores its layers and applies them in declaration
+  order; `parameters()` concatenates child params in the same
+  order.  Composes with itself recursively (a Sequential can
+  contain other Sequentials).
+- **`Fn`** wraps any `(Tensor) → Tensor` function as a Module with
+  no parameters.  Lets you stick `x.relu()` / `x.sigmoid()` /
+  custom math inline in a `Sequential` without authoring a full
+  Module class.
+
+#### Tests
+
+- 21 new vitest cases (`tests/nn-optim.test.ts`):
+  - 2 Optimizer base (empty-params rejected, zeroGrad behavior)
+  - 3 SGD (quadratic step, null-grad skip, hyperparam validation)
+  - 4 Adam (bias correction at t=1 yields ≈ lr-magnitude update,
+    step counter, hyperparam validation, full quadratic convergence)
+  - 6 Linear (shape, parameters() with/without bias, forward
+    shape, grad flow back to weight + bias, validation)
+  - 3 Sequential (chained forward, parameters() concatenation,
+    **end-to-end MLP training** — verifies loss drops at least 2×
+    over 30 epochs on a tiny regression problem)
+  - 2 Fn (no params, identity-ish forward)
+  - 1 Optimizer-base polymorphism check
+- Total **263 tests pass** (was 242 in v1.5).
+- `tsc --noEmit` clean.
+
+#### What this unlocks
+
+`Sequential(...).forward(...)` + `Adam(...).step()` IS the standard
+deep-learning training loop.  Everything from a 2-layer MNIST MLP
+to a multi-block CNN can now be expressed as a single `new
+Sequential(...)` call and trained without manually wiring layers.
+
+Phase A.7 (next + last in Phase A) adds safetensors save/load —
+the first cross-framework interop.  After A.7 you can load any
+Hugging Face checkpoint's weights into a `Sequential` model
+defined in this framework.
+
 ### Added — v1.5.0: Conv2D + MaxPool2D via im2col (Phase A.5)
 
 PR #5 of 7 in **Phase A** — adds the two operations that make CNN

--- a/code/packages/typescript/ml-framework-core/package.json
+++ b/code/packages/typescript/ml-framework-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/ml-framework-core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Complete PyTorch-shaped TypeScript ML framework on the Rust matrix-cpu engine.  Tensor + autograd + 15 differentiable ops (Add/Sub/Mul/Div/Neg/Abs/Pow/MatMul/ReLU/Sigmoid/Tanh/GELU/Softmax/Sum/Mean) with full forward and backward.  Small tensors use a pure-TypeScript fast path; tensors of 10k+ cells auto-dispatch through @coding-adventures/matrix-rust-napi to the Rust matrix-cpu executor for SIMD-accelerated f32 math.  End-to-end MLP training verified by the test suite.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/ml-framework-core/src/index.ts
+++ b/code/packages/typescript/ml-framework-core/src/index.ts
@@ -74,3 +74,5 @@ export {
 export { VERSION } from "./version.js";
 export { getMode, setMode } from "./mode.js";
 export type { Mode } from "./mode.js";
+export { Optimizer, SGD, Adam } from "./optim.js";
+export { Module, Linear, Sequential, Fn } from "./nn.js";

--- a/code/packages/typescript/ml-framework-core/src/nn.ts
+++ b/code/packages/typescript/ml-framework-core/src/nn.ts
@@ -1,0 +1,171 @@
+/**
+ * # nn.ts — neural-network layer abstractions (Phase A.6)
+ *
+ * Adds the two pieces that turn a pile of Tensor ops into something
+ * you can call `Sequential([...]).forward(x)` on:
+ *
+ *   - **`Module`** — the abstract base class.  A module owns
+ *     parameters (Tensors with `requiresGrad = true`) and exposes
+ *     `forward(...)` for inference.  Composing modules is just
+ *     putting one inside another; `parameters()` recursively collects
+ *     all leaf params for the optimizer.
+ *
+ *   - **`Linear`** — the standard fully-connected layer:
+ *     `y = x @ W + b`.  Weight shape is `(inFeatures, outFeatures)`
+ *     so the forward is a single matmul with no transpose needed.
+ *     This DIVERGES from PyTorch (which stores `(outFeatures,
+ *     inFeatures)` and does `x @ W.T`) — but our `Tensor.transpose()`
+ *     is currently a non-autograd shape op (it doesn't track
+ *     gradients back through itself), so doing `x @ W.T` would
+ *     silently drop the gradient on `W`.  Keeping weight in
+ *     `(in, out)` orientation sidesteps that.  A future PR can
+ *     add a `TransposeOp` that's autograd-aware and flip the
+ *     convention back if cross-framework state-dict compatibility
+ *     matters.  For v1.6 the framework's internal use cases all
+ *     work fine with `(in, out)`.
+ *
+ *   - **`Sequential`** — composes a list of modules; forward applies
+ *     them in order; `parameters()` concatenates child params.
+ *
+ * ## Initialization
+ *
+ * Linear uses Xavier-uniform: each weight ~ U(-L, L) where L =
+ * √(6 / (in + out)).  Bias is zero-init.  This matches PyTorch's
+ * default for `nn.Linear` and keeps activations roughly unit-variance
+ * through a stack of layers, which makes training much more stable
+ * than the naïve "uniform in [-1, 1]" alternative.
+ */
+
+import { Tensor } from "./tensor.js";
+
+/**
+ * Abstract module base.  Subclasses implement `parameters()` (returns
+ * the list of learnable Tensors, used by optimizers) and `forward(x)`
+ * (the computation graph).  A `Sequential` composes children; each
+ * child contributes its own `parameters()`.
+ */
+export abstract class Module {
+  /** All learnable parameters owned by this module + its children. */
+  abstract parameters(): Tensor[];
+
+  /** Apply this module to an input.  Subclasses override the signature. */
+  abstract forward(x: Tensor): Tensor;
+}
+
+/**
+ * Fully-connected (dense) layer: `y = x @ W + b`.
+ *
+ * - Input  shape: `(..., inFeatures)`
+ * - Weight shape: `(inFeatures, outFeatures)`
+ * - Bias   shape: `(outFeatures,)` (broadcast over leading dims) — optional
+ * - Output shape: `(..., outFeatures)`
+ *
+ * Both `weight` and `bias` have `requiresGrad = true` so gradients
+ * accumulate on `loss.backward()` and an optimizer can read them.
+ *
+ * Weight init: Xavier-uniform with limit √(6 / (in + out)).  Bias zero.
+ */
+export class Linear extends Module {
+  public readonly weight: Tensor;
+  public readonly bias: Tensor | null;
+
+  constructor(
+    public readonly inFeatures: number,
+    public readonly outFeatures: number,
+    useBias: boolean = true,
+  ) {
+    super();
+    if (inFeatures < 1 || outFeatures < 1) {
+      throw new RangeError(
+        `Linear requires positive in/out features, got in=${inFeatures}, out=${outFeatures}`,
+      );
+    }
+    // Xavier-uniform init: limit L = √(6 / (in + out))
+    const limit = Math.sqrt(6 / (inFeatures + outFeatures));
+    const wData = new Array<number>(inFeatures * outFeatures);
+    for (let i = 0; i < wData.length; i++) {
+      wData[i] = (Math.random() * 2 - 1) * limit;
+    }
+    this.weight = new Tensor(wData, { shape: [inFeatures, outFeatures] });
+    this.weight.requiresGrad = true;
+
+    if (useBias) {
+      this.bias = new Tensor(new Array<number>(outFeatures).fill(0));
+      this.bias.requiresGrad = true;
+    } else {
+      this.bias = null;
+    }
+  }
+
+  parameters(): Tensor[] {
+    return this.bias ? [this.weight, this.bias] : [this.weight];
+  }
+
+  forward(x: Tensor): Tensor {
+    // x: (..., inF) @ weight: (inF, outF) → (..., outF)
+    // Uses MatMulOp's N-D batched matmul (v1.2) so leading dims pass through.
+    let y = x.matmul(this.weight);
+    if (this.bias) y = y.add(this.bias); // bias (outF,) broadcasts over leading dims
+    return y;
+  }
+}
+
+/**
+ * Compose modules in sequence: `forward(x)` returns
+ * `lastLayer.forward(...secondLayer.forward(firstLayer.forward(x)))`.
+ *
+ * `parameters()` is the concatenation of every child's `parameters()`,
+ * in declaration order.  This is the list you hand to an optimizer.
+ *
+ * Layers can be Linear, Sequential nesting, or anything else extending
+ * `Module`.  Activation functions are NOT modules in v1.6 — they're
+ * pure Tensor methods (`x.relu()`, `x.sigmoid()`, etc.), so you wrap
+ * them in tiny custom modules if you want to drop them into a
+ * Sequential.  Helper class for that, `Fn`, is below.
+ */
+export class Sequential extends Module {
+  public readonly layers: Module[];
+
+  constructor(...layers: Module[]) {
+    super();
+    this.layers = layers;
+  }
+
+  parameters(): Tensor[] {
+    const out: Tensor[] = [];
+    for (const layer of this.layers) out.push(...layer.parameters());
+    return out;
+  }
+
+  forward(x: Tensor): Tensor {
+    let y = x;
+    for (const layer of this.layers) y = layer.forward(y);
+    return y;
+  }
+}
+
+/**
+ * Wrap any `Tensor → Tensor` function as a Module — useful for
+ * dropping activation functions into a `Sequential`:
+ *
+ * ```ts
+ * new Sequential(
+ *   new Linear(784, 128),
+ *   new Fn(x => x.relu()),
+ *   new Linear(128, 10),
+ * );
+ * ```
+ *
+ * `Fn` has no parameters of its own.  It's the universal escape hatch.
+ */
+export class Fn extends Module {
+  constructor(private readonly fn: (x: Tensor) => Tensor) {
+    super();
+  }
+  parameters(): Tensor[] {
+    return [];
+  }
+  forward(x: Tensor): Tensor {
+    return this.fn(x);
+  }
+}

--- a/code/packages/typescript/ml-framework-core/src/optim.ts
+++ b/code/packages/typescript/ml-framework-core/src/optim.ts
@@ -1,0 +1,154 @@
+/**
+ * # optim.ts — gradient-descent optimizers (Phase A.6)
+ *
+ * Once a model has `parameters()` (each a Tensor with `requiresGrad =
+ * true`) and you've called `loss.backward()`, the gradients sit in
+ * `param.grad`.  An Optimizer turns those gradients into parameter
+ * updates.  PyTorch convention: optimizer holds references to the
+ * params, mutates `param.data` in place during `step()`.
+ *
+ * Two optimizers ship in v1.6:
+ *
+ *   - **SGD** — `param -= lr * grad`.  The simplest possible update.
+ *     Great for getting started, lousy for non-trivial problems.
+ *   - **Adam** — adaptive moment estimation with bias correction.
+ *     Effectively the default for modern deep learning.  Tracks
+ *     per-parameter first (m) and second (v) moment estimates,
+ *     applies bias correction so early steps aren't tiny.
+ *
+ * ## In-place mutation
+ *
+ * The Tensor type declares `data` as `readonly` — that prevents
+ * reassigning the buffer, but element writes (`p.data[i] = ...`)
+ * are still allowed.  This matches PyTorch's `data.add_(grad,
+ * alpha=-lr)` style: optimizer updates skip autograd and just
+ * write to the underlying memory.
+ */
+
+import type { Tensor } from "./tensor.js";
+
+/**
+ * Common base — owns the parameter list and provides `zeroGrad()`.
+ * Subclasses implement `step()` with their update rule.
+ *
+ * Why `zeroGrad` sets `param.grad = null` rather than zeroing in
+ * place: matches the framework's existing accumulation semantics —
+ * `backwardImpl` allocates `param.grad` on first contribution and
+ * accumulates via `add()` thereafter.  Setting to null is just
+ * "forget what you accumulated"; the next `backward()` starts fresh.
+ */
+export abstract class Optimizer {
+  constructor(public readonly params: Tensor[]) {
+    if (params.length === 0) {
+      throw new RangeError("Optimizer requires at least one parameter");
+    }
+  }
+
+  /** Clear all parameter grads.  Call before each forward/backward step. */
+  zeroGrad(): void {
+    for (const p of this.params) p.grad = null;
+  }
+
+  /** Apply one gradient-descent step to each parameter. */
+  abstract step(): void;
+}
+
+/**
+ * Plain stochastic gradient descent.  `param -= lr * grad`.
+ *
+ * No momentum, no weight decay in v1.6 — those can be added as
+ * optional constructor args in a future PR without breaking the API.
+ */
+export class SGD extends Optimizer {
+  constructor(params: Tensor[], public lr: number) {
+    super(params);
+    if (lr <= 0) throw new RangeError(`SGD lr must be > 0, got ${lr}`);
+  }
+
+  step(): void {
+    for (const p of this.params) {
+      const g = p.grad;
+      if (!g) continue; // no gradient accumulated this step
+      const data = p.data; // Float32Array — element writes allowed despite readonly ref
+      const gd = g.data;
+      for (let i = 0; i < p.numel; i++) {
+        data[i]! -= this.lr * gd[i]!;
+      }
+    }
+  }
+}
+
+/**
+ * Adam — adaptive moment estimation (Kingma & Ba 2014).
+ *
+ * Per parameter, maintains two running estimates:
+ *
+ *   m_t = β1 * m_{t-1} + (1 - β1) * g_t           ← first moment (mean of grads)
+ *   v_t = β2 * v_{t-1} + (1 - β2) * g_t²          ← second moment (mean of grad²)
+ *
+ * Bias-corrected estimates:
+ *
+ *   m̂ = m_t / (1 - β1^t)
+ *   v̂ = v_t / (1 - β2^t)
+ *
+ * Update:
+ *
+ *   param -= lr * m̂ / (√v̂ + ε)
+ *
+ * Defaults match PyTorch's `torch.optim.Adam`: lr=1e-3, betas=(0.9, 0.999), eps=1e-8.
+ * No AMSGrad, no weight decay in v1.6.
+ */
+export class Adam extends Optimizer {
+  // Per-parameter moment buffers.  Float32Arrays sized to each param's numel.
+  private readonly m: Float32Array[];
+  private readonly v: Float32Array[];
+  // Step counter — bumped at the start of each step.
+  private t = 0;
+
+  constructor(
+    params: Tensor[],
+    public lr: number = 1e-3,
+    public beta1: number = 0.9,
+    public beta2: number = 0.999,
+    public eps: number = 1e-8,
+  ) {
+    super(params);
+    if (lr <= 0) throw new RangeError(`Adam lr must be > 0, got ${lr}`);
+    if (beta1 < 0 || beta1 >= 1) throw new RangeError(`Adam beta1 must be in [0, 1), got ${beta1}`);
+    if (beta2 < 0 || beta2 >= 1) throw new RangeError(`Adam beta2 must be in [0, 1), got ${beta2}`);
+    if (eps <= 0) throw new RangeError(`Adam eps must be > 0, got ${eps}`);
+    // Zero-init moment buffers (Float32Array default).  One per param,
+    // sized to the param's numel.
+    this.m = params.map((p) => new Float32Array(p.numel));
+    this.v = params.map((p) => new Float32Array(p.numel));
+  }
+
+  /** Current step number (post-increment value after the latest step()). */
+  get stepCount(): number {
+    return this.t;
+  }
+
+  step(): void {
+    this.t++;
+    // Bias-correction denominators — same for all params at this t.
+    const b1c = 1 - Math.pow(this.beta1, this.t);
+    const b2c = 1 - Math.pow(this.beta2, this.t);
+    for (let pi = 0; pi < this.params.length; pi++) {
+      const p = this.params[pi]!;
+      const g = p.grad;
+      if (!g) continue;
+      const data = p.data;
+      const gd = g.data;
+      const m = this.m[pi]!;
+      const v = this.v[pi]!;
+      for (let i = 0; i < p.numel; i++) {
+        const gi = gd[i]!;
+        m[i] = this.beta1 * m[i]! + (1 - this.beta1) * gi;
+        v[i] = this.beta2 * v[i]! + (1 - this.beta2) * gi * gi;
+        const mHat = m[i]! / b1c;
+        const vHat = v[i]! / b2c;
+        data[i]! -= (this.lr * mHat) / (Math.sqrt(vHat) + this.eps);
+      }
+    }
+  }
+}

--- a/code/packages/typescript/ml-framework-core/src/version.ts
+++ b/code/packages/typescript/ml-framework-core/src/version.ts
@@ -4,4 +4,4 @@
  * Kept in sync with package.json's `version` field by hand — there's no
  * build step that injects it.  When bumping, update both files.
  */
-export const VERSION = "1.5.0" as const;
+export const VERSION = "1.6.0" as const;

--- a/code/packages/typescript/ml-framework-core/tests/nn-optim.test.ts
+++ b/code/packages/typescript/ml-framework-core/tests/nn-optim.test.ts
@@ -1,0 +1,263 @@
+/**
+ * nn-optim.test.ts — Optimizer + Module/Linear/Sequential (Phase A.6).
+ *
+ * What's covered:
+ *  - Optimizer base: zeroGrad clears every param.grad; constructor
+ *    rejects empty params.
+ *  - SGD: a single step on a quadratic loss moves the param toward
+ *    the minimum.
+ *  - Adam: same quadratic converges; bias-correction at t=1 gives
+ *    an update with magnitude ≈ lr (NOT lr*(1-β1) which would be the
+ *    uncorrected naive form).
+ *  - Linear: shape, parameters() list with/without bias, forward
+ *    output shape, gradient flow back into weight and bias.
+ *  - Sequential: forward chains in order; parameters() collects from
+ *    all children; integration test trains a tiny 2-layer MLP on a
+ *    handcrafted regression to verify loss actually decreases.
+ *  - Fn wrapper: no params, identity-ish forward.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Tensor, SGD, Adam, Linear, Sequential, Fn, Optimizer } from "../src/index.js";
+
+/** Helper: create a leaf tensor with requiresGrad. */
+function param(data: number[], shape?: number[]): Tensor {
+  const t = shape ? new Tensor(data, { shape }) : new Tensor(data);
+  t.requiresGrad = true;
+  return t;
+}
+
+describe("Optimizer base", () => {
+  it("rejects empty params list", () => {
+    expect(() => new SGD([], 0.1)).toThrow(RangeError);
+  });
+
+  it("zeroGrad sets every param.grad to null", () => {
+    const a = param([1, 2, 3]);
+    const b = param([4, 5, 6]);
+    a.grad = new Tensor([0.1, 0.2, 0.3]);
+    b.grad = new Tensor([0.4, 0.5, 0.6]);
+    const opt = new SGD([a, b], 0.1);
+    opt.zeroGrad();
+    expect(a.grad).toBeNull();
+    expect(b.grad).toBeNull();
+  });
+});
+
+describe("SGD", () => {
+  it("step moves a param toward its quadratic minimum", () => {
+    // Loss = (x - 5)² → dL/dx = 2*(x - 5).  Starting at x=0, gradient = -10.
+    // After one SGD step with lr=0.1: x = 0 - 0.1*(-10) = 1.  Closer to 5.
+    const x = param([0]);
+    x.grad = new Tensor([-10]);
+    const opt = new SGD([x], 0.1);
+    opt.step();
+    expect(x.data[0]).toBeCloseTo(1.0, 6);
+  });
+
+  it("skips params with null grad", () => {
+    const a = param([1, 2, 3]);
+    const b = param([4, 5, 6]);
+    // a has grad; b does not.
+    a.grad = new Tensor([1, 1, 1]);
+    const opt = new SGD([a, b], 0.5);
+    opt.step();
+    expect(Array.from(a.data)).toEqual([0.5, 1.5, 2.5]);
+    expect(Array.from(b.data)).toEqual([4, 5, 6]); // unchanged
+  });
+
+  it("rejects non-positive lr", () => {
+    const a = param([1]);
+    expect(() => new SGD([a], 0)).toThrow(RangeError);
+    expect(() => new SGD([a], -0.1)).toThrow(RangeError);
+  });
+});
+
+describe("Adam", () => {
+  it("step 1 with constant grad: |update| ≈ lr (bias-corrected, NOT lr*(1-β1))", () => {
+    // Verify bias correction is applied at t=1.
+    // grad = 1 constant; lr=0.01.  Without bias correction the first
+    // step would be ~lr*(1-β1)/sqrt(1-β2)/(...), which is much smaller.
+    // With bias correction: m̂=g, v̂=g², so update = lr * g / (|g| + eps) ≈ lr.
+    const x = param([0]);
+    x.grad = new Tensor([1]);
+    const opt = new Adam([x], 0.01);
+    const before = x.data[0]!;
+    opt.step();
+    const delta = before - x.data[0]!;
+    // delta should be ≈ lr = 0.01, NOT lr*(1-0.9) = 0.001.
+    expect(delta).toBeCloseTo(0.01, 4);
+  });
+
+  it("step counter increments", () => {
+    const x = param([0]);
+    x.grad = new Tensor([1]);
+    const opt = new Adam([x]);
+    expect(opt.stepCount).toBe(0);
+    opt.step();
+    expect(opt.stepCount).toBe(1);
+    opt.step();
+    expect(opt.stepCount).toBe(2);
+  });
+
+  it("rejects out-of-range hyperparams", () => {
+    const a = param([1]);
+    expect(() => new Adam([a], -0.1)).toThrow(RangeError);
+    expect(() => new Adam([a], 0.001, 1.0)).toThrow(RangeError); // beta1 must be < 1
+    expect(() => new Adam([a], 0.001, 0.9, -0.1)).toThrow(RangeError);
+  });
+
+  it("converges on a quadratic loss", () => {
+    // L = (x - 7)². Use analytical grad to skip building an autograd subgraph.
+    const x = param([0]);
+    const opt = new Adam([x], 0.1);
+    for (let i = 0; i < 200; i++) {
+      x.grad = new Tensor([2 * (x.data[0]! - 7)]);
+      opt.step();
+    }
+    expect(x.data[0]).toBeCloseTo(7, 1);
+  });
+});
+
+describe("Linear", () => {
+  it("shape: weight (in, out), bias (out,)", () => {
+    const lin = new Linear(3, 5);
+    expect(lin.weight.shape).toEqual([3, 5]);
+    expect(lin.bias?.shape).toEqual([5]);
+  });
+
+  it("parameters() returns [weight, bias] when bias=true", () => {
+    const lin = new Linear(3, 5);
+    const ps = lin.parameters();
+    expect(ps.length).toBe(2);
+    expect(ps[0]).toBe(lin.weight);
+    expect(ps[1]).toBe(lin.bias);
+  });
+
+  it("parameters() returns [weight] only when bias=false", () => {
+    const lin = new Linear(3, 5, false);
+    const ps = lin.parameters();
+    expect(ps.length).toBe(1);
+    expect(ps[0]).toBe(lin.weight);
+    expect(lin.bias).toBeNull();
+  });
+
+  it("forward shape: (batch, in) → (batch, out)", () => {
+    const lin = new Linear(4, 7);
+    const x = Tensor.zeros(8, 4);
+    const y = lin.forward(x);
+    expect(y.shape).toEqual([8, 7]);
+  });
+
+  it("forward produces gradient flow back to weight + bias", () => {
+    const lin = new Linear(3, 2);
+    const x = Tensor.zeros(5, 3); // doesn't require grad
+    const y = lin.forward(x).sum();
+    y.backward();
+    expect(lin.weight.grad).not.toBeNull();
+    expect(lin.bias?.grad).not.toBeNull();
+    expect(lin.weight.grad?.shape).toEqual([3, 2]);
+    expect(lin.bias?.grad?.shape).toEqual([2]);
+  });
+
+  it("rejects non-positive in/out", () => {
+    expect(() => new Linear(0, 5)).toThrow(RangeError);
+    expect(() => new Linear(5, 0)).toThrow(RangeError);
+  });
+});
+
+describe("Sequential", () => {
+  it("forward chains layers in order", () => {
+    // Two Linear layers: 3 → 4 → 2.  Output shape should be (batch, 2).
+    const seq = new Sequential(new Linear(3, 4), new Linear(4, 2));
+    const x = Tensor.zeros(6, 3);
+    expect(seq.forward(x).shape).toEqual([6, 2]);
+  });
+
+  it("parameters() concatenates all children's parameters in declaration order", () => {
+    const l1 = new Linear(2, 3);  // 2 params
+    const l2 = new Linear(3, 1, false); // 1 param
+    const seq = new Sequential(l1, l2);
+    const ps = seq.parameters();
+    expect(ps).toEqual([l1.weight, l1.bias, l2.weight]);
+  });
+
+  it("training loop on a tiny MLP reduces loss (integration)", () => {
+    // Tiny regression: learn y = sum(x).  Two-layer MLP with ReLU between.
+    // Input dim 3, hidden dim 8, output dim 1.  Train on 20 random samples.
+    const model = new Sequential(
+      new Linear(3, 8),
+      new Fn((x) => x.relu()),
+      new Linear(8, 1),
+    );
+    const opt = new Adam(model.parameters(), 0.05);
+
+    // Generate fixed data so the test is deterministic across runs of
+    // Math.random — we precompute and hold both inputs and targets.
+    const N = 20;
+    const xData: number[][] = [];
+    const yTarget: number[] = [];
+    for (let i = 0; i < N; i++) {
+      const a = (i % 5) * 0.1, b = ((i * 3) % 7) * 0.1, c = ((i * 11) % 13) * 0.1;
+      xData.push([a, b, c]);
+      yTarget.push(a + b + c);
+    }
+
+    const computeLoss = (): number => {
+      let total = 0;
+      for (let i = 0; i < N; i++) {
+        const x = new Tensor(xData[i]!, { shape: [1, 3] });
+        const yHat = model.forward(x); // shape (1, 1)
+        const diff = yHat.data[0]! - yTarget[i]!;
+        total += diff * diff;
+      }
+      return total / N;
+    };
+
+    const lossStart = computeLoss();
+
+    for (let epoch = 0; epoch < 30; epoch++) {
+      for (let i = 0; i < N; i++) {
+        const x = new Tensor(xData[i]!, { shape: [1, 3] });
+        const yTrue = new Tensor([yTarget[i]!], { shape: [1, 1] });
+        const yHat = model.forward(x);
+        const diff = yHat.sub(yTrue);
+        const loss = diff.mul(diff).sum();
+        opt.zeroGrad();
+        loss.backward();
+        opt.step();
+      }
+    }
+
+    const lossEnd = computeLoss();
+    // Initial loss is whatever Xavier-init gives; final loss must be
+    // meaningfully smaller — at least a 2× reduction.
+    expect(lossEnd).toBeLessThan(lossStart * 0.5);
+  });
+});
+
+describe("Fn", () => {
+  it("has no parameters", () => {
+    const fn = new Fn((x) => x.relu());
+    expect(fn.parameters()).toEqual([]);
+  });
+
+  it("applies the wrapped function in forward", () => {
+    const fn = new Fn((x) => x.relu());
+    const x = new Tensor([-1, 0, 1, -2, 2]);
+    expect(fn.forward(x).toArray()).toEqual([0, 0, 1, 0, 2]);
+  });
+});
+
+describe("Optimizer integration via type", () => {
+  // Compile-time check that SGD/Adam are assignable to Optimizer base.
+  it("SGD and Adam are both Optimizers", () => {
+    const a = param([1]);
+    a.grad = new Tensor([1]);
+    const optimizers: Optimizer[] = [new SGD([a], 0.1), new Adam([a])];
+    for (const o of optimizers) {
+      expect(typeof o.step).toBe("function");
+      expect(typeof o.zeroGrad).toBe("function");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Phase A.6 of 7** in the TypeScript ml-framework expansion.

Turns the framework from "a bag of ops" into something you can call `Sequential(...).forward(x)` on, then hand parameters to an optimizer. Last step before HF interop in A.7.

### New: `src/optim.ts`
- **`Optimizer`** abstract base — `params`, `zeroGrad()`, abstract `step()`.
- **`SGD`** — plain `param -= lr * grad`.
- **`Adam`** — per-param `m`/`v` `Float32Array` moments + step counter, bias-corrected. Defaults match PyTorch (`lr=1e-3`, `betas=(0.9, 0.999)`, `eps=1e-8`).

### New: `src/nn.ts`
- **`Module`** abstract base with `parameters()` + `forward(x)`.
- **`Linear`** — `(inFeatures, outFeatures)` weight (NOT PyTorch's `(out, in)`; documented divergence — `Tensor.transpose()` is currently non-autograd, so `x @ W.T` would silently drop the grad on `W`). Xavier-uniform init, zero bias.
- **`Sequential(...layers)`** — chains forward, concatenates `parameters()`.
- **`Fn`** — wraps any `(Tensor) → Tensor` as a Module with no params; drops activations into a Sequential cleanly.

### Bumps to **v1.6.0**.

## Test plan

- [x] 263 vitest cases pass (242 → 263; +21 in `tests/nn-optim.test.ts`)
  - 2 Optimizer base (empty rejected, zeroGrad)
  - 3 SGD (quadratic step, null-grad skip, validation)
  - 4 Adam (**bias correction at t=1 gives ≈ lr-magnitude update**, step counter, validation, convergence on quadratic)
  - 6 Linear (shape, params with/without bias, forward, grad flow back to weight + bias, validation)
  - 3 Sequential (chained forward, params concatenation, **end-to-end MLP training** verifying loss drops 2× over 30 epochs)
  - 2 Fn (no params, identity-ish forward)
  - 1 polymorphism check
- [x] `tsc --noEmit` clean
- [x] Security review passed (no findings; Math.random for init + in-place data mutation are documented design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)