### PR TITLE
feat(ruby): `__END__` program terminator in the lexer

### DIFF
--- a/code/.commit-msg-end.txt
+++ b/code/.commit-msg-end.txt
@@ -1,0 +1,25 @@
+feat(ruby): `__END__` program terminator in the lexer (FC)
+
+`__END__` alone on a line (column 0) now ends tokenization — everything
+after it is Ruby's `DATA` section, not code, so it is no longer
+mis-lexed as a trailing run of identifiers/strings. The `push` scan loop
+checks at each line start whether the upcoming line is exactly `__END__`
+(new `is_end_marker` helper) and stops feeding the state machine;
+`finish()` still flushes the EOF token.
+
+Scope: halts tokenization only. `DATA` itself stays an ordinary constant
+read (no synthesized file handle) — a deliberate follow-up. Indented or
+mid-line `__END__` is unaffected (lexes as a normal Name), matching
+Ruby's column-0 requirement.
+
+Tests:
+- ruby-lexer: end_marker_halts_token_stream,
+  end_marker_at_eof_without_trailing_newline,
+  end_marker_requires_column_zero, end_marker_not_triggered_mid_line.
+- ruby-to-semantic-ir: program_with_end_marker_lowers_only_the_code
+  (E2E — a program with a trailing __END__ lowers + validates).
+
+ruby-lexer CHANGELOG 0.24.0 -> 0.25.0; ruby-to-semantic-ir 0.84.0 ->
+0.86.0 (test-only; 0.85.0 is the concurrent hash-pattern PR).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/code/packages/rust/ruby-lexer/CHANGELOG.md
+++ b/code/packages/rust/ruby-lexer/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-ruby-lexer` crate will be documented in this file.
 
+## [0.25.0] - 2026-06-03
+
+### Added (FC — `__END__` program terminator)
+
+`__END__` alone on a line (column 0) now ends tokenization: everything
+after it is Ruby's `DATA` section, not code, so it is no longer
+mis-lexed. The `push` scan loop checks, at each line start, whether the
+upcoming line is exactly `__END__` (via the new `is_end_marker` helper)
+and stops feeding the engine; `finish()` still flushes the EOF token.
+
+Scope: this halts tokenization only. `DATA` itself stays an ordinary
+constant read (no synthesized file handle) — a deliberate follow-up.
+Indented or mid-line `__END__` is unaffected (lexes as a normal Name),
+matching Ruby's column-0 requirement.
+
+New tests: `end_marker_halts_token_stream`,
+`end_marker_at_eof_without_trailing_newline`,
+`end_marker_requires_column_zero`, `end_marker_not_triggered_mid_line`.
+
 ## [0.24.0] - 2026-05-26
 
 ### Added (Phase 8a-2 (FC) — `>>` and `>>=` token fusion)

--- a/code/packages/rust/ruby-lexer/src/lib.rs
+++ b/code/packages/rust/ruby-lexer/src/lib.rs
@@ -237,6 +237,17 @@ impl RubyLexer {
         let chars: Vec<char> = source.chars().collect();
         let mut i = 0;
         while i < chars.len() {
+            // Phase FC — `__END__` alone on a line (column 0) terminates
+            // the program: everything after it is the `DATA` section, not
+            // Ruby code.  When we're at a line start and the upcoming line
+            // is exactly `__END__`, stop feeding the engine so no tokens
+            // are produced for the trailing data.  (`finish()` still
+            // flushes the EOF token.)  The line-start guard means we only
+            // trigger during normal lexing — heredoc bodies are consumed
+            // inside `capture_heredoc_bodies`, which bypasses this loop.
+            if (i == 0 || chars[i - 1] == '\n') && Self::is_end_marker(&chars, i) {
+                break;
+            }
             let ch = chars[i];
             // Phase 6p companion — `/=` compound-assignment guard.
             // If we're about to feed a `/` whose immediate follower is
@@ -255,6 +266,24 @@ impl RubyLexer {
             }
         }
         Ok(())
+    }
+
+    /// Phase FC — true iff `chars[i..]` is exactly the program-terminator
+    /// line `__END__` (assumed to start at column 0 by the caller),
+    /// followed by end-of-input, `\n`, or `\r`.  Ruby treats such a line
+    /// as the end of the source; the remainder is the `DATA` section.
+    ///
+    /// Scope: this only halts tokenization.  `DATA` itself stays an
+    /// ordinary constant read (no synthesized file handle) — a deliberate
+    /// follow-up if a real data stream is ever needed.  A line like
+    /// `__END__foo` (trailing non-newline) is *not* a marker, matching
+    /// Ruby, which requires `__END__` alone on the line.
+    fn is_end_marker(chars: &[char], i: usize) -> bool {
+        const MARK: [char; 7] = ['_', '_', 'E', 'N', 'D', '_', '_'];
+        if i + MARK.len() > chars.len() || chars[i..i + MARK.len()] != MARK {
+            return false;
+        }
+        matches!(chars.get(i + MARK.len()), None | Some('\n') | Some('\r'))
     }
 
     /// Phase 3c body slurp.  Called after the `\n` that ends the
@@ -2257,6 +2286,62 @@ mod tests {
                 (TokenType::Name, "foo"),
                 (TokenType::Newline, "\n"),
             ]
+        );
+    }
+
+    #[test]
+    fn end_marker_halts_token_stream() {
+        // Phase FC — `__END__` on its own line ends the program; the
+        // trailing data section must NOT be tokenized as code.
+        let toks = tokenize_ruby("foo\n__END__\nthis is data, not code!\n");
+        let vals: Vec<&str> = toks.iter().map(|t| t.value.as_str()).collect();
+        assert!(vals.contains(&"foo"), "expected the code before __END__");
+        // None of the data-section words leak into the token stream, and
+        // the `__END__` marker itself is consumed (not emitted).
+        for leaked in ["__END__", "this", "data", "code", "not"] {
+            assert!(
+                !vals.contains(&leaked),
+                "data-section token `{leaked}` leaked into the stream: {vals:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn end_marker_at_eof_without_trailing_newline() {
+        // `__END__` as the final line with no trailing newline still
+        // terminates cleanly (only the preceding code is tokenized).
+        let toks = tokenize_ruby("x = 1\n__END__");
+        let vals: Vec<&str> = toks.iter().map(|t| t.value.as_str()).collect();
+        assert!(vals.contains(&"x") && vals.contains(&"1"));
+        assert!(!vals.contains(&"__END__"), "marker should be consumed");
+    }
+
+    #[test]
+    fn end_marker_requires_column_zero() {
+        // An indented `  __END__` is NOT the terminator (Ruby requires
+        // column 0); it lexes as an ordinary Name and the following line
+        // is still tokenized as code.
+        let toks = tokenize_ruby("  __END__\nfoo\n");
+        let vals: Vec<&str> = toks.iter().map(|t| t.value.as_str()).collect();
+        assert!(
+            vals.contains(&"__END__"),
+            "indented __END__ should lex as a normal Name: {vals:?}"
+        );
+        assert!(
+            vals.contains(&"foo"),
+            "code after an indented (non-marker) __END__ must survive: {vals:?}"
+        );
+    }
+
+    #[test]
+    fn end_marker_not_triggered_mid_line() {
+        // `__END__` not at line start (here as an assignment RHS) is an
+        // ordinary Name, not the terminator.
+        let toks = tokenize_ruby("y = __END__\n");
+        let vals: Vec<&str> = toks.iter().map(|t| t.value.as_str()).collect();
+        assert!(
+            vals.contains(&"y") && vals.contains(&"__END__"),
+            "mid-line __END__ must be a normal Name: {vals:?}"
         );
     }
 

--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.86.0] - 2026-06-03
+
+### Added (FC — `__END__` end-to-end coverage; tests only)
+
+Coverage test that a program with a trailing `__END__` data section
+lowers cleanly from just the code above it (the lexer strips the data
+section — see `coding-adventures-ruby-lexer` 0.25.0).  No lowerer code
+change: `program_with_end_marker_lowers_only_the_code` pins the
+behaviour and round-trips the SIR validator.
+
+(0.85.0 is the concurrent hash-pattern PR; this entry is 0.86.0 to avoid
+a version collision.)
+
 ## [0.84.0] - 2026-06-01
 
 ### Added (Phase 26b (FC) — `refine Class do … end` refinement body)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -424,6 +424,27 @@ mod tests {
     // -----------------------------------------------------------------
 
     #[test]
+    fn program_with_end_marker_lowers_only_the_code() {
+        // Phase FC — a trailing `__END__` data section is stripped by the
+        // lexer, so the program lowers cleanly from just the code above it
+        // (the data is neither parsed nor lowered).
+        let m = lower("x = 1\nputs(x)\n__END__\nthis is data, not ruby code!\n");
+        let b = main_body(&m);
+        // The `x = 1` binding is present and the data produced no stmts
+        // beyond the code (puts is the trailing value).
+        assert!(
+            b.stmts.iter().any(|s| matches!(s, Stmt::LetBinding { name, .. } if name == "x")),
+            "expected `x = 1` from the code section"
+        );
+        let result = semantic_ir::validate(&m);
+        assert!(
+            result.is_ok(),
+            "validator rejected a program with a trailing __END__: {:?}",
+            result
+        );
+    }
+
+    #[test]
     fn while_lowers_to_stmt_while() {
         let m = lower("x = 0\nwhile x\n  y = 1\nend\n");
         let main = main_body(&m);


### PR DESCRIPTION
## `__END__` program terminator

Closes an audit-surfaced gap: the lexer didn't recognize `__END__`, so a trailing data section was mis-lexed as a run of identifiers/strings (often breaking the parse). Now `__END__` alone on a line (column 0) ends tokenization — everything after it is Ruby's `DATA` section, not code.

### Implementation
`RubyLexer::push` checks, at each line start, whether the upcoming line is exactly `__END__` (new `is_end_marker` helper — a bounds-checked compare against the 7-char marker followed by EOF/`\n`/`\r`) and `break`s out of the scan loop. `finish()` still flushes the EOF token, so the code section tokenizes normally and the data is simply never fed to the state machine. The line-start guard means heredoc bodies (consumed in `capture_heredoc_bodies`) are unaffected.

### Scope
Halts tokenization only. `DATA` itself remains an ordinary constant read — no synthesized file handle (a deliberate follow-up if a real data stream is ever needed). Indented or mid-line `__END__` is unaffected (lexes as a normal `Name`), matching Ruby's column-0 requirement.

### Tests
- **ruby-lexer**: `end_marker_halts_token_stream`, `end_marker_at_eof_without_trailing_newline`, `end_marker_requires_column_zero`, `end_marker_not_triggered_mid_line`.
- **ruby-to-semantic-ir**: `program_with_end_marker_lowers_only_the_code` — a full program with a trailing `__END__` lowers and round-trips the SIR validator.
- Suites green: 177 lexer, 336 lowerer.

CHANGELOGs: ruby-lexer 0.24.0 → 0.25.0; ruby-to-semantic-ir 0.84.0 → 0.86.0 (test-only; 0.85.0 is the concurrent hash-pattern PR #4957).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
