### PR TITLE
feat(mccarthy-lisp): L2b — COND (compiler lowering + VM control flow)

### DIFF
--- a/code/packages/rust/mccarthy-lisp-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — mccarthy-lisp-iir-compiler
 
+## v0.2.0 — 2026-06-04 — COND (L2b)
+
+* Lowers `(COND (p1 e1) … (pn en))` to a chain of `jmp_if_false` +
+  `label`s, with each clause's value funnelled into one `result`
+  register via `mov`. The value is the `ei` of the first true `pi`; if no
+  clause matches, the result is `nil` (the total extension of McCarthy's
+  otherwise-undefined `cond`).
+* Each clause must be a 2-element list `(predicate expression)` —
+  malformed clauses are a `CompileError`. The catch-all clause uses a
+  truthy predicate such as `('T …)` (a bare `T` is still an unbound
+  variable until bindings arrive in L2c).
+* New emitters: `mov` / `label` / `jmp` / `jmp_if_false`, plus a
+  fresh-label generator. The emitted IIR passes `IIRModule::validate`
+  (all branch targets are defined).
+* 3 new unit tests (branch/funnel op shape, clause-arity errors, empty
+  `COND`) + 7 new end-to-end tests on `mccarthy-lisp-vm` (first-true
+  clause, fall-through, `EQ` predicates, no-match→nil, COND value feeding
+  an enclosing form, nested COND, COND returning a cons).
+
 ## v0.1.0 — 2026-06-03 — initial release (L2a)
 
 First IIR lowering for McCarthy 1960 Lisp — the L2a slice of the

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mccarthy-lisp-iir-compiler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Lowers a McCarthy 1960 Lisp (Lisp 1.0) AST into an IIRModule. L2a v0.1.0 handles integer/nil literals, QUOTE (symbols + nested lists), and the primitives CONS/CAR/CDR/ATOM/EQ, emitting IIR over the `lispy-runtime` value model so the module runs end-to-end on `mccarthy-lisp-vm` and feeds every IIR backend. COND, LAMBDA, and LABEL land in L2b/L2c."
 

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/README.md
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/README.md
@@ -30,7 +30,7 @@ use mccarthy_lisp_vm::run;
 let value = run(&module).unwrap();   // → the symbol A
 ```
 
-## Lowering (L2a scope)
+## Lowering (through L2b)
 
 | Form               | IIR                                                     |
 |--------------------|---------------------------------------------------------|
@@ -42,6 +42,7 @@ let value = run(&module).unwrap();   // → the symbol A
 | `(CDR X)`          | `call_builtin "cdr" [X]`                                |
 | `(ATOM X)`         | `(not (pair? X))` — two `call_builtin`s                 |
 | `(EQ A B)`         | `call_builtin "equal?" [A, B]` (identity on atoms)      |
+| `(COND (p e) …)`   | chained `jmp_if_false` + `label`s; each clause's value funnels into one register via `mov`; no match → `nil` |
 
 These are the conventions of the shared `lispy-runtime` value model
 (tagged-`i64` symbols, cons cells, nil) — so the same IIR runs on
@@ -62,11 +63,10 @@ crate dev-depends on it only to run the end-to-end tests.
 
 ## Not yet (later phases)
 
-- **L2b** — `COND` (chained `jmp_if_false` + labels).
 - **L2c** — `LAMBDA` / `LABEL` / user-defined function application.
 
-A bare (unquoted) symbol in value position is an *unbound variable* in
-L2a (there are no bindings until LAMBDA/LABEL) and is reported as a
+A bare (unquoted) symbol in value position is an *unbound variable*
+(there are no bindings until LAMBDA/LABEL) and is reported as a
 `CompileError`.
 
 ## API

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/src/lib.rs
@@ -14,7 +14,7 @@
 //! the value of the **last** form (an empty program returns `nil`).
 //! The module's `entry_point` is `"main"`.
 //!
-//! ## Which Lisp we can lower *today* (L2a scope)
+//! ## Which Lisp we can lower *today* (through L2b)
 //!
 //! | Form                | Lowering                                             |
 //! |---------------------|------------------------------------------------------|
@@ -26,6 +26,7 @@
 //! | `(CDR X)`           | `call_builtin "cdr" [X]`                             |
 //! | `(ATOM X)`          | `call_builtin "pair?" [X]` then `call_builtin "not"` |
 //! | `(EQ A B)`          | `call_builtin "equal?" [A, B]`                       |
+//! | `(COND (p e) …)`    | chained `jmp_if_false` + `label`s; `mov` funnels each clause's value into one register; no match → nil |
 //!
 //! `QUOTE` materialises a literal S-expression as runtime values:
 //! a symbol `A` becomes `const v, Var("A")` (the IIR convention the
@@ -54,11 +55,10 @@
 //!
 //! ## Not yet (later phases)
 //!
-//! - **L2b** — `COND` (chained `jmp_if_false` + labels).
 //! - **L2c** — `LAMBDA` / `LABEL` / user-defined function application.
 //!
 //! A bare (unquoted) symbol in value position is therefore an *unbound
-//! variable* in L2a — there are no bindings yet — and is reported as a
+//! variable* — there are no bindings yet — and is reported as a
 //! [`CompileError`] rather than silently mis-lowered.
 //!
 //! ## Quick start
@@ -175,17 +175,26 @@ struct Compiler {
     instrs: Vec<IIRInstr>,
     /// Monotonic counter for fresh SSA temp names (`v0`, `v1`, …).
     tmp: usize,
+    /// Monotonic counter for fresh, unique branch-label names.
+    label: usize,
 }
 
 impl Compiler {
     fn new() -> Self {
-        Compiler { instrs: Vec::new(), tmp: 0 }
+        Compiler { instrs: Vec::new(), tmp: 0, label: 0 }
     }
 
     /// Allocate a fresh, never-reused temp register name.
     fn fresh(&mut self) -> String {
         let name = format!("v{}", self.tmp);
         self.tmp += 1;
+        name
+    }
+
+    /// Allocate a fresh, never-reused label name (for `COND` branches).
+    fn fresh_label(&mut self, hint: &str) -> String {
+        let name = format!("L_{hint}_{}", self.label);
+        self.label += 1;
         name
     }
 
@@ -291,17 +300,83 @@ impl Compiler {
                 let vb = self.lower_expr(a[1])?;
                 Ok(self.emit_builtin("equal?", &[va, vb], "bool"))
             }
-            "COND" => Err(CompileError::new(
-                "`COND` is not supported yet — it lands in L2b (chained jmp_if_false + labels)",
-            )),
+            "COND" => self.lower_cond(args),
             "LAMBDA" | "LABEL" => Err(CompileError::new(format!(
                 "`{name}` is not supported yet — user functions land in L2c"
             ))),
             other => Err(CompileError::new(format!(
-                "unknown form `{other}`: L2a supports QUOTE, CONS, CAR, CDR, ATOM, EQ \
-                 (COND→L2b, LAMBDA/LABEL→L2c)"
+                "unknown form `{other}`: supported forms are QUOTE, CONS, CAR, CDR, ATOM, EQ, COND \
+                 (LAMBDA/LABEL→L2c)"
             ))),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // COND lowering (control flow)
+    // -----------------------------------------------------------------------
+
+    /// Lower `(COND (p1 e1) (p2 e2) … (pn en))`.
+    ///
+    /// Evaluate each predicate in turn; the value of the COND is the `ei`
+    /// of the first `pi` that is true (non-`nil`, non-`#f`).  If no clause
+    /// matches, the result is `nil` (McCarthy's 1960 `cond` is undefined
+    /// in that case; returning `nil` is the conventional total extension).
+    ///
+    /// The lowering is a chain of `jmp_if_false` + labels, with every
+    /// clause's value funnelled into one `result` register via `mov`:
+    ///
+    /// ```text
+    ///       <lower p1> → vp1
+    ///       jmp_if_false vp1, L_next_0
+    ///       <lower e1>  → ve1
+    ///       mov result, ve1
+    ///       jmp L_end_0
+    ///   L_next_0:
+    ///       <lower p2> → vp2
+    ///       jmp_if_false vp2, L_next_1
+    ///       <lower e2>  → ve2
+    ///       mov result, ve2
+    ///       jmp L_end_0
+    ///   L_next_1:
+    ///       const result, nil          ; no clause matched
+    ///   L_end_0:
+    ///       ; result holds the value
+    /// ```
+    ///
+    /// The catch-all clause is written with a truthy predicate — e.g.
+    /// `('T …)`.  A bare `T` would be an unbound variable (bindings arrive
+    /// with `LAMBDA`/`LABEL` in L2c), so quote it.
+    fn lower_cond(&mut self, clauses: &[&LispExpr]) -> Result<String, CompileError> {
+        let result = self.fresh();
+        let end_label = self.fresh_label("cond_end");
+
+        for clause in clauses {
+            // Each clause is a proper list `(predicate expression)`.
+            let parts = proper_list(clause).ok_or_else(|| {
+                CompileError::new("a COND clause must be a list `(predicate expression)`")
+            })?;
+            if parts.len() != 2 {
+                return Err(CompileError::new(format!(
+                    "a COND clause must be `(predicate expression)` — 2 elements, got {}",
+                    parts.len()
+                )));
+            }
+            let (predicate, expression) = (parts[0], parts[1]);
+
+            let next_label = self.fresh_label("cond_next");
+            let vp = self.lower_expr(predicate)?;
+            self.emit_jmp_if_false(&vp, &next_label);
+            let ve = self.lower_expr(expression)?;
+            self.emit_mov(&result, &ve);
+            self.emit_jmp(&end_label);
+            self.emit_label(&next_label);
+        }
+
+        // Fell past every clause → nil.
+        let nil = self.emit_nil();
+        self.emit_mov(&result, &nil);
+        self.emit_label(&end_label);
+        Ok(result)
     }
 
     // -----------------------------------------------------------------------
@@ -390,6 +465,40 @@ impl Compiler {
         instr.may_alloc = builtin == "cons";
         self.emit(instr);
         v
+    }
+
+    // -----------------------------------------------------------------------
+    // Control-flow emitters (COND)
+    // -----------------------------------------------------------------------
+
+    /// `mov dest, src` — copy a register's value.
+    fn emit_mov(&mut self, dest: &str, src: &str) {
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.to_string()),
+            vec![Operand::Var(src.to_string())],
+            "any",
+        ));
+    }
+
+    /// `label NAME` — a branch-target marker.
+    fn emit_label(&mut self, name: &str) {
+        self.emit(IIRInstr::new("label", None, vec![Operand::Var(name.to_string())], "void"));
+    }
+
+    /// `jmp NAME` — unconditional branch.
+    fn emit_jmp(&mut self, target: &str) {
+        self.emit(IIRInstr::new("jmp", None, vec![Operand::Var(target.to_string())], "void"));
+    }
+
+    /// `jmp_if_false cond, NAME` — branch to `NAME` when `cond` is falsy.
+    fn emit_jmp_if_false(&mut self, cond: &str, target: &str) {
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(cond.to_string()), Operand::Var(target.to_string())],
+            "void",
+        ));
     }
 }
 
@@ -559,8 +668,31 @@ mod tests {
     }
 
     #[test]
-    fn cond_is_deferred() {
-        assert!(compile_source("(COND ('T 'A))", "t").unwrap_err().message.contains("L2b"));
+    fn cond_emits_branch_and_funnel_ops() {
+        // (COND ((ATOM 'X) 'A) ('T 'B)) — two clauses → two jmp_if_false,
+        // and every clause path funnels into one register via `mov`.
+        let m = compile_source("(COND ((ATOM 'X) 'A) ('T 'B))", "t").unwrap();
+        let ops: Vec<&str> =
+            m.functions[0].instructions.iter().map(|i| i.op.as_str()).collect();
+        assert_eq!(ops.iter().filter(|o| **o == "jmp_if_false").count(), 2);
+        assert!(ops.contains(&"jmp"));
+        assert!(ops.contains(&"label"));
+        assert!(ops.contains(&"mov"));
+        // The emitted IIR is well-formed (all branch targets are defined).
+        assert!(m.validate().is_empty());
+    }
+
+    #[test]
+    fn cond_clause_must_be_a_pair() {
+        assert!(compile_source("(COND ('T))", "t").unwrap_err().message.contains("2 elements"));
+        assert!(compile_source("(COND ('T 'A 'B))", "t").unwrap_err().message.contains("2 elements"));
+    }
+
+    #[test]
+    fn empty_cond_is_nil() {
+        // (COND) with no clauses lowers to a nil result — and validates.
+        let m = compile_source("(COND)", "t").unwrap();
+        assert!(m.validate().is_empty());
     }
 
     #[test]

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/tests/run_e2e.rs
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/tests/run_e2e.rs
@@ -150,3 +150,53 @@ fn dotted_pair_literal() {
     // (CDR '(A . B)) → B
     assert_eq!(sym_name(eval("(CDR '(A . B))")), "B");
 }
+
+// ============================================================
+// COND (L2b)
+// ============================================================
+
+#[test]
+fn cond_first_true_clause_wins() {
+    // 'X is an atom → first clause fires → 'A.
+    assert_eq!(sym_name(eval("(COND ((ATOM 'X) 'A) ('T 'B))")), "A");
+}
+
+#[test]
+fn cond_falls_through_to_later_clause() {
+    // '(X) is a cons (not an atom) → first clause false → catch-all → 'B.
+    assert_eq!(sym_name(eval("(COND ((ATOM '(X)) 'A) ('T 'B))")), "B");
+}
+
+#[test]
+fn cond_uses_eq_predicate() {
+    assert_eq!(sym_name(eval("(COND ((EQ 'A 'A) 'YES) ('T 'NO))")), "YES");
+    assert_eq!(sym_name(eval("(COND ((EQ 'A 'B) 'YES) ('T 'NO))")), "NO");
+}
+
+#[test]
+fn cond_with_no_matching_clause_is_nil() {
+    // No clause's predicate is true → the total extension returns nil.
+    assert!(eval("(COND ((EQ 'A 'B) 'YES))").is_nil());
+}
+
+#[test]
+fn cond_value_feeds_an_enclosing_form() {
+    // (CAR (COND ('T '(A B C)))) → A
+    assert_eq!(sym_name(eval("(CAR (COND ('T '(A B C))))")), "A");
+}
+
+#[test]
+fn nested_cond() {
+    // Inner COND yields 'B (since '(X) is not an atom), outer matches on EQ.
+    let src = "(COND ((EQ (COND ((ATOM '(X)) 'A) ('T 'B)) 'B) 'MATCHED) ('T 'NOPE))";
+    assert_eq!(sym_name(eval(src)), "MATCHED");
+}
+
+#[test]
+fn cond_returns_a_list_value() {
+    // A clause expression can be any expression, including one that
+    // builds a cons structure.
+    let v = eval("(COND ('T (CONS 'A 'B)))");
+    assert_eq!(sym_name(car(v)), "A");
+    assert_eq!(sym_name(cdr(v)), "B");
+}

--- a/code/packages/rust/mccarthy-lisp-vm/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-vm/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — mccarthy-lisp-vm
 
+## v0.2.0 — 2026-06-04 — control flow for COND (L2b)
+
+* Added the control-flow opcodes the `COND` lowering needs:
+  * `jmp NAME` — unconditional branch (`srcs[0]` = label `Var`).
+  * `jmp_if_false COND, NAME` — branch to `NAME` when `COND` is falsy
+    (`#f` or `nil`, via `LispyValue::is_truthy`); otherwise fall through.
+  * `mov dest, src` — copy a register (funnels each `COND` clause's value
+    into one result register).
+* `label NAME` instructions are pre-scanned into an O(1) name→index table
+  at function entry; branch targets resolve through it. A branch to an
+  undefined label is a clean `VmError::UnknownLabel` (never a panic).
+* The interpreter stays a flat dispatch loop — jumps only move `pc`
+  within one function, so there is still no native recursion over the
+  program, and the instruction budget bounds any loop a future phase
+  might introduce.
+* 5 new unit tests (`mov`, unconditional `jmp`, `jmp_if_false` on
+  truthy/falsy/nil, undefined-label error) — 19 unit + 1 doctest total.
+
 ## v0.1.0 — 2026-06-04 — initial release (L2a)
 
 McCarthy 1960 Lisp's own VM — a small interpreter built directly on

--- a/code/packages/rust/mccarthy-lisp-vm/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mccarthy-lisp-vm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A tiny interpreter for McCarthy 1960 Lisp (Lisp 1.0), built directly on `lispy-runtime`. Executes the `IIRModule` produced by `mccarthy-lisp-iir-compiler` against the lispy-runtime tagged-i64 value model (symbols, cons cells, nil, booleans), returning a `LispyValue`. McCarthy Lisp's own VM — deliberately independent of `twig-vm` (which is Twig-specific); both languages share only the `lispy-runtime` foundation."
 

--- a/code/packages/rust/mccarthy-lisp-vm/README.md
+++ b/code/packages/rust/mccarthy-lisp-vm/README.md
@@ -28,18 +28,21 @@ What both languages genuinely share is the **value model**:
 foundation — this crate. (Twig is a typed Lisp; McCarthy is its untyped
 cousin. Same value model, separate VMs.)
 
-## Instruction set (L2a)
+## Instruction set (through L2b)
 
 | Op             | Meaning                                                           |
 |----------------|------------------------------------------------------------------|
 | `const`        | `Int(n)`→int, `Int(0):ref<LispyPair>`→nil, `Var(name)`→interned symbol, `Bool(b)`→bool |
 | `call_builtin` | `srcs[0]` is the builtin name (a `Var`), the rest are args; dispatched to a `lispy-runtime` builtin |
+| `mov`          | copy a register (`dest ← srcs[0]`)                                |
+| `jmp`          | unconditional branch to the label in `srcs[0]`                   |
+| `jmp_if_false` | branch to the label in `srcs[1]` when `srcs[0]` is falsy (`#f`/`nil`); else fall through |
+| `label`        | branch-target marker (`srcs[0]` is its name)                    |
 | `ret`          | return the value in `srcs[0]`                                     |
-| `label`        | no-op marker (a jump target once L2b lands)                      |
 
-Control flow (`jmp` / `jmp_if_false`, for `COND`) and user-function
-`call` (for `LAMBDA` / `LABEL`) land with L2b / L2c — the VM grows to
-match the compiler phase by phase.
+`mov` / `jmp` / `jmp_if_false` / `label` are what `COND` lowers to
+(L2b). User-function `call` (for `LAMBDA` / `LABEL`) lands with L2c — the
+VM grows to match the compiler phase by phase.
 
 ## Usage
 

--- a/code/packages/rust/mccarthy-lisp-vm/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-vm/src/lib.rs
@@ -20,19 +20,23 @@
 //! pair? / not / equal?` builtins.  So McCarthy Lisp gets its *own* small
 //! VM built directly on that foundation — exactly what this crate is.
 //!
-//! ## The instruction set it executes (L2a)
+//! ## The instruction set it executes (through L2b)
 //!
-//! `mccarthy-lisp-iir-compiler` v0.1 emits a deliberately tiny IIR:
+//! `mccarthy-lisp-iir-compiler` emits a deliberately tiny IIR:
 //!
 //! | Op            | Meaning                                                        |
 //! |---------------|----------------------------------------------------------------|
 //! | `const`       | materialise a literal: `Int(n)`→int, `Int(0):ref<LispyPair>`→nil, `Var(name)`→interned symbol, `Bool(b)`→bool |
 //! | `call_builtin`| `srcs[0]` is the builtin name (a `Var`), the rest are argument registers; dispatched to a `lispy-runtime` builtin |
+//! | `mov`         | copy a register (`dest ← srcs[0]`)                             |
+//! | `jmp`         | unconditional branch to the label in `srcs[0]`                |
+//! | `jmp_if_false`| branch to the label in `srcs[1]` when `srcs[0]` is falsy (`#f`/`nil`); else fall through |
+//! | `label`       | branch-target marker (`srcs[0]` is its name)                  |
 //! | `ret`         | return the value in `srcs[0]`                                  |
 //!
-//! Control flow (`jmp` / `jmp_if_false` / `label`, for `COND`) and
-//! user-function `call` (for `LAMBDA` / `LABEL`) arrive with L2b / L2c;
-//! this VM grows to match the compiler phase by phase.
+//! `mov`/`jmp`/`jmp_if_false`/`label` are what `COND` lowers to (L2b).
+//! User-function `call` (for `LAMBDA` / `LABEL`) arrives with L2c; this
+//! VM grows to match the compiler phase by phase.
 //!
 //! ## Quick start
 //!
@@ -98,6 +102,9 @@ pub enum VmError {
     /// (`[-2^60, 2^60 - 1]`).  Caught here so it surfaces as a clean
     /// error rather than being silently truncated by `LispyValue::int`.
     IntegerOutOfRange(i64),
+    /// A `jmp` / `jmp_if_false` targeted a label the function doesn't
+    /// define.
+    UnknownLabel(String),
 }
 
 impl std::fmt::Display for VmError {
@@ -118,6 +125,7 @@ impl std::fmt::Display for VmError {
                 f,
                 "integer literal {n} is outside lispy-runtime's tagged-int range [-2^60, 2^60-1]"
             ),
+            VmError::UnknownLabel(l) => write!(f, "branch to undefined label {l:?}"),
         }
     }
 }
@@ -170,6 +178,11 @@ fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<Lisp
     let mut frame: Frame = HashMap::new();
     let mut pc: usize = 0;
 
+    // Resolve every `label NAME` to its instruction index once, so a jump
+    // is an O(1) lookup.  (`COND` lowering emits forward jumps to labels
+    // it also defines, so every target is present.)
+    let labels = label_table(func);
+
     while pc < func.instructions.len() {
         *steps += 1;
         if *steps > budget {
@@ -194,8 +207,37 @@ fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<Lisp
                 })?;
                 return read_operand(src, &frame);
             }
-            // `label` is a no-op marker; it only matters as a jump target
-            // (which lands with L2b's control-flow support).
+            // `mov dest, src` — copy a register (used by `COND` to funnel
+            // each clause's value into one result register).
+            "mov" => {
+                let src = instr.srcs.first().ok_or_else(|| {
+                    VmError::Malformed("`mov` requires a source operand".into())
+                })?;
+                let value = read_operand(src, &frame)?;
+                bind_dest(instr, value, &mut frame)?;
+                pc += 1;
+            }
+            // `jmp LABEL` — unconditional branch.  srcs[0] = Var(label).
+            "jmp" => {
+                let label = label_operand(instr, 0)?;
+                pc = resolve_label(&labels, label)?;
+            }
+            // `jmp_if_false COND, LABEL` — branch to LABEL when COND is
+            // falsy (`#f` or `nil`); otherwise fall through.  srcs[0] =
+            // Var(cond register), srcs[1] = Var(label).
+            "jmp_if_false" => {
+                let cond_src = instr.srcs.first().ok_or_else(|| {
+                    VmError::Malformed("`jmp_if_false` requires srcs[0] (the condition)".into())
+                })?;
+                let cond = read_operand(cond_src, &frame)?;
+                let label = label_operand(instr, 1)?;
+                if cond.is_truthy() {
+                    pc += 1;
+                } else {
+                    pc = resolve_label(&labels, label)?;
+                }
+            }
+            // `label` is a no-op marker; its only role is as a jump target.
             "label" => pc += 1,
             other => return Err(VmError::UnsupportedOp(other.to_string())),
         }
@@ -283,6 +325,38 @@ fn resolve_builtin(name: &str) -> Option<BuiltinFn> {
         "equal?" => Some(builtins::equal_p),
         _ => None,
     }
+}
+
+/// Map each `label NAME` instruction to its index in the function body.
+fn label_table(func: &IIRFunction) -> HashMap<String, usize> {
+    let mut labels = HashMap::new();
+    for (i, instr) in func.instructions.iter().enumerate() {
+        if instr.op == "label" {
+            if let Some(Operand::Var(name)) = instr.srcs.first() {
+                labels.insert(name.clone(), i);
+            }
+        }
+    }
+    labels
+}
+
+/// Read the label-name operand at `idx` from a branch instruction.
+fn label_operand(instr: &IIRInstr, idx: usize) -> Result<&str, VmError> {
+    match instr.srcs.get(idx) {
+        Some(Operand::Var(name)) => Ok(name.as_str()),
+        _ => Err(VmError::Malformed(format!(
+            "`{}` requires a label name (a Var) at srcs[{idx}]",
+            instr.op
+        ))),
+    }
+}
+
+/// Resolve a label name to its instruction index.
+fn resolve_label(labels: &HashMap<String, usize>, name: &str) -> Result<usize, VmError> {
+    labels
+        .get(name)
+        .copied()
+        .ok_or_else(|| VmError::UnknownLabel(name.to_string()))
 }
 
 /// Build a tagged integer, rejecting values outside `lispy-runtime`'s
@@ -433,6 +507,92 @@ mod tests {
         };
         assert!(run(&eq("A", "A")).unwrap().is_true());
         assert!(run(&eq("A", "B")).unwrap().is_false());
+    }
+
+    // ---- control flow (L2b) ----
+
+    fn label(name: &str) -> IIRInstr {
+        IIRInstr::new("label", None, vec![Operand::Var(name.into())], "void")
+    }
+    fn jmp(target: &str) -> IIRInstr {
+        IIRInstr::new("jmp", None, vec![Operand::Var(target.into())], "void")
+    }
+    fn jmp_if_false(cond: &str, target: &str) -> IIRInstr {
+        IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(cond.into()), Operand::Var(target.into())],
+            "void",
+        )
+    }
+    fn mov(dest: &str, src: &str) -> IIRInstr {
+        IIRInstr::new("mov", Some(dest.into()), vec![Operand::Var(src.into())], "any")
+    }
+
+    #[test]
+    fn mov_copies_a_register() {
+        let m = module(vec![konst("v0", Operand::Int(7), "i64"), mov("r", "v0"), ret("r")]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(7));
+    }
+
+    #[test]
+    fn unconditional_jmp_skips_instructions() {
+        // jmp over a `mov result, wrong` to the right answer.
+        let m = module(vec![
+            konst("right", Operand::Int(1), "i64"),
+            konst("wrong", Operand::Int(2), "i64"),
+            jmp("skip"),
+            mov("result", "wrong"), // jumped over
+            label("skip"),
+            mov("result", "right"),
+            ret("result"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(1));
+    }
+
+    #[test]
+    fn jmp_if_false_branches_on_falsy_and_falls_through_on_truthy() {
+        // A two-clause COND skeleton: if `cond` is truthy → 1, else → 2.
+        let cond_program = |cond_is_true: bool| {
+            module(vec![
+                IIRInstr::new("const", Some("c".into()), vec![Operand::Bool(cond_is_true)], "bool"),
+                jmp_if_false("c", "elsewhere"),
+                konst("t", Operand::Int(1), "i64"),
+                mov("result", "t"),
+                jmp("end"),
+                label("elsewhere"),
+                konst("e", Operand::Int(2), "i64"),
+                mov("result", "e"),
+                label("end"),
+                ret("result"),
+            ])
+        };
+        assert_eq!(run(&cond_program(true)).unwrap().as_int(), Some(1));
+        assert_eq!(run(&cond_program(false)).unwrap().as_int(), Some(2));
+    }
+
+    #[test]
+    fn nil_is_falsy_for_jmp_if_false() {
+        // nil branches (it is falsy), so this lands on the else value.
+        let m = module(vec![
+            konst("c", Operand::Int(0), "ref<LispyPair>"), // nil
+            jmp_if_false("c", "els"),
+            konst("t", Operand::Int(1), "i64"),
+            mov("result", "t"),
+            jmp("end"),
+            label("els"),
+            konst("e", Operand::Int(2), "i64"),
+            mov("result", "e"),
+            label("end"),
+            ret("result"),
+        ]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(2));
+    }
+
+    #[test]
+    fn jump_to_undefined_label_errors() {
+        let m = module(vec![jmp("nowhere")]);
+        assert!(matches!(run(&m), Err(VmError::UnknownLabel(_))));
     }
 
     // ---- error paths ----

--- a/code/specs/MCCARTHY-LISP-PLAN.md
+++ b/code/specs/MCCARTHY-LISP-PLAN.md
@@ -1,6 +1,6 @@
 # McCarthy Lisp on the LANG VM chain — plan
 
-**Status:** Active.  **L1 complete and grammar-driven as of 2026-06-03** (the lexer/parser were initially merged hand-written in #4967 and then rewritten to wrap the shared `GrammarLexer`/`GrammarParser` — see the "L1 divergence" note below).  **L2 in progress** — decomposed into L2a/L2b/L2c (see the L2 note below); L2a (literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`) lands first.  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
+**Status:** Active.  **L1 complete and grammar-driven as of 2026-06-03** (the lexer/parser were initially merged hand-written in #4967 and then rewritten to wrap the shared `GrammarLexer`/`GrammarParser` — see the "L1 divergence" note below).  **L2 in progress** — decomposed into L2a/L2b/L2c (see the L2 note below).  **L2a ✓** (literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`, run on the new `mccarthy-lisp-vm`) and **L2b ✓** (`COND`) are merged; **L2c** (`LAMBDA`/`LABEL`/user calls) is next.  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
 **Predecessors:** [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md), [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md).
 
 ## Goal
@@ -217,8 +217,8 @@ Same single-PR-per-phase cadence the historical-arch migration used.
 | Phase | Scope |
 |-------|-------|
 | **L1** ✓ | `mccarthy-lisp-lexer` + `mccarthy-lisp-parser` — **grammar-driven** (wrap `GrammarLexer`/`GrammarParser`; grammar in `code/grammars/mccarthy_lisp.tokens`+`.grammar`).  Tests pin S-expression round-trips + dialect errors.  *Done; rewritten from the hand-written #4967 merge — see L1 divergence note.* |
-| **L2a** | `mccarthy-lisp-iir-compiler` v0.1.0 + **`mccarthy-lisp-vm` v0.1.0** — literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`.  Compiles `(CAR '(A B C))` → `A`, `(CDR '(A B C))` → `(B C)`, `(CONS 'A 'B)` → `(A . B)`, etc., end-to-end on McCarthy Lisp's **own `lispy-runtime`-backed VM** (`vm-core` is scalar-only; `twig-vm` is Twig-specific — see the execution-VM correction). |
-| **L2b** | `COND` — chained `jmp_if_false` + labels. |
+| **L2a** ✓ | `mccarthy-lisp-iir-compiler` + **`mccarthy-lisp-vm`** — literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`.  Compiles `(CAR '(A B C))` → `A`, `(CDR '(A B C))` → `(B C)`, `(CONS 'A 'B)` → `(A . B)`, etc., end-to-end on McCarthy Lisp's **own `lispy-runtime`-backed VM** (`vm-core` is scalar-only; `twig-vm` is Twig-specific — see the execution-VM correction). |
+| **L2b** ✓ | `COND` — compiler lowers to chained `jmp_if_false` + `label`s (+ `mov` to funnel clause values); VM gains `jmp`/`jmp_if_false`/`mov`.  `(COND ((ATOM 'X) 'A) ('T 'B))` → `A`; no-match → `nil`. |
 | **L2c** | `LAMBDA` / `LABEL` / user-defined function application. |
 | **L3** | Wire `mccarthy-lisp` into `lang-aot` as a new `Language` variant.  All 10 existing backends light up automatically (CARSON the migration architecture). |
 | **L4** | `ibm704-encoder` + `ibm704-backend` v0.1.0 (minimal viable: `const_*` + `ret_*`, just like the Phase 5/6 minimal-viable backends). |


### PR DESCRIPTION
## Summary

Next plan item: **L2b — `COND`**. Extends both McCarthy crates in lockstep, on McCarthy Lisp's own `lispy-runtime`-backed VM (no `twig-vm`).

**`mccarthy-lisp-iir-compiler` v0.2.0** — lowers `(COND (p1 e1) … (pn en))` to a chain of `jmp_if_false` + `label`s, with each clause's value funnelled into one `result` register via `mov`. The value is the `ei` of the first true `pi`; if no clause matches, the result is `nil` (the total extension of McCarthy's otherwise-undefined `cond`). Each clause must be a 2-element list `(predicate expression)` (malformed → `CompileError`). The catch-all uses a truthy predicate like `('T …)` — a bare `T` is still an unbound variable until L2c bindings. Emitted IIR passes `IIRModule::validate`.

**`mccarthy-lisp-vm` v0.2.0** — new opcodes: `jmp` (`srcs[0]`=label), `jmp_if_false` (`srcs[0]`=cond, `srcs[1]`=label; branch when falsy via `is_truthy`), `mov` (copy register). `label`s are pre-scanned into an O(1) name→index table; an undefined target is a clean `VmError::UnknownLabel`. The interpreter stays a flat dispatch loop — jumps only move `pc` within one function (no native recursion), and the per-iteration instruction budget bounds any loop.

## Security

`/security-review` **PASSED**. Verified: the instruction budget gates every iteration including backward jumps (a hand-crafted `label L: jmp L` terminates with `InstructionBudgetExceeded`, not a hang); the VM stays iterative and compiler recursion is bounded by the parser's nesting cap; no panics (`parts[0]`/`parts[1]` guarded by `len==2`; VM branch operands use `.get()`/`.first()` + `ok_or_else`); undefined labels caught at compile time (`validate`) and runtime (`UnknownLabel`).

## Test plan

- [x] `cargo test -p mccarthy-lisp-iir-compiler` — 18 unit + 23 e2e + 1 doctest (7 new COND e2e)
- [x] `cargo test -p mccarthy-lisp-vm` — 19 unit + 1 doctest (5 new control-flow)
- [x] both crates clippy-clean
- [x] `/security-review` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
