### PR TITLE
Track browser media source and track descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1517,6 +1517,26 @@ pub struct BrowserMedia {
     pub controlslist_tokens: Vec<String>,
     pub disableremoteplayback: bool,
     pub disablepictureinpicture: bool,
+    pub sources: Vec<BrowserMediaSource>,
+    pub tracks: Vec<BrowserMediaTrack>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMediaSource {
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMediaTrack {
+    pub kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub srclang: Option<String>,
+    pub label: Option<String>,
+    pub default_track: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11240,7 +11260,61 @@ fn browser_media_element(element: &Element, base_href: Option<&str>) -> BrowserM
         controlslist_tokens: browser_media_controlslist_tokens(element),
         disableremoteplayback: browser_media_disableremoteplayback(element),
         disablepictureinpicture: browser_media_disablepictureinpicture(element),
+        sources: browser_media_sources(element, base_href),
+        tracks: browser_media_tracks(element, base_href),
     }
+}
+
+fn browser_media_sources(element: &Element, base_href: Option<&str>) -> Vec<BrowserMediaSource> {
+    if !matches!(element.name.as_str(), "audio" | "video") {
+        return Vec::new();
+    }
+
+    element
+        .children
+        .iter()
+        .filter_map(|node| match node {
+            Node::Element(child) if child.name == "source" => {
+                let src = child.attribute("src").map(ToOwned::to_owned);
+                Some(BrowserMediaSource {
+                    resolved_src: src
+                        .as_deref()
+                        .and_then(|src| resolve_browser_url(src, base_href)),
+                    src,
+                    type_hint: child.attribute("type").map(ToOwned::to_owned),
+                    media: child.attribute("media").map(ToOwned::to_owned),
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn browser_media_tracks(element: &Element, base_href: Option<&str>) -> Vec<BrowserMediaTrack> {
+    if !matches!(element.name.as_str(), "audio" | "video") {
+        return Vec::new();
+    }
+
+    element
+        .children
+        .iter()
+        .filter_map(|node| match node {
+            Node::Element(child) if child.name == "track" => {
+                let src = child.attribute("src").map(ToOwned::to_owned);
+                Some(BrowserMediaTrack {
+                    kind: browser_track_kind(child).unwrap_or_else(|| "subtitles".to_string()),
+                    resolved_src: src
+                        .as_deref()
+                        .and_then(|src| resolve_browser_url(src, base_href)),
+                    src,
+                    srclang: browser_track_srclang(child),
+                    label: browser_track_label(child),
+                    default_track: browser_track_default(child),
+                })
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 fn browser_media_poster(element: &Element) -> Option<String> {
@@ -16692,6 +16766,60 @@ mod tests {
         let render_tree = BrowserRenderTree::from_content_tree(&content_tree);
         assert_eq!(render_tree.children[0].display, "inline-replaced");
         assert!(render_tree.children[0].controls);
+    }
+
+    #[test]
+    fn browser_media_descriptor_metadata_tracks_sources_and_tracks() {
+        let document = parse_html(
+            "<base href=\"https://example.test/watch/index.html\"><body>\
+             <video controls>\
+               <source src=movie.webm type=video/webm media=\"(min-width: 700px)\">\
+               <source src=movie.mp4 type=video/mp4>\
+               <track kind=captions src=captions.vtt srclang=en label=English default>\
+               <track src=descriptions.vtt label=Descriptions>\
+             </video>\
+             <audio controls>\
+               <source src=theme.ogg type=audio/ogg>\
+             </audio>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        let video = &summary.media[0];
+        assert_eq!(video.sources.len(), 2);
+        assert_eq!(video.sources[0].src.as_deref(), Some("movie.webm"));
+        assert_eq!(
+            video.sources[0].resolved_src.as_deref(),
+            Some("https://example.test/watch/movie.webm")
+        );
+        assert_eq!(video.sources[0].type_hint.as_deref(), Some("video/webm"));
+        assert_eq!(
+            video.sources[0].media.as_deref(),
+            Some("(min-width: 700px)")
+        );
+        assert_eq!(video.sources[1].src.as_deref(), Some("movie.mp4"));
+        assert_eq!(video.tracks.len(), 2);
+        assert_eq!(video.tracks[0].kind, "captions");
+        assert_eq!(
+            video.tracks[0].resolved_src.as_deref(),
+            Some("https://example.test/watch/captions.vtt")
+        );
+        assert_eq!(video.tracks[0].srclang.as_deref(), Some("en"));
+        assert_eq!(video.tracks[0].label.as_deref(), Some("English"));
+        assert!(video.tracks[0].default_track);
+        assert_eq!(video.tracks[1].kind, "subtitles");
+        assert_eq!(
+            video.tracks[1].resolved_src.as_deref(),
+            Some("https://example.test/watch/descriptions.vtt")
+        );
+        assert_eq!(video.tracks[1].label.as_deref(), Some("Descriptions"));
+        assert!(!video.tracks[1].default_track);
+
+        let audio = &summary.media[1];
+        assert_eq!(audio.sources.len(), 1);
+        assert_eq!(audio.sources[0].src.as_deref(), Some("theme.ogg"));
+        assert_eq!(audio.sources[0].type_hint.as_deref(), Some("audio/ogg"));
+        assert!(audio.tracks.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -7,10 +7,10 @@ use coding_adventures_html_parser::{
     BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMeta, BrowserMetadataDirective,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserThemeColor,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
+    BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint,
+    BrowserScript, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -551,6 +551,38 @@ struct ExpectedMedia {
     disableremoteplayback: bool,
     #[serde(default)]
     disablepictureinpicture: bool,
+    #[serde(default)]
+    sources: Vec<ExpectedMediaSource>,
+    #[serde(default)]
+    tracks: Vec<ExpectedMediaTrack>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMediaSource {
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMediaTrack {
+    #[serde(default = "default_track_kind")]
+    kind: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    srclang: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    default_track: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2426,6 +2458,30 @@ fn browser_media_policy_metadata_tracks_controls_and_remote_playback_hints() {
 }
 
 #[test]
+fn browser_media_descriptor_metadata_tracks_sources_and_tracks() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "media-source-track-page")
+        .expect("media source and track fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("media source and track fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.resources, expected.resources,
+        "media child resources should preserve source candidates and track metadata",
+    );
+    assert_eq!(
+        actual.media, expected.media,
+        "media summaries should preserve nested source and track descriptors",
+    );
+}
+
+#[test]
 fn browser_interactive_element_metadata_tracks_focus_editing_and_commands() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3012,6 +3068,10 @@ fn default_browser_link_element() -> String {
     "a".to_string()
 }
 
+fn default_track_kind() -> String {
+    "subtitles".to_string()
+}
+
 impl ExpectedImage {
     fn into_browser_image(self) -> BrowserImage {
         BrowserImage {
@@ -3072,6 +3132,40 @@ impl ExpectedMedia {
             controlslist_tokens: self.controlslist_tokens,
             disableremoteplayback: self.disableremoteplayback,
             disablepictureinpicture: self.disablepictureinpicture,
+            sources: self
+                .sources
+                .into_iter()
+                .map(ExpectedMediaSource::into_browser_media_source)
+                .collect(),
+            tracks: self
+                .tracks
+                .into_iter()
+                .map(ExpectedMediaTrack::into_browser_media_track)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedMediaSource {
+    fn into_browser_media_source(self) -> BrowserMediaSource {
+        BrowserMediaSource {
+            src: self.src,
+            resolved_src: self.resolved_src,
+            type_hint: self.type_hint,
+            media: self.media,
+        }
+    }
+}
+
+impl ExpectedMediaTrack {
+    fn into_browser_media_track(self) -> BrowserMediaTrack {
+        BrowserMediaTrack {
+            kind: self.kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            srclang: self.srclang,
+            label: self.label,
+            default_track: self.default_track,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -546,6 +546,55 @@
       }
     },
     {
+      "id": "media-source-track-page",
+      "description": "Media summaries expose nested source candidates and timed-text track descriptors.",
+      "input": "<base href=\"https://example.test/watch/index.html\"><body><video controls><source src=movie.webm type=video/webm media=\"(min-width: 700px)\"><source src=movie.mp4 type=video/mp4><track kind=captions src=captions.vtt srclang=en label=English default><track src=descriptions.vtt label=Descriptions></video><audio controls><source src=theme.ogg type=audio/ogg></audio>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/watch/index.html",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "source", "url": "movie.webm", "resolved_url": "https://example.test/watch/movie.webm", "rel": null, "type_hint": "video/webm", "media": "(min-width: 700px)", "title": null, "async_script": false, "defer_script": false },
+          { "kind": "source", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "rel": null, "type_hint": "video/mp4", "media": null, "title": null, "async_script": false, "defer_script": false },
+          { "kind": "track", "url": "captions.vtt", "resolved_url": "https://example.test/watch/captions.vtt", "rel": null, "type_hint": null, "media": null, "title": null, "track_kind": "captions", "srclang": "en", "track_label": "English", "default_track": true, "async_script": false, "defer_script": false },
+          { "kind": "track", "url": "descriptions.vtt", "resolved_url": "https://example.test/watch/descriptions.vtt", "rel": null, "type_hint": null, "media": null, "title": null, "track_kind": "subtitles", "track_label": "Descriptions", "async_script": false, "defer_script": false },
+          { "kind": "source", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "rel": null, "type_hint": "audio/ogg", "media": null, "title": null, "async_script": false, "defer_script": false }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "media": [
+          {
+            "kind": "video",
+            "src": null,
+            "controls": true,
+            "sources": [
+              { "src": "movie.webm", "resolved_src": "https://example.test/watch/movie.webm", "type_hint": "video/webm", "media": "(min-width: 700px)" },
+              { "src": "movie.mp4", "resolved_src": "https://example.test/watch/movie.mp4", "type_hint": "video/mp4" }
+            ],
+            "tracks": [
+              { "kind": "captions", "src": "captions.vtt", "resolved_src": "https://example.test/watch/captions.vtt", "srclang": "en", "label": "English", "default_track": true },
+              { "kind": "subtitles", "src": "descriptions.vtt", "resolved_src": "https://example.test/watch/descriptions.vtt", "label": "Descriptions" }
+            ]
+          },
+          {
+            "kind": "audio",
+            "src": null,
+            "controls": true,
+            "sources": [
+              { "src": "theme.ogg", "resolved_src": "https://example.test/watch/theme.ogg", "type_hint": "audio/ogg" }
+            ],
+            "tracks": []
+          }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "script-style-loading-page",
       "description": "Browser document summaries expose stylesheet and script security/loading metadata for CSP, early fetch, execution, and style planning.",
       "input": "<base href=\"https://example.test/app/index.html\"><link rel=\"stylesheet preload\" href=app.css media=screen title=main integrity=sha256-css crossorigin=anonymous nonce=styleNonce referrerpolicy=no-referrer fetchpriority=high blocking=render><link rel=\"alternate stylesheet\" href=print.css title=print disabled><style media=print title=print nonce=inlineStyleNonce>body { color: black; }</style><script type=module src=app.js async integrity=sha384-js crossorigin=use-credentials nonce=moduleNonce referrerpolicy=origin fetchpriority=low blocking=render></script><script nomodule defer nonce=legacyNonce>legacy();</script><body><script src=late.js defer nonce=lateNonce></script>",


### PR DESCRIPTION
## Summary
- add nested `BrowserMediaSource` and `BrowserMediaTrack` descriptors to `BrowserMedia` for direct `<source>` and `<track>` children
- expose resolved source/track URLs plus type/media hints, timed-text language/label/default metadata, and the default `subtitles` track kind
- extend browser-readiness fixture expectations with a media source/track case

## Validation
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `cargo test -p coding-adventures-html-parser browser_media_descriptor_metadata_tracks_sources_and_tracks`
- `cargo test -p coding-adventures-html-parser browser_media_`
- `cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
