### PR TITLE
ADJ63/64 — bidirectional end-to-end + the underdetermination gate (missing-evidence)

### DIFF
--- a/code/specs/ADJ63-bidirectional-end-to-end.md
+++ b/code/specs/ADJ63-bidirectional-end-to-end.md
@@ -1,0 +1,72 @@
+# ADJ63 — Bidirectional Justification, End to End (and what it exposed)
+
+> **Status (2026-06-04):** Built and run. The ADJ61 (output) and ADJ62 (input)
+> justification gates, wired into one pipeline and run on a **fresh, non-medical** case
+> the agent found on its own — a railway-axle metallurgical failure analysis. All four
+> corners of the provenance grid held. The run also surfaced the failure that motivates
+> [ADJ64](ADJ64-underdetermination-gate.md): **over-attribution under missing evidence.**
+> Implementation: [`code/specs/data/adj57/pipeline/`](data/adj57/pipeline/)
+> (`bidirectional.workflow.js`, `run_bidirectional.py`).
+
+## 1. The run
+
+A brand-new domain (materials-failure-analysis, MDPI article PMC12387781), decomposed and
+answered under **both** justification gates in sequence:
+
+```
+[1] INPUT coverage      100%  — 17 facts = all 1975 bytes (nothing dropped)
+[2] INPUT extraction    32/32 — 24 extracted + 8 inferred, 0 rejected (nothing mis-extracted)
+[3] OUTPUT grounding    13/13 — 7 evidence + 6 conclusion, 0 rejected (nothing invented)
+=> BIDIRECTIONAL PROVENANCE COMPLETE
+```
+
+The input gate again did real work — it filed *"the failure mode is bending fatigue,"*
+*"material defects ruled out,"* and *"root cause is improper machining"* as **inferred**
+(syntheses across several bytes), keeping the directly-stated measurements as
+**extracted**. The mechanism generalized to a hard quantitative engineering domain with
+no changes. The full bidirectional provenance held on the first pass.
+
+## 2. The finding — faithfulness ≠ completeness
+
+The framework's byte-faithful answer: *"bending-fatigue cracking … driven by
+**manufacturing/surface condition rather than material defect**."*
+
+The held-aside ground truth: *"HIGH-STRESS FATIGUE FRACTURE — driven by **operating
+stress exceeding the material's fatigue strength** — **not** a manufacturing-flaw
+failure."* The decisive datum was an FEA result — operating stress ~273–299 MPa
+*exceeding* the measured fatigue limit ~265–273 MPa — and **that comparison was never in
+the decomposed `case_text`.**
+
+So the answer agreed on everything the bytes contained (bending fatigue, initiation at
+the fillet, surface stress concentrators, clean material) but **diverged on the top-line
+root cause** — and the divergence traces entirely to a missing input. Crucially, the
+framework **did not fabricate the FEA numbers to match a remembered answer.** It stayed
+grounded, hedged ("most plausibly"), and gave the answer the bytes support. The error is
+not an invention — it is a *visible gap*. An attending reading it would see every claim
+byte-cited and immediately notice the stress-vs-fatigue-limit comparison was never made.
+
+> **Byte provenance guarantees the answer follows from the bytes; it does not guarantee
+> the bytes are complete.** When they are not, it shows up as a traceable divergence, not
+> a confident fabrication.
+
+## 3. What it exposed — and the fix
+
+The byte-anchor stops *invented evidence*. It does **not** stop a subtler failure the
+ADJ63 answer committed: with the deciding datum absent, the conclusion **drifted to the
+loudest present lever** (the surface defects) and singled out one cause anyway. Every
+claim was grounded; the *selection among causes* was not. Invention is not the only way
+to be wrong — a conclusion can be **underdetermined**: several hypotheses fit the present
+bytes and the observation that would separate them is missing.
+
+That is the cut [ADJ64](ADJ64-underdetermination-gate.md) makes: when a conclusion cannot
+be discriminated from its rivals by the present bytes, refuse to single one out, and emit
+the missing discriminating observation as a *named provenance hole* — a query the
+spider/CAS can fetch. Re-run on this same axle conclusion, ADJ64 flags it
+**underdetermined** and names the exact missing measurement (operating stress vs. fatigue
+limit) — the ground-truth root cause.
+
+## 4. Honest note
+
+Both gates passed clean on the first pass (0 rejections), so the live reject/kickback
+path was again not exercised here. The reject path is covered by unit tests; a case (or
+deriver) engineered to force a live kickback remains the way to exercise it end-to-end.

--- a/code/specs/ADJ64-underdetermination-gate.md
+++ b/code/specs/ADJ64-underdetermination-gate.md
@@ -1,0 +1,96 @@
+# ADJ64 — The Underdetermination Gate (over-attribution under missing evidence)
+
+> **Status (2026-06-04):** Built and run. The dual of invention. ADJ60/61 stop a claim
+> from citing bytes that are not there; ADJ64 stops a *conclusion* from singling out one
+> cause when the datum that would distinguish it from the rivals **is not in the input**.
+> Run on the [ADJ63](ADJ63-bidirectional-end-to-end.md) axle conclusion, it flags it
+> **underdetermined** and names five missing measurements — including the exact one
+> (operating stress vs. fatigue limit) that is the held-aside ground-truth root cause.
+> Implementation:
+> [`underdetermination.py`](data/adj57/pipeline/underdetermination.py) +
+> [`underdetermination.workflow.js`](data/adj57/pipeline/underdetermination.workflow.js).
+
+## 1. Invention is not the only way to be wrong
+
+"If the data is not present, we cannot reason over it." True — and the byte-anchor
+enforces it: you cannot derive a fact the bytes do not entail. But ADJ63 showed the model
+has a *second* way to go wrong that the byte-anchor does not catch. When the observation
+that would decide between rival explanations is **absent**, the model does not fabricate
+it (the gate holds) — it lets the conclusion **drift to the loudest present lever** and
+names one cause anyway. The axle answer named "machining/surface" as the root cause; the
+truth was "operating stress exceeded the fatigue limit." Both fit the *same* bytes; the
+discriminating measurement was simply never decomposed. Every claim was grounded; the
+*selection among causes* was not.
+
+So a conclusion can be **underdetermined**: more than one hypothesis fits the present
+bytes, and the datum that separates them is missing. The honest move is not to guess — it
+is to keep the conclusion as a **disjunction** over the live rivals and emit the missing
+observation as a **named provenance hole**: a query the spider/CAS can fetch. *A single
+step cannot reason over absent data; naming the hole is how the loop turns absence into
+the next thing to retrieve.*
+
+## 2. The gate
+
+[`underdetermination.py`](data/adj57/pipeline/underdetermination.py). For each rival
+hypothesis that fits the same bytes, the model supplies the single **discriminating
+observation** that would settle leading-vs-rival, and whether it is PRESENT (with a
+verbatim citation) or ABSENT. The deterministic rule, mirroring every other gate —
+*"present" is only ever as good as a real byte*:
+
+- a rival is **resolved** iff its discriminating observation is marked present **and** the
+  citation is verbatim in the input (you cannot *claim* the data is there without a byte);
+- otherwise the rival is **open** — its discriminating observation is a **hole** (absent,
+  or a fabricated "present").
+
+The conclusion is **determined** iff no rival is open. If any rival is open it is
+**underdetermined**: soften to the disjunction over the open rivals, and report the holes
+as required-but-missing data. The model proposes the rivals; this module adjudicates. 5
+unit tests ([`test_underdetermination.py`](data/adj57/pipeline/test_underdetermination.py)),
+incl. *claimed-present-but-fabricated-citation is open* and *absent-datum becomes a hole*.
+
+## 3. The run — the gate catches the axle over-attribution
+
+[`underdetermination.workflow.js`](data/adj57/pipeline/underdetermination.workflow.js) +
+[`run_underdetermination.py`](data/adj57/pipeline/run_underdetermination.py), on the ADJ63
+leading conclusion:
+
+```
+7 rivals — 2 resolved by present bytes, 5 OPEN — conclusion UNDERDETERMINED
+```
+
+The five **named provenance holes** (queries to fetch before a cause can be singled out):
+
+1. the fillet radius / stress-concentration factor Kt vs. the design allowable;
+2. **a comparison of operating bending stress at the fillet to the EA1N fatigue limit;**
+3. fretting-damage evidence at the wheel-seat contact vs. a clean free-surface origin;
+4. the required surface residual-stress state (was compressive specified and absent?);
+5. the drawing surface-finish tolerance vs. the measured 342 µm step / 0.95 mm marks.
+
+Hole **#2 is the ground-truth root cause** — the exact measurement whose absence let
+ADJ63 over-attribute to "machining." The gate replaced the single-cause answer with a
+disjunction that keeps every grounded finding (bending fatigue at the fillet; surface
+concentrators present; material clean) and refuses to choose among the five mechanisms
+until the missing data are retrieved.
+
+## 4. Honest limitations
+
+- **The "resolved" verdict is an LLM judgment.** The deterministic gate verifies the
+  citation is verbatim, but cannot verify the cited datum actually *discriminates*. Two
+  rivals here were marked resolved on citations that merely show a feature is *present*
+  (e.g. "corrosion pits exist") without truly settling which feature nucleated the crack.
+  Read conservatively, those two are *also* open — which would only make the conclusion
+  **more** underdetermined, never less. So the gate erred toward calling rivals resolved,
+  yet still reached the safe verdict (UNDERDETERMINED). Hardening — a multi-verifier vote
+  on "does this cited byte actually discriminate?" — is the same fix flagged for ADJ61/62.
+- **Rival completeness is the model's.** The gate adjudicates the rivals it is given; it
+  cannot prove the rival set is exhaustive. A missing *rival* (not just a missing datum)
+  is a deeper hole — a candidate for the completeness-critic pattern.
+
+## 5. Where this leaves the framework
+
+The framework now distinguishes three epistemic states, all byte-disciplined: a claim is
+**grounded** (cites real bytes), a conclusion is **determined** (the present bytes
+discriminate it from its rivals), or it is **underdetermined** (and the missing
+discriminators are named as queries). It will no longer convert a missing measurement into
+a confident single cause — it converts it into a question. That is the antidote ADJ63
+asked for: not reasoning over absent data, but making the absence the next thing to fetch.

--- a/code/specs/data/adj57/CHANGELOG.md
+++ b/code/specs/data/adj57/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — adj57 byte-provenance pipeline
 
+## [0.7.0] — 2026-06-04
+
+### Added
+
+- **ADJ63 — bidirectional justification end-to-end** (`pipeline/bidirectional.workflow.js`,
+  `pipeline/run_bidirectional.py`). The ADJ61 (output) + ADJ62 (input) gates wired into one
+  pipeline and run on a fresh, non-medical case the agent found itself — railway-axle
+  metallurgical failure analysis (MDPI PMC12387781). All four provenance corners held:
+  coverage 100% (17 facts / 1975 bytes), input extraction 32/32 (24 extracted + 8 inferred),
+  output grounding 13/13 (7 evidence + 6 conclusion), 0 rejected. **Finding —
+  faithfulness ≠ completeness:** the byte-faithful answer ("manufacturing/surface cause")
+  diverged from the held-aside truth ("operating stress exceeded the fatigue limit")
+  because the decisive datum (the stress-vs-fatigue-limit comparison) was never in the
+  bytes. The framework did not fabricate it — it gave the answer the bytes support and the
+  gap stayed visible. Spec: [ADJ63](../../ADJ63-bidirectional-end-to-end.md).
+- **ADJ64 — the underdetermination gate** (`pipeline/underdetermination.py`,
+  `pipeline/underdetermination.workflow.js`, `pipeline/run_underdetermination.py`). The dual
+  of invention: stops a conclusion from singling out one cause when the datum that would
+  distinguish it from the rivals is **absent**. For each rival fitting the same bytes, the
+  model gives the discriminating observation + whether it is present (verbatim citation) or
+  absent; a rival is *resolved* iff present-and-cited, else *open* (its observation is a
+  **named provenance hole** — a query for the spider/CAS). Conclusion is *underdetermined*
+  iff any rival is open. 5 unit tests (`pipeline/test_underdetermination.py`). **Run** on
+  the ADJ63 axle conclusion: 7 rivals, 5 open → **UNDERDETERMINED**; the gate named five
+  missing measurements, including the **operating-stress-vs-fatigue-limit comparison — the
+  ground-truth root cause** — and replaced the single-cause answer with a disjunction that
+  keeps every grounded finding. **Honest limit:** the "resolved" verdict is an LLM judgment
+  (a citation being present ≠ it discriminating); read conservatively the 2 "resolved"
+  rivals are also open, making the safe verdict only stronger. Spec:
+  [ADJ64](../../ADJ64-underdetermination-gate.md).
+
 ## [0.6.0] — 2026-06-04
 
 ### Added

--- a/code/specs/data/adj57/bidirectional.json
+++ b/code/specs/data/adj57/bidirectional.json
@@ -1,0 +1,43 @@
+{
+  "domain": "materials-failure-analysis (metallurgical fractography)",
+  "leading_answer": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+  "coverage": {
+    "covered": true,
+    "clean": true,
+    "bytes": 1975
+  },
+  "input_extraction": {
+    "n": 32,
+    "grounded": 32,
+    "rejected": 0,
+    "by_kind": {
+      "extracted": 24,
+      "inferred": 8
+    }
+  },
+  "output_grounding": {
+    "n": 13,
+    "grounded": 13,
+    "rejected": 0,
+    "by_kind": {
+      "evidence": 7,
+      "conclusion": 6
+    }
+  },
+  "input_attempts": [
+    {
+      "attempt": 1,
+      "n": 32,
+      "n_rejected": 0
+    }
+  ],
+  "output_attempts": [
+    {
+      "attempt": 1,
+      "leading_answer": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+      "n": 13,
+      "n_rejected": 0
+    }
+  ],
+  "complete": true
+}

--- a/code/specs/data/adj57/pipeline/bidirectional-results.json
+++ b/code/specs/data/adj57/pipeline/bidirectional-results.json
@@ -1,0 +1,738 @@
+{
+  "summary": "ADJ61+ADJ62 end-to-end on a FRESH case. INPUT: decompose (coverage) -> account for every fact extracted/inferred with the bytes + justification -> input justification gate + kickback. OUTPUT: derive the answer as evidence/conclusion claims grounded by COMBINING input bytes -> output justification gate + kickback. Picks a brand-new documented case (prefer a non-medical identification domain) to test that the bidirectional justification gate generalizes.",
+  "agentCount": 5,
+  "logs": [
+    "domain=materials-failure-analysis (metallurgical fractography); coverage OK (1975 bytes)"
+  ],
+  "result": {
+    "domain": "materials-failure-analysis (metallurgical fractography)",
+    "source_url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12387781/",
+    "ground_truth": "The investigation concluded the axles suffered HIGH-STRESS FATIGUE FRACTURE (a bending-fatigue failure driven by operating stress exceeding the material's fatigue strength), NOT a material-defect or manufacturing-flaw (e.g., inclusion/porosity) failure. Established by: (a) macro/SEM fractography showing dual bending-fatigue initiation sites at the transition rounded corners with beach marks and a mixed ductile/cleavage final-fracture zone; (b) clean metallography/chemistry conforming to EA1N (UIC 811-1) with good inclusion ratings and no porosity/slag/decarburization at the crack source, ruling out material defects; (c) FEA-calculated operating stress (~272.8-298.7 MPa) exceeding the measured rotating-bending fatigue limit (~265-273 MPa); (d) surface tensile residual stress (~71-99 MPa) plus rough machining marks, ~342 um roughness, ~0.95 mm blade marks, V-shaped notches and corrosion pits at the wheel-seat transition arc providing the stress concentration that nucleated the cracks. Root cause: design/finish at the wheel-seat transition arc letting service stress exceed fatigue strength. Published in Materials (MDPI), article PMC12387781.",
+    "case_text": "During the development of a prototype PMDD electric locomotive, the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing, failing to meet validation requirements. After 3 million fatigue tests, axle 1# broke at the transition corner. After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#. After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle. The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns. Beach marks are present at both the top and bottom regions of the fracture section. The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone. Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist. The width of the blade marks on the surface is about 0.95 mm, and there are parallel processing textures at the bottom. The height difference between the highest point and the lowest point near the transition zone is 342 μm. There are small V-shaped notches in this section. The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1. The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite. The grain size is grade 7, and no characteristics of oxidation, decarburization, and overheated microstructure are found. No defects, such as porosity, slag inclusion, and repair welding, were found in this area. The surface of the arc region is manifested as tensile stress in both circumferential and axial directions. The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+    "segments": [
+      {
+        "text": "During the development of a prototype PMDD electric locomotive, the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing, failing to meet validation requirements. ",
+        "kind": "fact",
+        "reason": "Context: component (railway axle), service condition (wheel-seat fatigue testing), and the failure event being investigated."
+      },
+      {
+        "text": "After 3 million fatigue tests, axle 1# broke at the transition corner. ",
+        "kind": "fact",
+        "reason": "Fracture location (transition corner/wheel-seat arc) and life-to-failure (3M cycles) — key fatigue-life datum and stress-concentration locus."
+      },
+      {
+        "text": "After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#. ",
+        "kind": "fact",
+        "reason": "Magnetic-particle indication of cracking at the same transition geometry on a second specimen — reproducibility of the initiation site."
+      },
+      {
+        "text": "After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle. ",
+        "kind": "fact",
+        "reason": "Third specimen cracking at the same transition angle, at lower cycle count — confirms a systematic, geometry-driven failure, not a one-off."
+      },
+      {
+        "text": "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns. ",
+        "kind": "fact",
+        "reason": "Multiple initiation sites with bending-fatigue morphology localized at the transition radius — primary fractographic signature."
+      },
+      {
+        "text": "Beach marks are present at both the top and bottom regions of the fracture section. ",
+        "kind": "fact",
+        "reason": "Beach (crack-arrest) marks are the diagnostic macro feature of progressive fatigue crack growth."
+      },
+      {
+        "text": "The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone. ",
+        "kind": "fact",
+        "reason": "Final-overload zone morphology indicating direction/sequence of fracture and that overload completed a fatigue-initiated crack."
+      },
+      {
+        "text": "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist. ",
+        "kind": "fact",
+        "reason": "Surface condition at the initiation site: machining roughness and corrosion pits as candidate crack nucleation features."
+      },
+      {
+        "text": "The width of the blade marks on the surface is about 0.95 mm, and there are parallel processing textures at the bottom. ",
+        "kind": "fact",
+        "reason": "Quantified machining-mark geometry — stress-concentration/surface-finish evidence at the crack source."
+      },
+      {
+        "text": "The height difference between the highest point and the lowest point near the transition zone is 342 μm. ",
+        "kind": "fact",
+        "reason": "Quantified surface roughness (342 μm relief) at the transition — magnitude of the surface-finish stress raiser."
+      },
+      {
+        "text": "There are small V-shaped notches in this section. ",
+        "kind": "fact",
+        "reason": "Sharp V-notches act as local stress concentrators favoring fatigue initiation."
+      },
+      {
+        "text": "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1. ",
+        "kind": "fact",
+        "reason": "Material chemistry conforms to spec — rules out wrong/off-spec alloy as cause."
+      },
+      {
+        "text": "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite. ",
+        "kind": "fact",
+        "reason": "Uniform expected microstructure with no abnormal local structure at initiation — argues against metallurgical defect origin."
+      },
+      {
+        "text": "The grain size is grade 7, and no characteristics of oxidation, decarburization, and overheated microstructure are found. ",
+        "kind": "fact",
+        "reason": "Normal grain size and absence of thermal-processing anomalies — excludes heat-treatment/overheating defects."
+      },
+      {
+        "text": "No defects, such as porosity, slag inclusion, and repair welding, were found in this area. ",
+        "kind": "fact",
+        "reason": "Explicitly excludes internal material defects at the crack source — eliminates the defect-origin hypothesis, pointing to stress/surface origin."
+      },
+      {
+        "text": "The surface of the arc region is manifested as tensile stress in both circumferential and axial directions. ",
+        "kind": "fact",
+        "reason": "Surface residual stress is tensile (not protective compressive) — promotes crack opening/initiation."
+      },
+      {
+        "text": "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+        "kind": "fact",
+        "reason": "Quantified tensile residual stress magnitude at the initiation site — adds to applied service stress to exceed fatigue limit."
+      }
+    ],
+    "coverage_ok": true,
+    "input_facts": [
+      {
+        "fact": "The case concerns a prototype PMDD electric locomotive.",
+        "kind": "extracted",
+        "grounded_by": [
+          "During the development of a prototype PMDD electric locomotive"
+        ],
+        "justification": "The bytes directly state the subject is a 'prototype PMDD electric locomotive'.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Cited bytes state 'a prototype PMDD electric locomotive' verbatim.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The locomotive's axles were newly designed.",
+        "kind": "extracted",
+        "grounded_by": [
+          "the newly designed axles"
+        ],
+        "justification": "The text directly describes the axles as 'newly designed'.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'the newly designed axles' directly supports 'axles were newly designed.'",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The axles failed prematurely during wheel-seat–axle fatigue testing.",
+        "kind": "extracted",
+        "grounded_by": [
+          "the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing"
+        ],
+        "justification": "The bytes directly state premature failures during this specific fatigue testing.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state premature failures during wheel-seat-axle fatigue testing verbatim.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The axles did not meet validation requirements.",
+        "kind": "extracted",
+        "grounded_by": [
+          "failing to meet validation requirements"
+        ],
+        "justification": "The text directly states they failed to meet validation requirements.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'failing to meet validation requirements' directly supports the fact.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Axle 1# broke at the transition corner after 3 million fatigue tests.",
+        "kind": "extracted",
+        "grounded_by": [
+          "After 3 million fatigue tests, axle 1# broke at the transition corner"
+        ],
+        "justification": "The bytes directly state the cycle count, axle, and fracture location.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state 3 million tests, axle 1#, broke at transition corner.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "After 3.5 million fatigue tests, magnetic marks gathered on both sides of the transition corners of axle 2#.",
+        "kind": "extracted",
+        "grounded_by": [
+          "After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#"
+        ],
+        "justification": "The bytes directly state the cycle count, axle, and observation of magnetic marks.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state 3.5 million, axle 2#, magnetic marks on both sides of transition corners.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "After 1.6 million tests, accumulated magnetic marks were found on both sides of axle 3#'s transition angle.",
+        "kind": "extracted",
+        "grounded_by": [
+          "After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle"
+        ],
+        "justification": "The bytes directly state the cycle count, axle 3#, and accumulated magnetic marks.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state 1.6 million tests, axle 3#, accumulated magnetic marks on both sides of transition angle.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Magnetic marks (from magnetic particle inspection) indicate the presence of surface cracks at the transition corners of axles 2# and 3#.",
+        "kind": "inferred",
+        "grounded_by": [
+          "magnetic marks gathered on both sides of the transition corners of axle 2#",
+          "accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle"
+        ],
+        "justification": "Magnetic marks gathering/accumulating is the conventional signature of magnetic particle inspection detecting cracks; this reading is warranted but the text does not literally call them cracks.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Magnetic marks accumulating is the standard MPI signature of cracks; warranted interpretive reading, text does not literally say cracks. Appropriately marked inferred.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "There were dual fatigue initiation sites, located on surfaces A and B at the transition's rounded corners.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners"
+        ],
+        "justification": "The bytes directly state two fatigue initiation sites at surfaces A and B at the rounded corners.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state dual fatigue initiation sites on surfaces A and B at transition's rounded corners.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The fracture exhibits characteristic bending fatigue patterns.",
+        "kind": "extracted",
+        "grounded_by": [
+          "exhibit characteristic bending fatigue patterns"
+        ],
+        "justification": "The text directly identifies the patterns as bending fatigue.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'exhibit characteristic bending fatigue patterns' directly supports the fact.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The failure mode is bending fatigue.",
+        "kind": "inferred",
+        "grounded_by": [
+          "The identified dual fatigue initiation sites on surfaces A and B",
+          "exhibit characteristic bending fatigue patterns",
+          "Beach marks are present at both the top and bottom regions of the fracture section"
+        ],
+        "justification": "Dual opposite-side initiation, bending fatigue patterns, and beach marks at both top and bottom together warrant the interpretation that the loading mode is reversed bending fatigue; this is a synthesized reading, not stated verbatim.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Dual opposite-side initiation + beach marks top and bottom + bending fatigue patterns warrant reversed bending fatigue loading mode as a synthesized reading. Defensible inference.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Beach marks are present at both the top and bottom regions of the fracture section.",
+        "kind": "extracted",
+        "grounded_by": [
+          "Beach marks are present at both the top and bottom regions of the fracture section"
+        ],
+        "justification": "The bytes directly state beach marks at top and bottom regions.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state beach marks at both top and bottom regions of the fracture section.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The final fracture exhibits mixed modes: ductile shear lips at the edges and cleavage-dominated brittle fracture in the central zone.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone"
+        ],
+        "justification": "The bytes directly describe the mixed-mode final fracture with these two features.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes describe mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in central zone.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Parallel distributions of rough machining textures are observed on the side of the crack source.",
+        "kind": "extracted",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source"
+        ],
+        "justification": "The bytes directly state parallel rough machining textures at the crack source side.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state parallel distributions of rough machining textures on the crack source side.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Local corrosion pits exist at the crack source side.",
+        "kind": "extracted",
+        "grounded_by": [
+          "and local corrosion pits exist"
+        ],
+        "justification": "The text directly states local corrosion pits exist (in the context of the crack source side).",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'and local corrosion pits exist' supports; same sentence context as crack source side.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The width of the blade (machining) marks on the surface is about 0.95 mm.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The width of the blade marks on the surface is about 0.95 mm"
+        ],
+        "justification": "The bytes directly state the blade mark width as about 0.95 mm.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state blade marks width about 0.95 mm. 'blade (machining)' gloss is reasonable.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "There are parallel processing (machining) textures at the bottom of the blade marks.",
+        "kind": "extracted",
+        "grounded_by": [
+          "and there are parallel processing textures at the bottom"
+        ],
+        "justification": "The bytes directly state parallel processing textures at the bottom.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state parallel processing textures at the bottom.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The height difference between the highest and lowest point near the transition zone is 342 μm.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The height difference between the highest point and the lowest point near the transition zone is 342 μm"
+        ],
+        "justification": "The bytes directly state the 342 μm height difference near the transition zone.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state 342 um height difference between highest and lowest point near transition zone.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "There are small V-shaped notches in the transition section.",
+        "kind": "extracted",
+        "grounded_by": [
+          "There are small V-shaped notches in this section"
+        ],
+        "justification": "The bytes directly state small V-shaped notches are present in this section.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'There are small V-shaped notches in this section' directly supports.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The rough machining, blade marks, surface roughness (342 μm height difference), V-shaped notches, and corrosion pits act as stress concentrators / crack-initiation sites.",
+        "kind": "inferred",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source",
+          "local corrosion pits exist",
+          "The width of the blade marks on the surface is about 0.95 mm",
+          "The height difference between the highest point and the lowest point near the transition zone is 342 μm",
+          "There are small V-shaped notches in this section"
+        ],
+        "justification": "Co-location of these surface defects with the crack source warrants the engineering interpretation that they are stress raisers promoting fatigue initiation; the text describes them but does not explicitly label them as the cause.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Co-location of surface defects with crack source warrants stress-concentrator interpretation; text describes but does not label them as initiators. Properly inferred.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The chemical composition meets the standard requirements of EA1N in UIC 811-1.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1"
+        ],
+        "justification": "The bytes directly state the chemistry conforms to EA1N in UIC 811-1.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state chemical composition in line with EA1N in UIC 811-1.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Material defects in chemical composition are ruled out as a cause of failure.",
+        "kind": "inferred",
+        "grounded_by": [
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1"
+        ],
+        "justification": "Conformance to the standard warrants excluding chemistry as a failure cause; this is an interpretive conclusion not literally stated.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Conformance to standard warrants excluding chemistry as a cause; interpretive conclusion not stated. Properly inferred.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The microstructures at the crack source are the same as at the core: flake pearlite plus ferrite.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite"
+        ],
+        "justification": "The bytes directly state the microstructure identity and composition.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state microstructures at crack source same as core, flake pearlite + ferrite.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The grain size is grade 7.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The grain size is grade 7"
+        ],
+        "justification": "The bytes directly state grain size grade 7.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "'The grain size is grade 7' directly supports.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "No characteristics of oxidation, decarburization, or overheated microstructure were found.",
+        "kind": "extracted",
+        "grounded_by": [
+          "no characteristics of oxidation, decarburization, and overheated microstructure are found"
+        ],
+        "justification": "The bytes directly state none of these features were found.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state no oxidation, decarburization, overheated microstructure found.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "No defects such as porosity, slag inclusion, or repair welding were found in this area.",
+        "kind": "extracted",
+        "grounded_by": [
+          "No defects, such as porosity, slag inclusion, and repair welding, were found in this area"
+        ],
+        "justification": "The bytes directly state the absence of these defects.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state no porosity, slag inclusion, repair welding defects in this area.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "Metallurgical and material-quality defects are excluded as the cause; the failure originates from surface/manufacturing condition rather than material.",
+        "kind": "inferred",
+        "grounded_by": [
+          "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite",
+          "no characteristics of oxidation, decarburization, and overheated microstructure are found",
+          "No defects, such as porosity, slag inclusion, and repair welding, were found in this area",
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1"
+        ],
+        "justification": "The combined negatives on microstructure, heat-treatment anomalies, internal defects, and chemistry warrant the conclusion that material quality is not the cause; this synthesis is interpretive, not stated verbatim.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Combined negatives on microstructure, heat treatment, internal defects, chemistry warrant excluding material quality as cause; synthesis is interpretive. Defensible.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The surface of the arc region exhibits tensile stress in both circumferential and axial directions.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The surface of the arc region is manifested as tensile stress in both circumferential and axial directions"
+        ],
+        "justification": "The bytes directly state tensile stress in both directions at the arc region surface.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state arc region surface manifests tensile stress in both circumferential and axial directions.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The arc transition zone has residual tensile stress of 72–99 MPa circumferentially and 71–92 MPa axially.",
+        "kind": "extracted",
+        "grounded_by": [
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction"
+        ],
+        "justification": "The bytes directly state both residual tensile stress ranges.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bytes state 72-99 MPa circumferential and 71-92 MPa axial residual tensile stress.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The residual tensile stress at the transition is detrimental and promotes fatigue crack initiation/growth.",
+        "kind": "inferred",
+        "grounded_by": [
+          "The surface of the arc region is manifested as tensile stress in both circumferential and axial directions",
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction"
+        ],
+        "justification": "Surface residual tensile stress (rather than the desirable compressive stress) is known to accelerate fatigue; concluding it is detrimental is an interpretive reading warranted by the stress being tensile, not stated outright.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Surface residual tensile stress being detrimental to fatigue is standard engineering knowledge; concluding it promotes initiation/growth is warranted interpretation, not stated. Properly inferred.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "The root cause is improper machining/manufacturing of the transition fillet — rough surface, blade marks, notches, and tensile residual stress — rather than material defect.",
+        "kind": "inferred",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source",
+          "There are small V-shaped notches in this section",
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction",
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1",
+          "No defects, such as porosity, slag inclusion, and repair welding, were found in this area"
+        ],
+        "justification": "The overall case synthesis — surface manufacturing flaws and tensile residual stress at the fillet combined with ruled-out material defects — warrants attributing failure to manufacturing/machining of the transition; this is an inferred root-cause conclusion, not a verbatim statement.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Root-cause synthesis: surface manufacturing flaws + tensile residual stress at fillet with ruled-out material defects warrants attributing failure to machining of the transition. Defensible inferred conclusion, not verbatim.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "fact": "All three axles failed/showed cracks at the same location: the transition corner/fillet.",
+        "kind": "inferred",
+        "grounded_by": [
+          "axle 1# broke at the transition corner",
+          "magnetic marks gathered on both sides of the transition corners of axle 2#",
+          "accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle"
+        ],
+        "justification": "Each of the three axles is described with cracking/failure at the transition corner/angle; concluding a common failure location across all three is a warranted synthesis across the three separate statements.",
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Each of the three axles is described with cracking/failure at the transition corner/angle; common-location synthesis is warranted across the three statements.",
+        "grounded": true,
+        "reason": ""
+      }
+    ],
+    "input_attempts": [
+      {
+        "attempt": 1,
+        "n": 32,
+        "n_rejected": 0
+      }
+    ],
+    "leading_answer": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+    "output_claims": [
+      {
+        "claim": "The failures occurred in newly designed axles of a prototype PMDD electric locomotive during wheel-seat-axle fatigue testing, and the axles failed prematurely and did not meet validation requirements.",
+        "kind": "evidence",
+        "grounded_by": [
+          "During the development of a prototype PMDD electric locomotive, the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing, failing to meet validation requirements."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Cited sentence states prototype PMDD locomotive, newly designed axles, premature failures during wheel-seat-axle fatigue testing, and failure to meet validation requirements. Direct restatement.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "All three axles showed damage at the same location — the transition corner/fillet: axle 1# broke there, and magnetic-particle marks accumulated at the transition corners of axles 2# and 3#.",
+        "kind": "evidence",
+        "grounded_by": [
+          "After 3 million fatigue tests, axle 1# broke at the transition corner.",
+          "After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#.",
+          "After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "All three cited bytes locate damage at the same feature: 1# broke at transition corner; 2# magnetic marks at transition corners; 3# marks at transition angle. Same-location claim directly supported.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The magnetic marks accumulating at the transition corners of axles 2# and 3# indicate the presence of surface cracks at those fillets (magnetic particle inspection responds to surface/near-surface discontinuities).",
+        "kind": "conclusion",
+        "grounded_by": [
+          "it was found that magnetic marks gathered on both sides of the transition corners of axle 2#.",
+          "accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Magnetic-particle marks gathering at a feature is the warranted MPI reading of surface/near-surface discontinuity; conclusion hedged ('indicate'). Standard and not over-asserted.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The fracture has dual fatigue initiation sites (surfaces A and B) at the rounded transition corners and shows characteristic bending fatigue patterns with beach marks at both the top and bottom of the fracture section.",
+        "kind": "evidence",
+        "grounded_by": [
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns.",
+          "Beach marks are present at both the top and bottom regions of the fracture section."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Dual initiation sites A/B at rounded corners, characteristic bending fatigue patterns, and beach marks at top and bottom are all stated verbatim in the cited bytes.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The operative failure mechanism is most plausibly bending fatigue, evidenced by the characteristic bending fatigue patterns, dual opposed initiation sites, and beach marks at both top and bottom of the section.",
+        "kind": "conclusion",
+        "grounded_by": [
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns.",
+          "Beach marks are present at both the top and bottom regions of the fracture section."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Bending fatigue is the warranted reading from explicit 'characteristic bending fatigue patterns,' dual opposed sites, and top/bottom beach marks; hedged 'most plausibly.'",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The final (fast) fracture region is mixed-mode: ductile shear lips at the edges and cleavage-dominated brittle fracture in the central zone.",
+        "kind": "evidence",
+        "grounded_by": [
+          "The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Cited byte states mixed-mode final fracture: ductile shear lips at edges, cleavage-dominated brittle central zone. Verbatim.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The crack-source surface carries multiple stress-raising features: parallel rough machining textures, blade marks about 0.95 mm wide with parallel processing textures at the bottom, a near-transition surface height difference of 342 micrometers, small V-shaped notches, and local corrosion pits.",
+        "kind": "evidence",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist.",
+          "The width of the blade marks on the surface is about 0.95 mm, and there are parallel processing textures at the bottom.",
+          "The height difference between the highest point and the lowest point near the transition zone is 342 μm.",
+          "There are small V-shaped notches in this section."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Each listed feature (rough machining textures, ~0.95mm blade marks with bottom textures, 342um height difference, V-notches, corrosion pits) is stated in cited bytes.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "These surface features (rough machining, blade marks, 342 micrometer roughness, V-notches, corrosion pits) most plausibly act as stress concentrators that promote fatigue crack initiation at the fillet.",
+        "kind": "conclusion",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist.",
+          "There are small V-shaped notches in this section.",
+          "The height difference between the highest point and the lowest point near the transition zone is 342 μm.",
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "That machining textures, V-notches, roughness, and corrosion pits at the crack source act as stress concentrators promoting fillet fatigue initiation is warranted standard reasoning; hedged.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The chemical composition conforms to EA1N in UIC 811-1, and the microstructure at the crack source matches the core (flake pearlite plus ferrite), grade 7 grain size, with no oxidation, decarburization, overheating, porosity, slag inclusion, or repair welding.",
+        "kind": "evidence",
+        "grounded_by": [
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1.",
+          "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite.",
+          "The grain size is grade 7, and no characteristics of oxidation, decarburization, and overheated microstructure are found.",
+          "No defects, such as porosity, slag inclusion, and repair welding, were found in this area."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Composition conforming to EA1N UIC 811-1, crack-source microstructure matching core (pearlite+ferrite), grade 7 grain, and absence of oxidation/decarb/overheating/porosity/slag/repair weld all stated.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "Because composition is conforming and the microstructure is normal and defect-free, material/metallurgical defects can most plausibly be excluded as the cause, pointing instead to surface/manufacturing condition.",
+        "kind": "conclusion",
+        "grounded_by": [
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1.",
+          "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite.",
+          "no characteristics of oxidation, decarburization, and overheated microstructure are found.",
+          "No defects, such as porosity, slag inclusion, and repair welding, were found in this area."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Excluding metallurgical defects from conforming, normal, defect-free material is warranted; redirect to surface/manufacturing supported by text's surface findings; hedged 'most plausibly.'",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The arc transition zone surface is in tensile residual stress in both directions: 72-99 MPa circumferentially and 71-92 MPa axially.",
+        "kind": "evidence",
+        "grounded_by": [
+          "The surface of the arc region is manifested as tensile stress in both circumferential and axial directions.",
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Cited bytes state tensile residual stress both directions, 72-99 MPa circumferential and 71-92 MPa axial. Verbatim.",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The residual tensile stress at the transition is most plausibly detrimental, superimposing on service bending stress to aid fatigue crack initiation and growth at the fillet.",
+        "kind": "conclusion",
+        "grounded_by": [
+          "The surface of the arc region is manifested as tensile stress in both circumferential and axial directions.",
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Tensile residual stress being detrimental to fatigue initiation/growth is warranted standard reasoning; bending established in bytes; hedged 'most plausibly.'",
+        "grounded": true,
+        "reason": ""
+      },
+      {
+        "claim": "The most plausible root cause is improper machining/manufacturing of the transition fillet — rough surface finish, blade marks, notches, corrosion pits and residual tensile stress combining as stress concentrators to drive bending-fatigue initiation — rather than any material defect, consistent with all three axles cracking at the same fillet location.",
+        "kind": "conclusion",
+        "grounded_by": [
+          "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist.",
+          "There are small V-shaped notches in this section.",
+          "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+          "The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1.",
+          "The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite.",
+          "After 3 million fatigue tests, axle 1# broke at the transition corner.",
+          "The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns."
+        ],
+        "anchored": true,
+        "justified": true,
+        "verifier_note": "Root-cause synthesis (machining/manufacturing surface features + residual tensile stress as concentrators driving bending fatigue, not material defect, same fillet across all axles) is the warranted combined reading; each component byte-supported and hedged.",
+        "grounded": true,
+        "reason": ""
+      }
+    ],
+    "output_attempts": [
+      {
+        "attempt": 1,
+        "leading_answer": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+        "n": 13,
+        "n_rejected": 0
+      }
+    ],
+    "input_rejected": 0,
+    "output_rejected": 0
+  }
+}

--- a/code/specs/data/adj57/pipeline/bidirectional.workflow.js
+++ b/code/specs/data/adj57/pipeline/bidirectional.workflow.js
@@ -1,0 +1,185 @@
+export const meta = {
+  name: 'adj63-bidirectional-end-to-end',
+  description: 'ADJ61+ADJ62 end-to-end on a FRESH case. INPUT: decompose (coverage) -> account for every fact extracted/inferred with the bytes + justification -> input justification gate + kickback. OUTPUT: derive the answer as evidence/conclusion claims grounded by COMBINING input bytes -> output justification gate + kickback. Picks a brand-new documented case (prefer a non-medical identification domain) to test that the bidirectional justification gate generalizes.',
+  phases: [{ title: 'Ingest' }, { title: 'ExtractInput' }, { title: 'VerifyInput' }, { title: 'KickbackInput' }, { title: 'Derive' }, { title: 'VerifyOutput' }, { title: 'KickbackOutput' }],
+}
+
+const INGEST_SCHEMA = {
+  type: 'object',
+  required: ['source_url', 'domain', 'ground_truth', 'case_text', 'segments'],
+  properties: {
+    source_url: { type: 'string' },
+    domain: { type: 'string', description: 'the identification domain, e.g. mineralogy, materials-failure, forensic-entomology, numismatics, ornithology, medicine' },
+    ground_truth: { type: 'string', description: 'the confirmed answer + how established. Held aside from all later stages.' },
+    case_text: { type: 'string', description: 'the EXACT scenario text decomposed (~500-1500 chars): observed evidence up to the decision point, NOT the named answer. segments MUST concatenate to this exactly.' },
+    segments: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['text', 'kind'],
+        properties: { text: { type: 'string' }, kind: { type: 'string', enum: ['fact', 'discard'] }, reason: { type: 'string' } },
+      },
+    },
+  },
+}
+const FACTS_SCHEMA = {
+  type: 'object', required: ['facts'],
+  properties: {
+    facts: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['fact', 'kind', 'grounded_by', 'justification'],
+        properties: {
+          fact: { type: 'string' }, kind: { type: 'string', enum: ['extracted', 'inferred'] },
+          grounded_by: { type: 'array', items: { type: 'string' } }, justification: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+const DERIVE_SCHEMA = {
+  type: 'object', required: ['leading_answer', 'claims'],
+  properties: {
+    leading_answer: { type: 'string' },
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['claim', 'kind', 'grounded_by'],
+        properties: {
+          claim: { type: 'string' }, kind: { type: 'string', enum: ['evidence', 'conclusion'] },
+          grounded_by: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+  },
+}
+const VERIFY_SCHEMA = {
+  type: 'object', required: ['verdicts'],
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['idx', 'justified', 'note'],
+        properties: { idx: { type: 'integer' }, justified: { type: 'boolean' }, note: { type: 'string' } },
+      },
+    },
+  },
+}
+
+const ingestPrompt = `Find ONE real documented identification/diagnosis case to reason about. PREFER a domain OTHER than infectious-disease medicine — e.g. mineralogy/gemstone ID, materials/structural failure analysis, forensic entomology, numismatics (coin authentication), ornithology, meteoritics. Decompose its SCENARIO into a byte-covering IR.
+1. Choose a self-contained scenario passage (~500-1500 chars): the observed evidence up to the decision point. Do NOT include the named final answer. Copy VERBATIM into case_text.
+2. Partition case_text into ordered segments; concatenating segment.text must reproduce case_text EXACTLY (every char). Each is a fact or a discard (with reason).
+3. Return source_url, domain, and the held-aside ground_truth (the confirmed answer + how established).`
+
+const extractPrompt = (caseText) => `You have decomposed the case below. Now account for what you took from it.
+
+CASE TEXT:
+${caseText}
+
+List EVERY fact you extracted or inferred. For each: the fact; its kind — "extracted" (the bytes STATE it directly) or "inferred" (you DERIVED it, a reading/interpretation); grounded_by = byte span(s) copied VERBATIM from the case text (combine several if the fact is built from several); and a justification of why those exact bytes PROVE the fact (extracted) or WARRANT it (inferred). Be honest about kind: an interpretation or label you add is INFERRED, not extracted. Do NOT claim to have extracted a fact the bytes do not state.`
+
+const verifyInputPrompt = (caseText, facts) => `You are an adversarial extraction verifier. For EACH fact, decide whether the CITED bytes — and only those — justify it at its stated kind. Try to REFUTE each; default justified=false when the cited bytes do not carry it.
+
+THE CASE TEXT (the only ground truth):
+${caseText}
+
+Rules:
+  - extracted: the cited bytes must STATE the fact. If it adds any reading the bytes do not contain, justified=false (should be inferred).
+  - inferred: the cited bytes, combined, must WARRANT it as a defensible interpretation (not a leap).
+
+FACTS:
+${facts.map((f, i) => `  [${i}] kind=${f.kind} :: "${f.fact}"\n       cites: ${JSON.stringify(f.grounded_by)}\n       justification: ${f.justification}`).join('\n')}`
+
+const derivePrompt = (caseText, facts) => `Answer this case. You may COMBINE several input bytes into one fact, and you may state a CONCLUSION — but every claim must be JUSTIFIED by the input bytes it cites.
+
+CASE TEXT:
+${caseText}
+
+GROUNDED FACTS established from the input (you may rely on these):
+${facts.map((f) => `  - [${f.kind}] ${f.fact}`).join('\n')}
+
+Emit leading_answer + claims. Type EACH claim:
+  - kind="evidence": a statement ABOUT the input; its cited bytes must state or directly imply it. Do NOT assert a finding the case does not contain.
+  - kind="conclusion": an INFERENCE (the identification/diagnosis, a mechanism, a unifying pattern). You MAY name it even if the name is not a byte — PROVIDED it rests only on byte-grounded evidence and is stated as a hedged inference (a leading hypothesis), not a byte-fact.
+Every claim's grounded_by must be spans copied VERBATIM from the CASE TEXT above. The leading_answer must be a hedged conclusion the claims justify.`
+
+const verifyOutputPrompt = (caseText, claims) => `You are an adversarial grounding verifier. For EACH claim, decide whether the CITED bytes — read together — JUSTIFY it at its stated strength. Try to REFUTE each; default justified=false when the cited bytes do not carry the claim.
+
+THE INPUT (the only ground truth):
+${caseText}
+
+Rules:
+  - evidence: the cited bytes must STATE or directly imply the claim; an asserted finding not in the bytes is invention -> false.
+  - conclusion: the cited bytes, COMBINED, must make it the WARRANTED reading AND it must be hedged as an inference (not asserted as confirmed). If a different explanation fits the same bytes equally, or it over-asserts, justified=false.
+
+CLAIMS:
+${claims.map((c, i) => `  [${i}] kind=${c.kind} :: "${c.claim}"\n       cites: ${JSON.stringify(c.grounded_by)}`).join('\n')}`
+
+const kickbackInputPrompt = (rejected) => `The INPUT justification gate REJECTED these fact extractions:
+${rejected.map((r) => `  - [${r.kind}] "${r.fact}"\n      reason: ${r.reason}`).join('\n')}
+Fix EACH by: (a) cite the exact byte span(s) that prove it (verbatim; combine if needed); (b) if you labelled an interpretation "extracted", re-file as kind="inferred" with a justification; (c) if the bytes do not support it, REMOVE it. Re-emit the FULL corrected facts list.`
+
+const kickbackOutputPrompt = (prev, rejected) => `The OUTPUT justification gate REJECTED these claims:
+${rejected.map((r) => `  - [${r.kind}] "${r.claim}"\n      reason: ${r.reason}`).join('\n')}
+Your previous leading_answer: "${prev.leading_answer}".
+Fix EACH by: (a) cite span(s) copied EXACTLY from the case text that justify it (combine if needed); (b) if it is an over-asserted conclusion, SOFTEN to a hedged inference; (c) if the input does not support it, REMOVE it (and any specificity it lent the answer). Re-emit the FULL corrected leading_answer + claims.`
+
+// ---- gates (mirror of justify_gate.py) ----
+const anchoredIn = (hay, c) => {
+  const spans = (c.grounded_by || []).filter(Boolean)
+  return spans.length > 0 && spans.every((s) => hay.includes(s))
+}
+async function verifyStage(promptFn, items, phase) {
+  const v = await agent(promptFn(items), { phase, label: phase.toLowerCase(), agentType: 'general-purpose', schema: VERIFY_SCHEMA })
+  return new Map((v.verdicts || []).map((x) => [x.idx, x]))
+}
+function gradeItems(hay, items, verdicts, textKey) {
+  return items.map((it, i) => {
+    const verdict = verdicts.get(i) || { justified: false, note: 'no verdict returned' }
+    const isAnchored = anchoredIn(hay, it)
+    const grounded = isAnchored && !!verdict.justified
+    const reason = grounded ? '' : (!isAnchored ? 'byte-anchor FAIL — a cited span is not verbatim (or no citation)' : `justification FAIL — ${verdict.note}`)
+    return { ...it, [textKey]: it[textKey], anchored: isAnchored, justified: !!verdict.justified, verifier_note: verdict.note, grounded, reason }
+  })
+}
+
+// ---- run ----
+// INPUT
+const ingest = await agent(ingestPrompt, { phase: 'Ingest', label: 'ingest', agentType: 'general-purpose', schema: INGEST_SCHEMA })
+const caseText = ingest.case_text
+const coverage_ok = ingest.segments.map((s) => s.text).join('') === caseText
+log(`domain=${ingest.domain}; coverage ${coverage_ok ? 'OK' : 'BROKEN'} (${caseText.length} bytes)`)
+
+let facts = (await agent(extractPrompt(caseText), { phase: 'ExtractInput', label: 'extract', agentType: 'general-purpose', schema: FACTS_SCHEMA })).facts
+let inGraded = gradeItems(caseText, facts, await verifyStage((f) => verifyInputPrompt(caseText, f), facts, 'VerifyInput'), 'fact')
+const inputAttempts = [{ attempt: 1, n: inGraded.length, n_rejected: inGraded.filter((g) => !g.grounded).length }]
+for (let i = 2; i <= 4; i++) {
+  const rej = inGraded.filter((g) => !g.grounded)
+  if (!rej.length) break
+  log(`INPUT gate: ${rej.length} rejected -> kickback ${i}`)
+  facts = (await agent(kickbackInputPrompt(rej), { phase: 'KickbackInput', label: `re-extract-${i}`, agentType: 'general-purpose', schema: FACTS_SCHEMA })).facts
+  inGraded = gradeItems(caseText, facts, await verifyStage((f) => verifyInputPrompt(caseText, f), facts, 'VerifyInput'), 'fact')
+  inputAttempts.push({ attempt: i, n: inGraded.length, n_rejected: inGraded.filter((g) => !g.grounded).length })
+}
+const groundedFacts = inGraded.filter((g) => g.grounded)
+
+// OUTPUT
+let derived = await agent(derivePrompt(caseText, groundedFacts), { phase: 'Derive', label: 'derive', agentType: 'general-purpose', schema: DERIVE_SCHEMA })
+let outGraded = gradeItems(caseText, derived.claims, await verifyStage((c) => verifyOutputPrompt(caseText, c), derived.claims, 'VerifyOutput'), 'claim')
+const outputAttempts = [{ attempt: 1, leading_answer: derived.leading_answer, n: outGraded.length, n_rejected: outGraded.filter((g) => !g.grounded).length }]
+for (let i = 2; i <= 4; i++) {
+  const rej = outGraded.filter((g) => !g.grounded)
+  if (!rej.length) break
+  log(`OUTPUT gate: ${rej.length} rejected -> kickback ${i}`)
+  derived = await agent(kickbackOutputPrompt(derived, rej), { phase: 'KickbackOutput', label: `re-derive-${i}`, agentType: 'general-purpose', schema: DERIVE_SCHEMA })
+  outGraded = gradeItems(caseText, derived.claims, await verifyStage((c) => verifyOutputPrompt(caseText, c), derived.claims, 'VerifyOutput'), 'claim')
+  outputAttempts.push({ attempt: i, leading_answer: derived.leading_answer, n: outGraded.length, n_rejected: outGraded.filter((g) => !g.grounded).length })
+}
+
+return {
+  domain: ingest.domain, source_url: ingest.source_url, ground_truth: ingest.ground_truth,
+  case_text: caseText, segments: ingest.segments, coverage_ok,
+  input_facts: inGraded, input_attempts: inputAttempts,
+  leading_answer: derived.leading_answer, output_claims: outGraded, output_attempts: outputAttempts,
+  input_rejected: inGraded.filter((g) => !g.grounded).length,
+  output_rejected: outGraded.filter((g) => !g.grounded).length,
+}

--- a/code/specs/data/adj57/pipeline/run_bidirectional.py
+++ b/code/specs/data/adj57/pipeline/run_bidirectional.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""ADJ63 driver — report the full bidirectional justification pipeline on a fresh case.
+
+Verifies, end to end, every corner of the provenance grid:
+  INPUT  coverage   (stage.gate_text):    every input byte used or discarded-with-reason
+  INPUT  extraction (justify_gate.grade): every extracted/inferred fact byte-anchored AND justified
+  OUTPUT grounding  (justify_gate.grade): every evidence/conclusion claim byte-anchored AND justified
+
+Run: python run_bidirectional.py <bidirectional-results.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import justify_gate  # noqa: E402
+import stage  # noqa: E402
+
+
+def _breakdown(r: dict) -> str:
+    return " + ".join(f"{v} {k}" for k, v in r["by_kind"].items()) or "0"
+
+
+def main() -> None:
+    res = json.loads(Path(sys.argv[1]).read_text())
+    res = res.get("result", res)
+    case_text = res["case_text"]
+
+    print("=" * 74)
+    print("  ADJ63 — bidirectional justification, end to end")
+    print(f"  domain: {res.get('domain','?')}   source: {res.get('source_url','')}")
+    print("=" * 74)
+
+    # INPUT coverage
+    segs = [({"text": s["text"], "kind": "used", "produced": "fact"} if s.get("kind") == "fact"
+             else {"text": s["text"], "kind": "discard", "reason": s.get("reason", "")}) for s in res["segments"]]
+    cov = stage.gate_text("decompose", case_text, segs)
+    print("\n## [1] INPUT coverage — nothing dropped")
+    print(f"   {'100% COVERAGE' if cov.covered else 'VIOLATION'}: {cov.n_used} facts + {cov.n_discard} discards = {cov.n_input} bytes. clean={cov.clean}")
+
+    # INPUT extraction
+    ri = justify_gate.grade([case_text], res["input_facts"])
+    print("\n## [2] INPUT extraction — nothing mis-extracted")
+    print(f"   {ri['n_grounded']}/{ri['n_claims']} facts grounded ({_breakdown(ri)}); {ri['n_rejected']} rejected. fully={ri['fully_grounded']}")
+    for a in res.get("input_attempts", []):
+        print(f"      attempt {a['attempt']}: {a['n']} facts; {'clean' if a['n_rejected'] == 0 else str(a['n_rejected']) + ' rejected -> kickback'}")
+
+    # OUTPUT grounding
+    ro = justify_gate.grade([case_text], res["output_claims"])
+    print("\n## [3] OUTPUT grounding — nothing invented")
+    print(f"   {ro['n_grounded']}/{ro['n_claims']} claims grounded ({_breakdown(ro)}); {ro['n_rejected']} rejected. fully={ro['fully_grounded']}")
+    for a in res.get("output_attempts", []):
+        print(f"      attempt {a['attempt']}: \"{a['leading_answer'][:52]}\" ({a['n']} claims; {'clean' if a['n_rejected'] == 0 else str(a['n_rejected']) + ' rejected -> kickback'})")
+
+    print(f"\n## ANSWER (hedged, byte-justified): {res['leading_answer']}")
+    print("\n## CONCLUSION claims (each justified by COMBINING cited bytes):")
+    for g in [x for x in ro["grounded"] if x["kind"] == "conclusion"]:
+        print(f"     - {g['claim'][:72]}")
+        print(f"         from: {', '.join(s[:22] for s in g['spans'][:5])}")
+    print("\n## INFERRED input facts (read, not stated):")
+    for g in [x for x in ri["grounded"] if x["kind"] == "inferred"][:8]:
+        print(f"     - {g['claim'][:68]}")
+
+    if ri["rejected"] or ro["rejected"]:
+        print("\n## LIVE REJECTIONS (the gate biting):")
+        for u in ri["rejected"] + ro["rejected"]:
+            print(f"     - [{u['kind']}] {u['claim'][:50]}: {u['reason'][:46]}")
+
+    print(f"\n   ground truth (held aside): {res.get('ground_truth','')[:180]}")
+    allgood = cov.covered and ri["fully_grounded"] and ro["fully_grounded"]
+    print(f"\n   >>> BIDIRECTIONAL PROVENANCE {'COMPLETE — coverage + input extraction + output grounding all clean.' if allgood else 'INCOMPLETE (see above).'}")
+
+    out = {
+        "domain": res.get("domain"), "leading_answer": res["leading_answer"],
+        "coverage": {"covered": cov.covered, "clean": cov.clean, "bytes": cov.n_input},
+        "input_extraction": {"n": ri["n_claims"], "grounded": ri["n_grounded"], "rejected": ri["n_rejected"], "by_kind": ri["by_kind"]},
+        "output_grounding": {"n": ro["n_claims"], "grounded": ro["n_grounded"], "rejected": ro["n_rejected"], "by_kind": ro["by_kind"]},
+        "input_attempts": res.get("input_attempts", []), "output_attempts": res.get("output_attempts", []),
+        "complete": allgood,
+    }
+    (Path(__file__).resolve().parent.parent / "bidirectional.json").write_text(json.dumps(out, indent=2))
+    sys.exit(0 if allgood else 3)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/run_underdetermination.py
+++ b/code/specs/data/adj57/pipeline/run_underdetermination.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""ADJ64 driver — report the underdetermination gate on a graded run.
+
+Re-adjudicates with the deterministic gate (underdetermination.assess), then prints which
+rivals are resolved by present bytes, which are OPEN because their discriminating
+observation is missing, the named provenance holes (queries to fetch), and the honest
+disjunctive answer that replaces the over-attributed one.
+
+Run: python run_underdetermination.py <underdetermination-results.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import underdetermination as u  # noqa: E402
+
+
+def main() -> None:
+    res = json.loads(Path(sys.argv[1]).read_text())
+    res = res.get("result", res)
+    r = u.assess([res["case_text"]], res["rivals"])
+
+    print("=" * 74)
+    print("  ADJ64 — underdetermination gate (over-attribution under missing data)")
+    print("=" * 74)
+
+    print(f"\n## Rivals to the leading conclusion: {r['n_rivals']} "
+          f"({r['n_resolved']} resolved by present bytes, {r['n_open']} OPEN)")
+    print(f"## Conclusion is {'DETERMINED' if r['determined'] else 'UNDERDETERMINED'} by the input bytes.")
+
+    if r["resolved"]:
+        print("\n## RESOLVED rivals (ruled out by a present, cited datum):")
+        for x in r["resolved"]:
+            print(f"     - {x['hypothesis'][:52]:52s}  <- {x['citation'][:36]!r}")
+    if r["open"]:
+        print("\n## OPEN rivals (cannot be ruled out — the deciding datum is MISSING):")
+        for x in r["open"]:
+            print(f"     - rival: {x['hypothesis'][:60]}")
+            print(f"         would need: {x['discriminating_observation'][:64]}")
+            print(f"         status: {x['why'][:60]}")
+
+    if r["holes"]:
+        print("\n## NAMED PROVENANCE HOLES (queries the spider/CAS must fetch to decide):")
+        for h in r["holes"]:
+            print(f"     ? {h}")
+
+    print("\n## BEFORE (ADJ63 — over-attributed, single cause):")
+    print(f"   {res['leading_answer'][:300]}")
+    print("\n## AFTER (ADJ64 — honest disjunction + named missing data):")
+    print(f"   {res['corrected_answer'][:600]}")
+
+    out = {
+        "determined": r["determined"], "n_rivals": r["n_rivals"],
+        "n_resolved": r["n_resolved"], "n_open": r["n_open"],
+        "holes": r["holes"], "resolved": r["resolved"], "open": r["open"],
+        "before": res["leading_answer"], "after": res["corrected_answer"],
+    }
+    (Path(__file__).resolve().parent.parent / "underdetermination.json").write_text(json.dumps(out, indent=2))
+    print(f"\n   >>> {'DETERMINED — no missing discriminators.' if r['determined'] else 'UNDERDETERMINED — the gate refused to single out a cause and named the missing data instead of guessing.'}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/test_underdetermination.py
+++ b/code/specs/data/adj57/pipeline/test_underdetermination.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Tests for the underdetermination gate (underdetermination.py).
+Run: python test_underdetermination.py"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import underdetermination as u  # noqa: E402
+
+INPUT = ["Cultures were sterile. The chemical composition conforms to EA1N. Beach marks are present."]
+
+
+def test_determined_when_every_rival_has_a_present_cited_datum():
+    r = u.assess(INPUT, [
+        {"hypothesis": "material defect", "discriminating_observation": "chemistry conformance",
+         "present": True, "citation": "The chemical composition conforms to EA1N"}])
+    assert r["determined"] and r["n_open"] == 0 and not r["holes"]
+
+
+def test_underdetermined_when_discriminating_datum_absent():
+    # the observation that would rule out the rival is simply not in the bytes
+    r = u.assess(INPUT, [
+        {"hypothesis": "operating stress exceeded fatigue limit",
+         "discriminating_observation": "operating stress vs fatigue limit comparison",
+         "present": False, "citation": ""}])
+    assert not r["determined"] and r["n_open"] == 1
+    assert r["holes"] == ["operating stress vs fatigue limit comparison"]
+    assert "ABSENT" in r["open"][0]["why"]
+
+
+def test_claimed_present_but_fabricated_citation_is_open():
+    # cannot CLAIM the datum is present without a verbatim byte
+    r = u.assess(INPUT, [
+        {"hypothesis": "overstress", "discriminating_observation": "FEA stress 298 MPa",
+         "present": True, "citation": "FEA shows 298 MPa"}])  # not in input
+    assert not r["determined"] and r["n_open"] == 1
+    assert "not verbatim" in r["open"][0]["why"]
+
+
+def test_mixed_resolved_and_open():
+    r = u.assess(INPUT, [
+        {"hypothesis": "material defect", "discriminating_observation": "chemistry",
+         "present": True, "citation": "conforms to EA1N"},
+        {"hypothesis": "overstress", "discriminating_observation": "stress vs fatigue limit",
+         "present": False, "citation": ""}])
+    assert r["n_resolved"] == 1 and r["n_open"] == 1 and not r["determined"]
+    assert r["holes"] == ["stress vs fatigue limit"]
+
+
+def test_no_rivals_is_trivially_determined():
+    # nothing competes with the conclusion -> determined (vacuously)
+    r = u.assess(INPUT, [])
+    assert r["determined"] and r["n_open"] == 0
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"  ok  {fn.__name__}")
+    print(f"\n{len(fns)} tests passed.")

--- a/code/specs/data/adj57/pipeline/underdetermination-results.json
+++ b/code/specs/data/adj57/pipeline/underdetermination-results.json
@@ -1,0 +1,78 @@
+{
+  "summary": "ADJ64 — the underdetermination gate. Take the byte-grounded leading conclusion from the ADJ63 axle run and ask: what rival explanations fit the SAME bytes, and for each, is the discriminating observation PRESENT (cited verbatim) or ABSENT? If any rival cannot be ruled out because its deciding datum is missing, the conclusion is underdetermined — soften it to a disjunction and emit the missing data as named provenance holes (queries the spider/CAS can fetch). Demonstrates catching over-attribution-under-missing-evidence, the failure the byte-anchor alone does not catch.",
+  "agentCount": 2,
+  "logs": [
+    "rivals=7; open=5; determined=false"
+  ],
+  "result": {
+    "case_text": "During the development of a prototype PMDD electric locomotive, the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing, failing to meet validation requirements. After 3 million fatigue tests, axle 1# broke at the transition corner. After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#. After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle. The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns. Beach marks are present at both the top and bottom regions of the fracture section. The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone. Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist. The width of the blade marks on the surface is about 0.95 mm, and there are parallel processing textures at the bottom. The height difference between the highest point and the lowest point near the transition zone is 342 μm. There are small V-shaped notches in this section. The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1. The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite. The grain size is grade 7, and no characteristics of oxidation, decarburization, and overheated microstructure are found. No defects, such as porosity, slag inclusion, and repair welding, were found in this area. The surface of the arc region is manifested as tensile stress in both circumferential and axial directions. The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+    "leading_answer": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+    "rivals": [
+      {
+        "hypothesis": "The dominant root cause is geometric/design under-dimensioning of the transition fillet (insufficient fillet radius / high theoretical stress-concentration factor Kt), not the surface machining condition. The same dual-initiation bending-fatigue fractography at the fillet is fully consistent with a fillet radius too small for the service bending loads.",
+        "discriminating_observation": "The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry.",
+        "present": false,
+        "citation": "",
+        "resolved": false,
+        "why": "discriminating observation ABSENT from the input"
+      },
+      {
+        "hypothesis": "The failure is an overload / under-design issue: the applied bending stress in fatigue testing exceeded the EA1N fatigue endurance limit, so the axle would crack from bending fatigue regardless of surface finish or residual stress. Beach marks and dual initiation are equally consistent with a stress amplitude simply above the material's fatigue limit.",
+        "discriminating_observation": "A comparison of the operating/test bending stress amplitude at the fillet to the EA1N material fatigue limit.",
+        "present": false,
+        "citation": "",
+        "resolved": false,
+        "why": "discriminating observation ABSENT from the input"
+      },
+      {
+        "hypothesis": "Press-fit / fretting fatigue at the wheel-seat–axle interface is the primary driver (this is a wheel-seat fatigue test), with fretting at the seat edge near the transition initiating the cracks, rather than free-surface machining marks. Wheel-seat fatigue characteristically initiates near the seat/fillet boundary.",
+        "discriminating_observation": "Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit.",
+        "present": false,
+        "citation": "failing to meet validation requirements",
+        "resolved": false,
+        "why": "discriminating observation ABSENT from the input"
+      },
+      {
+        "hypothesis": "Residual tensile stress alone (e.g., from heat treatment or improper machining-induced residual stress) is the controlling factor, not the geometric machining marks; the 72-99 MPa tensile residual stress is detrimental because the as-designed surface should have been compressive (no shot-peening / surface treatment applied). The leading conclusion lumps residual stress with surface texture, but residual stress could be the standalone cause.",
+        "discriminating_observation": "The specified/required surface residual stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72-99 MPa tensile is out-of-spec versus normal.",
+        "present": false,
+        "citation": "The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.",
+        "resolved": false,
+        "why": "discriminating observation ABSENT from the input"
+      },
+      {
+        "hypothesis": "Corrosion-assisted (corrosion-fatigue) initiation is the primary driver: the local corrosion pits, not the machining textures, are the dominant crack nuclei, making the environment/storage condition the root cause rather than machining quality.",
+        "discriminating_observation": "Direct correlation of the crack origin to a corrosion pit versus to a machining-mark valley (i.e., which feature the fatigue crack actually nucleated from).",
+        "present": true,
+        "citation": "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist.",
+        "resolved": true,
+        "why": ""
+      },
+      {
+        "hypothesis": "A localized subsurface or surface material/processing anomaly that the sampled tests missed: composition and microstructure were checked at the crack source and core and found normal, but a discrete inclusion, micro-defect, or hard spot at the specific initiation point could be the true nucleus. Conformance of bulk chemistry/microstructure does not exclude a local defect at the initiation site.",
+        "discriminating_observation": "High-magnification (SEM) characterization of the exact fatigue-initiation point for an inclusion or local metallurgical anomaly.",
+        "present": true,
+        "citation": "No defects, such as porosity, slag inclusion, and repair welding, were found in this area.",
+        "resolved": true,
+        "why": ""
+      },
+      {
+        "hypothesis": "The roughness/step quantified near the transition (342 μm height difference, ~0.95 mm blade marks) reflects a gross machining step/mismatch that is a discrete geometric stress raiser (a machining error on specific axles) rather than a general 'rough surface finish' problem; the failure is a one-off process escape, not a systemic surface-condition design flaw.",
+        "discriminating_observation": "The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 μm step and 0.95 mm blade marks.",
+        "present": false,
+        "citation": "The height difference between the highest point and the lowest point near the transition zone is 342 μm.",
+        "resolved": false,
+        "why": "discriminating observation ABSENT from the input"
+      }
+    ],
+    "determined": false,
+    "holes": [
+      "The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry.",
+      "A comparison of the operating/test bending stress amplitude at the fillet to the EA1N material fatigue limit.",
+      "Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit.",
+      "The specified/required surface residual stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72-99 MPa tensile is out-of-spec versus normal.",
+      "The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 μm step and 0.95 mm blade marks."
+    ],
+    "corrected_answer": "HONEST REWRITE OF THE AXLE FAILURE CONCLUSION\n\nWhat the evidence actually supports (byte-grounded findings — keep these):\n- The fracture is a bending-fatigue failure that initiated at the machined transition fillet of the axle. Fractographic features are consistent with fatigue: beach/clamshell (progression) marks and dual crack initiation at the fillet.\n- Surface-condition stress concentrators are demonstrably present at/near the transition: rough machining texture, blade/tool marks (~0.95 mm), a measured surface step/height difference of 342 μm, surface notches/roughness, corrosion pits, and a measured tensile residual stress of 72–99 MPa at the fillet.\n- The material itself is clean: chemical composition and microstructure conform to EA1N specification — there is no evidence of a metallurgical/material defect (no inclusions, no microstructural anomaly, no off-spec chemistry) driving the failure.\n\nWhat CANNOT be concluded (the over-attribution to correct):\nThe leading conclusion asserts that manufacturing/surface condition — rough machining, blade marks, notches, pits, and tensile residual stress acting together — was THE root cause. The data do not establish this single cause. The same fractographic signature (dual-initiation bending fatigue at the fillet, with surface stress raisers present) is equally consistent with several rival mechanisms that the case text gives no information to rule out. The root cause must therefore be stated as a DISJUNCTION, not a single driver:\n\nROOT CAUSE = at least one (and possibly a combination) of the following, none of which can currently be excluded:\n1. Geometric under-dimensioning of the fillet — the fillet radius is too small / the theoretical stress-concentration factor Kt is too high for the service bending loads (a design/geometry cause, independent of surface finish).\n2. Overload / under-design in fatigue — the applied bending-stress amplitude at the fillet simply exceeded the EA1N fatigue endurance limit, so cracking would occur regardless of surface finish or residual stress.\n3. Press-fit / fretting fatigue at the wheel-seat–axle interface — fretting at the seat/fillet boundary, characteristic of wheel-seat fatigue tests, initiated the cracks rather than free-surface machining marks.\n4. Residual tensile stress as a standalone controlling factor — the 72–99 MPa tensile residual stress (rather than the surface texture it is lumped with) is the controlling driver, detrimental specifically if the qualified design required a compressive surface state that was absent.\n5. A discrete machining-step / process escape — the 342 μm step and ~0.95 mm blade marks represent a gross localized geometric mismatch on specific axles (a one-off manufacturing error / discrete stress raiser), not a systemic surface-finish design flaw.\n\nThese rivals are not mutually exclusive and several can co-act; the evidence in hand does not weight among them.\n\nMISSING DISCRIMINATING DATA — what must be retrieved to decide (not present in the case text; do not invent):\n- The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry. (discriminates rival 1)\n- A comparison of the operating/test bending-stress amplitude at the fillet to the EA1N material fatigue limit. (discriminates rival 2)\n- Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit. (discriminates rival 3)\n- The specified/required surface residual-stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72–99 MPa tensile is out-of-spec versus normal. (discriminates rival 4)\n- The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 μm step and 0.95 mm blade marks. (discriminates rival 5)\n\nBottom line: The failure is confidently a bending-fatigue crack initiating at the machined transition fillet, on conforming EA1N material with surface stress concentrators present — but the controlling root cause is UNDERDETERMINED among fillet geometry (Kt), overload relative to the fatigue limit, wheel-seat fretting, standalone residual tensile stress, and a discrete machining-step process escape. Resolving it requires the five missing measurements above, none of which appear in the available case text."
+  }
+}

--- a/code/specs/data/adj57/pipeline/underdetermination.py
+++ b/code/specs/data/adj57/pipeline/underdetermination.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""ADJ64 — the underdetermination gate (over-attribution under missing evidence).
+
+ADJ60/61 stop *invented evidence*: a claim cannot cite bytes that are not there. But the
+ADJ63 axle run exposed a *second* failure the byte-anchor does not catch. When the datum
+that would decide between rival explanations is **absent from the input**, the model does
+not fabricate it (good) — it lets the conclusion **drift to the loudest present lever** and
+singles out one cause anyway (bad). The axle answer named "machining/surface" as the root
+cause; the held-aside truth was "operating stress exceeded the fatigue limit". Both fit the
+*same* bytes — the discriminating measurement (operating stress vs. fatigue limit) was
+simply never decomposed. Every claim was byte-grounded; the *selection among causes* was
+not.
+
+So invention is not the only way to be wrong. A conclusion can be **underdetermined**: more
+than one hypothesis fits the present bytes, and the observation that would separate them is
+missing. The honest move is not to guess — it is to (a) keep the conclusion as a disjunction
+over the live rivals, and (b) emit the missing discriminating observation as a *named
+provenance hole* — a query the spider/CAS can go fetch. "If the data is not present we
+cannot reason over it" is true for a single step; naming the hole is how the *loop* turns
+absence into the next thing to retrieve.
+
+THE GATE. For each rival hypothesis that fits the same bytes, the model supplies the single
+**discriminating observation** that would settle leading-vs-rival, and whether that
+observation is PRESENT in the input (with a verbatim citation) or ABSENT. The deterministic
+rule:
+
+  - a rival is RESOLVED iff its discriminating observation is marked present AND the citation
+    is verbatim in the input (you cannot *claim* the data is there without a real byte);
+  - otherwise the rival is OPEN — the discriminating observation is a HOLE (absent, or a
+    fabricated "present").
+
+The conclusion is DETERMINED iff no rival is open. If any rival is open, the conclusion is
+underdetermined: it must soften to the disjunction over the open rivals, and the holes are
+reported as required-but-missing data. The model proposes; this module adjudicates — and,
+exactly as on every other gate, "present" is only ever as good as a verbatim byte.
+
+Usage (library): assess(input_units, rivals) -> report.
+  rivals: [{"hypothesis","discriminating_observation","present":bool,"citation":"verbatim span"}]
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def assess(input_units: list[str], rivals: list[dict]) -> dict:
+    """input_units: the bytes the answer may draw on. rivals: alternative explanations that
+    fit the same bytes, each with the observation that would discriminate it from the leading
+    answer and a claim about whether that observation is present in the input."""
+    hay = "\n".join(input_units)
+    resolved, open_ = [], []
+    for r in rivals:
+        obs = (r.get("discriminating_observation") or "").strip()
+        citation = (r.get("citation") or "").strip()
+        cite_ok = bool(citation) and citation in hay
+        present = bool(r.get("present")) and cite_ok
+        rec = {
+            "hypothesis": r.get("hypothesis", ""),
+            "discriminating_observation": obs,
+            "present": present,
+            "citation": citation if cite_ok else "",
+        }
+        if present and obs:
+            resolved.append(rec)
+        else:
+            rec["why"] = (
+                "discriminating observation ABSENT from the input — a required-but-missing datum"
+                if not r.get("present")
+                else "claimed present but citation is not verbatim in the input — treated as absent"
+                if not cite_ok
+                else "no discriminating observation supplied"
+            )
+            open_.append(rec)
+
+    holes = [o["discriminating_observation"] for o in open_ if o["discriminating_observation"]]
+    return {
+        "n_rivals": len(rivals),
+        "n_resolved": len(resolved),
+        "n_open": len(open_),
+        # determined iff no rival is left open (no rivals at all -> vacuously determined).
+        "determined": not open_,
+        "resolved": resolved,
+        "open": open_,
+        "holes": holes,
+    }
+
+
+def main() -> None:
+    """CLI: python underdetermination.py <case.txt> <rivals.json>"""
+    input_units = [Path(sys.argv[1]).read_text()]
+    rivals = json.loads(Path(sys.argv[2]).read_text())
+    r = assess(input_units, rivals)
+    print(json.dumps({k: v for k, v in r.items() if k not in ("resolved", "open")}, indent=2))
+    if r["determined"]:
+        print(f"\n>>> DETERMINED: all {r['n_rivals']} rival(s) discriminated by present, cited bytes.")
+        sys.exit(0)
+    print(f"\n>>> UNDERDETERMINED: {r['n_open']}/{r['n_rivals']} rival(s) cannot be ruled out — "
+          "the conclusion must stay a disjunction; these discriminating data are MISSING (go fetch):")
+    for o in r["open"]:
+        print(f"    - to rule out {o['hypothesis'][:48]!r}: {o['discriminating_observation'][:70]} ({o['why'][:40]})")
+    sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/underdetermination.workflow.js
+++ b/code/specs/data/adj57/pipeline/underdetermination.workflow.js
@@ -1,0 +1,87 @@
+export const meta = {
+  name: 'adj64-underdetermination',
+  description: 'ADJ64 — the underdetermination gate. Take the byte-grounded leading conclusion from the ADJ63 axle run and ask: what rival explanations fit the SAME bytes, and for each, is the discriminating observation PRESENT (cited verbatim) or ABSENT? If any rival cannot be ruled out because its deciding datum is missing, the conclusion is underdetermined — soften it to a disjunction and emit the missing data as named provenance holes (queries the spider/CAS can fetch). Demonstrates catching over-attribution-under-missing-evidence, the failure the byte-anchor alone does not catch.',
+  phases: [{ title: 'Rivals' }, { title: 'Soften' }],
+}
+
+// The axle case + the ADJ63 leading conclusion (byte-identical to bidirectional-results.json).
+const CASE_TEXT = `During the development of a prototype PMDD electric locomotive, the newly designed axles exhibited premature failures during wheel-seat–axle fatigue testing, failing to meet validation requirements. After 3 million fatigue tests, axle 1# broke at the transition corner. After 3.5 million fatigue tests, it was found that magnetic marks gathered on both sides of the transition corners of axle 2#. After 1.6 million tests, accumulated magnetic marks were also found on both sides of the # 3 axle's transition angle. The identified dual fatigue initiation sites on surfaces A and B at the transition's rounded corners exhibit characteristic bending fatigue patterns. Beach marks are present at both the top and bottom regions of the fracture section. The final fracture exhibits mixed modes: ductile shear lips at edges and cleavage-dominated brittle fracture in the central zone. Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist. The width of the blade marks on the surface is about 0.95 mm, and there are parallel processing textures at the bottom. The height difference between the highest point and the lowest point near the transition zone is 342 μm. There are small V-shaped notches in this section. The chemical composition test results are in line with the standard requirements of EA1N in UIC 811-1. The microstructures at the crack source are the same as those at the core, all of which are flake pearlite + ferrite. The grain size is grade 7, and no characteristics of oxidation, decarburization, and overheated microstructure are found. No defects, such as porosity, slag inclusion, and repair welding, were found in this area. The surface of the arc region is manifested as tensile stress in both circumferential and axial directions. The arc transition zone exhibits residual tensile stress values of 72–99 MPa in the circumferential direction and 71–92 MPa in the axial direction.`
+const LEADING_ANSWER = `The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.`
+
+const RIVALS_SCHEMA = {
+  type: 'object',
+  required: ['rivals'],
+  properties: {
+    rivals: {
+      type: 'array',
+      description: 'alternative explanations that fit the SAME bytes as the leading conclusion — the ones a careful reviewer would not be able to rule out from this text alone.',
+      items: {
+        type: 'object', required: ['hypothesis', 'discriminating_observation', 'present', 'citation'],
+        properties: {
+          hypothesis: { type: 'string', description: 'the rival explanation (e.g. a different root cause)' },
+          discriminating_observation: { type: 'string', description: 'the SINGLE observation/measurement that would let you choose between the leading conclusion and this rival' },
+          present: { type: 'boolean', description: 'is that discriminating observation actually present in the CASE TEXT?' },
+          citation: { type: 'string', description: 'if present: the span copied VERBATIM from the case text that supplies it. if absent: empty string.' },
+        },
+      },
+    },
+  },
+}
+
+const SOFTEN_SCHEMA = {
+  type: 'object',
+  required: ['corrected_answer'],
+  properties: {
+    corrected_answer: { type: 'string', description: 'the honest answer: grounded findings kept; the cause stated as a disjunction over the rivals that cannot be ruled out; the missing discriminating data named as what must be retrieved to decide.' },
+  },
+}
+
+const rivalsPrompt = `Here is a leading conclusion and the case text it was drawn from. Your job is adversarial: find the rival explanations that fit the SAME bytes equally well, so the leading conclusion may be OVER-ATTRIBUTING.
+
+CASE TEXT:
+${CASE_TEXT}
+
+LEADING CONCLUSION:
+${LEADING_ANSWER}
+
+List the rival hypotheses a careful failure analyst could NOT rule out from this text alone (e.g. a different root cause that the same fractography is consistent with). For EACH rival give:
+  - the SINGLE discriminating observation that would settle leading-vs-rival (the one measurement/test whose result picks a side);
+  - present = whether that discriminating observation is actually IN the case text;
+  - citation = if present, the verbatim span; if absent, "".
+Be ruthless about "present": if the deciding measurement (e.g. a comparison of operating stress to the material's fatigue limit) is NOT written in the case text, mark present=false. Do not credit the text with data it does not contain.`
+
+const softenPrompt = (open, holes) => `The leading conclusion is UNDERDETERMINED: these rival explanations fit the same bytes and cannot be ruled out, because the deciding observation is missing from the input:
+${open.map((o) => `  - rival: ${o.hypothesis}\n      would need: ${o.discriminating_observation} (NOT in the case text)`).join('\n')}
+
+LEADING CONCLUSION (do not just repeat it — it over-attributes):
+${LEADING_ANSWER}
+
+Rewrite it honestly: (1) keep the byte-grounded findings (bending fatigue at the transition fillet; surface stress concentrators present; material/chemistry clean); (2) state the ROOT CAUSE as a disjunction over the rivals that cannot be ruled out, NOT a single cause; (3) explicitly name the missing discriminating data — ${JSON.stringify(holes)} — as what must be retrieved to decide. Do NOT invent any of the missing data.`
+
+// ---- the gate (mirror of underdetermination.py) ----
+const isResolved = (r) => !!r.present && !!r.citation && CASE_TEXT.includes(r.citation)
+
+// ---- run ----
+const out = await agent(rivalsPrompt, { phase: 'Rivals', label: 'rivals', agentType: 'general-purpose', schema: RIVALS_SCHEMA })
+const graded = out.rivals.map((r) => {
+  const resolved = isResolved(r)
+  return { ...r, resolved, why: resolved ? '' : (!r.present ? 'discriminating observation ABSENT from the input' : 'claimed present but citation not verbatim — treated as absent') }
+})
+const open = graded.filter((g) => !g.resolved)
+const holes = open.map((o) => o.discriminating_observation).filter(Boolean)
+const determined = open.length === 0
+log(`rivals=${graded.length}; open=${open.length}; determined=${determined}`)
+
+let corrected_answer = LEADING_ANSWER
+if (!determined) {
+  corrected_answer = (await agent(softenPrompt(open, holes), { phase: 'Soften', label: 'soften', agentType: 'general-purpose', schema: SOFTEN_SCHEMA })).corrected_answer
+}
+
+return {
+  case_text: CASE_TEXT,
+  leading_answer: LEADING_ANSWER,
+  rivals: graded,
+  determined,
+  holes,
+  corrected_answer,
+}

--- a/code/specs/data/adj57/underdetermination.json
+++ b/code/specs/data/adj57/underdetermination.json
@@ -1,0 +1,66 @@
+{
+  "determined": false,
+  "n_rivals": 7,
+  "n_resolved": 2,
+  "n_open": 5,
+  "holes": [
+    "The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry.",
+    "A comparison of the operating/test bending stress amplitude at the fillet to the EA1N material fatigue limit.",
+    "Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit.",
+    "The specified/required surface residual stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72-99 MPa tensile is out-of-spec versus normal.",
+    "The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 \u03bcm step and 0.95 mm blade marks."
+  ],
+  "resolved": [
+    {
+      "hypothesis": "Corrosion-assisted (corrosion-fatigue) initiation is the primary driver: the local corrosion pits, not the machining textures, are the dominant crack nuclei, making the environment/storage condition the root cause rather than machining quality.",
+      "discriminating_observation": "Direct correlation of the crack origin to a corrosion pit versus to a machining-mark valley (i.e., which feature the fatigue crack actually nucleated from).",
+      "present": true,
+      "citation": "Parallel distributions of rough machining textures can be observed on the side of the crack source, and local corrosion pits exist."
+    },
+    {
+      "hypothesis": "A localized subsurface or surface material/processing anomaly that the sampled tests missed: composition and microstructure were checked at the crack source and core and found normal, but a discrete inclusion, micro-defect, or hard spot at the specific initiation point could be the true nucleus. Conformance of bulk chemistry/microstructure does not exclude a local defect at the initiation site.",
+      "discriminating_observation": "High-magnification (SEM) characterization of the exact fatigue-initiation point for an inclusion or local metallurgical anomaly.",
+      "present": true,
+      "citation": "No defects, such as porosity, slag inclusion, and repair welding, were found in this area."
+    }
+  ],
+  "open": [
+    {
+      "hypothesis": "The dominant root cause is geometric/design under-dimensioning of the transition fillet (insufficient fillet radius / high theoretical stress-concentration factor Kt), not the surface machining condition. The same dual-initiation bending-fatigue fractography at the fillet is fully consistent with a fillet radius too small for the service bending loads.",
+      "discriminating_observation": "The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry.",
+      "present": false,
+      "citation": "",
+      "why": "discriminating observation ABSENT from the input \u2014 a required-but-missing datum"
+    },
+    {
+      "hypothesis": "The failure is an overload / under-design issue: the applied bending stress in fatigue testing exceeded the EA1N fatigue endurance limit, so the axle would crack from bending fatigue regardless of surface finish or residual stress. Beach marks and dual initiation are equally consistent with a stress amplitude simply above the material's fatigue limit.",
+      "discriminating_observation": "A comparison of the operating/test bending stress amplitude at the fillet to the EA1N material fatigue limit.",
+      "present": false,
+      "citation": "",
+      "why": "discriminating observation ABSENT from the input \u2014 a required-but-missing datum"
+    },
+    {
+      "hypothesis": "Press-fit / fretting fatigue at the wheel-seat\u2013axle interface is the primary driver (this is a wheel-seat fatigue test), with fretting at the seat edge near the transition initiating the cracks, rather than free-surface machining marks. Wheel-seat fatigue characteristically initiates near the seat/fillet boundary.",
+      "discriminating_observation": "Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit.",
+      "present": false,
+      "citation": "failing to meet validation requirements",
+      "why": "discriminating observation ABSENT from the input \u2014 a required-but-missing datum"
+    },
+    {
+      "hypothesis": "Residual tensile stress alone (e.g., from heat treatment or improper machining-induced residual stress) is the controlling factor, not the geometric machining marks; the 72-99 MPa tensile residual stress is detrimental because the as-designed surface should have been compressive (no shot-peening / surface treatment applied). The leading conclusion lumps residual stress with surface texture, but residual stress could be the standalone cause.",
+      "discriminating_observation": "The specified/required surface residual stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72-99 MPa tensile is out-of-spec versus normal.",
+      "present": false,
+      "citation": "The arc transition zone exhibits residual tensile stress values of 72\u201399 MPa in the circumferential direction and 71\u201392 MPa in the axial direction.",
+      "why": "discriminating observation ABSENT from the input \u2014 a required-but-missing datum"
+    },
+    {
+      "hypothesis": "The roughness/step quantified near the transition (342 \u03bcm height difference, ~0.95 mm blade marks) reflects a gross machining step/mismatch that is a discrete geometric stress raiser (a machining error on specific axles) rather than a general 'rough surface finish' problem; the failure is a one-off process escape, not a systemic surface-condition design flaw.",
+      "discriminating_observation": "The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 \u03bcm step and 0.95 mm blade marks.",
+      "present": false,
+      "citation": "The height difference between the highest point and the lowest point near the transition zone is 342 \u03bcm.",
+      "why": "discriminating observation ABSENT from the input \u2014 a required-but-missing datum"
+    }
+  ],
+  "before": "The axle failures are most plausibly a case of bending-fatigue cracking initiated at the machined transition fillet, where the leading hypothesis is that the failure was driven by manufacturing/surface condition rather than material defect: rough machining textures, blade marks, surface notches/roughness, corrosion pits, and detrimental residual tensile stress at the fillet acted together as stress concentrators that nucleated dual fatigue cracks, while chemical composition and microstructure were normal and conforming.",
+  "after": "HONEST REWRITE OF THE AXLE FAILURE CONCLUSION\n\nWhat the evidence actually supports (byte-grounded findings \u2014 keep these):\n- The fracture is a bending-fatigue failure that initiated at the machined transition fillet of the axle. Fractographic features are consistent with fatigue: beach/clamshell (progression) marks and dual crack initiation at the fillet.\n- Surface-condition stress concentrators are demonstrably present at/near the transition: rough machining texture, blade/tool marks (~0.95 mm), a measured surface step/height difference of 342 \u03bcm, surface notches/roughness, corrosion pits, and a measured tensile residual stress of 72\u201399 MPa at the fillet.\n- The material itself is clean: chemical composition and microstructure conform to EA1N specification \u2014 there is no evidence of a metallurgical/material defect (no inclusions, no microstructural anomaly, no off-spec chemistry) driving the failure.\n\nWhat CANNOT be concluded (the over-attribution to correct):\nThe leading conclusion asserts that manufacturing/surface condition \u2014 rough machining, blade marks, notches, pits, and tensile residual stress acting together \u2014 was THE root cause. The data do not establish this single cause. The same fractographic signature (dual-initiation bending fatigue at the fillet, with surface stress raisers present) is equally consistent with several rival mechanisms that the case text gives no information to rule out. The root cause must therefore be stated as a DISJUNCTION, not a single driver:\n\nROOT CAUSE = at least one (and possibly a combination) of the following, none of which can currently be excluded:\n1. Geometric under-dimensioning of the fillet \u2014 the fillet radius is too small / the theoretical stress-concentration factor Kt is too high for the service bending loads (a design/geometry cause, independent of surface finish).\n2. Overload / under-design in fatigue \u2014 the applied bending-stress amplitude at the fillet simply exceeded the EA1N fatigue endurance limit, so cracking would occur regardless of surface finish or residual stress.\n3. Press-fit / fretting fatigue at the wheel-seat\u2013axle interface \u2014 fretting at the seat/fillet boundary, characteristic of wheel-seat fatigue tests, initiated the cracks rather than free-surface machining marks.\n4. Residual tensile stress as a standalone controlling factor \u2014 the 72\u201399 MPa tensile residual stress (rather than the surface texture it is lumped with) is the controlling driver, detrimental specifically if the qualified design required a compressive surface state that was absent.\n5. A discrete machining-step / process escape \u2014 the 342 \u03bcm step and ~0.95 mm blade marks represent a gross localized geometric mismatch on specific axles (a one-off manufacturing error / discrete stress raiser), not a systemic surface-finish design flaw.\n\nThese rivals are not mutually exclusive and several can co-act; the evidence in hand does not weight among them.\n\nMISSING DISCRIMINATING DATA \u2014 what must be retrieved to decide (not present in the case text; do not invent):\n- The actual fillet radius and its stress-concentration factor compared against the design value / allowable Kt for the axle geometry. (discriminates rival 1)\n- A comparison of the operating/test bending-stress amplitude at the fillet to the EA1N material fatigue limit. (discriminates rival 2)\n- Evidence of fretting damage (fretting scars, oxide debris, fretting initiation site) at the wheel-seat contact edge versus a clean free-surface initiation away from the press-fit. (discriminates rival 3)\n- The specified/required surface residual-stress state for a qualified axle (i.e., whether compressive residual stress was required and absent) to judge whether 72\u201399 MPa tensile is out-of-spec versus normal. (discriminates rival 4)\n- The drawing-specified surface-finish/profile tolerance for the transition zone compared to the measured 342 \u03bcm step and 0.95 mm blade marks. (discriminates rival 5)\n\nBottom line: The failure is confidently a bending-fatigue crack initiating at the machined transition fillet, on conforming EA1N material with surface stress concentrators present \u2014 but the controlling root cause is UNDERDETERMINED among fillet geometry (Kt), overload relative to the fatigue limit, wheel-seat fretting, standalone residual tensile stress, and a discrete machining-step process escape. Resolving it requires the five missing measurements above, none of which appear in the available case text."
+}


### PR DESCRIPTION
Two cuts, motivated by one finding. Builds on the now-merged ADJ60/61/62 (justification gate, both directions).

## ADJ63 — bidirectional justification, end to end
The ADJ61 (output) + ADJ62 (input) gates wired into one pipeline and run on a **fresh, non-medical** case the agent found itself — railway-axle metallurgical failure analysis (MDPI PMC12387781). All four provenance corners held:
```
INPUT  coverage    100%  — 17 facts = all 1975 bytes
INPUT  extraction  32/32 — 24 extracted + 8 inferred, 0 rejected
OUTPUT grounding   13/13 — 7 evidence + 6 conclusion, 0 rejected
```
**Finding — faithfulness ≠ completeness.** The byte-faithful answer (*"manufacturing/surface cause"*) diverged from the held-aside truth (*"operating stress exceeded the fatigue limit"*) because the decisive datum — the stress-vs-fatigue-limit comparison — was **never in the decomposed bytes**. The framework did *not* fabricate it; it gave the answer the bytes support, and the gap stayed visible. *Provenance guarantees the answer follows from the bytes; it does not guarantee the bytes are complete.*

## ADJ64 — the underdetermination gate (the fix)
The dual of invention. The byte-anchor stops a claim citing bytes that aren't there; it does **not** stop a *conclusion* from singling out one cause when the datum that would distinguish it from the rivals is **absent**. ADJ63 did exactly that — drifted to the loudest present lever.

`underdetermination.py`: for each rival fitting the same bytes, the model gives the **discriminating observation** + whether it's present (verbatim citation) or absent. A rival is *resolved* iff present-and-cited (you can't *claim* the data is there without a byte), else *open* — its observation becomes a **named provenance hole**, a query the spider/CAS can fetch. The conclusion is *underdetermined* iff any rival is open. 5 unit tests.

**Run on the ADJ63 axle conclusion:** 7 rivals, 5 open → **UNDERDETERMINED**. The gate named five missing measurements — including **a comparison of operating bending stress to the EA1N fatigue limit, which is the ground-truth root cause** — and replaced the single-cause answer with a disjunction that keeps every grounded finding.

> *"If the data is not present, we cannot reason over it"* is true for a single step. Naming the hole is how the **loop** turns absence into the next thing to retrieve.

The framework now distinguishes three byte-disciplined states: a claim is **grounded** (cites real bytes), a conclusion is **determined** (present bytes discriminate it from rivals), or **underdetermined** (and the missing discriminators are named as queries).

## Honest limitations (in both specs)
- The **"resolved"** verdict is an LLM judgment — a citation being *present* ≠ it actually *discriminating*. Read conservatively, the 2 "resolved" rivals are also open, which only makes the safe verdict (UNDERDETERMINED) stronger. Same fix as flagged before: a multi-verifier vote.
- Rival *completeness* is the model's — the gate adjudicates the rivals it's given; a missing *rival* is a deeper hole (completeness-critic territory).
- Both ADJ63 gates passed clean first-pass; the live kickback path is still only unit-tested.

Security review: passed. 20 gate tests green (15 justify + 5 underdetermination). Specs: `code/specs/ADJ63-bidirectional-end-to-end.md`, `code/specs/ADJ64-underdetermination-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)