### PR TITLE
feat(mccarthy-lisp): L1 — grammar-driven lexer/parser (#4967 follow-up) + full-backend spec

### DIFF
--- a/code/grammars/mccarthy_lisp.grammar
+++ b/code/grammars/mccarthy_lisp.grammar
@@ -1,0 +1,45 @@
+# Parser grammar for McCarthy's 1960 Lisp (Lisp 1.0)
+# @version 1
+#
+# Token names (UPPERCASE) match the types defined in
+# `mccarthy_lisp.tokens`.  The whole grammar fits in six rules — Lisp's
+# syntax is famously a single recursive shape, the S-expression.
+#
+# An S-expression is one of:
+#   * an atom          — a SYMBOL (CAR, X) or an INTEGER (42, -1)
+#   * a list           — `( ... )`, possibly with a dotted tail
+#   * a quoted form    — `'X`, sugar the extractor rewrites to (QUOTE X)
+#
+# A program is a sequence of top-level S-expressions, evaluated in
+# order — exactly McCarthy's "program = sequence of forms" reading.
+#
+# How lists desugar (handled by the AST extractor, not the grammar):
+#
+#   (A B C)    →  Cons(A, Cons(B, Cons(C, Nil)))   ; NIL-terminated
+#   (A B . C)  →  Cons(A, Cons(B, C))              ; explicit dotted tail
+#   ()         →  Nil                              ; the empty list
+#   'X         →  Cons(QUOTE, Cons(X, Nil))        ; = (QUOTE X)
+#
+# Note the optional `[ DOT sexpr ]` tail in `list_body`: the grammar
+# accepts at most one dotted tail per list and only after at least one
+# element, so `(. X)`, `(A . B C)`, and `(A . . B)` are all grammar
+# errors — no hand-written validation needed.
+
+# A program is zero or more S-expressions.  An empty file is a valid
+# (empty) program.
+program = { sexpr } ;
+
+# The single recursive shape.  Order of alternatives is irrelevant here
+# because each begins with a distinct token (SYMBOL/INTEGER, LPAREN,
+# QUOTE), so the PEG never has to backtrack.
+sexpr = atom | list | quoted ;
+
+# An atom is a bare symbol or integer literal.
+atom = SYMBOL | INTEGER ;
+
+# A parenthesised list with an optional dotted tail.
+list      = LPAREN list_body RPAREN ;
+list_body = [ sexpr { sexpr } [ DOT sexpr ] ] ;
+
+# `'X` — quote sugar.  The extractor rewrites it to `(QUOTE X)`.
+quoted = QUOTE sexpr ;

--- a/code/grammars/mccarthy_lisp.tokens
+++ b/code/grammars/mccarthy_lisp.tokens
@@ -1,0 +1,81 @@
+# Token definitions for McCarthy's 1960 Lisp (Lisp 1.0)
+# @version 1
+#
+# This is the *original* Lisp dialect described in John McCarthy's 1960
+# paper "Recursive Functions of Symbolic Expressions and Their
+# Computation by Machine, Part I".  It is deliberately distinct from the
+# repo's other Lisp grammar (`lisp.tokens`), which targets a modern
+# Scheme-ish dialect (lowercase symbols, strings, operator symbols).
+#
+#   | Feature          | McCarthy 1.0 (this file) | Scheme (`lisp.tokens`) |
+#   |------------------|--------------------------|------------------------|
+#   | Symbol case      | ALL-UPPERCASE            | mixed case             |
+#   | Strings          | none                     | yes  ("foo")           |
+#   | Decimals         | integers only            | yes                    |
+#   | Operator symbols | none                     | yes (+, <=, ...)       |
+#
+# Encoding the dialect *here*, in the grammar, is what lets the
+# `mccarthy-lisp-lexer` crate be a thin wrapper over the shared
+# `GrammarLexer` rather than a hand-written tokenizer — the lexer and
+# parser come "for free" from these two files.
+#
+# Example source exercising every token kind:
+#
+#   (CAR '(A B C))        ; CAR of a literal list
+#   (CONS A (CONS B NIL)) ; build (A B)
+#   (A . -42)             ; dotted pair with a negative integer
+#
+# Escape sequences: there are no string literals in Lisp 1.0, so there
+# is nothing to escape.
+escapes: none
+
+# ---------------------------------------------------------------------------
+# Skip patterns — consumed silently, never reach the parser.
+#
+# WHITESPACE swallows spaces, tabs, CR, and newlines.  COMMENT is the
+# Lisp `;`-to-end-of-line comment.  Comments were not in McCarthy's
+# 1958-1960 paper (they arrived with Lisp 1.5 in 1962), but we accept
+# them so test sources can be annotated.  The newline that ends a
+# comment is consumed by WHITESPACE on the next pass.
+# ---------------------------------------------------------------------------
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+  COMMENT    = /;[^\n]*/
+
+# ---------------------------------------------------------------------------
+# Numeric literals — signed decimal integers only.
+#
+# The leading `-?` makes negative literals (`-42`) a single token.
+# Because the lexer uses first-match / longest-match anchored regexes
+# and `/-?[0-9]+/` requires at least one digit, a bare `-` matches no
+# token at all and is therefore a lex error — exactly McCarthy 1.0's
+# rule that there are no operator symbols.
+#
+# INTEGER comes before SYMBOL so a leading digit commits to the numeric
+# rule (there is no overlap — SYMBOL must start with an uppercase
+# letter — but listing the unambiguous numeric shape first keeps intent
+# clear).
+# ---------------------------------------------------------------------------
+INTEGER = /-?[0-9]+/
+
+# ---------------------------------------------------------------------------
+# Symbols (atoms) — all-uppercase identifiers.
+#
+# A symbol starts with an uppercase letter and continues with uppercase
+# letters, digits, or hyphens: `CAR`, `CDR`, `X`, `FF`, `LIST-OF-3`.
+# Lowercase letters are intentionally excluded; lowercase source is a
+# lex error, signalling "this isn't McCarthy 1960 Lisp".
+# ---------------------------------------------------------------------------
+SYMBOL = /[A-Z][A-Z0-9-]*/
+
+# ---------------------------------------------------------------------------
+# Punctuation literals.
+#
+#   LPAREN / RPAREN  list & call delimiters
+#   QUOTE            `'X` reader sugar; the parser expands it to (QUOTE X)
+#   DOT              dotted-pair separator: `(A . B)`
+# ---------------------------------------------------------------------------
+LPAREN = "("
+RPAREN = ")"
+QUOTE  = "'"
+DOT    = "."

--- a/code/packages/rust/mccarthy-lisp-lexer/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-lexer/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — mccarthy-lisp-lexer
 
+## v0.2.0 — 2026-06-03 — grammar-driven rewrite (L1)
+
+**Breaking:** replaced the hand-written tokenizer with a thin wrapper
+over the shared, grammar-driven `GrammarLexer`.  The McCarthy 1.0
+dialect now lives in `code/grammars/mccarthy_lisp.tokens`, compiled to
+Rust at build time via a `build.rs` (the `twig-lexer` pattern).  This
+brings the crate in line with the repo rule that language frontends
+must wrap `GrammarLexer`/`GrammarParser` rather than hand-write
+lexers/parsers.
+
+* **Removed** the hand-written `Token` enum, `TokenWithLoc`, `Loc`, and
+  the bespoke `LexError` (with its `LoneMinus` / `LowercaseInSymbol` /
+  `IntegerOverflow` variants).
+* **Added**:
+  * `tokenize_mccarthy(src) -> Result<Vec<lexer::token::Token>, LexerError>`
+  * `create_mccarthy_lexer(src) -> GrammarLexer`
+  * `mccarthy_token_grammar_spec() -> &'static TokenGrammar`
+  * re-exports of `lexer::token::{Token as LispToken, TokenType, LexerError}`.
+* The dialect restrictions (all-uppercase symbols, integers only, no
+  strings, no operator symbols) are now enforced by the token regexes
+  in `mccarthy_lisp.tokens`.  Lowercase, bare `-`, and string literals
+  are still rejected — now as generic `LexerError`s rather than bespoke
+  variants.
+* New deps: `grammar-tools`, `lexer` (+ `grammar-tools` build-dep).
+
 ## v0.1.0 — 2026-06-03 — initial release (L1)
 
 McCarthy 1960 Lisp tokenizer.  Recognises all-uppercase atoms,

--- a/code/packages/rust/mccarthy-lisp-lexer/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-lexer/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "mccarthy-lisp-lexer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Tokenizer for McCarthy's 1960 Lisp (Lisp 1.0).  Recognises the original all-uppercase atoms, integers, parentheses, quote sugar, and dotted-pair separator — no strings, no operator symbols, no decimals.  Distinct from the generic `lisp-lexer` crate (which targets Scheme-ish modern Lisp).  L1 of the McCarthy Lisp implementation."
+description = "Tokenizer for McCarthy's 1960 Lisp (Lisp 1.0) — a thin wrapper over the shared grammar-driven GrammarLexer.  The dialect (all-uppercase atoms, integers only, no strings, no operator symbols) is defined entirely in `code/grammars/mccarthy_lisp.tokens`, which is compiled to Rust at build time.  Distinct from the generic `lisp-lexer` crate (which targets Scheme-ish modern Lisp).  L1 of the McCarthy Lisp implementation."
+build = "build.rs"
 
 [lib]
 name = "mccarthy_lisp_lexer"
 path = "src/lib.rs"
 
 [dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer         = { path = "../lexer" }
+
+[build-dependencies]
+grammar-tools = { path = "../grammar-tools" }

--- a/code/packages/rust/mccarthy-lisp-lexer/README.md
+++ b/code/packages/rust/mccarthy-lisp-lexer/README.md
@@ -5,6 +5,17 @@ Tokenizer for **McCarthy's 1960 Lisp** (Lisp 1.0).
 L1 of the McCarthy Lisp implementation — see
 [`MCCARTHY-LISP-PLAN.md`](../../../specs/MCCARTHY-LISP-PLAN.md).
 
+## Grammar-driven — the lexer comes "for free"
+
+This crate does **not** hand-write a tokenizer.  Every lexing rule
+lives in [`code/grammars/mccarthy_lisp.tokens`](../../../grammars/mccarthy_lisp.tokens),
+which `build.rs` compiles to Rust at build time.  The crate is a thin
+wrapper that hands that grammar to the shared
+[`GrammarLexer`](../lexer).  This is the same pattern used by
+`twig-lexer`, `nib-lexer`, and `oct-lexer` — there is exactly one
+lexer engine in the repo, and McCarthy Lisp joins it rather than
+forking a second implementation that could silently drift.
+
 ## Why a distinct crate (vs the existing `lisp-lexer`)
 
 The existing `lisp-lexer` targets a modern Scheme-ish Lisp: lowercase
@@ -25,13 +36,39 @@ McCarthy's 1960 Lisp predates almost all of that:
 in Lisp 1.5 (1962).  We accept them in v0.1.0 for ergonomic test
 sources.
 
-## Token kinds
+The dialect restrictions are enforced entirely by the token regexes,
+so they fall out of the grammar at no extra cost:
 
-| Variant | Source form        | Example  |
-|---------|--------------------|----------|
-| `LParen`| `(`                | `(`      |
-| `RParen`| `)`                | `)`      |
-| `Quote` | `'` (sugar)        | `'X`     |
-| `Dot`   | `.` (cons sep)     | `.`      |
-| `Symbol`| `[A-Z][A-Z0-9-]*`  | `CAR`    |
-| `Int`   | `-?[0-9]+`         | `42`     |
+- `SYMBOL = /[A-Z][A-Z0-9-]*/` rejects lowercase source.
+- `INTEGER = /-?[0-9]+/` requires a digit, so a bare `-` (an operator
+  symbol, which Lisp 1.0 has none of) matches nothing and is a lex
+  error.
+- There is no `STRING` rule, so `"…"` is a lex error.
+
+## Token kinds (per `mccarthy_lisp.tokens`)
+
+| Grammar token | Source form        | Example  |
+|---------------|--------------------|----------|
+| `LPAREN`      | `(`                | `(`      |
+| `RPAREN`      | `)`                | `)`      |
+| `QUOTE`       | `'` (sugar)        | `'X`     |
+| `DOT`         | `.` (cons sep)     | `.`      |
+| `SYMBOL`      | `[A-Z][A-Z0-9-]*`  | `CAR`    |
+| `INTEGER`     | `-?[0-9]+`         | `42`     |
+
+## API
+
+```rust
+use mccarthy_lisp_lexer::tokenize_mccarthy;
+
+let tokens = tokenize_mccarthy("(CAR '(A B C))").unwrap();
+// Vec<lexer::token::Token>, ending with an EOF token.
+// Inspect tokens via `t.effective_type_name()` and `t.value`.
+```
+
+- `tokenize_mccarthy(src) -> Result<Vec<Token>, LexerError>` — the
+  whole token stream (incl. trailing `EOF`).
+- `create_mccarthy_lexer(src) -> GrammarLexer` — the lexer object, for
+  streaming / incremental use.
+- `mccarthy_token_grammar_spec() -> &'static TokenGrammar` — the
+  build-time-compiled grammar, for tooling (LSP, highlighters).

--- a/code/packages/rust/mccarthy-lisp-lexer/build.rs
+++ b/code/packages/rust/mccarthy-lisp-lexer/build.rs
@@ -1,0 +1,55 @@
+//! # mccarthy-lisp-lexer build script — compile `mccarthy_lisp.tokens` to Rust.
+//!
+//! Reads `code/grammars/mccarthy_lisp.tokens`, parses it via
+//! [`grammar_tools::token_grammar::parse_token_grammar`], and runs
+//! [`grammar_tools::compiler::compile_token_grammar`] to emit Rust
+//! source that reconstructs the parsed `TokenGrammar` as native struct
+//! literals.  The output is written to
+//! `$OUT_DIR/mccarthy_lisp_token_grammar.rs`, which `lib.rs` `include!`s.
+//!
+//! This is the exact pattern used by `twig-lexer/build.rs`; see that
+//! file for the rationale.  In short:
+//!
+//! 1. **No runtime file I/O** — the grammar is baked into the binary,
+//!    so the crate ships standalone and runs under Miri's filesystem
+//!    sandbox.
+//! 2. **Build-time validation** — a malformed `.tokens` file fails
+//!    `cargo build`, not the first lexer call.
+//! 3. **One construction per process** — `lib.rs` wraps the generated
+//!    constructor in a `OnceLock`.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::compile_token_grammar;
+use grammar_tools::token_grammar::parse_token_grammar;
+
+fn main() {
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo");
+    // code/packages/rust/mccarthy-lisp-lexer → ../../../grammars
+    let grammar_path = PathBuf::from(&manifest_dir)
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("grammars")
+        .join("mccarthy_lisp.tokens");
+    let grammar_path = grammar_path.canonicalize().unwrap_or_else(|e| {
+        panic!("Failed to resolve mccarthy_lisp.tokens path {grammar_path:?}: {e}")
+    });
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", grammar_path.display());
+
+    let grammar_text = fs::read_to_string(&grammar_path)
+        .unwrap_or_else(|e| panic!("Failed to read {grammar_path:?}: {e}"));
+    let grammar = parse_token_grammar(&grammar_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {grammar_path:?}: {e}"));
+
+    let rust = compile_token_grammar(&grammar, "mccarthy_lisp.tokens");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR must be set by cargo");
+    let out_path = PathBuf::from(&out_dir).join("mccarthy_lisp_token_grammar.rs");
+    fs::write(&out_path, rust)
+        .unwrap_or_else(|e| panic!("Failed to write {out_path:?}: {e}"));
+}

--- a/code/packages/rust/mccarthy-lisp-lexer/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-lexer/src/lib.rs
@@ -1,407 +1,235 @@
 //! # `mccarthy-lisp-lexer` — tokenizer for McCarthy's 1960 Lisp.
 //!
 //! Lisp 1.0 (the language described in John McCarthy's 1960 paper
-//! *"Recursive Functions of Symbolic Expressions and Their
-//! Computation by Machine, Part I"*) has the simplest tokenizer of
-//! any production language ever shipped — six token kinds, no
-//! string literals, no operator symbols, no floats:
+//! *"Recursive Functions of Symbolic Expressions and Their Computation
+//! by Machine, Part I"*) has the simplest tokenizer of any production
+//! language ever shipped — six token kinds, no string literals, no
+//! operator symbols, no floats:
 //!
-//! | Token kind | Source form           | Notes                              |
-//! |------------|-----------------------|------------------------------------|
-//! | `LParen`   | `(`                   | list / call open                   |
-//! | `RParen`   | `)`                   | list / call close                  |
-//! | `Quote`    | `'`                   | sugar — `'X` → `(QUOTE X)` later   |
-//! | `Dot`      | `.`                   | dotted-pair separator              |
-//! | `Symbol`   | `[A-Z][A-Z0-9-]*`     | all-uppercase atoms                |
-//! | `Int`      | `-?[0-9]+`            | signed decimal integers            |
+//! | Grammar token | Source form        | `effective_type_name()` |
+//! |---------------|--------------------|-------------------------|
+//! | `LPAREN`      | `(`                | `"LPAREN"`              |
+//! | `RPAREN`      | `)`                | `"RPAREN"`              |
+//! | `QUOTE`       | `'`                | `"QUOTE"`               |
+//! | `DOT`         | `.`                | `"DOT"`                 |
+//! | `SYMBOL`      | `[A-Z][A-Z0-9-]*`  | `"SYMBOL"`              |
+//! | `INTEGER`     | `-?[0-9]+`         | `"INTEGER"`             |
 //!
-//! Plus whitespace and `;`-to-EOL comments (skipped — comments
-//! weren't in McCarthy's paper but Lisp 1.5 added them and they
-//! make test sources ergonomic).
+//! Plus whitespace and `;`-to-EOL comments, which are skipped.
 //!
-//! ## Why we built a new crate vs reusing `lisp-lexer`
+//! ## This crate is a *thin wrapper*, not a hand-written lexer
 //!
-//! The in-tree `lisp-lexer` targets a modern Scheme-ish dialect:
-//! lowercase symbols, strings, decimals, operator symbols
-//! (`+`, `<=`, `null?`).  None of those existed in 1960.
-//! Enforcing the McCarthy-1960 token grammar at the lexer keeps
-//! the downstream `mccarthy-lisp-parser` and
-//! `mccarthy-lisp-iir-compiler` honest about which Lisp dialect
-//! they consume.
+//! Every Lisp 1.0 lexing rule lives in
+//! [`code/grammars/mccarthy_lisp.tokens`](../../../grammars/mccarthy_lisp.tokens),
+//! which `build.rs` compiles to Rust at build time.  This module just
+//! materialises that grammar once (via a `OnceLock`) and hands it to
+//! the shared [`lexer::grammar_lexer::GrammarLexer`].  The same pattern
+//! is used by `twig-lexer`, `nib-lexer`, and `oct-lexer` — see
+//! [`feedback_no_handwritten_lexers_parsers`].  Hand-writing the
+//! tokenizer would fork the grammar into a second implementation that
+//! could silently drift.
 //!
-//! ## How tokenization disambiguates negative numbers
+//! ## Why a distinct crate vs reusing `lisp-lexer`
 //!
-//! `-1` is an integer.  `-` alone is not a valid Lisp 1.0 token
-//! (no operator symbols).  If we see `-` followed immediately by a
-//! digit, we consume it as the integer sign; otherwise we report
-//! [`LexError::InvalidByte`].  This rule matches how McCarthy's
-//! paper wrote negative literals (always glued to the digit
-//! sequence).
+//! The in-tree `lisp-lexer` (and its grammar, `lisp.tokens`) targets a
+//! modern Scheme-ish dialect: lowercase symbols, strings, decimals,
+//! operator symbols (`+`, `<=`, `null?`).  None of those existed in
+//! 1960.  The McCarthy grammar enforces the all-uppercase,
+//! integers-only, no-strings dialect at the token level, keeping the
+//! downstream `mccarthy-lisp-parser` and `mccarthy-lisp-iir-compiler`
+//! honest about which Lisp they consume.
 //!
-//! ## Source-location bookkeeping
+//! ## How the dialect rules fall out of the grammar
 //!
-//! Each emitted token carries a [`Loc`] with 1-based line and
-//! column, so error messages in later phases (parser, compiler)
-//! can point at the right character without re-tokenizing.
+//! - **Negative integers** — `INTEGER = /-?[0-9]+/` requires a digit,
+//!   so `-1` is one token while a bare `-` matches nothing and is a lex
+//!   error.  That *is* McCarthy 1.0's "no operator symbols" rule.
+//! - **All-uppercase symbols** — `SYMBOL = /[A-Z][A-Z0-9-]*/` excludes
+//!   lowercase, so lowercase source is a lex error.
 //!
 //! ## Quick start
 //!
 //! ```
-//! use mccarthy_lisp_lexer::{tokenize, Token};
+//! use mccarthy_lisp_lexer::tokenize_mccarthy;
 //!
 //! // The canonical "first Lisp program" — McCarthy 1960 §3.
-//! let toks = tokenize("(CAR '(A B C))").expect("tokenize");
-//! let kinds: Vec<&Token> = toks.iter().map(|t| &t.tok).collect();
-//! assert_eq!(kinds, vec![
-//!     &Token::LParen,
-//!     &Token::Symbol("CAR".into()),
-//!     &Token::Quote,
-//!     &Token::LParen,
-//!     &Token::Symbol("A".into()),
-//!     &Token::Symbol("B".into()),
-//!     &Token::Symbol("C".into()),
-//!     &Token::RParen,
-//!     &Token::RParen,
-//! ]);
+//! let toks = tokenize_mccarthy("(CAR '(A B C))").expect("tokenize");
+//! let names: Vec<&str> = toks
+//!     .iter()
+//!     .map(|t| t.effective_type_name())
+//!     .collect();
+//! assert_eq!(
+//!     names,
+//!     vec![
+//!         "LPAREN", "SYMBOL", "QUOTE", "LPAREN",
+//!         "SYMBOL", "SYMBOL", "SYMBOL", "RPAREN", "RPAREN", "EOF",
+//!     ]
+//! );
 //! ```
 
-use std::fmt;
+#![warn(missing_docs)]
 
-// ===========================================================================
-// Token + Loc
-// ===========================================================================
+use std::sync::OnceLock;
 
-/// A McCarthy 1960 Lisp token kind.
+use grammar_tools::token_grammar::TokenGrammar;
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+// Re-export the shared token types so callers (notably
+// `mccarthy-lisp-parser`) can name them without taking a direct
+// dependency on the `lexer` crate.
+pub use lexer::token::{LexerError, Token as LispToken, TokenType};
+
+// ---------------------------------------------------------------------------
+// Build-time-compiled token grammar
+// ---------------------------------------------------------------------------
+//
+// `build.rs` writes `$OUT_DIR/mccarthy_lisp_token_grammar.rs`, whose
+// body defines `pub fn token_grammar() -> TokenGrammar` from native
+// struct literals.  We `include!` it inside a private module and cache
+// the result in a `OnceLock` so the `Vec`/`HashMap` construction runs
+// at most once per process — every `tokenize_mccarthy` call after the
+// first is a pointer load.
+
+mod generated_grammar {
+    include!(concat!(env!("OUT_DIR"), "/mccarthy_lisp_token_grammar.rs"));
+}
+
+static MCCARTHY_TOKEN_GRAMMAR: OnceLock<TokenGrammar> = OnceLock::new();
+
+fn mccarthy_token_grammar() -> &'static TokenGrammar {
+    MCCARTHY_TOKEN_GRAMMAR.get_or_init(generated_grammar::token_grammar)
+}
+
+/// Borrow the build-time-compiled McCarthy Lisp [`TokenGrammar`].
 ///
-/// Six variants — that's the entire grammar at the lexer level.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Token {
-    /// `(`
-    LParen,
-    /// `)`
-    RParen,
-    /// `'` — quote sugar; the parser expands to `(QUOTE …)`.
-    Quote,
-    /// `.` — dotted-pair separator: `(A . B)`.
-    Dot,
-    /// All-uppercase atom: `[A-Z][A-Z0-9-]*`.
-    Symbol(String),
-    /// Signed decimal integer: `-?[0-9]+`.
-    Int(i64),
+/// Exposed for tooling (LSP servers, syntax-highlight generators) that
+/// wants to introspect the token set without re-parsing the canonical
+/// `.tokens` file — which is a build-time-only artifact and is not
+/// shipped at runtime.
+pub fn mccarthy_token_grammar_spec() -> &'static TokenGrammar {
+    mccarthy_token_grammar()
 }
 
-impl fmt::Display for Token {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Token::LParen => write!(f, "("),
-            Token::RParen => write!(f, ")"),
-            Token::Quote => write!(f, "'"),
-            Token::Dot => write!(f, "."),
-            Token::Symbol(s) => write!(f, "{s}"),
-            Token::Int(n) => write!(f, "{n}"),
-        }
-    }
-}
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
-/// 1-based source location of a token.
+/// Construct a [`GrammarLexer`] over a McCarthy Lisp source string.
 ///
-/// Line and column are 1-indexed so error messages match how IDEs,
-/// editors, and the original Lisp 1.5 manual numbered their listings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Loc {
-    /// 1-based line number (`\n` increments).
-    pub line: usize,
-    /// 1-based column number (resets on `\n`).
-    pub column: usize,
+/// Most callers want [`tokenize_mccarthy`]; reach for this when you
+/// need the lexer object itself (e.g. for incremental / streaming use).
+pub fn create_mccarthy_lexer(source: &str) -> GrammarLexer<'_> {
+    GrammarLexer::new(source, mccarthy_token_grammar())
 }
-
-impl Loc {
-    /// First character of the source — line 1, column 1.
-    pub const START: Loc = Loc { line: 1, column: 1 };
-}
-
-impl fmt::Display for Loc {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.line, self.column)
-    }
-}
-
-/// A token plus the source location it started at.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TokenWithLoc {
-    /// The token kind + payload.
-    pub tok: Token,
-    /// Where the token started in the source.
-    pub loc: Loc,
-}
-
-// ===========================================================================
-// Errors
-// ===========================================================================
-
-/// Errors the lexer can report.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LexError {
-    /// A character that's not part of any Lisp 1.0 token.
-    ///
-    /// Carries the offending byte (the character casted to `u8`), the
-    /// source location, and a short human reason.
-    InvalidByte {
-        /// The byte that broke tokenization.
-        byte: u8,
-        /// Where in the source it appeared.
-        loc: Loc,
-        /// Human-readable explanation.
-        reason: &'static str,
-    },
-    /// A `-` not followed by a digit.
-    ///
-    /// Lisp 1.0 has no operator symbols, so a bare `-` is meaningless.
-    LoneMinus {
-        /// Where the `-` appeared.
-        loc: Loc,
-    },
-    /// An integer literal that didn't fit in `i64`.
-    ///
-    /// The 1960 paper didn't bound integer sizes; we use Rust's
-    /// `i64` for parity with the rest of the IIR pipeline (`Operand::Int`
-    /// is `i64`).
-    IntegerOverflow {
-        /// The numeric text that overflowed.
-        text: String,
-        /// Where it appeared in the source.
-        loc: Loc,
-    },
-    /// A lowercase letter.
-    ///
-    /// McCarthy 1960 Lisp is all-uppercase.  Lowercase letters are
-    /// reserved for future Lisp 1.5+ extension by this crate.
-    LowercaseInSymbol {
-        /// The lowercase byte we saw.
-        byte: u8,
-        /// Where it appeared.
-        loc: Loc,
-    },
-}
-
-impl fmt::Display for LexError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LexError::InvalidByte { byte, loc, reason } => write!(
-                f,
-                "lex error at {loc}: invalid byte 0x{byte:02X} ({}) — {reason}",
-                escape_byte(*byte)
-            ),
-            LexError::LoneMinus { loc } => write!(
-                f,
-                "lex error at {loc}: `-` is not a valid Lisp 1.0 token \
-                 (no operator symbols); use as part of a signed integer like `-42`"
-            ),
-            LexError::IntegerOverflow { text, loc } => write!(
-                f,
-                "lex error at {loc}: integer literal {text:?} overflows i64"
-            ),
-            LexError::LowercaseInSymbol { byte, loc } => write!(
-                f,
-                "lex error at {loc}: lowercase {:?} — McCarthy 1960 Lisp is \
-                 all-uppercase; write symbols in CAPS",
-                *byte as char
-            ),
-        }
-    }
-}
-
-impl std::error::Error for LexError {}
-
-fn escape_byte(b: u8) -> String {
-    if b.is_ascii_graphic() {
-        (b as char).to_string()
-    } else {
-        format!("\\x{b:02X}")
-    }
-}
-
-// ===========================================================================
-// Tokenizer
-// ===========================================================================
 
 /// Tokenize a McCarthy 1960 Lisp source string.
 ///
-/// Returns the token stream plus per-token source locations.
-/// Whitespace and `;` line comments are skipped (no token emitted).
+/// Returns the full token stream including the trailing `EOF` token, as
+/// produced by the shared [`GrammarLexer`].  Whitespace and `;` line
+/// comments are skipped.
 ///
 /// # Errors
 ///
-/// See [`LexError`].  The lexer fails fast on the first offending
-/// byte and reports its location.
-pub fn tokenize(src: &str) -> Result<Vec<TokenWithLoc>, LexError> {
-    let bytes = src.as_bytes();
-    let mut out: Vec<TokenWithLoc> = Vec::new();
-    let mut i: usize = 0;
-    let mut line: usize = 1;
-    let mut col: usize = 1;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-        let loc = Loc { line, column: col };
-
-        // ----- Whitespace ------------------------------------------------
-        if matches!(b, b' ' | b'\t' | b'\r') {
-            i += 1;
-            col += 1;
-            continue;
-        }
-        if b == b'\n' {
-            i += 1;
-            line += 1;
-            col = 1;
-            continue;
-        }
-
-        // ----- Line comment (Lisp 1.5 convenience) -----------------------
-        if b == b';' {
-            while i < bytes.len() && bytes[i] != b'\n' {
-                i += 1;
-                col += 1;
-            }
-            continue;
-        }
-
-        // ----- Single-character punctuation ------------------------------
-        match b {
-            b'(' => {
-                out.push(TokenWithLoc { tok: Token::LParen, loc });
-                i += 1;
-                col += 1;
-                continue;
-            }
-            b')' => {
-                out.push(TokenWithLoc { tok: Token::RParen, loc });
-                i += 1;
-                col += 1;
-                continue;
-            }
-            b'\'' => {
-                out.push(TokenWithLoc { tok: Token::Quote, loc });
-                i += 1;
-                col += 1;
-                continue;
-            }
-            b'.' => {
-                out.push(TokenWithLoc { tok: Token::Dot, loc });
-                i += 1;
-                col += 1;
-                continue;
-            }
-            _ => {}
-        }
-
-        // ----- Negative integer ------------------------------------------
-        // `-` is only valid as the sign of an integer.  A bare `-` (not
-        // followed by a digit) is a lex error: Lisp 1.0 has no operator
-        // symbols.
-        if b == b'-' {
-            let next = bytes.get(i + 1).copied();
-            if !matches!(next, Some(d) if d.is_ascii_digit()) {
-                return Err(LexError::LoneMinus { loc });
-            }
-            let (text, end) = read_int_literal(bytes, i);
-            let parsed: i64 = text.parse().map_err(|_| LexError::IntegerOverflow {
-                text: text.clone(),
-                loc,
-            })?;
-            out.push(TokenWithLoc { tok: Token::Int(parsed), loc });
-            col += end - i;
-            i = end;
-            continue;
-        }
-
-        // ----- Unsigned integer ------------------------------------------
-        if b.is_ascii_digit() {
-            let (text, end) = read_int_literal(bytes, i);
-            let parsed: i64 = text.parse().map_err(|_| LexError::IntegerOverflow {
-                text: text.clone(),
-                loc,
-            })?;
-            out.push(TokenWithLoc { tok: Token::Int(parsed), loc });
-            col += end - i;
-            i = end;
-            continue;
-        }
-
-        // ----- Symbol -----------------------------------------------------
-        // McCarthy 1960 symbols: leading uppercase letter, then
-        // uppercase letters / digits / hyphens.
-        if b.is_ascii_uppercase() {
-            let (text, end) = read_symbol(bytes, i)?;
-            out.push(TokenWithLoc { tok: Token::Symbol(text), loc });
-            col += end - i;
-            i = end;
-            continue;
-        }
-
-        // ----- Caught lowercase explicitly -------------------------------
-        if b.is_ascii_lowercase() {
-            return Err(LexError::LowercaseInSymbol { byte: b, loc });
-        }
-
-        // ----- Otherwise — invalid byte ----------------------------------
-        return Err(LexError::InvalidByte {
-            byte: b,
-            loc,
-            reason: "not a valid Lisp 1.0 character",
-        });
-    }
-
-    Ok(out)
+/// Returns [`LexerError`] on the first byte that matches no token rule —
+/// e.g. a lowercase letter, a bare `-`, or any non-Lisp character.  The
+/// error carries the 1-based line and column.
+pub fn tokenize_mccarthy(source: &str) -> Result<Vec<Token>, LexerError> {
+    create_mccarthy_lexer(source).tokenize()
 }
 
-/// Read a digit-only span starting at `start`.  Includes a leading `-`
-/// if the caller has already verified the next byte is a digit.
-fn read_int_literal(bytes: &[u8], start: usize) -> (String, usize) {
-    let mut i = start;
-    if bytes.get(i) == Some(&b'-') {
-        i += 1;
-    }
-    while i < bytes.len() && bytes[i].is_ascii_digit() {
-        i += 1;
-    }
-    // SAFETY: every byte in [start, i) is ASCII (`-` or digit), so the
-    // slice is valid UTF-8.  Using `from_utf8` keeps the implementation
-    // safe-only.
-    let text = std::str::from_utf8(&bytes[start..i])
-        .expect("ASCII digits + optional leading `-` are valid UTF-8")
-        .to_string();
-    (text, i)
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-/// Read a symbol starting at `start`.  Leading byte must be ASCII
-/// uppercase; subsequent bytes may be uppercase / digits / hyphens.
-fn read_symbol(bytes: &[u8], start: usize) -> Result<(String, usize), LexError> {
-    let mut i = start;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'-' {
-            i += 1;
-        } else if b.is_ascii_lowercase() {
-            // Pinpoint a lowercase byte mid-symbol with its own location.
-            // Re-compute the location by walking line/column from start —
-            // for the symbol case the symbol is short, so this is cheap.
-            // The exposed `tokenize` caller doesn't need our internal
-            // line/col; we just report the byte.
-            return Err(LexError::LowercaseInSymbol {
-                byte: b,
-                // Without re-threading line/col, fall back to a marker
-                // location pointing at start.  Callers can still find
-                // the offending symbol by name in the source.
-                loc: Loc { line: 0, column: start + 1 },
-            });
-        } else {
-            break;
-        }
+    /// Token names (minus the trailing EOF) for a source string.
+    fn names(src: &str) -> Vec<String> {
+        let toks = tokenize_mccarthy(src).expect("tokenize");
+        toks.iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.effective_type_name().to_string())
+            .collect()
     }
-    let text = std::str::from_utf8(&bytes[start..i])
-        .expect("uppercase ASCII + digits + hyphen are valid UTF-8")
-        .to_string();
-    Ok((text, i))
+
+    #[test]
+    fn tokenizes_the_canonical_car_example() {
+        assert_eq!(
+            names("(CAR '(A B C))"),
+            vec![
+                "LPAREN", "SYMBOL", "QUOTE", "LPAREN", "SYMBOL", "SYMBOL", "SYMBOL", "RPAREN",
+                "RPAREN",
+            ]
+        );
+    }
+
+    #[test]
+    fn values_are_preserved() {
+        let toks = tokenize_mccarthy("(CONS A NIL)").unwrap();
+        let values: Vec<&str> = toks
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(values, vec!["(", "CONS", "A", "NIL", ")"]);
+    }
+
+    #[test]
+    fn negative_integers_are_one_token() {
+        assert_eq!(names("-42"), vec!["INTEGER"]);
+        let toks = tokenize_mccarthy("-42").unwrap();
+        assert_eq!(toks[0].value, "-42");
+    }
+
+    #[test]
+    fn dotted_pair_separator() {
+        assert_eq!(names("(A . B)"), vec!["LPAREN", "SYMBOL", "DOT", "SYMBOL", "RPAREN"]);
+    }
+
+    #[test]
+    fn hyphenated_symbol_is_one_token() {
+        assert_eq!(names("LIST-OF-3"), vec!["SYMBOL"]);
+        assert_eq!(tokenize_mccarthy("LIST-OF-3").unwrap()[0].value, "LIST-OF-3");
+    }
+
+    #[test]
+    fn comments_and_whitespace_are_skipped() {
+        assert_eq!(names("  CAR ; take the head\n  CDR"), vec!["SYMBOL", "SYMBOL"]);
+    }
+
+    #[test]
+    fn bare_minus_is_a_lex_error() {
+        // No operator symbols in Lisp 1.0 — a lone `-` matches no rule.
+        assert!(tokenize_mccarthy("(- A B)").is_err());
+    }
+
+    #[test]
+    fn lowercase_is_a_lex_error() {
+        // McCarthy 1960 Lisp is all-uppercase.
+        assert!(tokenize_mccarthy("car").is_err());
+    }
+
+    #[test]
+    fn position_tracking_is_one_based() {
+        let toks = tokenize_mccarthy("CAR\n CDR").unwrap();
+        assert_eq!((toks[0].line, toks[0].column), (1, 1));
+        assert_eq!((toks[1].line, toks[1].column), (2, 2));
+    }
+
+    #[test]
+    fn empty_source_yields_only_eof() {
+        let toks = tokenize_mccarthy("   ; just a comment\n").unwrap();
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].type_, TokenType::Eof);
+    }
+
+    #[test]
+    fn grammar_spec_is_accessible() {
+        let names: Vec<&str> = mccarthy_token_grammar_spec()
+            .definitions
+            .iter()
+            .map(|d| d.name.as_str())
+            .collect();
+        assert!(names.contains(&"SYMBOL"));
+        assert!(names.contains(&"INTEGER"));
+    }
 }

--- a/code/packages/rust/mccarthy-lisp-lexer/tests/test_lexer.rs
+++ b/code/packages/rust/mccarthy-lisp-lexer/tests/test_lexer.rs
@@ -1,15 +1,30 @@
 //! Integration tests for `mccarthy-lisp-lexer`.
 //!
-//! Test groups:
-//!   1. Single-token shapes
-//!   2. Canonical McCarthy 1960 paper expressions
-//!   3. Whitespace + comments
-//!   4. Error paths
+//! Since this crate is a thin wrapper over the shared, separately-tested
+//! `GrammarLexer`, these tests focus on the *McCarthy dialect contract*
+//! that lives in `code/grammars/mccarthy_lisp.tokens`:
+//!
+//!   1. Each token kind is recognised with the right name + value.
+//!   2. The canonical McCarthy 1960 paper expressions tokenize cleanly.
+//!   3. Whitespace and `;` comments are skipped.
+//!   4. The dialect restrictions (no lowercase, no operator symbols)
+//!      surface as lex errors.
 
-use mccarthy_lisp_lexer::{tokenize, LexError, Loc, Token};
+use mccarthy_lisp_lexer::{tokenize_mccarthy, TokenType};
 
-fn toks(src: &str) -> Vec<Token> {
-    tokenize(src).expect("tokenize").into_iter().map(|t| t.tok).collect()
+/// Token (name, value) pairs, excluding the trailing EOF.
+fn pairs(src: &str) -> Vec<(String, String)> {
+    tokenize_mccarthy(src)
+        .expect("tokenize")
+        .into_iter()
+        .filter(|t| t.type_ != TokenType::Eof)
+        .map(|t| (t.effective_type_name().to_string(), t.value))
+        .collect()
+}
+
+/// Just the token names, excluding EOF.
+fn names(src: &str) -> Vec<String> {
+    pairs(src).into_iter().map(|(n, _)| n).collect()
 }
 
 // ============================================================
@@ -17,54 +32,29 @@ fn toks(src: &str) -> Vec<Token> {
 // ============================================================
 
 #[test]
-fn lparen_alone() {
-    assert_eq!(toks("("), vec![Token::LParen]);
+fn single_tokens() {
+    assert_eq!(names("("), vec!["LPAREN"]);
+    assert_eq!(names(")"), vec!["RPAREN"]);
+    assert_eq!(names("'"), vec!["QUOTE"]);
+    assert_eq!(names("."), vec!["DOT"]);
+    assert_eq!(names("CAR"), vec!["SYMBOL"]);
+    assert_eq!(names("42"), vec!["INTEGER"]);
 }
 
 #[test]
-fn rparen_alone() {
-    assert_eq!(toks(")"), vec![Token::RParen]);
+fn integer_values_round_trip() {
+    assert_eq!(pairs("0"), vec![("INTEGER".into(), "0".into())]);
+    assert_eq!(pairs("42"), vec![("INTEGER".into(), "42".into())]);
+    assert_eq!(pairs("-1"), vec![("INTEGER".into(), "-1".into())]);
 }
 
 #[test]
-fn quote_alone() {
-    assert_eq!(toks("'"), vec![Token::Quote]);
-}
-
-#[test]
-fn dot_alone() {
-    assert_eq!(toks("."), vec![Token::Dot]);
-}
-
-#[test]
-fn single_symbol_uppercase() {
-    assert_eq!(toks("CAR"), vec![Token::Symbol("CAR".into())]);
-}
-
-#[test]
-fn symbol_with_digit_and_hyphen() {
-    assert_eq!(toks("X-1"), vec![Token::Symbol("X-1".into())]);
-}
-
-#[test]
-fn single_int_zero() {
-    assert_eq!(toks("0"), vec![Token::Int(0)]);
-}
-
-#[test]
-fn single_int_positive() {
-    assert_eq!(toks("42"), vec![Token::Int(42)]);
-}
-
-#[test]
-fn single_int_negative() {
-    assert_eq!(toks("-42"), vec![Token::Int(-42)]);
-}
-
-#[test]
-fn single_int_large() {
-    // McCarthy didn't bound integer size; we cap at i64::MAX.
-    assert_eq!(toks("9223372036854775807"), vec![Token::Int(i64::MAX)]);
+fn symbol_values_round_trip() {
+    assert_eq!(pairs("CAR"), vec![("SYMBOL".into(), "CAR".into())]);
+    assert_eq!(pairs("FF"), vec![("SYMBOL".into(), "FF".into())]);
+    assert_eq!(pairs("LIST-OF-3"), vec![("SYMBOL".into(), "LIST-OF-3".into())]);
+    // Digits are allowed inside (but not at the start of) a symbol.
+    assert_eq!(pairs("A1"), vec![("SYMBOL".into(), "A1".into())]);
 }
 
 // ============================================================
@@ -72,78 +62,34 @@ fn single_int_large() {
 // ============================================================
 
 #[test]
-fn car_of_quoted_list() {
-    // (CAR '(A B C)) — McCarthy 1960, §3 example 1.
+fn car_of_a_literal_list() {
     assert_eq!(
-        toks("(CAR '(A B C))"),
-        vec![
-            Token::LParen,
-            Token::Symbol("CAR".into()),
-            Token::Quote,
-            Token::LParen,
-            Token::Symbol("A".into()),
-            Token::Symbol("B".into()),
-            Token::Symbol("C".into()),
-            Token::RParen,
-            Token::RParen,
-        ]
+        names("(CAR '(A B C))"),
+        vec!["LPAREN", "SYMBOL", "QUOTE", "LPAREN", "SYMBOL", "SYMBOL", "SYMBOL", "RPAREN", "RPAREN"]
     );
 }
 
 #[test]
-fn identity_lambda() {
-    // (LAMBDA (X) X) — McCarthy 1960, §5.
+fn the_identity_lambda() {
     assert_eq!(
-        toks("(LAMBDA (X) X)"),
-        vec![
-            Token::LParen,
-            Token::Symbol("LAMBDA".into()),
-            Token::LParen,
-            Token::Symbol("X".into()),
-            Token::RParen,
-            Token::Symbol("X".into()),
-            Token::RParen,
-        ]
+        names("(LAMBDA (X) X)"),
+        vec!["LPAREN", "SYMBOL", "LPAREN", "SYMBOL", "RPAREN", "SYMBOL", "RPAREN"]
     );
 }
 
 #[test]
-fn label_named_recursion() {
-    // (LABEL FF (LAMBDA (X) (COND ((ATOM X) X) (T (FF (CAR X)))))) — McCarthy 1960, §6.
-    let toks = toks("(LABEL FF (LAMBDA (X) (COND ((ATOM X) X) (T (FF (CAR X))))))");
-    // 30 tokens — confirm the count rather than re-write the full vec.
-    assert_eq!(toks.len(), 30);
-    assert_eq!(toks[0], Token::LParen);
-    assert_eq!(toks[1], Token::Symbol("LABEL".into()));
-    assert_eq!(toks[2], Token::Symbol("FF".into()));
+fn a_dotted_pair() {
+    assert_eq!(names("(A . B)"), vec!["LPAREN", "SYMBOL", "DOT", "SYMBOL", "RPAREN"]);
 }
 
 #[test]
-fn cons_of_two_atoms() {
+fn the_label_recursive_definition_header() {
+    // (LABEL FF (LAMBDA (X) ...)) — just the token shape of the header.
     assert_eq!(
-        toks("(CONS 'A 'B)"),
+        names("(LABEL FF (LAMBDA (X) X))"),
         vec![
-            Token::LParen,
-            Token::Symbol("CONS".into()),
-            Token::Quote,
-            Token::Symbol("A".into()),
-            Token::Quote,
-            Token::Symbol("B".into()),
-            Token::RParen,
-        ]
-    );
-}
-
-#[test]
-fn dotted_pair_literal() {
-    assert_eq!(
-        toks("(A . B)"),
-        vec![
-            Token::LParen,
-            Token::Symbol("A".into()),
-            Token::Dot,
-            Token::Symbol("B".into()),
-            Token::RParen,
+            "LPAREN", "SYMBOL", "SYMBOL", "LPAREN", "SYMBOL", "LPAREN", "SYMBOL", "RPAREN",
+            "SYMBOL", "RPAREN", "RPAREN"
         ]
     );
 }
@@ -153,80 +99,40 @@ fn dotted_pair_literal() {
 // ============================================================
 
 #[test]
-fn empty_source_yields_nothing() {
-    assert_eq!(toks(""), Vec::<Token>::new());
+fn comments_are_skipped() {
+    assert_eq!(names("CAR ; comment\nCDR"), vec!["SYMBOL", "SYMBOL"]);
 }
 
 #[test]
-fn whitespace_only() {
-    assert_eq!(toks("   \t\n  \r\n  "), Vec::<Token>::new());
+fn newlines_and_tabs_are_skipped() {
+    assert_eq!(names("\t( A\n\tB )"), vec!["LPAREN", "SYMBOL", "SYMBOL", "RPAREN"]);
 }
 
 #[test]
-fn comment_to_end_of_line() {
-    assert_eq!(
-        toks("; this is a comment\nCAR"),
-        vec![Token::Symbol("CAR".into())]
-    );
-}
-
-#[test]
-fn comment_at_eof_no_newline() {
-    assert_eq!(toks("X ; trailing"), vec![Token::Symbol("X".into())]);
+fn only_whitespace_and_comments_is_empty() {
+    assert!(names("  \n ; nothing here\n").is_empty());
 }
 
 // ============================================================
-// 4. Locations
+// 4. Dialect-restriction error paths
 // ============================================================
 
 #[test]
-fn first_token_starts_at_1_1() {
-    let toks = tokenize("(CAR X)").expect("tokenize");
-    assert_eq!(toks[0].loc, Loc { line: 1, column: 1 });
-    assert_eq!(toks[1].loc, Loc { line: 1, column: 2 });
+fn lowercase_symbol_rejected() {
+    assert!(tokenize_mccarthy("car").is_err());
+    assert!(tokenize_mccarthy("(CAR x)").is_err());
 }
 
 #[test]
-fn newline_advances_line() {
-    let toks = tokenize("(\nCAR)").expect("tokenize");
-    assert_eq!(toks[0].loc, Loc { line: 1, column: 1 });
-    assert_eq!(toks[1].loc, Loc { line: 2, column: 1 });
-}
-
-// ============================================================
-// 5. Error paths
-// ============================================================
-
-#[test]
-fn lone_minus_is_lex_error() {
-    let err = tokenize("(- X)").expect_err("`-` is not a valid Lisp 1.0 token");
-    assert!(matches!(err, LexError::LoneMinus { .. }));
+fn bare_operator_symbols_rejected() {
+    // Lisp 1.0 has no operator symbols — these all match no token rule.
+    assert!(tokenize_mccarthy("+").is_err());
+    assert!(tokenize_mccarthy("-").is_err());
+    assert!(tokenize_mccarthy("<=").is_err());
 }
 
 #[test]
-fn lowercase_is_lex_error() {
-    let err = tokenize("car").expect_err("lowercase not allowed");
-    assert!(matches!(err, LexError::LowercaseInSymbol { .. }));
-}
-
-#[test]
-fn unknown_byte_is_lex_error() {
-    // `+` is an operator symbol — Lisp 1.0 has none.
-    let err = tokenize("+").expect_err("`+` is not a valid Lisp 1.0 token");
-    assert!(matches!(err, LexError::InvalidByte { .. }));
-}
-
-#[test]
-fn integer_overflow_is_caught() {
-    // i64::MAX + 1
-    let err = tokenize("9223372036854775808").expect_err("overflow");
-    assert!(matches!(err, LexError::IntegerOverflow { .. }));
-}
-
-#[test]
-fn error_display_includes_location() {
-    let err = tokenize("(- X)").expect_err("lone minus");
-    let msg = format!("{err}");
-    assert!(msg.contains("1:2"), "expected 1:2 in {msg}");
-    assert!(msg.contains("not a valid Lisp 1.0 token"), "{msg}");
+fn strings_are_rejected() {
+    // No string literals in Lisp 1.0 — the `"` matches nothing.
+    assert!(tokenize_mccarthy("\"hello\"").is_err());
 }

--- a/code/packages/rust/mccarthy-lisp-parser/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-parser/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog — mccarthy-lisp-parser
 
+## v0.2.0 — 2026-06-03 — grammar-driven rewrite (L1)
+
+**Breaking:** replaced the hand-written recursive-descent parser with a
+thin wrapper over the shared `GrammarParser` plus a CST → typed-AST
+extractor.  The S-expression grammar now lives in
+`code/grammars/mccarthy_lisp.grammar`, compiled to Rust at build time
+via a `build.rs` (the `twig-parser` pattern).
+
+* The `LispExpr` AST (`Nil`, `Symbol`, `Int`, `Cons`) and its helpers
+  (`sym`, `list`, `quote`, `Display`) are **unchanged** — downstream L2
+  consumes the same shape.
+* Sugar expansions (`'X` → `(QUOTE X)`, list nesting via NIL
+  terminator, direct dotted-pair `Cons`) are preserved, now applied in
+  the extractor.
+* **Structural validation moved into the grammar.**  The bespoke
+  `ParseError` variants (`StrayDot`, `MultipleDotsInList`,
+  `DotWithoutCdr`, `ExtraAfterDottedTail`, `UnexpectedToken`,
+  `UnexpectedEof`, `NestingTooDeep`) are gone; malformed dotted forms
+  and unbalanced parens are now rejected by the `GrammarParser`
+  itself.  `ParseError` is a flat `{ message, line, column }` struct
+  (the `twig-parser` shape).
+* **API changes:**
+  * `parse(src) -> Result<Vec<LispExpr>, ParseError>` — unchanged
+    signature.
+  * **Added** `parse_to_cst`, `extract_program`,
+    `create_mccarthy_parser_from_tokens`, `mccarthy_grammar`.
+  * **Removed** `parse_tokens` (the lexer no longer produces the old
+    `TokenWithLoc`; use `parse` or `create_mccarthy_parser_from_tokens`).
+* **DoS hardening retained:** `MAX_PAREN_DEPTH` is now **64** (down from
+  256) because the shared `GrammarParser` uses far more stack per paren
+  than the old hand-written descent did; sources deeper than that are
+  rejected before parsing.  A second `MAX_AST_DEPTH` guard bounds the
+  extractor.  Integer overflow remains a `ParseError`, not a panic.
+* New deps: `grammar-tools`, `lexer`, `parser` (+ `grammar-tools`
+  build-dep); still depends on `mccarthy-lisp-lexer`.
+
 ## v0.1.0 — 2026-06-03 — initial release (L1)
 
 McCarthy 1960 Lisp parser.

--- a/code/packages/rust/mccarthy-lisp-parser/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-parser/CHANGELOG.md
@@ -28,11 +28,19 @@ via a `build.rs` (the `twig-parser` pattern).
     `create_mccarthy_parser_from_tokens`, `mccarthy_grammar`.
   * **Removed** `parse_tokens` (the lexer no longer produces the old
     `TokenWithLoc`; use `parse` or `create_mccarthy_parser_from_tokens`).
-* **DoS hardening retained:** `MAX_PAREN_DEPTH` is now **64** (down from
-  256) because the shared `GrammarParser` uses far more stack per paren
-  than the old hand-written descent did; sources deeper than that are
-  rejected before parsing.  A second `MAX_AST_DEPTH` guard bounds the
-  extractor.  Integer overflow remains a `ParseError`, not a panic.
+* **DoS hardening retained and corrected:** `MAX_PAREN_DEPTH` is now
+  **64** (down from 256) because the shared `GrammarParser` uses far
+  more stack per nesting level than the old hand-written descent did.
+  The pre-parse guard (`check_nesting_depth`) bounds the *combined*
+  paren **and** pending-quote nesting depth — an important fix over a
+  first draft of this rewrite, which counted only parens: a long quote
+  chain (`''''…X`) has paren-depth 0 but unbounded `quoted = QUOTE
+  sexpr` recursion, so a ~5 KB all-`'` input would overflow the stack
+  and abort the process (the shared `GrammarParser` has no internal
+  recursion limit).  Both deep-paren and quote-chain inputs are now
+  rejected with a clean `ParseError` (regression-tested).  A second
+  `MAX_AST_DEPTH` guard bounds the extractor.  Integer overflow remains
+  a `ParseError`, not a panic.
 * New deps: `grammar-tools`, `lexer`, `parser` (+ `grammar-tools`
   build-dep); still depends on `mccarthy-lisp-lexer`.
 

--- a/code/packages/rust/mccarthy-lisp-parser/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-parser/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "mccarthy-lisp-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Parser for McCarthy's 1960 Lisp (Lisp 1.0) — turns the `mccarthy-lisp-lexer` token stream into an S-expression AST (Nil / Symbol / Int / Cons).  Expands `'X` to `(QUOTE X)` and `(A . B)` to dotted pairs.  L1 of the McCarthy Lisp implementation."
+description = "Parser for McCarthy's 1960 Lisp (Lisp 1.0) — a thin wrapper over the shared grammar-driven GrammarParser plus a typed-AST extractor.  The S-expression grammar lives in `code/grammars/mccarthy_lisp.grammar` (compiled to Rust at build time); the extractor lowers the generic CST to a `LispExpr` AST (Nil / Symbol / Int / Cons), expanding `'X` to `(QUOTE X)` and desugaring lists to cons cells.  L1 of the McCarthy Lisp implementation."
+build = "build.rs"
 
 [lib]
 name = "mccarthy_lisp_parser"
 path = "src/lib.rs"
 
 [dependencies]
+grammar-tools       = { path = "../grammar-tools" }
+lexer               = { path = "../lexer" }
+parser              = { path = "../parser" }
 mccarthy-lisp-lexer = { path = "../mccarthy-lisp-lexer" }
+
+[build-dependencies]
+grammar-tools = { path = "../grammar-tools" }

--- a/code/packages/rust/mccarthy-lisp-parser/README.md
+++ b/code/packages/rust/mccarthy-lisp-parser/README.md
@@ -5,10 +5,24 @@ Parser for **McCarthy's 1960 Lisp** (Lisp 1.0).
 L1 of the McCarthy Lisp implementation — see
 [`MCCARTHY-LISP-PLAN.md`](../../../specs/MCCARTHY-LISP-PLAN.md).
 
-## What it does
+## Grammar-driven — the parser comes "for free"
 
-Turns the token stream from `mccarthy-lisp-lexer` into an
-S-expression AST shaped exactly like McCarthy's 1960 definition:
+This crate does **not** hand-write a recursive-descent parser.  The
+S-expression grammar lives in
+[`code/grammars/mccarthy_lisp.grammar`](../../../grammars/mccarthy_lisp.grammar),
+which `build.rs` compiles to Rust at build time.  Parsing is two
+stages — the `twig-parser` pattern:
+
+1. **Grammar parse** — the shared [`GrammarParser`](../parser) turns
+   the token stream into a generic concrete syntax tree
+   (`GrammarASTNode`).  All structural rules — balanced parens,
+   at-most-one dotted tail, "a dot must follow an element" — are
+   enforced *by the grammar*, so there is no hand-written validation to
+   drift out of sync.
+2. **AST extraction** — a small extractor lowers that CST into the
+   typed `LispExpr` tree below, applying the sugar expansions.
+
+## AST
 
 ```rust
 enum LispExpr {
@@ -19,16 +33,38 @@ enum LispExpr {
 }
 ```
 
-Two sugar expansions happen at parse time:
+Two sugar expansions happen during extraction:
 
 * `'X` → `(QUOTE X)`
-* `(A B C)` → `(A . (B . (C . NIL)))` — the standard list-as-nested-pairs encoding from McCarthy 1960 §2.
+* `(A B C)` → `(A . (B . (C . NIL)))` — the standard
+  list-as-nested-pairs encoding from McCarthy 1960 §2.
 
-A dotted-pair literal `(A . B)` parses directly to `Cons(Symbol("A"), Symbol("B"))` — no NIL terminator.
+A dotted-pair literal `(A . B)` extracts directly to
+`Cons(Symbol("A"), Symbol("B"))` — no NIL terminator.
+
+### NIL vs ()
+
+The *symbol* `NIL` and the empty list `()` are kept distinct at this
+layer: `()` → `LispExpr::Nil`, while a literal `NIL` token →
+`Symbol("NIL")`.  Unifying them (as real Lisp does) is a semantic
+decision deferred to the L2 `mccarthy-lisp-iir-compiler`.
 
 ## API
 
-* `parse(src) -> Result<Vec<LispExpr>, ParseError>` — top-level convenience.
-* `parse_tokens(toks) -> Result<Vec<LispExpr>, ParseError>` — same, but on an already-tokenized stream.
+* `parse(src) -> Result<Vec<LispExpr>, ParseError>` — tokenize →
+  grammar-parse → extract the typed AST.  A program is zero-or-more
+  top-level S-expressions.
+* `parse_to_cst(src) -> Result<GrammarASTNode, ParseError>` — stop at
+  the generic CST (for tooling / introspection).
+* `extract_program(&GrammarASTNode) -> Result<Vec<LispExpr>, ParseError>`
+  — the CST → AST lowering on its own.
+* `create_mccarthy_parser_from_tokens(tokens) -> GrammarParser`,
+  `mccarthy_grammar() -> &'static ParserGrammar`.
 
-A program is zero-or-more S-expressions (matching McCarthy's "program = sequence of forms" reading).
+## Robustness
+
+`parse` rejects sources whose `(` nesting exceeds `MAX_PAREN_DEPTH`
+(64) *before* invoking the recursive grammar parser, and the extractor
+caps its own recursion at `MAX_AST_DEPTH` — both guard against
+stack-overflow on pathological input.  Integer literals that overflow
+`i64` are a `ParseError`, not a panic.

--- a/code/packages/rust/mccarthy-lisp-parser/build.rs
+++ b/code/packages/rust/mccarthy-lisp-parser/build.rs
@@ -1,0 +1,45 @@
+//! # mccarthy-lisp-parser build script — compile `mccarthy_lisp.grammar` to Rust.
+//!
+//! Mirror of `mccarthy-lisp-lexer/build.rs` for the *parser* grammar.
+//! Reads `code/grammars/mccarthy_lisp.grammar`, parses it via
+//! [`grammar_tools::parser_grammar::parse_parser_grammar`], and runs
+//! [`grammar_tools::compiler::compile_parser_grammar`] to emit Rust
+//! source defining `pub fn parser_grammar() -> ParserGrammar`.  The
+//! output is written to `$OUT_DIR/mccarthy_lisp_parser_grammar.rs`,
+//! which `lib.rs` `include!`s and wraps in a `OnceLock`.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::compile_parser_grammar;
+use grammar_tools::parser_grammar::parse_parser_grammar;
+
+fn main() {
+    let manifest_dir =
+        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo");
+    // code/packages/rust/mccarthy-lisp-parser → ../../../grammars
+    let grammar_path = PathBuf::from(&manifest_dir)
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("grammars")
+        .join("mccarthy_lisp.grammar");
+    let grammar_path = grammar_path.canonicalize().unwrap_or_else(|e| {
+        panic!("Failed to resolve mccarthy_lisp.grammar path {grammar_path:?}: {e}")
+    });
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", grammar_path.display());
+
+    let grammar_text = fs::read_to_string(&grammar_path)
+        .unwrap_or_else(|e| panic!("Failed to read {grammar_path:?}: {e}"));
+    let grammar = parse_parser_grammar(&grammar_text)
+        .unwrap_or_else(|e| panic!("Failed to parse {grammar_path:?}: {e}"));
+
+    let rust = compile_parser_grammar(&grammar, "mccarthy_lisp.grammar");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR must be set by cargo");
+    let out_path = PathBuf::from(&out_dir).join("mccarthy_lisp_parser_grammar.rs");
+    fs::write(&out_path, rust)
+        .unwrap_or_else(|e| panic!("Failed to write {out_path:?}: {e}"));
+}

--- a/code/packages/rust/mccarthy-lisp-parser/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-parser/src/lib.rs
@@ -1,36 +1,46 @@
 //! # `mccarthy-lisp-parser` — S-expression parser for McCarthy Lisp 1.0.
 //!
-//! Turns the token stream from
-//! [`mccarthy_lisp_lexer::tokenize`] into an [`LispExpr`] AST that
+//! Turns McCarthy 1960 Lisp source into a typed [`LispExpr`] AST that
 //! matches McCarthy's 1960 paper definition exactly:
 //!
 //! ```text
-//! e ::= NIL                            ; the empty list
+//! e ::= NIL                            ; the empty list  ()
 //!     | Symbol                         ; FOO, CAR, X
 //!     | Integer                        ; 42, -1, 0
 //!     | (e . e)                        ; dotted pair (cons cell)
 //! ```
 //!
-//! A "list" in McCarthy's paper is a *nested cons cell terminated
-//! by NIL*: the sequence `(A B C)` is sugar for
-//! `(A . (B . (C . NIL)))`.  Our parser performs that desugaring at
-//! parse time — every list literal materialises as `Cons` cells
-//! with a NIL terminator.
+//! A "list" in McCarthy's paper is a *nested cons cell terminated by
+//! NIL*: `(A B C)` is sugar for `(A . (B . (C . NIL)))`.  The
+//! extractor performs that desugaring — every list literal materialises
+//! as [`LispExpr::Cons`] cells with a [`LispExpr::Nil`] terminator.
 //!
-//! Two more sugar expansions happen here:
+//! ## This crate is a *thin wrapper*, not a hand-written parser
 //!
-//! 1. **`'X` → `(QUOTE X)`** — McCarthy 1960 §3 introduces `QUOTE`
-//!    as the way to write a literal S-expression; the apostrophe
-//!    is the standard reader macro since.
-//! 2. **Dotted pair `(A . B)`** parses as `Cons(A, B)` directly,
-//!    *without* a NIL terminator — that's the whole point of the
-//!    dot notation.
+//! The S-expression grammar lives in
+//! [`code/grammars/mccarthy_lisp.grammar`](../../../grammars/mccarthy_lisp.grammar),
+//! which `build.rs` compiles to Rust at build time.  Parsing happens in
+//! two stages — exactly the `twig-parser` pattern (see
+//! [`feedback_no_handwritten_lexers_parsers`]):
 //!
-//! ## A program is a sequence of forms
+//! 1. **Grammar parse** — the shared [`parser::grammar_parser::GrammarParser`]
+//!    turns the token stream into a generic concrete syntax tree
+//!    ([`GrammarASTNode`]).  All the structural rules — balanced parens,
+//!    at-most-one dotted tail, "dot must follow an element" — are
+//!    enforced *here, by the grammar*, so there is no hand-written
+//!    validation to drift out of sync.
+//! 2. **AST extraction** — [`extract_program`] lowers that CST to the
+//!    typed [`LispExpr`] tree, applying the two sugar expansions:
+//!      * `'X` → `(QUOTE X)`
+//!      * `(A B C)` → `(A . (B . (C . NIL)))`
 //!
-//! Like Scheme `(define …) (define …) (main)`, a McCarthy program
-//! is a `Vec<LispExpr>` — top-level forms evaluated in order.  The
-//! parser returns that vector.
+//! ## NIL vs ()
+//!
+//! Like the v0.1 hand-written parser, the *symbol* `NIL` and the empty
+//! list `()` are kept distinct at this layer: `()` extracts to
+//! [`LispExpr::Nil`], while a literal `NIL` token extracts to
+//! `Symbol("NIL")`.  Unifying them (as real Lisp does) is a semantic
+//! decision left to the L2 `mccarthy-lisp-iir-compiler`.
 //!
 //! ## Quick start
 //!
@@ -52,9 +62,15 @@
 //! assert_eq!(prog[0], expected);
 //! ```
 
-use std::fmt;
+#![warn(missing_docs)]
 
-use mccarthy_lisp_lexer::{tokenize, LexError, Loc, Token, TokenWithLoc};
+use std::fmt;
+use std::sync::OnceLock;
+
+use grammar_tools::parser_grammar::ParserGrammar;
+use lexer::token::{Token, TokenType};
+use mccarthy_lisp_lexer::{tokenize_mccarthy, LexerError};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode, GrammarParser};
 
 // ===========================================================================
 // AST
@@ -62,16 +78,16 @@ use mccarthy_lisp_lexer::{tokenize, LexError, Loc, Token, TokenWithLoc};
 
 /// McCarthy 1960 Lisp S-expression.
 ///
-/// Four cases — matches the abstract grammar of the 1960 paper
-/// exactly.  Modern Lisps add strings, vectors, hash tables, etc.;
-/// McCarthy 1.0 has only these four.
+/// Four cases — matches the abstract grammar of the 1960 paper exactly.
+/// Modern Lisps add strings, vectors, hash tables, etc.; McCarthy 1.0
+/// has only these four.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LispExpr {
-    /// `()` — the empty list, also the false value (any other
-    /// value is true under McCarthy's `COND`).
+    /// `()` — the empty list, also the false value (any other value is
+    /// true under McCarthy's `COND`).
     Nil,
-    /// `FOO` — an all-uppercase identifier (interned later as a
-    /// symbol pointer at runtime).
+    /// `FOO` — an all-uppercase identifier (interned later as a symbol
+    /// pointer at runtime).
     Symbol(String),
     /// `42` — a signed 64-bit integer.
     Int(i64),
@@ -96,8 +112,8 @@ impl LispExpr {
         acc
     }
 
-    /// Wrap an expression in `(QUOTE …)` — the standard
-    /// expansion of the `'` reader macro.
+    /// Wrap an expression in `(QUOTE …)` — the standard expansion of the
+    /// `'` reader macro.
     pub fn quote(inner: LispExpr) -> Self {
         LispExpr::list([LispExpr::sym("QUOTE"), inner])
     }
@@ -109,7 +125,7 @@ impl fmt::Display for LispExpr {
             LispExpr::Nil => write!(f, "NIL"),
             LispExpr::Symbol(s) => write!(f, "{s}"),
             LispExpr::Int(n) => write!(f, "{n}"),
-            LispExpr::Cons(car, cdr) => write!(f, "({} . {})", car, cdr),
+            LispExpr::Cons(car, cdr) => write!(f, "({car} . {cdr})"),
         }
     }
 }
@@ -118,278 +134,494 @@ impl fmt::Display for LispExpr {
 // Errors
 // ===========================================================================
 
-/// Errors the parser can report.
+/// A parse-time error.
+///
+/// Wraps any of:
+/// - a lexer failure (invalid character — e.g. lowercase, a bare `-`),
+/// - a [`GrammarParser`] failure (unbalanced paren, stray dot, …),
+/// - an extractor-detected shape problem (integer overflow, depth
+///   limit).
+///
+/// Source positions are 1-indexed and point at the offending token.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ParseError {
-    /// The lexer rejected the source.
-    Lex(LexError),
-    /// Hit end-of-input mid-form (unbalanced open paren).
-    UnexpectedEof {
-        /// Where the open paren started.
-        opened_at: Loc,
-        /// What we were looking for next.
-        expected: &'static str,
-    },
-    /// Saw a token where it doesn't belong.
-    UnexpectedToken {
-        /// The offending token.
-        token: Token,
-        /// Where it appeared.
-        loc: Loc,
-        /// What we expected instead.
-        expected: &'static str,
-    },
-    /// A `.` outside a `(A . B)` form.
-    StrayDot {
-        /// Where the dot appeared.
-        loc: Loc,
-    },
-    /// More than one `.` in a single list — McCarthy 1960 only
-    /// allows one dotted-tail per list.
-    MultipleDotsInList {
-        /// Where the second dot appeared.
-        loc: Loc,
-    },
-    /// `(A . )` — dot without a cdr term.
-    DotWithoutCdr {
-        /// Where the dot appeared.
-        loc: Loc,
-    },
-    /// `(A . B C)` — dotted-tail followed by extra elements.
-    ExtraAfterDottedTail {
-        /// Where the extra token appeared.
-        loc: Loc,
-    },
-    /// Recursive-descent depth exceeded [`MAX_NESTING`].
-    ///
-    /// Guards against a stack overflow on pathological inputs like
-    /// `((((((((((…))))))))))` with thousands of nested parens, or
-    /// `'''''…X` quote chains.  In practice McCarthy 1960 programs
-    /// never approach this depth; the guard is purely a DoS
-    /// hardening for untrusted source.
-    NestingTooDeep {
-        /// Where the parser tipped over the depth limit.
-        loc: Loc,
-    },
+pub struct ParseError {
+    /// Human-readable explanation.
+    pub message: String,
+    /// 1-based line number of the offending token.
+    pub line: usize,
+    /// 1-based column number of the offending token.
+    pub column: usize,
 }
-
-/// Maximum recursive-descent depth.
-///
-/// Picked to be:
-///
-/// 1. **Far above** anything a hand-written McCarthy program would
-///    reach (the deepest example in the 1960 paper is ~10 levels —
-///    256 leaves a 25× headroom for generated code and nested
-///    macros).
-/// 2. **Far below** the Windows 1 MB default test-thread stack
-///    ceiling.  Each `(` requires *two* stack frames
-///    (`parse_list` + the inner `parse_expr`), so 256 levels =
-///    ~512 frames of recursive parser code, well inside even the
-///    most constrained Rust thread stack.
-///
-/// Matches `serde-json`'s default nesting limit, which has the
-/// same trade-off.
-pub const MAX_NESTING: usize = 256;
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ParseError::Lex(e) => write!(f, "parse error: {e}"),
-            ParseError::UnexpectedEof { opened_at, expected } => write!(
-                f,
-                "parse error: unexpected end of input (expected {expected}); \
-                 form opened at {opened_at}"
-            ),
-            ParseError::UnexpectedToken { token, loc, expected } => write!(
-                f,
-                "parse error at {loc}: unexpected {token:?} (expected {expected})"
-            ),
-            ParseError::StrayDot { loc } => write!(
-                f,
-                "parse error at {loc}: stray `.` outside a (A . B) form"
-            ),
-            ParseError::MultipleDotsInList { loc } => write!(
-                f,
-                "parse error at {loc}: more than one `.` in a list; \
-                 McCarthy 1960 allows only one dotted-tail per list"
-            ),
-            ParseError::DotWithoutCdr { loc } => write!(
-                f,
-                "parse error at {loc}: `.` must be followed by exactly one expression (the cdr)"
-            ),
-            ParseError::ExtraAfterDottedTail { loc } => write!(
-                f,
-                "parse error at {loc}: extra tokens after dotted tail; \
-                 `(A . B C)` is not a valid Lisp 1.0 form"
-            ),
-            ParseError::NestingTooDeep { loc } => write!(
-                f,
-                "parse error at {loc}: nesting depth exceeds {} \
-                 (stack-overflow DoS guard)",
-                MAX_NESTING
-            ),
-        }
+        write!(f, "parse error at {}:{}: {}", self.line, self.column, self.message)
     }
 }
 
 impl std::error::Error for ParseError {}
 
-impl From<LexError> for ParseError {
-    fn from(e: LexError) -> Self {
-        ParseError::Lex(e)
+impl From<LexerError> for ParseError {
+    fn from(e: LexerError) -> Self {
+        ParseError { message: format!("lexer error: {}", e.message), line: e.line, column: e.column }
     }
+}
+
+impl From<parser::grammar_parser::GrammarParseError> for ParseError {
+    fn from(e: parser::grammar_parser::GrammarParseError) -> Self {
+        ParseError { message: e.message, line: e.token.line, column: e.token.column }
+    }
+}
+
+// ===========================================================================
+// DoS-hardening depth guards
+// ===========================================================================
+
+/// Maximum LPAREN nesting depth permitted before the grammar parser
+/// runs.
+///
+/// The downstream [`GrammarParser`] is recursive, and a pathological
+/// input like `((((((…))))))` with thousands of nested parens could
+/// blow the OS thread stack (an abort Rust cannot catch).  We reject
+/// such sources up front by counting paren depth in the token stream.
+///
+/// The cap is **64**, matching `twig-parser`'s `MAX_PAREN_DEPTH`.  The
+/// generic `GrammarParser` spends several recursion frames per paren
+/// (`program → sexpr → list → list_body → sexpr → …`), so a default
+/// 2 MiB Rust test-thread stack overflows somewhere around ~80 levels —
+/// 64 leaves a comfortable margin while still admitting any realistic
+/// McCarthy program (the deepest example in the 1960 paper is ~10
+/// levels deep).  Note this is necessarily lower than the v0.1
+/// hand-written parser's 256: that recursive-descent parser used far
+/// less stack per level than the shared grammar engine does.
+pub const MAX_PAREN_DEPTH: usize = 64;
+
+/// Maximum AST-extraction recursion depth.
+///
+/// A second guard, applied while lowering the CST to [`LispExpr`], in
+/// case a future grammar change lets a deeply-nested tree through the
+/// paren check (e.g. long `'''''…X` quote chains, which add depth
+/// without parens).
+pub const MAX_AST_DEPTH: usize = 256;
+
+/// Reject a source whose maximum LPAREN nesting exceeds
+/// [`MAX_PAREN_DEPTH`], pointing at the offending token.
+fn check_paren_depth(tokens: &[Token]) -> Result<(), ParseError> {
+    let mut depth: usize = 0;
+    for t in tokens {
+        match t.type_ {
+            TokenType::LParen => {
+                depth += 1;
+                if depth > MAX_PAREN_DEPTH {
+                    return Err(ParseError {
+                        message: format!(
+                            "LPAREN nesting exceeds MAX_PAREN_DEPTH ({MAX_PAREN_DEPTH}) — \
+                             refusing to invoke the parser to avoid stack overflow"
+                        ),
+                        line: t.line,
+                        column: t.column,
+                    });
+                }
+            }
+            TokenType::RParen => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_depth(depth: usize, line: usize, column: usize) -> Result<(), ParseError> {
+    if depth > MAX_AST_DEPTH {
+        Err(ParseError {
+            message: format!(
+                "AST nesting exceeds MAX_AST_DEPTH ({MAX_AST_DEPTH}) — \
+                 refusing to recurse further to avoid stack overflow"
+            ),
+            line,
+            column,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// Build-time-compiled parser grammar
+// ===========================================================================
+
+mod generated_grammar {
+    include!(concat!(env!("OUT_DIR"), "/mccarthy_lisp_parser_grammar.rs"));
+}
+
+static MCCARTHY_PARSER_GRAMMAR: OnceLock<ParserGrammar> = OnceLock::new();
+
+fn mccarthy_parser_grammar() -> &'static ParserGrammar {
+    MCCARTHY_PARSER_GRAMMAR.get_or_init(generated_grammar::parser_grammar)
+}
+
+/// Borrow the build-time-compiled McCarthy Lisp [`ParserGrammar`].
+///
+/// Re-exported for tooling that needs to inspect the rules without
+/// re-parsing the canonical `.grammar` file.
+pub fn mccarthy_grammar() -> &'static ParserGrammar {
+    mccarthy_parser_grammar()
 }
 
 // ===========================================================================
 // Public API
 // ===========================================================================
 
-/// Tokenize and parse a McCarthy 1960 Lisp source string.
+/// Build a [`GrammarParser`] from a pre-tokenized stream.
 ///
-/// Returns the top-level form sequence (a program is zero-or-more
-/// S-expressions).
-pub fn parse(src: &str) -> Result<Vec<LispExpr>, ParseError> {
-    let toks = tokenize(src)?;
-    parse_tokens(&toks)
+/// Useful for editor / LSP integrations that already hold a
+/// `Vec<Token>` (e.g. from `mccarthy_lisp_lexer::create_mccarthy_lexer`).
+pub fn create_mccarthy_parser_from_tokens(tokens: Vec<Token>) -> GrammarParser {
+    GrammarParser::new(tokens, mccarthy_parser_grammar().clone())
 }
 
-/// Parse a pre-tokenized stream into the top-level form sequence.
-pub fn parse_tokens(toks: &[TokenWithLoc]) -> Result<Vec<LispExpr>, ParseError> {
-    let mut p = Parser { toks, pos: 0 };
-    let mut forms = Vec::new();
-    while p.pos < p.toks.len() {
-        forms.push(p.parse_expr(0)?);
-    }
-    Ok(forms)
+/// Parse McCarthy Lisp source into the generic [`GrammarASTNode`] CST.
+///
+/// The lower-level entry point — most callers want [`parse`], which
+/// goes one step further and returns a typed `Vec<LispExpr>`.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] for any lex failure, paren-depth-limit
+/// breach, or grammar mismatch (unbalanced paren, stray dot, …).
+pub fn parse_to_cst(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mccarthy(source)?;
+    check_paren_depth(&tokens)?;
+    let mut p = create_mccarthy_parser_from_tokens(tokens);
+    p.parse().map_err(Into::into)
+}
+
+/// Parse McCarthy 1960 Lisp source into the top-level form sequence.
+///
+/// A program is zero-or-more S-expressions (McCarthy's "program =
+/// sequence of forms" reading).
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] for lex/grammar mismatches *or*
+/// extractor-detected shape problems (integer overflow, depth limit).
+pub fn parse(source: &str) -> Result<Vec<LispExpr>, ParseError> {
+    let cst = parse_to_cst(source)?;
+    extract_program(&cst)
 }
 
 // ===========================================================================
-// Recursive-descent parser
+// CST → typed AST extraction
 // ===========================================================================
 
-struct Parser<'a> {
-    toks: &'a [TokenWithLoc],
-    pos: usize,
+/// Best-effort source position of a CST node (falls back to 1:1).
+fn pos(node: &GrammarASTNode) -> (usize, usize) {
+    (node.start_line.unwrap_or(1), node.start_column.unwrap_or(1))
 }
 
-impl<'a> Parser<'a> {
-    /// Parse one expression at the current position.
-    ///
-    /// `depth` is the current recursion level; we trip
-    /// [`ParseError::NestingTooDeep`] before any pathological input
-    /// can blow the stack.
-    fn parse_expr(&mut self, depth: usize) -> Result<LispExpr, ParseError> {
-        let twl = self.peek_or_eof("an expression")?;
-        if depth >= MAX_NESTING {
-            return Err(ParseError::NestingTooDeep { loc: twl.loc });
-        }
-        match &twl.tok {
-            Token::LParen => self.parse_list(twl.loc, depth + 1),
-            Token::Quote => self.parse_quote(twl.loc, depth + 1),
-            Token::Symbol(name) => {
-                let n = name.clone();
-                self.pos += 1;
-                Ok(LispExpr::Symbol(n))
-            }
-            Token::Int(n) => {
-                let v = *n;
-                self.pos += 1;
-                Ok(LispExpr::Int(v))
-            }
-            Token::Dot => Err(ParseError::StrayDot { loc: twl.loc }),
-            Token::RParen => Err(ParseError::UnexpectedToken {
-                token: Token::RParen,
-                loc: twl.loc,
-                expected: "an expression",
-            }),
-        }
-    }
-
-    /// Parse a `(…)` form.  Caller has already peeked the `(`; we
-    /// consume it here.
-    fn parse_list(&mut self, opened_at: Loc, depth: usize) -> Result<LispExpr, ParseError> {
-        // Consume `(`.
-        self.pos += 1;
-
-        let mut items: Vec<LispExpr> = Vec::new();
-        let mut dotted_tail: Option<LispExpr> = None;
-
-        loop {
-            let twl = self.peek().ok_or(ParseError::UnexpectedEof {
-                opened_at,
-                expected: "`)` or another expression",
-            })?;
-
-            match &twl.tok {
-                Token::RParen => {
-                    self.pos += 1;
-                    return Ok(build_list(items, dotted_tail));
-                }
-                Token::Dot => {
-                    if dotted_tail.is_some() {
-                        return Err(ParseError::MultipleDotsInList { loc: twl.loc });
-                    }
-                    if items.is_empty() {
-                        // `(. X)` — dot must come after at least one car.
-                        return Err(ParseError::UnexpectedToken {
-                            token: Token::Dot,
-                            loc: twl.loc,
-                            expected: "the head of a dotted pair before `.`",
-                        });
-                    }
-                    let dot_loc = twl.loc;
-                    self.pos += 1; // consume `.`
-
-                    // Must be followed by EXACTLY one expression, then `)`.
-                    let after = self.peek_or_eof("the cdr of the dotted pair")?;
-                    if matches!(after.tok, Token::RParen) {
-                        return Err(ParseError::DotWithoutCdr { loc: dot_loc });
-                    }
-                    let cdr = self.parse_expr(depth)?;
-                    dotted_tail = Some(cdr);
-
-                    // Anything other than `)` next is a parse error.
-                    let nxt = self.peek_or_eof("`)` after dotted tail")?;
-                    if !matches!(nxt.tok, Token::RParen) {
-                        return Err(ParseError::ExtraAfterDottedTail { loc: nxt.loc });
-                    }
-                    // Loop iterates once more and consumes `)`.
-                }
-                _ => {
-                    items.push(self.parse_expr(depth)?);
-                }
-            }
-        }
-    }
-
-    /// Parse `'X` — sugar for `(QUOTE X)`.
-    fn parse_quote(&mut self, _quote_loc: Loc, depth: usize) -> Result<LispExpr, ParseError> {
-        // Consume `'`.
-        self.pos += 1;
-        let inner = self.parse_expr(depth)?;
-        Ok(LispExpr::quote(inner))
-    }
-
-    fn peek(&self) -> Option<&'a TokenWithLoc> {
-        self.toks.get(self.pos)
-    }
-
-    fn peek_or_eof(&self, expected: &'static str) -> Result<&'a TokenWithLoc, ParseError> {
-        self.peek().ok_or(ParseError::UnexpectedEof {
-            opened_at: Loc::START,
-            expected,
+/// The nested-node children of `node`, dropping bare punctuation tokens.
+fn ast_children(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
         })
+        .collect()
+}
+
+/// Lower a parsed `program` CST node into the typed form sequence.
+///
+/// Expects `root.rule_name == "program"` (the grammar's start symbol).
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] if the tree shape is unexpected (should not
+/// happen for output of [`parse_to_cst`]) or an integer literal
+/// overflows `i64`.
+pub fn extract_program(root: &GrammarASTNode) -> Result<Vec<LispExpr>, ParseError> {
+    if root.rule_name != "program" {
+        let (line, column) = pos(root);
+        return Err(ParseError {
+            message: format!("expected 'program' root, got {:?}", root.rule_name),
+            line,
+            column,
+        });
+    }
+    ast_children(root).into_iter().map(|c| extract_sexpr(c, 0)).collect()
+}
+
+/// `sexpr = atom | list | quoted` — dispatch on the single child rule.
+fn extract_sexpr(node: &GrammarASTNode, depth: usize) -> Result<LispExpr, ParseError> {
+    let (line, column) = pos(node);
+    check_depth(depth, line, column)?;
+    if node.rule_name != "sexpr" {
+        return Err(ParseError {
+            message: format!("expected 'sexpr', got {:?}", node.rule_name),
+            line,
+            column,
+        });
+    }
+    let inner = ast_children(node).into_iter().next().ok_or_else(|| ParseError {
+        message: "empty sexpr node".into(),
+        line,
+        column,
+    })?;
+    match inner.rule_name.as_str() {
+        "atom" => extract_atom(inner),
+        "list" => extract_list(inner, depth + 1),
+        "quoted" => extract_quoted(inner, depth + 1),
+        other => Err(ParseError {
+            message: format!("unexpected sexpr child: {other:?}"),
+            line,
+            column,
+        }),
     }
 }
 
-/// Build a McCarthy-style list from collected items + optional dotted tail.
+/// `atom = SYMBOL | INTEGER` — a single bare token.
+fn extract_atom(node: &GrammarASTNode) -> Result<LispExpr, ParseError> {
+    let (line, column) = pos(node);
+    let tok = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t),
+            ASTNodeOrToken::Node(_) => None,
+        })
+        .ok_or_else(|| ParseError { message: "empty atom node".into(), line, column })?;
+    let (l, c) = (tok.line, tok.column);
+    match tok.effective_type_name() {
+        "SYMBOL" => Ok(LispExpr::Symbol(tok.value.clone())),
+        "INTEGER" => {
+            let value: i64 = tok.value.parse().map_err(|_| ParseError {
+                message: format!("integer literal {:?} does not fit in i64", tok.value),
+                line: l,
+                column: c,
+            })?;
+            Ok(LispExpr::Int(value))
+        }
+        other => Err(ParseError {
+            message: format!("unexpected atom token: type={other:?} value={:?}", tok.value),
+            line: l,
+            column: c,
+        }),
+    }
+}
+
+/// `list = LPAREN list_body RPAREN`, where
+/// `list_body = [ sexpr { sexpr } [ DOT sexpr ] ]`.
 ///
-/// `(A B C)` → `Cons(A, Cons(B, Cons(C, Nil)))`.
-/// `(A B . C)` → `Cons(A, Cons(B, C))`.
-fn build_list(items: Vec<LispExpr>, dotted_tail: Option<LispExpr>) -> LispExpr {
-    let mut acc = dotted_tail.unwrap_or(LispExpr::Nil);
-    for x in items.into_iter().rev() {
+/// Builds the nested-`Cons` encoding.  A list with no dotted tail is
+/// `NIL`-terminated; an explicit `DOT` tail becomes the final `cdr`.
+fn extract_list(node: &GrammarASTNode, depth: usize) -> Result<LispExpr, ParseError> {
+    let (line, column) = pos(node);
+    check_depth(depth, line, column)?;
+
+    // The single nested child is `list_body` (the LPAREN/RPAREN are bare
+    // tokens, dropped by `ast_children`).  An empty list `()` may yield a
+    // list_body node with no children — treat a missing/empty body as NIL.
+    let body = match ast_children(node).into_iter().next() {
+        Some(b) => b,
+        None => return Ok(LispExpr::Nil),
+    };
+
+    let mut elems: Vec<LispExpr> = Vec::new();
+    let mut tail: Option<LispExpr> = None;
+    let mut after_dot = false;
+
+    for child in &body.children {
+        match child {
+            ASTNodeOrToken::Token(t) if t.effective_type_name() == "DOT" => {
+                after_dot = true;
+            }
+            ASTNodeOrToken::Node(n) if n.rule_name == "sexpr" => {
+                let expr = extract_sexpr(n, depth + 1)?;
+                if after_dot {
+                    tail = Some(expr);
+                } else {
+                    elems.push(expr);
+                }
+            }
+            // Any other token (none expected from this grammar) is ignored.
+            _ => {}
+        }
+    }
+
+    let mut acc = tail.unwrap_or(LispExpr::Nil);
+    for x in elems.into_iter().rev() {
         acc = LispExpr::Cons(Box::new(x), Box::new(acc));
     }
-    acc
+    Ok(acc)
+}
+
+/// `quoted = QUOTE sexpr` — rewrite `'X` to `(QUOTE X)`.
+fn extract_quoted(node: &GrammarASTNode, depth: usize) -> Result<LispExpr, ParseError> {
+    let (line, column) = pos(node);
+    check_depth(depth, line, column)?;
+    let inner = ast_children(node).into_iter().next().ok_or_else(|| ParseError {
+        message: "expected an expression after '".into(),
+        line,
+        column,
+    })?;
+    Ok(LispExpr::quote(extract_sexpr(inner, depth + 1)?))
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(src: &str) -> LispExpr {
+        let mut p = parse(src).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        assert_eq!(p.len(), 1, "expected exactly one top-level form");
+        p.pop().unwrap()
+    }
+
+    #[test]
+    fn empty_program() {
+        assert!(parse("").unwrap().is_empty());
+        assert!(parse("  ; just a comment\n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn atoms() {
+        assert_eq!(one("CAR"), LispExpr::Symbol("CAR".into()));
+        assert_eq!(one("42"), LispExpr::Int(42));
+        assert_eq!(one("-1"), LispExpr::Int(-1));
+    }
+
+    #[test]
+    fn empty_list_is_nil() {
+        assert_eq!(one("()"), LispExpr::Nil);
+    }
+
+    #[test]
+    fn nil_symbol_is_distinct_from_empty_list() {
+        assert_eq!(one("NIL"), LispExpr::Symbol("NIL".into()));
+    }
+
+    #[test]
+    fn proper_list_desugars_to_nested_cons() {
+        assert_eq!(
+            one("(A B C)"),
+            LispExpr::list([LispExpr::sym("A"), LispExpr::sym("B"), LispExpr::sym("C")])
+        );
+    }
+
+    #[test]
+    fn dotted_pair() {
+        assert_eq!(
+            one("(A . B)"),
+            LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::sym("B")))
+        );
+    }
+
+    #[test]
+    fn dotted_tail_after_elements() {
+        // (A B . C) → (A . (B . C))
+        assert_eq!(
+            one("(A B . C)"),
+            LispExpr::Cons(
+                Box::new(LispExpr::sym("A")),
+                Box::new(LispExpr::Cons(
+                    Box::new(LispExpr::sym("B")),
+                    Box::new(LispExpr::sym("C"))
+                ))
+            )
+        );
+    }
+
+    #[test]
+    fn quote_sugar_expands() {
+        assert_eq!(one("'X"), LispExpr::quote(LispExpr::sym("X")));
+        assert_eq!(
+            one("'(A B)"),
+            LispExpr::quote(LispExpr::list([LispExpr::sym("A"), LispExpr::sym("B")]))
+        );
+    }
+
+    #[test]
+    fn the_canonical_car_example() {
+        assert_eq!(
+            one("(CAR '(A B C))"),
+            LispExpr::list([
+                LispExpr::sym("CAR"),
+                LispExpr::quote(LispExpr::list([
+                    LispExpr::sym("A"),
+                    LispExpr::sym("B"),
+                    LispExpr::sym("C"),
+                ])),
+            ])
+        );
+    }
+
+    #[test]
+    fn the_identity_lambda() {
+        assert_eq!(
+            one("(LAMBDA (X) X)"),
+            LispExpr::list([
+                LispExpr::sym("LAMBDA"),
+                LispExpr::list([LispExpr::sym("X")]),
+                LispExpr::sym("X"),
+            ])
+        );
+    }
+
+    #[test]
+    fn multiple_top_level_forms() {
+        let forms = parse("(CAR X) (CDR X)").unwrap();
+        assert_eq!(forms.len(), 2);
+    }
+
+    #[test]
+    fn display_round_trips_dotted_form() {
+        // Display always prints the fully-dotted cons form.
+        assert_eq!(one("(A B)").to_string(), "(A . (B . NIL))");
+        assert_eq!(one("(A . B)").to_string(), "(A . B)");
+    }
+
+    // ---- error paths ----
+
+    #[test]
+    fn unbalanced_paren_is_an_error() {
+        assert!(parse("(CAR").is_err());
+        assert!(parse("CAR)").is_err());
+    }
+
+    #[test]
+    fn stray_dot_forms_are_grammar_errors() {
+        assert!(parse("(. X)").is_err()); // dot with no head
+        assert!(parse("(A . B C)").is_err()); // extra after dotted tail
+        assert!(parse("(A . . B)").is_err()); // two dots
+    }
+
+    #[test]
+    fn lexer_errors_propagate() {
+        assert!(parse("car").is_err()); // lowercase
+        assert!(parse("(- A B)").is_err()); // operator symbol
+    }
+
+    #[test]
+    fn integer_overflow_is_an_error() {
+        let err = parse("99999999999999999999").unwrap_err();
+        assert!(err.message.contains("does not fit in i64"));
+    }
+
+    #[test]
+    fn deeply_nested_parens_are_rejected() {
+        let deep = format!("{}{}", "(".repeat(MAX_PAREN_DEPTH + 5), ")".repeat(MAX_PAREN_DEPTH + 5));
+        let err = parse(&deep).unwrap_err();
+        assert!(err.message.contains("MAX_PAREN_DEPTH"));
+    }
+
+    #[test]
+    fn legal_moderate_nesting_is_accepted() {
+        // Comfortably under MAX_PAREN_DEPTH (64) — must parse cleanly.
+        let n = 40;
+        let src = format!("{}A{}", "(".repeat(n), ")".repeat(n));
+        assert!(parse(&src).is_ok());
+    }
 }

--- a/code/packages/rust/mccarthy-lisp-parser/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-parser/src/lib.rs
@@ -177,21 +177,33 @@ impl From<parser::grammar_parser::GrammarParseError> for ParseError {
 // DoS-hardening depth guards
 // ===========================================================================
 
-/// Maximum LPAREN nesting depth permitted before the grammar parser
-/// runs.
+/// Maximum *structural nesting* depth permitted before the grammar
+/// parser runs.
 ///
-/// The downstream [`GrammarParser`] is recursive, and a pathological
-/// input like `((((((…))))))` with thousands of nested parens could
-/// blow the OS thread stack (an abort Rust cannot catch).  We reject
-/// such sources up front by counting paren depth in the token stream.
+/// The downstream [`GrammarParser`] is recursive and has **no** internal
+/// recursion-depth limit, so a deeply-nested input drives it into
+/// native call-stack recursion — one frame per nesting level — until
+/// the OS thread stack overflows.  That overflow is a `SIGABRT` Rust
+/// cannot catch: it crashes the whole process.  We therefore reject
+/// over-deep sources up front by scanning the token stream.
+///
+/// **Two token shapes add nesting depth, not just parens:**
+///
+/// - `LPAREN` — `((((…))))`, via the `list` rule.
+/// - `QUOTE`  — `''''…X`, via the `quoted = QUOTE sexpr` rule, which
+///   recurses *without consuming a paren*.  A long run of `'` has
+///   paren-depth 0 yet unbounded parser-recursion depth — a ~5 KB
+///   all-`'` file is enough to abort the process if only parens are
+///   counted.  [`check_nesting_depth`] therefore bounds the *combined*
+///   paren + pending-quote depth.
 ///
 /// The cap is **64**, matching `twig-parser`'s `MAX_PAREN_DEPTH`.  The
-/// generic `GrammarParser` spends several recursion frames per paren
-/// (`program → sexpr → list → list_body → sexpr → …`), so a default
-/// 2 MiB Rust test-thread stack overflows somewhere around ~80 levels —
-/// 64 leaves a comfortable margin while still admitting any realistic
-/// McCarthy program (the deepest example in the 1960 paper is ~10
-/// levels deep).  Note this is necessarily lower than the v0.1
+/// generic `GrammarParser` spends several recursion frames per nesting
+/// level (`program → sexpr → list → list_body → sexpr → …`), so a
+/// default 2 MiB Rust test-thread stack overflows somewhere around ~80
+/// levels — 64 leaves a comfortable margin while still admitting any
+/// realistic McCarthy program (the deepest example in the 1960 paper is
+/// ~10 levels deep).  Note this is necessarily lower than the v0.1
 /// hand-written parser's 256: that recursive-descent parser used far
 /// less stack per level than the shared grammar engine does.
 pub const MAX_PAREN_DEPTH: usize = 64;
@@ -204,27 +216,72 @@ pub const MAX_PAREN_DEPTH: usize = 64;
 /// without parens).
 pub const MAX_AST_DEPTH: usize = 256;
 
-/// Reject a source whose maximum LPAREN nesting exceeds
-/// [`MAX_PAREN_DEPTH`], pointing at the offending token.
-fn check_paren_depth(tokens: &[Token]) -> Result<(), ParseError> {
-    let mut depth: usize = 0;
+/// Reject a source whose maximum *structural nesting* (parens **and**
+/// pending quotes) exceeds [`MAX_PAREN_DEPTH`], pointing at the token
+/// that tipped it over.
+///
+/// This runs **before** [`GrammarParser::parse`], which has no internal
+/// recursion guard, so it is the only thing standing between untrusted
+/// input and a stack-overflow `SIGABRT`.  It must therefore account for
+/// *every* token shape that adds parser-recursion depth — both `LPAREN`
+/// (the `list` rule) and `QUOTE` (the `quoted` rule, which recurses
+/// without a paren).
+///
+/// We track an explicit stack of open contexts.  A `QUOTE` opens a
+/// pending-quote context that is *discharged* as soon as its single
+/// operand sexpr completes (an atom, or a list closed by `RPAREN`); an
+/// `LPAREN` opens a list context closed by its `RPAREN`.  The high-water
+/// mark of the stack is the maximum live recursion depth the grammar
+/// parser will reach.  (Slight miscounting on *malformed* input is
+/// harmless — such input is rejected by the grammar anyway; what matters
+/// is that we never *under*-count a well-formed deep nest.)
+fn check_nesting_depth(tokens: &[Token]) -> Result<(), ParseError> {
+    // 'p' = open paren (list), 'q' = pending quote.
+    let mut stack: Vec<u8> = Vec::new();
+
+    // Discharge every pending quote sitting on top of the stack: a
+    // completed sexpr satisfies all quotes directly wrapping it.
+    fn discharge_quotes(stack: &mut Vec<u8>) {
+        while matches!(stack.last(), Some(b'q')) {
+            stack.pop();
+        }
+    }
+
     for t in tokens {
         match t.type_ {
-            TokenType::LParen => {
-                depth += 1;
-                if depth > MAX_PAREN_DEPTH {
-                    return Err(ParseError {
-                        message: format!(
-                            "LPAREN nesting exceeds MAX_PAREN_DEPTH ({MAX_PAREN_DEPTH}) — \
-                             refusing to invoke the parser to avoid stack overflow"
-                        ),
-                        line: t.line,
-                        column: t.column,
-                    });
+            TokenType::LParen => stack.push(b'p'),
+            TokenType::RParen => {
+                // The list just closed is itself a completed sexpr: pop
+                // its paren, then discharge any quotes wrapping the list.
+                // Pop down to and including the nearest paren (tolerating
+                // stray pending quotes on malformed input).
+                while matches!(stack.last(), Some(b'q')) {
+                    stack.pop();
                 }
+                if matches!(stack.last(), Some(b'p')) {
+                    stack.pop();
+                }
+                discharge_quotes(&mut stack);
             }
-            TokenType::RParen => depth = depth.saturating_sub(1),
+            // A bare quote token: only QUOTE maps to type_name "QUOTE".
+            _ if t.effective_type_name() == "QUOTE" => stack.push(b'q'),
+            // An atom (SYMBOL / INTEGER) completes a sexpr.
+            _ if matches!(t.effective_type_name(), "SYMBOL" | "INTEGER") => {
+                discharge_quotes(&mut stack);
+            }
             _ => {}
+        }
+
+        if stack.len() > MAX_PAREN_DEPTH {
+            return Err(ParseError {
+                message: format!(
+                    "structural nesting (parens + quotes) exceeds MAX_PAREN_DEPTH \
+                     ({MAX_PAREN_DEPTH}) — refusing to invoke the parser to avoid \
+                     stack overflow"
+                ),
+                line: t.line,
+                column: t.column,
+            });
         }
     }
     Ok(())
@@ -290,7 +347,7 @@ pub fn create_mccarthy_parser_from_tokens(tokens: Vec<Token>) -> GrammarParser {
 /// breach, or grammar mismatch (unbalanced paren, stray dot, …).
 pub fn parse_to_cst(source: &str) -> Result<GrammarASTNode, ParseError> {
     let tokens = tokenize_mccarthy(source)?;
-    check_paren_depth(&tokens)?;
+    check_nesting_depth(&tokens)?;
     let mut p = create_mccarthy_parser_from_tokens(tokens);
     p.parse().map_err(Into::into)
 }
@@ -618,10 +675,40 @@ mod tests {
     }
 
     #[test]
+    fn deeply_nested_quotes_are_rejected() {
+        // Regression for the quote-chain stack-overflow DoS: a long run
+        // of `'` has paren-depth 0 but unbounded parser recursion.  It
+        // must be rejected *before* the GrammarParser runs, not abort
+        // the process.  MAX+5_000 is far past the cap and well into
+        // crash territory if the guard regresses.
+        let deep = format!("{}X", "'".repeat(MAX_PAREN_DEPTH + 5_000));
+        let err = parse(&deep).unwrap_err();
+        assert!(err.message.contains("MAX_PAREN_DEPTH"));
+    }
+
+    #[test]
+    fn quote_then_deep_parens_rejected() {
+        // A quote wrapping a deep list — the quote adds one level on top
+        // of the parens, so the combined depth must be what trips.
+        let deep = format!("'{}A{}", "(".repeat(MAX_PAREN_DEPTH), ")".repeat(MAX_PAREN_DEPTH));
+        assert!(parse(&deep).is_err());
+    }
+
+    #[test]
     fn legal_moderate_nesting_is_accepted() {
         // Comfortably under MAX_PAREN_DEPTH (64) — must parse cleanly.
         let n = 40;
         let src = format!("{}A{}", "(".repeat(n), ")".repeat(n));
         assert!(parse(&src).is_ok());
+    }
+
+    #[test]
+    fn legal_moderate_quote_chain_is_accepted() {
+        // A quote chain just under the cap parses fine (and does not
+        // overflow): '''...'X with 40 quotes → 40 nested QUOTE forms.
+        let n = 40;
+        let src = format!("{}X", "'".repeat(n));
+        let forms = parse(&src).expect("should parse");
+        assert_eq!(forms.len(), 1);
     }
 }

--- a/code/packages/rust/mccarthy-lisp-parser/tests/test_parser.rs
+++ b/code/packages/rust/mccarthy-lisp-parser/tests/test_parser.rs
@@ -1,22 +1,18 @@
 //! Integration tests for `mccarthy-lisp-parser`.
 //!
-//! Test groups:
-//!   1. Atoms
-//!   2. Empty list / NIL
-//!   3. List nesting (the McCarthy-1960 encoding)
-//!   4. Dotted pairs
-//!   5. Quote sugar
-//!   6. Canonical paper examples (CAR / LAMBDA / LABEL / COND)
-//!   7. Error paths
-//!   8. Multi-form programs
-//!   9. Display round-trip
+//! The crate is a thin wrapper over the shared `GrammarParser` plus a
+//! typed-AST extractor.  These tests pin the *McCarthy-1960 AST
+//! contract* — the desugaring of lists and quote, the dotted-pair
+//! shape, and the canonical paper examples — plus the error paths that
+//! the grammar now enforces for free.
 
-use mccarthy_lisp_parser::{parse, LispExpr, ParseError};
+use mccarthy_lisp_parser::{parse, LispExpr};
 
+/// Parse a source that must contain exactly one top-level form.
 fn one(src: &str) -> LispExpr {
-    let forms = parse(src).expect("parse");
-    assert_eq!(forms.len(), 1, "expected exactly one form, got {forms:?}");
-    forms.into_iter().next().unwrap()
+    let mut forms = parse(src).unwrap_or_else(|e| panic!("parse failed for {src:?}: {e}"));
+    assert_eq!(forms.len(), 1, "expected exactly one form in {src:?}");
+    forms.pop().unwrap()
 }
 
 // ============================================================
@@ -24,22 +20,21 @@ fn one(src: &str) -> LispExpr {
 // ============================================================
 
 #[test]
-fn parse_symbol() {
+fn symbol_atom() {
     assert_eq!(one("CAR"), LispExpr::sym("CAR"));
+    assert_eq!(one("FF"), LispExpr::sym("FF"));
+    assert_eq!(one("LIST-OF-3"), LispExpr::sym("LIST-OF-3"));
 }
 
 #[test]
-fn parse_int() {
+fn integer_atom() {
+    assert_eq!(one("0"), LispExpr::Int(0));
     assert_eq!(one("42"), LispExpr::Int(42));
-}
-
-#[test]
-fn parse_negative_int() {
-    assert_eq!(one("-1"), LispExpr::Int(-1));
+    assert_eq!(one("-7"), LispExpr::Int(-7));
 }
 
 // ============================================================
-// 2. NIL / empty list
+// 2. Empty list / NIL
 // ============================================================
 
 #[test]
@@ -47,36 +42,44 @@ fn empty_list_is_nil() {
     assert_eq!(one("()"), LispExpr::Nil);
 }
 
+#[test]
+fn nil_symbol_is_a_symbol() {
+    // At the parser layer, `NIL` the symbol is distinct from `()`.
+    assert_eq!(one("NIL"), LispExpr::sym("NIL"));
+}
+
 // ============================================================
-// 3. List nesting
+// 3. List nesting (the McCarthy-1960 encoding)
 // ============================================================
 
 #[test]
-fn single_element_list() {
-    // (A) == (A . NIL) == Cons(A, Nil)
-    let expected = LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::Nil));
-    assert_eq!(one("(A)"), expected);
+fn proper_list_nests_to_cons_cells() {
+    // (A B C) → (A . (B . (C . NIL)))
+    let expected = LispExpr::Cons(
+        Box::new(LispExpr::sym("A")),
+        Box::new(LispExpr::Cons(
+            Box::new(LispExpr::sym("B")),
+            Box::new(LispExpr::Cons(Box::new(LispExpr::sym("C")), Box::new(LispExpr::Nil))),
+        )),
+    );
+    assert_eq!(one("(A B C)"), expected);
+    assert_eq!(one("(A B C)"), LispExpr::list([LispExpr::sym("A"), LispExpr::sym("B"), LispExpr::sym("C")]));
 }
 
 #[test]
-fn three_element_list_uses_nested_cons() {
-    // (A B C) == (A . (B . (C . NIL)))
-    let expected = LispExpr::list([
-        LispExpr::sym("A"),
-        LispExpr::sym("B"),
-        LispExpr::sym("C"),
-    ]);
-    assert_eq!(one("(A B C)"), expected);
+fn singleton_list() {
+    assert_eq!(one("(A)"), LispExpr::list([LispExpr::sym("A")]));
 }
 
 #[test]
 fn nested_lists() {
-    // (CAR (CDR X)) parses to a 2-element list, second element being a list.
-    let expected = LispExpr::list([
-        LispExpr::sym("CAR"),
-        LispExpr::list([LispExpr::sym("CDR"), LispExpr::sym("X")]),
-    ]);
-    assert_eq!(one("(CAR (CDR X))"), expected);
+    assert_eq!(
+        one("((A) (B))"),
+        LispExpr::list([
+            LispExpr::list([LispExpr::sym("A")]),
+            LispExpr::list([LispExpr::sym("B")]),
+        ])
+    );
 }
 
 // ============================================================
@@ -84,23 +87,31 @@ fn nested_lists() {
 // ============================================================
 
 #[test]
-fn dotted_pair_atoms() {
-    // (A . B) == Cons(A, B) — no NIL terminator.
-    let expected = LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::sym("B")));
-    assert_eq!(one("(A . B)"), expected);
+fn simple_dotted_pair() {
+    assert_eq!(
+        one("(A . B)"),
+        LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::sym("B")))
+    );
 }
 
 #[test]
-fn dotted_tail_after_items() {
-    // (A B . C) == Cons(A, Cons(B, C))
-    let expected = LispExpr::Cons(
-        Box::new(LispExpr::sym("A")),
-        Box::new(LispExpr::Cons(
-            Box::new(LispExpr::sym("B")),
-            Box::new(LispExpr::sym("C")),
-        )),
+fn dotted_tail_after_elements() {
+    // (A B . C) → (A . (B . C))
+    assert_eq!(
+        one("(A B . C)"),
+        LispExpr::Cons(
+            Box::new(LispExpr::sym("A")),
+            Box::new(LispExpr::Cons(Box::new(LispExpr::sym("B")), Box::new(LispExpr::sym("C"))))
+        )
     );
-    assert_eq!(one("(A B . C)"), expected);
+}
+
+#[test]
+fn dotted_pair_with_integer_cdr() {
+    assert_eq!(
+        one("(A . -42)"),
+        LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::Int(-42)))
+    );
 }
 
 // ============================================================
@@ -108,123 +119,110 @@ fn dotted_tail_after_items() {
 // ============================================================
 
 #[test]
-fn quote_sugar_atom() {
-    // 'X == (QUOTE X) == Cons(QUOTE, Cons(X, NIL))
-    let expected = LispExpr::quote(LispExpr::sym("X"));
-    assert_eq!(one("'X"), expected);
+fn quote_a_symbol() {
+    assert_eq!(one("'X"), LispExpr::quote(LispExpr::sym("X")));
 }
 
 #[test]
-fn quote_sugar_list() {
-    // '(A B C) == (QUOTE (A B C))
-    let expected = LispExpr::quote(LispExpr::list([
-        LispExpr::sym("A"),
-        LispExpr::sym("B"),
-        LispExpr::sym("C"),
-    ]));
-    assert_eq!(one("'(A B C)"), expected);
-}
-
-// ============================================================
-// 6. Canonical McCarthy 1960 paper examples
-// ============================================================
-
-#[test]
-fn car_of_quoted_list_paper_example() {
-    // (CAR '(A B C)) — McCarthy 1960, §3 example 1.
-    let expected = LispExpr::list([
-        LispExpr::sym("CAR"),
+fn quote_a_list() {
+    assert_eq!(
+        one("'(A B C)"),
         LispExpr::quote(LispExpr::list([
             LispExpr::sym("A"),
             LispExpr::sym("B"),
             LispExpr::sym("C"),
-        ])),
-    ]);
-    assert_eq!(one("(CAR '(A B C))"), expected);
+        ]))
+    );
 }
 
 #[test]
-fn identity_lambda_paper_example() {
-    // (LAMBDA (X) X) — McCarthy 1960, §5.
-    let expected = LispExpr::list([
-        LispExpr::sym("LAMBDA"),
-        LispExpr::list([LispExpr::sym("X")]),
-        LispExpr::sym("X"),
-    ]);
-    assert_eq!(one("(LAMBDA (X) X)"), expected);
+fn nested_quotes() {
+    // ''X → (QUOTE (QUOTE X))
+    assert_eq!(one("''X"), LispExpr::quote(LispExpr::quote(LispExpr::sym("X"))));
+}
+
+// ============================================================
+// 6. Canonical paper examples
+// ============================================================
+
+#[test]
+fn car_of_a_literal_list() {
+    assert_eq!(
+        one("(CAR '(A B C))"),
+        LispExpr::list([
+            LispExpr::sym("CAR"),
+            LispExpr::quote(LispExpr::list([
+                LispExpr::sym("A"),
+                LispExpr::sym("B"),
+                LispExpr::sym("C"),
+            ])),
+        ])
+    );
 }
 
 #[test]
-fn label_named_recursion_paper_example() {
-    // McCarthy 1960 §6: (LABEL FF (LAMBDA (X) (COND ((ATOM X) X) (T (FF (CAR X))))))
-    // Just confirm it parses cleanly and the outermost shape is right.
-    let forms = parse("(LABEL FF (LAMBDA (X) (COND ((ATOM X) X) (T (FF (CAR X))))))").expect("parse");
-    assert_eq!(forms.len(), 1);
-    match &forms[0] {
-        LispExpr::Cons(car, _) => match car.as_ref() {
-            LispExpr::Symbol(s) => assert_eq!(s, "LABEL"),
-            other => panic!("expected LABEL, got {other:?}"),
-        },
-        other => panic!("expected outer Cons, got {other:?}"),
+fn identity_lambda() {
+    assert_eq!(
+        one("(LAMBDA (X) X)"),
+        LispExpr::list([
+            LispExpr::sym("LAMBDA"),
+            LispExpr::list([LispExpr::sym("X")]),
+            LispExpr::sym("X"),
+        ])
+    );
+}
+
+#[test]
+fn label_recursive_definition() {
+    // (LABEL FF (LAMBDA (X) (COND ((ATOM X) X) ((QUOTE T) (FF (CAR X))))))
+    let src = "(LABEL FF (LAMBDA (X) (COND ((ATOM X) X) ('T (FF (CAR X))))))";
+    let form = one(src);
+    // Spot-check the spine: (LABEL FF (LAMBDA ...))
+    match form {
+        LispExpr::Cons(ref head, _) => assert_eq!(**head, LispExpr::sym("LABEL")),
+        other => panic!("expected a Cons, got {other:?}"),
+    }
+}
+
+#[test]
+fn cond_form() {
+    let src = "(COND ((ATOM X) (QUOTE A)) ('T (QUOTE B)))";
+    let form = one(src);
+    match form {
+        LispExpr::Cons(ref head, _) => assert_eq!(**head, LispExpr::sym("COND")),
+        other => panic!("expected a Cons, got {other:?}"),
     }
 }
 
 // ============================================================
-// 7. Error paths
+// 7. Error paths (now enforced by the grammar)
 // ============================================================
 
 #[test]
-fn unbalanced_open_paren_errors() {
-    let err = parse("(CAR").expect_err("missing close paren");
-    assert!(matches!(err, ParseError::UnexpectedEof { .. }));
+fn unbalanced_parens_error() {
+    assert!(parse("(CAR").is_err());
+    assert!(parse("CAR)").is_err());
+    assert!(parse("(((").is_err());
 }
 
 #[test]
-fn stray_close_paren_errors() {
-    let err = parse(")").expect_err("stray rparen");
-    assert!(matches!(err, ParseError::UnexpectedToken { token: mccarthy_lisp_lexer::Token::RParen, .. }));
+fn malformed_dotted_forms_error() {
+    assert!(parse("(. X)").is_err()); // no head before dot
+    assert!(parse("(A . B C)").is_err()); // extra element after dotted tail
+    assert!(parse("(A . . B)").is_err()); // two dots
+    assert!(parse("(A .)").is_err()); // dot with no cdr
 }
 
 #[test]
-fn stray_dot_at_top_level_errors() {
-    let err = parse(".").expect_err("stray dot");
-    assert!(matches!(err, ParseError::StrayDot { .. }));
+fn dialect_violations_error() {
+    assert!(parse("car").is_err()); // lowercase
+    assert!(parse("(+ A B)").is_err()); // operator symbol
+    assert!(parse("\"hi\"").is_err()); // string literal
 }
 
 #[test]
-fn dot_at_list_head_errors() {
-    let err = parse("(. X)").expect_err("dot without car");
-    assert!(matches!(err, ParseError::UnexpectedToken { .. }));
-}
-
-#[test]
-fn dot_without_cdr_errors() {
-    let err = parse("(A .)").expect_err("dot without cdr");
-    assert!(matches!(err, ParseError::DotWithoutCdr { .. }));
-}
-
-#[test]
-fn extra_after_dotted_tail_errors() {
-    let err = parse("(A . B C)").expect_err("extra after dotted tail");
-    assert!(matches!(err, ParseError::ExtraAfterDottedTail { .. }));
-}
-
-#[test]
-fn multiple_dots_in_list_errors() {
-    let err = parse("(A . B . C)").expect_err("multiple dots");
-    // The parser flags this at the second dot — could be either
-    // MultipleDotsInList (preferred) or ExtraAfterDottedTail
-    // depending on which check fires first.
-    assert!(matches!(
-        err,
-        ParseError::MultipleDotsInList { .. } | ParseError::ExtraAfterDottedTail { .. }
-    ));
-}
-
-#[test]
-fn lex_error_propagates_to_parser() {
-    let err = parse("(+).").expect_err("`+` is not a valid Lisp 1.0 token");
-    assert!(matches!(err, ParseError::Lex(_)));
+fn integer_overflow_errors() {
+    assert!(parse("123456789012345678901234567890").is_err());
 }
 
 // ============================================================
@@ -232,22 +230,10 @@ fn lex_error_propagates_to_parser() {
 // ============================================================
 
 #[test]
-fn multi_form_program() {
-    let forms = parse("(QUOTE A)\n(QUOTE B)\n42").expect("parse");
+fn sequence_of_forms() {
+    let forms = parse("(CAR X)\n(CDR X)\nNIL").unwrap();
     assert_eq!(forms.len(), 3);
-    assert_eq!(forms[2], LispExpr::Int(42));
-}
-
-#[test]
-fn empty_program_yields_no_forms() {
-    let forms = parse("").expect("parse");
-    assert!(forms.is_empty());
-}
-
-#[test]
-fn whitespace_and_comments_only_yields_no_forms() {
-    let forms = parse("\n; comment\n   \n").expect("parse");
-    assert!(forms.is_empty());
+    assert_eq!(forms[2], LispExpr::sym("NIL"));
 }
 
 // ============================================================
@@ -255,63 +241,10 @@ fn whitespace_and_comments_only_yields_no_forms() {
 // ============================================================
 
 #[test]
-fn display_of_dotted_pair() {
-    let e = LispExpr::Cons(Box::new(LispExpr::sym("A")), Box::new(LispExpr::sym("B")));
-    assert_eq!(format!("{e}"), "(A . B)");
-}
-
-#[test]
-fn display_of_nil() {
-    assert_eq!(format!("{}", LispExpr::Nil), "NIL");
-}
-
-// ============================================================
-// 10. DoS-hardening — bounded recursion depth
-// ============================================================
-
-#[test]
-fn deep_paren_nesting_is_rejected_before_stack_overflow() {
-    use mccarthy_lisp_parser::MAX_NESTING;
-
-    // MAX_NESTING + 8 open parens, no close — guaranteed to trip
-    // the depth guard before we run out of input or stack.
-    let depth = MAX_NESTING + 8;
-    let src = "(".repeat(depth);
-    let err = parse(&src).expect_err("must trip NestingTooDeep");
-    assert!(matches!(err, ParseError::NestingTooDeep { .. }),
-        "expected NestingTooDeep, got {err:?}");
-}
-
-#[test]
-fn deep_quote_chains_are_rejected_before_stack_overflow() {
-    use mccarthy_lisp_parser::MAX_NESTING;
-
-    // MAX_NESTING + 8 quote characters, then `X`.  Each `'` recurses
-    // through parse_quote → parse_expr; depth guard must catch it.
-    let depth = MAX_NESTING + 8;
-    let mut src = "'".repeat(depth);
-    src.push('X');
-    let err = parse(&src).expect_err("must trip NestingTooDeep");
-    assert!(matches!(err, ParseError::NestingTooDeep { .. }),
-        "expected NestingTooDeep, got {err:?}");
-}
-
-#[test]
-fn legal_deep_nesting_still_parses() {
-    // 100 nested parens with no body — well below MAX_NESTING — must
-    // round-trip without the depth guard firing.  Confirms the guard
-    // doesn't reject reasonable programs.
-    let mut src = "(".repeat(100);
-    src.push_str(&")".repeat(100));
-    let forms = parse(&src).expect("100 levels of nesting is well within MAX_NESTING");
-    assert_eq!(forms.len(), 1);
-}
-
-#[test]
-fn display_of_list_uses_dotted_form() {
-    // McCarthy's printed form for a list IS the dotted form.
-    // Pretty-printing as `(A B C)` is a future enhancement; for now
-    // the canonical form matches the AST exactly.
-    let e = LispExpr::list([LispExpr::sym("A"), LispExpr::sym("B")]);
-    assert_eq!(format!("{e}"), "(A . (B . NIL))");
+fn display_prints_dotted_cons_form() {
+    assert_eq!(one("(A B)").to_string(), "(A . (B . NIL))");
+    assert_eq!(one("(A . B)").to_string(), "(A . B)");
+    assert_eq!(one("NIL").to_string(), "NIL");
+    assert_eq!(one("()").to_string(), "NIL");
+    assert_eq!(one("-5").to_string(), "-5");
 }

--- a/code/packages/rust/mccarthy-lisp-parser/tests/test_parser.rs
+++ b/code/packages/rust/mccarthy-lisp-parser/tests/test_parser.rs
@@ -225,6 +225,15 @@ fn integer_overflow_errors() {
     assert!(parse("123456789012345678901234567890").is_err());
 }
 
+#[test]
+fn pathological_nesting_does_not_crash() {
+    // DoS hardening: neither a deep paren nest nor a long quote chain
+    // (which has paren-depth 0 but unbounded parser recursion) may abort
+    // the process — both must return a clean Err.
+    assert!(parse(&"(".repeat(10_000)).is_err());
+    assert!(parse(&format!("{}X", "'".repeat(10_000))).is_err());
+}
+
 // ============================================================
 // 8. Multi-form programs
 // ============================================================

--- a/code/specs/MCCARTHY-LISP-PLAN.md
+++ b/code/specs/MCCARTHY-LISP-PLAN.md
@@ -1,6 +1,6 @@
 # McCarthy Lisp on the LANG VM chain — plan
 
-**Status:** Active.  L1 in progress as of 2026-06-03.  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
+**Status:** Active.  **L1 complete and grammar-driven as of 2026-06-03** (the lexer/parser were initially merged hand-written in #4967 and then rewritten to wrap the shared `GrammarLexer`/`GrammarParser` — see the "L1 divergence" note below).  L2 next.  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
 **Predecessors:** [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md), [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md).
 
 ## Goal
@@ -35,16 +35,22 @@ So the work splits into three buckets: **frontend**, **runtime support**, **IBM 
 
 ## Bucket 1 — Frontend crates
 
-Three new crates, mirroring the structure of the existing language frontends:
+Three crates, mirroring the structure of the existing language frontends — and, critically, **grammar-driven**: the lexer and parser are thin wrappers over the shared `GrammarLexer`/`GrammarParser`, exactly like `twig-lexer`/`twig-parser` and `nib`/`oct`.  Per the repo rule (`feedback_no_handwritten_lexers_parsers`), new language frontends MUST NOT hand-write lexers/parsers.
+
+### Grammar files (the single source of truth)
+
+Two files in `code/grammars/` encode the entire Lisp 1.0 surface syntax:
+
+- **`mccarthy_lisp.tokens`** — six token kinds: `LPAREN` `RPAREN` `QUOTE` `DOT`, `SYMBOL = /[A-Z][A-Z0-9-]*/` (all-uppercase), `INTEGER = /-?[0-9]+/`; skips whitespace and `;` comments.  The dialect restrictions are enforced *here*: no lowercase, no operator symbols (a bare `-` matches nothing), no strings.
+- **`mccarthy_lisp.grammar`** — six rules: `program / sexpr / atom / list / list_body / quoted`.  All structural rules — balanced parens, at-most-one dotted tail, "a dot must follow an element" — live in the grammar, so there is no hand-written validation to drift.
+
+Both files are deliberately distinct from the existing `lisp.tokens` / `lisp.grammar`, which target a modern Scheme-ish dialect (lowercase symbols, strings, operator symbols).
 
 ### `mccarthy-lisp-lexer`
-S-expression tokenizer.  Recognises:
-- `(`, `)`, `'` (quote sugar), `.` (dotted pair separator)
-- Atoms: symbols `[A-Z][A-Z0-9-]*` (original Lisp was all-uppercase) and integers
-- Whitespace, comments (`;` to end of line — added in Lisp 1.5; original 704 Lisp had no comments)
+Thin wrapper over `GrammarLexer`.  `build.rs` compiles `mccarthy_lisp.tokens` to Rust at build time (the `twig-lexer` pattern: no runtime file I/O, Miri-safe, `OnceLock`-cached).  Public API: `tokenize_mccarthy(src) -> Result<Vec<lexer::token::Token>, LexerError>`, `create_mccarthy_lexer`, `mccarthy_token_grammar_spec`.
 
 ### `mccarthy-lisp-parser`
-S-expression AST.  Tree shape:
+Thin wrapper over `GrammarParser` plus a CST → typed-AST extractor.  `build.rs` compiles `mccarthy_lisp.grammar` at build time.  The extractor lowers the generic `GrammarASTNode` CST into the typed AST:
 
 ```rust
 enum LispExpr {
@@ -55,7 +61,9 @@ enum LispExpr {
 }
 ```
 
-The parser also expands `'X` → `(QUOTE X)` and `(a . b)` → `Cons(a, b)`.
+Sugar expansions happen in the extractor: `'X` → `(QUOTE X)`, `(A B C)` → `(A . (B . (C . NIL)))`, and `(a . b)` → `Cons(a, b)`.  Public API: `parse(src) -> Result<Vec<LispExpr>, ParseError>`, plus `parse_to_cst` / `extract_program` for tooling.  DoS hardening: `MAX_PAREN_DEPTH = 64` (pre-parse) + `MAX_AST_DEPTH = 64` (extractor).
+
+> **L1 divergence note.** #4967 first merged this frontend as a *hand-written* lexer (bespoke `Token`/`Loc`/`LexError` enums, a byte-at-a-time tokenizer) and a *hand-written* recursive-descent parser (with bespoke `ParseError` variants `StrayDot`, `MultipleDotsInList`, …).  That violated `feedback_no_handwritten_lexers_parsers`.  The follow-up rewrite (this spec revision) deleted both hand-written implementations in favour of the grammar-driven wrappers above and authored the two `code/grammars/mccarthy_lisp.*` files.  The `LispExpr` AST shape is unchanged, so L2 is unaffected.  `MAX_PAREN_DEPTH` dropped from 256 → 64 because the shared `GrammarParser` uses much more stack per paren than the old hand-written descent did.
 
 ### `mccarthy-lisp-iir-compiler`
 Source → `IIRModule`.  Lowering shape:
@@ -132,13 +140,76 @@ Add `--emit=ibm704` (aliases `704`, `ibm-704`) routing through the standard `aot
 
 ---
 
+## The backend pipeline (L3 detail) — every target from one IIR module
+
+This is the heart of the user-facing ask: *get Lisp all the way through AOT, VM, JIT, CLR, JVM, WASM, BEAM, and the historical backends.*  The key insight is that **all of this is downstream of a single artifact** — the `IIRModule` that L2's `mccarthy-lisp-iir-compiler` produces.  Once that module exists, every backend is a fan-out, not new frontend work.
+
+### Flow
+
+```text
+McCarthy source
+   │  mccarthy-lisp-lexer  (GrammarLexer)        ← L1 ✓ grammar-driven
+   ▼  mccarthy-lisp-parser (GrammarParser → LispExpr)
+LispExpr AST
+   │  mccarthy-lisp-iir-compiler                  ← L2
+   ▼
+IIRModule  ──────────────────────────────────────────────────┐
+   │                                                          │
+   │  aot_core::infer → aot_core::specialise → CIR            │  (typed/optimised)
+   ▼                                                          ▼
+ ┌─ vm-core ............... interpret IIR directly  → VM result
+ ├─ jit-core::GenericCirJit  CIR → host machine code → JIT result
+ ├─ x86_64-backend / aarch64-backend (via lang-aot) → native object
+ ├─ iir-to-wasm ........... → .wasm module
+ ├─ iir-to-jvm-class-file . → .class file
+ ├─ iir-to-cil-bytecode ... → CLR assembly
+ ├─ iir-to-beam ........... → BEAM .beam (classic AtU8 atoms — see lessons)
+ ├─ iir-to-llvm ........... → LLVM IR text
+ ├─ ge225 / intel4004 / intel8008 / armv7 / rv32i backends → historical byte code
+ └─ ibm704-backend ........ → IBM 704 byte code (L4/L5, the birthplace round-trip)
+```
+
+Nothing in that fan-out is McCarthy-specific — it is the same IIR→CIR→Backend-trait layer the historical-arch migration (predecessor spec) already shipped.  L3 is therefore mostly *wiring*: adding a `Language::McCarthyLisp` variant to `lang-aot` and routing the existing `--emit` flags through `mccarthy_lisp_iir_compiler::compile`.
+
+### `lang-aot --emit` matrix + per-target acceptance
+
+L3 is "done" when each of these emits a non-trivial artifact for the worked example `(CAR '(A B C))` (expected value `A`) and the listed acceptance test passes.  CONS-using programs are in scope for every modern target; the historical/small-machine targets are restricted to no-CONS programs in v0.1.0 (decision 3).
+
+| `--emit` | Backend crate | Artifact | Acceptance test | CONS in v0.1.0 |
+|----------|---------------|----------|-----------------|----------------|
+| `vm` (default) | `vm-core` | in-process value | interpreter returns `A` | ✓ |
+| `jit` | `jit-core::GenericCirJit` | host code | JIT-run returns `A` | ✓ |
+| `native` / `x86_64` / `aarch64` | `*-backend` via `lang-aot` | object/exe | run exits `0`, prints `A` | ✓ |
+| `wasm` | `iir-to-wasm` | `.wasm` | `wasmtime`/in-repo runner returns `A` | ✓ |
+| `jvm` | `iir-to-jvm-class-file` | `.class` | class verifies; `main` returns `A` | ✓ |
+| `clr` | `iir-to-cil-bytecode` | CLR asm | bytecode validates; returns `A` | ✓ |
+| `beam` | `iir-to-beam` | `.beam` | OTP 27 loads module (classic AtU8); returns `A` | ✓ |
+| `llvm` | `iir-to-llvm` | `.ll` text | `llc`/FileCheck pins IR shape | ✓ |
+| `ge225` / `intel4004` / `intel8008` / `armv7` / `rv32i` | `*-backend` | byte code | e2e smoke test pins byte sequence | ✗ (no-CONS only) |
+| `ibm704` (aliases `704`, `ibm-704`) | `ibm704-backend` (L4) | byte code | e2e smoke test pins byte sequence | ✗ (no-CONS only) |
+
+> **BEAM caveat (carried from lessons):** `iir-to-beam` must emit the classic `AtU8` atom-table format; the nibble-packed form breaks OTP 27 in CI.  See `project_beam_atom_format_otp27`.
+
+### Worked end-to-end example (the L6 demo)
+
+One source file, eleven+ artifacts:
+
+```lisp
+(CAR '(A B C))   ; → A   (no CONS needed → emittable on every target incl. IBM 704)
+(CDR '(A B C))   ; → (B C)  (needs CONS → modern targets only in v0.1.0)
+```
+
+L6 pins, per backend, either the runtime result (`A`) or the exact emitted byte sequence, in a single table-driven e2e test.  That test is the proof that "Lisp runs everywhere in the chain."
+
+---
+
 ## Phases
 
 Same single-PR-per-phase cadence the historical-arch migration used.
 
 | Phase | Scope |
 |-------|-------|
-| **L1** | `mccarthy-lisp-lexer` + `mccarthy-lisp-parser` — tokenize + AST.  Tests pin S-expression round-trips. |
+| **L1** ✓ | `mccarthy-lisp-lexer` + `mccarthy-lisp-parser` — **grammar-driven** (wrap `GrammarLexer`/`GrammarParser`; grammar in `code/grammars/mccarthy_lisp.tokens`+`.grammar`).  Tests pin S-expression round-trips + dialect errors.  *Done; rewritten from the hand-written #4967 merge — see L1 divergence note.* |
 | **L2** | `mccarthy-lisp-iir-compiler` v0.1.0 — handles the 7 primitives + `LAMBDA` + `LABEL` + literal symbols/ints.  Compiles small examples (`(CAR '(A B C))` → `A`, etc.) end-to-end via the existing `vm-core` interpreter. |
 | **L3** | Wire `mccarthy-lisp` into `lang-aot` as a new `Language` variant.  All 10 existing backends light up automatically (CARSON the migration architecture). |
 | **L4** | `ibm704-encoder` + `ibm704-backend` v0.1.0 (minimal viable: `const_*` + `ret_*`, just like the Phase 5/6 minimal-viable backends). |


### PR DESCRIPTION
## Summary

Follow-up to #4967. That PR merged the McCarthy 1960 Lisp L1 frontend with a **hand-written** tokenizer and recursive-descent parser — which violates the repo rule that new language frontends MUST wrap the shared `GrammarLexer`/`GrammarParser` driven by `.tokens`/`.grammar` files (`feedback_no_handwritten_lexers_parsers`). This rewrites both crates to the grammar-driven pattern used by **twig** / **nib** / **oct**, so the lexer and parser now come "for free" from two new grammar files. It also fleshes out the spec for the full multi-backend pipeline.

## What changed

**New grammar files** (single source of truth for the Lisp 1.0 dialect):
- `code/grammars/mccarthy_lisp.tokens` — `SYMBOL`/`INTEGER`/`LPAREN`/`RPAREN`/`QUOTE`/`DOT`. All-uppercase symbols, integers only, no strings — the dialect restrictions are enforced by the token regexes.
- `code/grammars/mccarthy_lisp.grammar` — `program`/`sexpr`/`atom`/`list`/`list_body`/`quoted`. Balanced parens + at-most-one-dotted-tail are enforced by the grammar, not hand-written validation.

**`mccarthy-lisp-lexer` v0.2.0** — thin wrapper over `GrammarLexer`; `build.rs` compiles the `.tokens` file to Rust at build time (twig pattern: no runtime file I/O, Miri-safe, `OnceLock`-cached). Public API: `tokenize_mccarthy() -> Vec<lexer::token::Token>`.

**`mccarthy-lisp-parser` v0.2.0** — thin wrapper over `GrammarParser` + a CST→typed-AST extractor. The `LispExpr` AST (`Nil`/`Symbol`/`Int`/`Cons`) and its sugar expansions (`'X`→`(QUOTE X)`, list nesting, dotted pairs) are **unchanged**, so L2 is unaffected. Bespoke `ParseError` variants are gone — malformed dotted forms / unbalanced parens are now grammar errors.

**Spec** — `MCCARTHY-LISP-PLAN.md` updated: frontend bucket rewritten for the grammar-driven design, an "L1 divergence" note records why/how the hand-written merge was replaced, and a new **"backend pipeline (L3 detail)"** section spells out the full **AOT / VM / JIT / CLR / JVM / WASM / BEAM / LLVM + historical-arch** fan-out — the `--emit` matrix, per-target acceptance criteria, and the end-to-end worked example.

## Security

Ran the mandated security review (2 rounds). Round 1 found a **HIGH** DoS: a quote chain (`''''…X`) has paren-depth 0, so a paren-only guard let it bypass the depth check and overflow the stack inside the shared `GrammarParser` (no internal recursion limit) — a ~5 KB input aborted the process. Fixed by `check_nesting_depth`, which bounds the **combined** paren + pending-quote nesting before parsing. Round 2 **PASSED** (verified the guard's high-water mark equals true recursion depth across interleaved/malformed inputs; regression tests added).

## Test plan

- [x] `cargo test -p mccarthy-lisp-lexer` — 24 unit/integration + 1 doctest pass
- [x] `cargo test -p mccarthy-lisp-parser` — 45 unit/integration + 1 doctest pass (incl. quote-chain + deep-paren DoS guards)
- [x] both crates clippy-clean
- [x] `/security-review` passed (2 rounds: 1 HIGH fixed, then PASSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)