### PR TITLE
feat(visicalc): UI34 PR-4 — collapse Grid.desktop.mll to pkg:: ref

### DIFF
--- a/code/packages/mosaic-pkg-grid/src/Cell.mil
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mil
@@ -53,14 +53,29 @@
 //   onCancel      fired when an in-progress edit is abandoned
 
 component Cell {
-  slot value       : text ;
-  slot editable    : bool ;
-  slot is-editing  : bool ;
-  slot is-selected : bool ;
-  slot alignment   : text ;
-  slot cell-type   : text ;
+  slot value        : text ;
+  // edit-content — the host's live edit buffer (UI28-1 v0.3.0).  When
+  // the cell is promoted to editing, the HostInput's `value=` is
+  // wired to this slot rather than the underlying `value` so the
+  // input actually accepts keystrokes.  A controlled
+  // `<input value={X}>` without an `onChange` companion freezes
+  // (React rejects keystrokes); pairing edit-content with onChange
+  // restores the writable round-trip.  Hosts typically maintain a
+  // single edit-content string in their state and thread the SAME
+  // buffer through every Cell — at most one Cell edits at a time.
+  slot edit-content : text ;
+  slot editable     : bool ;
+  slot is-editing   : bool ;
+  slot is-selected  : bool ;
+  slot alignment    : text ;
+  slot cell-type    : text ;
 
   emit onClick ;
+  // onChange fires every keystroke while editing.  Carries the new
+  // input value so the host's reducer can update `edit-content`.
+  // Paired with the `edit-content` slot to complete the
+  // controlled-input round-trip.
+  emit onChange ( value : text ) ;
   emit onCommit ( value : text ) ;
   emit onCancel ;
 }

--- a/code/packages/mosaic-pkg-grid/src/Cell.mll
+++ b/code/packages/mosaic-pkg-grid/src/Cell.mll
@@ -37,12 +37,31 @@ layout Cell {
   // ADDITION to the structural If branch that swaps Text for
   // HostInput.
   Box [ cell ] (
-    state-when-selected: ( is-selected ) ,
-    state-when-editing:  ( is-editing )
+    // Use the `slot:` form (not the `( name )` expression form) so
+    // the UI34 package resolver's `rewrite_bindings` step
+    // substitutes the call-site's bound value at compile time.
+    // With the expression form, identifiers inside the parentheses
+    // pass through as raw text and would land in the emitter as
+    // invalid JS identifiers (`is-selected` has a hyphen).  The
+    // slot-ref form goes through the resolver's existing
+    // SlotRef-rewrite path, so the call-site predicate
+    // (`r == selectedRow && c == selectedCol`) ends up inlined
+    // here verbatim.
+    state-when-selected: slot: is-selected ,
+    state-when-editing:  slot: is-editing
   ) {
     If ( when: slot: is-editing ) {
+      // value: slot: edit-content — the host's live edit buffer,
+      // not the underlying cell value.  A controlled HostInput
+      // pointed at `slot: value` without an `onChange` companion
+      // would freeze (React rejects keystrokes); pairing
+      // edit-content with onChange lets the host's reducer track
+      // the in-flight edit and the input accepts characters
+      // normally.  When the user hits Enter, onCommit carries
+      // the final value to the host's persistence layer.
       HostInput (
-        value:    slot: value ,
+        value:    slot: edit-content ,
+        onChange: emit: onChange ,
         onCommit: emit: onCommit ,
         onCancel: emit: onCancel
       )

--- a/code/packages/mosaic-pkg-grid/src/Grid.mil
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mil
@@ -87,7 +87,13 @@ component Grid {
   slot edit-col       : number ;
   slot edit-content   : text ;
 
-  emit onNavigate    ( row : number , col : number ) ;
-  emit onEditCommit  ( value : text ) ;
+  emit onNavigate       ( row : number , col : number ) ;
+  // onFormulaChange fires every keystroke inside an editing cell;
+  // the host's reducer updates `edit-content` in response, and the
+  // value flows back into the cell on the next render.  Without
+  // this round-trip the cell's HostInput freezes — see Cell.mil
+  // for the controlled-input rationale.
+  emit onFormulaChange  ( value : text ) ;
+  emit onEditCommit     ( value : text ) ;
   emit onEditCancel ;
 }

--- a/code/packages/mosaic-pkg-grid/src/Grid.mll
+++ b/code/packages/mosaic-pkg-grid/src/Grid.mll
@@ -128,14 +128,34 @@ layout Grid {
       For ( each: slot: viewport-rows , as: row , index: r ) {
         Row [ data-row ] {
           For ( each: row , as: v , index: c ) {
-            Cell [ body ] (
+            // No call-site part name here.  Earlier drafts used
+            // `Cell [body]` to give the call site its own
+            // addressable part, but Grid.dark.msl never targets
+            // `body` and the consumer-side part-name override
+            // (UI34 §5.1) would then shadow Cell's own `cell` part,
+            // breaking any consumer .msl that styles `cell`.
+            // Dropping the label lets Cell.mll's root `Box [cell]`
+            // flow through after resolution.
+            Cell (
               value:        ( v ) ,
+              // edit-content forwards the host's live edit buffer
+              // (the same buffer the FormulaBar drives) into every
+              // cell.  Only the cell with `is-editing: true` will
+              // actually render a HostInput pointed at it; the
+              // others receive the buffer but never display it.
+              edit-content: slot: edit-content ,
               is-editing:   ( r == editRow && c == editCol ) ,
               is-selected:  ( r == selectedRow && c == selectedCol ) ,
               editable:     true ,
               alignment:    "left" ,
               cell-type:    "text" ,
               onClick:      emit: onNavigate ,
+              // onChange propagates per-keystroke updates to the
+              // host as `onFormulaChange` so the host's reducer can
+              // update edit-content.  Without this round-trip the
+              // controlled HostInput in Cell freezes — see Cell.mll
+              // for the rationale.
+              onChange:     emit: onFormulaChange ,
               onCommit:     emit: onEditCommit ,
               onCancel:     emit: onEditCancel
             )

--- a/demo/visicalc/mosaic/Grid.desktop.mll
+++ b/demo/visicalc/mosaic/Grid.desktop.mll
@@ -1,135 +1,73 @@
-// Grid.desktop.mll — desktop layout for the VisiCalc spreadsheet grid.
+// Grid.desktop.mll — UI34 PR-4 (final).
 //
-// UI28-1 / U29-D1 rewrite — replaces the L10 "degraded HostTable"
-// composition with the v0.2.0 cell-and-column shape pioneered by
-// mosaic-pkg-grid v0.2.0 (see code/packages/mosaic-pkg-grid).  The
-// VisiCalc demo cannot yet `import` Grid from that package cross-
-// repo because mosaic-compile's package-resolver isn't wired through
-// the demo's build script — so the composition is inlined here.  When
-// the package-resolver lands, this whole file collapses to:
+// THE COLLAPSE — what this file used to be vs what it is now
+// ----------------------------------------------------------
 //
-//   layout Grid {
-//     pkg::mosaic-pkg-grid::Grid (
-//       viewport-rows:  slot: viewport-rows ,
-//       column-headers: slot: column-headers ,
-//       column-widths:  slot: column-widths ,
-//       selected-row:   slot: selected-row ,
-//       selected-col:   slot: selected-col ,
-//       edit-row:       slot: edit-row ,
-//       edit-col:       slot: edit-col ,
-//       edit-content:   slot: edit-content ,
-//       onNavigate:     emit: onNavigate ,
-//       onEditCommit:   emit: onEditCommit ,
-//       onEditCancel:   emit: onEditCancel
-//     )
-//   }
+// Before UI34: 148 lines of hand-rolled
+// HostTable + HostTableColGroup + HostTableHead + HostTableBody
+// + nested For + Box[cell] + state-when-* + If/Else + HostInput
+// composition.  Inlined here because mosaic-compile's package
+// resolver wasn't wired through the demo build script.
 //
-// Features recovered vs the L10 degraded version
-// ----------------------------------------------
+// After UI34 (PR-3 #4969 + PR-4 #4974): one `pkg::mosaic-pkg-grid::Grid`
+// reference.  mosaic-compile locates the package on its
+// `--package-search-path`, recursively compiles
+// `mosaic-pkg-grid`'s Grid + Cell triple, substitutes the resolved
+// sub-tree at this call site, and rewires every slot/emit
+// reference inside it to the visicalc consumer's matching slot /
+// emit name.  The generated `src/components/Grid.tsx` is
+// **byte-identical** to the pre-collapse output — same 74 lines
+// of React, same behaviour, same per-cell state-when style spreads.
 //
-//   1. Per-cell click — every body Cell's HostInput / Text sits inside
-//      a Box [cell] in a Row that dispatches `onNavigate(r, c)`.
-//   2. Selection highlight — sub-part styling (`sheet/cell:selected`)
-//      fires when `r == selectedRow && c == selectedCol`.  The
-//      predicate value is computed at the cell call site via
-//      expression-in-slot-binding (UI29 §3.3).
-//   3. Inline editing — `If (when: r == editRow && c == editCol)`
-//      renders a HostInput in place of the Text leaf.  `onCommit` /
-//      `onCancel` forward to the App's reducer.
-//   4. Per-column widths — `HostTableColGroup` with
-//      `For (each: slot: column-widths, as: w)` emits one <col width>
-//      per column.
-//   5. Stable React keys — every For binds an explicit `index:`.
-//      mosaic-emit-react auto-emits `<React.Fragment key={r}>` per
-//      iteration (UI28-1 §6.3 / PR #4396), so the diff cost stays
-//      O(1) per render for the VisiCalc-scale 100×26 grid.
+// What the collapse proves
+// ------------------------
 //
-// Still NOT in v0.2.0 (deferred to UI28-2)
-// ----------------------------------------
+//   1. UI34's `pkg::P::C` syntax works end-to-end on the React
+//      backend — grammar, AST, resolver, emitter all line up.
+//   2. The package is now the single source of truth for what a
+//      Grid is.  When `mosaic-pkg-grid` ships sticky-header
+//      support or a new state-when predicate, this demo
+//      automatically gets the new behaviour at the next
+//      `bash scripts/build.sh`.  No `.mll` drift, no copy-paste
+//      maintenance.
+//   3. The other six VisiCalc demos (visicalc-html, -webcomp,
+//      -swiftui, -qt, -flutter, -compose, -android) — all of
+//      which currently hand-write their grid widget directly in
+//      the host language — can follow the same path once their
+//      respective backend emitters are confirmed to handle the
+//      kernel primitives `mosaic-pkg-grid::Grid` expands into.
 //
-//   - Sticky header (per UI28-1 §2 constraint 5).  The header
-//     scrolls away with the body.
+// How the bindings work
+// ---------------------
 //
-// Composition (kernel primitives + HostInput + If/Else only — no
-// per-backend special cases)
-// --------------------------------------------------------------
+// Every prop name on the left side of `:` is a slot or emit
+// declared in `mosaic-pkg-grid`'s `Grid.mil`.  Every value on the
+// right side is bound to a slot or emit declared in this demo's
+// own `Grid.mil`.  Because the demo's `Grid.mil` declares slots
+// with the SAME names as the package's, every binding is a
+// pass-through (`viewport-rows: slot: viewport-rows`).
 //
-//   HostTable [ sheet ]                  ← semantic data table
-//     HostTableColGroup                  ← <colgroup>
-//       For ( each: slot: column-widths, as: w, index: cw )
-//         Col [ col ] ( width: ( w ) )
-//     HostTableHead                      ← <thead>
-//       Row [ header-row ]               ← <tr>
-//         For ( each: slot: column-headers, as: h, index: ch )
-//           Box [ header-cell ]          ← <th>
-//             Text ( content: ( h ) )
-//     HostTableBody                      ← <tbody>
-//       For ( each: slot: viewport-rows, as: row, index: r )
-//         Row [ data-row ]               ← <tr>
-//           For ( each: row, as: v, index: c )    ← UI29 §3.4
-//             Box [ cell ]               ← <td>, styled by part `sheet/cell`
-//               If ( when: ( r == editRow && c == editCol ) )
-//                 HostInput ( value: ( v ),
-//                             onCommit: emit: onEditCommit,
-//                             onCancel: emit: onEditCancel )
-//               Else
-//                 Text ( content: ( v ) )
+// The resolver's `rewrite_bindings` step walks the inlined Grid
+// sub-tree and substitutes every `slot: viewport-rows` reference
+// in the package's body with the call-site's
+// `slot: viewport-rows` — which here is the SAME slot name
+// because the consumer mirrors the package's interface, but
+// the indirection is what makes a name-mismatched consumer
+// (e.g. `viewport-rows: slot: my-data`) work too.
 
 layout Grid {
-  HostTable [ sheet ] {
-    HostTableColGroup {
-      For ( each: slot: column-widths , as: w , index: cw ) {
-        Col [ col ] ( width: ( w ) )
-      }
-    }
-    HostTableHead {
-      Row [ header-row ] {
-        For ( each: slot: column-headers , as: h , index: ch ) {
-          Box [ header-cell ] {
-            Text ( content: ( h ) )
-          }
-        }
-      }
-    }
-    HostTableBody {
-      For ( each: slot: viewport-rows , as: row , index: r ) {
-        Row [ data-row ] {
-          For ( each: row , as: v , index: c ) {
-            Box [ cell ] (
-              // Task #35 — per-cell sub-part state toggles. mosstyle
-              // declares `state selected { ... }` and `state editing
-              // { ... }` blocks under `part sheet/cell` in
-              // Grid.dark.msl; the React emitter looks up these
-              // `state-when-*` predicates and emits conditional style
-              // spreads inside the cell's `style={{...}}` JSX object.
-              // Result: the selected cell visually highlights as the
-              // user navigates, and the editing cell carries a
-              // distinct background while inline editing is active.
-              state-when-selected: ( r == selectedRow && c == selectedCol ) ,
-              state-when-editing:  ( r == editRow && c == editCol )
-            ) {
-              If ( when: ( r == editRow && c == editCol ) ) {
-                // value: ( slot: edit-content ) reflects the host's
-                // live edit buffer.  Using `( v )` would freeze the
-                // input at the cell's stored value because React's
-                // controlled `<input value={v} />` rejects keystrokes
-                // when there is no onChange.  Pairing edit-content
-                // with onFormulaChange below restores the writable
-                // round-trip the FormulaBar already enjoys.
-                HostInput (
-                  value:    slot: edit-content ,
-                  onChange: emit: onFormulaChange ,
-                  onCommit: emit: onEditCommit ,
-                  onCancel: emit: onEditCancel
-                )
-              }
-              Else {
-                Text ( content: ( v ) )
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  pkg::mosaic-pkg-grid::Grid (
+    viewport-rows:    slot: viewport-rows ,
+    column-headers:   slot: column-headers ,
+    column-widths:    slot: column-widths ,
+    selected-row:     slot: selected-row ,
+    selected-col:     slot: selected-col ,
+    edit-row:         slot: edit-row ,
+    edit-col:         slot: edit-col ,
+    edit-content:     slot: edit-content ,
+    onNavigate:       emit: onNavigate ,
+    onFormulaChange:  emit: onFormulaChange ,
+    onEditCommit:     emit: onEditCommit ,
+    onEditCancel:     emit: onEditCancel
+  )
 }

--- a/demo/visicalc/scripts/build.sh
+++ b/demo/visicalc/scripts/build.sh
@@ -36,10 +36,19 @@ OUT_DIR="$DEMO_DIR/src/components"
 mkdir -p "$OUT_DIR"
 
 echo "Compiling Grid..."
+# UI34 PR-4 — Grid.desktop.mll is now a one-liner that references
+# `pkg::mosaic-pkg-grid::Grid`.  We pass --package-search-path
+# explicitly so the build works regardless of the directory the
+# script is invoked from; the resolver locates the package,
+# recursively compiles its Grid + Cell triple, and substitutes
+# the resolved sub-tree into the demo's layout before the React
+# emitter runs.  The generated Grid.tsx is byte-identical to the
+# pre-UI34 inlined-kernel-primitives output.
 "$MOSAIC_COMPILE" --backend react \
-  --interface "$DEMO_DIR/mosaic/Grid.mil" \
-  --layout    "$DEMO_DIR/mosaic/Grid.desktop.mll" \
-  --style     "$DEMO_DIR/mosaic/Grid.dark.msl" \
+  --interface           "$DEMO_DIR/mosaic/Grid.mil" \
+  --layout              "$DEMO_DIR/mosaic/Grid.desktop.mll" \
+  --style               "$DEMO_DIR/mosaic/Grid.dark.msl" \
+  --package-search-path "$REPO_ROOT/code/packages" \
   -o "$OUT_DIR/Grid.tsx"
 
 echo "Compiling FormulaBar..."


### PR DESCRIPTION
## Summary

**The dividend of the entire UI34 ladder.**

The 148-line inlined kernel-primitive `Grid.desktop.mll` collapses to a 13-line `pkg::mosaic-pkg-grid::Grid (…)` reference. The leading comment of the old file explicitly anticipated this moment — and now it's here.

## Verification — byte-identical output

```
diff /tmp/Grid.inline.tsx demo/visicalc/src/components/Grid.tsx
# exit 0 — no diff
```

The generated React component is 74 lines, identical to the pre-collapse output. Same per-cell state-when style spreads, same nested map / If / Else / HostInput shape. No visual regression. No runtime difference.

## Dependency chain

Depends on **PR #4974** (`mosaic-pkg-grid` edit-content + slot-form state-whens). Opening as **draft** — will mark ready-to-review once #4974 lands. Will rebase onto main after #4974 merges.

## What's permanently different

- `Grid.desktop.mll` is a 13-line wiring file, not a 148-line composition.
- When `mosaic-pkg-grid` v0.3.0 ships sticky-header support (or anything else), this demo gets the new behaviour automatically at the next build. No copy-paste drift.
- `scripts/build.sh` now passes `--package-search-path` so the build is location-independent.

## Follow-up

The other six hand-written VisiCalc demos (`-html`, `-webcomp`, `-swiftui`, `-qt`, `-flutter`, `-compose`, `-android`) can follow the same path in their own PRs once each backend's emitter is confirmed to handle the kernel primitives `mosaic-pkg-grid::Grid` expands into. Current state: emit-html got the Else fix in #4971; emit-swiftui has a separate type-checker issue queued; the rest will be audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)