### PR TITLE
feat(ge225-backend): Migration Phase 2 — Backend trait impl over CIR

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -661,6 +661,7 @@ members = [
     "iir-to-intel4004",
     "iir-to-ge225",
     "ge225-encoder",
+    "ge225-backend",
     "aot-debug",
     "twig-to-beam",
     "twig-to-wasm",

--- a/code/packages/rust/ge225-backend/BUILD
+++ b/code/packages/rust/ge225-backend/BUILD
@@ -1,0 +1,1 @@
+cargo test -p ge225-backend

--- a/code/packages/rust/ge225-backend/CHANGELOG.md
+++ b/code/packages/rust/ge225-backend/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog — ge225-backend
+
+## v0.1.0 — 2026-06-03 — Phase 2 of historical-arch backend migration
+
+Initial release.  Implements `jit_core::backend::Backend` for the
+GE-225, consuming monomorphised CIR.  Mirror of `aarch64-backend`
+/ `x86_64-backend` in shape and intent.
+
+### Added
+
+- `pub struct Ge225Backend` with `impl Backend`:
+  - `name() -> "ge225"`.
+  - `compile(&[CIRInstr]) -> Option<Vec<u8>>`.
+  - `compile_function(&FunctionContext, &[CIRInstr]) -> Option<Vec<u8>>`.
+  - `run(_, _) -> Value` panics with `"ge225 backend is emit-only;
+    load bytes into a ge225 simulator to execute"`.  Per the
+    migration spec, JIT support is best-effort for historical
+    arches; this satisfies the trait so the backend can plug into
+    the `jit-core` registry, but `run` is intentionally not
+    implemented.
+- `pub fn compile(ctx, cir) -> Result<Vec<u8>, BackendError>` — the
+  direct AOT entry point (same shape as `aarch64_backend::compile`).
+- `pub enum BackendError` — structured diagnostics: `UnsupportedOp`,
+  `InvalidOperand`, `UndefinedVariable`, `ImmediateOutOfRange`,
+  `OutOfRegisters`, `UndefinedLabel`, `BranchTargetOutOfRange`.
+
+### Covered CIR ops
+
+- `const_*` (every int type + bool), `mov_*`, `add_*`, `sub_*`,
+  `neg_*`, `cmp_{lt,gt,eq,ne,le,ge}_*`, `label`, `jmp`,
+  `jmp_if_true`, `jmp_if_false`, `ret_*`, `ret_void`,
+  `call_builtin` (no-op).
+- `call` (cross-function) returns `Err(UnsupportedOp)` until
+  Phase 3 adds module-level relocation support via `aot-core`.
+
+### Byte-for-byte parity with iir-to-ge225 v0.9.0
+
+The 24 unit tests pin the same trivial-ROM byte sequences (6-byte
+const+ret, 21-byte add/sub, 33-byte cmp_lt, 15-byte neg), just
+built from CIR instead of IIR.
+
+### Source
+
+Lowering algorithm carved from `iir-to-ge225` v0.9.0 and adapted
+to consume `CIRInstr` (typed) instead of `IIRInstr` (dynamic).
+The CIR ops dispatch via prefix-strip (`op.strip_prefix("const_")`
+etc.) — much cleaner than the IIR-level approach that needed
+explicit per-type arms.
+
+### Reference
+
+- Spec: `code/specs/ge225-backend.md`
+- Migration plan: `code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md`

--- a/code/packages/rust/ge225-backend/Cargo.toml
+++ b/code/packages/rust/ge225-backend/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ge225-backend"
+version = "0.1.0"
+edition = "2021"
+description = "GE-225 backend for jit-core / aot-core.  Lowers a `Vec<CIRInstr>` into 20-bit GE-225 machine code via `ge225-encoder`.  Plugs into both `aot-core` (AOT byte emission) and `jit-core` (via the shared `Backend` trait) — same shape as `aarch64-backend` / `x86_64-backend`, just for an emit-only historical-arch target (the 1959 General Electric mainframe where Dartmouth BASIC was designed in 1964).  `Backend::run` panics with an 'emit-only' message; execution happens in a downstream simulator.  See code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md."
+
+[lib]
+name = "ge225_backend"
+path = "src/lib.rs"
+
+[dependencies]
+ge225-encoder = { path = "../ge225-encoder" }
+jit-core      = { path = "../jit-core" }
+vm-core       = { path = "../vm-core" }

--- a/code/packages/rust/ge225-backend/README.md
+++ b/code/packages/rust/ge225-backend/README.md
@@ -1,0 +1,64 @@
+# ge225-backend
+
+GE-225 backend for `jit-core` / `aot-core`.  Mirror of
+`aarch64-backend` / `x86_64-backend` for the 1959 General Electric
+mainframe where Dartmouth BASIC was designed in 1964.
+
+## What this crate is
+
+- A `Ge225Backend` zero-sized struct that implements
+  `jit_core::backend::Backend`.
+- A public `compile(ctx, cir) -> Result<Vec<u8>, BackendError>`
+  function for direct AOT use (the same shape as
+  `aarch64_backend::compile`).
+- A structured `BackendError` enum for diagnostic reporting.
+
+## What it does
+
+Lowers a `Vec<CIRInstr>` (typed, monomorphised compiler-IR
+produced by `aot_core::specialise`) into 20-bit GE-225 instruction
+words packed 3 bytes each.  Uses `ge225-encoder` for the actual
+byte construction.
+
+## Backed CIR ops (Phase 2, v0.1.0)
+
+| Family | CIR mnemonics | Status |
+|--------|---------------|--------|
+| Constants | `const_i8` … `const_i64`, `const_u8` … `const_u64`, `const_bool` | ✓ |
+| Move | `mov_*` | ✓ |
+| Add / Sub | `add_*`, `sub_*` | ✓ |
+| Neg | `neg_*` | ✓ |
+| Compare | `cmp_{lt,gt,eq,ne,le,ge}_*` | ✓ |
+| Control flow | `label`, `jmp`, `jmp_if_true`, `jmp_if_false` | ✓ |
+| Returns | `ret_*`, `ret_void` | ✓ |
+| Built-in call | `call_builtin` | ✓ (no-op) |
+| Cross-function call | `call` | Returns `None` until Phase 3 wires module-level relocations |
+| Mul / Div / Shifts / Bitwise / Float / Globals / Type guards | — | Returns `None` (graceful AOT/JIT fallback) |
+
+## Why is `Backend::run` not implemented?
+
+The GE-225 has no in-process simulator in this crate.  Per the
+[migration spec](../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md),
+the historical-arch backends are **emit-only** — bytes go to a
+downstream simulator (`ge225-simulator`) or a custom decoder.
+`Backend::run` panics with a clear message.
+
+## Byte-for-byte parity with `iir-to-ge225` v0.9.0
+
+The 24 unit tests in `tests/test_backend.rs` pin the same trivial-
+ROM byte sequences `iir-to-ge225` did, just built from CIR
+(`const_i64`/`add_i64`/etc.) instead of IIR (`const`/`add`):
+
+| Program | Bytes |
+|---------|-------|
+| `const v=N; ret v` | 6 (LDA + HLT) |
+| `const a; const b; add c, a, b; ret c` | 21 |
+| `const a; const b; cmp_lt c, a, b; ret c` | 33 |
+| `const v; neg w, v; ret w` | 15 |
+
+## See also
+
+- [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md) — phase plan.
+- [`ge225-encoder`](../ge225-encoder) — pure byte-encoding tables this crate consumes.
+- [`iir-to-ge225`](../iir-to-ge225) — the older IIR-level crate this PR migrates away from.  Will be deprecated in Phase 3.
+- [`aarch64-backend`](../aarch64-backend) — the architectural model this crate follows.

--- a/code/packages/rust/ge225-backend/src/lib.rs
+++ b/code/packages/rust/ge225-backend/src/lib.rs
@@ -1,0 +1,622 @@
+//! # `ge225-backend` — GE-225 backend for jit-core / aot-core.
+//!
+//! Lowers a `Vec<CIRInstr>` into 20-bit GE-225 machine code via
+//! [`ge225_encoder`].  Plugs into both `aot-core` (AOT byte
+//! emission) and `jit-core` (via the shared
+//! [`jit_core::backend::Backend`] trait) — same shape as
+//! `aarch64-backend` / `x86_64-backend`.
+//!
+//! ## Scope
+//!
+//! | Family | CIR mnemonics | Lowering shape |
+//! |--------|---------------|----------------|
+//! | Constants | `const_i8` … `const_i64`, `const_u8` … `const_u64`, `const_bool` | `(STA r_evict)?` + `LDA n` |
+//! | Move | `mov_i8` … `mov_i64`, `mov_u8` … `mov_u64`, `mov_bool` | `(STA r_evict_src)?` + `LD r_src` + `STA r_dest` |
+//! | Add | `add_i8` … `add_i64`, `add_u8` … `add_u64` | `(evict)?` + `LD r_lhs` + `ADD r_rhs` |
+//! | Sub | `sub_i8` … `sub_i64`, `sub_u8` … `sub_u64` | `(evict)?` + `LD r_lhs` + `SUB r_rhs` |
+//! | Neg | `neg_i8` … `neg_i64` | `(evict)?` + `LDA 0` + `SUB r_src` |
+//! | Cmp | `cmp_lt_*`, `cmp_eq_*`, `cmp_ne_*`, `cmp_le_*`, `cmp_gt_*`, `cmp_ge_*` (signed and unsigned) | SUB-then-test boolean materialisation |
+//! | Control flow | `label`, `jmp`, `jmp_if_true`, `jmp_if_false` | `BR` / `BNZ` / `BZ` with per-function backpatching |
+//! | Returns | `ret_*`, `ret_void` | `(LD r_var)?` + `HLT` |
+//! | Calls | `call`, `call_builtin` | `call_builtin` is a no-op; `call` returns `None` from `compile` until Phase 3 adds module-level relocation support |
+//! | Float, send, properties, globals, type_assert | **NOT YET** | returns `None` |
+//!
+//! Anything outside this list returns `None` from `compile`, which
+//! both `aot-core` and `jit-core` treat as a compile failure for
+//! that function (graceful fallback).
+//!
+//! ## Why CIR (not IIR)?
+//!
+//! The previous historical-arch crate (`iir-to-ge225`) consumed
+//! IIR directly — dynamically typed, requiring the backend to do
+//! its own type inference.  This crate consumes the **monomorphised
+//! CIR** that `aot_core::infer::infer_types` +
+//! `aot_core::specialise::aot_specialise` produce.  Every op is
+//! type-suffixed (`add_i64`, `cmp_lt_u32`), so the backend just
+//! pattern-matches the prefix.
+//!
+//! For GE-225 specifically: the silicon has one 20-bit accumulator
+//! width.  Every `const_*` variant lowers to the same `LDA n` (with
+//! a 16-bit-immediate range check); every `add_*` to the same
+//! `ADD r`; etc.  CIR's type suffix is informational only on this
+//! arch.
+//!
+//! ## Why is `Backend::run` not implemented?
+//!
+//! Per the migration spec
+//! ([`HISTORICAL-ARCH-BACKEND-MIGRATION.md`]), the historical-arch
+//! backends are **emit-only**.  No in-process simulator exists in
+//! this crate; downstream the bytes are loaded into
+//! `ge225-simulator` or a custom decoder for execution.
+//! `Backend::run` panics with a clear message — the trait is
+//! satisfied so the backend can plug into the `jit-core` registry,
+//! but no caller should reach `run`.
+//!
+//! [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`]: ../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md
+//!
+//! ## Status — v0.1.0 (Phase 2 of the migration)
+//!
+//! - Implements `Backend` trait.  `compile_function` is the real
+//!   entry point; bare `compile` delegates to it with an empty
+//!   `FunctionContext`.
+//! - Single-function emit only — cross-function `call` returns
+//!   `None`.  Phase 3 will add module-level orchestration via
+//!   `aot_core::link` + relocations.
+//! - Byte sequences are identical to `iir-to-ge225` v0.9.0 for
+//!   equivalent CIR inputs: the trivial-case ROMs (6-byte
+//!   const+ret, 21-byte add, 33-byte cmp_lt, 15-byte neg) all
+//!   round-trip via the same exact bytes.
+
+use ge225_encoder::{
+    encode_add, encode_bmi, encode_bnz, encode_br, encode_bz, encode_ld, encode_lda, encode_sta,
+    encode_sub, HALT_WORD,
+};
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+use std::collections::HashMap;
+use std::fmt;
+use vm_core::value::Value;
+
+// ===========================================================================
+// Public types
+// ===========================================================================
+
+/// The GE-225 backend handle.  Zero-sized — all state lives per
+/// compile invocation.
+///
+/// Construct with [`Ge225Backend::new()`] (or `Default`).  Register
+/// with `jit-core` via `Box<dyn Backend>` if you want JIT
+/// integration (but see the module docs — JIT execution will panic
+/// because the backend is emit-only).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Ge225Backend;
+
+impl Ge225Backend {
+    /// Construct a new backend handle.
+    pub fn new() -> Self {
+        Ge225Backend
+    }
+}
+
+/// Per-instruction lowering errors.  Returned by [`compile`] for
+/// diagnostic use.  The `Backend` trait coerces these to `None`
+/// for the JIT / AOT graceful-failure paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendError {
+    /// CIR op not yet handled by this backend.
+    UnsupportedOp(String),
+    /// An operand has an unexpected shape.
+    InvalidOperand(String),
+    /// A variable was referenced before being defined by a prior
+    /// CIR instruction's `dest`.
+    UndefinedVariable(String),
+    /// `const_*` immediate didn't fit in the GE-225's 16-bit
+    /// immediate field (range `[-32768, 65535]`).
+    ImmediateOutOfRange(i64),
+    /// More than the 17-slot pool (ACC + r0..r15) could hold.
+    OutOfRegisters(String),
+    /// A `jmp` referenced a label not defined in this function.
+    UndefinedLabel(String),
+    /// A branch target's byte offset exceeded the 16-bit address
+    /// field (max 65535).
+    BranchTargetOutOfRange(usize),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedOp(op) => write!(f, "ge225-backend: unsupported op {op:?}"),
+            Self::InvalidOperand(d) => write!(f, "ge225-backend: invalid operand: {d}"),
+            Self::UndefinedVariable(name) => {
+                write!(f, "ge225-backend: undefined variable {name:?}")
+            }
+            Self::ImmediateOutOfRange(n) => write!(
+                f,
+                "ge225-backend: const {n} exceeds the GE-225 16-bit immediate range [-32768, 65535]"
+            ),
+            Self::OutOfRegisters(name) => write!(
+                f,
+                "ge225-backend: out of registers (ACC + r0..r15 = 17 slots) while binding {name:?}"
+            ),
+            Self::UndefinedLabel(label) => {
+                write!(f, "ge225-backend: undefined label {label:?}")
+            }
+            Self::BranchTargetOutOfRange(off) => write!(
+                f,
+                "ge225-backend: branch target byte offset {off} exceeds the 16-bit address field"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+// ===========================================================================
+// Public compile() — single-function emit, no cross-function refs
+// ===========================================================================
+
+/// Compile a single function's CIR into GE-225 bytes.
+///
+/// This is the canonical single-function entry point — the same
+/// shape as `aarch64_backend::compile`.  Errors carry a structured
+/// `BackendError`; the `Backend` trait's `compile_function` coerces
+/// them to `None` for graceful fallback.
+///
+/// **v0.1.0 scope**: cross-function `call` returns
+/// `Err(UnsupportedOp("call"))`.  Phase 3 will add module-level
+/// relocation support so `call` can resolve to a callee entry
+/// address via `aot_core::link`.
+///
+/// The `_ctx` parameter is currently unused but kept in the
+/// signature to match `aarch64_backend::compile`.  Future versions
+/// will use it for entry-vs-non-entry function detection (the
+/// `ret_*`-emits-`HLT` vs `RTS` discriminator), at which point the
+/// caller will need to populate `FunctionContext::name` correctly.
+pub fn compile(_ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    compile_single_function(cir)
+}
+
+// ===========================================================================
+// Internals — single-function compile
+// ===========================================================================
+
+/// Sentinel `env` value meaning "this var currently lives in ACC".
+const ACC_MARKER: u8 = 16;
+
+/// Number of GP registers — re-exported from `ge225-encoder` for
+/// the eviction-budget check.
+const GP_REGISTER_COUNT: usize = ge225_encoder::GP_REGISTER_COUNT;
+
+fn compile_single_function(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    // Empty CIR → just emit a HLT so the output is still a valid
+    // halting program.  Mirrors iir-to-ge225's empty-module path.
+    if cir.is_empty() {
+        return Ok(HALT_WORD.to_vec());
+    }
+
+    let mut bytes = Vec::new();
+    let mut env: HashMap<String, u8> = HashMap::new();
+    let mut next_reg: usize = 0;
+    let mut acc_owner: Option<String> = None;
+    let mut labels: HashMap<String, usize> = HashMap::new();
+    let mut pending_branches: Vec<(usize, String)> = Vec::new();
+
+    for instr in cir {
+        let op = instr.op.as_str();
+
+        // ── label "<name>": record current byte offset ─────────────
+        if op == "label" {
+            let name = parse_var_src(instr, 0, "label")?;
+            labels.insert(name, bytes.len());
+            continue;
+        }
+
+        // ── jmp "<target>": BR + 16-bit address (backpatched) ──────
+        if op == "jmp" {
+            let target = parse_var_src(instr, 0, "jmp")?;
+            bytes.extend_from_slice(&encode_br(0));
+            // encode_br emitted 3 bytes; the high byte is at bytes.len()-2,
+            // low byte at bytes.len()-1 — but encode_br doesn't expose
+            // intermediate slots, so we re-slice manually.
+            let slot = bytes.len() - 2;
+            pending_branches.push((slot, target));
+            continue;
+        }
+
+        // ── jmp_if_true / jmp_if_false cond, "<target>" ────────────
+        if op == "jmp_if_true" || op == "jmp_if_false" {
+            let cond_name = parse_var_src(instr, 0, op)?;
+            let target = parse_var_src(instr, 1, op)?;
+            stage_var_into_acc(&cond_name, &mut env, &mut acc_owner, &mut bytes)?;
+            let encode_fn = if op == "jmp_if_true" {
+                encode_bnz
+            } else {
+                encode_bz
+            };
+            bytes.extend_from_slice(&encode_fn(0));
+            let slot = bytes.len() - 2;
+            pending_branches.push((slot, target));
+            continue;
+        }
+
+        // ── call_builtin (dest =)? builtin, args... ────────────────
+        //
+        // No-op lowering (GE-225 has no I/O opcode on this skeleton).
+        // If dest is bound, evict current ACC owner and emit
+        // `LDA 0` as a deterministic placeholder return value.
+        if op == "call_builtin" {
+            // First src must be Var(builtin_name).
+            if !matches!(instr.srcs.first(), Some(CIROperand::Var(_))) {
+                return Err(BackendError::InvalidOperand(
+                    "call_builtin requires srcs[0] = Var(builtin_name)".into(),
+                ));
+            }
+            // Validate remaining Var args are bound.
+            for arg in instr.srcs.iter().skip(1) {
+                if let CIROperand::Var(name) = arg {
+                    if !env.contains_key(name) {
+                        return Err(BackendError::UndefinedVariable(name.clone()));
+                    }
+                }
+            }
+            if let Some(dest) = instr.dest.as_deref() {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+                bytes.extend_from_slice(&encode_lda(0));
+                env.insert(dest.to_string(), ACC_MARKER);
+                acc_owner = Some(dest.to_string());
+            }
+            continue;
+        }
+
+        // ── call dest = fn_name, args... ───────────────────────────
+        //
+        // Phase 2 stub: single-function emit cannot resolve a
+        // cross-function callee address.  Phase 3 will add
+        // relocation support.
+        if op == "call" {
+            return Err(BackendError::UnsupportedOp(
+                "call (cross-function — needs Phase 3 relocation support)".into(),
+            ));
+        }
+
+        // ── ret_void: HLT ──────────────────────────────────────────
+        if op == "ret_void" {
+            bytes.extend_from_slice(&HALT_WORD);
+            continue;
+        }
+
+        // ── ret_<ty>: stage var into ACC, then HLT ─────────────────
+        if op.strip_prefix("ret_").is_some() {
+            let src_name = parse_var_src(instr, 0, op)?;
+            let loc = *env
+                .get(&src_name)
+                .ok_or_else(|| BackendError::UndefinedVariable(src_name.clone()))?;
+            if loc != ACC_MARKER {
+                bytes.extend_from_slice(&encode_ld(loc));
+            }
+            bytes.extend_from_slice(&HALT_WORD);
+            continue;
+        }
+
+        // ── const_<ty> dest, lit ───────────────────────────────────
+        if op.strip_prefix("const_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let imm16 = encode_immediate_16(instr.srcs.first())?;
+            evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            bytes.extend_from_slice(&encode_lda(imm16));
+            env.insert(dest.to_string(), ACC_MARKER);
+            acc_owner = Some(dest.to_string());
+            continue;
+        }
+
+        // ── mov_<ty> dest, src ─────────────────────────────────────
+        if op.strip_prefix("mov_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let src_name = parse_var_src(instr, 0, op)?;
+            if !env.contains_key(&src_name) {
+                return Err(BackendError::UndefinedVariable(src_name.clone()));
+            }
+            if matches!(env.get(&src_name), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            let src_reg = env[&src_name];
+            bytes.extend_from_slice(&encode_ld(src_reg));
+            let r_dest = alloc_register(&mut next_reg, dest)?;
+            bytes.extend_from_slice(&encode_sta(r_dest));
+            env.insert(dest.to_string(), r_dest);
+            acc_owner = None;
+            continue;
+        }
+
+        // ── add_<ty> / sub_<ty> ────────────────────────────────────
+        if op.strip_prefix("add_").is_some() || op.strip_prefix("sub_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let (lhs, rhs) = parse_binop_srcs(instr, op)?;
+            check_bound(&env, &lhs)?;
+            check_bound(&env, &rhs)?;
+            // Same 3-step eviction prep as iir-to-ge225 v0.4.0.
+            if matches!(env.get(&lhs), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            if matches!(env.get(&rhs), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            let r_lhs = env[&lhs];
+            let r_rhs = env[&rhs];
+            bytes.extend_from_slice(&encode_ld(r_lhs));
+            if op.starts_with("add_") {
+                bytes.extend_from_slice(&encode_add(r_rhs));
+            } else {
+                bytes.extend_from_slice(&encode_sub(r_rhs));
+            }
+            env.insert(dest.to_string(), ACC_MARKER);
+            acc_owner = Some(dest.to_string());
+            continue;
+        }
+
+        // ── neg_<ty> dest, src ─────────────────────────────────────
+        if op.strip_prefix("neg_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let src = parse_var_src(instr, 0, op)?;
+            check_bound(&env, &src)?;
+            if matches!(env.get(&src), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            let r_src = env[&src];
+            bytes.extend_from_slice(&encode_lda(0));
+            bytes.extend_from_slice(&encode_sub(r_src));
+            env.insert(dest.to_string(), ACC_MARKER);
+            acc_owner = Some(dest.to_string());
+            continue;
+        }
+
+        // ── cmp_{lt,gt,eq,ne,le,ge}_<ty> ───────────────────────────
+        //
+        // CIR cmp ops are type-suffixed (cmp_lt_i64).  We strip the
+        // type suffix and dispatch on the predicate.
+        if let Some(rest) = op.strip_prefix("cmp_") {
+            // The predicate is the first underscore-separated piece.
+            let predicate = rest.split('_').next().unwrap_or(rest);
+            let (test_opcodes, swap_operands): (&[u8], bool) = match predicate {
+                "lt" => (&[ge225_encoder::BMI_OPCODE_NIBBLE], false),
+                "gt" => (&[ge225_encoder::BMI_OPCODE_NIBBLE], true),
+                "eq" => (&[ge225_encoder::BZ_OPCODE_NIBBLE], false),
+                "ne" => (&[ge225_encoder::BNZ_OPCODE_NIBBLE], false),
+                "le" => (
+                    &[
+                        ge225_encoder::BMI_OPCODE_NIBBLE,
+                        ge225_encoder::BZ_OPCODE_NIBBLE,
+                    ],
+                    false,
+                ),
+                "ge" => (
+                    &[
+                        ge225_encoder::BMI_OPCODE_NIBBLE,
+                        ge225_encoder::BZ_OPCODE_NIBBLE,
+                    ],
+                    true,
+                ),
+                _ => return Err(BackendError::UnsupportedOp(op.to_string())),
+            };
+            let dest = require_dest(instr, op)?;
+            let (lhs_orig, rhs_orig) = parse_binop_srcs(instr, op)?;
+            let (lhs, rhs) = if swap_operands {
+                (rhs_orig, lhs_orig)
+            } else {
+                (lhs_orig, rhs_orig)
+            };
+            check_bound(&env, &lhs)?;
+            check_bound(&env, &rhs)?;
+            if matches!(env.get(&lhs), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            if matches!(env.get(&rhs), Some(&ACC_MARKER)) {
+                evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            }
+            evict_acc(&mut bytes, &mut env, &mut acc_owner, &mut next_reg)?;
+            let r_lhs = env[&lhs];
+            let r_rhs = env[&rhs];
+            bytes.extend_from_slice(&encode_ld(r_lhs));
+            bytes.extend_from_slice(&encode_sub(r_rhs));
+
+            // Materialise the 0/1 boolean.  Layout after this point
+            // (relative to `anchor = bytes.len()`):
+            //   anchor + 3*n_tests           — test_1, ..., test_n branches to true_target
+            //   anchor + 3*n_tests + 3       — LDA 0   (false branch)
+            //   anchor + 3*n_tests + 6       — BR end_target
+            //   anchor + 3*n_tests + 9       — LDA 1   (true branch — true_target)
+            //   anchor + 3*n_tests + 12      — end_target (no bytes; just an address)
+            let anchor = bytes.len();
+            let n_tests = test_opcodes.len();
+            let true_target = anchor + 3 * n_tests + 6;
+            let end_target = anchor + 3 * n_tests + 9;
+            if end_target > u16::MAX as usize {
+                return Err(BackendError::BranchTargetOutOfRange(end_target));
+            }
+            let true_target_u16 = true_target as u16;
+            let end_target_u16 = end_target as u16;
+            for &opcode in test_opcodes {
+                // Reuse the encoders so the byte sequences match
+                // iir-to-ge225 v0.7.0 exactly.
+                let bytes_arr: [u8; 3] = match opcode {
+                    o if o == ge225_encoder::BMI_OPCODE_NIBBLE => encode_bmi(true_target_u16),
+                    o if o == ge225_encoder::BZ_OPCODE_NIBBLE => encode_bz(true_target_u16),
+                    o if o == ge225_encoder::BNZ_OPCODE_NIBBLE => encode_bnz(true_target_u16),
+                    _ => unreachable!(),
+                };
+                bytes.extend_from_slice(&bytes_arr);
+            }
+            bytes.extend_from_slice(&encode_lda(0));
+            bytes.extend_from_slice(&encode_br(end_target_u16));
+            bytes.extend_from_slice(&encode_lda(1));
+            env.insert(dest.to_string(), ACC_MARKER);
+            acc_owner = Some(dest.to_string());
+            continue;
+        }
+
+        // ── Unhandled op ───────────────────────────────────────────
+        return Err(BackendError::UnsupportedOp(op.to_string()));
+    }
+
+    // ── Per-function backpatching pass ────────────────────────────
+    for (slot, target) in pending_branches {
+        let offset = *labels
+            .get(&target)
+            .ok_or_else(|| BackendError::UndefinedLabel(target.clone()))?;
+        if offset > u16::MAX as usize {
+            return Err(BackendError::BranchTargetOutOfRange(offset));
+        }
+        let offset_u16 = offset as u16;
+        bytes[slot] = ((offset_u16 >> 8) & 0xFF) as u8;
+        bytes[slot + 1] = (offset_u16 & 0xFF) as u8;
+    }
+
+    if bytes.is_empty() {
+        bytes.extend_from_slice(&HALT_WORD);
+    }
+    Ok(bytes)
+}
+
+// ===========================================================================
+// Per-instruction helpers
+// ===========================================================================
+
+fn require_dest<'a>(instr: &'a CIRInstr, op: &str) -> Result<&'a str, BackendError> {
+    instr
+        .dest
+        .as_deref()
+        .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))
+}
+
+fn parse_var_src(instr: &CIRInstr, idx: usize, op: &str) -> Result<String, BackendError> {
+    match instr.srcs.get(idx) {
+        Some(CIROperand::Var(s)) => Ok(s.clone()),
+        _ => Err(BackendError::InvalidOperand(format!(
+            "{op} srcs[{idx}] must be Var"
+        ))),
+    }
+}
+
+fn parse_binop_srcs(instr: &CIRInstr, op: &str) -> Result<(String, String), BackendError> {
+    Ok((parse_var_src(instr, 0, op)?, parse_var_src(instr, 1, op)?))
+}
+
+fn check_bound(env: &HashMap<String, u8>, name: &str) -> Result<(), BackendError> {
+    if env.contains_key(name) {
+        Ok(())
+    } else {
+        Err(BackendError::UndefinedVariable(name.to_string()))
+    }
+}
+
+fn evict_acc(
+    bytes: &mut Vec<u8>,
+    env: &mut HashMap<String, u8>,
+    acc_owner: &mut Option<String>,
+    next_reg: &mut usize,
+) -> Result<(), BackendError> {
+    if let Some(name) = acc_owner.take() {
+        if *next_reg >= GP_REGISTER_COUNT {
+            return Err(BackendError::OutOfRegisters(name));
+        }
+        let r = *next_reg as u8;
+        *next_reg += 1;
+        bytes.extend_from_slice(&encode_sta(r));
+        env.insert(name, r);
+    }
+    Ok(())
+}
+
+fn alloc_register(next_reg: &mut usize, dest: &str) -> Result<u8, BackendError> {
+    if *next_reg >= GP_REGISTER_COUNT {
+        return Err(BackendError::OutOfRegisters(dest.to_string()));
+    }
+    let r = *next_reg as u8;
+    *next_reg += 1;
+    Ok(r)
+}
+
+/// Stage a variable's value into ACC.  Used by `jmp_if_*` to read
+/// the condition.
+///
+/// If the var is the current ACC owner, no `LD` is needed.
+/// Otherwise emits `LD r_var` and sets `acc_owner = None` (since
+/// the var's canonical home is still its register; ACC just has a
+/// copy now).
+fn stage_var_into_acc(
+    name: &str,
+    env: &HashMap<String, u8>,
+    acc_owner: &mut Option<String>,
+    bytes: &mut Vec<u8>,
+) -> Result<(), BackendError> {
+    let loc = *env
+        .get(name)
+        .ok_or_else(|| BackendError::UndefinedVariable(name.to_string()))?;
+    if loc != ACC_MARKER {
+        bytes.extend_from_slice(&encode_ld(loc));
+        *acc_owner = None;
+    }
+    Ok(())
+}
+
+/// Decode and range-check a `const_*` immediate operand into a
+/// 16-bit value.  CIR's `CIROperand::Int(i64)` covers all integer
+/// widths via cast; we just check the value fits the GE-225's
+/// 16-bit immediate field.
+fn encode_immediate_16(op: Option<&CIROperand>) -> Result<u16, BackendError> {
+    let n: i64 = match op {
+        Some(CIROperand::Int(n)) => *n,
+        Some(CIROperand::Bool(b)) => {
+            if *b {
+                1
+            } else {
+                0
+            }
+        }
+        _ => {
+            return Err(BackendError::InvalidOperand(
+                "const_* srcs[0] must be Int or Bool".into(),
+            ));
+        }
+    };
+    if (-32_768..=32_767).contains(&n) {
+        Ok((n as i16) as u16)
+    } else if (32_768..=65_535).contains(&n) {
+        Ok(n as u16)
+    } else {
+        Err(BackendError::ImmediateOutOfRange(n))
+    }
+}
+
+// ===========================================================================
+// Backend trait impl
+// ===========================================================================
+
+impl Backend for Ge225Backend {
+    fn name(&self) -> &str {
+        "ge225"
+    }
+
+    fn compile(&self, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        compile_single_function(ir).ok()
+    }
+
+    fn compile_function(&self, _ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        compile_single_function(ir).ok()
+    }
+
+    fn run(&self, _binary: &[u8], _args: &[Value]) -> Value {
+        // Per the migration spec: ge225-backend is emit-only.  No
+        // in-process simulator is wired here.  A future increment
+        // could forward to `ge225-simulator` if/when an executor
+        // contract is defined; until then, calling `run` is a bug
+        // (jit-core should never reach it because `compile` returns
+        // bytes for emit-only inspection, not execution).
+        panic!(
+            "ge225 backend is emit-only; load bytes into a ge225 simulator to execute.  \
+             See code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md."
+        );
+    }
+}

--- a/code/packages/rust/ge225-backend/tests/test_backend.rs
+++ b/code/packages/rust/ge225-backend/tests/test_backend.rs
@@ -1,0 +1,455 @@
+// Tests for ge225-backend.
+//
+// These pin the SAME byte sequences `iir-to-ge225` v0.9.0 pinned,
+// but build CIR programs (not IIR) — proving the migration
+// preserves output byte-for-byte while moving the dispatch to the
+// proper architectural layer.
+//
+// Every "trivial ROM" size from the iir-to-ge225 README is
+// re-pinned here:
+//   * `const + ret_<ty>` (entry function): 6 bytes
+//   * `const + const + add + ret`: 21 bytes
+//   * `const + const + cmp_lt + ret`: 33 bytes
+//   * `const + neg + ret`: 15 bytes
+
+use ge225_backend::{compile, BackendError, Ge225Backend};
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn ctx<'a>(name: &'a str, params: &'a [(String, String)], ret_ty: &'a str) -> FunctionContext<'a> {
+    FunctionContext {
+        name,
+        params,
+        return_type: ret_ty,
+    }
+}
+
+fn ci(op: &str, dest: Option<&str>, srcs: Vec<CIROperand>, ty: &str) -> CIRInstr {
+    CIRInstr::new(op, dest, srcs, ty)
+}
+
+// ===========================================================================
+// §1. Empty CIR + Backend trait basics
+// ===========================================================================
+
+#[test]
+fn empty_cir_emits_halt() {
+    let bytes = compile(&ctx("empty", &[], "void"), &[]).expect("lowering");
+    assert_eq!(bytes, vec![0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn backend_name_is_ge225() {
+    assert_eq!(Ge225Backend.name(), "ge225");
+}
+
+#[test]
+fn backend_compile_returns_some_on_valid_input() {
+    let cir = vec![ci("ret_void", None, vec![], "void")];
+    assert_eq!(
+        Ge225Backend.compile(&cir),
+        Some(vec![0x00, 0x00, 0x00]),
+        "Backend::compile must return Some for valid input"
+    );
+}
+
+#[test]
+fn backend_compile_returns_none_on_unsupported_op() {
+    let cir = vec![ci("mul_i64", Some("z"), vec![], "i64")];
+    assert_eq!(
+        Ge225Backend.compile(&cir),
+        None,
+        "Backend::compile must return None for unsupported op"
+    );
+}
+
+#[test]
+#[should_panic(expected = "ge225 backend is emit-only")]
+fn backend_run_panics_per_spec() {
+    Ge225Backend.run(&[0x00, 0x00, 0x00], &[]);
+}
+
+// ===========================================================================
+// §2. Trivial ROM regressions — byte-for-byte parity with iir-to-ge225 v0.9.0
+// ===========================================================================
+
+/// `const_i64 v=5; ret_i64 v` — the canonical 6-byte ROM.
+#[test]
+fn trivial_const_ret_is_six_bytes_for_i64() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(5)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("five", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x00, 0x05, 0x00, 0x00, 0x00]);
+}
+
+/// All const_* type variants flow through the same LDA + HLT path
+/// (GE-225 has only one accumulator width).
+#[test]
+fn trivial_const_ret_six_bytes_for_every_int_type() {
+    for ty in &["i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64"] {
+        let const_op = format!("const_{ty}");
+        let ret_op = format!("ret_{ty}");
+        let cir = vec![
+            ci(&const_op, Some("v"), vec![CIROperand::Int(5)], ty),
+            ci(&ret_op, None, vec![CIROperand::Var("v".into())], ty),
+        ];
+        let bytes = compile(&ctx("test", &[], ty), &cir).expect("lowering");
+        assert_eq!(
+            bytes.len(),
+            6,
+            "trivial ROM should be 6 bytes for {ty}; got {bytes:02x?}"
+        );
+    }
+}
+
+/// `const_bool b=true; ret_bool b` — Bool literals lower the same way.
+#[test]
+fn const_bool_true_lowers_to_lda_1() {
+    let cir = vec![
+        ci("const_bool", Some("b"), vec![CIROperand::Bool(true)], "bool"),
+        ci("ret_bool", None, vec![CIROperand::Var("b".into())], "bool"),
+    ];
+    let bytes = compile(&ctx("btrue", &[], "bool"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x01, 0x00, 0x01, 0x00, 0x00, 0x00]);
+}
+
+/// `const a=3; const b=4; add c, a, b; ret c` → 21 bytes.
+#[test]
+fn trivial_add_is_twentyone_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(3)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(4)], "i64"),
+        ci(
+            "add_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "i64",
+        ),
+        ci("ret_i64", None, vec![CIROperand::Var("c".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("add", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x03, // LDA 3
+            0x02, 0x00, 0x00, // STA r0 (evict a)
+            0x01, 0x00, 0x04, // LDA 4
+            0x02, 0x00, 0x01, // STA r1 (evict b)
+            0x03, 0x00, 0x00, // LD r0
+            0x04, 0x00, 0x01, // ADD r1
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+/// `const a=10; const b=3; sub c, a, b; ret c` → 21 bytes with SUB.
+#[test]
+fn trivial_sub_is_twentyone_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(10)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(3)], "i64"),
+        ci(
+            "sub_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "i64",
+        ),
+        ci("ret_i64", None, vec![CIROperand::Var("c".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("sub", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes[15], 0x05, "SUB opcode at byte 15");
+    assert_eq!(bytes.len(), 21);
+}
+
+/// `const v=5; neg w, v; ret w` → 15 bytes via the LDA 0 + SUB pattern.
+#[test]
+fn trivial_neg_is_fifteen_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(5)], "i64"),
+        ci("neg_i64", Some("w"), vec![CIROperand::Var("v".into())], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("w".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("neg", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x05, // LDA 5
+            0x02, 0x00, 0x00, // STA r0 (evict v)
+            0x01, 0x00, 0x00, // LDA 0
+            0x05, 0x00, 0x00, // SUB r0
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+/// `const a=2; const b=5; cmp_lt c, a, b; ret c` — the 33-byte
+/// canonical comparison ROM.
+#[test]
+fn trivial_cmp_lt_is_thirtythree_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(2)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(5)], "i64"),
+        ci(
+            "cmp_lt_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci("ret_bool", None, vec![CIROperand::Var("c".into())], "bool"),
+    ];
+    let bytes = compile(&ctx("cmp_lt", &[], "bool"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x02, // LDA 2
+            0x02, 0x00, 0x00, // STA r0 (evict a)
+            0x01, 0x00, 0x05, // LDA 5
+            0x02, 0x00, 0x01, // STA r1 (evict b)
+            0x03, 0x00, 0x00, // LD r0
+            0x05, 0x00, 0x01, // SUB r1
+            0x0B, 0x00, 0x1B, // BMI 27 (true target)
+            0x01, 0x00, 0x00, // LDA 0
+            0x06, 0x00, 0x1E, // BR 30 (end target)
+            0x01, 0x00, 0x01, // LDA 1
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+/// `cmp_eq` swaps BMI for BZ at offset 18.
+#[test]
+fn cmp_eq_uses_bz_at_offset_18() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(3)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(3)], "i64"),
+        ci(
+            "cmp_eq_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci("ret_bool", None, vec![CIROperand::Var("c".into())], "bool"),
+    ];
+    let bytes = compile(&ctx("cmp_eq", &[], "bool"), &cir).expect("lowering");
+    assert_eq!(bytes[18], 0x08, "cmp_eq must use BZ (0x08) at offset 18");
+}
+
+/// `cmp_gt` swaps operands before lowering (cmp_gt a, b == cmp_lt b, a).
+#[test]
+fn cmp_gt_swaps_operands() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(2)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(5)], "i64"),
+        ci(
+            "cmp_gt_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let bytes = compile(&ctx("cmp_gt", &[], "void"), &cir).expect("lowering");
+    // After swap: LD r1 (b) then SUB r0 (a) at offsets 12..18.
+    assert_eq!(&bytes[12..15], &[0x03, 0x00, 0x01], "LD r1 (b after swap)");
+    assert_eq!(&bytes[15..18], &[0x05, 0x00, 0x00], "SUB r0 (a after swap)");
+    assert_eq!(bytes[18], 0x0B, "cmp_gt uses BMI after swap");
+}
+
+/// `cmp_le` is the double-test (BMI + BZ) variant.
+#[test]
+fn cmp_le_uses_double_test() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(2)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(5)], "i64"),
+        ci(
+            "cmp_le_i64",
+            Some("c"),
+            vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+            "bool",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let bytes = compile(&ctx("cmp_le", &[], "void"), &cir).expect("lowering");
+    assert_eq!(bytes[18], 0x0B, "cmp_le's first test is BMI");
+    assert_eq!(bytes[21], 0x08, "cmp_le's second test is BZ");
+}
+
+// ===========================================================================
+// §3. Control flow — label / jmp / jmp_if_* with backpatching
+// ===========================================================================
+
+#[test]
+fn trivial_jmp_backpatches_forward_target() {
+    let cir = vec![
+        ci("jmp", None, vec![CIROperand::Var("x".into())], "void"),
+        ci("label", None, vec![CIROperand::Var("x".into())], "void"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let bytes = compile(&ctx("jmp", &[], "void"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x06, 0x00, 0x03, // BR 3 (label x)
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+#[test]
+fn jmp_to_undefined_label_errors() {
+    let cir = vec![
+        ci("jmp", None, vec![CIROperand::Var("missing".into())], "void"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("bad", &[], "void"), &cir)
+        .expect_err("jmp to undefined label must error");
+    matches!(err, BackendError::UndefinedLabel(s) if s == "missing");
+}
+
+#[test]
+fn jmp_if_true_with_cond_in_acc_skips_ld_prefix() {
+    let cir = vec![
+        ci("const_bool", Some("c"), vec![CIROperand::Bool(true)], "bool"),
+        ci(
+            "jmp_if_true",
+            None,
+            vec![
+                CIROperand::Var("c".into()),
+                CIROperand::Var("skip".into()),
+            ],
+            "void",
+        ),
+        ci("label", None, vec![CIROperand::Var("skip".into())], "void"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let bytes = compile(&ctx("if", &[], "void"), &cir).expect("lowering");
+    // After LDA 1, c is ACC owner — no LD before BNZ.
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x01, // LDA 1
+            0x07, 0x00, 0x06, // BNZ 6 (skip)
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+// ===========================================================================
+// §4. call_builtin no-op
+// ===========================================================================
+
+#[test]
+fn call_builtin_no_dest_emits_zero_bytes() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(5)], "i64"),
+        ci(
+            "call_builtin",
+            None,
+            vec![
+                CIROperand::Var("print_i64".into()),
+                CIROperand::Var("v".into()),
+            ],
+            "void",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let bytes = compile(&ctx("print", &[], "void"), &cir).expect("lowering");
+    // Same as `const v=5; ret_void` — call_builtin emits nothing.
+    assert_eq!(bytes, vec![0x01, 0x00, 0x05, 0x00, 0x00, 0x00]);
+}
+
+#[test]
+fn call_builtin_with_dest_emits_lda_zero() {
+    let cir = vec![
+        ci(
+            "call_builtin",
+            Some("x"),
+            vec![CIROperand::Var("input_i64".into())],
+            "i64",
+        ),
+        ci("ret_i64", None, vec![CIROperand::Var("x".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("input", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(
+        bytes,
+        vec![
+            0x01, 0x00, 0x00, // LDA 0 (placeholder return)
+            0x00, 0x00, 0x00, // HLT
+        ]
+    );
+}
+
+#[test]
+fn cross_function_call_returns_unsupported_until_phase_3() {
+    let cir = vec![
+        ci(
+            "call",
+            Some("x"),
+            vec![CIROperand::Var("helper".into())],
+            "i64",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("main", &[], "void"), &cir)
+        .expect_err("cross-function call must be UnsupportedOp in Phase 2");
+    matches!(err, BackendError::UnsupportedOp(s) if s.contains("call"));
+}
+
+// ===========================================================================
+// §5. Error cases
+// ===========================================================================
+
+#[test]
+fn const_out_of_range_errors() {
+    let cir = vec![
+        ci(
+            "const_i32",
+            Some("v"),
+            vec![CIROperand::Int(70_000)],
+            "i32",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("big", &[], "void"), &cir)
+        .expect_err("70_000 overflows the 16-bit ceiling");
+    matches!(err, BackendError::ImmediateOutOfRange(70_000));
+}
+
+#[test]
+fn undefined_var_in_add_errors() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(1)], "i64"),
+        ci(
+            "add_i64",
+            Some("c"),
+            vec![
+                CIROperand::Var("a".into()),
+                CIROperand::Var("undefined".into()),
+            ],
+            "i64",
+        ),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("bad_add", &[], "void"), &cir)
+        .expect_err("undefined rhs must error");
+    matches!(err, BackendError::UndefinedVariable(s) if s == "undefined");
+}
+
+#[test]
+fn unsupported_op_returns_err() {
+    // CIR `mul_*` isn't yet supported by GE-225.
+    let cir = vec![ci(
+        "mul_i64",
+        Some("c"),
+        vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+        "i64",
+    )];
+    let err = compile(&ctx("nope", &[], "void"), &cir).expect_err("mul_i64 must error");
+    matches!(err, BackendError::UnsupportedOp(s) if s == "mul_i64");
+}

--- a/code/specs/ge225-backend.md
+++ b/code/specs/ge225-backend.md
@@ -1,0 +1,145 @@
+# `ge225-backend` — GE-225 backend for jit-core / aot-core
+
+**Status:** v0.1.0 — Phase 2 of the historical-arch backend migration.
+**Migration plan:** [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md).
+**Predecessor (deprecated in Phase 3):** [`iir-to-ge225`](iir-to-ge225.md).
+
+## Why this crate exists
+
+The original `iir-to-ge225` (and its A1–A4 siblings: `iir-to-riscv`,
+`iir-to-intel8008`, `iir-to-armv7`, `iir-to-intel4004`) was hooked
+at the wrong layer in the compiler stack: it consumed
+**dynamically-typed IIR** directly and bypassed the
+`jit_core::backend::Backend` trait that `aarch64-backend` and
+`x86_64-backend` use to plug into **both** AOT and JIT in one shot.
+
+This crate is the architectural fix for the GE-225 lane:
+
+```text
+IIR (dynamic-typed)
+  ↓ aot_core::infer
+  ↓ aot_core::specialise
+CIR (typed: add_i64, cmp_lt_u32, neg_i16)
+  ↓ Ge225Backend::compile_function     ← this crate
+  ↓ ge225_encoder::encode_*
+Vec<u8>  (20-bit GE-225 words, packed 3 bytes each)
+  ├──→ aot_core::link → AOT executable bytes
+  └──→ jit_core::JITCore  → JIT cache (in-process execution NOT supported — see below)
+```
+
+## Public surface (v0.1.0)
+
+```rust
+pub struct Ge225Backend;
+
+impl Ge225Backend {
+    pub fn new() -> Self;
+}
+
+impl jit_core::backend::Backend for Ge225Backend {
+    fn name(&self) -> &str;
+    fn compile(&self, ir: &[CIRInstr]) -> Option<Vec<u8>>;
+    fn compile_function(&self, ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>>;
+    fn run(&self, _: &[u8], _: &[vm_core::value::Value]) -> vm_core::value::Value;
+        // panics — see "Backend::run is intentionally not implemented" below
+}
+
+pub fn compile(
+    ctx: &FunctionContext<'_>,
+    cir: &[CIRInstr],
+) -> Result<Vec<u8>, BackendError>;
+
+pub enum BackendError { ... }   // 7 variants — see crate CHANGELOG
+```
+
+## Covered CIR ops
+
+| Family | CIR mnemonics | Lowering shape |
+|--------|---------------|----------------|
+| Constants | `const_i8`/`const_i16`/`const_i32`/`const_i64`, `const_u8`/`u16`/`u32`/`u64`, `const_bool` | `(STA r_evict)?` + `LDA n` |
+| Move | `mov_*` (any width) | `(STA r_evict_src)?` + `LD r_src` + `STA r_dest` |
+| Arith | `add_*`, `sub_*` | (3-step eviction prep) + `LD r_lhs` + `ADD r_rhs` |
+| Negate | `neg_*` | (evict) + `LDA 0` + `SUB r_src` |
+| Cmp | `cmp_{lt,gt,eq,ne,le,ge}_*` (signed & unsigned) | SUB-then-test boolean materialisation |
+| Control flow | `label`, `jmp`, `jmp_if_true`, `jmp_if_false` | `BR` / `BNZ` / `BZ` with per-function backpatching |
+| Returns | `ret_*`, `ret_void` | `(LD r_var)?` + `HLT` |
+| Builtin | `call_builtin` | no-op (with `LDA 0` placeholder if dest bound) |
+| Cross-function call | `call` | **Err(UnsupportedOp)** — Phase 3 will add module-level relocations |
+| Float, mul, div, shifts, bitwise, globals, type_assert, send, properties | — | **None** (graceful AOT/JIT fallback) |
+
+## Why is `Backend::run` intentionally not implemented?
+
+Per the [migration spec](HISTORICAL-ARCH-BACKEND-MIGRATION.md#what-about-backendrun--and-jit-in-general):
+
+> **JIT support for the historical arches is explicitly
+> best-effort, and "no working JIT" is an acceptable outcome for
+> any individual arch.**
+
+The GE-225 has no in-process simulator in this crate (the
+in-workspace `ge225-simulator` crate exists but isn't wired here),
+so `run` panics with a clear "emit-only; use a downstream
+simulator" message.  The trait is satisfied so the backend plugs
+cleanly into the `jit-core` registry; nobody should reach `run`.
+
+A future increment could:
+- Wire `run` to forward to `ge225-simulator`.
+- Or skip `jit-core` registration entirely and only expose this
+  backend through `aot-core`.
+
+Both are fine — neither blocks the migration.
+
+## Trivial-ROM regressions (byte-for-byte parity with iir-to-ge225 v0.9.0)
+
+| Program | CIR | Bytes |
+|---------|-----|-------|
+| 6-byte ROM | `const_i64 v=5; ret_i64 v` | `[0x01, 0x00, 0x05, 0x00, 0x00, 0x00]` |
+| 21-byte ROM | `const a=3; const b=4; add c, a, b; ret c` | `LDA 3 + STA r0 + LDA 4 + STA r1 + LD r0 + ADD r1 + HLT` |
+| 15-byte ROM | `const v=5; neg w, v; ret w` | `LDA 5 + STA r0 + LDA 0 + SUB r0 + HLT` |
+| 33-byte ROM | `const a=2; const b=5; cmp_lt c, a, b; ret c` | `LDA 2 + STA r0 + LDA 5 + STA r1 + LD r0 + SUB r1 + BMI 27 + LDA 0 + BR 30 + LDA 1 + HLT` |
+
+## What's NOT in this crate (yet)
+
+Out of scope for Phase 2; covered by Phase 3 (wiring) or future
+increments:
+
+- **Cross-function `call`** — needs module-level relocations via
+  `aot_core::link`.  Phase 3 will add `compile_with_relocs` /
+  `compile_with_globals` style entry points alongside `compile`.
+- **Multi-function lowering / linking** — Phase 3.
+- **lang-aot --emit=ge225 wiring** — currently goes through the
+  legacy `iir-to-ge225` crate; Phase 3 re-routes it through
+  `aot_core::link` + `ge225-backend`.
+- **`iir-to-ge225` deprecation** — Phase 3 marks it
+  `#[deprecated]`.
+
+## Tests
+
+24 unit tests in `tests/test_backend.rs`:
+
+- `empty_cir_emits_halt`, `backend_name_is_ge225`,
+  `backend_compile_returns_some_on_valid_input`,
+  `backend_compile_returns_none_on_unsupported_op`,
+  `backend_run_panics_per_spec` (the `#[should_panic]` regression).
+- 4 trivial-ROM byte-for-byte pins (const+ret, add, sub, neg).
+- 1 type-parametric test that runs the trivial ROM for every
+  `const_*` variant: i8, u8, i16, u16, i32, u32, i64, u64.
+- 4 comparison byte-shape tests (cmp_lt full byte trace, cmp_eq
+  BZ position, cmp_gt operand-swap, cmp_le double-test).
+- 3 control-flow tests (forward jmp backpatch, undefined-label
+  error, jmp_if_true skip-LD).
+- 3 call_builtin tests (no-dest, with-dest, cross-function `call`
+  returns UnsupportedOp).
+- 3 error-case tests (out-of-range immediate, undefined var in
+  add, unsupported op).
+
+All 24 pass without modification across cargo test runs.
+
+## Non-goals (v0.1.0)
+
+- No `run` execution (the panic is the contract).
+- No cross-function `call` support — Phase 3.
+- No registration with `jit-core::default_backends()` or similar —
+  Phase 3 decides whether to register based on whether the
+  registry's contract is satisfiable.
+- No multiplication, division, bitwise, shift, or floating-point
+  ops — out of scope for the historical-arch lane.


### PR DESCRIPTION
## Migration Phase 2 of 7

Phase 1 (PR #4954) carved out the pure encoder. This PR adds the **backend**: a new \`ge225-backend\` crate that implements \`jit_core::backend::Backend\` over monomorphised CIR — the **correct** architectural layer, mirroring \`aarch64-backend\` and \`x86_64-backend\`.

Migration plan: \`code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md\`.

## What this PR does

| Surface | What |
|---------|------|
| \`pub struct Ge225Backend\` | Zero-sized handle implementing \`Backend\` |
| \`Backend::name()\` | Returns \`"ge225"\` |
| \`Backend::compile(&[CIRInstr])\` | Returns \`Some(bytes)\` on success, \`None\` on unsupported op |
| \`Backend::compile_function(ctx, ir)\` | Same — delegates to single-function emit |
| \`Backend::run(_, _)\` | **Panics** with \"ge225 backend is emit-only\" (per GUIDING CONSTRAINT: JIT is best-effort for historical arches) |
| \`pub fn compile(ctx, cir)\` | Direct AOT entry point returning \`Result<Vec<u8>, BackendError>\` (same shape as \`aarch64_backend::compile\`) |
| \`pub enum BackendError\` | 7 structured diagnostic variants |

## CIR op coverage

| Family | Status |
|--------|--------|
| \`const_*\`, \`mov_*\`, \`add_*\`, \`sub_*\`, \`neg_*\` | ✓ |
| \`cmp_{lt,gt,eq,ne,le,ge}_*\` (signed + unsigned) | ✓ |
| \`label\`, \`jmp\`, \`jmp_if_true\`, \`jmp_if_false\` | ✓ |
| \`ret_*\`, \`ret_void\` | ✓ |
| \`call_builtin\` (no-op) | ✓ |
| \`call\` (cross-function) | Returns \`UnsupportedOp\` until Phase 3 wires module-level relocations |
| Mul / Div / Shifts / Bitwise / Float / Globals / Type guards | Returns \`None\` (graceful fallback) |

Dispatch uses \`op.strip_prefix(\"const_\")\` / \`add_\` / etc. — much cleaner than the IIR-level approach that needed explicit per-type arms.

## Byte-for-byte parity with iir-to-ge225 v0.9.0

24 unit tests pin the same trivial-ROM byte sequences as the old crate, just built from CIR:

| Program | Bytes |
|---------|-------|
| \`const_i64 v=5; ret_i64 v\` | 6 |
| \`const a; const b; add c, a, b; ret c\` | 21 |
| \`const a; const b; cmp_lt c, a, b; ret c\` | 33 |
| \`const v; neg w, v; ret w\` | 15 |

Plus a parametric test that runs the 6-byte ROM for every \`const_*\` variant: i8, u8, i16, u16, i32, u32, i64, u64.

## Test plan

- [x] \`cargo test -p ge225-backend\` — **24/24 pass**
- [x] All trivial-ROM byte sequences match iir-to-ge225 v0.9.0 byte-for-byte
- [x] \`Backend::run\` panics with the documented message (\`#[should_panic]\` regression)
- [x] Cross-function \`call\` returns \`UnsupportedOp\` (Phase 3 scope)
- [x] Unsupported ops (\`mul_i64\`) → \`Backend::compile\` returns \`None\` cleanly
- [x] Error cases: out-of-range immediate, undefined var, undefined label
- [x] Security review passed (round 1, clean) — same allocator + backpatching as security-reviewed iir-to-ge225 v0.9.0
- [ ] CI green
- [ ] Babysitter cron monitors

## What's NOT in this PR (later phases)

- **Phase 3**: \`lang-aot --emit=ge225\` routes through \`aot_core::link\` + \`ge225-backend\`; cross-function \`call\` support via relocations; \`iir-to-ge225\` marked \`#[deprecated]\`
- **Phases 4-7**: same shape for intel4004, armv7, intel8008, riscv

🤖 Generated with [Claude Code](https://claude.com/claude-code)