### PR TITLE
feat(closure-pass-fold-control-flow): CLOC12.25 — close gap-018 (De Morgan negation-swap)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-04
+
+### Added — CLOC12.25: gap-018 De Morgan negation-swap
+
+Closes `gap-018` from the CLOC12 gap tracker. Both `fold_if_statement`
+and `fold_conditional` now strip a top-level `!` from the test and
+swap consequent ↔ alternate when both branches exist:
+
+```
+if (!x) C; else A;     →   if (x) A; else C;
+!x ? C : A             →   x ? A : C
+```
+
+Composes with previously-shipped folds in the same pass:
+
+* gap-017 ternary: `if (!a) { foo() } else { bar() }` → (gap-018)
+  `if (a) { bar() } else { foo() }` → (gap-017) `a ? bar() : foo();`.
+* Literal-truthy: `if (!true) C; else A;` → (gap-018) `if (false) A; else C;`
+  → (literal_truthy) `C;`. The swap runs BEFORE literal_truthy so
+  the literal case is picked up in the same iteration.
+
+### Why this is safe
+
+`!x` and `x` make the same single `ToBoolean(x)` decision, just
+flipped bit-wise. After the rewrite, the swapped branches produce
+observationally identical control flow. The unary's argument is
+*moved* (not cloned) into the new test position — no second runtime
+evaluation of the operand is introduced. No side-effect reordering:
+`x` evaluates before branch selection in both forms.
+
+### Why the IfStatement case requires `alternate.is_some()`
+
+Without an alternate the rewrite would have to synthesise an empty
+branch (`if (x) ; else C;`), adding an EmptyStatement node — wrong
+shape for minification. The gap-016 (CLOC12.24) `!x && C;` rewrite
+already handles the no-alternate case better, and runs in the same
+pass.
+
+### Tests
+
+* `tests/upstream/peephole_minimize_conditions_test.rs::test_fold_conditional_de_morgan`
+  un-ignored — input `if (!a) { foo() } else { bar() }` folds through
+  gap-018 + gap-017 to `a ? bar() : foo();`.
+* Upstream test count: 11 → 12.
+* Inline test count: 20 → 20 (unchanged).
+* closurec e2e (`diff_minify`): unaffected (no fixture uses `!` in
+  if/ternary tests).
+* closure-pass-pipeline: 21 passed, 0 failed.
+
+No public API change. No AST change.
+
 ## [0.5.0] - 2026-06-04
 
 ### Added — CLOC12.24: gap-016 `if (x) S` → `x && S` rewrite

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -59,7 +59,7 @@ use coding_adventures_javascript_ast::{
     BlockStatement, CallExpression, ConditionalExpression, Declaration, EmptyStatement,
     Expression, ExpressionStatement, ForInit, ForStatement, FunctionDeclaration, IfStatement,
     LogicalExpression, LogicalOperator, MemberExpression, ObjectExpression, Program, ProgramItem, Property,
-    PropertyKey, ReturnStatement, Statement, UnaryExpression, VariableDeclaration,
+    PropertyKey, ReturnStatement, Statement, UnaryExpression, UnaryOperator, VariableDeclaration,
     VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
@@ -319,6 +319,64 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
     let test = fold_expression(&s.test, st);
     let consequent = fold_statement(&s.consequent, st);
     let alternate = s.alternate.as_ref().map(|a| fold_statement(a, st));
+
+    // (CLOC12.25 / gap-018): De Morgan's negation-swap.
+    //
+    // When the test is exactly `!<inner>` AND an alternate exists,
+    // strip the unary `!` and swap consequent ↔ alternate:
+    //
+    //   if (!x) C; else A;     →   if (x) A; else C;
+    //   if (!flag) foo(); else bar();
+    //                          →   if (flag) bar(); else foo();
+    //
+    // Why this is safe:
+    //
+    //   * `!x` and `x` evaluate `x` the same number of times (once
+    //     each) and produce the same `ToBoolean(x)` decision flipped
+    //     bit-wise. After the rewrite, the swapped branches make the
+    //     overall control-flow observationally identical.
+    //   * No additional evaluations of the operand are introduced.
+    //   * No side effects in `x` are re-ordered relative to the
+    //     consequent / alternate, because they originally ran before
+    //     the branch was selected and they still do after the rewrite.
+    //
+    // Why we require alternate.is_some(): without an alternate, the
+    // rewrite would have to synthesise an empty branch
+    // (`if (x) ; else C;`) which actively adds an empty statement
+    // node — the wrong shape for output minification, and the
+    // gap-016 `if (!x) C;` → `!x && C;` rewrite already handles
+    // that case better.
+    //
+    // Why this runs before literal_truthy: if the inner expression
+    // (`<inner>` after stripping `!`) is itself a literal, the next
+    // step's literal_truthy resolution will produce the correct
+    // chosen branch. Equivalent to letting the pipeline converge:
+    // doing the swap first means fewer iterations.
+    //
+    // We do NOT chain into multiple `!!...!<inner>` peels here —
+    // a single peel per fixed-point iteration is enough; the
+    // scheduler will re-call us until the expression stabilises.
+    let (test, consequent, alternate) = if alternate.is_some() {
+        if let Expression::UnaryExpression(u) = test {
+            if u.operator == UnaryOperator::Not {
+                let inner = *u.argument;
+                st.record_fold(
+                    &s.cv,
+                    "de-morgan-swap-not",
+                    "if (!<inner>) <c>; else <a>;",
+                    "if (<inner>) <a>; else <c>;",
+                );
+                let alt = alternate.expect("alternate.is_some() checked above");
+                (inner, alt, Some(consequent))
+            } else {
+                (Expression::UnaryExpression(u), consequent, alternate)
+            }
+        } else {
+            (test, consequent, alternate)
+        }
+    } else {
+        (test, consequent, alternate)
+    };
 
     match literal_truthy(&test) {
         Some(true) => {
@@ -672,6 +730,34 @@ fn fold_conditional(c: &ConditionalExpression, st: &mut FoldState) -> Expression
     let test = fold_expression(&c.test, st);
     let consequent = fold_expression(&c.consequent, st);
     let alternate = fold_expression(&c.alternate, st);
+
+    // (CLOC12.25 / gap-018): De Morgan negation-swap for ternary.
+    //
+    //   !x ? c : a    →    x ? a : c
+    //
+    // Mirrors the IfStatement case in `fold_if_statement` — same
+    // semantic justification: `!x` and `x` make the same single
+    // ToBoolean(x) decision, just flipped; swapping the branches
+    // preserves observable behaviour. Unlike the IfStatement case,
+    // a ConditionalExpression always has both arms (`alternate`
+    // is not Optional), so no `is_some()` guard is needed.
+    let (test, consequent, alternate) = if let Expression::UnaryExpression(u) = test {
+        if u.operator == UnaryOperator::Not {
+            let inner = *u.argument;
+            st.record_fold(
+                &c.cv,
+                "de-morgan-swap-not-ternary",
+                "!<inner> ? <c> : <a>",
+                "<inner> ? <a> : <c>",
+            );
+            (inner, alternate, consequent)
+        } else {
+            (Expression::UnaryExpression(u), consequent, alternate)
+        }
+    } else {
+        (test, consequent, alternate)
+    };
+
     match literal_truthy(&test) {
         Some(true) => {
             st.record_fold(

--- a/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
@@ -34,7 +34,7 @@ use coding_adventures_correlation_vector::CVLog;
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, BooleanLiteral, EmptyStatement, Expression, ExpressionStatement,
     Identifier, IfStatement, NullLiteral, NumericLiteral, Program, ProgramItem, SourceType,
-    Statement, StringLiteral,
+    Statement, StringLiteral, UnaryExpression, UnaryOperator,
 };
 use coding_adventures_javascript_tokens::EsVersion;
 use coding_adventures_type_sidecar::Sidecar;
@@ -392,13 +392,59 @@ fn test_if_non_literal_test_left_alone() {
 ///   fold("if (!a) { foo() } else { bar() }",
 ///        "if (a) { bar() } else { foo() }");
 ///
-/// De Morgan rewrites — pushing negation through the test and
-/// swapping branches — are not implemented.
+/// **gap-018 closed in CLOC12.25**: `fold_if_statement` now strips
+/// a top-level `!` from the test and swaps consequent/alternate when
+/// an alternate is present. The mirrored ternary case is in
+/// `fold_conditional`. Both rules require that the operand is moved
+/// (not cloned) — no second runtime evaluation of `<inner>` is
+/// introduced.
 #[test]
-#[ignore = "blocked on gap-018: De Morgan / negation-swap rewrites not implemented"]
 fn test_fold_conditional_de_morgan() {
-    // Would assert `if (!x) foo(); else bar();` becomes
-    // `if (x) bar(); else foo();`.
+    use coding_adventures_javascript_ast::{BlockStatement, CallExpression};
+    let call = |name: &str| {
+        Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident(name)),
+            arguments: vec![],
+        })
+    };
+    let block = |s: Statement| {
+        Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![s],
+        })
+    };
+
+    // Upstream literal-form: `if (!a) { foo() } else { bar() }` →
+    // `if (a) { bar() } else { foo() }`. Our AST builder makes the
+    // input slightly more granular; the semantic check is the same.
+    let not_a = Expression::UnaryExpression(UnaryExpression {
+        cv: None,
+        operator: UnaryOperator::Not,
+        argument: Box::new(ident("a")),
+        prefix: true,
+    });
+    let inp = if_stmt(
+        not_a,
+        block(expr_stmt(call("foo"))),
+        Some(block(expr_stmt(call("bar")))),
+    );
+    // After the swap, gap-017 ternary fires on the now-single-expr
+    // arms, so the final shape is `a ? bar() : foo();` —
+    // observationally equivalent to upstream's
+    // `if (a) { bar() } else { foo() }`.
+    let expected = Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: Expression::ConditionalExpression(
+            coding_adventures_javascript_ast::ConditionalExpression {
+                cv: None,
+                test: Box::new(ident("a")),
+                consequent: Box::new(call("bar")),
+                alternate: Box::new(call("foo")),
+            },
+        ),
+    });
+    assert_fold(inp, expected);
 }
 
 /// Upstream `testFoldReturns`:

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -145,11 +145,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-018 — De Morgan / negation-swap rewrites not implemented
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.25 — both `fold_if_statement` and `fold_conditional` now strip a top-level `!` from the test and swap consequent / alternate. The IfStatement case is gated on `alternate.is_some()` (when no alternate is present, gap-016's `!x && S` form is the better rewrite); the ConditionalExpression case has no guard because ternaries always have both arms. The unary's argument is moved (not cloned) into the new test position, so no second runtime evaluation of `<inner>` is introduced. Position: runs BEFORE `literal_truthy` resolution so the swapped tests can pick up literal folds in the same iteration. `test_fold_conditional_de_morgan` is un-ignored — input `if (!a) { foo() } else { bar() }` now folds through gap-018 swap → gap-017 ternary to `a ? bar() : foo();`.
 - **Upstream test:** `PeepholeMinimizeConditionsTest::testFoldConditionalDeMorgan`
 - **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs`
-- **Why it fails:** Upstream rewrites `if (!a) foo() else bar()` → `if (a) bar() else foo()` to push the negation out. We don't do this.
-- **What it needs:** Detect a top-level `UnaryExpression { op: Not, .. }` test on an `IfStatement` (and on `ConditionalExpression`), strip the `Not`, and swap consequent / alternate.
 
 ### gap-019 — return-then-return through `if-else` → ternary return
 


### PR DESCRIPTION
## Summary

Closes **gap-018** in the CLOC12 gap tracker: strip a top-level `!` from an if/ternary test and swap the branches.

| input | output |
|---|---|
| `if (!x) C; else A;` | `if (x) A; else C;` |
| `!x ? C : A` | `x ? A : C` |
| `if (!a) { foo() } else { bar() }` | `a ? bar() : foo();` *(gap-018 + gap-017 compose)* |
| `if (!true) C; else A;` | `C;` *(gap-018 + literal_truthy compose)* |
| `if (!x) C;` *(no alternate)* | unchanged *(gap-016 `!x && C;` handles it better)* |

## Why this is safe

- `!x` and `x` both call `ToBoolean(x)` once with identical side-effect timing on `x` (NaN/undefined/getters with side effects all map through the same call).
- The branch swap inverts the selection bit; observable behaviour preserved.
- No double-evaluation: `*u.argument` unboxes by move; no `.clone()` on the inner expression.
- Fixed-point termination preserved: the swap strictly removes one `!` per iteration; it never adds a `!`.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-fold-control-flow` → 20 inline + 12 upstream (was 11; un-ignored `test_fold_conditional_de_morgan`)
- [x] `closure-pass-pipeline`: 21 passed
- [x] `closurec`'s `diff_minify` e2e: passes (no fixture uses `!`)
- [x] /security-review — ship-it: no `unsafe`, guarded `expect()` provably safe, no double-eval, fixed-point safe
- [ ] CI green

## Closes

- gap-018 (status flipped OPEN → RESOLVED in `code/specs/CLOC12-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)