### PR TITLE
feat(closure-pass-fold-control-flow): CLOC12.26 — close gap-019 (return-then-return → ternary return)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-04
+
+### Added — CLOC12.26: gap-019 return-then-return through if-else → ternary return
+
+Closes `gap-019`. `fold_if_statement` now hoists terminal
+`return` branches through an if-else into a single ternary-returning
+return:
+
+```
+if (x) return E1; else return E2;       →   return x ? E1 : E2;
+if (x) { return E1; } else { return E2; } →   return x ? E1 : E2;
+```
+
+Composes with the same-pass folds:
+
+* gap-018 De Morgan: `if (!x) return E1; else return E2;` →
+  (gap-018) `if (x) return E2; else return E1;` → (gap-019)
+  `return x ? E2 : E1;`.
+* literal_truthy: `if (true) return E1; else return E2;` →
+  (literal_truthy) `return E1;` (still wins because literal_truthy
+  fires before gap-019).
+
+Both arguments must be `Some` — `if (x) return; else return E;`
+stays unchanged. Synthesising an `undefined` expression for the
+bare-return case requires `UndefinedLiteral` plumbing in this
+pass and is tracked separately.
+
+### Why this is safe
+
+The if-else evaluates `test` once, takes exactly one branch, and
+runs that branch's `return`. The ternary form also evaluates `test`
+once, picks exactly one of `E1`/`E2`, then returns. The set of
+values evaluated and the function's exit value match identically.
+
+Control-flow preserved: in both forms the function returns
+immediately after the chosen argument evaluates. No fall-through
+possible because both branches were terminal returns.
+
+### New helper
+
+`single_return_with_arg(stmt: &Statement) -> Option<Expression>` —
+mirror of `single_expr_stmt`. Returns the argument expression when
+`stmt` is a single ReturnStatement with `argument: Some`; recurses
+through single-statement BlockStatement layers; returns None on
+multi-statement blocks, bare returns, or any other shape.
+
+### Tests
+
+* `tests/upstream/peephole_minimize_conditions_test.rs::test_fold_returns_into_ternary`
+  un-ignored — exercises 3 shapes: bare return both sides, block-
+  wrapped returns, and the conservative bail on `return;` (no arg).
+* Upstream test count: 12 → 13.
+* Inline tests: 20 → 20 (unchanged).
+* closurec e2e (`diff_minify`): unaffected (no fixture uses returns).
+* closure-pass-pipeline: 21 passed, 0 failed.
+
+No public API change. No AST change.
+
 ## [0.6.0] - 2026-06-04
 
 ### Added — CLOC12.25: gap-018 De Morgan negation-swap

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -457,6 +457,69 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
                 }
             }
 
+            // (CLOC12.26 / gap-019): when both branches reduce to a
+            // ReturnStatement-with-argument, hoist the return out and
+            // wrap the argument expressions in a ternary:
+            //
+            //   if (x) return E1; else return E2;
+            //                              → return x ? E1 : E2;
+            //   if (x) { return E1; } else { return E2; }
+            //                              → return x ? E1 : E2;
+            //
+            // Upstream Closure performs the same rewrite under
+            // `PeepholeMinimizeConditions.tryFoldReturns`.
+            //
+            // Why this is safe:
+            //
+            //   * The if-else evaluates `x` once, then takes exactly
+            //     one branch and runs `return E1` or `return E2`. The
+            //     ternary form also evaluates `x` once, then takes
+            //     exactly one of `E1` / `E2`, then returns. The set of
+            //     values evaluated and the function's exit value match.
+            //   * Side-effect ordering preserved: `x` runs first; then
+            //     exactly the chosen branch's argument expression runs.
+            //   * Control flow preserved: in both forms the function
+            //     returns immediately after the chosen argument
+            //     evaluates. No fall-through possible because both
+            //     branches were terminal returns.
+            //
+            // Why we require both arguments to be `Some`: a bare
+            // `return;` with no value is equivalent to `return undefined;`
+            // but we can't synthesise an `undefined` expression on the
+            // typed AST cleanly without `UndefinedLiteral` care that
+            // belongs in its own follow-up. Conservative: bail when
+            // either side is bare-return.
+            //
+            // Why we don't fire on `if (x) return E;` (no alternate
+            // with a return): the fall-through case after a missing
+            // alternate has implicit `return undefined` (or the next
+            // statement's behaviour), which doesn't compose cleanly
+            // with a ternary in statement position. The caller-supplied
+            // gap-016 path also doesn't apply here (returns aren't
+            // expression statements). Tracked separately.
+            if let Some(alt) = &alternate {
+                if let (Some(c_arg), Some(a_arg)) =
+                    (single_return_with_arg(&consequent), single_return_with_arg(alt))
+                {
+                    st.record_fold(
+                        &s.cv,
+                        "if-else-returns-to-ternary-return",
+                        "if (<test>) return <e1>; else return <e2>;",
+                        "return <test> ? <e1> : <e2>;",
+                    );
+                    let cond = Expression::ConditionalExpression(ConditionalExpression {
+                        cv: None,
+                        test: Box::new(test),
+                        consequent: Box::new(c_arg),
+                        alternate: Box::new(a_arg),
+                    });
+                    return Statement::return_statement(ReturnStatement {
+                        cv: s.cv.clone(),
+                        argument: Some(cond),
+                    });
+                }
+            }
+
             // (CLOC12.24 / gap-016): when there's *no* alternate and
             // the consequent reduces to a single ExpressionStatement,
             // rewrite the IfStatement to `<test> && <consequent>` as
@@ -555,6 +618,25 @@ fn single_expr_stmt(stmt: &Statement) -> Option<Expression> {
         }
         Statement::Tagged(TaggedStatement::BlockStatement(b)) if b.body.len() == 1 => {
             single_expr_stmt(&b.body[0])
+        }
+        _ => None,
+    }
+}
+
+/// Helper for the return-then-return fold (gap-019). Returns the
+/// `argument` expression when `stmt` is exactly one ReturnStatement
+/// whose argument is `Some` (possibly wrapped in single-statement
+/// BlockStatement layers); returns `None` for everything else,
+/// including `return;` (bare return with no value).
+///
+/// Mirrors `single_expr_stmt`'s shape — both recurse through
+/// single-statement BlockStatement layers but bail on anything that
+/// changes statement count.
+fn single_return_with_arg(stmt: &Statement) -> Option<Expression> {
+    match stmt {
+        Statement::Tagged(TaggedStatement::ReturnStatement(rs)) => rs.argument.clone(),
+        Statement::Tagged(TaggedStatement::BlockStatement(b)) if b.body.len() == 1 => {
+            single_return_with_arg(&b.body[0])
         }
         _ => None,
     }

--- a/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
@@ -455,11 +455,84 @@ fn test_fold_conditional_de_morgan() {
 /// Hoisting two return statements through an if-else into a single
 /// ternary-returning return needs the ternary rewrite from gap-017
 /// plus return-statement-aware rewriting.
+/// **gap-019 closed in CLOC12.26**: `fold_if_statement` now hoists
+/// terminal `return E1; / return E2;` branches into a single
+/// `return test ? E1 : E2;`. See `single_return_with_arg` for the
+/// helper that recognises the single-ReturnStatement-with-argument
+/// shape (recurses through single-statement BlockStatement layers).
 #[test]
-#[ignore = "blocked on gap-019: return-then-return through if-else into ternary not implemented"]
 fn test_fold_returns_into_ternary() {
-    // Would assert `function f(){if(x)return 1;else return 2;}` becomes
-    // `function f(){return x?1:2;}`.
+    use coding_adventures_javascript_ast::{
+        BlockStatement, ConditionalExpression, ReturnStatement,
+    };
+    let block = |s: Statement| {
+        Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![s],
+        })
+    };
+    let ret = |arg: Expression| {
+        Statement::return_statement(ReturnStatement {
+            cv: None,
+            argument: Some(arg),
+        })
+    };
+    let num_lit = |v: f64| {
+        Expression::NumericLiteral(NumericLiteral {
+            cv: None,
+            value: v,
+            raw: format!("{}", v as i64),
+        })
+    };
+
+    // Bare returns on both branches: `if (x) return 1; else return 2;`
+    // → `return x ? 1 : 2;`.
+    let inp = if_stmt(
+        ident("x"),
+        ret(num_lit(1.0)),
+        Some(ret(num_lit(2.0))),
+    );
+    let expected = Statement::return_statement(ReturnStatement {
+        cv: None,
+        argument: Some(Expression::ConditionalExpression(ConditionalExpression {
+            cv: None,
+            test: Box::new(ident("x")),
+            consequent: Box::new(num_lit(1.0)),
+            alternate: Box::new(num_lit(2.0)),
+        })),
+    });
+    assert_fold(inp, expected);
+
+    // Block-wrapped returns: `if (x) { return 1; } else { return 2; }`
+    // → `return x ? 1 : 2;`. Same shape after fold.
+    let inp_blocks = if_stmt(
+        ident("x"),
+        block(ret(num_lit(1.0))),
+        Some(block(ret(num_lit(2.0)))),
+    );
+    let expected_again = Statement::return_statement(ReturnStatement {
+        cv: None,
+        argument: Some(Expression::ConditionalExpression(ConditionalExpression {
+            cv: None,
+            test: Box::new(ident("x")),
+            consequent: Box::new(num_lit(1.0)),
+            alternate: Box::new(num_lit(2.0)),
+        })),
+    });
+    assert_fold(inp_blocks, expected_again);
+
+    // Bare-return on one side should NOT fold (the helper bails
+    // when argument is None). Verifies the conservative guard.
+    let inp_bare = if_stmt(
+        ident("x"),
+        Statement::return_statement(ReturnStatement {
+            cv: None,
+            argument: None,
+        }),
+        Some(ret(num_lit(2.0))),
+    );
+    let inp_bare_clone = inp_bare.clone();
+    assert_fold(inp_bare, inp_bare_clone);
 }
 
 /// Upstream `testMinimizeIfWithThrow`:

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -151,11 +151,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-019 — return-then-return through `if-else` → ternary return
 
-- **Status:** OPEN
+- **Status:** RESOLVED in CLOC12.26 — `fold_if_statement` now has a fourth rewriting branch (after gap-018 swap, literal_truthy, gap-017 ternary, and now gap-019 — gap-016 stays after, gated on no alternate). When both branches reduce to a single `ReturnStatement` whose `argument` is `Some` (recursing through single-statement `BlockStatement` layers via the new `single_return_with_arg` helper), the IfStatement is replaced with `return test ? E1 : E2;`. The conservative `Some`-on-both-sides guard skips the `return;` (no argument) case — synthesising an `undefined` expression for it requires `UndefinedLiteral` plumbing in this pass and is tracked separately. `test_fold_returns_into_ternary` un-ignored. Composes with the gap-018 De Morgan swap so `if (!x) return E1; else return E2;` → (gap-018) `if (x) return E2; else return E1;` → (gap-019) `return x ? E2 : E1;`.
 - **Upstream test:** `PeepholeMinimizeConditionsTest::testFoldReturns`
 - **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs`
-- **Why it fails:** Upstream rewrites `if(x) return 1; else return 2;` to `return x ? 1 : 2;` — needs gap-017 (the ternary rewrite) plus a special case that recognises `ReturnStatement` branches.
-- **What it needs:** Land gap-017 first, then add a `ReturnStatement`-aware shape recogniser on top.
 
 ### gap-020 — `ThrowStatement` not in Phase 1 AST
 


### PR DESCRIPTION
## Summary

Closes **gap-019** in the CLOC12 gap tracker: hoists `if (x) return E1; else return E2;` into `return x ? E1 : E2;`.

Mirrors gap-017's if-else→ternary fold but for the ReturnStatement shape — sits between gap-017 and gap-016 in `fold_if_statement`.

| input | output |
|---|---|
| `if (x) return 1; else return 2;` | `return x ? 1 : 2;` |
| `if (x) { return 1; } else { return 2; }` | `return x ? 1 : 2;` |
| `if (!x) return E1; else return E2;` | `return x ? E2 : E1;` *(gap-018 + gap-019 compose)* |
| `if (true) return E1; else return E2;` | `return E1;` *(literal_truthy still wins)* |
| `if (x) return; else return E;` | unchanged *(bare-return bail; needs UndefinedLiteral plumbing)* |

## Why this is safe

- Both forms evaluate `test` once and exactly one of `E1`/`E2`.
- Identical function exit value and side-effect ordering.
- Control flow preserved: function returns immediately after the chosen argument evaluates.
- No fall-through possible because both branches were terminal returns.

## New helper

`single_return_with_arg`: mirror of `single_expr_stmt`. Requires `argument: Some` on both branches; recurses through single-statement BlockStatement layers; bails on multi-statement blocks, bare returns, or other shapes.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-fold-control-flow` → 20 inline + 13 upstream (was 12; un-ignored `test_fold_returns_into_ternary` with 3 sub-cases)
- [x] `closure-pass-pipeline`: 21 passed
- [x] `closurec`'s `diff_minify` e2e: passes (no fixture uses returns)
- [x] /security-review — ship-it: mutually exclusive with gap-017 (different Statement variants), gated on alternate.is_some(), cv preserved from original IfStatement, no unsafe
- [ ] CI green

## Closes

- gap-019 (status flipped OPEN → RESOLVED in `code/specs/CLOC12-gaps.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)