### PR TITLE
test(python-backend): Ruby → Semantic IR → Python end-to-end tests

### DIFF
--- a/code/.commit-msg-e2e.txt
+++ b/code/.commit-msg-e2e.txt
@@ -1,0 +1,29 @@
+test(python-backend): add Ruby → Semantic IR → Python end-to-end tests
+
+Drives the Ruby frontend (`ruby-to-semantic-ir`) through the existing
+Python backend to prove the narrow-waist Semantic IR decouples
+frontends from backends — Ruby source in, runnable Python out, with no
+Ruby-specific code in this crate.
+
+- dev-dependency `ruby-to-semantic-ir` added (mirrors the existing
+  `twig-to-semantic-ir` dev-dep).
+- New tests mirroring the Twig→Python e2e tests:
+  - end_to_end_ruby_to_python_puts: `puts("hello")` →
+    `_sir_call_builtin("puts", ["hello"])`
+  - end_to_end_ruby_to_python_def_and_call: `def add(a,b); a+b; end;
+    puts(add(1,2))` → `def add(a, b):` / `return _sir_plus(a, b)` /
+    `_sir_call_builtin("puts", [add(1, 2)])`
+  - end_to_end_ruby_to_python_locals: `x=1; y=2; puts(x+y)` →
+    `_sir_call_builtin("puts", [_sir_plus(x, y)])`
+  - end_to_end_ruby_to_python_is_deterministic
+
+Snippets are restricted to the backend's ACCEPTED_FEATURES
+(puts/arithmetic/defs/locals); Ruby constructs that lower to
+Sequences/Maps/ShortCircuit (arrays, hashes, case/in) are intentionally
+excluded — the backend rejects those features at its capability check by
+design, so they lower+validate but don't emit Python yet.
+
+Tests only; no production code or output changes.
+CHANGELOG 0.1.2 -> 0.1.3.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.3 — Ruby → Python end-to-end tests (tests only)
+
+Adds end-to-end tests that drive the **Ruby** frontend
+(`ruby-to-semantic-ir`) through this Python backend, proving the
+narrow-waist Semantic IR decouples frontends from backends: Ruby source
+in, runnable Python out, with zero Ruby-specific code in this crate.
+
+- New dev-dependency `ruby-to-semantic-ir` (alongside the existing
+  `twig-to-semantic-ir`).
+- New tests: `end_to_end_ruby_to_python_puts`,
+  `end_to_end_ruby_to_python_def_and_call`,
+  `end_to_end_ruby_to_python_locals`,
+  `end_to_end_ruby_to_python_is_deterministic`.
+- Snippets are restricted to the backend's `ACCEPTED_FEATURES`
+  (puts/arithmetic/defs/locals); Ruby constructs lowering to
+  `Sequences`/`Maps`/`ShortCircuit` are intentionally excluded (rejected
+  at the capability check by design). No production-code or output
+  changes.
+
 ## 0.1.2 — SIR18 exhaustiveness (no behaviour change)
 
 semantic-ir 0.10.0 adds `Expr::StrConcat` (the SIR18 string-concat

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -9,3 +9,4 @@ semantic-ir = { path = "../semantic-ir" }
 
 [dev-dependencies]
 twig-to-semantic-ir = { path = "../twig-to-semantic-ir" }
+ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -222,4 +222,97 @@ mod tests {
         let a = compile(&m).expect("compile");
         assert_eq!(a.filename, "compiler_lexer.py");
     }
+
+    // ── End-to-end: Ruby → Semantic IR → Python ─────────────────────────
+    //
+    // These mirror the Twig→Python e2e tests above, but drive the *Ruby*
+    // frontend (`ruby_to_semantic_ir::compile_source`) through the exact
+    // same Python backend.  They prove the narrow-waist SIR genuinely
+    // decouples frontends from backends: Ruby source in, runnable Python
+    // out, with no Ruby-specific code in this crate.
+    //
+    // Snippets are restricted to the backend's `ACCEPTED_FEATURES`
+    // (puts/arithmetic/defs/locals).  Ruby constructs that lower to
+    // `Sequences`/`Maps`/`ShortCircuit` (arrays, hashes, case/in patterns)
+    // are intentionally excluded — the backend rejects those features by
+    // design, so they lower+validate but don't emit Python yet.
+
+    #[test]
+    fn end_to_end_ruby_to_python_puts() {
+        // `puts("hello")` → a top-level `main` that calls the `puts`
+        // builtin through the runtime dispatcher.
+        let module = ruby_to_semantic_ir::compile_source("puts(\"hello\")\n", "demo")
+            .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("def _sir_user_main():"),
+            "expected a main function; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("_sir_call_builtin(\"puts\", [\"hello\"])"),
+            "expected the puts call with the string literal; got:\n{}",
+            a.source
+        );
+        assert!(a.source.contains("_sir_user_main()"), "expected main invocation");
+        assert!(a.filename.ends_with(".py"));
+    }
+
+    #[test]
+    fn end_to_end_ruby_to_python_def_and_call() {
+        // A Ruby method definition + call round-trips to a Python `def`
+        // whose body uses the runtime `_sir_plus`, invoked from `main`.
+        let module = ruby_to_semantic_ir::compile_source(
+            "def add(a, b)\n  a + b\nend\nputs(add(1, 2))\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("def add(a, b):"),
+            "expected the add function def; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("return _sir_plus(a, b)"),
+            "expected `a + b` to lower to _sir_plus; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("_sir_call_builtin(\"puts\", [add(1, 2)])"),
+            "expected puts(add(1, 2)); got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_to_python_locals() {
+        // Local assignments thread through to the Python body: the final
+        // `puts(x + y)` references both locals via `_sir_plus(x, y)`.
+        let module = ruby_to_semantic_ir::compile_source(
+            "x = 1\ny = 2\nputs(x + y)\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("_sir_call_builtin(\"puts\", [_sir_plus(x, y)])"),
+            "expected puts(x + y) referencing both locals; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_to_python_is_deterministic() {
+        // Same Ruby input → byte-identical Python (no nondeterministic
+        // ordering leaking through the Ruby frontend).
+        let module = ruby_to_semantic_ir::compile_source(
+            "def add(a, b)\n  a + b\nend\nputs(add(1, 2))\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile");
+        let b = compile(&module).expect("compile again");
+        assert_eq!(a.source, b.source);
+    }
 }


### PR DESCRIPTION
## Ruby → Semantic IR → Python, end-to-end

Adds end-to-end tests that drive the **Ruby** frontend (`ruby-to-semantic-ir`) through the existing **Python** backend (`semantic-ir-to-python`) — demonstrating that the narrow-waist Semantic IR genuinely decouples frontends from backends. Ruby source goes in; runnable Python comes out; there is **zero Ruby-specific code in this crate**.

### What it proves
The same backend that already serves the Twig frontend now visibly serves Ruby too, through the shared SIR. For example:

| Ruby in | Python out (asserted) |
|---|---|
| `puts("hello")` | `_sir_call_builtin("puts", ["hello"])` inside `def _sir_user_main():` |
| `def add(a, b)\n  a + b\nend\nputs(add(1, 2))` | `def add(a, b):` / `return _sir_plus(a, b)` / `_sir_call_builtin("puts", [add(1, 2)])` |
| `x = 1\ny = 2\nputs(x + y)` | `_sir_call_builtin("puts", [_sir_plus(x, y)])` |

### Changes
- **dev-dependency** `ruby-to-semantic-ir` added (mirrors the existing `twig-to-semantic-ir` dev-dep). Production deps unchanged.
- Four `#[cfg(test)]` tests mirroring the Twig→Python e2e tests: `end_to_end_ruby_to_python_puts`, `…_def_and_call`, `…_locals`, `…_is_deterministic`.
- CHANGELOG 0.1.2 → 0.1.3.

### Scope note
Snippets are restricted to the backend's `ACCEPTED_FEATURES` (Closures, Pairs, Symbols, Strings, DynamicTyping, OptionalTypeAnnotations, MutualRecursion, Globals). Ruby constructs that lower to `Sequences`/`Maps`/`ShortCircuit` (arrays, hashes, `case/in` patterns) are intentionally excluded — the backend rejects those features at its capability check by design, so they lower + validate but don't emit Python yet. This is pre-existing backend behaviour, not a regression.

**Tests only — no production code or emitted-output changes.** Full `semantic-ir-to-python` suite green (23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
