### PR TITLE
feat(closure-pass-constant-fold): CLOC12.21 — close gap-003 (null cross-type loose equality)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.9.0] - 2026-06-02
+
+### Added — CLOC12.21: gap-003 `null == <primitive>` cross-type loose-equality fold
+
+Closes `gap-003` from the CLOC12 gap tracker. `try_fold_binary_op` now
+implements the `null`-side branch of the ECMAScript abstract-equality
+algorithm (§IsLooselyEqual) for compile-time-known partner literals.
+
+What's folded:
+
+* `null == X` and `X == null` where `X` is any non-null primitive
+  literal (`number`, `string`, `boolean`, `bigint`, or `undefined`).
+* The result is `true` iff the partner is `undefined` (the spec
+  hard-codes `null == undefined → true`); every other partner is `false`.
+* `null != X` and `X != null` fold to the boolean negation.
+
+Truth table:
+
+```
+partner          ==     !=
+---------------+------+------
+null           | true | false   (already covered by gap-007 path)
+undefined      | true | false
+number         | false| true
+string         | false| true
+boolean        | false| true
+bigint         | false| true
+```
+
+Unsoundness guard: if the partner side is an `Identifier` (or anything
+non-literal we can't statically classify), the fold bails out. The
+identifier's runtime value could itself be `null`/`undefined`, and
+folding to a concrete boolean would change observable behaviour.
+
+Ordering: the new branch runs *after* the existing null/null branch
+(gap-007) — so by the time we reach it, at most one side is a
+NullLiteral — and *before* the cross-type strict-equality branch
+(gap-008), which is unaffected because that branch only fires on
+`===`/`!==`. A regression test in the inline tests pins gap-008's
+behaviour for `null === 0` / `null !== 0`.
+
+Tests:
+
+* `peephole_fold_constants_test::test_null_comparison_1_loose_against_other_types`
+  is un-ignored (was `#[ignore = "blocked on gap-003"]`).
+* 6 new inline unit tests cover both directions, the `!=` complement,
+  the `null == undefined → true` special case, the identifier
+  unsoundness guard, and the gap-008 regression check.
+
+No changes to public API or AST surface.
+
 ## [0.8.0] - 2026-06-02
 
 ### Added — CLOC12.20: gap-002 `void <pure-literal>` → `undefined` fold

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -579,6 +579,69 @@ fn try_fold_binary_op(
         };
     }
 
+    // Cross-type LOOSE equality involving `null` (closes CLOC12 gap-003).
+    //
+    // The ECMAScript abstract-equality algorithm (§IsLooselyEqual) has
+    // exactly two ways for `null == x` (or `x == null`) to be `true`:
+    //
+    //   1. `x` is also `null` (same primitive value).            ← gap-007 above
+    //   2. `x` is `undefined`. The spec hard-codes that
+    //      `null == undefined → true` (and symmetrically).
+    //
+    // Every other case — `null == 0`, `null == ""`, `null == true`,
+    // `null == 1n` — falls through the algorithm and produces `false`.
+    // None of the type-coercion clauses (Number↔String, Boolean → Number,
+    // Object → primitive) apply when one side is `null`: `null` is its
+    // own ECMAScript "Null" type, and the coercion clauses are written
+    // against Number/String/Boolean/BigInt/Object operands.
+    //
+    // Truth table once `null` is on one side and a *literal* of known JS
+    // type sits on the other:
+    //
+    //     other side          ==     !=
+    //     -------------------+------+------
+    //     null               | true | false   ← gap-007 (already returned above)
+    //     undefined          | true | false
+    //     number             | false| true
+    //     string             | false| true
+    //     boolean            | false| true
+    //     bigint             | false| true
+    //
+    // We deliberately bail out when the non-null side is *not* a literal
+    // we recognise (e.g. an Identifier, a function call): a runtime
+    // value could itself be `null` or `undefined`, and folding to a
+    // concrete boolean would be unsound.
+    //
+    // Why this runs after the null/null branch above: that branch
+    // already settled `null == null`, so by the time we get here we
+    // know at most one side is a NullLiteral. We pick whichever side it
+    // is and inspect the *other* side.
+    if matches!(op, Eq | NotEq) {
+        let other = match (left, right) {
+            (Expression::NullLiteral(_), other) if !matches!(other, Expression::NullLiteral(_)) => {
+                Some(other)
+            }
+            (other, Expression::NullLiteral(_)) if !matches!(other, Expression::NullLiteral(_)) => {
+                Some(other)
+            }
+            _ => None,
+        };
+        if let Some(other) = other {
+            if let Some(other_type) = js_literal_type(other) {
+                // `other_type` ∈ {"number", "string", "boolean",
+                // "bigint", "undefined"} here — "null" is excluded by
+                // the `other` filter above, so the only `true` case is
+                // when the partner is the undefined literal.
+                let eq = other_type == "undefined";
+                return match op {
+                    Eq => Some(FoldedLiteral::Boolean(eq)),
+                    NotEq => Some(FoldedLiteral::Boolean(!eq)),
+                    _ => unreachable!(),
+                };
+            }
+        }
+    }
+
     // Cross-type strict equality (closes CLOC12 gap-008).
     //
     // Per ECMAScript §IsStrictlyEqual, `===` between two values
@@ -1285,6 +1348,146 @@ mod tests {
                 other => panic!("expected BooleanLiteral; got {:?}", other),
             }
         }
+    }
+
+    // ------------------- null cross-type equality (gap-003) ----------
+    //
+    // These tests pin the behaviour added when CLOC12 gap-003 was
+    // closed: the abstract-equality algorithm's `null`-side branch is
+    // implemented for compile-time-known partner literals.
+
+    fn undefined_(cv: Option<&str>) -> Expression {
+        Expression::UndefinedLiteral(UndefinedLiteral {
+            cv: cv.map(|s| s.to_string()),
+        })
+    }
+
+    fn binary_with(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+        Expression::BinaryExpression(BinaryExpression {
+            cv: Some("bin.1".to_string()),
+            operator: op,
+            left: Box::new(left),
+            right: Box::new(right),
+        })
+    }
+
+    fn run_and_extract_bool(expr: Expression) -> Option<bool> {
+        let (out, _, _, _) = run_pass(program_with_expr(expr, true));
+        if let Expression::BooleanLiteral(bl) = extract_expr(&out) {
+            Some(bl.value)
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn gap003_null_loose_eq_other_primitives_folds_false() {
+        // Left-side null vs every non-null/non-undefined literal kind.
+        for partner in [
+            num(0.0, None),
+            num(42.0, None),
+            string("hi", None),
+            string("", None),
+            boolean(true, None),
+            boolean(false, None),
+        ] {
+            let folded = run_and_extract_bool(binary_with(
+                BinaryOperator::Eq,
+                null(None),
+                partner.clone(),
+            ));
+            assert_eq!(folded, Some(false), "null == {:?} should fold to false", partner);
+        }
+    }
+
+    #[test]
+    fn gap003_null_loose_eq_other_primitives_is_symmetric() {
+        // Same as above but with `null` on the right — fold must still fire.
+        for partner in [num(0.0, None), string("hi", None), boolean(true, None)] {
+            let folded = run_and_extract_bool(binary_with(
+                BinaryOperator::Eq,
+                partner.clone(),
+                null(None),
+            ));
+            assert_eq!(folded, Some(false), "{:?} == null should fold to false", partner);
+        }
+    }
+
+    #[test]
+    fn gap003_null_loose_neq_other_primitives_folds_true() {
+        // `!=` is the boolean negation of `==`.
+        for partner in [num(0.0, None), string("hi", None), boolean(true, None)] {
+            let folded = run_and_extract_bool(binary_with(
+                BinaryOperator::NotEq,
+                null(None),
+                partner.clone(),
+            ));
+            assert_eq!(folded, Some(true), "null != {:?} should fold to true", partner);
+        }
+    }
+
+    #[test]
+    fn gap003_null_loose_eq_undefined_folds_true() {
+        // The one cross-type partner that's NOT false: `null == undefined`.
+        // Per ES §IsLooselyEqual, the spec hard-codes this case.
+        let folded = run_and_extract_bool(binary_with(
+            BinaryOperator::Eq,
+            null(None),
+            undefined_(None),
+        ));
+        assert_eq!(folded, Some(true), "null == undefined must fold to true");
+
+        // Symmetric.
+        let folded = run_and_extract_bool(binary_with(
+            BinaryOperator::Eq,
+            undefined_(None),
+            null(None),
+        ));
+        assert_eq!(folded, Some(true), "undefined == null must fold to true");
+
+        // And the `!=` complement.
+        let folded = run_and_extract_bool(binary_with(
+            BinaryOperator::NotEq,
+            null(None),
+            undefined_(None),
+        ));
+        assert_eq!(folded, Some(false), "null != undefined must fold to false");
+    }
+
+    #[test]
+    fn gap003_null_loose_eq_identifier_does_not_fold() {
+        // Critical unsoundness guard: an Identifier's runtime value
+        // could itself be null/undefined. Folding `null == someVar` to
+        // a concrete boolean would change observable behaviour.
+        let expr = binary_with(BinaryOperator::Eq, null(None), ident("x"));
+        let (out, _, _, _) = run_pass(program_with_expr(expr, true));
+        // Output should still be a BinaryExpression — i.e., NOT a
+        // BooleanLiteral.
+        assert!(
+            matches!(extract_expr(&out), Expression::BinaryExpression(_)),
+            "null == identifier must NOT fold"
+        );
+    }
+
+    #[test]
+    fn gap003_null_strict_eq_is_handled_by_gap008_not_this_branch() {
+        // Sanity check that we didn't accidentally break gap-008's
+        // strict-equality cross-type fold by adding the loose branch
+        // ahead of it. `null === 0` should still fold to false (via
+        // gap-008's StrictEq/StrictNotEq branch).
+        let folded = run_and_extract_bool(binary_with(
+            BinaryOperator::StrictEq,
+            null(None),
+            num(0.0, None),
+        ));
+        assert_eq!(folded, Some(false), "null === 0 (gap-008) must still fold to false");
+
+        let folded = run_and_extract_bool(binary_with(
+            BinaryOperator::StrictNotEq,
+            null(None),
+            num(0.0, None),
+        ));
+        assert_eq!(folded, Some(true), "null !== 0 (gap-008) must still fold to true");
     }
 
     // ------------------- string ops ----------------------------------

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -252,8 +252,14 @@ fn test_null_comparison_1_self_relations() {
 /// `false`. Our pass folds `==` only when both sides are the *same* JS
 /// type (sound default — see crate-level docs); these are blocked
 /// pending a richer fold rule.
+///
+/// **gap-003 closed in CLOC12.21** — the constant-fold pass now
+/// implements the `null`-side branch of the ECMAScript abstract
+/// equality algorithm for compile-time-known partners. `null == X` is
+/// `true` iff `X` is `null` or `undefined`; every other literal partner
+/// yields `false`. `!=` is the negation. See `try_fold_binary_op` for
+/// the truth table and unsoundness guard.
 #[test]
-#[ignore = "blocked on gap-003: cross-type `null == x` fold not implemented"]
 fn test_null_comparison_1_loose_against_other_types() {
     assert_fold(b(null_(), BinaryOperator::Eq, n(0.0)), bool_(false));
     assert_fold(b(null_(), BinaryOperator::Eq, n(1.0)), bool_(false));

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -41,11 +41,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-003 — cross-type `null == x` fold not implemented
 
-- **Status:** OPEN
-- **Upstream test:** `PeepholeFoldConstantsTest::testNullComparison1` (cross-type loose-equality lines)
-- **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** Our `==` fold rule only fires when both literals are the same JS type (sound default per crate docs). The JS abstract-equality algorithm says `null == 0` is `false`, `null == "hi"` is `false`, etc., but folding that requires implementing the actual algorithm.
-- **What it needs:** Implement the abstract-equality algorithm for the cases where both sides are compile-time constants. Mirror upstream's `PeepholeFoldConstants.tryFoldComparison`.
+- **Status:** RESOLVED in CLOC12.21 — `try_fold_binary_op` now implements the `null`-side branch of ECMAScript §IsLooselyEqual for compile-time-known partner literals. `null == X` (or `X == null`) folds to `true` iff `X` is `null` (the existing gap-007 branch, untouched) or `undefined`; every other primitive-literal partner (`number`, `string`, `boolean`, `bigint`) folds to `false`. `!=` is the boolean negation. Identifier-on-other-side bails out — the runtime value could itself be null/undefined, and folding to a concrete boolean would be unsound. `test_null_comparison_1_loose_against_other_types` is un-ignored. Inline tests cover both directions (left/right swap of null), the `!=` complement, the `null == undefined → true` special case (both directions), the unsoundness guard against identifiers, and a regression check that gap-008's strict-equality cross-type branch still fires.
 
 ### gap-004 — abstract-equality and abstract-comparison folds across Number/String
 


### PR DESCRIPTION
## Summary

Closes **gap-003** in the CLOC12 gap tracker: cross-type `null == X` (and symmetric / `!=` forms) now fold per the ECMAScript abstract-equality algorithm (§IsLooselyEqual).

| partner kind | `null == X` | `null != X` |
|---|---|---|
| null | `true` *(gap-007 path; unchanged)* | `false` |
| **undefined** | **`true`** *(spec hard-codes nullish equality)* | `false` |
| number / string / boolean / bigint | `false` | `true` |

Bidirectional — `X == null` and `X != null` fold identically.

## Why this is safe

The new branch is positioned between gap-007 (null/null) and gap-008 (strict cross-type) and gated on `matches!(op, Eq | NotEq)`. It cannot interfere with strict equality. A regression test pins `null === 0 → false` and `null !== 0 → true` still firing via gap-008.

**Unsoundness guard**: if the partner is anything non-literal (Identifier, Call, MemberExpression, ...) the fold bails. The identifier's runtime value could itself be null/undefined; folding to a concrete boolean would change observable behaviour. Tested with `gap003_null_loose_eq_identifier_does_not_fold`.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-constant-fold` → 33 inline (was 27) + 12 upstream (was 11) passing
- [x] Upstream test `test_null_comparison_1_loose_against_other_types` un-ignored (was `#[ignore = "blocked on gap-003"]`)
- [x] gap-008 regression test (`gap003_null_strict_eq_is_handled_by_gap008_not_this_branch`) confirms strict path unaffected
- [x] /security-review run — clean (no unsafe, no I/O, statically-unreachable `unreachable!` arms)
- [ ] CI green
- [ ] No new clippy warnings (clippy currently red on unrelated `directed-graph` crate on main — not from this PR)

## Closes

- gap-003 (status flipped OPEN → RESOLVED in `code/specs/CLOC12-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)