### PR TITLE
feat(mosaic-pkg-grid): wire is-selected / is-editing state into Cell

### DIFF
--- a/code/packages/mosaic-pkg-grid/src/Cell.dark.msl
+++ b/code/packages/mosaic-pkg-grid/src/Cell.dark.msl
@@ -1,21 +1,36 @@
 // Cell.dark.msl — dark theme style for the Cell component.
 //
 // Targets exactly one part: `cell` (the Box wrapping the Text/HostInput).
-// State `editing` is appended via class suffix at render time — when the
-// host promotes a Cell to editing, the React/SwiftUI/Qt emitter adds the
-// `editing` state class so this block's rules apply.
+// States `selected` and `editing` apply via the Box's `state-when-*`
+// predicates declared in Cell.mll — when the host (typically Grid)
+// passes the matching boolean slot, the React / SwiftUI / Qt
+// emitters fold the corresponding state block into the cell's
+// rendered style attribute.
 //
 // Colour palette:
 //   #1e1e1e   — VS Code dark surface, matches Grid sheet background
 //   #cccccc   — VS Code dark foreground text
-//   #007acc   — VS Code accent blue, used for editing outline
+//   #007acc   — VS Code accent blue, used for editing outline + selection ring
+//   #264f78   — VS Code accent dark-blue, used for selected-cell background
 //   #1f4f3f   — desaturated green tint signalling an active edit field
+//   #ffffff   — pure white for selected-cell foreground
 
 style Cell {
   part cell {
     padding:    4px ;
     background: #1e1e1e ;
     color:      #cccccc ;
+
+    // Selected cell — host's currently-focused cell.  The visicalc
+    // Grid.dark.msl palette uses the same colour shape for
+    // selection; pinning it here means a consumer that styles the
+    // grid via `pkg::mosaic-pkg-grid::Cell` gets a sensible default
+    // without re-declaring it at every call site.
+    state selected {
+      background: #264f78 ;
+      color:      #ffffff ;
+      outline:    1px solid #007acc ;
+    }
 
     state editing {
       outline:    1px solid #007acc ;

--- a/code/packages/mosaic-pkg-grid/src/Cell.mll
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mll
@@ -25,7 +25,21 @@
 // can actually lower it depends on which U29-K-* PR has landed.
 
 layout Cell {
-  Box [ cell ] {
+  // The Box's `state-when-*` predicates wire the call-site's
+  // `is-selected` / `is-editing` slots into mosstyle's sub-part
+  // state mechanism (Task #35 / UI28-1).  When the host (typically
+  // Grid) supplies `is-selected: ( r == selectedRow && c == selectedCol )`
+  // at the Cell call site, the boolean propagates to this Box and
+  // the React / SwiftUI / Qt emitters fold the `cell:selected`
+  // mosstyle block into the cell's rendered style attribute.  The
+  // `editing` predicate is the same idea — the Cell visually
+  // highlights while the host has it promoted to edit mode, in
+  // ADDITION to the structural If branch that swaps Text for
+  // HostInput.
+  Box [ cell ] (
+    state-when-selected: ( is-selected ) ,
+    state-when-editing:  ( is-editing )
+  ) {
     If ( when: slot: is-editing ) {
       HostInput (
         value:    slot: value ,


### PR DESCRIPTION
## Summary

The package's `Cell` declared `is-selected` and `is-editing` as slots in `Cell.mil` (UI28-1 §3.1) but never USED the `is-selected` value to style anything — the Box's `state-when-*` predicates were missing. A host (typically the package's own `Grid`) could pass `is-selected` per cell and see no visual change.

This PR wires both predicates through, mirroring the Task #35 mechanism the visicalc consumer already uses.

## Changes

- `Cell.mll`: Box gains `state-when-selected: ( is-selected )` and `state-when-editing: ( is-editing )`.
- `Cell.dark.msl`: adds `state selected { ... }` with the same palette the visicalc demo uses (`#264f78` background, `#007acc` outline, `#ffffff` text).

## Why now

UI34 PR-3 (#4969) just merged, so `mosaic-compile`'s resolver can substitute `pkg::mosaic-pkg-grid::Cell` at consumer build time. Without this state wiring, a consumer switching from inlined kernel primitives to the package via `pkg::` would lose its per-cell selection highlight — a visible regression. This is the last package-side gap before visicalc-React can migrate to the `pkg::` form end-to-end.

## Test plan

- [x] `cargo test` in `code/packages/mosaic-pkg-grid` — all 12 smoke tests pass
- [x] Slot declarations + grammar shape unchanged (the slot was already declared; this PR adds the layout-level consumer)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)