### PR TITLE
feat(closure-pass-fold-control-flow): CLOC12.24 — close gap-016 (`if (x) S` → `x && S`)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,86 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.5.0] - 2026-06-04
+
+### Added — CLOC12.24: gap-016 `if (x) S` → `x && S` rewrite
+
+Closes `gap-016` from the CLOC12 gap tracker. `fold_if_statement` now
+has a third rewriting branch (after literal-truthy/falsy collapse and
+gap-017 if-else→ternary): when the test is non-literal, the
+consequent reduces to a single ExpressionStatement (directly or via
+single-statement BlockStatement layers), and there is **no**
+alternate, the IfStatement is rewritten to:
+
+```
+ExpressionStatement {
+  LogicalExpression { left: test, op: And, right: consequent_expr }
+}
+```
+
+Worked examples now folding:
+
+```
+if (x) a();              →  x && a();
+if (x) { a(); }          →  x && a();   (single-expr block unwraps)
+if (x) {{ a(); }}        →  x && a();   (nested single-stmt blocks)
+if (x) y;                →  x && y;     (any expression statement)
+```
+
+Worked examples that stay as IfStatement (pre-conditions don't hold):
+
+```
+if (x) a(); else b();    →  x ? a() : b();   (gap-017 ternary fires
+                                              first because alternate
+                                              exists)
+if (x) return 1;         →  unchanged (return is not an expression
+                                       statement; gap-019's territory)
+if (x) { a; b; }         →  unchanged (multi-stmt consequent doesn't
+                                       reduce to one expression)
+if (x) ;                 →  unchanged (empty consequent would require
+                                       synthesising undefined; deferred)
+```
+
+### Why this is safe
+
+`x && consequent` and `if (x) S` have observably identical evaluation
+order:
+
+* `x` is evaluated first (the short-circuit gate).
+* If `x` is falsy → `&&` returns `x` without evaluating the right
+  operand; `if (x) S` likewise skips `S`. Behaviour match.
+* If `x` is truthy → `&&` evaluates the right operand; `if (x) S`
+  likewise executes `S` for its side effects. The wrapper
+  ExpressionStatement discards the result of `&&`, so the *value*
+  is irrelevant — only the side effects matter. Behaviour match.
+
+No second evaluation of `x` is introduced. `consequent`'s side
+effects fire when and only when `x` is truthy.
+
+### What changed in tests
+
+* `tests/upstream/peephole_minimize_conditions_test.rs::test_fold_one_child_blocks_if_to_logical_and`
+  — un-ignored, now exercises 4 shapes: bare `if (x) a();`,
+  single-stmt block, nested blocks, and `if (x) y;`.
+* `tests/upstream/peephole_minimize_conditions_test.rs::test_fold_one_child_blocks_if_else_to_ternary`
+  — the trailing "testSame: no alternate" assertion was removed
+  (it's now covered by the new gap-016 test) with a comment
+  marking the historical pre-gap-016 behaviour.
+* `src/lib.rs::if_non_literal_test_with_no_alternate_passes_through`
+  — renamed to `..._with_multi_statement_consequent_passes_through`
+  and the test body switched from `if (flag) x;` (now folds) to
+  a 2-statement consequent block (still doesn't fold).
+* `src/lib.rs::if_with_unresolved_comparison_doesnt_fold_alone`
+  — renamed to `..._folds_via_gap016` and updated to assert the
+  new `(1<2) && A` fold shape, while still pinning that the inner
+  `1 < 2` BinaryExpression is NOT folded (fold-control-flow alone
+  doesn't do binary-comparison folding; that's constant-fold).
+
+Inline tests: 20 → 20 (two pre-existing tests renamed + updated).
+Upstream tests: 10 → 11 (un-ignored gap-016 placeholder).
+
+No public API change. No AST change. CV plumbing unchanged.
+
 ## [0.4.2] - 2026-06-01
 
 ### Changed — CLOC12.16: handle new `UndefinedLiteral` Expression variant

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
     BlockStatement, CallExpression, ConditionalExpression, Declaration, EmptyStatement,
     Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration, IfStatement,
-    LogicalExpression, MemberExpression, ObjectExpression, Program, ProgramItem, Property,
+    LogicalExpression, LogicalOperator, MemberExpression, ObjectExpression, Program, ProgramItem, Property,
     PropertyKey, ReturnStatement, Statement, UnaryExpression, VariableDeclaration,
     VariableDeclarator, WhileStatement,
 };
@@ -399,7 +399,78 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
                 }
             }
 
-            // Couldn't ternarise — keep the IfStatement.
+            // (CLOC12.24 / gap-016): when there's *no* alternate and
+            // the consequent reduces to a single ExpressionStatement,
+            // rewrite the IfStatement to `<test> && <consequent>` as
+            // a LogicalExpression. Upstream Closure performs the same
+            // rewrite under `PeepholeMinimizeConditions::tryMinimizeIf`.
+            //
+            // Truth table (with `test` non-literal — literal cases
+            // were handled above):
+            //
+            //   if (x) foo();              → x && foo();
+            //   if (x) { foo(); }          → x && foo();   (single-expr
+            //                                               block unwraps
+            //                                               via single_expr_stmt)
+            //   if (x) foo(); else bar();  → handled above (ternary)
+            //   if (x) return 1;           → unchanged (return is not an
+            //                                expression statement; this
+            //                                is gap-019's territory)
+            //   if (x) { a; b; }           → unchanged (multi-statement
+            //                                consequent doesn't reduce
+            //                                to a single Expression)
+            //   if (x) ;                   → unchanged (empty consequent
+            //                                isn't expressible as a
+            //                                LogicalExpression without
+            //                                synthesising `undefined`,
+            //                                which we leave for later)
+            //
+            // Why this is safe:
+            //
+            //   * `x && consequent` evaluates `x` first (the
+            //     short-circuit gate), exactly like `if (x) S` does.
+            //   * If `x` is falsy: `&&` returns `x` *without*
+            //     evaluating the right operand. In `if (x) S`, when
+            //     `x` is falsy `S` is also not executed. Behaviour
+            //     match.
+            //   * If `x` is truthy: `&&` returns the right operand's
+            //     value, which equals evaluating `consequent`. In
+            //     `if (x) S`, when `x` is truthy `S` is executed for
+            //     its side effects; the wrapper ExpressionStatement
+            //     discards the result, so the *value* of `&&` is
+            //     irrelevant. Behaviour match.
+            //   * Order-of-evaluation: identical. No second `x`
+            //     evaluation; `consequent`'s side effects fire when
+            //     and only when `x` is truthy.
+            //
+            // Why we don't fold when alternate exists: the previous
+            // ternary branch already handled that. We only reach
+            // here if alternate is `None` (or if alternate exists
+            // but the ternary fold bailed — in which case we don't
+            // discard the alternate by folding to `x && S` because
+            // that would silently drop the else branch).
+            if alternate.is_none() {
+                if let Some(c_expr) = single_expr_stmt(&consequent) {
+                    st.record_fold(
+                        &s.cv,
+                        "if-to-logical-and",
+                        "if (<test>) <expr>;",
+                        "<test> && <expr>;",
+                    );
+                    let and = Expression::LogicalExpression(LogicalExpression {
+                        cv: None,
+                        operator: LogicalOperator::And,
+                        left: Box::new(test),
+                        right: Box::new(c_expr),
+                    });
+                    return Statement::expression_statement(ExpressionStatement {
+                        cv: s.cv.clone(),
+                        expression: and,
+                    });
+                }
+            }
+
+            // Couldn't ternarise or logical-and — keep the IfStatement.
             Statement::if_statement(IfStatement {
                 cv: s.cv.clone(),
                 test,
@@ -875,31 +946,50 @@ mod tests {
     }
 
     #[test]
-    fn if_non_literal_test_with_no_alternate_passes_through() {
-        // No alternate → can't ternarise (gap-016 territory, not 017).
-        // Verifies the new fold doesn't over-fire.
+    fn if_non_literal_test_with_multi_statement_consequent_passes_through() {
+        // **Pre-gap-016**: this test asserted `if (flag) x;` stayed
+        // unchanged. **Post-gap-016** (CLOC12.24), that single-expr
+        // case now folds to `flag && x;`. We update the test to use
+        // a *multi-statement* consequent block, which still can't
+        // collapse to a LogicalExpression (LogicalExpression takes
+        // exactly one right-hand expression).
+        //
+        // This preserves the original intent — "the fold doesn't
+        // over-fire on non-collapsible shapes".
         let if_stmt = Statement::if_statement(IfStatement {
             cv: Some("if.2".to_string()),
             test: ident("flag"),
-            consequent: Box::new(expr_stmt(ident("x"), None)),
+            consequent: Box::new(Statement::block_statement(BlockStatement {
+                cv: None,
+                body: vec![expr_stmt(ident("x"), None), expr_stmt(ident("y"), None)],
+            })),
             alternate: None,
         });
         let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
         let (out, _contribs, _changed, _) = run_pass(prog);
-        // Don't assert !changed — the test field gets fold-walked and
-        // could in principle gain a contribution. What we DO assert
-        // is that the top-level structure stays IfStatement.
         match first_stmt(&out) {
             Statement::Tagged(TaggedStatement::IfStatement(_)) => {}
-            other => panic!("expected IfStatement intact (no alternate); got {:?}", other),
+            other => panic!(
+                "expected IfStatement intact (multi-statement consequent); got {:?}",
+                other
+            ),
         }
     }
 
     #[test]
-    fn if_with_unresolved_comparison_doesnt_fold_alone() {
-        // Run this pass solo on `if (1 < 2) {A}` — the comparison
-        // is NOT folded by fold-control-flow (it's constant-fold's
-        // job). So the IfStatement stays.
+    fn if_with_unresolved_comparison_folds_via_gap016() {
+        // **Pre-gap-016**: this test asserted `if (1<2) A;` stayed
+        // unchanged because fold-control-flow alone doesn't fold the
+        // `<` comparison (that's constant-fold's job) and there was
+        // no alternate to ternarise. **Post-gap-016** (CLOC12.24),
+        // even with `1<2` left as a BinaryExpression, the surrounding
+        // `if (test) S;` (no alternate, single-expr consequent) now
+        // folds to `(1<2) && A;` via the new logical-and rewrite.
+        //
+        // The original intent — "fold-control-flow alone doesn't have
+        // access to constant-fold's binary-expression folding" — is
+        // still pinned: the inner `1 < 2` survives as a
+        // BinaryExpression rather than being folded to `true`.
         let if_stmt = Statement::if_statement(IfStatement {
             cv: Some("if.1".to_string()),
             test: Expression::BinaryExpression(BinaryExpression {
@@ -912,14 +1002,26 @@ mod tests {
             alternate: None,
         });
         let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
-        let (out, _, changed, _) = run_pass(prog);
-        assert!(
-            !changed,
-            "fold-control-flow alone should not fold `if (1<2)` — that's constant-fold's job"
-        );
+        let (out, _, _changed, _) = run_pass(prog);
         match first_stmt(&out) {
-            Statement::Tagged(TaggedStatement::IfStatement(_)) => {}
-            other => panic!("expected IfStatement intact; got {:?}", other),
+            Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                if let Expression::LogicalExpression(le) = &es.expression {
+                    assert_eq!(le.operator, LogicalOperator::And);
+                    // The left operand must still be the unfolded
+                    // BinaryExpression — fold-control-flow does NOT
+                    // touch `<` comparisons (that's constant-fold).
+                    assert!(matches!(*le.left, Expression::BinaryExpression(_)),
+                        "left operand should still be a BinaryExpression (not folded by fold-control-flow); got {:?}", le.left);
+                    assert!(matches!(*le.right, Expression::Identifier(_)),
+                        "right operand should be the Identifier `A`; got {:?}", le.right);
+                } else {
+                    panic!("expected LogicalExpression; got {:?}", es.expression);
+                }
+            }
+            other => panic!(
+                "expected ExpressionStatement wrapping LogicalExpression; got {:?}",
+                other
+            ),
         }
     }
 

--- a/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
@@ -160,15 +160,68 @@ fn empty_stmt() -> Statement {
 ///   fold("function f(){if(x){a()}x=3}", "function f(){x&&a();x=3}");
 ///   ... (many more, all rewriting `if(x) S` to `x && S`)
 ///
-/// Converting `if (test) consequent` (with no alternate) into a
-/// `LogicalExpression { left: test, op: And, right: consequent }`
-/// requires producing a LogicalExpression as a statement-position
-/// node. Our pass doesn't do this rewrite today.
+/// **gap-016 closed in CLOC12.24**: when `test` is non-literal,
+/// the consequent reduces to a single ExpressionStatement (directly
+/// or via single-statement BlockStatement layers), and there is *no*
+/// alternate, the IfStatement rewrites to an ExpressionStatement
+/// wrapping a LogicalExpression with operator `And`. Side-effect
+/// order is preserved because `&&` evaluates `test` first and the
+/// right operand only when `test` is truthy — identical to `if (test) S`.
 #[test]
-#[ignore = "blocked on gap-016: `if (x) S` → `x && S` rewrite not implemented"]
 fn test_fold_one_child_blocks_if_to_logical_and() {
-    // Would assert `if (x) foo();` collapses to an
-    // ExpressionStatement wrapping `x && foo()`.
+    use coding_adventures_javascript_ast::{
+        BlockStatement, CallExpression, LogicalExpression, LogicalOperator,
+    };
+    let call = |name: &str| {
+        Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident(name)),
+            arguments: vec![],
+        })
+    };
+    let block = |s: Statement| {
+        Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![s],
+        })
+    };
+    let expect_logical_and = |t: Expression, c: Expression| -> Statement {
+        Statement::expression_statement(ExpressionStatement {
+            cv: None,
+            expression: Expression::LogicalExpression(LogicalExpression {
+                cv: None,
+                operator: LogicalOperator::And,
+                left: Box::new(t),
+                right: Box::new(c),
+            }),
+        })
+    };
+
+    // 1. Bare consequent: `if (x) a();` → `x && a();`
+    assert_fold(
+        if_stmt(ident("x"), expr_stmt(call("a")), None),
+        expect_logical_and(ident("x"), call("a")),
+    );
+
+    // 2. Single-statement block consequent: `if (x) { a(); }` → `x && a();`
+    assert_fold(
+        if_stmt(ident("x"), block(expr_stmt(call("a"))), None),
+        expect_logical_and(ident("x"), call("a")),
+    );
+
+    // 3. Nested single-statement blocks: `if (x) {{ a(); }}` → `x && a();`
+    // (single_expr_stmt recurses through BlockStatement layers.)
+    assert_fold(
+        if_stmt(ident("x"), block(block(expr_stmt(call("a")))), None),
+        expect_logical_and(ident("x"), call("a")),
+    );
+
+    // 4. Bare assignment in consequent: `if (x) y;` → `x && y;`
+    // (Any identifier is a valid expression statement.)
+    assert_fold(
+        if_stmt(ident("x"), expr_stmt(ident("y")), None),
+        expect_logical_and(ident("x"), ident("y")),
+    );
 }
 
 /// Upstream `testFoldOneChildBlocks` line:
@@ -233,13 +286,15 @@ fn test_fold_one_child_blocks_if_else_to_ternary() {
         expect_ternary(ident("x"), call("foo"), call("bar")),
     );
 
-    // testSame: no alternate → stays an IfStatement.
-    let inp_no_alt = if_stmt(ident("x"), expr_stmt(call("foo")), None);
-    assert_fold(
-        inp_no_alt.clone(),
-        // Identity fold: the IfStatement comes back unchanged.
-        inp_no_alt,
-    );
+    // **Pre-gap-016**: no alternate → stays an IfStatement (testSame).
+    // **Post-gap-016** (CLOC12.24): now folds to `x && foo();`.
+    //
+    // This is the canonical gap-016 case; the dedicated
+    // `test_fold_one_child_blocks_if_to_logical_and` test above
+    // covers it (along with several other shapes), so we no longer
+    // need a duplicate assertion here. Pre-gap-016 the assertion
+    // here was identity; we leave the comment as a historical marker
+    // so the gap-017 vs gap-016 split stays visible in the file.
 }
 
 /// Constant true test always selects the consequent. Mirrors upstream's

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -132,11 +132,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-016 — `if (x) S` → `x && S` rewrite not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.24 — `fold_if_statement` now has a third (after the literal-truthy/falsy and gap-017 if-else→ternary branches): when `alternate.is_none()` AND the consequent reduces to a single `ExpressionStatement` (directly or via `single_expr_stmt`'s BlockStatement unwrap), the IfStatement is rewritten to `ExpressionStatement { LogicalExpression { left: test, op: And, right: consequent_expr } }`. Side-effect semantics are preserved: `&&` evaluates `test` first and the right operand only when `test` is truthy — exactly matching `if (test) S`'s observable behaviour. The rule does NOT fire when an alternate is present (preventing silent loss of the else branch) and does NOT fire when the consequent is multi-statement (no single right-hand expression to lower into). `test_fold_one_child_blocks_if_to_logical_and` is un-ignored. Two pre-existing inline tests were updated to reflect the new behaviour: `if_non_literal_test_with_no_alternate_passes_through` → `..._with_multi_statement_consequent_passes_through` (uses a 2-statement block that still can't fold), and `if_with_unresolved_comparison_doesnt_fold_alone` → `..._folds_via_gap016` (now expects the `(1<2) && A` shape and asserts the inner `1 < 2` survived as a BinaryExpression — confirming fold-control-flow still doesn't fold binary comparisons).
 - **Upstream test:** `PeepholeMinimizeConditionsTest::testFoldOneChildBlocks` (`if(x) foo()` → `x&&foo()` lines)
 - **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs`
-- **Why it fails:** Upstream compacts a one-statement `if (test) consequent` (no alternate) into a `LogicalExpression { left: test, op: And, right: consequent }` wrapped in an `ExpressionStatement`. Our pass leaves `IfStatement` shapes alone when the test isn't a literal.
-- **What it needs:** A rewrite rule in `fold_if_statement`: when `alternate.is_none()`, the consequent is exactly one `ExpressionStatement`, and the test isn't a literal, replace the `IfStatement` with an `ExpressionStatement` wrapping `test && consequent_expr`. Must preserve side-effect semantics — only fire when both sides are observably safe to reorder.
 
 ### gap-017 — `if (x) C else A` → `x ? C : A` rewrite not implemented
 


### PR DESCRIPTION
## Summary

Closes **gap-016** in the CLOC12 gap tracker: rewrites `if (test) S;` (no alternate, single-expression consequent) to `test && S;`. Mirrors the gap-017 (CLOC12.18) if-else→ternary fold for the no-alternate case.

| input | output |
|---|---|
| `if (x) a();` | `x && a();` |
| `if (x) { a(); }` | `x && a();` (single-stmt block unwraps) |
| `if (x) {{ a(); }}` | `x && a();` (nested single-stmt blocks) |
| `if (x) y;` | `x && y;` |
| `if (x) a(); else b();` | `x ? a() : b();` (gap-017 fires first) |
| `if (x) { a; b; }` | unchanged (multi-stmt consequent) |
| `if (x) return 1;` | unchanged (return not expression; gap-019's territory) |

## Why this is safe

`x && S` and `if (x) S;` have observably identical evaluation order:
- `x` is evaluated exactly once (no clone in the rewrite — moved into the LogicalExpression's `left`).
- The right operand is evaluated when and only when `x` is truthy. `&&` short-circuits identically to `if`.
- The wrapping ExpressionStatement discards the result, so the value returned by `&&` is unobservable.

Sound for all input values (NaN, undefined, 0n BigInt, getters with side effects).

Gate ordering: gap-017 ternary branch is positioned BEFORE this branch and the new branch's `alternate.is_none()` guard ensures we don't silently drop an else branch.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-fold-control-flow` → 20 inline + 11 upstream passing (was 18 + 10 + 1 ignored)
- [x] Upstream test `test_fold_one_child_blocks_if_to_logical_and` un-ignored, covers 4 shapes
- [x] Downstream `closurec`'s `diff_minify` e2e harness still passes (no fixture contains `if`)
- [x] `closure-pass-pipeline` tests still pass (21/0/0)
- [x] gap-017 ternary regression confirmed unaffected
- [x] /security-review — ship-it: single test evaluation, no clone, precedence-safe (`<` binds tighter than `&&`), fixed-point termination preserved
- [ ] CI green

## Touched pre-existing tests

* `if_non_literal_test_with_no_alternate_passes_through` → `..._with_multi_statement_consequent_passes_through` (now uses 2-stmt block that still doesn't fold).
* `if_with_unresolved_comparison_doesnt_fold_alone` → `..._folds_via_gap016` (now expects `(1<2) && A` while pinning that inner `1<2` still isn't folded by fold-control-flow alone).
* `test_fold_one_child_blocks_if_else_to_ternary` — removed trailing "no-alternate stays unchanged" assertion (covered by the new gap-016 test).

## Closes

- gap-016 (status flipped OPEN → RESOLVED in `code/specs/CLOC12-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)