### PR TITLE
chore(visicalc-webcomp): drop edit-row=-1 sentinel workaround

### DIFF
--- a/demo/visicalc-webcomp/index.html
+++ b/demo/visicalc-webcomp/index.html
@@ -164,8 +164,21 @@
       ],
       selectedRow: 1,
       selectedCol: 1,
-      editRow:    -1,
-      editCol:    -1,
+      // No edit-row / edit-col set on initial mount: the per-cell
+      // editing predicate is `r == editRow && c == editCol`.  The
+      // WC emitter's default initializer for Number-typed slots
+      // (PR #4999) reads an absent attribute as `NaN`, and `NaN`'s
+      // `==` is always `false` — so no cell renders the input
+      // editor on initial paint.  To enter edit mode, the host
+      // calls `grid.setAttribute("edit-row", String(r))` etc.;
+      // until then the editor stays hidden everywhere.
+      //
+      // Before #4999 this demo had to set `edit-row="-1"` as a
+      // sentinel because the emitter defaulted Number slots to
+      // `""`, and JS `0 == ""` is `true` — so cell (0, 0) would
+      // mistakenly render its editor by default.  The emitter
+      // fix moves the sentinel into the generated code, so the
+      // host can simply omit the attribute.
       editContent: "",
     };
     const grid = document.getElementById("grid");
@@ -174,8 +187,6 @@
     grid.setAttribute("viewport-rows",  JSON.stringify(SAMPLE.viewportRows));
     grid.setAttribute("selected-row",   String(SAMPLE.selectedRow));
     grid.setAttribute("selected-col",   String(SAMPLE.selectedCol));
-    grid.setAttribute("edit-row",       String(SAMPLE.editRow));
-    grid.setAttribute("edit-col",       String(SAMPLE.editCol));
     grid.setAttribute("edit-content",   SAMPLE.editContent);
 
     // Post-process: paint the selected-cell highlight.  The


### PR DESCRIPTION
## Summary

- **Drops the `edit-row=\"-1\"` / `edit-col=\"-1\"` sentinel workaround** in the visicalc-webcomp demo. The pre-#4999 emitter defaulted Number slots to `\"\"`, and JS `0 == \"\"` is true — so without the `-1` sentinel, cell (0, 0) would mistakenly render its editor on initial paint. PR #4999 moved that sentinel into the emitter as `NaN`, so the host can simply omit the attribute.
- **Pure demo cleanup**: removes two `setAttribute` calls + two SAMPLE fields, adds a multi-line comment explaining the change and referencing #4999. No emitter / runtime / build changes.

## Why this is the idiomatic shape

Every other VisiCalc demo (React, HTML, SwiftUI, Compose, …) only sets edit-row / edit-col WHEN ENTERING EDIT MODE — never as a default-state sentinel. This change brings the WC demo in line.

## Test plan

- [x] `bash demo/visicalc-webcomp/scripts/build.sh` succeeds
- [x] Generated `Grid.js` reads `editRow = ... !== null ? Number(...) : NaN` (NaN sentinel from the emitter)
- [ ] Open `demo/visicalc-webcomp/index.html` in browser; confirm no `<input>` editor renders on initial paint
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)