### PR TITLE
feat(visicalc-webcomp): generate Grid as a <mos-grid> Custom Element

### DIFF
--- a/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-webcomponent/src/pipeline.rs
@@ -510,12 +510,30 @@ fn emit_render(
     for slot in slots {
         let camel = to_camel_case_first_lower(&slot.name);
         validate_safe_identifier(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
-        writeln!(
-            out,
-            "    const {camel} = this.getAttribute(\"{}\") ?? \"\";",
-            slot.name
-        )
-        .unwrap();
+        // List-typed slots get JSON.parse so the rendered template can
+        // call `.map(...)` on them.  Without this step the generated
+        // `_render()` would read the raw attribute string and call
+        // `.map` on it — JS strings have a `.map` method but it
+        // iterates characters, not the intended list elements, so the
+        // output would be silently wrong for any layout that uses a
+        // `For each: slot: X` over a list slot.  Default `"[]"` so
+        // `JSON.parse` succeeds when the host has not yet set the
+        // attribute.
+        //
+        // `text` / `number` / `bool` and the singular forms fall
+        // through to the legacy string-default — JS loose equality
+        // (`==`) handles the runtime comparisons the layout produces
+        // (`3 == "3"` is `true`), and `${var}` template interpolation
+        // strings-coerces uniformly.  A future PR can tighten those
+        // to typed parses for clarity, but the string default does not
+        // produce visible bugs today.
+        let initializer = match slot.r#type {
+            SlotType::List(_) => {
+                format!("JSON.parse(this.getAttribute(\"{}\") ?? \"[]\")", slot.name)
+            }
+            _ => format!("this.getAttribute(\"{}\") ?? \"\"", slot.name),
+        };
+        writeln!(out, "    const {camel} = {initializer};").unwrap();
     }
 
     // The HTML walker also accumulates "post-render" snippets — small
@@ -1814,10 +1832,35 @@ fn build_text_content(node: &LayoutNode) -> Option<String> {
         LayoutPropValue::Keyword(k) => escape_html_text(k),
         LayoutPropValue::Number(n) => format!("{n}"),
         LayoutPropValue::EmitRef(_) => String::new(),
-        // An `Expr` shouldn't appear as a `content:` prop today (the
-        // grammar only produces it for `when:` / `each:` arguments),
-        // but defensively render it as empty rather than crashing.
-        LayoutPropValue::Expr(_) => String::new(),
+        // UI29 §3.4 — `Expr` DOES appear as a `Text` content prop when
+        // the layout author writes a parenthesised loop-binding
+        // reference such as `Text ( content: ( v ) )`.  The
+        // expression text is interpolated inside the surrounding
+        // template literal so the JS engine picks up the in-scope
+        // loop binding (the inner-most `as:` name from a `For`
+        // lowering).  Without this case the cell would render an
+        // empty `<span></span>` and the visicalc-style spreadsheet
+        // demo would show empty cells.
+        //
+        // One outer layer of parens is stripped via
+        // `strip_outer_parens` so `( v )` reduces to `v` in the
+        // interpolation; a complex expression like `( row.cells )`
+        // survives the strip and becomes `${row.cells}` so the V8
+        // JS engine evaluates the member access against the current
+        // loop scope.  The interpolated text is *not* re-escaped
+        // here because the surrounding template literal places the
+        // result directly into `shadowRoot.innerHTML` — the same
+        // surface the legitimate `SlotRef` content path already
+        // uses (`${displayName}`).  Host code is responsible for
+        // sanitising attribute values before setting them.
+        LayoutPropValue::Expr(e) => {
+            let trimmed = strip_outer_parens(e.trim());
+            if trimmed.is_empty() {
+                String::new()
+            } else {
+                format!("${{{trimmed}}}")
+            }
+        }
     })
 }
 
@@ -1948,6 +1991,44 @@ fn insert_attrs_before_close(open_tag: &str, attrs: &str) -> String {
 /// Convert `kebab-case` (and `lowerCamelCase` / `PascalCase`) to
 /// `lowerCamelCase`. The first character of the output is lowered so
 /// PascalCase inputs still produce a JS-style identifier.
+/// Strip a single layer of surrounding parentheses + interior
+/// whitespace from an expression text.
+///
+/// `( v )`     → `v`
+/// `(a + b)`   → `a + b`
+/// `(a) + (b)` → `(a) + (b)` (outer chars are parens but NOT a
+///   matching pair — depth check guards against this)
+/// `a + b`    → `a + b` (no change when there is no outer pair)
+///
+/// Used by `build_text_content` so a parenthesised loop-binding
+/// reference (`Text ( content: ( v ) )`) reaches the template
+/// literal as a clean `${v}` rather than the literal text `${ v }`.
+/// Mirrors the helper of the same name in `mosaic-emit-html` for
+/// consistency.
+fn strip_outer_parens(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'(' || bytes[bytes.len() - 1] != b')' {
+        return s;
+    }
+    let mut depth = 0i32;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 && i + 1 < bytes.len() {
+                    return s;
+                }
+            }
+            _ => {}
+        }
+    }
+    if depth != 0 {
+        return s;
+    }
+    s[1..s.len() - 1].trim()
+}
+
 fn to_camel_case_first_lower(s: &str) -> String {
     let mut out = String::new();
     let mut cap_next = false;
@@ -4422,5 +4503,102 @@ mod tests {
             !proj.index_html.contains("http://"),
             "shell must not reference an absolute HTTP URL"
         );
+    }
+
+    // ── List-typed slot JSON.parse + Text Expr interpolation ──────
+
+    /// A `list<text>` slot's `_render()` initializer must wrap the
+    /// `getAttribute` call in `JSON.parse(... ?? "[]")`.  Without
+    /// this, downstream `.map(...)` calls in the rendered template
+    /// would run against a JS string and iterate characters, not
+    /// list elements — silently wrong for any layout that uses
+    /// `For each: slot: X` over a list-typed slot.
+    #[test]
+    fn list_typed_slot_uses_json_parse_initializer() {
+        let m = component(
+            "X",
+            vec![slot(
+                "rows",
+                SlotType::List(Box::new(ListInnerType::Text)),
+                true,
+            )],
+            vec![],
+        );
+        let l = single_box_layout("X");
+        let s = empty_style("X");
+        let out = from_pipeline(&m, &l, &s).unwrap().output;
+        assert!(
+            out.contains(
+                "const rows = JSON.parse(this.getAttribute(\"rows\") ?? \"[]\");"
+            ),
+            "expected JSON.parse initializer for list-typed slot, got:\n{out}"
+        );
+    }
+
+    /// A non-list slot keeps the legacy string-default initializer
+    /// shape — `getAttribute(...) ?? ""`.  Pins the back-compat
+    /// guarantee for `text` / `number` / `bool` slots.
+    #[test]
+    fn scalar_slot_keeps_string_default_initializer() {
+        let m = component(
+            "X",
+            vec![slot("label", SlotType::Text, true)],
+            vec![],
+        );
+        let l = single_box_layout("X");
+        let s = empty_style("X");
+        let out = from_pipeline(&m, &l, &s).unwrap().output;
+        assert!(
+            out.contains("const label = this.getAttribute(\"label\") ?? \"\";"),
+            "expected string-default initializer, got:\n{out}"
+        );
+        assert!(
+            !out.contains("JSON.parse(this.getAttribute(\"label\")"),
+            "scalar slot must NOT be JSON.parsed:\n{out}"
+        );
+    }
+
+    /// `Text ( content: ( v ) )` — where `v` is a `For`-loop binding —
+    /// interpolates as `${v}` inside the surrounding template literal.
+    /// Before this fix the cell rendered an empty `<span></span>` and
+    /// the visicalc-style grid demo would show empty cells.
+    #[test]
+    fn text_with_paren_expr_content_emits_template_literal_interpolation() {
+        let root = LayoutNode {
+            tag: "Text".to_string(),
+            part_name: None,
+            props: vec![LayoutProp {
+                name: "content".to_string(),
+                value: LayoutPropValue::Expr("( v )".to_string()),
+            }],
+            children: Vec::new(),
+        };
+        let l = root_layout("X", root);
+        let out = from_pipeline(&component("X", vec![], vec![]), &l, &empty_style("X"))
+            .unwrap()
+            .output;
+        assert!(
+            out.contains("${v}"),
+            "expected `${{v}}` interpolation, got:\n{out}"
+        );
+        // Empty-span regression — fail loudly if it ever returns.
+        assert!(
+            !out.contains("<span></span>"),
+            "Text with Expr content must NOT emit empty <span></span>:\n{out}"
+        );
+    }
+
+    /// `strip_outer_parens` — the helper that drives the Expr
+    /// interpolation — has the same shape as the HTML emitter's
+    /// version.  Pinning the contract here keeps the two backends
+    /// from drifting.
+    #[test]
+    fn strip_outer_parens_unit_cases() {
+        assert_eq!(strip_outer_parens("( v )"), "v");
+        assert_eq!(strip_outer_parens("(a + b)"), "a + b");
+        assert_eq!(strip_outer_parens("(a) + (b)"), "(a) + (b)");
+        assert_eq!(strip_outer_parens("a + b"), "a + b");
+        assert_eq!(strip_outer_parens(""), "");
+        assert_eq!(strip_outer_parens("("), "(");
     }
 }

--- a/demo/visicalc-webcomp/index.html
+++ b/demo/visicalc-webcomp/index.html
@@ -17,10 +17,12 @@
     4. Typing into the input fires `mosaic:formulaChange` events the
        page handler logs to the console (proof the wiring works).
 
-  The Grid below is still a hand-written <table> because the
-  WebComponent emitter doesn't yet support the `Grid` built-in
-  primitive (only the React emitter does). When `<mos-grid>` lands
-  via the same pipeline, this hand-written block gets replaced.
+  The Grid below is ALSO a Custom Element — `<mos-grid>`, registered
+  by `build/Grid.js`, compiled from demo/visicalc/mosaic/Grid.* via
+  the same `mosaic-compile --backend webcomponent` pipeline.
+  Grid.desktop.mll itself is a UI34 `pkg::mosaic-pkg-grid::Grid`
+  one-liner, so the element's structure comes from the authoritative
+  package composition.  No hand-written widgets in this file.
 
   To regenerate: cd demo/visicalc-webcomp && bash scripts/build.sh
   To view:       open demo/visicalc-webcomp/index.html in any browser.
@@ -97,74 +99,24 @@
     </mos-formula-bar>
 
     <!--
-      ===== Grid (hand-written placeholder) =====
-      Same gap as VC2-html — the WebComponent pipeline emitter
-      doesn't yet support the `Grid` built-in primitive. Visual
-      contract matches Grid.dark.msl (#1e1e1e bg, #3f3f46 gridlines,
-      #264f78 selected cell). Once `<mos-grid>` lands, this block
-      becomes `<mos-grid column-headers="A,B,C,D,E" ...>`.
+      ===== Grid (compiled Custom Element) =====
+      `<mos-grid>` is registered by `build/Grid.js`, compiled from
+      demo/visicalc/mosaic/Grid.{mil,desktop.mll,dark.msl} via
+      `mosaic-compile --backend webcomponent`.  Grid.desktop.mll
+      itself is a UI34 `pkg::mosaic-pkg-grid::Grid` one-liner, so the
+      element's structure comes from `mosaic-pkg-grid`'s authoritative
+      Grid + Cell composition.  No hand-written widget in this file.
+
+      The element reads its slots via observed attributes; list-typed
+      slots (`column-headers`, `viewport-rows`, `column-widths`) are
+      JSON.parsed at render time (the WebComponent emitter detects
+      `SlotType::List(_)` and emits `JSON.parse(getAttribute(...))`).
+      The small inline script below sets the attributes after the
+      element is created so the JSON payloads don't have to be
+      hand-escaped into raw HTML attributes.
     -->
-    <div data-mosaic-component="Grid">
-      <div style="overflow: auto; max-height: 400px; margin-top: 4px;">
-        <table style="font-family: monospace; font-size: 12px; color: #cccccc; background: #1e1e1e; border-collapse: collapse; width: 100%">
-          <colgroup>
-            <col style="width: 48px"><col style="width: 96px"><col style="width: 96px">
-            <col style="width: 96px"><col style="width: 96px"><col style="width: 96px">
-          </colgroup>
-          <thead style="position: sticky; top: 0; z-index: 1;">
-            <tr style="height: 24px">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46"></th>
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">A</th>
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">B</th>
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">C</th>
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">D</th>
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">E</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr style="height: 22px; background: #1e1e1e">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">1</th>
-              <td style="border: 1px solid #3f3f46; padding: 2px; background: #264f78; color: #ffffff; outline: 1px solid #007acc">15</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">3</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">12</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">8</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">5</td>
-            </tr>
-            <tr style="height: 22px; background: #252526">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">2</th>
-              <td style="border: 1px solid #3f3f46; padding: 2px">8</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">14</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">7</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">22</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">11</td>
-            </tr>
-            <tr style="height: 22px; background: #1e1e1e">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">3</th>
-              <td style="border: 1px solid #3f3f46; padding: 2px">12</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">9</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">18</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">6</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">25</td>
-            </tr>
-            <tr style="height: 22px; background: #252526">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">4</th>
-              <td style="border: 1px solid #3f3f46; padding: 2px">4</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">11</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">3</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">17</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">9</td>
-            </tr>
-            <tr style="height: 22px; background: #1e1e1e">
-              <th style="background: #2d2d30; color: #9d9d9d; font-weight: normal; text-align: center; border: 1px solid #3f3f46">5</th>
-              <td style="border: 1px solid #3f3f46; padding: 2px">7</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">5</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">13</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">10</td>
-              <td style="border: 1px solid #3f3f46; padding: 2px">19</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div data-mosaic-component="Grid" style="overflow: auto; max-height: 400px; margin-top: 4px;">
+      <mos-grid id="grid"></mos-grid>
     </div>
 
     <h1 style="margin-top: 24px;">Events from &lt;mos-formula-bar&gt;</h1>
@@ -179,25 +131,83 @@
       shadow DOM, observed attributes, and fires
       <code>mosaic:formulaChange</code> / <code>mosaic:commit</code> /
       <code>mosaic:cancel</code> CustomEvents on user input — visible
-      in the log above. The Grid is still hand-written until the
-      WebComponent emitter learns the <code>Grid</code> primitive.
+      in the log above.  The Grid is also a Custom Element
+      (<code>&lt;mos-grid&gt;</code>), compiled from
+      <code>demo/visicalc/mosaic/Grid.*</code> — the same source
+      the React + HTML demos consume.
     </div>
   </div>
 
   <script type="module">
-    // Import the compiled bundle — defines the <mos-formula-bar>
-    // element. The bundle is a plain script (not an ES module) so it
-    // self-registers via `customElements.define` on load. Using
-    // type="module" here is just a convenience for the small event-
-    // logging glue below; the FormulaBar bundle works in plain
-    // <script src="..."> too.
+    // Import the compiled bundles — defines `<mos-formula-bar>` and
+    // `<mos-grid>` as Custom Elements.  Both bundles are plain
+    // scripts (not ES modules); they self-register via
+    // `customElements.define` on load.  Using type="module" here is
+    // just a convenience for the inline glue below.
     import "./build/FormulaBar.js";
+    import "./build/Grid.js";
 
-    // Listen for the FormulaBar's custom events and log them. The
-    // events bubble + cross the shadow boundary because the emitter
-    // sets `bubbles: true, composed: true`. Listening on the host
-    // element rather than `document` keeps the log scoped to this
-    // FormulaBar instance.
+    // ── Grid wiring ─────────────────────────────────────────────
+    // `<mos-grid>` reads list-typed slots via JSON.parse, so the
+    // attribute values are JSON literals.  Setting them via
+    // setAttribute after the element is mounted avoids the need to
+    // escape `[`/`]`/`"` inside raw HTML.
+    const SAMPLE = {
+      columnHeaders: ["", "A", "B", "C", "D", "E"],
+      columnWidths:  [48, 96, 96, 96, 96, 96],
+      viewportRows: [
+        ["1", "15", "3",  "12", "8",  "5"],
+        ["2", "8",  "14", "7",  "22", "11"],
+        ["3", "12", "9",  "18", "6",  "25"],
+        ["4", "4",  "11", "3",  "17", "9"],
+        ["5", "7",  "5",  "13", "10", "19"],
+      ],
+      selectedRow: 1,
+      selectedCol: 1,
+      editRow:    -1,
+      editCol:    -1,
+      editContent: "",
+    };
+    const grid = document.getElementById("grid");
+    grid.setAttribute("column-headers", JSON.stringify(SAMPLE.columnHeaders));
+    grid.setAttribute("column-widths",  JSON.stringify(SAMPLE.columnWidths));
+    grid.setAttribute("viewport-rows",  JSON.stringify(SAMPLE.viewportRows));
+    grid.setAttribute("selected-row",   String(SAMPLE.selectedRow));
+    grid.setAttribute("selected-col",   String(SAMPLE.selectedCol));
+    grid.setAttribute("edit-row",       String(SAMPLE.editRow));
+    grid.setAttribute("edit-col",       String(SAMPLE.editCol));
+    grid.setAttribute("edit-content",   SAMPLE.editContent);
+
+    // Post-process: paint the selected-cell highlight.  The
+    // WebComponent emitter's static template lowering does not yet
+    // fold `state-when-*` predicates into the shadow-DOM render
+    // (sub-part state needs runtime evaluation in the shadow DOM,
+    // and that's a follow-up); we add the highlight via a style
+    // injection into the shadow root so the demo's selected cell
+    // carries the same VS Code-blue accent as the React / SwiftUI
+    // / HTML renders.
+    //
+    // We retry briefly to handle the connectedCallback race — if
+    // the bundle hasn't registered the element yet, shadowRoot is
+    // null on the first frame.
+    function paintHighlight() {
+      const root = grid.shadowRoot;
+      if (!root) return false;
+      const tds = root.querySelectorAll("tbody td");
+      const cols = SAMPLE.viewportRows[0].length;
+      const sel = SAMPLE.selectedRow * cols + SAMPLE.selectedCol;
+      const td = tds[sel];
+      if (!td) return false;
+      td.style.background = "#264f78";
+      td.style.color      = "#ffffff";
+      td.style.outline    = "1px solid #007acc";
+      return true;
+    }
+    if (!paintHighlight()) {
+      requestAnimationFrame(() => paintHighlight() || setTimeout(paintHighlight, 50));
+    }
+
+    // ── FormulaBar event log (preserved from pre-rewire demo) ───
     const fb = document.querySelector("mos-formula-bar");
     const log = document.getElementById("event-log");
     for (const evt of ["formulaChange", "commit", "cancel"]) {

--- a/demo/visicalc-webcomp/scripts/build.sh
+++ b/demo/visicalc-webcomp/scripts/build.sh
@@ -51,9 +51,22 @@ echo "Compiling FormulaBar (WebComponent)..."
   --style     "$SRC/FormulaBar.dark.msl" \
   -o "$OUT_DIR/FormulaBar.js"
 
-# TODO(VC2-webcomp-grid): wire Grid once the WebComponent pipeline
-# emitter supports the `Grid` built-in primitive. Until then,
-# index.html uses a hand-written static-HTML <table> placeholder.
+echo "Compiling Grid (WebComponent)..."
+# UI34 PR — Grid is now generated from the shared visicalc/mosaic/
+# Grid.{mil,desktop.mll,dark.msl} triple (same source the React +
+# HTML demos consume).  Grid.desktop.mll is a UI34
+# `pkg::mosaic-pkg-grid::Grid (...)` one-liner; we pass
+# --package-search-path so the resolver locates the package and
+# substitutes its full composition before the WebComponent emitter
+# runs.  The output registers `<mos-grid>` as a Custom Element with
+# shadow DOM that reads list-typed slots via JSON.parse (so attribute
+# values like `column-headers='["A","B","C"]'` work).
+"$MOSAIC_COMPILE" --backend webcomponent \
+  --interface           "$SRC/Grid.mil" \
+  --layout              "$SRC/Grid.desktop.mll" \
+  --style               "$SRC/Grid.dark.msl" \
+  --package-search-path "$REPO_ROOT/code/packages" \
+  -o "$OUT_DIR/Grid.js"
 
 echo "Done. Generated:"
 ls -la "$OUT_DIR"


### PR DESCRIPTION
## Summary

Replaces the 60-line hand-written `<table>` in `demo/visicalc-webcomp/index.html` with a generated `<mos-grid>` Custom Element + sample-data attribute setters. **The third VisiCalc demo derived from the shared `demo/visicalc/mosaic/Grid.*` source** (after #4975 React and #4981 HTML).

Depends on **PR #4984** (`emit-webcomponent` JSON.parse + Text Expr fix). Opening as **draft** — will mark ready when #4984 lands.

## How it works

1. `scripts/build.sh` adds a Grid compile line using `--package-search-path` so the UI34 resolver substitutes `pkg::mosaic-pkg-grid::Grid` at build time. Output → `demo/visicalc-webcomp/build/Grid.js`.
2. `index.html` imports `./build/Grid.js`; the bundle self-registers `<mos-grid>` via `customElements.define`.
3. Inline `<script>` sets slot attributes after the element mounts. List-typed slots get JSON.stringify'd; the WebComponent emitter JSON.parse's them at render time (PR #4984).
4. Selected-cell highlight is painted into the shadow root via `requestAnimationFrame`.

## Test plan

- [x] `bash scripts/build.sh` produces `build/Grid.js` (2.4 KB)
- [ ] Open `index.html` in a browser, verify the 5×5 grid renders with A1 highlighted
- [ ] CI

## Why this matters

Three different backends (React, static HTML, WebComponent), one source of truth (`demo/visicalc/mosaic/Grid.*`), zero hand-written widgets across all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)