### PR TITLE
feat(mosaic-pkg-grid): edit-content / onChange + slot-form state-whens

### DIFF
--- a/code/packages/mosaic-pkg-grid/src/Cell.mil
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mil
@@ -53,14 +53,29 @@
 //   onCancel      fired when an in-progress edit is abandoned
 
 component Cell {
-  slot value       : text ;
-  slot editable    : bool ;
-  slot is-editing  : bool ;
-  slot is-selected : bool ;
-  slot alignment   : text ;
-  slot cell-type   : text ;
+  slot value        : text ;
+  // edit-content — the host's live edit buffer (UI28-1 v0.3.0).  When
+  // the cell is promoted to editing, the HostInput's `value=` is
+  // wired to this slot rather than the underlying `value` so the
+  // input actually accepts keystrokes.  A controlled
+  // `<input value={X}>` without an `onChange` companion freezes
+  // (React rejects keystrokes); pairing edit-content with onChange
+  // restores the writable round-trip.  Hosts typically maintain a
+  // single edit-content string in their state and thread the SAME
+  // buffer through every Cell — at most one Cell edits at a time.
+  slot edit-content : text ;
+  slot editable     : bool ;
+  slot is-editing   : bool ;
+  slot is-selected  : bool ;
+  slot alignment    : text ;
+  slot cell-type    : text ;
 
   emit onClick ;
+  // onChange fires every keystroke while editing.  Carries the new
+  // input value so the host's reducer can update `edit-content`.
+  // Paired with the `edit-content` slot to complete the
+  // controlled-input round-trip.
+  emit onChange ( value : text ) ;
   emit onCommit ( value : text ) ;
   emit onCancel ;
 }

--- a/code/packages/mosaic-pkg-grid/src/Cell.mll
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mll
@@ -37,12 +37,31 @@ layout Cell {
   // ADDITION to the structural If branch that swaps Text for
   // HostInput.
   Box [ cell ] (
-    state-when-selected: ( is-selected ) ,
-    state-when-editing:  ( is-editing )
+    // Use the `slot:` form (not the `( name )` expression form) so
+    // the UI34 package resolver's `rewrite_bindings` step
+    // substitutes the call-site's bound value at compile time.
+    // With the expression form, identifiers inside the parentheses
+    // pass through as raw text and would land in the emitter as
+    // invalid JS identifiers (`is-selected` has a hyphen).  The
+    // slot-ref form goes through the resolver's existing
+    // SlotRef-rewrite path, so the call-site predicate
+    // (`r == selectedRow && c == selectedCol`) ends up inlined
+    // here verbatim.
+    state-when-selected: slot: is-selected ,
+    state-when-editing:  slot: is-editing
   ) {
     If ( when: slot: is-editing ) {
+      // value: slot: edit-content — the host's live edit buffer,
+      // not the underlying cell value.  A controlled HostInput
+      // pointed at `slot: value` without an `onChange` companion
+      // would freeze (React rejects keystrokes); pairing
+      // edit-content with onChange lets the host's reducer track
+      // the in-flight edit and the input accepts characters
+      // normally.  When the user hits Enter, onCommit carries
+      // the final value to the host's persistence layer.
       HostInput (
-        value:    slot: value ,
+        value:    slot: edit-content ,
+        onChange: emit: onChange ,
         onCommit: emit: onCommit ,
         onCancel: emit: onCancel
       )

--- a/code/packages/mosaic-pkg-grid/src/Grid.mil
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mil
@@ -87,7 +87,13 @@ component Grid {
   slot edit-col       : number ;
   slot edit-content   : text ;
 
-  emit onNavigate    ( row : number , col : number ) ;
-  emit onEditCommit  ( value : text ) ;
+  emit onNavigate       ( row : number , col : number ) ;
+  // onFormulaChange fires every keystroke inside an editing cell;
+  // the host's reducer updates `edit-content` in response, and the
+  // value flows back into the cell on the next render.  Without
+  // this round-trip the cell's HostInput freezes — see Cell.mil
+  // for the controlled-input rationale.
+  emit onFormulaChange  ( value : text ) ;
+  emit onEditCommit     ( value : text ) ;
   emit onEditCancel ;
 }

--- a/code/packages/mosaic-pkg-grid/src/Grid.mll
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mll
@@ -128,14 +128,34 @@ layout Grid {
       For ( each: slot: viewport-rows , as: row , index: r ) {
         Row [ data-row ] {
           For ( each: row , as: v , index: c ) {
-            Cell [ body ] (
+            // No call-site part name here.  Earlier drafts used
+            // `Cell [body]` to give the call site its own
+            // addressable part, but Grid.dark.msl never targets
+            // `body` and the consumer-side part-name override
+            // (UI34 §5.1) would then shadow Cell's own `cell` part,
+            // breaking any consumer .msl that styles `cell`.
+            // Dropping the label lets Cell.mll's root `Box [cell]`
+            // flow through after resolution.
+            Cell (
               value:        ( v ) ,
+              // edit-content forwards the host's live edit buffer
+              // (the same buffer the FormulaBar drives) into every
+              // cell.  Only the cell with `is-editing: true` will
+              // actually render a HostInput pointed at it; the
+              // others receive the buffer but never display it.
+              edit-content: slot: edit-content ,
               is-editing:   ( r == editRow && c == editCol ) ,
               is-selected:  ( r == selectedRow && c == selectedCol ) ,
               editable:     true ,
               alignment:    "left" ,
               cell-type:    "text" ,
               onClick:      emit: onNavigate ,
+              // onChange propagates per-keystroke updates to the
+              // host as `onFormulaChange` so the host's reducer can
+              // update edit-content.  Without this round-trip the
+              // controlled HostInput in Cell freezes — see Cell.mll
+              // for the rationale.
+              onChange:     emit: onFormulaChange ,
               onCommit:     emit: onEditCommit ,
               onCancel:     emit: onEditCancel
             )


### PR DESCRIPTION
## Summary

Closes the last package-side gap before the **visicalc-React demo can migrate** from its 148-line inlined kernel-primitive `Grid.desktop.mll` to a single `pkg::mosaic-pkg-grid::Grid (…)` reference without any behavioural regression.

## Verified end-to-end

Wrote a 16-line consumer `.mll` using `pkg::mosaic-pkg-grid::Grid`. Compiled with `mosaic-compile --backend react` against the visicalc `Grid.mil` + `Grid.dark.msl`. Diffed against the existing inlined-kernel-primitives compile:

✅ **Byte-identical** Grid.tsx (74 lines, same React code).

## Four small but coupled changes

1. **`Cell.mil`** — adds `slot edit-content : text` and `emit onChange ( value : text )`. Together they complete the controlled-input round-trip an absent `onChange` would otherwise break (React rejects keystrokes on a controlled `<input value={X}>` without `onChange`).
2. **`Cell.mll`** — editing `HostInput`'s `value=` now points at `slot: edit-content`; `onChange` wires to the new emit. **Crucially flips the Box state-when predicates from the expression form `( is-selected )` to the slot-ref form `slot: is-selected`.** The UI34 resolver's `rewrite_bindings` substitutes call-site values into `SlotRef` props but doesn't rewrite identifiers inside an `Expr`; the slot-ref form routes through the existing substitution path, so the call-site predicate ends up inlined verbatim — exactly what the React emitter needs.
3. **`Grid.mil`** — adds `emit onFormulaChange ( value : text )` (matches the visicalc demo's existing FormulaBar shape).
4. **`Grid.mll`** — Cell call site forwards `edit-content` + `onChange` to its host. Also drops the previously-unused `[ body ]` part label so Cell's own `cell` part flows through to the consumer's `.msl` (per UI34 §5.1 the call-site part name would otherwise shadow it).

## Test plan

- [x] `cargo test --test package_compiles` — 12 passed, 0 failed
- [x] End-to-end visicalc-style consumer `.mll` compiles clean and produces byte-identical 74-line Grid.tsx vs the inlined version
- [ ] CI

## Follow-up

Once this lands, a tiny PR will replace the 148-line `demo/visicalc/mosaic/Grid.desktop.mll` with a `pkg::mosaic-pkg-grid::Grid (...)` reference. That's the user-visible win the UI34 ladder has been building toward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)