### PR TITLE
ADJ55 — three-arm comparison: plain Claude also misses the PE

### DIFF
--- a/code/specs/ADJ55-provenance-first-corpus.md
+++ b/code/specs/ADJ55-provenance-first-corpus.md
@@ -99,17 +99,25 @@ provenance is the variable that flips one to the other.**
 - The grounded vs ungrounded contrast isolates *grounding the numbers* — but the arms did
   not get perfectly matched inputs (the ungrounded arm also misread the prose). Both are
   failure modes the provenance-first pipeline structurally prevents.
-- **Not yet tested: grounded corpus vs *plain* frontier Claude** (no framework). Plain
-  Claude is a strong diagnostician and may also reach the right disposition here; if so,
-  the grounded corpus's edge is *auditability*, not a different answer. That clean 3-arm
-  comparison is the next experiment.
+- **Plain frontier Claude was tested (the third arm) — and it was wrong too.** Given the
+  same case with no framework, plain Claude put PE at **3–5%** and was "comfortable not
+  doing CTPA" on a patient who had a PE — the same Wells-0/D-dimer-distractor trap the
+  ungrounded deriver fell into. Only the grounded corpus (0.28 → image → 0.89) caught it.
+  So on this case the framework's edge was **correctness, not merely auditability**: the
+  grounded base rate (0.192, vs Claude's ~3–5% gestalt) and mechanical LR application kept
+  the real PE on the table where unconstrained reasoning let a better-fitting narrative
+  exclude it. Full three-arm writeup + verbatim plain-Claude run:
+  [`provenance/pe/arms/`](data/adj52/provenance/pe/arms/three-arm-comparison.md).
+  **Caveat: n = 1** — an existence proof, not a rate; the rule-out and high-Wells cases are
+  still owed (see §6).
 - The corpus grounds *present*-finding LRs; LR-for-absence is not yet grounded (it is why
   the corpus correctly does not over-weight Wells-0, but a fuller corpus would ground both).
 
 ## 6. Next
 
-- The clean 3-arm comparison (plain Claude / grounded corpus / ungrounded framework) over
-  several PE cases (a true rule-out, a high-Wells confirm).
+- **Extend the three-arm comparison to n > 1** — a true rule-out (low Wells + *negative*
+  D-dimer) and a high-Wells confirm — to learn whether PMC11999957 flattered the framework
+  or the pattern holds. (The first three-arm run is done; see §5.)
 - LR-for-absence grounding.
 - A second grounded domain, to show the construction generalizes.
 - Wire the deterministic evaluator into the adj52 engine path so a grounded `corpus.json`

--- a/code/specs/data/adj52/CHANGELOG.md
+++ b/code/specs/data/adj52/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the ADJ52 experiment runner.
 
+## [0.3.1] — 2026-06-04
+
+### Added
+
+- **ADJ55 three-arm comparison (the control arm §5 owed).** Ran plain frontier Claude
+  (no framework) on the PMC11999957 PE case alongside the grounded corpus and the
+  ungrounded deriver. Result: plain Claude put PE at **3–5%** and was "comfortable not
+  imaging" a patient who had a PE — the same Wells-0/D-dimer trap; only the grounded
+  corpus (0.28 → 0.89) caught it. On this case the framework's edge was **correctness**,
+  not merely auditability. Writeup + verbatim run in `provenance/pe/arms/`; ADJ55 §5/§6
+  updated. **n = 1 — existence proof, not a rate** (rule-out + high-Wells cases still owed).
+
 ## [0.3.0] — 2026-06-04
 
 ### Added

--- a/code/specs/data/adj52/provenance/pe/arms/plain-claude.md
+++ b/code/specs/data/adj52/provenance/pe/arms/plain-claude.md
@@ -1,0 +1,55 @@
+# Arm A — plain Claude (no framework), verbatim
+
+The PMC11999957 case given to plain Claude with no rulebook, no corpus, no forced
+structure, no web lookup — just the clinical question. This is the control arm
+ADJ55 §5 flagged as not-yet-run. **Ground truth: PE was present** (CTPA filling
+defect, DVT confirmed; pretest scores were low but PE was real).
+
+## Prompt
+
+> You are an experienced physician. A colleague hands you the following case and
+> asks for your read. Reason it through and answer naturally — there is no template
+> to fill in. Do NOT search the web or look up any published case; reason from your
+> own clinical knowledge.
+>
+> CASE: "A 55-year-old man presented with exertional chest pain, palpitations, and
+> dyspnea. HR 80, no leg edema. ECG showed ST-elevation mimicking ACS. D-dimer
+> elevated. Wells score 0 (low clinical probability). Angiography clean."
+>
+> 1. Most likely diagnosis + differential? 2. Specifically, probability of PE? 3.
+> What would you do next? 4. How confident, and what would change your mind?
+
+(Identical case prose to the one the framework arms received.)
+
+## Response (verbatim)
+
+**Most likely diagnosis:** a STEMI-mimic / MINOCA-type presentation; leading
+diagnosis **acute pericarditis / myopericarditis**, then myocarditis, Takotsubo,
+vasospasm/SCAD, aortic pathology. PE is "on the list because of the elevated
+D-dimer and dyspnea, but … a poor fit."
+
+**Probability of PE:** *"Low. I'd put it around **3–5%**, roughly at or below the
+population baseline."* Reasoning: Wells 0, HR 80 (not tachycardic), no leg edema,
+clean angiogram; *"The elevated D-dimer is almost certainly explained by the
+inflammatory/myocardial process … not by clot. A positive D-dimer on top of a low
+Wells score does not raise PE probability much … PE is a distractor here."*
+
+**What next:** troponin, echo, careful ECG re-read, inflammatory markers. On PE
+specifically: *"rather than reflexively CT every such patient … If a coherent
+pericarditis/myocarditis picture consolidates and there's no RV strain or hypoxia,
+I'd be comfortable not doing CTPA. If anything points to RV strain, hypoxia, or
+syncope, I'd get a CTPA promptly."*
+
+**Confidence:** *"high confidence that PE is not the answer."* Bottom line: *"don't
+let the elevated D-dimer hijack the case … reserve CTPA for actual signs of RV
+strain or hypoxia rather than the D-dimer alone."*
+
+## Verdict
+
+**Incorrect.** Sophisticated reasoning — it correctly reframed the ECG/clean-angio
+picture as a cardiac mimic and even named the anchoring trap — but its operative
+conclusion was to put PE at 3–5% and **be comfortable not imaging**, on a patient
+who had a PE. The two errors are quantified in
+[`three-arm-comparison.md`](three-arm-comparison.md): it under-anchored the base
+rate (~3–5% vs the grounded 0.192) and let the better-fitting narrative override
+the positive-D-dimer's standing mandate to image.

--- a/code/specs/data/adj52/provenance/pe/arms/three-arm-comparison.md
+++ b/code/specs/data/adj52/provenance/pe/arms/three-arm-comparison.md
@@ -1,0 +1,68 @@
+# PE case PMC11999957 — three-arm comparison (the moment of truth)
+
+The clean comparison [ADJ55](../../../../ADJ55-provenance-first-corpus.md) §5
+flagged as not-yet-run: **plain Claude** vs **the grounded corpus** vs **the
+ungrounded invent-LRs framework**, all on the same case, blind to ground truth.
+
+**Case:** 55-year-old man, exertional chest pain / palpitations / dyspnea, HR 80,
+no leg edema, ECG ST-elevation mimicking ACS, D-dimer elevated, **Wells score 0**
+(low pretest), coronary angiography clean.
+
+**Ground truth:** **PE was present** — CTPA filling defect, DVT confirmed, ACS
+excluded. *The pretest score was low but the PE was real.* (Source PMC11999957.)
+
+## Result
+
+| arm | P(PE) | disposition | correct? |
+|---|---|---|---|
+| **Plain Claude** (no framework) | **3–5%** | "PE is not the answer"; CTPA only *if* RV strain / hypoxia appears | ❌ would likely miss it |
+| **Ungrounded framework** (invented LRs, self-disclosed) | **1%** | "PE excluded" | ❌ |
+| **Grounded corpus** (every LR → a study) | **0.28 pretest → 0.89 after CTPA** | "can't exclude → image" → CTPA confirms | ✅ |
+
+**Both unconstrained reasoners excluded a real PE. Only the byte-grounded corpus
+kept it on the table and caught it.** Plain Claude's reasoning was excellent — it
+reframed the case as a cardiac mimic (MINOCA / pericarditis) and explicitly named
+the anchoring trap — yet its operative conclusion was still wrong.
+
+## Why the grounded corpus diverged (and was right)
+
+Two grounded numbers, neither a gestalt:
+
+1. **Base rate.** Plain Claude anchored the pretest at ~3–5%. The grounded
+   prevalence for a *worked-up suspected-PE* patient is **0.192** (Christopher
+   study, 634/3306); even the Wells-"unlikely" subgroup is **12%**. Plain Claude
+   under-anchored the floor ~4–5×. The framework cannot, because the prior is a
+   published number with a byte-anchored chain.
+2. **D-dimer.** All three arms agree the positive D-dimer is a weak rule-in
+   (grounded `LR+ = 1.64`, sens 0.97 / spec 0.41). But the two Claude arms used
+   that weakness to *dismiss* PE; the grounded math multiplies `0.192 × 1.64 = 0.28`
+   and **stays there** — a positive D-dimer can't rule PE *out*. There is no
+   narrative in the engine to override that, so the better-fitting pericarditis
+   story can't talk it out of imaging.
+
+The framework's edge here is therefore **not only auditability — it produced a
+different, correct answer** where frontier reasoning was confidently wrong. The
+discipline (published base rate + mechanical LR application + no story to override
+the data) is the mechanism.
+
+## Honest caveats
+
+- **n = 1.** One case — possibly one that flatters the framework. The honest
+  follow-up is the same three-arm run on a true rule-out (low Wells + *negative*
+  D-dimer) and a high-Wells confirm. Until then this is an existence proof, not a
+  rate.
+- The case prose is terse and contains "Wells 0" + "angiography clean" (mildly
+  leading) — but **both Claude arms got identical prose**, so the head-to-head is
+  fair; only the grounded arm differs by construction.
+- The grounded arm also benefits from controlled-vocabulary ingestion (part of the
+  framework, not separable here).
+- Plain Claude was not reckless — it said "I can't rule out PE on D-dimer alone" and
+  "CTPA promptly if RV strain/hypoxia." Its *headline* (3–5%, comfortable not
+  imaging) is what was wrong.
+
+## Artifacts
+
+- Plain-Claude run, verbatim: [`plain-claude.md`](plain-claude.md).
+- Grounded corpus eval: `../eval_case.py` over `../../../corpus/pulmonary_embolism/corpus.json`
+  (`provenance/pe/eval_case.py case-PMC11999957.json grounded`).
+- Ungrounded deriver output + the case record: `../case-results.json`.


### PR DESCRIPTION
Adds the control arm ADJ55 §5 flagged as not-yet-run: **plain frontier Claude (no framework)** on the PMC11999957 PE case, head-to-head with the grounded corpus and the ungrounded deriver. Docs-only (no code).

**Ground truth: PE was present** (CTPA filling defect, DVT confirmed; pretest scores low but the PE was real).

| arm | P(PE) | disposition | correct? |
|---|---|---|---|
| **Plain Claude** (no framework) | **3–5%** | "PE is not the answer"; CTPA only if RV strain/hypoxia | ❌ would likely miss it |
| **Ungrounded framework** | 1% | "PE excluded" | ❌ |
| **Grounded corpus** | **0.28 → 0.89** | "can't exclude → image" → CTPA confirms | ✅ |

**Both unconstrained reasoners excluded a real PE; only the byte-grounded corpus caught it.** Plain Claude's reasoning was excellent (it reframed the case as a cardiac mimic and named the anchoring trap) but its operative conclusion was still 3–5% and "comfortable not imaging."

**Why the grounded corpus diverged and was right:** it under-anchored nothing — the prior is a *published* number (0.192, Christopher; even the Wells-"unlikely" subgroup is 12%) vs Claude's ~3–5% gestalt, and it applies D-dimer's true `LR+ = 1.64` mechanically (`0.192 × 1.64 = 0.28`, stays there) with no narrative to override the positive-D-dimer's standing mandate to image. **The framework's edge here is correctness, not just auditability.**

**Honest scope: n = 1** — an existence proof, not a rate. The rule-out (low Wells + negative D-dimer) and high-Wells confirm cases are still owed (ADJ55 §6).

Artifacts: verbatim plain-Claude run + full writeup in `code/specs/data/adj52/provenance/pe/arms/`; ADJ55 §5/§6 and CHANGELOG (0.3.1) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)