### PR TITLE
ADJ58 — universal stage contract (byte provenance at every arrow)

### DIFF
--- a/code/specs/ADJ58-universal-stage-contract.md
+++ b/code/specs/ADJ58-universal-stage-contract.md
@@ -1,0 +1,111 @@
+# ADJ58 — The Universal Stage Contract (byte provenance at every stage)
+
+> **Status (2026-06-04):** Built and run end-to-end. The byte-provenance invariant
+> is now enforced at EVERY pipeline arrow, not just case→IR. A generic `Stage`
+> gate + a composed `Trail` make the framework prove it accounted for 100% of each
+> stage's input — or show the hole. Implementation:
+> [`code/specs/data/adj57/pipeline/`](data/adj57/pipeline/) (`stage.py`, `run.py`).
+> Builds on [ADJ57](ADJ57-byte-provenance-pipeline.md) (which gated one arrow).
+
+## 1. The principle, absolute
+
+> There is no privileged stage. Every transform — normalize, decompose, derive,
+> ground, aggregate — takes an input and must **prove it accounted for 100% of that
+> input**: every used unit cites the output it produced, every discarded unit
+> carries a reason, and the proof is appended to one composed, auditable trail.
+
+ADJ57 gated *one* arrow (case→IR). That was the hole: the framework *claimed*
+end-to-end auditability while `derive` dropped facts silently, `ground` read a page
+without a discard ledger, and `aggregate` abstained ad hoc. ADJ58 closes it — the
+gate runs at every arrow, and a stage that fails to cover its input is a visible
+**hole in the trail**, not a silent gap.
+
+## 2. The contract — one gate, two input shapes
+
+A stage's coverage proof partitions its input completely:
+
+- **TEXT input** (a case, a source page): the proof is a byte partition — the
+  segments must concatenate back to the input exactly. Each segment is `used`
+  (cites what it produced) or `discard` (carries a reason).
+- **ELEMENT input** (a list of facts, a set of grounded LRs): the proof partitions
+  the set of element ids. `used ∪ discard == all ids`, disjoint; every used cites a
+  `produced`, every discard a `reason`.
+
+`clean` = covered AND every used cites + every discard reasons.
+`Trail.ok()` = every stage clean = the byte-trail is **unbroken** from raw input to
+final output. ([`stage.py`](data/adj57/pipeline/stage.py); 9 unit tests in
+`test_stage.py`.)
+
+## 3. The arrows, now all gated ([`run.py`](data/adj57/pipeline/run.py))
+
+| stage | input | the contract it now honors |
+|---|---|---|
+| **decompose** | case bytes | typed facts (used, cite term) + reasoned discards = 100% of bytes (ADJ57) |
+| **derive** | the facts | EVERY fact is used (role) or discarded-with-reason — *no silent drop of comorbidities* |
+| **ground:**\* | each source page | the cited span (used) + the surrounding page (discarded-as-context) = 100% of the excerpt |
+| **aggregate** | the grounded LRs | each LR used in the posterior, or abstained-with-reason (`direction_only`/`fabricated`) |
+
+The `derive` retrofit is the visible win: in the prior brucella run, `glaucoma`,
+`dyslipidemia`, `hypertension` were silently ignored. Under the contract they must
+appear as `discarded: "comorbidity, no bearing on the leading diagnosis"` — logged,
+auditable, defensible.
+
+## 4. The run — Kikuchi-Fujimoto disease (PMC11724740)
+
+A fresh case: 32-year-old woman, FUO + non-tender cervical lymphadenopathy +
+pancytopenia. Ground truth (held aside): **Kikuchi-Fujimoto disease** — a *rare*
+histiocytic necrotizing lymphadenitis, diagnosed by node biopsy. The leading
+diagnosis the framework derived from the facts: **`kikuchi_fujimoto_disease` —
+correct.**
+
+**The audit trail came back UNBROKEN** — every stage accounted for 100% of its input:
+
+```
+[OK] decompose   text  1788 bytes = 46 used (1088b) + 47 discard (700b)
+[OK] derive      elem    46 facts = 24 used      + 22 discard-with-reason
+[OK] ground:prior          + 4 source pages, each = cited span + discarded context
+[OK] aggregate   elem     4 units = 0 used       + 4 abstained-with-reason
+=> trail UNBROKEN (every stage byte-accounted)    trail_ok=True, holes=[]
+```
+
+**The `derive` hole is closed.** All 46 facts are accounted for; the 22 discards each
+carry a reason — `fatigue(increased)`: *"nonspecific constitutional symptom, no
+discriminating value"*; `past_history(post_streptococcal_glomerulonephritis)`:
+*"remote comorbidity, no current findings"*; `iv_drug_use(absent)`: *"lowers
+blood-borne-infection prior, not discriminating for KFD"*. Negatives and
+comorbidities are no longer silently dropped.
+
+**And the verdict is the honest part:** the framework **abstained from a posterior.**
+The prior came back `direction_only` (KFD is rare — no grounded prevalence), and the
+three finding LRs all came back `direction_only` (there is essentially no published
+likelihood-ratio literature for clinical-finding→KFD, because the entity is too rare
+and biopsy-defined). So `aggregate` had **0 grounded inputs**, and the framework
+reported: *"prior not grounded — no defensible posterior."*
+
+That is exactly right. A hallucinating system would emit a confident "KFD 90%" with
+invented LRs. This framework instead: (1) correctly named the leading suspicion, (2)
+accounted for every byte of every stage (unbroken trail), and (3) **refused to
+produce a number the evidence base cannot support** — the same conclusion the real
+workup reached (it went to biopsy). The framework tells you precisely what it could
+and could not ground, and the trail proves it left nothing out.
+
+## 5. Why this matters
+
+The framework's promise is *auditability* — a verdict you can trace to source bytes.
+A single ungated arrow breaks that promise everywhere downstream of it: you cannot
+trust a number whose derivation dropped part of its input for reasons it never
+recorded. Making the gate universal is what lets the framework *truthfully* claim
+the trail is unbroken — and, where it isn't yet (a stage that can't cover its
+input), say so out loud instead of papering over it.
+
+## 6. Next
+
+- **Normalization stages** (source-text + IR) plug into the same contract — each is
+  a provenance-preserving transform with its own used/discarded ledger and a
+  raw→normalized offset map (the recursive byte-provenance applied to normalization
+  itself).
+- **CAS-first grounding** (hash the normalized page before decomposing; reuse the
+  decomposition on a hit) — so the `ground` stages are skipped when a source is
+  already decomposed in the store.
+- Promote the trail into the audit-trail schema (ADJ07) so replay covers every
+  stage, not just LLM calls.

--- a/code/specs/data/adj57/CHANGELOG.md
+++ b/code/specs/data/adj57/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — adj57 byte-provenance pipeline
 
+## [0.2.0] — 2026-06-04
+
+### Added
+
+- **ADJ58 — the universal stage contract.** Byte provenance enforced at EVERY
+  pipeline arrow, not just case→IR.
+  - **`pipeline/stage.py`** — a generic `Stage` gate + composed `Trail`. Two input
+    shapes, one contract: TEXT inputs partition byte-for-byte; ELEMENT inputs
+    partition the id set. `clean` = covered + every used cites a `produced` + every
+    discard a `reason`. `Trail.ok()` = unbroken byte-trail end to end. 9 unit tests
+    (`pipeline/test_stage.py`).
+  - **`pipeline/run.py`** — drives a full-run result through EVERY stage's gate
+    (decompose / derive / ground:\* / aggregate), composing the trail, interning
+    sources into the CAS, computing the verdict. A stage that fails to cover its
+    input shows up as a HOLE — the framework stops claiming auditability it lacks.
+  - **`derive` retrofit** — the workflow now emits `fact_dispositions`: every fact
+    is USED (with a role) or DISCARDED (with a reason). Closes the silent-drop hole
+    (comorbidities like glaucoma must be discarded-with-reason, not ignored).
+  - Spec: [ADJ58](../../ADJ58-universal-stage-contract.md).
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/code/specs/data/adj57/README.md
+++ b/code/specs/data/adj57/README.md
@@ -10,8 +10,9 @@ Spec: [ADJ57](../../ADJ57-byte-provenance-pipeline.md).
 |---|---|---|
 | **L0 — CAS** | [`pipeline/cas.py`](pipeline/cas.py) | content-addressed source store; `cite()` rejects any quote not literally present in the source |
 | **L1 — coverage** | [`pipeline/coverage.py`](pipeline/coverage.py) | the case→IR partition must reconstruct the input byte-for-byte (total coverage) |
-| **L1–L3 — ingest/derive/spider** | [`pipeline/slice.workflow.js`](pipeline/slice.workflow.js) | LLM layers: lossless typed partition, fact-driven link derivation, recursive-to-root grounding |
+| **L1–L3 — ingest/derive/spider** | [`pipeline/slice.workflow.js`](pipeline/slice.workflow.js), [`full.workflow.js`](pipeline/full.workflow.js) | LLM layers: lossless typed partition, fact-driven link derivation (with total fact coverage), recursive-to-root grounding |
 | **driver** | [`pipeline/assemble.py`](pipeline/assemble.py) | runs the coverage check, interns sources into the CAS, byte-provenances each citation, writes the rulebook |
+| **ADJ58 — universal stage contract** | [`pipeline/stage.py`](pipeline/stage.py), [`run.py`](pipeline/run.py) | the gate at EVERY arrow: each stage proves 100% input coverage (used-cited + discarded-with-reason), composed into one auditable `Trail`. `run.py` drives a full run through every gate + computes the verdict. Tests: [`test_stage.py`](pipeline/test_stage.py) |
 
 ## Run
 

--- a/code/specs/data/adj57/cas/index.json
+++ b/code/specs/data/adj57/cas/index.json
@@ -5,6 +5,12 @@
     "title": "Does this patient have Pheochromocytoma? a systematic review of clinical signs and symptoms (Soltani et al., J Diabetes Metab Disord 2016)",
     "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4815191/"
   },
+  "3e2f44185ed5ae7e8a4a14564e026042f80ccb561bfd172f2b39c8dc0d1cf50f": {
+    "bytes": 321,
+    "citations": 1,
+    "title": "Kikuchi-Fujimoto Disease: analysis of 244 cases (Kucukardali et al., Clin Rheumatol 2006)",
+    "url": "https://pubmed.ncbi.nlm.nih.gov/16538388/"
+  },
   "51c8f2ae371fe4ac51ee676d68b22f3136d316d6443685612449767d5017cd29": {
     "bytes": 629,
     "citations": 1,
@@ -17,10 +23,28 @@
     "title": "Weight loss / hypermetabolism in pheochromocytoma (energy metabolism literature, via search synthesis)",
     "url": "https://pubmed.ncbi.nlm.nih.gov/23436923/"
   },
+  "8ad32ecbd7c43b5ec47c0a99ee773afba4fd658a50a922ec5fef81e0bf090e43": {
+    "bytes": 220,
+    "citations": 1,
+    "title": "Kikuchi-Fujimoto disease in the Eastern Mediterranean zone (Scientific Reports 2022)",
+    "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8854556/"
+  },
+  "8b0e6439162f4f69213b5ce76613349103c9a698f73feb20e98a5f9d417b4e02": {
+    "bytes": 164,
+    "citations": 1,
+    "title": "Kikuchi-Fujimoto disease (review, Bosch & Guilabert) - PMC",
+    "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC1481509/"
+  },
   "dc6c6b6ae14161b4263862ee25165e4756647a1c2a51a4a31f5e655c83d15611": {
     "bytes": 401,
     "citations": 1,
     "title": "Does this patient have Pheochromocytoma? a systematic review of clinical signs and symptoms (Soltani et al., J Diabetes Metab Disord 2016)",
     "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC4797176/"
+  },
+  "e7fbee489f3acb0c3a02a41077e9dc7d6e0b731b4a9d6def66a15c8ab5e72086": {
+    "bytes": 311,
+    "citations": 1,
+    "title": "Kikuchi-Fujimoto Disease - StatPearls (NCBI Bookshelf)",
+    "url": "https://www.ncbi.nlm.nih.gov/books/NBK430830/"
   }
 }

--- a/code/specs/data/adj57/cas/objects/3e2f44185ed5ae7e8a4a14564e026042f80ccb561bfd172f2b39c8dc0d1cf50f.json
+++ b/code/specs/data/adj57/cas/objects/3e2f44185ed5ae7e8a4a14564e026042f80ccb561bfd172f2b39c8dc0d1cf50f.json
@@ -1,0 +1,16 @@
+{
+  "hash": "3e2f44185ed5ae7e8a4a14564e026042f80ccb561bfd172f2b39c8dc0d1cf50f",
+  "url": "https://pubmed.ncbi.nlm.nih.gov/16538388/",
+  "title": "Kikuchi-Fujimoto Disease: analysis of 244 cases (Kucukardali et al., Clin Rheumatol 2006)",
+  "interned_at": "",
+  "content": "The disease was reported in 244 patients (33% males and 77% females). Mean age was 25 (1-64) and 70% was younger than 30. The most common clinical features were lymphadenomegaly (100%), fever (35%), and the most common laboratory features were leucopenia (43%), high erythrocyte sedimentation rate (40%) and anemia (23%).",
+  "citations": [
+    {
+      "start": 203,
+      "end": 260,
+      "quote": "the most common laboratory features were leucopenia (43%)",
+      "used_for": "wbc(1.35, leukopenia) LR+ for Kikuchi-Fujimoto disease->kikuchi_fujimoto_disease"
+    }
+  ],
+  "onward_citations": []
+}

--- a/code/specs/data/adj57/cas/objects/8ad32ecbd7c43b5ec47c0a99ee773afba4fd658a50a922ec5fef81e0bf090e43.json
+++ b/code/specs/data/adj57/cas/objects/8ad32ecbd7c43b5ec47c0a99ee773afba4fd658a50a922ec5fef81e0bf090e43.json
@@ -1,0 +1,16 @@
+{
+  "hash": "8ad32ecbd7c43b5ec47c0a99ee773afba4fd658a50a922ec5fef81e0bf090e43",
+  "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8854556/",
+  "title": "Kikuchi-Fujimoto disease in the Eastern Mediterranean zone (Scientific Reports 2022)",
+  "interned_at": "",
+  "content": "Between 2006 and 2021, 1968 lymph node biopsies were submitted to the histopathology laboratory, with eleven cases (0.6%) having the diagnosis of KFD. The mean patient age was 32 years (range 4-59), and 73% were females.",
+  "citations": [
+    {
+      "start": 0,
+      "end": 150,
+      "quote": "Between 2006 and 2021, 1968 lymph node biopsies were submitted to the histopathology laboratory, with eleven cases (0.6%) having the diagnosis of KFD.",
+      "used_for": "prior:kikuchi_fujimoto_disease"
+    }
+  ],
+  "onward_citations": []
+}

--- a/code/specs/data/adj57/cas/objects/8b0e6439162f4f69213b5ce76613349103c9a698f73feb20e98a5f9d417b4e02.json
+++ b/code/specs/data/adj57/cas/objects/8b0e6439162f4f69213b5ce76613349103c9a698f73feb20e98a5f9d417b4e02.json
@@ -1,0 +1,21 @@
+{
+  "hash": "8b0e6439162f4f69213b5ce76613349103c9a698f73feb20e98a5f9d417b4e02",
+  "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC1481509/",
+  "title": "Kikuchi-Fujimoto disease (review, Bosch & Guilabert) - PMC",
+  "interned_at": "",
+  "content": "Leukopenia can be found in up to 50% of the cases. Lymph node size has been found to range from 0.5 to 4 cm, but it may reach 5 to 6 cm and rarely larger than 6 cm.",
+  "citations": [
+    {
+      "start": 0,
+      "end": 50,
+      "quote": "Leukopenia can be found in up to 50% of the cases.",
+      "used_for": "wbc(1.35, leukopenia) LR+ for Kikuchi-Fujimoto disease->kikuchi_fujimoto_disease"
+    }
+  ],
+  "onward_citations": [
+    {
+      "citation": "Review borrows the leukopenia frequency; root primary measured number is Kucukardali et al, analysis of 244 cases (next hop).",
+      "interned_hash": ""
+    }
+  ]
+}

--- a/code/specs/data/adj57/cas/objects/e7fbee489f3acb0c3a02a41077e9dc7d6e0b731b4a9d6def66a15c8ab5e72086.json
+++ b/code/specs/data/adj57/cas/objects/e7fbee489f3acb0c3a02a41077e9dc7d6e0b731b4a9d6def66a15c8ab5e72086.json
@@ -1,0 +1,25 @@
+{
+  "hash": "e7fbee489f3acb0c3a02a41077e9dc7d6e0b731b4a9d6def66a15c8ab5e72086",
+  "url": "https://www.ncbi.nlm.nih.gov/books/NBK430830/",
+  "title": "Kikuchi-Fujimoto Disease - StatPearls (NCBI Bookshelf)",
+  "interned_at": "",
+  "content": "The most prevalent manifestation is unilateral tender posterior cervical lymphadenopathy, observed in 60% to 90% of cases, with occasional involvement of the supraclavicular and axillary nodes. In approximately half of cases, the affected lymph nodes are typically mobile, solitary, nonsuppurative, and painful.",
+  "citations": [
+    {
+      "start": 194,
+      "end": 311,
+      "quote": "In approximately half of cases, the affected lymph nodes are typically mobile, solitary, nonsuppurative, and painful.",
+      "used_for": "cervical_lymphadenopathy(non_tender) LR+ for Kikuchi-Fujimoto disease->kikuchi_fujimoto_disease"
+    }
+  ],
+  "onward_citations": [
+    {
+      "citation": "StatPearls cites refs [4][30][31] (review/textbook sources); no primary specificity data for non-tender nodes among the competing differential (lymphoma, TB, SLE) exists. Sensitivity side (~50% painful, hence ~50% non-tender) is the only quantity traceable; LR+ requires specificity which is absent.",
+      "interned_hash": ""
+    },
+    {
+      "citation": "Node-size and posterior-cervical (level V) frequency are review statements [31][4][30]. A 2cm, left, level-V node matches the modal KFD presentation, but no primary study reports P(this node profile | competing diagnoses), so specificity and hence LR+ cannot be derived. Distribution-of-lymphadenopathy primary paper (S1684118219301525) was paywalled (403).",
+      "interned_hash": ""
+    }
+  ]
+}

--- a/code/specs/data/adj57/pipeline/full-results.json
+++ b/code/specs/data/adj57/pipeline/full-results.json
@@ -1,0 +1,892 @@
+{
+  "ingest": {
+    "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC11724740/",
+    "ground_truth": "Kikuchi-Fujimoto Disease (KFD), also called histiocytic necrotizing lymphadenitis. Established by cervical lymph node excision biopsy showing necrotizing lymphadenitis with abundant karyorrhectic (apoptotic) debris, histiocytes, and a characteristic absence of neutrophils, with positive myeloperoxidase immunohistochemistry.",
+    "case_text": "A 32-year-old female patient with a past history of post-streptococcal glomerulonephritis presented with high-grade fever associated with arthralgia, myalgia, increased fatiguability, and malaise for a duration of two weeks. She had a significant loss of appetite and loss of weight as well. She did not reveal a past history of oral ulcers, alopecia, photosensitive rashes, any other cutaneous manifestations, or inflammatory-type arthritis. There was no history of chronic cough, hemoptysis, or past history of or close contact history of tuberculosis. She denied recent travel history, risky sexual encounters, intravenous drug abuse, or blood transfusions.\n\nExamination revealed that the patient was febrile and pale, with a body mass index of 23 kg/m2. There was non-tender cervical lymphadenopathy, with the largest being 2 cm in diameter in the left side level five lymph node group. Associated palpable inguinal or axillary lymphadenopathy was not there. There was no alopecia, peri-orbital puffiness, or ankle edema.\n\nThe cardiovascular system revealed blood pressure of 110/70 mmHg with a pulse rate of 100 bpm, which was of normal volume. She maintained the oxygen saturation at 98% in room air, with bilateral air entry being equal without added sounds. There was a palpable spleen up to 2 cm below the costal margin without associated hepatomegaly or free fluid in the abdomen. Neurological examination revealed no abnormality.\n\nFull blood count on admission showed a total white cell count of 1.35 \u00d7 109 cells/L, hemoglobin 10 g/dL, and platelet count of 84 \u00d7 109 cells/L. The blood picture revealed features that suggested acute viral infection or an autoimmune process. Her erythrocyte sedimentation rate was 75 mm at the first hour, while C-reactive protein was 35 mg/dL.",
+    "segments": [
+      {
+        "text": "A ",
+        "kind": "discard",
+        "reason": "article and whitespace, no diagnostic content"
+      },
+      {
+        "text": "32-year-old",
+        "kind": "fact",
+        "term": "age(32_years)"
+      },
+      {
+        "text": " ",
+        "kind": "discard",
+        "reason": "whitespace"
+      },
+      {
+        "text": "female",
+        "kind": "fact",
+        "term": "sex(female)"
+      },
+      {
+        "text": " patient with a past history of ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "post-streptococcal glomerulonephritis",
+        "kind": "fact",
+        "term": "past_history(post_streptococcal_glomerulonephritis)"
+      },
+      {
+        "text": " presented with ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "high-grade fever",
+        "kind": "fact",
+        "term": "fever(high_grade)"
+      },
+      {
+        "text": " associated with ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "arthralgia",
+        "kind": "fact",
+        "term": "arthralgia(present)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "myalgia",
+        "kind": "fact",
+        "term": "myalgia(present)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "increased fatiguability",
+        "kind": "fact",
+        "term": "fatigue(increased)"
+      },
+      {
+        "text": ", and ",
+        "kind": "discard",
+        "reason": "punctuation and conjunction"
+      },
+      {
+        "text": "malaise",
+        "kind": "fact",
+        "term": "malaise(present)"
+      },
+      {
+        "text": " for a duration of ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "two weeks",
+        "kind": "fact",
+        "term": "symptom_duration(two_weeks)"
+      },
+      {
+        "text": ". She had a significant ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "loss of appetite",
+        "kind": "fact",
+        "term": "appetite_loss(present)"
+      },
+      {
+        "text": " and ",
+        "kind": "discard",
+        "reason": "conjunction"
+      },
+      {
+        "text": "loss of weight",
+        "kind": "fact",
+        "term": "weight_loss(present)"
+      },
+      {
+        "text": " as well. She did not reveal a past history of ",
+        "kind": "discard",
+        "reason": "connective phrasing introducing negatives"
+      },
+      {
+        "text": "oral ulcers",
+        "kind": "fact",
+        "term": "oral_ulcers(absent)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "alopecia",
+        "kind": "fact",
+        "term": "alopecia(absent)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "photosensitive rashes",
+        "kind": "fact",
+        "term": "photosensitive_rash(absent)"
+      },
+      {
+        "text": ", any other ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "cutaneous manifestations",
+        "kind": "fact",
+        "term": "cutaneous_manifestations(absent)"
+      },
+      {
+        "text": ", or ",
+        "kind": "discard",
+        "reason": "punctuation and conjunction"
+      },
+      {
+        "text": "inflammatory-type arthritis",
+        "kind": "fact",
+        "term": "inflammatory_arthritis(absent)"
+      },
+      {
+        "text": ". There was no history of ",
+        "kind": "discard",
+        "reason": "connective phrasing introducing negatives"
+      },
+      {
+        "text": "chronic cough",
+        "kind": "fact",
+        "term": "chronic_cough(absent)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "hemoptysis",
+        "kind": "fact",
+        "term": "hemoptysis(absent)"
+      },
+      {
+        "text": ", or past history of or close contact history of ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "tuberculosis",
+        "kind": "fact",
+        "term": "tuberculosis_exposure(absent)"
+      },
+      {
+        "text": ". She denied recent ",
+        "kind": "discard",
+        "reason": "connective phrasing introducing negatives"
+      },
+      {
+        "text": "travel history",
+        "kind": "fact",
+        "term": "recent_travel(absent)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "risky sexual encounters",
+        "kind": "fact",
+        "term": "risky_sexual_exposure(absent)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "intravenous drug abuse",
+        "kind": "fact",
+        "term": "iv_drug_use(absent)"
+      },
+      {
+        "text": ", or ",
+        "kind": "discard",
+        "reason": "punctuation and conjunction"
+      },
+      {
+        "text": "blood transfusions",
+        "kind": "fact",
+        "term": "blood_transfusion(absent)"
+      },
+      {
+        "text": ".\n\nExamination revealed that the patient was ",
+        "kind": "discard",
+        "reason": "paragraph break and connective phrasing"
+      },
+      {
+        "text": "febrile",
+        "kind": "fact",
+        "term": "febrile(present)"
+      },
+      {
+        "text": " and ",
+        "kind": "discard",
+        "reason": "conjunction"
+      },
+      {
+        "text": "pale",
+        "kind": "fact",
+        "term": "pallor(present)"
+      },
+      {
+        "text": ", with a ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "body mass index of 23 kg/m2",
+        "kind": "fact",
+        "term": "bmi(23)"
+      },
+      {
+        "text": ". There was ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "non-tender cervical lymphadenopathy",
+        "kind": "fact",
+        "term": "cervical_lymphadenopathy(non_tender)"
+      },
+      {
+        "text": ", with the largest being ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "2 cm in diameter in the left side level five lymph node group",
+        "kind": "fact",
+        "term": "largest_node(2cm_left_level_five)"
+      },
+      {
+        "text": ". Associated palpable ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "inguinal or axillary lymphadenopathy was not there",
+        "kind": "fact",
+        "term": "inguinal_axillary_lymphadenopathy(absent)"
+      },
+      {
+        "text": ". There was no ",
+        "kind": "discard",
+        "reason": "connective phrasing introducing negatives"
+      },
+      {
+        "text": "alopecia",
+        "kind": "fact",
+        "term": "alopecia(absent_on_exam)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "peri-orbital puffiness",
+        "kind": "fact",
+        "term": "periorbital_puffiness(absent)"
+      },
+      {
+        "text": ", or ",
+        "kind": "discard",
+        "reason": "punctuation and conjunction"
+      },
+      {
+        "text": "ankle edema",
+        "kind": "fact",
+        "term": "ankle_edema(absent)"
+      },
+      {
+        "text": ".\n\nThe cardiovascular system revealed ",
+        "kind": "discard",
+        "reason": "paragraph break and connective phrasing"
+      },
+      {
+        "text": "blood pressure of 110/70 mmHg",
+        "kind": "fact",
+        "term": "blood_pressure(110_70)"
+      },
+      {
+        "text": " with a ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "pulse rate of 100 bpm",
+        "kind": "fact",
+        "term": "pulse(100_bpm)"
+      },
+      {
+        "text": ", which was of normal volume. She maintained the ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "oxygen saturation at 98% in room air",
+        "kind": "fact",
+        "term": "oxygen_saturation(98_room_air)"
+      },
+      {
+        "text": ", with ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "bilateral air entry being equal without added sounds",
+        "kind": "fact",
+        "term": "lung_exam(clear_equal)"
+      },
+      {
+        "text": ". There was a ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "palpable spleen up to 2 cm below the costal margin",
+        "kind": "fact",
+        "term": "splenomegaly(2cm)"
+      },
+      {
+        "text": " without associated ",
+        "kind": "discard",
+        "reason": "connective phrasing introducing negative"
+      },
+      {
+        "text": "hepatomegaly",
+        "kind": "fact",
+        "term": "hepatomegaly(absent)"
+      },
+      {
+        "text": " or ",
+        "kind": "discard",
+        "reason": "conjunction"
+      },
+      {
+        "text": "free fluid in the abdomen",
+        "kind": "fact",
+        "term": "ascites(absent)"
+      },
+      {
+        "text": ". ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "Neurological examination revealed no abnormality",
+        "kind": "fact",
+        "term": "neuro_exam(normal)"
+      },
+      {
+        "text": ".\n\nFull blood count on admission showed a ",
+        "kind": "discard",
+        "reason": "paragraph break and connective phrasing"
+      },
+      {
+        "text": "total white cell count of 1.35 \u00d7 109 cells/L",
+        "kind": "fact",
+        "term": "wbc(1_35_leukopenia)"
+      },
+      {
+        "text": ", ",
+        "kind": "discard",
+        "reason": "punctuation"
+      },
+      {
+        "text": "hemoglobin 10 g/dL",
+        "kind": "fact",
+        "term": "hemoglobin(10_anemia)"
+      },
+      {
+        "text": ", and ",
+        "kind": "discard",
+        "reason": "punctuation and conjunction"
+      },
+      {
+        "text": "platelet count of 84 \u00d7 109 cells/L",
+        "kind": "fact",
+        "term": "platelets(84_thrombocytopenia)"
+      },
+      {
+        "text": ". The blood picture revealed features that suggested ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "acute viral infection or an autoimmune process",
+        "kind": "fact",
+        "term": "blood_picture(viral_or_autoimmune)"
+      },
+      {
+        "text": ". Her ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "erythrocyte sedimentation rate was 75 mm at the first hour",
+        "kind": "fact",
+        "term": "esr(75_elevated)"
+      },
+      {
+        "text": ", while ",
+        "kind": "discard",
+        "reason": "connective phrasing"
+      },
+      {
+        "text": "C-reactive protein was 35 mg/dL",
+        "kind": "fact",
+        "term": "crp(35_elevated)"
+      },
+      {
+        "text": ".",
+        "kind": "discard",
+        "reason": "terminal punctuation"
+      }
+    ],
+    "candidate_diagnoses": [
+      "Kikuchi-Fujimoto disease (histiocytic necrotizing lymphadenitis)",
+      "Systemic lupus erythematosus",
+      "Lymphoma (Hodgkin or non-Hodgkin)",
+      "Tuberculous lymphadenitis",
+      "Acute viral infection (e.g., EBV/CMV)",
+      "Adult-onset Still's disease"
+    ]
+  },
+  "derived": {
+    "leading_diagnosis": "kikuchi_fujimoto_disease",
+    "prior_population": "young_women_presenting_with_febrile_cervical_lymphadenopathy_and_leukopenia",
+    "fact_dispositions": [
+      {
+        "fact": "age(32_years)",
+        "used": true,
+        "role": "sets_prior_population"
+      },
+      {
+        "fact": "sex(female)",
+        "used": true,
+        "role": "sets_prior_population"
+      },
+      {
+        "fact": "past_history(post_streptococcal_glomerulonephritis)",
+        "used": false,
+        "reason": "remote childhood-type renal comorbidity; no current renal findings (no edema, normal BP), does not bear on KFD"
+      },
+      {
+        "fact": "fever(high_grade)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "arthralgia(present)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "myalgia(present)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "fatigue(increased)",
+        "used": false,
+        "reason": "nonspecific constitutional symptom, no discriminating value among candidates"
+      },
+      {
+        "fact": "malaise(present)",
+        "used": false,
+        "reason": "nonspecific constitutional symptom, no discriminating value"
+      },
+      {
+        "fact": "symptom_duration(two_weeks)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "appetite_loss(present)",
+        "used": false,
+        "reason": "nonspecific constitutional symptom"
+      },
+      {
+        "fact": "weight_loss(present)",
+        "used": false,
+        "reason": "nonspecific B-symptom; present across multiple candidates, low discrimination for KFD"
+      },
+      {
+        "fact": "oral_ulcers(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "alopecia(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "photosensitive_rash(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "cutaneous_manifestations(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "inflammatory_arthritis(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "chronic_cough(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "hemoptysis(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "tuberculosis_exposure(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "recent_travel(absent)",
+        "used": false,
+        "reason": "travel/exposure context; argues against geographically-acquired infection but not specific to KFD discrimination"
+      },
+      {
+        "fact": "risky_sexual_exposure(absent)",
+        "used": false,
+        "reason": "lowers HIV/STI prior but not discriminating between remaining candidates"
+      },
+      {
+        "fact": "iv_drug_use(absent)",
+        "used": false,
+        "reason": "lowers blood-borne infection prior; not discriminating for KFD"
+      },
+      {
+        "fact": "blood_transfusion(absent)",
+        "used": false,
+        "reason": "lowers transfusion-borne infection prior; not discriminating"
+      },
+      {
+        "fact": "febrile(present)",
+        "used": false,
+        "reason": "duplicate of fever(high_grade) already counted; avoid double-counting"
+      },
+      {
+        "fact": "pallor(present)",
+        "used": false,
+        "reason": "physical correlate of anemia already captured by hemoglobin(10_anemia)"
+      },
+      {
+        "fact": "bmi(23)",
+        "used": false,
+        "reason": "normal body habitus, no diagnostic bearing"
+      },
+      {
+        "fact": "cervical_lymphadenopathy(non_tender)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "largest_node(2cm_left_level_five)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "inguinal_axillary_lymphadenopathy(absent)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "alopecia(absent_on_exam)",
+        "used": false,
+        "reason": "duplicate of alopecia(absent) already counted; avoid double-counting"
+      },
+      {
+        "fact": "periorbital_puffiness(absent)",
+        "used": false,
+        "reason": "absence of renal/nephrotic sign; no current bearing given remote PSGN excluded"
+      },
+      {
+        "fact": "ankle_edema(absent)",
+        "used": false,
+        "reason": "absence of renal/fluid-overload sign; no bearing on KFD"
+      },
+      {
+        "fact": "blood_pressure(110_70)",
+        "used": false,
+        "reason": "normal vital sign, no diagnostic discrimination"
+      },
+      {
+        "fact": "pulse(100_bpm)",
+        "used": false,
+        "reason": "mild tachycardia expected with fever; nonspecific"
+      },
+      {
+        "fact": "oxygen_saturation(98_room_air)",
+        "used": false,
+        "reason": "normal; argues against pulmonary process but already covered by clear lung exam"
+      },
+      {
+        "fact": "lung_exam(clear_equal)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "splenomegaly(2cm)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "hepatomegaly(absent)",
+        "used": false,
+        "reason": "absence; low discriminating value among candidates"
+      },
+      {
+        "fact": "ascites(absent)",
+        "used": false,
+        "reason": "absence of serositis/fluid; nonspecific here"
+      },
+      {
+        "fact": "neuro_exam(normal)",
+        "used": false,
+        "reason": "normal exam, no diagnostic bearing"
+      },
+      {
+        "fact": "wbc(1_35_leukopenia)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "hemoglobin(10_anemia)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "platelets(84_thrombocytopenia)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "blood_picture(viral_or_autoimmune)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "esr(75_elevated)",
+        "used": true,
+        "role": "evidence_for_leading"
+      },
+      {
+        "fact": "crp(35_elevated)",
+        "used": false,
+        "reason": "nonspecific acute-phase elevation; redundant with ESR and present across all inflammatory candidates"
+      }
+    ],
+    "finding_links": [
+      {
+        "finding": "cervical_lymphadenopathy(non_tender)",
+        "expected_metric": "LR+",
+        "decisive": true
+      },
+      {
+        "finding": "largest_node(2cm_left_level_five)",
+        "expected_metric": "LR+",
+        "decisive": true
+      },
+      {
+        "finding": "wbc(1_35_leukopenia)",
+        "expected_metric": "LR+",
+        "decisive": true
+      },
+      {
+        "finding": "sex(female)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "age(32_years)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "fever(high_grade)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "oral_ulcers(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "photosensitive_rash(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "cutaneous_manifestations(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "inflammatory_arthritis(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "tuberculosis_exposure(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "chronic_cough(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "hemoptysis(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "inguinal_axillary_lymphadenopathy(absent)",
+        "expected_metric": "LR-",
+        "decisive": false
+      },
+      {
+        "finding": "esr(75_elevated)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "platelets(84_thrombocytopenia)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "hemoglobin(10_anemia)",
+        "expected_metric": "LR+",
+        "decisive": false
+      },
+      {
+        "finding": "splenomegaly(2cm)",
+        "expected_metric": "LR+",
+        "decisive": false
+      }
+    ]
+  },
+  "spidered": {
+    "prior": {
+      "value": 0.15,
+      "verdict": "direction_only",
+      "chain": [
+        {
+          "hop": 0,
+          "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC8854556/",
+          "source_title": "Kikuchi-Fujimoto disease in the Eastern Mediterranean zone (Scientific Reports 2022)",
+          "content_excerpt": "Between 2006 and 2021, 1968 lymph node biopsies were submitted to the histopathology laboratory, with eleven cases (0.6%) having the diagnosis of KFD. The mean patient age was 32 years (range 4-59), and 73% were females.",
+          "cited_quote": "Between 2006 and 2021, 1968 lymph node biopsies were submitted to the histopathology laboratory, with eleven cases (0.6%) having the diagnosis of KFD.",
+          "gives_root_data": true,
+          "onward_citation": ""
+        }
+      ]
+    },
+    "grounded_findings": [
+      {
+        "finding": "cervical_lymphadenopathy(non_tender) LR+ for Kikuchi-Fujimoto disease",
+        "computed_lr": 1,
+        "lr_formula": "LR+ = sens/(1-spec); sens (P(non-tender|KFD)) ~ 0.5 derivable from root, but spec (P(non-tender|competing dx)) has NO primary data, so LR+ is not computable. Direction: non-tender is mildly ATYPICAL for KFD (KFD nodes are characteristically tender/painful in ~50%), so if anything LR+<1 for this finding favoring KFD.",
+        "reached_root": false,
+        "verdict": "direction_only",
+        "chain": [
+          {
+            "hop": 0,
+            "source_url": "https://www.ncbi.nlm.nih.gov/books/NBK430830/",
+            "source_title": "Kikuchi-Fujimoto Disease - StatPearls (NCBI Bookshelf)",
+            "content_excerpt": "The most prevalent manifestation is unilateral tender posterior cervical lymphadenopathy, observed in 60% to 90% of cases, with occasional involvement of the supraclavicular and axillary nodes. In approximately half of cases, the affected lymph nodes are typically mobile, solitary, nonsuppurative, and painful.",
+            "cited_quote": "In approximately half of cases, the affected lymph nodes are typically mobile, solitary, nonsuppurative, and painful.",
+            "gives_root_data": false,
+            "onward_citation": "StatPearls cites refs [4][30][31] (review/textbook sources); no primary specificity data for non-tender nodes among the competing differential (lymphoma, TB, SLE) exists. Sensitivity side (~50% painful, hence ~50% non-tender) is the only quantity traceable; LR+ requires specificity which is absent."
+          }
+        ]
+      },
+      {
+        "finding": "largest_node(2cm, left, level V / posterior cervical) LR+ for Kikuchi-Fujimoto disease",
+        "computed_lr": 1,
+        "lr_formula": "LR+ = sens/(1-spec). Root data give sens-side facts: node diameter typically 1-2 cm; posterior cervical (level V) involvement in 60-90%. NO primary specificity data (P(2cm posterior-cervical node|competing dx)). LR+ not computable. Direction: a ~2cm posterior-cervical (level V) node is CONCORDANT with KFD's typical presentation, mildly supportive (LR+ >1 plausible) but unquantifiable.",
+        "reached_root": false,
+        "verdict": "direction_only",
+        "chain": [
+          {
+            "hop": 0,
+            "source_url": "https://www.ncbi.nlm.nih.gov/books/NBK430830/",
+            "source_title": "Kikuchi-Fujimoto Disease - StatPearls (NCBI Bookshelf)",
+            "content_excerpt": "Generally, these nodes are enlarged to a diameter of 1 to 2 cm, although larger sizes of up to 7 cm have been reported. The most prevalent manifestation is unilateral tender posterior cervical lymphadenopathy, observed in 60% to 90% of cases, with occasional involvement of the supraclavicular and axillary nodes.",
+            "cited_quote": "Generally, these nodes are enlarged to a diameter of 1 to 2 cm, although larger sizes of up to 7 cm have been reported.",
+            "gives_root_data": false,
+            "onward_citation": "Node-size and posterior-cervical (level V) frequency are review statements [31][4][30]. A 2cm, left, level-V node matches the modal KFD presentation, but no primary study reports P(this node profile | competing diagnoses), so specificity and hence LR+ cannot be derived. Distribution-of-lymphadenopathy primary paper (S1684118219301525) was paywalled (403)."
+          }
+        ]
+      },
+      {
+        "finding": "wbc(1.35, leukopenia) LR+ for Kikuchi-Fujimoto disease",
+        "computed_lr": 1,
+        "lr_formula": "LR+ = sens/(1-spec). Root sensitivity = P(leukopenia|KFD) = 43% (105/244, Kucukardali 2006). Specificity (P(leukopenia|competing dx among young women with febrile cervical lymphadenopathy)) has NO primary data; lymphoma/TB/SLE can also cause leukopenia (esp. SLE), so spec is not ~1. LR+ not computable from root. Direction: leukopenia is moderately sensitive for KFD (~43%) and helps distinguish from reactive/infectious lymphadenitis (typically leukocytosis), so LR+ >1 plausible but unquantified.",
+        "reached_root": true,
+        "verdict": "direction_only",
+        "chain": [
+          {
+            "hop": 0,
+            "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC1481509/",
+            "source_title": "Kikuchi-Fujimoto disease (review, Bosch & Guilabert) - PMC",
+            "content_excerpt": "Leukopenia can be found in up to 50% of the cases. Lymph node size has been found to range from 0.5 to 4 cm, but it may reach 5 to 6 cm and rarely larger than 6 cm.",
+            "cited_quote": "Leukopenia can be found in up to 50% of the cases.",
+            "gives_root_data": false,
+            "onward_citation": "Review borrows the leukopenia frequency; root primary measured number is Kucukardali et al, analysis of 244 cases (next hop)."
+          },
+          {
+            "hop": 1,
+            "source_url": "https://pubmed.ncbi.nlm.nih.gov/16538388/",
+            "source_title": "Kikuchi-Fujimoto Disease: analysis of 244 cases (Kucukardali et al., Clin Rheumatol 2006)",
+            "content_excerpt": "The disease was reported in 244 patients (33% males and 77% females). Mean age was 25 (1-64) and 70% was younger than 30. The most common clinical features were lymphadenomegaly (100%), fever (35%), and the most common laboratory features were leucopenia (43%), high erythrocyte sedimentation rate (40%) and anemia (23%).",
+            "cited_quote": "the most common laboratory features were leucopenia (43%)",
+            "gives_root_data": true,
+            "onward_citation": ""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/code/specs/data/adj57/pipeline/full.workflow.js
+++ b/code/specs/data/adj57/pipeline/full.workflow.js
@@ -1,0 +1,137 @@
+export const meta = {
+  name: 'adj57-full-run',
+  description: 'Full end-to-end run of the generic byte-provenance framework on one fresh case, no comparison arms. L1: ingest into a byte-COVERING partition of typed facts + reasoned discards. L2: derive the leading diagnosis + the links needed to compute its posterior (prior + observed-finding LRs). L3: spider each link to a ROOT source, byte-provenanced. The parent then runs the deterministic Bayesian verdict, every step traced to a CAS span.',
+  phases: [{ title: 'Ingest' }, { title: 'Derive' }, { title: 'SpiderToRoot' }],
+}
+
+const INGEST_SCHEMA = {
+  type: 'object',
+  required: ['source_url', 'ground_truth', 'case_text', 'segments', 'candidate_diagnoses'],
+  properties: {
+    source_url: { type: 'string' },
+    ground_truth: { type: 'string', description: 'final confirmed diagnosis + how established. Held aside.' },
+    case_text: { type: 'string', description: 'the EXACT case-presentation text decomposed (~500-1500 chars, to the decision point, no final answer). segments MUST concatenate to this exactly.' },
+    segments: {
+      type: 'array',
+      description: 'ordered partition of case_text; concatenating segment.text in order reproduces case_text character-for-character.',
+      items: {
+        type: 'object', required: ['text', 'kind'],
+        properties: {
+          text: { type: 'string', description: 'verbatim substring of case_text' },
+          kind: { type: 'string', enum: ['fact', 'discard'] },
+          term: { type: 'string', description: 'for fact: a snake_case predicate, e.g. heart_rate(over_100)' },
+          reason: { type: 'string', description: 'for discard: why this span carries no diagnostic fact' },
+        },
+      },
+    },
+    candidate_diagnoses: { type: 'array', items: { type: 'string' } },
+  },
+}
+const DERIVE_SCHEMA = {
+  type: 'object',
+  required: ['leading_diagnosis', 'prior_population', 'fact_dispositions', 'finding_links'],
+  properties: {
+    leading_diagnosis: { type: 'string', description: 'the single most likely diagnosis the FACTS point to (snake_case), derived from the IR — not ground truth' },
+    prior_population: { type: 'string', description: 'the population whose pretest prevalence of leading_diagnosis is the right prior (e.g. "adults presenting with X")' },
+    fact_dispositions: {
+      type: 'array',
+      description: 'BYTE-PROVENANCE CONTRACT: account for EVERY fact term in the IR exactly once. Each is either USED (it bears on the leading diagnosis or sets the prior) or DISCARDED (with a reason — e.g. an unrelated comorbidity). No fact may be silently ignored.',
+      items: {
+        type: 'object', required: ['fact', 'used'],
+        properties: {
+          fact: { type: 'string', description: 'the fact term, verbatim from the IR (must match an IR fact exactly)' },
+          used: { type: 'boolean' },
+          role: { type: 'string', description: 'if used: how — e.g. "evidence_for_leading", "sets_prior_population", "confirmatory_test"' },
+          reason: { type: 'string', description: 'if discarded: why it does not bear on the leading diagnosis (e.g. "comorbidity unrelated to brucellosis")' },
+        },
+      },
+    },
+    finding_links: {
+      type: 'array',
+      description: 'the subset of USED facts that are LR links to ground for the leading diagnosis. Use the fact term VERBATIM as `finding`.',
+      items: {
+        type: 'object', required: ['finding', 'expected_metric', 'decisive'],
+        properties: {
+          finding: { type: 'string', description: 'the fact term, verbatim from the IR' },
+          expected_metric: { type: 'string', description: 'LR+ | LR- | OR' },
+          decisive: { type: 'boolean' },
+        },
+      },
+    },
+  },
+}
+const SPIDER_SCHEMA = {
+  type: 'object',
+  required: ['prior', 'grounded_findings'],
+  properties: {
+    prior: {
+      type: 'object', required: ['value', 'verdict', 'chain'],
+      properties: {
+        value: { type: 'number', description: 'pretest prevalence of the leading diagnosis as a probability (0 if ungroundable)' },
+        verdict: { type: 'string', enum: ['grounded', 'direction_only', 'fabricated'] },
+        chain: { type: 'array', items: { type: 'object' } },
+      },
+    },
+    grounded_findings: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['finding', 'computed_lr', 'verdict', 'chain'],
+        properties: {
+          finding: { type: 'string' },
+          computed_lr: { type: 'number' },
+          lr_formula: { type: 'string' },
+          verdict: { type: 'string', enum: ['grounded', 'direction_only', 'fabricated'] },
+          reached_root: { type: 'boolean' },
+          chain: {
+            type: 'array',
+            items: {
+              type: 'object', required: ['hop', 'source_url', 'content_excerpt', 'cited_quote'],
+              properties: {
+                hop: { type: 'number' },
+                source_url: { type: 'string' }, source_title: { type: 'string' },
+                content_excerpt: { type: 'string', description: 'the passage read from this source (interned verbatim into the CAS)' },
+                cited_quote: { type: 'string', description: 'the LITERAL sentence within content_excerpt bearing on the claim (verbatim substring)' },
+                gives_root_data: { type: 'boolean' },
+                onward_citation: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const ingestPrompt = `Find ONE real published clinical case (prefer open-access PMC) with a documented final diagnosis, and decompose its PRESENTATION into a byte-covering IR. Pick a DIFFERENT case domain each time (vary it).
+
+1. Choose a self-contained presentation passage (~500-1500 chars), to the diagnostic decision point. Do NOT include the final answer. Copy VERBATIM into case_text.
+2. Partition case_text into ordered segments. CRITICAL: concatenating every segment.text in order must reproduce case_text EXACTLY, character for character — every space, comma, newline, digit. No paraphrase, no reordering, no omission.
+3. Each segment is a fact (diagnostically meaningful — give a snake_case term) or a discard (give a reason). Punctuation/whitespace between facts is usually a discard.
+4. Return candidate_diagnoses, source_url, and held-aside ground_truth.
+Self-check: mentally concatenate the segments and confirm they equal case_text byte-for-byte (including newlines).`
+
+const derivePrompt = (o) => `From the extracted facts of a case, identify the leading diagnosis and the links needed to compute its posterior. Derive from the FACTS, not from any answer.
+
+CANDIDATE DIAGNOSES: ${JSON.stringify(o.candidate_diagnoses)}
+EXTRACTED FACTS (account for EVERY one):
+${o.segments.filter((s) => s.kind === 'fact').map((s) => `  - ${s.term}`).join('\n')}
+
+BYTE-PROVENANCE CONTRACT FOR THIS STAGE: this stage consumes the facts above. You must account for EVERY fact term exactly once in fact_dispositions — each is either USED (with a role: evidence_for_leading / sets_prior_population / confirmatory_test) or DISCARDED (with a reason it does not bear on the leading diagnosis, e.g. an unrelated comorbidity). Do NOT silently ignore any fact. Copy each fact term VERBATIM.
+
+Return: leading_diagnosis (the single most likely, from the facts); prior_population (whose prevalence is the right pretest prior); fact_dispositions (every fact, used-or-discarded-with-reason); and finding_links — the subset of USED facts that are LR links to ground (verbatim finding term, expected_metric, decisive).`
+
+const spiderPrompt = (lead, pop, links) => `You are a byte-provenance spider. Ground the numbers for a Bayesian verdict on diagnosis(${lead}), FOLLOWING CITATIONS BACK TO ROOT SOURCES.
+
+(1) PRIOR: find the pretest prevalence of ${lead} in: ${pop}. Report it as a probability with a chain to a root source.
+(2) FINDING LRs: for EACH decisive link below, compute the likelihood ratio from primary data.
+${links.map((l) => `  - ${l.finding}  (${l.expected_metric})`).join('\n')}
+
+For every source: record content_excerpt (the passage you read, verbatim) and cited_quote (the literal sentence within it). If a source borrows the number, set gives_root_data=false + onward_citation and add a hop fetching that citation; continue to a ROOT source (primary measured number with an N). Compute LR (LR+ = sens/(1-spec); LR- = (1-sens)/spec) and grade verdict (grounded only if it traces to root primary data; direction_only if no usable number; fabricated if unsupported). cited_quote must be a verbatim substring of content_excerpt.`
+
+const ingest = await agent(ingestPrompt, { phase: 'Ingest', label: 'ingest:case', agentType: 'general-purpose', schema: INGEST_SCHEMA })
+const derived = await agent(derivePrompt(ingest), { phase: 'Derive', label: 'derive:leading+links', agentType: 'general-purpose', schema: DERIVE_SCHEMA })
+const decisive = derived.finding_links.filter((l) => l.decisive)
+const spidered = await agent(spiderPrompt(derived.leading_diagnosis, derived.prior_population, (decisive.length ? decisive : derived.finding_links).slice(0, 5)),
+  { phase: 'SpiderToRoot', label: 'spider:root', agentType: 'general-purpose', schema: SPIDER_SCHEMA })
+
+return { ingest, derived, spidered }

--- a/code/specs/data/adj57/pipeline/run.py
+++ b/code/specs/data/adj57/pipeline/run.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""ADJ58 — full run under the universal stage contract.
+
+Drives a full-run workflow result through EVERY stage's coverage gate, composing
+one auditable Trail, interning sources into the CAS, and computing the verdict.
+A stage that fails to account for 100% of its input shows up as a HOLE in the
+trail — the framework no longer claims auditability it doesn't have.
+
+Stages gated here:
+  decompose   case_text (bytes)        -> typed facts + reasoned discards
+  derive      facts (elements)         -> used (link/prior) + discarded-with-reason
+  ground:N    each source page (bytes) -> cited spans + discarded context
+  aggregate   grounded LRs (elements)  -> used in posterior + abstained-with-reason
+
+Run: python run.py <full-results.json>
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import cas  # noqa: E402
+import stage  # noqa: E402
+
+HERE = Path(__file__).resolve().parent.parent
+
+
+def sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def intern_chain(chain: list, used_for: str) -> list:
+    prov = []
+    for hop in chain:
+        content = hop.get("content_excerpt", "")
+        if not content:
+            continue
+        h = cas.find_by_url(hop.get("source_url", "")) or cas.intern(
+            content, url=hop.get("source_url", ""), title=hop.get("source_title", ""))
+        try:
+            sp = cas.cite(h, hop.get("cited_quote", ""), used_for=used_for)
+            prov.append({"hop": hop.get("hop"), "cas": h[:12], "span": [sp["start"], sp["end"]],
+                         "root": hop.get("gives_root_data", False), "quote": hop.get("cited_quote", "")})
+        except ValueError as e:
+            prov.append({"hop": hop.get("hop"), "cas": h[:12], "error": str(e)[:80]})
+        if hop.get("onward_citation"):
+            cas.add_onward(h, hop["onward_citation"])
+    return prov
+
+
+def main() -> None:
+    res = json.loads(Path(sys.argv[1]).read_text())
+    res = res.get("result", res)
+    ingest, derived, spidered = res["ingest"], res["derived"], res["spidered"]
+    lead = derived["leading_diagnosis"]
+    trail = stage.Trail()
+
+    print("=" * 74)
+    print(f"  ADJ58 FULL RUN under the universal stage contract — leading dx: {lead}")
+    print(f"  case: {ingest.get('source_url','')}")
+    print("=" * 74)
+
+    # ---- STAGE: decompose (case bytes -> facts) ----
+    segs = [
+        ({"text": s["text"], "kind": "used", "produced": s.get("term")} if s.get("kind") == "fact"
+         else {"text": s["text"], "kind": "discard", "reason": s.get("reason")})
+        for s in ingest["segments"]
+    ]
+    trail.record(stage.gate_text("decompose", ingest["case_text"], segs))
+    fact_terms = [s["term"] for s in ingest["segments"] if s.get("kind") == "fact"]
+
+    # ---- STAGE: derive (facts -> used/discarded) ----
+    disp = derived.get("fact_dispositions", [])
+    used = [{"id": d["fact"], "produced": d.get("role") or "used"} for d in disp if d.get("used")]
+    disc = [{"id": d["fact"], "reason": d.get("reason")} for d in disp if not d.get("used")]
+    trail.record(stage.gate_elements("derive", fact_terms, used, disc))
+
+    # ---- STAGE(s): ground (each source page -> cited spans + discarded context) ----
+    prior = spidered["prior"]
+    intern_chain(prior.get("chain", []), used_for=f"prior:{lead}")
+    DISCARD_CTX = "surrounding source context; the load-bearing figure is the cited span"
+    for i, hop in enumerate(prior.get("chain", [])):
+        ce = hop.get("content_excerpt", "")
+        if ce:
+            p = stage.partition_text_by_used(ce, [{"text": hop.get("cited_quote", ""), "produced": f"prior P({lead})"}], DISCARD_CTX)
+            trail.record(stage.gate_text("ground:prior", ce, p))
+    for gf in spidered["grounded_findings"]:
+        intern_chain(gf.get("chain", []), used_for=f"{gf['finding']}->{lead}")
+        for hop in gf.get("chain", []):
+            ce = hop.get("content_excerpt", "")
+            if ce:
+                p = stage.partition_text_by_used(ce, [{"text": hop.get("cited_quote", ""), "produced": f"LR {gf.get('finding')}"}], DISCARD_CTX)
+                trail.record(stage.gate_text(f"ground:{gf['finding'][:18]}", ce, p))
+
+    # ---- STAGE: aggregate (grounded LRs -> posterior, abstain-with-reason) ----
+    p0 = prior.get("value", 0)
+    agg_input = [f"prior:{lead}"] + [gf["finding"] for gf in spidered["grounded_findings"]]
+    agg_used, agg_disc = [], []
+    logodds, used_steps = None, []
+    if prior.get("verdict") == "grounded" and 0 < p0 < 1:
+        logodds = math.log(p0 / (1 - p0))
+        agg_used.append({"id": f"prior:{lead}", "produced": f"P0={p0}"})
+    else:
+        agg_disc.append({"id": f"prior:{lead}", "reason": f"prior not grounded ({prior.get('verdict')})"})
+    for gf in spidered["grounded_findings"]:
+        if gf.get("verdict") == "grounded" and gf.get("computed_lr") and logodds is not None:
+            logodds += math.log(gf["computed_lr"])
+            used_steps.append((gf["finding"], gf["computed_lr"], sigmoid(logodds)))
+            agg_used.append({"id": gf["finding"], "produced": f"xLR {gf['computed_lr']}"})
+        else:
+            agg_disc.append({"id": gf["finding"], "reason": f"{gf.get('verdict','?')}: no root LR — abstained"})
+    trail.record(stage.gate_elements("aggregate", agg_input, agg_used, agg_disc))
+
+    # ---- THE TRAIL + THE VERDICT ----
+    print("\n" + trail.summary())
+
+    print("\n## Verdict (every multiplier byte-anchored; abstentions logged above):")
+    if logodds is None:
+        print("   prior not grounded — no defensible posterior.")
+    else:
+        print(f"   prior P({lead}) = {p0:.3f}")
+        for fn, lr, p in used_steps:
+            print(f"   x LR {lr:<6} ({fn:40s}) -> P = {p:.3f}")
+        posterior = sigmoid(logodds)
+        print(f"\n   >>> P({lead}) = {posterior:.4f}   "
+              f"({len(used_steps)} byte-grounded findings; {len(agg_disc)} abstained)")
+    print(f"\n   ground truth (held aside): {ingest.get('ground_truth','')[:180]}")
+    print(f"   CAS: {json.dumps(cas.stats())}")
+    print(f"\n   >>> AUDIT TRAIL {'UNBROKEN — every stage accounted for 100% of its input' if trail.ok() else 'HAS HOLES (see above)'}")
+
+    out = {"leading_diagnosis": lead, "posterior": sigmoid(logodds) if logodds is not None else None,
+           "trail_ok": trail.ok(), "holes": trail.holes(),
+           "trail": json.loads(trail.to_json()),
+           "verdict_steps": [{"finding": f, "lr": lr} for f, lr, _ in used_steps]}
+    (HERE / "run.json").write_text(json.dumps(out, indent=2))
+    sys.exit(0 if trail.ok() else 3)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/stage.py
+++ b/code/specs/data/adj57/pipeline/stage.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""ADJ58 — the universal stage contract.
+
+There is no privileged stage. Every transform in the framework — normalize,
+decompose, derive, ground, aggregate — takes an input and must PROVE it accounted
+for 100% of that input: every used unit cites the output it produced, every
+discarded unit carries a reason, and the proof is appended to one composed,
+auditable Trail. A stage that drops part of its input silently is a hole; the gate
+refuses it.
+
+Two input shapes, one contract:
+
+  - TEXT inputs (a case, a source page): the proof is a PARTITION of the string.
+    Concatenating the segments in order must reproduce the input byte-for-byte.
+    Each segment is `used` (cites what it produced) or `discard` (carries a reason).
+
+  - ELEMENT inputs (a list of facts, a set of grounded LRs): the proof partitions
+    the SET of element ids. Every id is either `used` (cites its output) or
+    `discard` (carries a reason); used ∪ discard == all ids, disjoint.
+
+`clean` means: covered AND every used cites a `produced` AND every discard a
+`reason`. `Trail.ok()` means every stage is clean — the byte-trail is unbroken
+from raw input to final output.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Coverage:
+    stage: str
+    kind: str  # 'text' | 'elements'
+    covered: bool
+    clean: bool
+    n_input: int
+    n_used: int
+    n_discard: int
+    used: list = field(default_factory=list)
+    discards: list = field(default_factory=list)
+    detail: dict = field(default_factory=dict)
+
+
+def gate_text(stage: str, input_text: str, segments: list[dict]) -> Coverage:
+    """segments: ordered [{text, kind:'used'|'discard', produced?:..., reason?:...}].
+    Covered iff concatenating segment.text reproduces input_text exactly."""
+    recon = "".join(s["text"] for s in segments)
+    covered = recon == input_text
+    detail: dict = {}
+    if not covered:
+        i = 0
+        m = min(len(recon), len(input_text))
+        while i < m and recon[i] == input_text[i]:
+            i += 1
+        detail = {"first_divergence": i, "expected": input_text[i:i + 50], "got": recon[i:i + 50]}
+    used = [s for s in segments if s.get("kind") == "used"]
+    disc = [s for s in segments if s.get("kind") == "discard"]
+    clean = covered and all(s.get("produced") for s in used) and all(s.get("reason") for s in disc)
+    return Coverage(stage, "text", covered, clean, len(input_text), len(used), len(disc),
+                    used=used, discards=disc, detail=detail)
+
+
+def partition_text_by_used(input_text: str, used: list[dict], discard_reason: str) -> list[dict]:
+    """Build a text partition from a list of verbatim `used` substrings: locate each
+    (in order, non-overlapping) and fill the gaps between them as `discard` segments
+    with a default reason. Used for stages (like ground) where the agent gives the
+    load-bearing quotes and the surrounding page is context to discard-with-reason."""
+    segments: list[dict] = []
+    pos = 0
+    for u in used:
+        q = u["text"]
+        idx = input_text.find(q, pos)
+        if idx < 0:
+            # quote not verbatim in input -> a provenance break; record it as such
+            segments.append({"text": "", "kind": "discard", "reason": f"BROKEN: quote not found verbatim: {q[:60]!r}"})
+            continue
+        if idx > pos:
+            segments.append({"text": input_text[pos:idx], "kind": "discard", "reason": discard_reason})
+        segments.append({"text": q, "kind": "used", "produced": u.get("produced")})
+        pos = idx + len(q)
+    if pos < len(input_text):
+        segments.append({"text": input_text[pos:], "kind": "discard", "reason": discard_reason})
+    return segments
+
+
+def gate_elements(stage: str, input_ids: list[str], used: list[dict], discards: list[dict]) -> Coverage:
+    """used: [{id, produced}], discards: [{id, reason}]. Covered iff used ∪ discard
+    == set(input_ids) with no id in both and none missing."""
+    uids = [u["id"] for u in used]
+    dids = [d["id"] for d in discards]
+    seen = set(uids) | set(dids)
+    allids = set(input_ids)
+    missing = allids - seen           # silently dropped -> the hole
+    extra = seen - allids             # cited an id that wasn't in the input
+    overlap = set(uids) & set(dids)   # both used and discarded
+    covered = not missing and not extra and not overlap
+    clean = covered and all(u.get("produced") for u in used) and all(d.get("reason") for d in discards)
+    detail = {"missing": sorted(missing), "extra": sorted(extra), "overlap": sorted(overlap)}
+    return Coverage(stage, "elements", covered, clean, len(allids), len(used), len(discards),
+                    used=used, discards=discards, detail=detail)
+
+
+class Trail:
+    """The one composed, auditable log. Every stage appends its Coverage; the trail
+    is ok iff every stage is clean (the byte-trail is unbroken end to end)."""
+
+    def __init__(self) -> None:
+        self.stages: list[Coverage] = []
+
+    def record(self, cov: Coverage) -> Coverage:
+        self.stages.append(cov)
+        return cov
+
+    def ok(self) -> bool:
+        return bool(self.stages) and all(c.clean for c in self.stages)
+
+    def holes(self) -> list[str]:
+        out = []
+        for c in self.stages:
+            if not c.covered:
+                out.append(f"{c.stage}: NOT COVERED ({c.detail})")
+            elif not c.clean:
+                bad_u = [u for u in c.used if not u.get("produced")]
+                bad_d = [d for d in c.discards if not d.get("reason")]
+                out.append(f"{c.stage}: covered but unclean ({len(bad_u)} used w/o citation, {len(bad_d)} discard w/o reason)")
+        return out
+
+    def summary(self) -> str:
+        lines = ["AUDIT TRAIL — every stage must account for 100% of its input:"]
+        for c in self.stages:
+            mark = "OK " if c.clean else ("!! " if not c.covered else " ~ ")
+            if c.kind == "text":
+                ub = sum(len(u["text"]) for u in c.used)
+                db = sum(len(d["text"]) for d in c.discards)
+                lines.append(f"  [{mark}] {c.stage:14s} text  {c.n_input:5d} bytes = "
+                             f"{c.n_used} used ({ub}b) + {c.n_discard} discard ({db}b)")
+            else:
+                lines.append(f"  [{mark}] {c.stage:14s} elem  {c.n_input:5d} units = "
+                             f"{c.n_used} used + {c.n_discard} discard"
+                             + (f"  MISSING={c.detail['missing']}" if c.detail.get("missing") else ""))
+        lines.append(f"  => trail {'UNBROKEN (every stage byte-accounted)' if self.ok() else 'HAS HOLES: ' + '; '.join(self.holes())}")
+        return "\n".join(lines)
+
+    def to_json(self) -> str:
+        return json.dumps([{
+            "stage": c.stage, "kind": c.kind, "covered": c.covered, "clean": c.clean,
+            "n_input": c.n_input, "n_used": c.n_used, "n_discard": c.n_discard,
+            "discards": [{"reason": d.get("reason"), **({"id": d["id"]} if "id" in d else {"bytes": len(d.get("text", ""))})} for d in c.discards],
+            "detail": c.detail,
+        } for c in self.stages], indent=2)

--- a/code/specs/data/adj57/pipeline/test_stage.py
+++ b/code/specs/data/adj57/pipeline/test_stage.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tests for the universal stage contract (stage.py). Run: python test_stage.py"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import stage  # noqa: E402
+
+
+def test_text_full_partition_is_clean():
+    cov = stage.gate_text("decompose", "HR 120. Glaucoma.", [
+        {"text": "HR 120.", "kind": "used", "produced": "heart_rate(120)"},
+        {"text": " ", "kind": "discard", "reason": "whitespace"},
+        {"text": "Glaucoma.", "kind": "used", "produced": "glaucoma(present)"}])
+    assert cov.covered and cov.clean
+    assert cov.n_used == 2 and cov.n_discard == 1
+
+
+def test_text_lossy_partition_is_caught():
+    cov = stage.gate_text("decompose", "HR 120. Glaucoma.", [
+        {"text": "HR 120.", "kind": "used", "produced": "heart_rate(120)"}])  # drops " Glaucoma."
+    assert not cov.covered
+    assert cov.detail["first_divergence"] == 7
+
+
+def test_text_used_without_citation_is_unclean():
+    cov = stage.gate_text("decompose", "X", [{"text": "X", "kind": "used"}])  # no produced
+    assert cov.covered and not cov.clean
+
+
+def test_elements_silent_drop_is_caught():
+    cov = stage.gate_elements("derive", ["a", "b"], used=[{"id": "a", "produced": "link"}], discards=[])
+    assert not cov.covered
+    assert cov.detail["missing"] == ["b"]
+
+
+def test_elements_full_accounting_is_clean():
+    cov = stage.gate_elements("derive", ["a", "b"],
+                              used=[{"id": "a", "produced": "link"}],
+                              discards=[{"id": "b", "reason": "unrelated comorbidity"}])
+    assert cov.covered and cov.clean
+
+
+def test_elements_discard_without_reason_is_unclean():
+    cov = stage.gate_elements("derive", ["a"], used=[], discards=[{"id": "a"}])  # no reason
+    assert cov.covered and not cov.clean
+
+
+def test_partition_by_used_fills_gaps():
+    text = "Background. Sensitivity was 0.92 here. End."
+    segs = stage.partition_text_by_used(text, [{"text": "Sensitivity was 0.92", "produced": "LR"}], "context")
+    assert "".join(s["text"] for s in segs) == text  # reconstructs exactly
+    assert sum(s["kind"] == "used" for s in segs) == 1
+    assert sum(s["kind"] == "discard" for s in segs) == 2
+
+
+def test_partition_by_used_flags_nonverbatim_quote():
+    segs = stage.partition_text_by_used("real text", [{"text": "NOT PRESENT", "produced": "x"}], "ctx")
+    assert any("BROKEN" in s.get("reason", "") for s in segs)
+
+
+def test_trail_ok_only_when_all_clean():
+    t = stage.Trail()
+    t.record(stage.gate_text("a", "X", [{"text": "X", "kind": "used", "produced": "p"}]))
+    assert t.ok()
+    t.record(stage.gate_elements("b", ["x"], used=[], discards=[]))  # hole
+    assert not t.ok()
+    assert any("b:" in h for h in t.holes())
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"  ok  {fn.__name__}")
+    print(f"\n{len(fns)} tests passed.")

--- a/code/specs/data/adj57/pipeline/verdict.py
+++ b/code/specs/data/adj57/pipeline/verdict.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""ADJ57 full-run verdict — the deterministic answer at the end of the byte-
+provenance pipeline.
+
+From a full-run workflow result it: (L1) checks the case partition reconstructs
+the input byte-for-byte; (L0/L3) interns the prior + every finding source into the
+CAS with byte-anchored citation spans; then computes the posterior for the leading
+diagnosis as a sequential Bayesian update where EVERY step prints the CAS source
+it came from. Ungrounded numbers (direction_only / fabricated) do not move the
+posterior — the framework abstains rather than invent.
+
+Run: python verdict.py <full-results.json>
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import cas  # noqa: E402
+import coverage  # noqa: E402
+
+HERE = Path(__file__).resolve().parent.parent
+
+
+def sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def intern_chain(chain: list, used_for: str) -> list:
+    """Intern every hop's source into the CAS and byte-provenance its quote."""
+    prov = []
+    for hop in chain:
+        content = hop.get("content_excerpt", "")
+        if not content:
+            prov.append({"hop": hop.get("hop"), "error": "no content_excerpt"})
+            continue
+        h = cas.find_by_url(hop.get("source_url", "")) or cas.intern(
+            content, url=hop.get("source_url", ""), title=hop.get("source_title", ""))
+        try:
+            span = cas.cite(h, hop.get("cited_quote", ""), used_for=used_for)
+            prov.append({"hop": hop.get("hop"), "cas": h[:12], "span": [span["start"], span["end"]],
+                         "root": hop.get("gives_root_data", False), "url": hop.get("source_url", ""),
+                         "quote": hop.get("cited_quote", "")[:110]})
+        except ValueError as e:
+            prov.append({"hop": hop.get("hop"), "cas": h[:12], "error": str(e)[:80]})
+        if hop.get("onward_citation"):
+            cas.add_onward(h, hop["onward_citation"])
+    return prov
+
+
+def main() -> None:
+    res = json.loads(Path(sys.argv[1]).read_text())
+    res = res.get("result", res)
+    ingest, derived, spidered = res["ingest"], res["derived"], res["spidered"]
+    lead = derived["leading_diagnosis"]
+
+    print("=" * 72)
+    print(f"  ADJ57 FULL RUN — leading diagnosis: {lead}")
+    print(f"  case source: {ingest.get('source_url','')}")
+    print("=" * 72)
+
+    print("\n## L1 — case -> IR byte coverage")
+    cov = coverage.check(ingest["case_text"], ingest["segments"])
+    if cov["covered"]:
+        print(f"   TOTAL COVERAGE: {cov['facts']} typed facts ({cov['pct_in_facts']}%) + "
+              f"{cov['discards']} reasoned discards ({cov['pct_discarded']}%) = 100% of {cov['total_bytes']} bytes."
+              f"  clean={cov['clean']}")
+    else:
+        print(f"   COVERAGE VIOLATION at byte {cov['first_divergence_offset']}: "
+              f"expects {cov['expected_next']!r}, got {cov['got_next']!r}")
+
+    print("\n## L0/L3 — intern sources, byte-provenance to root, then VERDICT")
+    prior = spidered["prior"]
+    prior_prov = intern_chain(prior.get("chain", []), used_for=f"prior:{lead}")
+    p0 = prior.get("value", 0)
+    if prior.get("verdict") != "grounded" or not (0 < p0 < 1):
+        print(f"   prior NOT grounded (verdict={prior.get('verdict')}, value={p0}) — cannot compute a grounded posterior.")
+        return
+    logodds = math.log(p0 / (1 - p0))
+    root = next((p for p in reversed(prior_prov) if p.get("root")), prior_prov[-1] if prior_prov else {})
+    print(f"\n   prior P({lead}) = {p0:.3f}   [grounded]  CAS {root.get('cas','?')} bytes {root.get('span')}")
+    print(f"     \"{root.get('quote','')}\"")
+
+    used, gaps = [], []
+    for f in spidered["grounded_findings"]:
+        prov = intern_chain(f.get("chain", []), used_for=f"{f['finding']}->{lead}")
+        if f.get("verdict") != "grounded" or not f.get("computed_lr"):
+            gaps.append((f["finding"], f.get("verdict"), prov))
+            continue
+        lr = f["computed_lr"]
+        logodds += math.log(lr)
+        r = next((p for p in reversed(prov) if p.get("root")), prov[-1] if prov else {})
+        used.append((f["finding"], lr, sigmoid(logodds), r))
+        print(f"   x LR {lr:<6} ({f['finding']:42s}) -> P = {sigmoid(logodds):.3f}  "
+              f"[grounded] CAS {r.get('cas','?')} {r.get('span')}")
+
+    print(f"\n   >>> VERDICT: P({lead}) = {sigmoid(logodds):.4f}  "
+          f"(from {len(used)} byte-grounded findings x grounded prior)")
+    if gaps:
+        print("\n   data-gaps (did NOT move the posterior — no root number, framework abstains):")
+        for fn, v, _ in gaps:
+            print(f"     - {fn}: {v}")
+    print(f"\n   ground truth (held aside from the pipeline): {ingest.get('ground_truth','')[:200]}")
+    print(f"   CAS now holds: {json.dumps(cas.stats())}")
+
+    out = {"leading_diagnosis": lead, "posterior": sigmoid(logodds), "prior": p0,
+           "coverage": {k: cov.get(k) for k in ("covered", "clean", "facts", "discards", "total_bytes")},
+           "used_findings": [{"finding": f, "lr": lr} for f, lr, _, _ in used],
+           "data_gaps": [{"finding": fn, "verdict": v} for fn, v, _ in gaps]}
+    (HERE / "verdict.json").write_text(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/run.json
+++ b/code/specs/data/adj57/run.json
@@ -1,0 +1,429 @@
+{
+  "leading_diagnosis": "kikuchi_fujimoto_disease",
+  "posterior": null,
+  "trail_ok": true,
+  "holes": [],
+  "trail": [
+    {
+      "stage": "decompose",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 1788,
+      "n_used": 46,
+      "n_discard": 47,
+      "discards": [
+        {
+          "reason": "article and whitespace, no diagnostic content",
+          "bytes": 2
+        },
+        {
+          "reason": "whitespace",
+          "bytes": 1
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 32
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 16
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 17
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation and conjunction",
+          "bytes": 6
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 19
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 24
+        },
+        {
+          "reason": "conjunction",
+          "bytes": 5
+        },
+        {
+          "reason": "connective phrasing introducing negatives",
+          "bytes": 47
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 12
+        },
+        {
+          "reason": "punctuation and conjunction",
+          "bytes": 5
+        },
+        {
+          "reason": "connective phrasing introducing negatives",
+          "bytes": 26
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 49
+        },
+        {
+          "reason": "connective phrasing introducing negatives",
+          "bytes": 20
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation and conjunction",
+          "bytes": 5
+        },
+        {
+          "reason": "paragraph break and connective phrasing",
+          "bytes": 45
+        },
+        {
+          "reason": "conjunction",
+          "bytes": 5
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 9
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 12
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 25
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 22
+        },
+        {
+          "reason": "connective phrasing introducing negatives",
+          "bytes": 15
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation and conjunction",
+          "bytes": 5
+        },
+        {
+          "reason": "paragraph break and connective phrasing",
+          "bytes": 38
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 8
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 49
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 7
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 14
+        },
+        {
+          "reason": "connective phrasing introducing negative",
+          "bytes": 20
+        },
+        {
+          "reason": "conjunction",
+          "bytes": 4
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "paragraph break and connective phrasing",
+          "bytes": 42
+        },
+        {
+          "reason": "punctuation",
+          "bytes": 2
+        },
+        {
+          "reason": "punctuation and conjunction",
+          "bytes": 6
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 53
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 6
+        },
+        {
+          "reason": "connective phrasing",
+          "bytes": 8
+        },
+        {
+          "reason": "terminal punctuation",
+          "bytes": 1
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "derive",
+      "kind": "elements",
+      "covered": true,
+      "clean": true,
+      "n_input": 46,
+      "n_used": 24,
+      "n_discard": 22,
+      "discards": [
+        {
+          "reason": "remote childhood-type renal comorbidity; no current renal findings (no edema, normal BP), does not bear on KFD",
+          "id": "past_history(post_streptococcal_glomerulonephritis)"
+        },
+        {
+          "reason": "nonspecific constitutional symptom, no discriminating value among candidates",
+          "id": "fatigue(increased)"
+        },
+        {
+          "reason": "nonspecific constitutional symptom, no discriminating value",
+          "id": "malaise(present)"
+        },
+        {
+          "reason": "nonspecific constitutional symptom",
+          "id": "appetite_loss(present)"
+        },
+        {
+          "reason": "nonspecific B-symptom; present across multiple candidates, low discrimination for KFD",
+          "id": "weight_loss(present)"
+        },
+        {
+          "reason": "travel/exposure context; argues against geographically-acquired infection but not specific to KFD discrimination",
+          "id": "recent_travel(absent)"
+        },
+        {
+          "reason": "lowers HIV/STI prior but not discriminating between remaining candidates",
+          "id": "risky_sexual_exposure(absent)"
+        },
+        {
+          "reason": "lowers blood-borne infection prior; not discriminating for KFD",
+          "id": "iv_drug_use(absent)"
+        },
+        {
+          "reason": "lowers transfusion-borne infection prior; not discriminating",
+          "id": "blood_transfusion(absent)"
+        },
+        {
+          "reason": "duplicate of fever(high_grade) already counted; avoid double-counting",
+          "id": "febrile(present)"
+        },
+        {
+          "reason": "physical correlate of anemia already captured by hemoglobin(10_anemia)",
+          "id": "pallor(present)"
+        },
+        {
+          "reason": "normal body habitus, no diagnostic bearing",
+          "id": "bmi(23)"
+        },
+        {
+          "reason": "duplicate of alopecia(absent) already counted; avoid double-counting",
+          "id": "alopecia(absent_on_exam)"
+        },
+        {
+          "reason": "absence of renal/nephrotic sign; no current bearing given remote PSGN excluded",
+          "id": "periorbital_puffiness(absent)"
+        },
+        {
+          "reason": "absence of renal/fluid-overload sign; no bearing on KFD",
+          "id": "ankle_edema(absent)"
+        },
+        {
+          "reason": "normal vital sign, no diagnostic discrimination",
+          "id": "blood_pressure(110_70)"
+        },
+        {
+          "reason": "mild tachycardia expected with fever; nonspecific",
+          "id": "pulse(100_bpm)"
+        },
+        {
+          "reason": "normal; argues against pulmonary process but already covered by clear lung exam",
+          "id": "oxygen_saturation(98_room_air)"
+        },
+        {
+          "reason": "absence; low discriminating value among candidates",
+          "id": "hepatomegaly(absent)"
+        },
+        {
+          "reason": "absence of serositis/fluid; nonspecific here",
+          "id": "ascites(absent)"
+        },
+        {
+          "reason": "normal exam, no diagnostic bearing",
+          "id": "neuro_exam(normal)"
+        },
+        {
+          "reason": "nonspecific acute-phase elevation; redundant with ESR and present across all inflammatory candidates",
+          "id": "crp(35_elevated)"
+        }
+      ],
+      "detail": {
+        "missing": [],
+        "extra": [],
+        "overlap": []
+      }
+    },
+    {
+      "stage": "ground:prior",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 220,
+      "n_used": 1,
+      "n_discard": 1,
+      "discards": [
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 70
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "ground:cervical_lymphaden",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 311,
+      "n_used": 1,
+      "n_discard": 1,
+      "discards": [
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 194
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "ground:largest_node(2cm, ",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 313,
+      "n_used": 1,
+      "n_discard": 1,
+      "discards": [
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 194
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "ground:wbc(1.35, leukopen",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 164,
+      "n_used": 1,
+      "n_discard": 1,
+      "discards": [
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 114
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "ground:wbc(1.35, leukopen",
+      "kind": "text",
+      "covered": true,
+      "clean": true,
+      "n_input": 321,
+      "n_used": 1,
+      "n_discard": 2,
+      "discards": [
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 203
+        },
+        {
+          "reason": "surrounding source context; the load-bearing figure is the cited span",
+          "bytes": 61
+        }
+      ],
+      "detail": {}
+    },
+    {
+      "stage": "aggregate",
+      "kind": "elements",
+      "covered": true,
+      "clean": true,
+      "n_input": 4,
+      "n_used": 0,
+      "n_discard": 4,
+      "discards": [
+        {
+          "reason": "prior not grounded (direction_only)",
+          "id": "prior:kikuchi_fujimoto_disease"
+        },
+        {
+          "reason": "direction_only: no root LR \u2014 abstained",
+          "id": "cervical_lymphadenopathy(non_tender) LR+ for Kikuchi-Fujimoto disease"
+        },
+        {
+          "reason": "direction_only: no root LR \u2014 abstained",
+          "id": "largest_node(2cm, left, level V / posterior cervical) LR+ for Kikuchi-Fujimoto disease"
+        },
+        {
+          "reason": "direction_only: no root LR \u2014 abstained",
+          "id": "wbc(1.35, leukopenia) LR+ for Kikuchi-Fujimoto disease"
+        }
+      ],
+      "detail": {
+        "missing": [],
+        "extra": [],
+        "overlap": []
+      }
+    }
+  ],
+  "verdict_steps": []
+}


### PR DESCRIPTION
**There is no privileged stage.** ADJ57 gated one arrow (case→IR); ADJ58 makes the byte-provenance gate **universal**. Every transform must prove it accounted for 100% of its input — used units cite the output they produced, discarded units carry a reason — composed into one auditable `Trail`.

## The contract (`pipeline/stage.py`, 9 unit tests)
Two input shapes, one gate:
- **TEXT** (a case, a source page): segments must concatenate back to the input byte-for-byte.
- **ELEMENT** (facts, grounded LRs): `used ∪ discard == all ids`, disjoint.

`clean` = covered + every used cites + every discard reasons. `Trail.ok()` = unbroken byte-trail end to end. A stage that drops part of its input is a **visible HOLE**, not a silent gap.

## Every arrow now gated (`pipeline/run.py`)
`decompose` (bytes→facts) · **`derive`** (facts→used/discarded — the retrofit) · `ground:*` (page→cited span + discarded context) · `aggregate` (LRs→posterior / abstain-with-reason).

The **`derive` retrofit** closes the visible hole: the workflow now emits `fact_dispositions` — every fact is USED (role) or DISCARDED (reason). Comorbidities/negatives can no longer be silently ignored.

## The run — Kikuchi-Fujimoto disease (PMC11724740), a *rare* biopsy-defined entity
```
[OK] decompose  text 1788 bytes = 46 used + 47 discard
[OK] derive     elem   46 facts = 24 used + 22 discarded-with-reason
[OK] ground:*          5 source pages, each = cited span + discarded context
[OK] aggregate  elem    4 units = 0 used  + 4 abstained-with-reason
=> trail UNBROKEN     trail_ok=True, holes=[]
```
**Verdict: the framework ABSTAINED** — leading dx `kikuchi_fujimoto_disease` (correct), but the prior + all finding LRs came back `direction_only` (no LR literature exists for this rare disease), so *"no defensible posterior."* A hallucinating system would emit a confident "KFD 90%" with invented numbers; this one names the suspicion, accounts for every byte (unbroken trail), and **refuses to fabricate** — the same conclusion the real workup reached (biopsy). The CAS also **accumulated** pheo + KFD sources (4 → 8), demonstrating reuse.

Security review: passed. Spec: `code/specs/ADJ58-universal-stage-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)