### PR TITLE
test(closure-pass-constant-fold): CLOC12.23 — close gap-006 (unary on identifier in comparison)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.10.1] - 2026-06-04
+
+### Added — CLOC12.23: gap-006 unary plus / minus on identifier bookkeeping
+
+Closes `gap-006` from the CLOC12 gap tracker. Pure test-only change —
+no production code modified.
+
+The pass already does the right thing structurally: `fold_unary` only
+folds `+<literal>` / `-<literal>` (the runtime value of `+x` is
+unknown when `x` is an identifier), and `try_fold_binary_op` declines
+when either side isn't a recognised literal. So `+x > +y` and friends
+pass through verbatim. gap-006 was waiting on bookkeeping — port the
+upstream `testSame("+x > +y")` / `testSame("+x == +y")` lines from
+`PeepholeFoldConstantsTest::testNumberNumberComparison`.
+
+The new `test_same_unary_on_identifier_in_comparison` test in
+`peephole_fold_constants_test.rs` pins:
+
+* `+x > +y`, `+x == +y`, `+x === +y` survive unchanged.
+* `-x < -y` survives (Negate variant — same reasoning).
+* Asymmetric `0 < +x` survives (literal on one side, unary-of-
+  identifier on the other — fold must bail because identifier side
+  can't be resolved).
+* `+x == +x` survives even with the same identifier on both sides:
+  `x` could be NaN at runtime, and `NaN == NaN` is `false`.
+
+Upstream test count: 13 → 14.
+
 ## [0.10.0] - 2026-06-04
 
 ### Added — CLOC12.22: gap-004 Number/String cross-type abstract equality + relational comparison

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -498,9 +498,17 @@ fn test_basic_arithmetic_folds() {
 ///   testSame("+x > +y");
 ///   testSame("+x == +y");
 ///
-/// Identifier-bearing expressions stay put. Lines that use `+x` (unary
-/// plus on identifier) are deferred to gap-006; we cover the plain
+/// Identifier-bearing expressions stay put. We cover the plain
 /// identifier shape here to lock in the "don't touch identifiers" rule.
+///
+/// **gap-006 closed in CLOC12.23** — the `+x > +y` / `-x > -y` / `+x ==
+/// +y` shapes are now covered explicitly in
+/// `test_same_unary_on_identifier_in_comparison` below. `fold_unary`
+/// already declines to fold `+<identifier>` (or `-<identifier>`) because
+/// the runtime value is unknown, so the wrapped UnaryExpression survives
+/// into `try_fold_binary_op` — which then declines because neither side
+/// is a recognised literal. The fix was purely test bookkeeping; no
+/// production code changed.
 #[test]
 fn test_same_when_either_side_has_an_identifier_subset() {
     use coding_adventures_javascript_ast::Identifier;
@@ -514,4 +522,84 @@ fn test_same_when_either_side_has_an_identifier_subset() {
     assert_same(b(ident("x"), BinaryOperator::Eq, ident("y")));
     assert_same(b(ident("x"), BinaryOperator::StrictEq, ident("y")));
     assert_same(b(ident("x"), BinaryOperator::Gt, ident("x")));
+}
+
+/// Upstream `testNumberNumberComparison` (closes gap-006):
+///
+///   testSame("+x > +y");
+///   testSame("+x == +y");
+///
+/// Pins that unary plus / minus over an identifier survives, both
+/// individually and on both sides of a comparison. The desired
+/// production behaviour is that the pass leaves the whole expression
+/// alone — `+x` cannot be folded because `x`'s runtime value is
+/// unknown, and the surrounding comparison can't be folded because
+/// neither side is a recognised literal.
+///
+/// We verify each operand-level UnaryExpression survives (no
+/// accidental coercion to NumericLiteral(0) or similar), then assert
+/// the parent BinaryExpression survives under several operators.
+#[test]
+fn test_same_unary_on_identifier_in_comparison() {
+    use coding_adventures_javascript_ast::Identifier;
+    let ident = |name: &str| {
+        Expression::Identifier(Identifier {
+            cv: None,
+            name: name.to_string(),
+        })
+    };
+    let unary = |op: UnaryOperator, inner: Expression| {
+        Expression::UnaryExpression(UnaryExpression {
+            cv: None,
+            operator: op,
+            argument: Box::new(inner),
+            prefix: true,
+        })
+    };
+
+    // Both sides wrapped in unary plus.
+    assert_same(b(
+        unary(UnaryOperator::Plus, ident("x")),
+        BinaryOperator::Gt,
+        unary(UnaryOperator::Plus, ident("y")),
+    ));
+    assert_same(b(
+        unary(UnaryOperator::Plus, ident("x")),
+        BinaryOperator::Eq,
+        unary(UnaryOperator::Plus, ident("y")),
+    ));
+    assert_same(b(
+        unary(UnaryOperator::Plus, ident("x")),
+        BinaryOperator::StrictEq,
+        unary(UnaryOperator::Plus, ident("y")),
+    ));
+
+    // Unary negate variant — same reasoning.
+    assert_same(b(
+        unary(UnaryOperator::Negate, ident("x")),
+        BinaryOperator::Lt,
+        unary(UnaryOperator::Negate, ident("y")),
+    ));
+
+    // Asymmetric: literal on one side, unary-of-identifier on the
+    // other. The fold must still bail because the identifier side
+    // can't be resolved.
+    assert_same(b(
+        Expression::NumericLiteral(NumericLiteral {
+            cv: None,
+            value: 0.0,
+            raw: "0".to_string(),
+        }),
+        BinaryOperator::Lt,
+        unary(UnaryOperator::Plus, ident("x")),
+    ));
+
+    // Same identifier on both sides (the structural form `+x == +x`).
+    // Even though x is the same identifier, we still don't fold —
+    // `x` could be NaN at runtime, and `NaN == NaN` is `false`.
+    assert_same(b(
+        unary(UnaryOperator::Plus, ident("x")),
+        BinaryOperator::Eq,
+        unary(UnaryOperator::Plus, ident("x")),
+    ));
 }

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -72,11 +72,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-006 — unary plus / minus on identifiers, plus identifier-arithmetic shape
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.23 — pure test-only port; no production code changed. The pass already declines to fold `+<identifier>` / `-<identifier>` in `fold_unary` (runtime value is unknown), and the surrounding `try_fold_binary_op` declines whenever either side isn't a recognised literal. The new `test_same_unary_on_identifier_in_comparison` test in `peephole_fold_constants_test.rs` pins the upstream `testSame("+x > +y")` / `testSame("+x == +y")` lines plus several adjacent shapes: `+x === +y`, `-x < -y` (Negate variant), asymmetric `0 < +x`, and `+x == +x` (same identifier on both sides — must NOT fold because `x` could be NaN at runtime).
 - **Upstream test:** `PeepholeFoldConstantsTest::testNumberNumberComparison` (`+x > +y` `testSame` lines)
 - **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs`
-- **Why it fails:** Upstream's `testSame("+x > +y")` asserts the pass leaves the expression alone (`x` is unknown). Our pass already does the right thing structurally; this gap is mostly the bookkeeping of porting the remaining `testSame` lines that use unary-plus on identifiers.
-- **What it needs:** Trivial — extend the ported tests once `gap-005` lands so the batch reflects the full upstream method.
 
 ### gap-009 — `LabeledStatement` / `BreakStatement` not modelled in Phase 1 AST
 


### PR DESCRIPTION
## Summary

Closes **gap-006** in the CLOC12 gap tracker. **Pure test-only port** — no production code changed.

The pass already handles `+x > +y` correctly:

- `fold_unary` declines on `+<Identifier>` — runtime value of `x` is unknown, so no NumericLiteral substitution.
- `try_fold_binary_op` then declines on the surrounding comparison — neither side is a recognised literal.

Gap-006 was waiting on bookkeeping: port the upstream `testSame("+x > +y")` / `testSame("+x == +y")` lines from `PeepholeFoldConstantsTest::testNumberNumberComparison`.

## What's new

The `test_same_unary_on_identifier_in_comparison` test pins:

| input | survives? |
|---|---|
| `+x > +y`, `+x == +y`, `+x === +y` | ✓ |
| `-x < -y` (Negate variant) | ✓ |
| `0 < +x` (asymmetric — literal vs unary-of-identifier) | ✓ |
| `+x == +x` (same identifier both sides — `x` could be NaN at runtime) | ✓ |

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-constant-fold` → 14 upstream tests (was 13), 41 inline (unchanged)
- [x] /security-review — clean (pure test-only AST construction; no I/O, no unsafe)
- [ ] CI green

## Closes

- gap-006 (status flipped OPEN → RESOLVED in `code/specs/CLOC12-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)