### PR TITLE
test(closure-pass-constant-fold): CLOC12.27 — close gap-012 (route testHook to constant-fold)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
+++ b/code/packages/rust/closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs
@@ -603,3 +603,56 @@ fn test_same_unary_on_identifier_in_comparison() {
         unary(UnaryOperator::Plus, ident("x")),
     ));
 }
+
+// =====================================================================
+// Re-ports from `PeepholeRemoveDeadCodeTest` (CLOC12 gap-012 routing)
+// =====================================================================
+//
+// Upstream's `PeepholeRemoveDeadCodeTest::testHook` exercises
+// `ConditionalExpression` (ternary) cleanups. Those cleanups belong
+// in *this* crate (constant-fold), not in `closure-pass-dce`. CLOC12
+// gap-012 tracks the routing of those tests across crates.
+//
+// What we can already cover today:
+//
+//   * Literal-test ternary collapse: `true ? c : a` → `c`,
+//     `false ? c : a` → `a`. Handled in `fold_conditional` via
+//     `literal_truthy`; pinned by existing inline tests in
+//     `closure-pass-constant-fold/src/lib.rs::tests::fold_*` and
+//     by upstream `testHook` lines like `assertFoldSameTo(...)`.
+//
+// What requires Phase 1.x AST extensions before we can land:
+//
+//   * `var x = a ? true : true;` → `var x = (a, true);` — needs the
+//     `SequenceExpression` AST node (the comma operator).
+//     `a` could have observable side effects (call, getter, even an
+//     undeclared-identifier ReferenceError), so the cleanup is *not*
+//     `var x = true;` — it must preserve evaluating `a` for effect.
+//     Without `SequenceExpression`, the upstream rewrite shape is
+//     unrepresentable.
+//
+// Resolution: gap-012 is RESOLVED for the lines we can model today
+// (via existing same-arm-folding code paths) and the
+// SequenceExpression-dependent rewrites are tracked as a separate
+// Phase 1.x AST gap (not a missing fold rule). The placeholder below
+// makes the routing visible in the constant-fold port file's test
+// listing.
+
+/// Routing marker for CLOC12 gap-012. The upstream
+/// `PeepholeRemoveDeadCodeTest::testHook` lines that depend on
+/// SequenceExpression (`a ? X : X` → `(a, X)`) remain deferred until
+/// `javascript-ast` grows the `SequenceExpression` variant. The
+/// literal-test cases are covered by `fold_conditional` and the
+/// inline tests `fold_conditional_*` in the crate's `src/lib.rs`.
+#[test]
+#[ignore = "blocked on SequenceExpression AST variant (Phase 1.x); literal-test cases covered by fold_conditional inline tests"]
+fn test_hook_ternary_cleanup_sequence_dependent() {
+    // Would assert (when SequenceExpression lands):
+    //   fold("var x = a ? true : true", "var x = (a, true)");
+    //   fold("var x = a ? false : false", "var x = (a, false)");
+    //   fold("var x = a ? 1 : 1", "var x = (a, 1)");
+    //
+    // These shapes collapse the two-equal-arms case while still
+    // evaluating `a` once for its observable side effects (call,
+    // getter, ReferenceError from undeclared identifier).
+}

--- a/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
@@ -398,12 +398,19 @@ fn test_if_with_constant_test_collapse() {
 ///   fold("var x = a ? true : true", "var x = (a, true)");
 ///   ... (ConditionalExpression cleanup) ...
 ///
-/// ConditionalExpression (ternary) cleanup is constant-fold's
-/// responsibility, not DCE's.
+/// **gap-012 routed in CLOC12.27**: ConditionalExpression cleanup is
+/// constant-fold's responsibility. The routing test stub lives at
+/// `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs::test_hook_ternary_cleanup_sequence_dependent`.
+/// The literal-test ternary cases are already covered by
+/// `fold_conditional` + `literal_truthy` (inline tests in the
+/// constant-fold crate). The SequenceExpression-dependent rewrites
+/// (`a ? X : X` → `(a, X)`) are deferred until `javascript-ast`
+/// grows a `SequenceExpression` variant.
 #[test]
-#[ignore = "blocked on gap-012: ConditionalExpression cleanup lives in constant-fold, not DCE"]
+#[ignore = "routed in CLOC12.27 to closure-pass-constant-fold (gap-012); SequenceExpression-dependent shapes deferred to Phase 1.x AST work"]
 fn test_hook_cleanup() {
-    // Belongs in constant-fold's tests/upstream/, not here.
+    // Routed. See doc comment above for the new home in
+    // constant-fold's port file.
 }
 
 /// Upstream `testFoldUselessFor`:

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -100,11 +100,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-012 — `ConditionalExpression` cleanup lives in `constant-fold`, not DCE
 
-- **Status:** ROUTING (not a missing feature)
+- **Status:** RESOLVED in CLOC12.27 — the upstream `testHook` test was re-routed to `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs::test_hook_ternary_cleanup_sequence_dependent` (an `#[ignore]`-d stub), and the DCE port file's `test_hook_cleanup` was reannotated to point at the new home. The literal-test ternary cases (`true ? c : a` → `c`, `false ? c : a` → `a`) are already covered by `fold_conditional` + `literal_truthy` in the constant-fold crate's inline tests. The SequenceExpression-dependent rewrites (`a ? X : X` → `(a, X)`) are *not* a fold-rule gap but a Phase 1.x AST gap — they require `javascript-ast` to grow a `SequenceExpression` variant before they can be represented, let alone folded. Tracked separately under "needs SequenceExpression" — *not* under any CLOC12 gap-NNN entry, because the missing piece is a primary AST node rather than a constant-fold rule.
 - **Upstream test:** `PeepholeRemoveDeadCodeTest::testHook` (`a ? b : c` cleanup)
-- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
-- **Why it fails:** Belongs in `closure-pass-constant-fold`. Some of these are already covered by the constant-fold inline tests; the rest will get ported when CLOC12.0N expands the `PeepholeFoldConstantsTest` coverage.
-- **What it needs:** Re-port into `closure-pass-constant-fold/tests/upstream/`.
+- **Ported file:** `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs` (re-routed in CLOC12.27); the original DCE port file points to the new home via a doc comment.
 
 ### gap-013 — useless-loop-body folding not in DCE
 


### PR DESCRIPTION
## Summary

Closes **gap-012**. Pure bookkeeping. No production code changed.

Routes the upstream `PeepholeRemoveDeadCodeTest::testHook` test from its incorrect home in `closure-pass-dce`'s port file to the correct home in `closure-pass-constant-fold`'s port file, where ConditionalExpression cleanup actually lives.

## What's covered today vs deferred

- ✅ Literal-test ternary collapse (`true ? c : a` → `c`, `false ? c : a` → `a`) — already handled by `fold_conditional` + `literal_truthy` in the constant-fold crate; covered by existing inline tests.
- ⏳ Same-arms SequenceExpression rewrite (`a ? X : X` → `(a, X)`) — requires `SequenceExpression` AST variant. Not a fold-rule gap; a primary AST gap. Tracked separately.

## Changes

- `closure-pass-constant-fold/tests/upstream/peephole_fold_constants_test.rs` — adds `test_hook_ternary_cleanup_sequence_dependent` (`#[ignore]`-d stub) documenting the routing.
- `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs` — updates `test_hook_cleanup`'s ignore reason to mark the routing and point at the new home.
- `code/specs/CLOC12-gaps.md` — gap-012 flipped ROUTING → RESOLVED.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-constant-fold` → 41 inline + 14 upstream (1 → 2 ignored; new routing stub)
- [x] `cargo test -p coding-adventures-closure-pass-dce` → 14 inline + 8 upstream (4 ignored — unchanged counts; one ignore reason updated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)