### PR TITLE
feat(intel8008): Migration Phase 6 — encoder + backend (minimal viable) + lang-aot wiring + deprecate iir-to-intel8008

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -663,6 +663,8 @@ members = [
     "intel4004-backend",
     "armv7-encoder",
     "armv7-backend",
+    "intel8008-encoder",
+    "intel8008-backend",
     "iir-to-ge225",
     "ge225-encoder",
     "ge225-backend",

--- a/code/packages/rust/iir-to-intel8008/Cargo.toml
+++ b/code/packages/rust/iir-to-intel8008/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-intel8008"
-version = "0.3.9"
+version = "0.4.0"
 edition = "2021"
 description = "IIR → Intel 8008 machine code backend (Oct's native target) — lowers IIRModule to a Vec<u8> of 8-bit Intel 8008 opcodes.  v0.3.9 (A2++.5.5 eighth slice, FINAL): adds real RET (0x07, 1-byte unconditional return — NOT 0x03 which is RFC conditional) and CAL (CRITICAL: 0x7E, NOT 0x46 which is CFZ — 3-byte unconditional call with 14-bit address).  New IIR op `call dest, fn_name` lowers to CAL + return-value-from-A capture; ret/ret_void emit RET for non-entry functions, HLT for the entry point (RET on entry would underflow the empty return-address stack).  Module-level pending_calls + function_addrs handle cross-function CAL backpatching.  v0.4.0 (A2+++) brings lang-aot --target=intel8008 wiring."
 

--- a/code/packages/rust/iir-to-intel8008/src/lib.rs
+++ b/code/packages/rust/iir-to-intel8008/src/lib.rs
@@ -1,4 +1,15 @@
-//! # iir-to-intel8008 — IIR → Intel 8008 machine code backend (v0.1.0 skeleton).
+//! # iir-to-intel8008 — IIR → Intel 8008 machine code backend (v0.4.0).
+//!
+//! ## ⚠ DEPRECATED — use `intel8008-backend` instead
+//!
+//! As of Phase 6 of the historical-arch backend migration, this
+//! crate is deprecated.  Use `intel8008-encoder` for byte
+//! encoding and `intel8008-backend` for CIR lowering via the
+//! `Backend` trait.  `intel8008-backend` v0.1.0 is a minimal-
+//! viable port (just `const_*` + `ret_*`); the full op set this
+//! crate had can be ported in future increments.
+//!
+//! ## Original module docs (still applicable)
 //!
 //! Lowers an [`interpreter_ir::IIRModule`] to a `Vec<u8>` of encoded
 //! 8-bit Intel 8008 opcodes, suitable to drop into the in-tree
@@ -46,6 +57,7 @@
 //! ## Quick start
 //!
 //! ```
+//! #![allow(deprecated)]
 //! use interpreter_ir::IIRModule;
 //! use iir_to_intel8008::{validate_for_intel8008, lower_iir_to_intel8008, IIRIntel8008Config};
 //!
@@ -473,6 +485,10 @@ const SUPPORTED_OPS: &[&str] = &[
     "call",
 ];
 
+#[deprecated(
+    since = "0.4.0",
+    note = "use `intel8008_backend::compile` over CIR — see code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md"
+)]
 pub fn lower_iir_to_intel8008(
     module: &IIRModule,
     _cfg: &IIRIntel8008Config,

--- a/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-intel8008/tests/test_backend.rs
@@ -1,5 +1,10 @@
 //! Integration tests for `iir-to-intel8008` v0.1.0 (A2 skeleton).
 //!
+//! Note: this crate is deprecated as of v0.4.0 (Phase 6 of the
+//! historical-arch backend migration).  Tests still exercise the
+//! deprecated API as a regression invariant.
+#![allow(deprecated)]
+//!
 //! Smoke-level — confirms the validator stub, the emitter shape, and
 //! the exact encoded `HLT` byte (`0x76`).
 

--- a/code/packages/rust/intel8008-backend/BUILD
+++ b/code/packages/rust/intel8008-backend/BUILD
@@ -1,0 +1,1 @@
+cargo test -p intel8008-backend

--- a/code/packages/rust/intel8008-backend/CHANGELOG.md
+++ b/code/packages/rust/intel8008-backend/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — intel8008-backend
+
+## v0.1.0 — 2026-06-03 — Phase 6 of historical-arch backend migration
+
+Initial release.  Minimal viable Backend trait impl over CIR.
+Covers `const_*` + `ret_*` — enough to keep the existing lang-aot
+Intel 8008 e2e smoke test passing byte-for-byte
+(`[0x3E, 0x2A, 0x76]` for `const_i64 v=42; ret_i64 v`).
+
+10 unit tests pin every byte sequence.

--- a/code/packages/rust/intel8008-backend/Cargo.toml
+++ b/code/packages/rust/intel8008-backend/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "intel8008-backend"
+version = "0.1.0"
+edition = "2021"
+description = "Intel 8008 backend for jit-core / aot-core.  Lowers Vec<CIRInstr> to Intel 8008 machine code via intel8008-encoder.  Phase 6 of the historical-arch backend migration."
+
+[lib]
+name = "intel8008_backend"
+path = "src/lib.rs"
+
+[dependencies]
+intel8008-encoder = { path = "../intel8008-encoder" }
+jit-core          = { path = "../jit-core" }
+vm-core           = { path = "../vm-core" }

--- a/code/packages/rust/intel8008-backend/README.md
+++ b/code/packages/rust/intel8008-backend/README.md
@@ -1,0 +1,5 @@
+# intel8008-backend
+
+Intel 8008 backend for `jit-core` / `aot-core`.  Phase 6 of the
+historical-arch backend migration.  Minimal-viable port —
+covers `const_*` + `ret_*` only.

--- a/code/packages/rust/intel8008-backend/src/lib.rs
+++ b/code/packages/rust/intel8008-backend/src/lib.rs
@@ -1,0 +1,176 @@
+//! # `intel8008-backend` — Intel 8008 backend for jit-core / aot-core.
+//!
+//! Phase 6 of the historical-arch backend migration.  Mirror of
+//! `ge225-backend` / `intel4004-backend` / `armv7-backend` in
+//! shape, just for the 8-bit Intel 8008 (1972) — the second-
+//! generation Intel microprocessor, Oct's native target.
+//!
+//! ## v0.1.0 scope — minimal viable
+//!
+//! Same scope as `armv7-backend` v0.1.0: just enough to keep the
+//! existing lang-aot Intel 8008 e2e smoke test passing
+//! byte-for-byte (Twig `42` → `MVI A, 42; HLT` =
+//! `[0x3E, 0x2A, 0x76]`).
+//!
+//! | CIR family | Status |
+//! |------------|--------|
+//! | `const_*` (8-bit immediate, single-var case) | ✓ → `MVI A, n` |
+//! | `ret_*`, `ret_void` | ✓ → `HLT` (entry-function exit) |
+//! | Anything else | returns `None` |
+//!
+//! Per the GUIDING CONSTRAINT, the architectural correctness win
+//! (IIR → CIR via Backend trait) is delivered regardless of
+//! op-set parity.  Future increments to `intel8008-backend` can
+//! port the richer op coverage that `iir-to-intel8008` v0.3.9
+//! had (mov/add/sub/cmp/branches/calls).
+
+use intel8008_encoder::{encode_mvi_a, HLT, MVI_MAX};
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+use std::fmt;
+use vm_core::value::Value;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Intel8008Backend;
+
+impl Intel8008Backend {
+    pub fn new() -> Self {
+        Intel8008Backend
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendError {
+    UnsupportedOp(String),
+    InvalidOperand(String),
+    UndefinedVariable(String),
+    ImmediateOutOfRange(i64),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedOp(op) => write!(f, "intel8008-backend: unsupported op {op:?}"),
+            Self::InvalidOperand(d) => write!(f, "intel8008-backend: invalid operand: {d}"),
+            Self::UndefinedVariable(n) => {
+                write!(f, "intel8008-backend: undefined variable {n:?}")
+            }
+            Self::ImmediateOutOfRange(n) => write!(
+                f,
+                "intel8008-backend: const {n} exceeds 8-bit MVI immediate range [0, 255]"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BackendError {}
+
+pub fn compile(_ctx: &FunctionContext<'_>, cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    compile_single_function(cir)
+}
+
+fn compile_single_function(cir: &[CIRInstr]) -> Result<Vec<u8>, BackendError> {
+    if cir.is_empty() {
+        return Ok(vec![HLT]);
+    }
+
+    let mut bytes = Vec::new();
+    let mut last_const_var: Option<String> = None;
+
+    for instr in cir {
+        let op = instr.op.as_str();
+
+        if op == "ret_void" {
+            bytes.push(HLT);
+            continue;
+        }
+
+        if op.strip_prefix("ret_").is_some() {
+            let src_name = parse_var_src(instr, 0, op)?;
+            if last_const_var.as_deref() != Some(src_name.as_str()) {
+                return Err(BackendError::UnsupportedOp(format!(
+                    "ret of {src_name:?} which is not the current accumulator var; \
+                     multi-register allocation lands in a future increment"
+                )));
+            }
+            bytes.push(HLT);
+            continue;
+        }
+
+        if op.strip_prefix("const_").is_some() {
+            let dest = require_dest(instr, op)?;
+            let imm8 = encode_immediate_8(instr.srcs.first())?;
+            bytes.extend_from_slice(&encode_mvi_a(imm8));
+            last_const_var = Some(dest.to_string());
+            continue;
+        }
+
+        return Err(BackendError::UnsupportedOp(op.to_string()));
+    }
+
+    if bytes.is_empty() {
+        bytes.push(HLT);
+    }
+    Ok(bytes)
+}
+
+fn require_dest<'a>(instr: &'a CIRInstr, op: &str) -> Result<&'a str, BackendError> {
+    instr
+        .dest
+        .as_deref()
+        .ok_or_else(|| BackendError::InvalidOperand(format!("{op} requires a dest")))
+}
+
+fn parse_var_src(instr: &CIRInstr, idx: usize, op: &str) -> Result<String, BackendError> {
+    match instr.srcs.get(idx) {
+        Some(CIROperand::Var(s)) => Ok(s.clone()),
+        _ => Err(BackendError::InvalidOperand(format!(
+            "{op} srcs[{idx}] must be Var"
+        ))),
+    }
+}
+
+fn encode_immediate_8(op: Option<&CIROperand>) -> Result<u8, BackendError> {
+    let n: i64 = match op {
+        Some(CIROperand::Int(n)) => *n,
+        Some(CIROperand::Bool(b)) => {
+            if *b {
+                1
+            } else {
+                0
+            }
+        }
+        _ => {
+            return Err(BackendError::InvalidOperand(
+                "const_* srcs[0] must be Int or Bool".into(),
+            ));
+        }
+    };
+    if (0..=MVI_MAX as i64).contains(&n) {
+        Ok(n as u8)
+    } else {
+        Err(BackendError::ImmediateOutOfRange(n))
+    }
+}
+
+impl Backend for Intel8008Backend {
+    fn name(&self) -> &str {
+        "intel8008"
+    }
+
+    fn compile(&self, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        compile_single_function(ir).ok()
+    }
+
+    fn compile_function(&self, _ctx: &FunctionContext<'_>, ir: &[CIRInstr]) -> Option<Vec<u8>> {
+        self.compile(ir)
+    }
+
+    fn run(&self, _binary: &[u8], _args: &[Value]) -> Value {
+        panic!(
+            "intel8008 backend is emit-only; load bytes into an Intel 8008 simulator \
+             or burn to a 1702 EPROM to execute.  \
+             See code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md."
+        );
+    }
+}

--- a/code/packages/rust/intel8008-backend/tests/test_backend.rs
+++ b/code/packages/rust/intel8008-backend/tests/test_backend.rs
@@ -1,0 +1,117 @@
+use intel8008_backend::{compile, BackendError, Intel8008Backend};
+use jit_core::backend::{Backend, FunctionContext};
+use jit_core::cir::{CIRInstr, CIROperand};
+
+fn ctx<'a>(name: &'a str, params: &'a [(String, String)], ret_ty: &'a str) -> FunctionContext<'a> {
+    FunctionContext {
+        name,
+        params,
+        return_type: ret_ty,
+    }
+}
+
+fn ci(op: &str, dest: Option<&str>, srcs: Vec<CIROperand>, ty: &str) -> CIRInstr {
+    CIRInstr::new(op, dest, srcs, ty)
+}
+
+#[test]
+fn empty_cir_emits_hlt() {
+    let bytes = compile(&ctx("empty", &[], "void"), &[]).expect("lowering");
+    assert_eq!(bytes, vec![0x76]);
+}
+
+#[test]
+fn backend_name_is_intel8008() {
+    assert_eq!(Intel8008Backend.name(), "intel8008");
+}
+
+#[test]
+#[should_panic(expected = "intel8008 backend is emit-only")]
+fn backend_run_panics_per_spec() {
+    Intel8008Backend.run(&[], &[]);
+}
+
+/// Twig `42` canonical: MVI A, 42 ; HLT = [0x3E, 0x2A, 0x76].
+/// This is the EXACT byte sequence the lang-aot Intel 8008 e2e
+/// smoke test pins.  Byte-for-byte parity with iir-to-intel8008
+/// v0.3.9.
+#[test]
+fn canonical_const_42_then_ret() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(42)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("fortytwo", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x3E, 0x2A, 0x76]);
+}
+
+#[test]
+fn const_zero_then_ret() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(0)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("z", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x3E, 0x00, 0x76]);
+}
+
+#[test]
+fn const_max_8bit() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(255)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("v".into())], "i64"),
+    ];
+    let bytes = compile(&ctx("m", &[], "i64"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x3E, 0xFF, 0x76]);
+}
+
+#[test]
+fn const_out_of_range_errors() {
+    let cir = vec![
+        ci("const_i64", Some("v"), vec![CIROperand::Int(256)], "i64"),
+        ci("ret_void", None, vec![], "void"),
+    ];
+    let err = compile(&ctx("big", &[], "void"), &cir).expect_err("256 overflows 8-bit MVI imm");
+    assert!(matches!(err, BackendError::ImmediateOutOfRange(256)));
+}
+
+#[test]
+fn ret_void_alone_emits_just_hlt() {
+    let cir = vec![ci("ret_void", None, vec![], "void")];
+    let bytes = compile(&ctx("noop", &[], "void"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x76]);
+}
+
+#[test]
+fn const_bool_true() {
+    let cir = vec![
+        ci("const_bool", Some("b"), vec![CIROperand::Bool(true)], "bool"),
+        ci("ret_bool", None, vec![CIROperand::Var("b".into())], "bool"),
+    ];
+    let bytes = compile(&ctx("btrue", &[], "bool"), &cir).expect("lowering");
+    assert_eq!(bytes, vec![0x3E, 0x01, 0x76]);
+}
+
+#[test]
+fn unsupported_op_returns_err() {
+    let cir = vec![ci(
+        "add_i64",
+        Some("c"),
+        vec![CIROperand::Var("a".into()), CIROperand::Var("b".into())],
+        "i64",
+    )];
+    let err = compile(&ctx("addtest", &[], "i64"), &cir).expect_err("add not yet supported");
+    assert!(matches!(err, BackendError::UnsupportedOp(s) if s == "add_i64"));
+}
+
+#[test]
+fn multi_const_ret_falls_through() {
+    let cir = vec![
+        ci("const_i64", Some("a"), vec![CIROperand::Int(1)], "i64"),
+        ci("const_i64", Some("b"), vec![CIROperand::Int(2)], "i64"),
+        ci("ret_i64", None, vec![CIROperand::Var("a".into())], "i64"),
+    ];
+    let err = compile(&ctx("two_const_ret_first", &[], "i64"), &cir)
+        .expect_err("multi-var ret should fall through");
+    assert!(matches!(err, BackendError::UnsupportedOp(_)));
+}

--- a/code/packages/rust/intel8008-encoder/BUILD
+++ b/code/packages/rust/intel8008-encoder/BUILD
@@ -1,0 +1,1 @@
+cargo test -p intel8008-encoder

--- a/code/packages/rust/intel8008-encoder/CHANGELOG.md
+++ b/code/packages/rust/intel8008-encoder/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — intel8008-encoder
+
+## v0.1.0 — 2026-06-03 — initial carve-out
+
+Phase 6 of the historical-arch backend migration.  Opcode
+constants + canonical word constants + `encode_*` helpers
+carved from iir-to-intel8008 v0.3.9.

--- a/code/packages/rust/intel8008-encoder/Cargo.toml
+++ b/code/packages/rust/intel8008-encoder/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "intel8008-encoder"
+version = "0.1.0"
+edition = "2021"
+description = "Pure-Rust Intel 8008 instruction encoder.  Covers the subset of 8008 opcodes the LANG VM intel8008-backend uses to lower CIR to 8-bit-data Intel 8008 machine code.  No IR knowledge.  Phase 6 of the historical-arch backend migration."
+
+[lib]
+name = "intel8008_encoder"
+path = "src/lib.rs"
+
+[dependencies]

--- a/code/packages/rust/intel8008-encoder/README.md
+++ b/code/packages/rust/intel8008-encoder/README.md
@@ -1,0 +1,7 @@
+# intel8008-encoder
+
+Pure-Rust Intel 8008 instruction encoder.  Mirror of
+`ge225-encoder` / `intel4004-encoder` / `armv7-encoder`.
+
+Phase 6 of the historical-arch backend migration — see
+[`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](../../../specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md).

--- a/code/packages/rust/intel8008-encoder/src/lib.rs
+++ b/code/packages/rust/intel8008-encoder/src/lib.rs
@@ -1,0 +1,96 @@
+//! # `intel8008-encoder` — pure Intel 8008 instruction encoder.
+//!
+//! Mirror of [`ge225-encoder`] / [`intel4004-encoder`] /
+//! [`armv7-encoder`] for the Intel 8008 (1972) — the
+//! second-generation 8-bit Intel microprocessor.
+//!
+//! Phase 6 of the historical-arch backend migration.
+//!
+//! ## ISA quick reference (subset used here)
+//!
+//! | Mnemonic | Opcode | Bytes | Effect |
+//! |----------|--------|-------|--------|
+//! | `HLT` | `0x76` | 1 | halt — `01_110_110` |
+//! | `MVI A, n` | `0x3E nn` | 2 | A ← 8-bit immediate `n` |
+//! | `RET` | `0x07` | 1 | return from subroutine |
+//!
+//! ## Quick start
+//!
+//! ```
+//! use intel8008_encoder::{encode_mvi_a, HLT, RET};
+//!
+//! // MVI A, 42 → [0x3E, 0x2A]
+//! assert_eq!(encode_mvi_a(42), [0x3E, 0x2A]);
+//! assert_eq!(HLT, 0x76);
+//! assert_eq!(RET, 0x07);
+//! ```
+
+// ===========================================================================
+// Opcodes
+// ===========================================================================
+
+/// `HLT` — halt the CPU.  Bit pattern: `01_110_110`.
+pub const HLT: u8 = 0x76;
+
+/// `RET` — return from subroutine (unconditional, encoded as
+/// `00 000 111`).  Used for non-entry-function returns; the entry
+/// function emits `HLT` instead.
+pub const RET: u8 = 0x07;
+
+/// `MVI A, n` — load 8-bit immediate into accumulator (register A).
+/// 2-byte instruction: `0x3E nn`.
+pub const MVI_A: u8 = 0x3E;
+
+/// `JMP addr` — unconditional jump to a 14-bit address.  3-byte
+/// instruction (`0x44` is JFC, NOT JMP — bit-2/3 family hazard).
+pub const JMP: u8 = 0x7C;
+
+/// `CAL addr` — call subroutine at 14-bit address.  3-byte
+/// instruction.  Pairs with `RET` for function returns.
+pub const CAL: u8 = 0x7E;
+
+// ===========================================================================
+// Capacity constants
+// ===========================================================================
+
+/// Number of 7 GP registers (A, B, C, D, E, H, L).  The 8008 has
+/// no fully general r0..r15 — these are named registers in the
+/// AAPCS-like ABI the LANG VM uses.
+pub const GP_REGISTER_COUNT: usize = 7;
+
+/// Maximum unsigned 8-bit `MVI A` immediate (= 255).
+pub const MVI_MAX: u8 = 255;
+
+// ===========================================================================
+// encode_* helpers
+// ===========================================================================
+
+/// Encode `MVI A, n` as a 2-byte instruction: `[0x3E, n]`.
+#[inline]
+pub fn encode_mvi_a(n: u8) -> [u8; 2] {
+    [MVI_A, n]
+}
+
+/// Encode `JMP addr` as a 3-byte instruction.  The 14-bit address
+/// is encoded as low byte first, then `(high_byte | 0x40)`.
+#[inline]
+pub fn encode_jmp(addr: u16) -> [u8; 3] {
+    let masked = addr & 0x3FFF; // 14 bits
+    [
+        JMP,
+        (masked & 0xFF) as u8,
+        ((masked >> 8) & 0x3F) as u8,
+    ]
+}
+
+/// Encode `CAL addr` as a 3-byte instruction (same address shape
+/// as JMP).
+#[inline]
+pub fn encode_cal(addr: u16) -> [u8; 3] {
+    let masked = addr & 0x3FFF;
+    [
+        CAL,
+        (masked & 0xFF) as u8,
+        ((masked >> 8) & 0x3F) as u8,
+    ]
+}

--- a/code/packages/rust/intel8008-encoder/tests/test_encoder.rs
+++ b/code/packages/rust/intel8008-encoder/tests/test_encoder.rs
@@ -1,0 +1,62 @@
+use intel8008_encoder::*;
+
+#[test]
+fn opcode_constants_pinned() {
+    assert_eq!(HLT, 0x76);
+    assert_eq!(RET, 0x07);
+    assert_eq!(MVI_A, 0x3E);
+    assert_eq!(JMP, 0x7C);
+    assert_eq!(CAL, 0x7E);
+}
+
+#[test]
+fn capacity_constants_pinned() {
+    assert_eq!(GP_REGISTER_COUNT, 7);
+    assert_eq!(MVI_MAX, 255);
+}
+
+#[test]
+fn encode_mvi_a_canonical_42() {
+    // The bytes the existing intel8008 e2e test pins.
+    assert_eq!(encode_mvi_a(42), [0x3E, 0x2A]);
+}
+
+#[test]
+fn encode_mvi_a_zero() {
+    assert_eq!(encode_mvi_a(0), [0x3E, 0x00]);
+}
+
+#[test]
+fn encode_mvi_a_max() {
+    assert_eq!(encode_mvi_a(255), [0x3E, 0xFF]);
+}
+
+#[test]
+fn encode_jmp_simple() {
+    assert_eq!(encode_jmp(0x000), [0x7C, 0x00, 0x00]);
+    assert_eq!(encode_jmp(0x001), [0x7C, 0x01, 0x00]);
+    assert_eq!(encode_jmp(0x100), [0x7C, 0x00, 0x01]);
+    assert_eq!(encode_jmp(0x3FFF), [0x7C, 0xFF, 0x3F]);
+}
+
+#[test]
+fn encode_jmp_masks_high_bits() {
+    // 14-bit address; anything above bit 13 should mask off.
+    assert_eq!(encode_jmp(0xC000), [0x7C, 0x00, 0x00]);
+}
+
+#[test]
+fn encode_cal_simple() {
+    assert_eq!(encode_cal(0x123), [0x7E, 0x23, 0x01]);
+}
+
+#[test]
+fn hlt_versus_jmp_versus_cal_distinct() {
+    // Group-01 jump/call/return family-bit hazards documented
+    // in iir-to-intel8008's comments.
+    assert_ne!(HLT, JMP);
+    assert_ne!(JMP, CAL);
+    assert_eq!(JMP & 0x80, 0x00, "JMP is in group 01");
+    assert_eq!(CAL & 0x80, 0x00, "CAL is in group 01");
+    assert_eq!(HLT & 0x80, 0x00, "HLT is in group 01");
+}

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -15,7 +15,8 @@ interpreter-ir        = { path = "../interpreter-ir" }
 cli-builder           = { path = "../cli-builder" }
 iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-riscv          = { path = "../iir-to-riscv" }
-iir-to-intel8008      = { path = "../iir-to-intel8008" }
+intel8008-backend     = { path = "../intel8008-backend" }
+intel8008-encoder     = { path = "../intel8008-encoder" }
 armv7-backend         = { path = "../armv7-backend" }
 armv7-encoder         = { path = "../armv7-encoder" }
 intel4004-backend     = { path = "../intel4004-backend" }

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -398,9 +398,28 @@ pub fn compile_file_to_intel8008_bin(
     let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("lang");
     let module = compile_source_to_iir(language, &source, stem)?;
 
-    let cfg = iir_to_intel8008::IIRIntel8008Config::new(stem);
-    let bytes = iir_to_intel8008::lower_iir_to_intel8008(&module, &cfg)
-        .map_err(|e| LangAotError::Intel8008BackendError(format!("{e}")))?;
+    // Phase 6 of the historical-arch backend migration: route
+    // through aot_core::infer + aot_core::specialise +
+    // intel8008_backend::compile per function, same pattern as
+    // Phases 3-5.
+    let _ = stem;
+    let mut bytes = Vec::new();
+    let empty_params: Vec<(String, String)> = Vec::new();
+    for f in &module.functions {
+        let inferred = aot_core::infer::infer_types(f);
+        let cir = aot_core::specialise::aot_specialise(f, Some(&inferred));
+        let ctx = jit_core::backend::FunctionContext {
+            name: f.name.as_str(),
+            params: &empty_params,
+            return_type: f.return_type.as_str(),
+        };
+        let fn_bytes = intel8008_backend::compile(&ctx, &cir)
+            .map_err(|e| LangAotError::Intel8008BackendError(format!("{e}")))?;
+        bytes.extend_from_slice(&fn_bytes);
+    }
+    if bytes.is_empty() {
+        bytes.push(intel8008_encoder::HLT);
+    }
 
     std::fs::write(out, &bytes)?;
     Ok(())

--- a/code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md
+++ b/code/specs/HISTORICAL-ARCH-BACKEND-MIGRATION.md
@@ -1,6 +1,6 @@
 # Historical-arch backend migration — `iir-to-*` → `*-encoder` + `*-backend`
 
-**Status:** Phases 1–5 done.  GE-225 + Intel 4004 + ARMv7 lanes migrated.  Phase 6 next (Intel 8008).
+**Status:** Phases 1–6 done.  GE-225 + Intel 4004 + ARMv7 + Intel 8008 lanes migrated.  Phase 7 next (RV32I — the original mistake from A1+ that started this whole pattern).
 **Plan:** [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md) (which produced the A1–A5 lanes this migration corrects).
 
 ## The architectural mistake the A1–A5 cascades made
@@ -67,7 +67,7 @@ arches are mechanical applications (1 phase each).
 | ✅ **3** | `ge225-backend` wiring + `iir-to-ge225` deprecation | **this PR** — `lang-aot --emit=ge225` routes through `aot_core::infer` + `aot_core::specialise` + `ge225_backend::compile`.  `iir-to-ge225` marked `#[deprecated]` at the API level; existing callers keep working with warnings.  All 5 GE-225 + 3 BASIC e2e tests produce byte-for-byte-identical output. |
 | ✅ **4** | Intel 4004 migration | **this PR** — `intel4004-encoder` + `intel4004-backend` + lang-aot wiring + `iir-to-intel4004` marked `#[deprecated]`.  Byte-for-byte parity verified by the existing Intel 4004 e2e smoke test. |
 | ✅ **5** | ARMv7 migration | **this PR** — `armv7-encoder` + `armv7-backend` (minimal viable: `const_*` + `ret_*` only) + lang-aot wiring + `iir-to-armv7` marked `#[deprecated]`.  Byte-for-byte parity for the trivial `MOV r0, #N; BX LR` ROM verified by the e2e smoke test.  Full op coverage (add/sub/cmp/branches/calls) is intentionally NOT ported — future increments can add to `armv7-backend` as needed. |
-| 🔜 **6** | Intel 8008 migration | `intel8008-encoder` + `intel8008-backend` + wiring + deprecate `iir-to-intel8008`. |
+| ✅ **6** | Intel 8008 migration | **this PR** — `intel8008-encoder` + `intel8008-backend` (minimal viable: `const_*` + `ret_*`) + lang-aot wiring + `iir-to-intel8008` deprecated.  Byte-for-byte parity for `MVI A, 42; HLT` ROM verified. |
 | 🔜 **7** | RV32I migration | `riscv-encoder` + `riscv-backend` + wiring + deprecate `iir-to-riscv`. |
 
 Each phase = 1 PR + babysitter cron + auto-merge + next-phase


### PR DESCRIPTION
## Migration Phase 6 of 7 — Intel 8008 lane

Mirrors Phase 4 (Intel 4004) and Phase 5 (ARMv7).  Single-PR consolidated migration.

## What's in this PR

- **\`intel8008-encoder\` v0.1.0** — 5 opcodes (HLT/RET/MVI_A/JMP/CAL), 3 encoders (\`encode_mvi_a\`/\`encode_jmp\`/\`encode_cal\`).  9 unit tests.
- **\`intel8008-backend\` v0.1.0** — implements \`Backend\` over CIR.  Minimal viable: \`const_*\` + \`ret_*\` only.  Outputs \`Vec<u8>\` directly.  \`run\` panics.  11 unit tests.
- **lang-aot wiring**: \`compile_file_to_intel8008_bin\` now routes through \`aot_core::infer\` + \`aot_core::specialise\` + \`intel8008_backend::compile\` per function.
- **\`iir-to-intel8008\` deprecated** (v0.3.9 → v0.4.0).

## Byte-for-byte parity verified

E2e test \`end_to_end_twig_42_emits_intel8008_bin_via_lang_aot\` produces \`[0x3E, 0x2A, 0x76]\` exactly (MVI A, 42 ; HLT) through the new CIR pipeline.

## Test plan

- [x] \`cargo test -p intel8008-encoder\` — **9/9 pass**
- [x] \`cargo test -p intel8008-backend\` — **11/11 pass**
- [x] \`cargo test -p iir-to-intel8008\` — **61/61 + 1 doctest still pass**
- [x] \`cargo test -p lang-aot\` — **30/30 pass**
- [x] Security review passed (round 1, clean)
- [ ] CI green
- [ ] Babysitter cron monitors → kicks off Phase 7 (RV32I — the final lane) on merge

## Phase status

| Phase | Status |
|-------|--------|
| 1-3 GE-225 | ✅ merged |
| 4 Intel 4004 | ✅ merged |
| 5 ARMv7 | ✅ merged |
| **6 Intel 8008** | **this PR** |
| 7 RV32I | queued (last one!) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)