### PR TITLE
feat(closure-pass-dce): CLOC12.34 — gap-014 step 2/N empty-switch elimination

### DIFF
--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.6.0] - 2026-06-04
+
+### Added — CLOC12.34: empty-switch elimination (gap-014 step 2/N)
+
+First peephole on top of the SwitchStatement AST that CLOC12.33
+landed. Drops `switch(<x>){}` (and equivalent shapes) entirely
+when **all** of the following hold:
+
+1. Every case's `consequent` is empty (or no cases at all).
+2. The discriminant is a leaf literal — one of
+   `NumericLiteral` / `StringLiteral` / `BooleanLiteral` /
+   `NullLiteral` / `UndefinedLiteral` / `BigIntLiteral`.
+3. Every case's `test` is either `None` (the `default:` clause)
+   or also a leaf literal.
+
+When the switch matches, the pass rewrites it to
+`EmptyStatement`. The block walker drops that on its next sweep,
+so the whole switch disappears from the output. One
+`Contribution { tag: "switch_eliminated", before: ..., after:
+"EmptyStatement" }` lands per elimination, tagged against the
+switch's own `cv`.
+
+### Why the conservative-bail design
+
+The rule deliberately treats `Identifier` as not-pure. Reading
+an `Identifier` can throw under TDZ for an uninitialised `let` /
+`const`. Without scope analysis (which is `closure-scope-analyzer`'s
+territory), we can't prove the read is safe to drop, so we leave
+the switch intact. The same reasoning applies to member access,
+calls, binary/unary, etc.
+
+This means we DO eliminate `switch(1){}` / `switch("k"){}` /
+`switch(true){}` / `switch(null){}` / `switch(void 0){}` /
+`switch(2n){}` and the same shapes with all-empty case clauses,
+but NOT `switch(x){}` or `switch(a.b){}` — those keep the switch.
+A future "switch-with-pure-effect-analysis-cleared-discriminant"
+slice can replace this when the broader effect-analysis pass
+lands.
+
+### Helper
+
+`is_pure_leaf(expr: &Expression) -> bool` — private helper used
+only by the switch rule. Six match-arms over the literal types
+listed above. Documented inline.
+
+### Tests (6 new inline, 14 → 20 total)
+
+| Test | Pins |
+|------|------|
+| `empty_switch_with_literal_discriminant_drops_entirely` | `switch(1){}` → `;` (then dropped) |
+| `empty_switch_with_pure_cases_drops_entirely` | `switch(1){case 2:;default:;}` → drop |
+| `empty_switch_with_identifier_discriminant_keeps_switch` | `switch(x){}` → unchanged (TDZ conservative) |
+| `switch_with_non_empty_consequent_keeps_switch` | `switch(1){case 1:y;}` → unchanged |
+| `empty_switch_with_identifier_case_test_keeps_switch` | `switch(1){case k:;}` → unchanged |
+| `empty_switch_with_boolean_discriminant_drops` | `switch(true){}` → drop |
+
+closurec's `diff_minify` and other e2e suites stay green — no
+existing fixture exercises empty-switch shapes, so behaviour is
+purely additive.
+
+### Version bump
+
+`0.5.2` → `0.6.0` (new behaviour; not a strict semver minor
+since the public `DcePass` impl is unchanged, but the
+`Contribution` stream gains a new `tag`).
+
 ## [0.5.2] - 2026-06-01
 
 ### Changed — CLOC12.16: handle new `UndefinedLiteral` Expression variant

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -67,12 +67,13 @@ use coding_adventures_closure_pass_pipeline::{
 };
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
-    statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BlockStatement, CallExpression, ConditionalExpression, Declaration, Expression,
-    ExpressionStatement, ForInit, ForStatement, FunctionDeclaration, IfStatement,
-    LogicalExpression, MemberExpression, ObjectExpression, Program, ProgramItem, Property,
-    PropertyKey, ReturnStatement, Statement, UnaryExpression, VarKind, VariableDeclaration,
-    VariableDeclarator, WhileStatement,
+    statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression,
+    Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit, ForStatement,
+    FunctionDeclaration, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
+    NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
+    ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, VarKind,
+    VariableDeclaration, VariableDeclarator, WhileStatement,
 };
 use serde_json::json;
 
@@ -174,6 +175,30 @@ impl DceState<'_> {
     fn visit(&mut self) {
         self.nodes_touched += 1;
     }
+}
+
+/// Is `expr` a leaf literal we can guarantee has no observable side
+/// effects when evaluated?
+///
+/// Conservative: only the seven primitive-literal node types qualify.
+/// Identifier reads can throw under TDZ (for unitialized `let` /
+/// `const`), and we don't do scope analysis here. Member / call /
+/// binary / unary / etc. can all have effects. So we bail.
+///
+/// Used by gap-014 step 2's empty-switch elimination: when the
+/// switch has no observable side effects (pure discriminant +
+/// pure tests + empty consequents), the entire switch can drop to
+/// `;`. Anything non-literal: leave alone.
+fn is_pure_leaf(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::NumericLiteral(NumericLiteral { .. })
+            | Expression::StringLiteral(StringLiteral { .. })
+            | Expression::BooleanLiteral(BooleanLiteral { .. })
+            | Expression::NullLiteral(NullLiteral { .. })
+            | Expression::UndefinedLiteral(UndefinedLiteral { .. })
+            | Expression::BigIntLiteral(BigIntLiteral { .. })
+    )
 }
 
 // =====================================================================
@@ -284,27 +309,58 @@ fn dce_tagged_statement(stmt: &TaggedStatement, st: &mut DceState) -> TaggedStat
         }
         TaggedStatement::SwitchStatement(s) => {
             // Recurse into discriminant, each case's test, and each
-            // statement in each consequent. No peephole rule yet —
-            // the "empty switch removal" and "constant-discriminant
-            // → single matching case body" optimisations are gap-014
-            // follow-ups; this PR ships the structural walk so they
-            // have a place to land.
+            // statement in each consequent first — peephole rules
+            // run on the folded shape so we catch switches whose
+            // bodies *became* empty after constant-fold +
+            // fold-control-flow ran earlier in the pipeline.
+            let new_disc = dce_expression(&s.discriminant, st);
+            let new_cases: Vec<_> = s
+                .cases
+                .iter()
+                .map(|c| coding_adventures_javascript_ast::SwitchCase {
+                    cv: c.cv.clone(),
+                    test: c.test.as_ref().map(|e| dce_expression(e, st)),
+                    consequent: c
+                        .consequent
+                        .iter()
+                        .map(|s| dce_statement(s, st))
+                        .collect(),
+                })
+                .collect();
+
+            // gap-014 step 2 / CLOC12.34 — empty-switch elimination.
+            //
+            // If every case's consequent is empty (or there are no
+            // cases at all) AND both the discriminant and every
+            // case-test are leaf literals (no side-effect risk),
+            // collapse the whole switch to `;`. The block-walker
+            // (`dce_block_statement`) will drop the EmptyStatement
+            // in its next sweep.
+            //
+            // Conservative bail: anything else (Identifier
+            // discriminant, computed test, non-empty consequent)
+            // keeps the switch intact. The "drop after pure
+            // discriminant with side-effecting tests" rule is a
+            // future slice that needs a proper effect analysis.
+            let all_consequents_empty = new_cases.iter().all(|c| c.consequent.is_empty());
+            let discriminant_pure = is_pure_leaf(&new_disc);
+            let all_tests_pure_or_none = new_cases
+                .iter()
+                .all(|c| c.test.as_ref().map_or(true, is_pure_leaf));
+            if all_consequents_empty && discriminant_pure && all_tests_pure_or_none {
+                st.record(
+                    &s.cv,
+                    "switch_eliminated",
+                    "SwitchStatement{<empty body>}",
+                    "EmptyStatement",
+                );
+                return TaggedStatement::EmptyStatement(EmptyStatement { cv: s.cv.clone() });
+            }
+
             TaggedStatement::SwitchStatement(coding_adventures_javascript_ast::SwitchStatement {
                 cv: s.cv.clone(),
-                discriminant: dce_expression(&s.discriminant, st),
-                cases: s
-                    .cases
-                    .iter()
-                    .map(|c| coding_adventures_javascript_ast::SwitchCase {
-                        cv: c.cv.clone(),
-                        test: c.test.as_ref().map(|e| dce_expression(e, st)),
-                        consequent: c
-                            .consequent
-                            .iter()
-                            .map(|s| dce_statement(s, st))
-                            .collect(),
-                    })
-                    .collect(),
+                discriminant: new_disc,
+                cases: new_cases,
             })
         }
         TaggedStatement::BreakStatement(_)
@@ -614,7 +670,7 @@ mod tests {
     use coding_adventures_closure_pass_pipeline::{PassPipeline, PipelineOutput};
     use coding_adventures_javascript_ast::{
         statement::TaggedStatement, BinaryOperator, BooleanLiteral, EmptyStatement, Identifier,
-        NumericLiteral, SourceType,
+        NumericLiteral, SourceType, SwitchCase, SwitchStatement,
     };
     use coding_adventures_javascript_tokens::EsVersion;
     use coding_adventures_type_sidecar::Sidecar;
@@ -1018,5 +1074,122 @@ mod tests {
             &final_block.body[0],
             Statement::Tagged(TaggedStatement::ReturnStatement(_))
         ));
+    }
+
+    // =====================================================================
+    // gap-014 step 2 / CLOC12.34 — empty-switch elimination
+    // =====================================================================
+
+    fn switch_stmt(disc: Expression, cases: Vec<SwitchCase>) -> Statement {
+        Statement::switch_statement(SwitchStatement {
+            cv: Some("sw.1".to_string()),
+            discriminant: disc,
+            cases,
+        })
+    }
+
+    fn case_empty(test: Option<Expression>) -> SwitchCase {
+        SwitchCase {
+            cv: None,
+            test,
+            consequent: vec![],
+        }
+    }
+
+    /// `function f() { switch (1) {} }` → `function f() {}`.
+    /// Empty switch with literal discriminant collapses; the
+    /// resulting EmptyStatement is then dropped by the block
+    /// walker, so the function body ends up empty.
+    #[test]
+    fn empty_switch_with_literal_discriminant_drops_entirely() {
+        let body = vec![switch_stmt(num(1.0), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, changed, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+        assert!(changed);
+        assert!(
+            contribs.iter().any(|c| c.tag == "switch_eliminated"),
+            "expected switch_eliminated contribution"
+        );
+    }
+
+    /// `function f() { switch (1) { case 2: ; default: ; } }` →
+    /// `function f() {}`. All cases empty, literal tests, literal
+    /// discriminant — drops.
+    #[test]
+    fn empty_switch_with_pure_cases_drops_entirely() {
+        let cases = vec![
+            case_empty(Some(num(2.0))),
+            case_empty(None), // default
+        ];
+        let body = vec![switch_stmt(num(1.0), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty(), "expected empty body; got {:?}", block.body);
+        assert!(contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// Conservative bail: Identifier discriminant might TDZ-throw
+    /// for an uninitialised `let` / `const`. Keep the switch.
+    #[test]
+    fn empty_switch_with_identifier_discriminant_keeps_switch() {
+        let body = vec![switch_stmt(ident("x"), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, contribs, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        // SwitchStatement preserved.
+        assert!(matches!(
+            &block.body[0],
+            Statement::Tagged(TaggedStatement::SwitchStatement(_))
+        ));
+        assert!(!contribs.iter().any(|c| c.tag == "switch_eliminated"));
+    }
+
+    /// Non-empty consequent keeps the switch even with a pure
+    /// discriminant — the consequent's statements have effect
+    /// potential we don't analyse.
+    #[test]
+    fn switch_with_non_empty_consequent_keeps_switch() {
+        let cases = vec![SwitchCase {
+            cv: None,
+            test: Some(num(1.0)),
+            consequent: vec![expr_stmt(ident("y"))],
+        }];
+        let body = vec![switch_stmt(num(1.0), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, _, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(matches!(
+            &block.body[0],
+            Statement::Tagged(TaggedStatement::SwitchStatement(_))
+        ));
+    }
+
+    /// Identifier case-test (not pure under TDZ) keeps the
+    /// switch even though discriminant is pure and consequents
+    /// are empty.
+    #[test]
+    fn empty_switch_with_identifier_case_test_keeps_switch() {
+        let cases = vec![case_empty(Some(ident("k")))];
+        let body = vec![switch_stmt(num(1.0), cases)];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, _, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(matches!(
+            &block.body[0],
+            Statement::Tagged(TaggedStatement::SwitchStatement(_))
+        ));
+    }
+
+    /// Boolean / Null discriminants are pure too.
+    #[test]
+    fn empty_switch_with_boolean_discriminant_drops() {
+        let body = vec![switch_stmt(boolean(true), vec![])];
+        let prog = program_with_function(body, Some("fn.1"));
+        let (out, _, _, _) = run_pass(prog);
+        let block = extract_function_body(&out);
+        assert!(block.body.is_empty());
     }
 }

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -112,7 +112,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-014 — `SwitchStatement` not in Phase 1 AST
 
-- **Status:** AST + emitter RESOLVED in CLOC12.33. **Switch-optimisation peepholes (empty-switch elimination, constant-discriminant collapse, drop-after-break)** remain a follow-up.
+- **Status:** AST + emitter RESOLVED in CLOC12.33. **Empty-switch elimination** RESOLVED in CLOC12.34 (closure-pass-dce 0.6.0 — drops `switch(<pure literal>){}` and equivalent shapes with empty consequents and pure case-tests). **Constant-discriminant collapse** and **drop-after-break** remain follow-ups.
 - **Upstream test:** `PeepholeRemoveDeadCodeTest::testOptimizeSwitch*` (a dozen tests)
 - **Ported file:** `closure-pass-dce/tests/upstream/peephole_remove_dead_code_test.rs`
 - **Resolution note:** CLOC12.33 adds `SwitchStatement { cv, discriminant, cases }` and `SwitchCase { cv, test: Option<Expression>, consequent: Vec<Statement> }` to `javascript-ast`, plus the `TaggedStatement::SwitchStatement` arm and `Statement::switch_statement` convenience constructor. The closure-emitter learns `emit_switch` / `emit_switch_case` covering both compact and pretty modes (compact `switch(x){case 1:y;default:z;}`, pretty indented). DCE / fold-control-flow / constant-fold / scope-analyzer each gained a passthrough match arm that recurses into the discriminant, each case's test, and each consequent statement — no peephole rules yet. The structural prerequisite is in place; the per-test arms (empty-switch removal, etc.) land in CLOC12.34+ as separate slices. `BreakStatement` was already in the AST (CLOC12.13).


### PR DESCRIPTION
## Summary

First peephole on top of the SwitchStatement AST that CLOC12.33 landed. `switch(<pure literal>){}` (and equivalent shapes with empty case consequents and pure case-tests) drops to `EmptyStatement`; the existing block walker then sweeps that out, so the whole switch disappears from the output.

## The rule

In `dce_tagged_statement::SwitchStatement`, after recursing into the discriminant + cases:

1. All cases' consequents must be `Vec::is_empty()` (or no cases at all).
2. The discriminant must be `is_pure_leaf` — one of `NumericLiteral`, `StringLiteral`, `BooleanLiteral`, `NullLiteral`, `UndefinedLiteral`, `BigIntLiteral`.
3. Every case's `test` must be `None` (the `default:` clause) or also `is_pure_leaf`.

If all three hold: replace with `EmptyStatement` (preserving the switch's CV) and record a `Contribution { tag: "switch_eliminated", ... }`.

## Why conservative

`Identifier` is deliberately NOT pure — reading an uninitialised `let` / `const` throws under TDZ, and we don't have scope analysis at this layer. Member access, calls, binary, unary all have effect potential we don't analyse. Literal-only is the safe subset.

## What this catches

- `switch(1){}` / `switch(true){}` / `switch(\"k\"){}` / `switch(null){}` / `switch(void 0){}` / `switch(2n){}` → drop
- Same shapes with all-empty case clauses (`case 1:;default:;`) → drop

## What it doesn't (yet)

- `switch(x){}` — Identifier discriminant, TDZ risk → keep
- `switch(1){case 1:y;}` — non-empty consequent → keep
- `switch(1){case k:;}` — Identifier case-test → keep
- `switch(1){case 1:;}` where consequent is `vec![EmptyStatement]` not `vec![]` → keep (existing DCE block walker doesn't dive into SwitchCase consequents; future polish)

## Tests (6 new, 14 → 20 inline)

All 6 cover the standard family — drop-on-pure-discriminant, drop-on-pure-cases, keep-on-identifier-discriminant, keep-on-non-empty-consequent, keep-on-identifier-test, drop-on-boolean.

## Test plan

- [x] `cargo test -p coding-adventures-closure-pass-dce` → 20 inline + 8 upstream-port passing, 4 ignored unchanged
- [x] `cargo test` in closurec → all e2e suites green
- [x] Security review (subagent): PASS — pure-leaf classification correct, conservative bail safe, §13.12 semantics hold, CV wiring correct
- [ ] CI green

## Closes

- gap-014 step 2/N (status updated in `code/specs/CLOC12-gaps.md`)
- closure-pass-dce 0.5.2 → 0.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)