### PR TITLE
feat(mccarthy-lisp): L2c-1 — direct LAMBDA application (VM call opcode + multi-fn compiler)

### DIFF
--- a/code/packages/rust/mccarthy-lisp-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — mccarthy-lisp-iir-compiler
 
+## v0.3.0 — 2026-06-04 — direct LAMBDA application (L2c-1)
+
+* Lowers direct lambda application `((LAMBDA (p1 … pn) body) a1 … an)`:
+  the lambda becomes a fresh top-level `IIRFunction` (gensym
+  `lambda_<n>`) with parameters `p1…pn`, and the application emits a
+  `call` to it with the lowered argument registers.
+* The compiler now produces **multiple functions** (the lambdas + `main`)
+  and tracks the **parameter scope** of the function being lowered. A
+  bare symbol resolves to a register read **only** if it is a parameter
+  of the enclosing lambda; the VM binds each parameter to a register
+  named after it.
+* **No closures yet (deferred):** a lambda body may reference only its
+  own parameters — a free variable is an unbound-variable error, and an
+  unapplied `LAMBDA` (lambda-as-value) is rejected with a clear message.
+  `LABEL` (named/recursive functions) is deferred to **L2c-2**.
+* Validation: malformed lambdas (wrong shape, non-symbol or duplicate
+  parameters, arity mismatch) are `CompileError`s; the emitted multi-
+  function module passes `IIRModule::validate`.
+* 7 new unit tests (function+call shape, param-in-scope, free-variable
+  unbound, arity, duplicate param, bare-lambda rejected, LABEL deferred)
+  + 8 new end-to-end tests on `mccarthy-lisp-vm` (identity on
+  symbol/int, `CAR` of arg, two-param `CONS`, param used twice, body
+  using `COND`, argument that is itself a lambda application, lambda
+  result feeding a primitive).
+
 ## v0.2.0 — 2026-06-04 — COND (L2b)
 
 * Lowers `(COND (p1 e1) … (pn en))` to a chain of `jmp_if_false` +

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mccarthy-lisp-iir-compiler"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Lowers a McCarthy 1960 Lisp (Lisp 1.0) AST into an IIRModule. L2a v0.1.0 handles integer/nil literals, QUOTE (symbols + nested lists), and the primitives CONS/CAR/CDR/ATOM/EQ, emitting IIR over the `lispy-runtime` value model so the module runs end-to-end on `mccarthy-lisp-vm` and feeds every IIR backend. COND, LAMBDA, and LABEL land in L2b/L2c."
 

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/README.md
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/README.md
@@ -30,7 +30,7 @@ use mccarthy_lisp_vm::run;
 let value = run(&module).unwrap();   // → the symbol A
 ```
 
-## Lowering (through L2b)
+## Lowering (through L2c-1)
 
 | Form               | IIR                                                     |
 |--------------------|---------------------------------------------------------|
@@ -43,6 +43,7 @@ let value = run(&module).unwrap();   // → the symbol A
 | `(ATOM X)`         | `(not (pair? X))` — two `call_builtin`s                 |
 | `(EQ A B)`         | `call_builtin "equal?" [A, B]` (identity on atoms)      |
 | `(COND (p e) …)`   | chained `jmp_if_false` + `label`s; each clause's value funnels into one register via `mov`; no match → `nil` |
+| `((LAMBDA (p…) body) a…)` | a fresh `IIRFunction` for the lambda + a `call` to it with the lowered args (params bound by name; no free-variable capture) |
 
 These are the conventions of the shared `lispy-runtime` value model
 (tagged-`i64` symbols, cons cells, nil) — so the same IIR runs on
@@ -63,11 +64,14 @@ crate dev-depends on it only to run the end-to-end tests.
 
 ## Not yet (later phases)
 
-- **L2c** — `LAMBDA` / `LABEL` / user-defined function application.
+- **L2c-2** — `LABEL` (named / recursive functions).
+- **Closures** — a lambda used as a *value* (passed or returned) and
+  free-variable capture. For now a lambda body may reference only its own
+  parameters; an unapplied `LAMBDA` is rejected.
 
 A bare (unquoted) symbol in value position is an *unbound variable*
-(there are no bindings until LAMBDA/LABEL) and is reported as a
-`CompileError`.
+unless it is a parameter of the enclosing lambda, and is otherwise
+reported as a `CompileError`.
 
 ## API
 

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/src/lib.rs
@@ -14,7 +14,7 @@
 //! the value of the **last** form (an empty program returns `nil`).
 //! The module's `entry_point` is `"main"`.
 //!
-//! ## Which Lisp we can lower *today* (through L2b)
+//! ## Which Lisp we can lower *today* (through L2c-1)
 //!
 //! | Form                | Lowering                                             |
 //! |---------------------|------------------------------------------------------|
@@ -27,6 +27,7 @@
 //! | `(ATOM X)`          | `call_builtin "pair?" [X]` then `call_builtin "not"` |
 //! | `(EQ A B)`          | `call_builtin "equal?" [A, B]`                       |
 //! | `(COND (p e) …)`    | chained `jmp_if_false` + `label`s; `mov` funnels each clause's value into one register; no match → nil |
+//! | `((LAMBDA (p…) body) a…)` | a fresh `IIRFunction` for the lambda + a `call` to it with the lowered args |
 //!
 //! `QUOTE` materialises a literal S-expression as runtime values:
 //! a symbol `A` becomes `const v, Var("A")` (the IIR convention the
@@ -55,10 +56,14 @@
 //!
 //! ## Not yet (later phases)
 //!
-//! - **L2c** — `LAMBDA` / `LABEL` / user-defined function application.
+//! - **L2c-2** — `LABEL` (named / recursive functions).
+//! - **Closures** — a lambda as a *value* (passed / returned) and
+//!   free-variable capture.  For now a lambda body sees only its own
+//!   parameters, and an unapplied `LAMBDA` is rejected.
 //!
-//! A bare (unquoted) symbol in value position is therefore an *unbound
-//! variable* — there are no bindings yet — and is reported as a
+//! A bare (unquoted) symbol in value position is an *unbound variable*
+//! unless it is a parameter of the enclosing lambda, and is otherwise
+//! reported as a
 //! [`CompileError`] rather than silently mis-lowered.
 //!
 //! ## Quick start
@@ -72,6 +77,8 @@
 //! ```
 
 #![warn(missing_docs)]
+
+use std::collections::HashSet;
 
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use mccarthy_lisp_parser::{parse, LispExpr};
@@ -142,11 +149,13 @@ pub fn compile_forms(forms: &[LispExpr], module_name: &str) -> Result<IIRModule,
         "main",
         Vec::new(),       // no parameters
         "any",            // a Lisp value of any shape
-        c.instrs,
+        std::mem::take(&mut c.instrs),
     );
     main.register_count = c.tmp;
 
     let mut module = IIRModule::new(module_name, "mccarthy-lisp");
+    // The `LAMBDA` functions first, then the `main` entry point.
+    module.functions = c.functions;
     module.functions.push(main);
     module.entry_point = Some("main".to_string());
 
@@ -170,18 +179,39 @@ pub fn compile_forms(forms: &[LispExpr], module_name: &str) -> Result<IIRModule,
 /// `call_builtin "cons"` into a fresh pair.
 const REF_PAIR: &str = "ref<LispyPair>";
 
-/// Accumulates the instruction stream for the `main` function.
+/// Accumulates the instruction stream of the function currently being
+/// lowered (the top-level `main` body, or — temporarily, while lowering
+/// a `LAMBDA` — that lambda's body).
 struct Compiler {
+    /// Instructions of the function under construction.
     instrs: Vec<IIRInstr>,
+    /// Completed `LAMBDA` functions, to be added to the module alongside
+    /// `main`.
+    functions: Vec<IIRFunction>,
     /// Monotonic counter for fresh SSA temp names (`v0`, `v1`, …).
     tmp: usize,
     /// Monotonic counter for fresh, unique branch-label names.
     label: usize,
+    /// Monotonic counter for gensym `LAMBDA` function names.
+    fn_ctr: usize,
+    /// The parameter names visible in the function currently being
+    /// lowered.  A bare symbol resolves to a register read **only** if it
+    /// is one of these — McCarthy Lisp lambdas in L2c-1 do not capture
+    /// free variables (no closures yet), so an out-of-scope symbol is an
+    /// unbound-variable error.
+    params: HashSet<String>,
 }
 
 impl Compiler {
     fn new() -> Self {
-        Compiler { instrs: Vec::new(), tmp: 0, label: 0 }
+        Compiler {
+            instrs: Vec::new(),
+            functions: Vec::new(),
+            tmp: 0,
+            label: 0,
+            fn_ctr: 0,
+            params: HashSet::new(),
+        }
     }
 
     /// Allocate a fresh, never-reused temp register name.
@@ -227,9 +257,16 @@ impl Compiler {
         match expr {
             LispExpr::Int(n) => Ok(self.emit_int(*n)),
             LispExpr::Nil => Ok(self.emit_nil()),
+            // A bare symbol is a variable reference.  It resolves to a
+            // register read *only* if it is a parameter of the function
+            // currently being lowered; the VM binds each parameter to a
+            // register named after it, so the register name *is* the
+            // parameter name.
+            LispExpr::Symbol(name) if self.params.contains(name) => Ok(name.clone()),
             LispExpr::Symbol(name) => Err(CompileError::new(format!(
-                "unbound variable `{name}`: bare symbols need a binding, which arrives \
-                 with LAMBDA/LABEL in a later phase. Did you mean to quote it as `'{name}`?"
+                "unbound variable `{name}`: it is not a parameter in scope. \
+                 (Lambdas don't capture free variables yet — closures are a later phase.) \
+                 Did you mean to quote it as `'{name}`?"
             ))),
             LispExpr::Cons(..) => self.lower_application(expr),
         }
@@ -248,6 +285,14 @@ impl Compiler {
             CompileError::new("empty application `()` cannot be evaluated (quote it as `'()` for nil)")
         })?;
 
+        // A `LAMBDA` form in head position is a *direct application*:
+        // `((LAMBDA (p …) body) a …)`.  (A bare, unapplied `LAMBDA` is
+        // handled as a `Symbol("LAMBDA")` head below — it's an error,
+        // since lambda-as-a-value needs closures.)
+        if is_lambda_form(head) {
+            return self.lower_lambda_application(head, args);
+        }
+
         let name = match head {
             LispExpr::Symbol(s) => s.as_str(),
             // Describe the head by *kind*, never via `Display` — a quoted
@@ -256,7 +301,8 @@ impl Compiler {
             // cdr-spine (a huge flat list would overflow formatting it).
             other => {
                 return Err(CompileError::new(format!(
-                    "the head of a call must be a primitive symbol in L2a, got a {}",
+                    "the head of a call must be a primitive, a LAMBDA form, or (later) a \
+                     function name — got a {}",
                     kind_of(other)
                 )))
             }
@@ -301,14 +347,86 @@ impl Compiler {
                 Ok(self.emit_builtin("equal?", &[va, vb], "bool"))
             }
             "COND" => self.lower_cond(args),
-            "LAMBDA" | "LABEL" => Err(CompileError::new(format!(
-                "`{name}` is not supported yet — user functions land in L2c"
-            ))),
+            // A bare `LAMBDA` reached here means it is in *value* position
+            // (not applied) — that requires first-class functions
+            // (closures), which L2c-1 does not have.
+            "LAMBDA" => Err(CompileError::new(
+                "a LAMBDA must be applied directly — `((LAMBDA (params) body) args …)`. \
+                 Using a lambda as a value (passing or returning it) needs closures, \
+                 which are a later phase.",
+            )),
+            "LABEL" => Err(CompileError::new(
+                "`LABEL` (named/recursive functions) is not supported yet — it lands in L2c-2",
+            )),
             other => Err(CompileError::new(format!(
-                "unknown form `{other}`: supported forms are QUOTE, CONS, CAR, CDR, ATOM, EQ, COND \
-                 (LAMBDA/LABEL→L2c)"
+                "unknown form `{other}`: supported forms are QUOTE, CONS, CAR, CDR, ATOM, EQ, COND, \
+                 and direct LAMBDA application (LABEL → L2c-2)"
             ))),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // LAMBDA application (L2c-1)
+    // -----------------------------------------------------------------------
+
+    /// Lower a direct lambda application
+    /// `((LAMBDA (p1 … pn) body) a1 … an)`.
+    ///
+    /// The lambda becomes a fresh top-level [`IIRFunction`] (a gensym
+    /// name) whose parameters are `p1…pn` and whose body is lowered with
+    /// **only those** parameters in scope — McCarthy Lisp lambdas do not
+    /// capture free variables in L2c-1 (closures are a later phase), so a
+    /// body reference to anything other than its own params is an
+    /// unbound-variable error.  The application itself lowers its
+    /// arguments in the *caller's* scope and emits a `call` to the new
+    /// function.
+    fn lower_lambda_application(
+        &mut self,
+        lambda: &LispExpr,
+        args: &[&LispExpr],
+    ) -> Result<String, CompileError> {
+        let (params, body) = lambda_parts(lambda)?;
+        if args.len() != params.len() {
+            return Err(CompileError::new(format!(
+                "lambda expects {} argument(s), got {}",
+                params.len(),
+                args.len()
+            )));
+        }
+
+        let fn_name = format!("lambda_{}", self.fn_ctr);
+        self.fn_ctr += 1;
+
+        // Build the lambda's body in a fresh instruction buffer with a
+        // fresh parameter scope, then restore the caller's buffer + scope.
+        let saved_instrs = std::mem::take(&mut self.instrs);
+        let saved_params =
+            std::mem::replace(&mut self.params, params.iter().map(|p| p.to_string()).collect());
+        let body_reg = self.lower_expr(body)?;
+        self.emit(IIRInstr::new("ret", None, vec![Operand::Var(body_reg)], "any"));
+        let body_instrs = std::mem::replace(&mut self.instrs, saved_instrs);
+        self.params = saved_params;
+
+        let mut f = IIRFunction::new(
+            fn_name.clone(),
+            params.iter().map(|p| (p.to_string(), "any".to_string())).collect(),
+            "any",
+            body_instrs,
+        );
+        f.register_count = self.tmp;
+        self.functions.push(f);
+
+        // Back in the caller: lower the arguments, then emit the call.
+        let mut arg_regs = Vec::with_capacity(args.len());
+        for a in args {
+            arg_regs.push(self.lower_expr(a)?);
+        }
+        let dest = self.fresh();
+        let mut srcs = Vec::with_capacity(arg_regs.len() + 1);
+        srcs.push(Operand::Var(fn_name));
+        srcs.extend(arg_regs.into_iter().map(Operand::Var));
+        self.emit(IIRInstr::new("call", Some(dest.clone()), srcs, "any"));
+        Ok(dest)
     }
 
     // -----------------------------------------------------------------------
@@ -517,6 +635,47 @@ fn kind_of(expr: &LispExpr) -> &'static str {
     }
 }
 
+/// True iff `expr` is a `(LAMBDA …)` form (a list whose head is the
+/// symbol `LAMBDA`).
+fn is_lambda_form(expr: &LispExpr) -> bool {
+    matches!(expr, LispExpr::Cons(car, _) if matches!(car.as_ref(), LispExpr::Symbol(s) if s == "LAMBDA"))
+}
+
+/// Destructure a `(LAMBDA (p1 … pn) body)` form into its parameter names
+/// and body.  The caller guarantees `is_lambda_form(lambda)`.
+fn lambda_parts(lambda: &LispExpr) -> Result<(Vec<&str>, &LispExpr), CompileError> {
+    let items = proper_list(lambda)
+        .ok_or_else(|| CompileError::new("malformed LAMBDA (improper list)"))?;
+    if items.len() != 3 {
+        return Err(CompileError::new(format!(
+            "a LAMBDA must be `(LAMBDA (params) body)` — 3 elements, got {}",
+            items.len()
+        )));
+    }
+    let param_list = proper_list(items[1]).ok_or_else(|| {
+        CompileError::new("a LAMBDA parameter list must be a proper list `(p1 p2 …)`")
+    })?;
+    let mut params: Vec<&str> = Vec::with_capacity(param_list.len());
+    for p in &param_list {
+        match p {
+            LispExpr::Symbol(s) => params.push(s.as_str()),
+            other => {
+                return Err(CompileError::new(format!(
+                    "a LAMBDA parameter must be a symbol, got a {}",
+                    kind_of(other)
+                )))
+            }
+        }
+    }
+    let mut seen = HashSet::new();
+    for p in &params {
+        if !seen.insert(*p) {
+            return Err(CompileError::new(format!("duplicate LAMBDA parameter `{p}`")));
+        }
+    }
+    Ok((params, items[2]))
+}
+
 /// Flatten a proper list (`Cons` chain terminated by `Nil`) into its
 /// elements.  Returns `None` if the chain is improper (ends in a dotted
 /// tail) — those are data, never callable forms.
@@ -696,8 +855,53 @@ mod tests {
     }
 
     #[test]
-    fn lambda_is_deferred() {
-        assert!(compile_source("(LAMBDA (X) X)", "t").unwrap_err().message.contains("L2c"));
+    fn applied_lambda_emits_a_function_and_a_call() {
+        // ((LAMBDA (X) (CAR X)) '(A B)) → a `lambda_0` function + a `call`.
+        let m = compile_source("((LAMBDA (X) (CAR X)) '(A B))", "t").unwrap();
+        // Two functions: the lambda and `main`.
+        assert_eq!(m.functions.len(), 2);
+        assert!(m.functions.iter().any(|f| f.name == "lambda_0"));
+        let lam = m.functions.iter().find(|f| f.name == "lambda_0").unwrap();
+        assert_eq!(lam.param_names(), vec!["X"]);
+        // main contains a `call` to the lambda.
+        let main = m.get_function("main").unwrap();
+        assert!(main.instructions.iter().any(|i| i.op == "call"
+            && matches!(i.srcs.first(), Some(Operand::Var(s)) if s == "lambda_0")));
+        assert!(m.validate().is_empty());
+    }
+
+    #[test]
+    fn lambda_param_is_in_scope_in_its_body() {
+        // The body may reference its own param `X` (a register read).
+        assert!(compile_source("((LAMBDA (X) X) 'A)", "t").is_ok());
+    }
+
+    #[test]
+    fn lambda_body_free_variable_is_unbound() {
+        // `Y` is not a parameter — no closures yet, so it is unbound.
+        let e = compile_source("((LAMBDA (X) Y) 'A)", "t").unwrap_err();
+        assert!(e.message.contains("unbound variable"));
+    }
+
+    #[test]
+    fn lambda_arity_is_checked() {
+        assert!(compile_source("((LAMBDA (X Y) X) 'A)", "t").unwrap_err().message.contains("argument"));
+    }
+
+    #[test]
+    fn duplicate_lambda_param_rejected() {
+        assert!(compile_source("((LAMBDA (X X) X) 'A 'B)", "t").unwrap_err().message.contains("duplicate"));
+    }
+
+    #[test]
+    fn bare_lambda_value_is_rejected() {
+        // An unapplied LAMBDA (lambda-as-value) needs closures — deferred.
+        assert!(compile_source("(LAMBDA (X) X)", "t").unwrap_err().message.contains("must be applied"));
+    }
+
+    #[test]
+    fn label_is_deferred() {
+        assert!(compile_source("(LABEL F (LAMBDA (X) X))", "t").unwrap_err().message.contains("L2c-2"));
     }
 
     #[test]

--- a/code/packages/rust/mccarthy-lisp-iir-compiler/tests/run_e2e.rs
+++ b/code/packages/rust/mccarthy-lisp-iir-compiler/tests/run_e2e.rs
@@ -200,3 +200,57 @@ fn cond_returns_a_list_value() {
     assert_eq!(sym_name(car(v)), "A");
     assert_eq!(sym_name(cdr(v)), "B");
 }
+
+// ============================================================
+// LAMBDA application (L2c-1)
+// ============================================================
+
+#[test]
+fn identity_lambda_on_a_symbol() {
+    assert_eq!(sym_name(eval("((LAMBDA (X) X) 'A)")), "A");
+}
+
+#[test]
+fn identity_lambda_on_an_int() {
+    assert_eq!(eval("((LAMBDA (N) N) 42)").as_int(), Some(42));
+}
+
+#[test]
+fn lambda_takes_car_of_its_argument() {
+    assert_eq!(sym_name(eval("((LAMBDA (X) (CAR X)) '(A B))")), "A");
+}
+
+#[test]
+fn two_parameter_lambda() {
+    // ((LAMBDA (X Y) (CONS X Y)) 'A 'B) → (A . B)
+    let p = eval("((LAMBDA (X Y) (CONS X Y)) 'A 'B)");
+    assert_eq!(sym_name(car(p)), "A");
+    assert_eq!(sym_name(cdr(p)), "B");
+}
+
+#[test]
+fn lambda_uses_its_param_twice() {
+    // ((LAMBDA (X) (CONS X X)) 'A) → (A . A)
+    let p = eval("((LAMBDA (X) (CONS X X)) 'A)");
+    assert_eq!(sym_name(car(p)), "A");
+    assert_eq!(sym_name(cdr(p)), "A");
+}
+
+#[test]
+fn lambda_body_can_use_cond() {
+    assert_eq!(sym_name(eval("((LAMBDA (X) (COND ((ATOM X) 'YES) ('T 'NO))) 'Q)")), "YES");
+    assert_eq!(sym_name(eval("((LAMBDA (X) (COND ((ATOM X) 'YES) ('T 'NO))) '(Q))")), "NO");
+}
+
+#[test]
+fn argument_is_itself_a_lambda_application() {
+    // Outer identity applied to the result of an inner lambda.
+    // ((LAMBDA (X) X) ((LAMBDA (Y) (CAR Y)) '(P Q))) → P
+    assert_eq!(sym_name(eval("((LAMBDA (X) X) ((LAMBDA (Y) (CAR Y)) '(P Q)))")), "P");
+}
+
+#[test]
+fn lambda_result_feeds_a_primitive() {
+    // (CDR ((LAMBDA (X) X) '(A B C))) → (B C); car of that → B
+    assert_eq!(sym_name(eval("(CAR (CDR ((LAMBDA (X) X) '(A B C))))")), "B");
+}

--- a/code/packages/rust/mccarthy-lisp-vm/CHANGELOG.md
+++ b/code/packages/rust/mccarthy-lisp-vm/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — mccarthy-lisp-vm
 
+## v0.3.0 — 2026-06-04 — user-function calls (L2c-1)
+
+* Added the `call FN, args…` opcode: looks the callee up in the module
+  by name (`srcs[0]` = `Var(name)`), evaluates the argument registers,
+  runs the callee in a fresh frame with its parameters bound to the
+  argument values, and stores the return value in `dest`.
+* `run_function` now takes the module, the call arguments, and a call
+  `depth`; the entry point runs at depth 0 with no arguments. Parameters
+  are bound by name (the VM frame register named after each parameter).
+  Arity must match exactly → `VmError::ArityMismatch`.
+* **DoS guards for untrusted IIR:**
+  * Call nesting is bounded by `MAX_CALL_DEPTH` (256) — a self-calling
+    function trips `VmError::CallDepthExceeded` instead of overflowing
+    the native stack. (The instruction budget is shared across the whole
+    call tree, so it also bounds total work.)
+  * A `call` carrying more than `MAX_CALL_ARGS` (4096) operands is
+    rejected before the argument vector is allocated.
+* 5 new unit tests (param passthrough, builtin-in-callee, arity mismatch,
+  unknown callee, and a self-recursive function hitting the depth guard).
+
 ## v0.2.0 — 2026-06-04 — control flow for COND (L2b)
 
 * Added the control-flow opcodes the `COND` lowering needs:

--- a/code/packages/rust/mccarthy-lisp-vm/Cargo.toml
+++ b/code/packages/rust/mccarthy-lisp-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mccarthy-lisp-vm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A tiny interpreter for McCarthy 1960 Lisp (Lisp 1.0), built directly on `lispy-runtime`. Executes the `IIRModule` produced by `mccarthy-lisp-iir-compiler` against the lispy-runtime tagged-i64 value model (symbols, cons cells, nil, booleans), returning a `LispyValue`. McCarthy Lisp's own VM — deliberately independent of `twig-vm` (which is Twig-specific); both languages share only the `lispy-runtime` foundation."
 

--- a/code/packages/rust/mccarthy-lisp-vm/README.md
+++ b/code/packages/rust/mccarthy-lisp-vm/README.md
@@ -28,21 +28,24 @@ What both languages genuinely share is the **value model**:
 foundation — this crate. (Twig is a typed Lisp; McCarthy is its untyped
 cousin. Same value model, separate VMs.)
 
-## Instruction set (through L2b)
+## Instruction set (through L2c-1)
 
 | Op             | Meaning                                                           |
 |----------------|------------------------------------------------------------------|
 | `const`        | `Int(n)`→int, `Int(0):ref<LispyPair>`→nil, `Var(name)`→interned symbol, `Bool(b)`→bool |
 | `call_builtin` | `srcs[0]` is the builtin name (a `Var`), the rest are args; dispatched to a `lispy-runtime` builtin |
+| `call`         | `srcs[0]` is the callee function name; the rest are arguments. Runs the callee in a fresh frame (params bound to args) and returns its value into `dest` |
 | `mov`          | copy a register (`dest ← srcs[0]`)                                |
 | `jmp`          | unconditional branch to the label in `srcs[0]`                   |
 | `jmp_if_false` | branch to the label in `srcs[1]` when `srcs[0]` is falsy (`#f`/`nil`); else fall through |
 | `label`        | branch-target marker (`srcs[0]` is its name)                    |
 | `ret`          | return the value in `srcs[0]`                                     |
 
-`mov` / `jmp` / `jmp_if_false` / `label` are what `COND` lowers to
-(L2b). User-function `call` (for `LAMBDA` / `LABEL`) lands with L2c — the
-VM grows to match the compiler phase by phase.
+`mov`/`jmp`/`jmp_if_false`/`label` are what `COND` lowers to (L2b);
+`call` is what lambda application lowers to (L2c-1). Call nesting is
+bounded by `MAX_CALL_DEPTH` (256) and the shared instruction budget, so
+an untrusted self-recursive module errors cleanly rather than
+overflowing the stack.
 
 ## Usage
 

--- a/code/packages/rust/mccarthy-lisp-vm/src/lib.rs
+++ b/code/packages/rust/mccarthy-lisp-vm/src/lib.rs
@@ -20,7 +20,7 @@
 //! pair? / not / equal?` builtins.  So McCarthy Lisp gets its *own* small
 //! VM built directly on that foundation — exactly what this crate is.
 //!
-//! ## The instruction set it executes (through L2b)
+//! ## The instruction set it executes (through L2c-1)
 //!
 //! `mccarthy-lisp-iir-compiler` emits a deliberately tiny IIR:
 //!
@@ -28,15 +28,18 @@
 //! |---------------|----------------------------------------------------------------|
 //! | `const`       | materialise a literal: `Int(n)`→int, `Int(0):ref<LispyPair>`→nil, `Var(name)`→interned symbol, `Bool(b)`→bool |
 //! | `call_builtin`| `srcs[0]` is the builtin name (a `Var`), the rest are argument registers; dispatched to a `lispy-runtime` builtin |
+//! | `call`        | `srcs[0]` is the callee function name; the rest are arguments. Runs the callee in a fresh frame (params bound to args), returns into `dest` |
 //! | `mov`         | copy a register (`dest ← srcs[0]`)                             |
 //! | `jmp`         | unconditional branch to the label in `srcs[0]`                |
 //! | `jmp_if_false`| branch to the label in `srcs[1]` when `srcs[0]` is falsy (`#f`/`nil`); else fall through |
 //! | `label`       | branch-target marker (`srcs[0]` is its name)                  |
 //! | `ret`         | return the value in `srcs[0]`                                  |
 //!
-//! `mov`/`jmp`/`jmp_if_false`/`label` are what `COND` lowers to (L2b).
-//! User-function `call` (for `LAMBDA` / `LABEL`) arrives with L2c; this
-//! VM grows to match the compiler phase by phase.
+//! `mov`/`jmp`/`jmp_if_false`/`label` are what `COND` lowers to (L2b);
+//! `call` is what lambda application lowers to (L2c-1).  Call nesting is
+//! bounded by [`MAX_CALL_DEPTH`] and the shared instruction budget, so an
+//! untrusted self-recursive module errors cleanly rather than overflowing
+//! the native stack.
 //!
 //! ## Quick start
 //!
@@ -105,6 +108,20 @@ pub enum VmError {
     /// A `jmp` / `jmp_if_false` targeted a label the function doesn't
     /// define.
     UnknownLabel(String),
+    /// A `call` was made to a function whose parameter count doesn't match
+    /// the number of arguments supplied.
+    ArityMismatch {
+        /// The callee's name.
+        function: String,
+        /// How many parameters it declares.
+        expected: usize,
+        /// How many arguments the `call` supplied.
+        got: usize,
+    },
+    /// User-function call recursion exceeded [`MAX_CALL_DEPTH`].  Guards
+    /// against a stack overflow from a self-calling (or mutually
+    /// recursive) `IIRModule` on untrusted input.
+    CallDepthExceeded(usize),
 }
 
 impl std::fmt::Display for VmError {
@@ -126,6 +143,13 @@ impl std::fmt::Display for VmError {
                 "integer literal {n} is outside lispy-runtime's tagged-int range [-2^60, 2^60-1]"
             ),
             VmError::UnknownLabel(l) => write!(f, "branch to undefined label {l:?}"),
+            VmError::ArityMismatch { function, expected, got } => write!(
+                f,
+                "function {function:?} expects {expected} argument(s), got {got}"
+            ),
+            VmError::CallDepthExceeded(d) => {
+                write!(f, "call depth exceeded {d} — possible unbounded recursion")
+            }
         }
     }
 }
@@ -140,6 +164,18 @@ impl std::error::Error for VmError {}
 /// step count, but a hard backstop against a runaway loop (once `jmp`
 /// arrives in L2b) blocking the interpreter forever.
 pub const DEFAULT_INSTRUCTION_BUDGET: u64 = 10_000_000;
+
+/// Maximum user-function call-nesting depth.  `call` recurses in native
+/// Rust (one [`run_function`] frame per active call), so an untrusted
+/// `IIRModule` with a self-calling function could otherwise overflow the
+/// OS thread stack.  256 is deep enough for any realistic McCarthy
+/// program yet far below the stack ceiling.
+pub const MAX_CALL_DEPTH: usize = 256;
+
+/// Maximum number of arguments a single `call` may carry.  Bounds the
+/// up-front argument-vector allocation so a hand-crafted `call` with
+/// millions of operands can't OOM before the instruction budget fires.
+pub const MAX_CALL_ARGS: usize = 4096;
 
 /// Execute `module`'s entry-point function and return its result value.
 ///
@@ -163,7 +199,8 @@ pub fn run_with_budget(module: &IIRModule, budget: u64) -> Result<LispyValue, Vm
         .get_function(entry)
         .ok_or_else(|| VmError::UnknownFunction(entry.to_string()))?;
     let mut steps: u64 = 0;
-    run_function(func, &mut steps, budget)
+    // The entry point takes no arguments and starts at call depth 0.
+    run_function(module, func, &[], &mut steps, budget, 0)
 }
 
 // ===========================================================================
@@ -174,8 +211,31 @@ pub fn run_with_budget(module: &IIRModule, budget: u64) -> Result<LispyValue, Vm
 /// VM independent of any register-numbering scheme the compiler uses.
 type Frame = HashMap<String, LispyValue>;
 
-fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<LispyValue, VmError> {
+fn run_function(
+    module: &IIRModule,
+    func: &IIRFunction,
+    args: &[LispyValue],
+    steps: &mut u64,
+    budget: u64,
+    depth: usize,
+) -> Result<LispyValue, VmError> {
+    if depth > MAX_CALL_DEPTH {
+        return Err(VmError::CallDepthExceeded(MAX_CALL_DEPTH));
+    }
+
+    // Bind the arguments to the callee's parameter registers.  Arity must
+    // match exactly — McCarthy Lisp has no variadics.
+    if args.len() != func.params.len() {
+        return Err(VmError::ArityMismatch {
+            function: func.name.clone(),
+            expected: func.params.len(),
+            got: args.len(),
+        });
+    }
     let mut frame: Frame = HashMap::new();
+    for ((pname, _ty), val) in func.params.iter().zip(args.iter()) {
+        frame.insert(pname.clone(), *val);
+    }
     let mut pc: usize = 0;
 
     // Resolve every `label NAME` to its instruction index once, so a jump
@@ -236,6 +296,41 @@ fn run_function(func: &IIRFunction, steps: &mut u64, budget: u64) -> Result<Lisp
                 } else {
                     pc = resolve_label(&labels, label)?;
                 }
+            }
+            // `call FN, args…` — invoke a user function.  srcs[0] =
+            // Var(callee name); the rest are argument registers.  The
+            // callee runs in a fresh frame (its params bound to the
+            // argument values) at depth+1; its return value lands in
+            // `dest`.  The instruction budget is shared across the whole
+            // call tree (passed by `&mut`), and `depth` is bounded by
+            // `MAX_CALL_DEPTH`, so neither the budget nor the native stack
+            // can be exhausted by recursion.
+            "call" => {
+                let callee_name = match instr.srcs.first() {
+                    Some(Operand::Var(n)) => n.as_str(),
+                    _ => {
+                        return Err(VmError::Malformed(
+                            "`call` requires srcs[0] = Var(function name)".into(),
+                        ))
+                    }
+                };
+                if instr.srcs.len() > MAX_CALL_ARGS + 1 {
+                    return Err(VmError::Malformed(format!(
+                        "`call` has too many arguments ({})",
+                        instr.srcs.len() - 1
+                    )));
+                }
+                let callee = module
+                    .get_function(callee_name)
+                    .ok_or_else(|| VmError::UnknownFunction(callee_name.to_string()))?;
+                let mut call_args: Vec<LispyValue> = Vec::with_capacity(instr.srcs.len() - 1);
+                for src in &instr.srcs[1..] {
+                    call_args.push(read_operand(src, &frame)?);
+                }
+                let result =
+                    run_function(module, callee, &call_args, steps, budget, depth + 1)?;
+                bind_dest(instr, result, &mut frame)?;
+                pc += 1;
             }
             // `label` is a no-op marker; its only role is as a jump target.
             "label" => pc += 1,
@@ -593,6 +688,91 @@ mod tests {
     fn jump_to_undefined_label_errors() {
         let m = module(vec![jmp("nowhere")]);
         assert!(matches!(run(&m), Err(VmError::UnknownLabel(_))));
+    }
+
+    // ---- user-function calls (L2c) ----
+
+    /// Build a module from a `main` body plus extra (callee) functions.
+    fn module_with(funcs: Vec<IIRFunction>, main_body: Vec<IIRInstr>) -> IIRModule {
+        let mut m = IIRModule::new("test", "mccarthy-lisp");
+        m.functions = funcs;
+        m.functions.push(IIRFunction::new("main", Vec::new(), "any", main_body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    fn func(name: &str, params: &[&str], body: Vec<IIRInstr>) -> IIRFunction {
+        let params = params.iter().map(|p| (p.to_string(), "any".to_string())).collect();
+        IIRFunction::new(name, params, "any", body)
+    }
+
+    fn call(dest: &str, callee: &str, args: &[&str]) -> IIRInstr {
+        let mut srcs = vec![Operand::Var(callee.into())];
+        srcs.extend(args.iter().map(|a| Operand::Var((*a).into())));
+        IIRInstr::new("call", Some(dest.into()), srcs, "any")
+    }
+
+    #[test]
+    fn call_binds_param_and_returns() {
+        // f(X) = X ; main = f(42)
+        let f = func("f", &["X"], vec![ret("X")]);
+        let m = module_with(vec![f], vec![konst("a", Operand::Int(42), "i64"), call("r", "f", &["a"]), ret("r")]);
+        assert_eq!(run(&m).unwrap().as_int(), Some(42));
+    }
+
+    #[test]
+    fn call_runs_builtin_in_callee() {
+        // head(X) = (CAR X) ; main = head( (CONS 'A 'B) ) → A
+        let head = func(
+            "head",
+            &["X"],
+            vec![
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("h".into()),
+                    vec![Operand::Var("car".into()), Operand::Var("X".into())],
+                    "any",
+                ),
+                ret("h"),
+            ],
+        );
+        let main = vec![
+            konst("a", Operand::Var("A".into()), "symbol"),
+            konst("b", Operand::Var("B".into()), "symbol"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("p".into()),
+                vec![Operand::Var("cons".into()), Operand::Var("a".into()), Operand::Var("b".into())],
+                "ref<LispyPair>",
+            ),
+            call("r", "head", &["p"]),
+            ret("r"),
+        ];
+        let v = run(&module_with(vec![head], main)).unwrap();
+        assert_eq!(name_of(v.as_symbol().unwrap()).as_deref(), Some("A"));
+    }
+
+    #[test]
+    fn call_arity_mismatch_errors() {
+        let f = func("f", &["X", "Y"], vec![ret("X")]);
+        // Only one argument supplied for a two-param function.
+        let m = module_with(vec![f], vec![konst("a", Operand::Int(1), "i64"), call("r", "f", &["a"]), ret("r")]);
+        assert!(matches!(run(&m), Err(VmError::ArityMismatch { .. })));
+    }
+
+    #[test]
+    fn call_to_unknown_function_errors() {
+        let m = module_with(vec![], vec![konst("a", Operand::Int(1), "i64"), call("r", "ghost", &["a"]), ret("r")]);
+        assert!(matches!(run(&m), Err(VmError::UnknownFunction(_))));
+    }
+
+    #[test]
+    fn unbounded_recursion_hits_call_depth_guard() {
+        // loop() = loop()  — a self-calling function must hit the call-depth
+        // guard (a clean error), never a native stack overflow.
+        let loop_fn = func("loop", &[], vec![call("r", "loop", &[]), ret("r")]);
+        let m = module_with(vec![loop_fn], vec![call("r", "loop", &[]), ret("r")]);
+        assert!(matches!(run(&m), Err(VmError::CallDepthExceeded(_))));
     }
 
     // ---- error paths ----

--- a/code/specs/MCCARTHY-LISP-PLAN.md
+++ b/code/specs/MCCARTHY-LISP-PLAN.md
@@ -1,6 +1,6 @@
 # McCarthy Lisp on the LANG VM chain — plan
 
-**Status:** Active.  **L1 complete and grammar-driven as of 2026-06-03** (the lexer/parser were initially merged hand-written in #4967 and then rewritten to wrap the shared `GrammarLexer`/`GrammarParser` — see the "L1 divergence" note below).  **L2 in progress** — decomposed into L2a/L2b/L2c (see the L2 note below).  **L2a ✓** (literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`, run on the new `mccarthy-lisp-vm`) and **L2b ✓** (`COND`) are merged; **L2c** (`LAMBDA`/`LABEL`/user calls) is next.  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
+**Status:** Active.  **L1 complete and grammar-driven as of 2026-06-03** (the lexer/parser were initially merged hand-written in #4967 and then rewritten to wrap the shared `GrammarLexer`/`GrammarParser` — see the "L1 divergence" note below).  **L2 in progress** — decomposed into L2a/L2b/L2c (see the L2 note below).  **L2a ✓** (literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`, run on the new `mccarthy-lisp-vm`), **L2b ✓** (`COND`), and **L2c-1 ✓** (direct `LAMBDA` application + the VM `call` opcode) are merged; **L2c-2** (`LABEL` recursion) is next, then **L2c-3** (closures).  Confirmed decisions: **Lisp 1.0** (1960 paper), **IBM 704** as historical arch target, **no-CONS at runtime** on the historical-arch backends in v0.1.0.  Crate naming follows the existing `*-lexer` / `*-parser` / `*-iir-compiler` pattern.
 **Predecessors:** [`HISTORICAL-ARCH-BACKEND-MIGRATION.md`](HISTORICAL-ARCH-BACKEND-MIGRATION.md), [`MULTILANG-ARCHITECTURE-BACKENDS.md`](MULTILANG-ARCHITECTURE-BACKENDS.md).
 
 ## Goal
@@ -100,7 +100,10 @@ McCarthy Lisp will reuse `lispy-runtime` directly (Twig is essentially a typed L
 > **L2 decomposition.** L2 is split into mergeable increments (per the smaller-PRs working style):
 > - **L2a** — `mccarthy-lisp-iir-compiler` v0.1.0 **+ `mccarthy-lisp-vm` v0.1.0**: lower a single top-level form sequence over integer/nil literals, `QUOTE` (symbols + nested lists → cons), and the data primitives `CONS`/`CAR`/`CDR` plus the predicates `ATOM` (= `not pair?`) and `EQ` (= `equal?`); run it end-to-end on McCarthy Lisp's own `lispy-runtime`-backed VM.  *No control flow or user functions yet.*
 > - **L2b** — `COND` (chained `jmp_if_false` + labels).
-> - **L2c** — `LAMBDA` / `LABEL` / user-defined function application (a function table + parameter binding + `call`).
+> - **L2c** — `LAMBDA` / `LABEL` / user-defined function application.  Itself split:
+>   - **L2c-1** — direct lambda application `((LAMBDA (p…) body) a…)`: each lambda becomes a top-level `IIRFunction`, the application emits a `call`, the VM gains a `call` opcode (fresh frame, params bound to args, call-depth guard).  *No closures: a lambda body sees only its own params; lambda-as-value is rejected.*
+>   - **L2c-2** — `LABEL` (named / recursive functions).
+>   - **L2c-3** — closures: lambda as a first-class value + free-variable capture (needed for the L7 metacircular evaluator).
 
 For the historical-arch and IBM 704 backends, allocation is awkward (no heap on a 4004!).  Plan: **disallow CONS** at the IBM 704 backend for v0.1.0 — only programs that operate on pre-existing symbol literals are emittable.  This still covers a surprising amount of McCarthy Lisp's example programs (which were heavily symbol-shuffling).  Real CONS support on IBM 704 needs a static heap area which is a future increment.
 
@@ -219,7 +222,9 @@ Same single-PR-per-phase cadence the historical-arch migration used.
 | **L1** ✓ | `mccarthy-lisp-lexer` + `mccarthy-lisp-parser` — **grammar-driven** (wrap `GrammarLexer`/`GrammarParser`; grammar in `code/grammars/mccarthy_lisp.tokens`+`.grammar`).  Tests pin S-expression round-trips + dialect errors.  *Done; rewritten from the hand-written #4967 merge — see L1 divergence note.* |
 | **L2a** ✓ | `mccarthy-lisp-iir-compiler` + **`mccarthy-lisp-vm`** — literals + `QUOTE` + `CONS`/`CAR`/`CDR`/`ATOM`/`EQ`.  Compiles `(CAR '(A B C))` → `A`, `(CDR '(A B C))` → `(B C)`, `(CONS 'A 'B)` → `(A . B)`, etc., end-to-end on McCarthy Lisp's **own `lispy-runtime`-backed VM** (`vm-core` is scalar-only; `twig-vm` is Twig-specific — see the execution-VM correction). |
 | **L2b** ✓ | `COND` — compiler lowers to chained `jmp_if_false` + `label`s (+ `mov` to funnel clause values); VM gains `jmp`/`jmp_if_false`/`mov`.  `(COND ((ATOM 'X) 'A) ('T 'B))` → `A`; no-match → `nil`. |
-| **L2c** | `LAMBDA` / `LABEL` / user-defined function application. |
+| **L2c-1** ✓ | Direct `LAMBDA` application `((LAMBDA (p…) body) a…)` — each lambda → a top-level `IIRFunction`; the application emits a `call`; the VM gains a `call` opcode (fresh frame, params bound to args, `MAX_CALL_DEPTH` guard).  `((LAMBDA (X) (CAR X)) '(A B))` → `A`.  *No closures yet.* |
+| **L2c-2** | `LABEL` (named / recursive functions). |
+| **L2c-3** | Closures — lambda as a first-class value + free-variable capture. |
 | **L3** | Wire `mccarthy-lisp` into `lang-aot` as a new `Language` variant.  All 10 existing backends light up automatically (CARSON the migration architecture). |
 | **L4** | `ibm704-encoder` + `ibm704-backend` v0.1.0 (minimal viable: `const_*` + `ret_*`, just like the Phase 5/6 minimal-viable backends). |
 | **L5** | Wire `lang-aot --emit=ibm704` through `ibm704-backend`. |


### PR DESCRIPTION
## Summary

First slice of **L2c — `LAMBDA`/`LABEL`/user calls**. This is **L2c-1: direct lambda application** `((LAMBDA (p…) body) a…)`. Both McCarthy crates extended in lockstep, on McCarthy's own `lispy-runtime`-backed VM.

**`mccarthy-lisp-vm` v0.3.0** — new `call FN, args…` opcode. Looks up the callee by name, evaluates the argument registers, runs the callee in a **fresh frame with its params bound to the args**, and returns into `dest`. `run_function` now threads the module, the args, and a call `depth`; the entry point runs at depth 0.

**`mccarthy-lisp-iir-compiler` v0.3.0** — lowers `((LAMBDA (p…) body) a…)`: the lambda becomes a fresh top-level `IIRFunction` (gensym `lambda_<n>`), and the application emits a `call` with the lowered args. The compiler now produces **multiple functions** and tracks the **parameter scope** of the function being lowered — a bare symbol resolves to a register read only if it's a param of the enclosing lambda.

### Scope (deliberately bounded)

- **No closures yet** (deferred to **L2c-3**): a lambda body may reference only its own params — a free variable is an unbound-variable error, and an unapplied `LAMBDA` (lambda-as-value) is rejected with a clear message.
- **`LABEL`** (named/recursive functions) → **L2c-2**.

## Security

`/security-review` **PASSED**. Verified against hand-crafted IIR:
- **Native-stack recursion**: `MAX_CALL_DEPTH` (256) checked at `run_function` entry, before the body — a self- or mutually-recursive module trips `CallDepthExceeded`, never overflows the stack. 256 frames is far under the stack budget (HashMap *contents* are heap, not stack).
- **Budget**: the instruction budget is shared by `&mut` across the whole call tree — many-tiny-calls can't escape it.
- **Compile-time recursion** bounded by the parser's depth-64 cap; the `mem::take`/`replace` buffer/scope save-restore is leak-free.
- No panics: `call` operands use `.first()`/`.get()`; `lambda_parts` indexing guarded by the `len==3` check; `MAX_CALL_ARGS` (4096) guard sits before the arg-vector allocation; arity checked before the param `zip`.

## Test plan

- [x] `cargo test -p mccarthy-lisp-vm` — 24 unit + 1 doctest (5 new: param passthrough, builtin-in-callee, arity, unknown callee, depth-guard on self-recursion)
- [x] `cargo test -p mccarthy-lisp-iir-compiler` — 24 unit + 31 e2e + 1 doctest (7 + 8 new lambda)
- [x] both crates clippy-clean
- [x] `/security-review` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
