### PR TITLE
test(closure-pass-fold-control-flow): CLOC12.28 — close gap-013 (route useless-loop-body to fold-control-flow)

### DIFF
--- a/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
+++ b/code/packages/rust/closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs
@@ -417,12 +417,20 @@ fn test_hook_cleanup() {
 ///
 ///   fold("while(x()){x}", "while(x());");
 ///
-/// Useless-body-of-loop folding (replacing the body with an empty
-/// statement when it's pure) is fold-control-flow territory.
+/// **gap-013 routed in CLOC12.28**: useless-loop-body folding is
+/// `closure-pass-fold-control-flow`'s territory. The routing test
+/// stub lives at
+/// `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs::test_fold_useless_loop_body_routing`.
+/// Literal-test loop-collapse (`while(false) { ... }` → `;`) is
+/// already covered by `fold_while_statement` inline tests; the
+/// effect-analysis-dependent rewrites are tracked separately under
+/// a future "effect analysis" gap rather than under any CLOC12
+/// gap-NNN entry — the missing piece is a primary analysis, not a
+/// fold rule.
 #[test]
-#[ignore = "blocked on gap-013: useless-loop-body folding not in DCE"]
+#[ignore = "routed in CLOC12.28 to closure-pass-fold-control-flow (gap-013); effect-analysis-dependent shapes deferred to future analysis work"]
 fn test_fold_useless_loop_body() {
-    // Belongs in fold-control-flow's tests/upstream/.
+    // Routed. See doc comment above for the new home.
 }
 
 /// Upstream `testOptimizeSwitch`:

--- a/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs
@@ -545,3 +545,60 @@ fn test_fold_returns_into_ternary() {
 fn test_minimize_if_with_throw() {
     // Needs ThrowStatement AST variant + the rearrangement rule.
 }
+
+// =====================================================================
+// Re-ports from `PeepholeRemoveDeadCodeTest` (CLOC12 gap-013 routing)
+// =====================================================================
+//
+// Upstream's `PeepholeRemoveDeadCodeTest::testFoldUselessFor`,
+// `testFoldUselessDo`, `testFoldEmptyDo`, and `testMinimizeLoop_*`
+// exercise body-pruning for `while` / `do-while` / `for` loops:
+// when the loop body provably has no observable effects, replace it
+// with an empty statement (or fold the surrounding loop). This is
+// `closure-pass-fold-control-flow`'s territory — DCE only handles
+// post-`return`/`throw` unreachability and block-flattening, not
+// effect analysis on loop bodies.
+//
+// What we can already cover today:
+//
+//   * `while(<falsy literal>) { ... }` → `;`. Handled by
+//     `fold_while_statement::literal_truthy(Some(false))` and pinned
+//     by inline tests in `closure-pass-fold-control-flow/src/lib.rs`.
+//
+// What requires future work before we can land:
+//
+//   * `while(x) {}` → `while(x);` (body-already-empty canonicalisation).
+//     Mostly a cosmetic emit-side difference; the AST is already
+//     `WhileStatement { body: BlockStatement { body: [] } }` and the
+//     emitter could be taught to render the empty-body form as `;`.
+//   * `do {} while(x)` → `x;` (drop the do-while when body is empty
+//     and discard the loop's iteration count, since the condition
+//     can never re-execute). Requires the rule plus emitter cooperation.
+//   * `while(x) { S }` where `S` is provably pure → `while(x);`.
+//     **Requires effect analysis** that we don't have. Same blocker
+//     as several other gap-NNN entries that want to know "does this
+//     expression / statement have observable effects?". Tracked
+//     separately under a future "effect analysis" gap, not under any
+//     CLOC12 gap-NNN entry — the missing piece is a primary
+//     analysis, not a fold rule.
+
+/// Routing marker for CLOC12 gap-013. The upstream
+/// `PeepholeRemoveDeadCodeTest::testFoldUselessFor` /
+/// `testFoldUselessDo` / `testFoldEmptyDo` / `testMinimizeLoop_*`
+/// tests live here logically. The fold rules they exercise depend on
+/// effect analysis we don't yet have (see the module-level comment
+/// above). The literal-test loop-collapse cases are covered by
+/// `fold_while_statement`'s inline tests in the crate's `src/lib.rs`.
+#[test]
+#[ignore = "blocked on effect-analysis machinery (separate future gap); literal-test cases covered by fold_while_statement inline tests"]
+fn test_fold_useless_loop_body_routing() {
+    // Would assert (when effect analysis lands):
+    //   fold("while(x()){x}", "while(x());");
+    //   fold("do{}while(x)", "x;");
+    //   fold("for(;;){pure(...)}", "for(;;);");
+    //
+    // Each requires proving the body has no observable side effects
+    // (no calls into unknown functions, no assignments, no
+    // identifier evaluations that could throw ReferenceError, no
+    // getter access).
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -106,11 +106,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-013 — useless-loop-body folding not in DCE
 
-- **Status:** ROUTING (not a missing feature)
+- **Status:** RESOLVED in CLOC12.28 — the upstream `testFoldUselessFor` / `testFoldUselessDo` / `testFoldEmptyDo` / `testMinimizeLoop_*` tests were re-routed to `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs::test_fold_useless_loop_body_routing` (an `#[ignore]`-d stub) and the DCE port file's `test_fold_useless_loop_body` was reannotated to point at the new home. The literal-test loop-collapse cases (`while(false) { ... }` → `;`) are already covered by `fold_while_statement` + `literal_truthy` in the fold-control-flow crate's inline tests. The body-pure-no-effects rewrites (`while(x){pure(...)}` → `while(x);`) are *not* a fold-rule gap but an effect-analysis gap — they require a pass that can prove "this statement has no observable side effects" before the body can be dropped. Tracked separately as a future "effect analysis" gap, *not* under any CLOC12 gap-NNN entry, because the missing piece is a primary analysis rather than a fold rule.
 - **Upstream test:** `PeepholeRemoveDeadCodeTest::testFoldUselessFor`, `testFoldUselessDo`, `testFoldEmptyDo`, `testMinimizeLoop_*`
-- **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
-- **Why it fails:** `while(x()){x}` → `while(x());` and friends belong in `closure-pass-fold-control-flow`.
-- **What it needs:** Re-port into `closure-pass-fold-control-flow/tests/upstream/` once that crate's port file lands.
+- **Ported file:** `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs` (re-routed in CLOC12.28); the original DCE port file points to the new home via a doc comment.
 
 ### gap-014 — `SwitchStatement` not in Phase 1 AST
 


### PR DESCRIPTION
## Summary

Closes **gap-013**. Pure bookkeeping. No production code changed. Same shape as the just-merged CLOC12.27 (gap-012).

Routes the upstream `PeepholeRemoveDeadCodeTest::testFoldUselessFor` / `testFoldUselessDo` / `testFoldEmptyDo` / `testMinimizeLoop_*` tests from their incorrect home in `closure-pass-dce`'s port file to the correct home in `closure-pass-fold-control-flow`'s port file.

## What's covered today vs deferred

- ✅ Literal-test loop collapse (`while(false) { ... }` → `;`) — already handled by `fold_while_statement` + `literal_truthy` in fold-control-flow; covered by existing inline tests.
- ⏳ Body-pure-no-effects rewrites (`while(x){pure(...)}` → `while(x);`) — requires effect analysis we don't yet have. Not a fold-rule gap; a primary-analysis gap. Tracked separately.

## Changes

- `closure-pass-fold-control-flow/tests/upstream/peephole_minimize_conditions_test.rs` — adds `test_fold_useless_loop_body_routing` (`#[ignore]`-d stub) documenting the routing.
- `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs` — updates `test_fold_useless_loop_body`'s ignore reason to mark the routing and point at the new home.
- `code/specs/CLOC12-gaps.md` — gap-013 flipped ROUTING → RESOLVED.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-fold-control-flow` → 20 inline + 13 upstream (0 → 1 ignored; new routing stub)
- [x] `cargo test -p coding-adventures-closure-pass-dce` → 14 inline + 8 upstream (4 ignored — unchanged counts; one ignore reason updated)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)