### PR TITLE
feat: CLOC12.33 — gap-014 SwitchStatement AST + emitter + passthrough wiring

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.11.0] - 2026-06-04
+
+### Added — CLOC12.33: `SwitchStatement` emitter rule (gap-014)
+
+Adds `emit_switch` + `emit_switch_case` covering the new
+`SwitchStatement` / `SwitchCase` variants shipped in
+`javascript-ast` 0.7.0.
+
+Output shape (compact mode):
+
+```
+switch(<discriminant>){case <test>:<consequent>...case <test>:<consequent>...default:<consequent>...}
+```
+
+- `case <test>:` is emitted with a single space between `case`
+  and the test expression (required to avoid `case1:` ambiguity).
+- `default:` has no space (no expression follows the colon).
+- Empty consequent emits just `case <test>:` / `default:` with
+  nothing after the colon.
+- Multiple cases concatenate in source order. The trailing `}`
+  closes the switch directly — no separating semicolons.
+
+Pretty mode (`opts.pretty = true`) lays each case on its own
+indented line and each consequent statement on its own
+double-indented line under the case header. Same trailing-comma
+discipline as block: no separator before the closing brace.
+
+Six new inline tests pin: empty switch, single `case 1:` with
+expression-statement body, `default:` with body, `case 1:` with
+empty body, full `case/case/default` triple in order, and
+`case 1: break;` (break-in-consequent invariant).
+
 ## [Unreleased] — CLOC12.32: trailing-comma ports (gap-022)
 
 Test-only. Closes `gap-022`.

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -71,8 +71,8 @@ use coding_adventures_javascript_ast::{
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem,
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
-    ThrowStatement, UnaryExpression, UnaryOperator, UndefinedLiteral, VarKind,
-    VariableDeclaration, VariableDeclarator, WhileStatement,
+    SwitchCase, SwitchStatement, ThrowStatement, UnaryExpression, UnaryOperator, UndefinedLiteral,
+    VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -296,6 +296,7 @@ impl<'a> Emitter<'a> {
             TaggedStatement::ContinueStatement(c) => self.emit_continue(c),
             TaggedStatement::LabeledStatement(l) => self.emit_labeled(l),
             TaggedStatement::ThrowStatement(t) => self.emit_throw(t),
+            TaggedStatement::SwitchStatement(s) => self.emit_switch(s),
             TaggedStatement::EmptyStatement(e) => self.emit_empty(e),
         }
     }
@@ -473,6 +474,80 @@ impl<'a> Emitter<'a> {
         self.required_ws();
         self.emit_expression(&t.argument);
         self.write_str(";");
+    }
+
+    /// `switch (discriminant) { case test: <consequent>; default: <consequent>; }`.
+    ///
+    /// Lays out as `switch(<expr>){case <test>:<stmts>case <test>:<stmts>default:<stmts>}`
+    /// in compact mode. The closing `}` is emitted directly — no
+    /// trailing `;` because a switch is itself a statement
+    /// (the block-form, not the expression-form), and the inner
+    /// statements terminate themselves.
+    ///
+    /// Per ECMAScript §13.12, each case clause's consequent is a
+    /// list of statements (not a single statement), so we
+    /// emit each one in order. Fallthrough is the default; an
+    /// explicit `break` inside the consequent terminates the case.
+    fn emit_switch(&mut self, s: &SwitchStatement) {
+        self.maybe_map(&s.cv);
+        self.write_str("switch");
+        self.pretty_ws();
+        self.write_str("(");
+        self.emit_expression(&s.discriminant);
+        self.write_str(")");
+        self.pretty_ws();
+        self.write_str("{");
+        if self.opts.pretty && !s.cases.is_empty() {
+            self.newline();
+            self.indent += 1;
+        }
+        for (i, case) in s.cases.iter().enumerate() {
+            if self.opts.pretty {
+                if i > 0 {
+                    self.newline();
+                }
+                self.indent_str();
+            }
+            self.emit_switch_case(case);
+        }
+        if self.opts.pretty && !s.cases.is_empty() {
+            self.indent -= 1;
+            self.newline();
+            self.indent_str();
+        }
+        self.write_str("}");
+    }
+
+    fn emit_switch_case(&mut self, c: &SwitchCase) {
+        self.maybe_map(&c.cv);
+        match &c.test {
+            Some(test) => {
+                self.write_str("case");
+                self.required_ws();
+                self.emit_expression(test);
+                self.write_str(":");
+            }
+            None => self.write_str("default:"),
+        }
+        if c.consequent.is_empty() {
+            return;
+        }
+        if self.opts.pretty {
+            self.newline();
+            self.indent += 1;
+            for (i, s) in c.consequent.iter().enumerate() {
+                if i > 0 {
+                    self.newline();
+                }
+                self.indent_str();
+                self.emit_statement(s);
+            }
+            self.indent -= 1;
+        } else {
+            for s in &c.consequent {
+                self.emit_statement(s);
+            }
+        }
     }
 
     // ---- Declarations --------------------------------------------
@@ -1791,6 +1866,125 @@ mod tests {
         });
         // quote-choice picks double quotes by default for plain strings
         assert_eq!(emit_stmt(s), "throw \"oops\";");
+    }
+
+    // ---- SwitchStatement (gap-014, CLOC12.33) ----------------
+
+    #[test]
+    fn switch_empty_emits_braces() {
+        // switch (x) {}
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![],
+        });
+        assert_eq!(emit_stmt(s), "switch(x){}");
+    }
+
+    #[test]
+    fn switch_with_single_case_emits_case_test_colon_body() {
+        // switch (x) { case 1: y; }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![SwitchCase {
+                cv: None,
+                test: Some(num(1.0)),
+                consequent: vec![Statement::expression_statement(ExpressionStatement {
+                    cv: None,
+                    expression: ident("y"),
+                })],
+            }],
+        });
+        // `case 1:` then `y;` (the ExpressionStatement adds the `;`).
+        assert_eq!(emit_stmt(s), "switch(x){case 1:y;}");
+    }
+
+    #[test]
+    fn switch_with_default_emits_default_colon_body() {
+        // switch (x) { default: y; }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![SwitchCase {
+                cv: None,
+                test: None,
+                consequent: vec![Statement::expression_statement(ExpressionStatement {
+                    cv: None,
+                    expression: ident("y"),
+                })],
+            }],
+        });
+        assert_eq!(emit_stmt(s), "switch(x){default:y;}");
+    }
+
+    #[test]
+    fn switch_case_with_empty_consequent_emits_colon_only() {
+        // switch (x) { case 1: }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![SwitchCase {
+                cv: None,
+                test: Some(num(1.0)),
+                consequent: vec![],
+            }],
+        });
+        assert_eq!(emit_stmt(s), "switch(x){case 1:}");
+    }
+
+    #[test]
+    fn switch_with_two_cases_and_default_concatenates_in_order() {
+        // switch (x) { case 1: a; case 2: b; default: c; }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![
+                SwitchCase {
+                    cv: None,
+                    test: Some(num(1.0)),
+                    consequent: vec![Statement::expression_statement(ExpressionStatement {
+                        cv: None,
+                        expression: ident("a"),
+                    })],
+                },
+                SwitchCase {
+                    cv: None,
+                    test: Some(num(2.0)),
+                    consequent: vec![Statement::expression_statement(ExpressionStatement {
+                        cv: None,
+                        expression: ident("b"),
+                    })],
+                },
+                SwitchCase {
+                    cv: None,
+                    test: None,
+                    consequent: vec![Statement::expression_statement(ExpressionStatement {
+                        cv: None,
+                        expression: ident("c"),
+                    })],
+                },
+            ],
+        });
+        assert_eq!(emit_stmt(s), "switch(x){case 1:a;case 2:b;default:c;}");
+    }
+
+    #[test]
+    fn switch_with_break_in_consequent_emits_break_semicolon() {
+        // switch (x) { case 1: break; }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: ident("x"),
+            cases: vec![SwitchCase {
+                cv: None,
+                test: Some(num(1.0)),
+                consequent: vec![Statement::break_statement(BreakStatement {
+                    cv: None,
+                    label: None,
+                })],
+            }],
+        });
+        assert_eq!(emit_stmt(s), "switch(x){case 1:break;}");
     }
 
     // ---- BigIntLiteral (gap-021, CLOC12.15) -----------------

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -308,6 +308,29 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> TaggedSt
                 argument: fold_expression(&s.argument, st),
             })
         }
+        TaggedStatement::SwitchStatement(s) => {
+            // Fold the discriminant and each case's test + consequent.
+            // No structural peephole here — constant-fold doesn't
+            // rewrite control flow; the matching-case-only collapse
+            // belongs in fold-control-flow as a follow-up.
+            TaggedStatement::SwitchStatement(coding_adventures_javascript_ast::SwitchStatement {
+                cv: s.cv.clone(),
+                discriminant: fold_expression(&s.discriminant, st),
+                cases: s
+                    .cases
+                    .iter()
+                    .map(|c| coding_adventures_javascript_ast::SwitchCase {
+                        cv: c.cv.clone(),
+                        test: c.test.as_ref().map(|e| fold_expression(e, st)),
+                        consequent: c
+                            .consequent
+                            .iter()
+                            .map(|s| fold_statement(s, st))
+                            .collect(),
+                    })
+                    .collect(),
+            })
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => stmt.clone(),

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -282,6 +282,31 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
                 argument: dce_expression(&s.argument, st),
             })
         }
+        TaggedStatement::SwitchStatement(s) => {
+            // Recurse into discriminant, each case's test, and each
+            // statement in each consequent. No peephole rule yet —
+            // the "empty switch removal" and "constant-discriminant
+            // → single matching case body" optimisations are gap-014
+            // follow-ups; this PR ships the structural walk so they
+            // have a place to land.
+            TaggedStatement::SwitchStatement(coding_adventures_javascript_ast::SwitchStatement {
+                cv: s.cv.clone(),
+                discriminant: dce_expression(&s.discriminant, st),
+                cases: s
+                    .cases
+                    .iter()
+                    .map(|c| coding_adventures_javascript_ast::SwitchCase {
+                        cv: c.cv.clone(),
+                        test: c.test.as_ref().map(|e| dce_expression(e, st)),
+                        consequent: c
+                            .consequent
+                            .iter()
+                            .map(|s| dce_statement(s, st))
+                            .collect(),
+                    })
+                    .collect(),
+            })
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => stmt.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -261,6 +261,33 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
                 },
             ))
         }
+        TaggedStatement::SwitchStatement(s) => {
+            // Walk the discriminant + each case's test + consequent
+            // through fold_expression / fold_statement. No peephole
+            // rule yet — the "empty switch", "constant discriminant
+            // → single case body" optimisations are gap-014
+            // follow-ups; this PR ships the AST + recursive walk so
+            // those rules have a place to land.
+            Statement::Tagged(TaggedStatement::SwitchStatement(
+                coding_adventures_javascript_ast::SwitchStatement {
+                    cv: s.cv.clone(),
+                    discriminant: fold_expression(&s.discriminant, st),
+                    cases: s
+                        .cases
+                        .iter()
+                        .map(|c| coding_adventures_javascript_ast::SwitchCase {
+                            cv: c.cv.clone(),
+                            test: c.test.as_ref().map(|e| fold_expression(e, st)),
+                            consequent: c
+                                .consequent
+                                .iter()
+                                .map(|s| fold_statement(s, st))
+                                .collect(),
+                        })
+                        .collect(),
+                },
+            ))
+        }
         TaggedStatement::BreakStatement(_)
         | TaggedStatement::ContinueStatement(_)
         | TaggedStatement::EmptyStatement(_) => Statement::Tagged(stmt.clone()),

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -645,6 +645,22 @@ fn walk_tagged_statement(
         TaggedStatement::ThrowStatement(ts) => {
             walk_expression(&ts.argument, ctx, analysis, pending);
         }
+        TaggedStatement::SwitchStatement(ss) => {
+            // Visit the discriminant in the enclosing scope, then
+            // each case's test expression and consequent. Per
+            // ECMAScript §13.12, switch bodies share a single
+            // lexical scope spanning all cases, so we keep `ctx`
+            // unchanged across consequents.
+            walk_expression(&ss.discriminant, ctx, analysis, pending);
+            for case in &ss.cases {
+                if let Some(test) = &case.test {
+                    walk_expression(test, ctx, analysis, pending);
+                }
+                for s in &case.consequent {
+                    walk_statement(s, ctx, analysis, pending);
+                }
+            }
+        }
         TaggedStatement::BreakStatement(_) => {}
         TaggedStatement::ContinueStatement(_) => {}
         TaggedStatement::EmptyStatement(_) => {}

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.7.0] - 2026-06-04
+
+### Added — CLOC12.33: `SwitchStatement` + `SwitchCase` (Phase 1.x, closes gap-014)
+
+Adds `SwitchStatement { cv, discriminant, cases: Vec<SwitchCase> }`
+and `SwitchCase { cv, test: Option<Expression>, consequent: Vec<Statement> }`.
+A new `TaggedStatement::SwitchStatement` variant and a
+`Statement::switch_statement` convenience constructor round out
+the surface.
+
+ESTree wire format:
+
+```json
+{
+  "type": "SwitchStatement",
+  "discriminant": <Expression>,
+  "cases": [
+    { "type": "SwitchCase", "test": <Expression> | null, "consequent": [<Statement>...] },
+    ...
+  ]
+}
+```
+
+`SwitchCase.test` is `None` (serialised as `null`) for the
+`default:` clause; the parser is responsible for the at-most-one-
+default invariant per ECMAScript §13.12, the AST doesn't enforce
+it.
+
+Three new roundtrip tests cover empty / case+default / untraced
+cases plus inner `"type": "SwitchCase"` tag verification.
+
+This unblocks the DCE port's `testRemoveSwitch*` cases and the
+fold-control-flow port's `testRemoveEmptySwitch` case. The
+peephole optimisations that consume this node — empty-switch
+elimination, constant-discriminant collapse — are gap-014
+follow-ups.
+
 ## [0.6.0] - 2026-06-01
 
 ### Added — CLOC12.16: `UndefinedLiteral` Expression variant (Phase 1.x, closes gap-001)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
 pub use statement::{
     BlockStatement, BreakStatement, ContinueStatement, EmptyStatement, ExpressionStatement,
     ForInit, ForStatement, IfStatement, LabeledStatement, ReturnStatement, Statement,
-    ThrowStatement, WhileStatement,
+    SwitchCase, SwitchStatement, ThrowStatement, WhileStatement,
 };
 
 /// A correlation-vector identifier. Aliased to `String` for v1 to match

--- a/code/packages/rust/javascript-ast/src/statement.rs
+++ b/code/packages/rust/javascript-ast/src/statement.rs
@@ -16,14 +16,17 @@
 //!   the DCE port's `testRemoveNoOpLabelledStatement` case)
 //! - [`ThrowStatement`] (Phase 1.x — added in CLOC12.14 to unblock
 //!   the fold-control-flow port's `testMinimizeIfWithThrow` case)
+//! - [`SwitchStatement`] + [`SwitchCase`] (Phase 1.x — added in
+//!   CLOC12.33 to unblock the DCE / fold-control-flow ports'
+//!   switch-related cases, gap-014)
 //! - [`EmptyStatement`]
 //! - `Statement::Declaration(Declaration)` — untagged wrap so JSON
 //!   collapses to the inner `{"type": "VariableDeclaration", ...}`
 //!   shape directly.
 //!
-//! Phase 2 will add `SwitchStatement`, `TryStatement`,
-//! `DoWhileStatement`, `ForInStatement`, `ForOfStatement`,
-//! `DebuggerStatement`, and `WithStatement`.
+//! Phase 2 will add `TryStatement`, `DoWhileStatement`,
+//! `ForInStatement`, `ForOfStatement`, `DebuggerStatement`, and
+//! `WithStatement`.
 
 use crate::declaration::{Declaration, VariableDeclaration};
 use crate::expression::{Expression, Identifier};
@@ -66,6 +69,7 @@ pub enum TaggedStatement {
     ContinueStatement(ContinueStatement),
     LabeledStatement(LabeledStatement),
     ThrowStatement(ThrowStatement),
+    SwitchStatement(SwitchStatement),
     EmptyStatement(EmptyStatement),
 }
 
@@ -101,6 +105,9 @@ impl Statement {
     }
     pub fn throw_statement(s: ThrowStatement) -> Self {
         Self::Tagged(TaggedStatement::ThrowStatement(s))
+    }
+    pub fn switch_statement(s: SwitchStatement) -> Self {
+        Self::Tagged(TaggedStatement::SwitchStatement(s))
     }
     pub fn empty_statement(s: EmptyStatement) -> Self {
         Self::Tagged(TaggedStatement::EmptyStatement(s))
@@ -244,6 +251,59 @@ pub struct ThrowStatement {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub argument: Expression,
+}
+
+/// `switch (discriminant) { case test1: ...; case test2: ...; default: ...; }`.
+///
+/// Per ECMAScript §13.12:
+///
+/// - The `discriminant` is evaluated once.
+/// - Each `case` is compared against it with strict equality (`===`).
+/// - Execution falls through from one case to the next unless an
+///   explicit `break` (or `return`/`throw`) ends the case body.
+/// - At most one `default` clause is allowed. Its position in the
+///   `cases` array matters for fallthrough.
+///
+/// Added in Phase 1.x (CLOC12.33) to unblock the DCE port's
+/// `testRemoveSwitch*` cases and the fold-control-flow port's
+/// `testRemoveEmptySwitch` case (gap-014). The optimisation passes
+/// that consume this node — eliminating empty switches, folding
+/// switches with a constant discriminant down to the matching
+/// case body — are a separate follow-up; modelling the node first
+/// is the structural prerequisite.
+///
+/// # ESTree compatibility
+///
+/// ESTree shape `{ type: "SwitchStatement", discriminant, cases }`,
+/// where each `cases[i]` is `{ type: "SwitchCase", test, consequent }`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwitchStatement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub discriminant: Expression,
+    pub cases: Vec<SwitchCase>,
+}
+
+/// One arm of a [`SwitchStatement`].
+///
+/// - `test: Some(expr)` — the `case expr:` form. Matched against
+///   the discriminant with strict equality (`===`).
+/// - `test: None` — the `default:` clause. Per the spec, a switch
+///   may have at most one `default` (semantically; we don't
+///   enforce this at the AST level — it's the parser's job).
+/// - `consequent` — the list of statements making up the body of
+///   the case. Fallthrough to the next case happens implicitly if
+///   none of these terminate with a `break`/`return`/`throw`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename = "SwitchCase", rename_all = "camelCase")]
+pub struct SwitchCase {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    /// `None` means the `default:` clause. `Some(expr)` is the
+    /// `case expr:` form.
+    pub test: Option<Expression>,
+    pub consequent: Vec<Statement>,
 }
 
 /// A lone semicolon `;`. Rare in user code but legal everywhere a
@@ -543,6 +603,65 @@ mod tests {
         });
         assert_eq!(s.clone(), roundtrip(s.clone()));
         assert_eq!(type_tag(&s), "EmptyStatement");
+    }
+
+    #[test]
+    fn switch_statement_empty_cases_roundtrips() {
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: Some("sw.1".to_string()),
+            discriminant: lit(1.0),
+            cases: vec![],
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "SwitchStatement");
+    }
+
+    #[test]
+    fn switch_statement_with_case_and_default_roundtrips() {
+        // switch (1) { case 2: ; default: ; }
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: Some("sw.2".to_string()),
+            discriminant: lit(1.0),
+            cases: vec![
+                SwitchCase {
+                    cv: Some("sc.case.1".to_string()),
+                    test: Some(lit(2.0)),
+                    consequent: vec![Statement::empty_statement(EmptyStatement {
+                        cv: None,
+                    })],
+                },
+                SwitchCase {
+                    cv: Some("sc.default".to_string()),
+                    test: None,
+                    consequent: vec![Statement::empty_statement(EmptyStatement {
+                        cv: None,
+                    })],
+                },
+            ],
+        });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "SwitchStatement");
+        // Verify inner case type tags too — they should be
+        // "SwitchCase" per the ESTree wire format.
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        let cases = json["cases"].as_array().unwrap();
+        assert_eq!(cases[0]["type"], "SwitchCase");
+        assert_eq!(cases[1]["type"], "SwitchCase");
+        // The default case has `test: null` (None serialises that way).
+        assert!(cases[1]["test"].is_null());
+    }
+
+    #[test]
+    fn switch_statement_untraced_omits_cv() {
+        let s = Statement::switch_statement(SwitchStatement {
+            cv: None,
+            discriminant: lit(0.0),
+            cases: vec![],
+        });
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(s.clone(), roundtrip(s));
     }
 
     #[test]

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -112,11 +112,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-014 — `SwitchStatement` not in Phase 1 AST
 
-- **Status:** OPEN
+- **Status:** AST + emitter RESOLVED in CLOC12.33. **Switch-optimisation peepholes (empty-switch elimination, constant-discriminant collapse, drop-after-break)** remain a follow-up.
 - **Upstream test:** `PeepholeRemoveDeadCodeTest::testOptimizeSwitch*` (a dozen tests)
 - **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
-- **Why it fails:** No `SwitchStatement`, `SwitchCase`, `BreakStatement` in the Phase 1 typed AST.
-- **What it needs:** Phase 1.x AST extension to model `switch (x) { case 1: ...; default: ...; }`, plus the switch-optimisation logic. Substantial — multiple PRs.
+- **Resolution note:** CLOC12.33 adds `SwitchStatement { cv, discriminant, cases }` and `SwitchCase { cv, test: Option<Expression>, consequent: Vec<Statement> }` to `javascript-ast`, plus the `TaggedStatement::SwitchStatement` arm and `Statement::switch_statement` convenience constructor. The closure-emitter learns `emit_switch` / `emit_switch_case` covering both compact and pretty modes (compact `switch(x){case 1:y;default:z;}`, pretty indented). DCE / fold-control-flow / constant-fold / scope-analyzer each gained a passthrough match arm that recurses into the discriminant, each case's test, and each consequent statement — no peephole rules yet. The structural prerequisite is in place; the per-test arms (empty-switch removal, etc.) land in CLOC12.34+ as separate slices. `BreakStatement` was already in the AST (CLOC12.13).
 
 ### gap-015 — `var` / `let` / `const` lifting and hoisting
 


### PR DESCRIPTION
## Summary

Closes the **structural half of gap-014**: adds `SwitchStatement` / `SwitchCase` to the Phase 1.x AST, the emitter rule that round-trips them, and passthrough match arms in every downstream pass. Peephole optimisations (empty-switch elimination, constant-discriminant collapse, drop-after-break) remain as gap-014 follow-ups.

## Crates touched

- **javascript-ast 0.6.0 → 0.7.0** — new `SwitchStatement`, `SwitchCase`, `TaggedStatement::SwitchStatement` variant, `Statement::switch_statement` constructor, module-doc update, +3 roundtrip tests.
- **closure-emitter 0.10.0 → 0.11.0** — `emit_switch` + `emit_switch_case` in compact + pretty modes, +6 inline tests.
- **closure-scope-analyzer / closure-pass-constant-fold / closure-pass-dce / closure-pass-fold-control-flow** — passthrough arms that recurse into discriminant + each case's test + consequent. No version bumps (no API change).

The other transitive consumers (rename, inline, treeshake, collapse-properties, remove-unused-vars, typechecker, pipeline) contain no `TaggedStatement` matches — they consume scope-analyzer's output which has the new arm walking case bodies. Identifier references inside switch consequents are recorded; rename sees them.

## ESTree wire format

```json
{
  "type": "SwitchStatement",
  "discriminant": <Expression>,
  "cases": [
    { "type": "SwitchCase", "test": <Expression> | null, "consequent": [<Statement>...] }
  ]
}
```

`test: null` means the `default:` clause.

## Emitter output (compact)

```
switch(<x>){case <test>:<body>case <test>:<body>default:<body>}
```

- `case <test>:` writes a required space between `case` and the expression (same pattern as `emit_throw`).
- `default:` has no space.
- Empty consequent emits just `case <test>:` / `default:`.

## Test plan

- [x] `cargo test` in javascript-ast → 61 passing
- [x] `cargo test` in closure-scope-analyzer → 33 passing
- [x] `cargo test` in closure-pass-constant-fold → 41 + 14 ports
- [x] `cargo test` in closure-pass-fold-control-flow → 20 + 13 ports
- [x] `cargo test` in closure-pass-dce → 14 + 8 ports
- [x] `cargo test` in closure-emitter → 45 inline + 6 + 14 + 16 ports
- [x] `cargo test` in closurec → all e2e suites green
- [x] Security review (subagent): PASS — no output injection, no silent corruption, recursion risk identical to existing IfStatement/BlockStatement
- [ ] CI green

## What's NOT in this PR (queued follow-ups)

- gap-014 step 2: empty-switch elimination
- gap-014 step 3: constant-discriminant collapse
- gap-014 step 4: drop-after-break inside consequents

Each of these is a peephole rule that fits cleanly inside the new match arms that this PR ships.

## Closes

- gap-014 structural half (status flipped in `code/specs/CLOC12-gaps.md` from OPEN to "AST + emitter RESOLVED; peephole follow-ups remain")

🤖 Generated with [Claude Code](https://claude.com/claude-code)