### PR TITLE
feat(visicalc-qt): generate Grid via mosaic-compile

### DIFF
--- a/demo/visicalc-qt/main.qml
+++ b/demo/visicalc-qt/main.qml
@@ -1,9 +1,16 @@
 // main.qml — VisiCalc Qt host (VC2-qt).
 //
-// Mounts the auto-generated `FormulaBar` from build/ and a
-// hand-written grid block below it. Hard-coded 5×5 sample
-// spreadsheet matches the data in VC2-html / VC2-webcomp /
-// VC2-flutter so all four demos look visually identical.
+// Mounts the auto-generated `FormulaBar` and `Grid` components from
+// build/.  Both come from `bash scripts/build.sh` which runs
+// `mosaic-compile --backend qt` against the shared
+// `demo/visicalc/mosaic/{FormulaBar,Grid}.{mil,desktop.mll,dark.msl}`
+// triples.  Grid.desktop.mll is a UI34 `pkg::mosaic-pkg-grid::Grid`
+// one-liner — the QML component you see below is the package's
+// authoritative Grid composition lowered to QtQuick by the Qt
+// emitter.  No hand-written widgets in this file.
+//
+// Hard-coded 5×5 sample spreadsheet matches the data in every other
+// VC2-* demo so all five renders look visually identical.
 //
 // Run:
 //   qml main.qml          # one-shot QML viewer (Qt 6)
@@ -85,106 +92,45 @@ Window {
             onCancel: { root.formulaText = root.sampleRows[root.selectedRow][root.selectedCol] }
         }
 
-        // Grid — HAND-WRITTEN placeholder (mosaic-emit-qt's pipeline
-        // doesn't yet support the `Grid` built-in primitive; only the
-        // React emitter does). Visual contract matches Grid.dark.msl.
-        Rectangle {
-            id: gridContainer
+        // Grid — AUTO-GENERATED from
+        // demo/visicalc/mosaic/Grid.{mil,desktop.mll,dark.msl} via
+        // `mosaic-compile --backend qt`.  Grid.desktop.mll is a UI34
+        // `pkg::mosaic-pkg-grid::Grid` one-liner; the QML component
+        // you see here is the package's authoritative Grid +
+        // Cell composition lowered to QtQuick by mosaic-emit-qt.
+        //
+        // List-typed slots (columnHeaders / viewportRows /
+        // columnWidths) are passed as JS arrays through the
+        // property bindings; the Qt emitter declares them as
+        // `property var`.  The four signals (`navigate`,
+        // `formulaChange`, `editCommit`, `editCancel`) are wired
+        // back into the host's selection state.
+        Grid {
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.margins: 16
-            color: "#1E1E1E"
-            border.color: "#3F3F46"
-            border.width: 1
 
-            ColumnLayout {
-                anchors.fill: parent
-                spacing: 0
+            columnHeaders: ["A", "B", "C", "D", "E"]
+            // 6 widths: row-label column + 5 data columns.
+            columnWidths: [48, 96, 96, 96, 96, 96]
+            viewportRows: root.sampleRows
+            selectedRow: root.selectedRow
+            selectedCol: root.selectedCol
+            // Negative coordinates ⇒ no cell is editing — matches
+            // every other VC2-* demo's default state.
+            editRow: -1
+            editCol: -1
+            editContent: ""
+            totalHeight: 0
 
-                // Header row: row-label cell + column-letter cells.
-                RowLayout {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 24
-                    spacing: 0
-                    Repeater {
-                        model: ["", "A", "B", "C", "D", "E"]
-                        Rectangle {
-                            Layout.preferredWidth: 96
-                            Layout.preferredHeight: 24
-                            color: "#2D2D30"
-                            border.color: "#3F3F46"
-                            border.width: 1
-                            Text {
-                                anchors.centerIn: parent
-                                text: modelData
-                                color: "#9D9D9D"
-                                font.family: "monospace"
-                                font.pixelSize: 12
-                            }
-                        }
-                    }
-                }
-
-                // Data rows. We loop 5×5 with nested Repeaters.
-                Repeater {
-                    model: root.sampleRows.length
-                    RowLayout {
-                        property int rowIdx: index
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 22
-                        spacing: 0
-
-                        // Leading row-label cell.
-                        Rectangle {
-                            Layout.preferredWidth: 96
-                            Layout.preferredHeight: 22
-                            color: "#2D2D30"
-                            border.color: "#3F3F46"
-                            border.width: 1
-                            Text {
-                                anchors.centerIn: parent
-                                text: (rowIdx + 1).toString()
-                                color: "#9D9D9D"
-                                font.family: "monospace"
-                                font.pixelSize: 12
-                            }
-                        }
-
-                        // Data cells for this row.
-                        Repeater {
-                            model: root.sampleRows[rowIdx]
-                            Rectangle {
-                                property int colIdx: index
-                                property bool isSelected:
-                                    rowIdx === root.selectedRow &&
-                                    colIdx === root.selectedCol
-                                Layout.preferredWidth: 96
-                                Layout.preferredHeight: 22
-                                color: isSelected ? "#264F78" : (rowIdx % 2 === 0 ? "#1E1E1E" : "#252526")
-                                border.color: isSelected ? "#007ACC" : "#3F3F46"
-                                border.width: 1
-                                Text {
-                                    anchors.right: parent.right
-                                    anchors.rightMargin: 4
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    text: modelData
-                                    color: isSelected ? "white" : "#CCCCCC"
-                                    font.family: "monospace"
-                                    font.pixelSize: 12
-                                }
-                                MouseArea {
-                                    anchors.fill: parent
-                                    onClicked: {
-                                        root.selectedRow = rowIdx;
-                                        root.selectedCol = colIdx;
-                                        root.formulaText = root.sampleRows[rowIdx][colIdx];
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            onNavigate: (row, col) => {
+                root.selectedRow = row;
+                root.selectedCol = col;
+                root.formulaText = root.sampleRows[row][col];
             }
+            onFormulaChange: (_value) => { /* live-edit deferred */ }
+            onEditCommit:    () => { /* live-edit deferred */ }
+            onEditCancel:    () => { /* live-edit deferred */ }
         }
     }
 }

--- a/demo/visicalc-qt/qml/qmldir
+++ b/demo/visicalc-qt/qml/qmldir
@@ -11,3 +11,4 @@
 # build/ keeps both well-behaved under version control.
 module qml
 FormulaBar 1.0 ../build/FormulaBar.qml
+Grid 1.0 ../build/Grid.qml

--- a/demo/visicalc-qt/scripts/build.sh
+++ b/demo/visicalc-qt/scripts/build.sh
@@ -49,9 +49,22 @@ echo "Compiling FormulaBar (Qt / QML)..."
   --style     "$SRC/FormulaBar.dark.msl" \
   -o "$OUT_DIR/FormulaBar.qml"
 
-# TODO(VC2-qt-grid): wire Grid once the Qt pipeline emitter
-# supports the `Grid` built-in primitive. Until then, main.qml
-# inlines a hand-written QtQuick.Controls TableView placeholder.
+echo "Compiling Grid (Qt / QML)..."
+# UI34 — Grid is now generated from the shared visicalc/mosaic/
+# Grid.{mil,desktop.mll,dark.msl} triple (same source the React +
+# HTML + WebComponent + SwiftUI demos consume).  Grid.desktop.mll
+# is a UI34 `pkg::mosaic-pkg-grid::Grid` one-liner; we pass
+# --package-search-path so the resolver substitutes the package's
+# full composition before the Qt emitter runs.  The output is a
+# QML Item with `Repeater` loops, `Loader` if/else gates, and
+# typed signals — exposed to main.qml through the local `qml/`
+# module by adding a `Grid 1.0 ../build/Grid.qml` line to qmldir.
+"$MOSAIC_COMPILE" --backend qt \
+  --interface           "$SRC/Grid.mil" \
+  --layout              "$SRC/Grid.desktop.mll" \
+  --style               "$SRC/Grid.dark.msl" \
+  --package-search-path "$REPO_ROOT/code/packages" \
+  -o "$OUT_DIR/Grid.qml"
 
 echo "Done. Generated:"
 ls -la "$OUT_DIR"


### PR DESCRIPTION
## Summary

Replaces the 100-line hand-written QtQuick Repeater table in `demo/visicalc-qt/main.qml` with the auto-generated `Grid` QML component from `mosaic-compile --backend qt`.

**The fifth VisiCalc demo** derived from the shared `demo/visicalc/mosaic/Grid.*` source (after React #4975, HTML #4981, WebComponent #4985, SwiftUI #4988).

## Changes

- `scripts/build.sh` adds Grid compile line with `--package-search-path` for UI34 resolution.
- `qml/qmldir` registers `Grid 1.0 ../build/Grid.qml`.
- `main.qml`'s 100-line hand-rolled `Rectangle + nested Repeaters + Text + MouseArea` composition collapses to a `Grid { columnHeaders: …, viewportRows: …, onNavigate: (row, col) => { … } }` reference.

## Test plan

- [x] `bash scripts/build.sh` produces `build/Grid.qml` (83 lines of QtQuick)
- [x] `main.qml` shrinks from 190 → 135 lines; hand-written grid section gone
- [ ] CI

## Why this matters

Five backends now (React, HTML, WebComponent, SwiftUI, Qt), one source of truth (`demo/visicalc/mosaic/Grid.*`), zero hand-written widgets across the whole set. Two more to go (Flutter, Compose/Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)