### PR TITLE
ADJ65 — uncertainty as a first-class primitive (weight of evidence + decision sensitivity)

### DIFF
--- a/code/specs/ADJ65-uncertainty-primitive.md
+++ b/code/specs/ADJ65-uncertainty-primitive.md
@@ -1,0 +1,110 @@
+# ADJ65 — Uncertainty as a First-Class Primitive (weight of evidence + decision sensitivity)
+
+> **Status (2026-06-04):** Built and run. The gates so far answer yes/no — grounded?
+> determined? ADJ65 makes the *competition between hypotheses* first-class and answers the
+> question Adhithya posed: **"if we make some probability shift, how would the decision
+> shift?"** Each grounded fact carries a weight of evidence (decibans) toward each
+> hypothesis; the deterministic engine computes the decision **and its sensitivity** — the
+> margin, the load-bearing evidence, what flips it, and whether the margin rests on
+> ungrounded weights. Run on the neurobrucellosis case it produced a *confidently wrong*
+> answer **and flagged precisely why it can't be trusted** — the best possible
+> demonstration of the primitive. Implementation:
+> [`sensitivity.py`](data/adj57/pipeline/sensitivity.py) +
+> [`sensitivity.workflow.js`](data/adj57/pipeline/sensitivity.workflow.js).
+
+## 1. The model
+
+Good's weight of evidence — the formulation behind MYCIN's certainty factors. Each fact
+E_j contributes, for each hypothesis H_i, a weight in **decibans** (ten times the log10
+likelihood ratio): +10 dB ⇒ the fact makes H_i ten times more likely. Scores add in log
+space; the **decision is the argmax** — deterministic, no softmax, no temperature (we show
+posteriors via softmax only as a *view*; nothing depends on it, so the past softmax mistake
+is not repeated). The model's *job* is only to propose the hypotheses and the weight matrix,
+each weight tagged **grounded** (cites a real likelihood ratio) or **assumed** (an
+estimate). The engine does the rest. 10 unit tests
+([`test_sensitivity.py`](data/adj57/pipeline/test_sensitivity.py)).
+
+## 2. Why sensitivity, not a point probability
+
+A single winner is the least useful output. What a decision-maker needs is how *robust* the
+call is:
+
+- **margin** M = score(leader) − score(runner-up), in decibans — the decision survives any
+  single weight perturbation smaller than M;
+- **load-bearing** evidence, ranked by how much each fact pushes leader-over-runner;
+- **what flips it** — which single facts, or how many, must fail to change the answer, and
+  how far one weight must move (the literal "probability shift → decision shift");
+- **provenance of the margin** — of the load-bearing weights, which are grounded and which
+  are assumed. *A decision whose margin rests on assumed weights is fragile in the one way
+  that matters.*
+
+The weights are the soft underbelly (mostly interpretation, not byte-grounded). The honest
+response to soft inputs is not false precision — it is to report exactly how far the
+softness can move the answer, and which soft weight to ground first.
+
+## 3. The run — a confidently WRONG answer, correctly exposed
+
+The model weighed 12 grounded facts across 7 hypotheses for the neurobrucellosis case. The
+engine's verdict:
+
+```
+DECISION: East African trypanosomiasis   99.7%   (+58 dB)
+runner-up: visceral leishmaniasis        (+32 dB)
+...   Brucellosis (the TRUTH)             4th, +16 dB
+MARGIN: +26 dB  (leader ~400x the runner-up's odds)
+```
+
+It is **wrong** — the held-aside truth is neurobrucellosis, ranked *fourth*. A naive system
+would stop here and report "99.7% trypanosomiasis." ADJ65 keeps going, and that is the whole
+point:
+
+```
+## What would flip the decision:
+   - no SINGLE fact's removal flips it; minimum that must fail: 4
+## PROVENANCE OF THE MARGIN:
+   ⚠ the margin RESTS ON ASSUMED weights:
+       ? pontine_t2_flair_lesions_meningeal_enhancement (+10 dB)
+       ? ankle_swelling_after_insect_bite               (+9 dB)
+       ? travel_to_east_africa                          (+7 dB)
+       ? csf_acellular_normal_glucose_raised_protein    (+6 dB)
+```
+
+**Every load-bearing weight is `assumed`.** The only *grounded* weights in the whole model
+(the negative malaria smear, the negative Widal) contribute essentially **0 dB** to the
+leader-over-runner margin — they rule out malaria and typhoid, which were not in contention.
+So the 99.7% confidence is an artifact of four numbers the model **made up**. The single
+biggest one — *insect bite → trypanosomiasis, +13 dB* — is the very red herring ADJ60 fell
+for (the bite was the brucellosis inoculation site, not a tsetse bite).
+
+> ADJ65 does not make the model right. It makes the model's **confidence auditable**. A
+> 99.7% built on assumed weights is correctly exposed as untrustworthy — and converted into
+> a *prioritized fetch-list*: ground these four weights before believing the answer.
+
+## 4. The through-line — this is the spider's priority queue
+
+This composes exactly with ADJ64. Trypanosomiasis-vs-brucellosis is *underdetermined* (the
+discriminating datum — Brucella serology — was held aside). ADJ64 names the missing data;
+ADJ65 says **which missing weight the decision is most sensitive to**, so the spider/CAS
+fetches in priority order. Grounding the four assumed load-bearing weights — most of which a
+real LR would shrink dramatically — would very likely collapse trypanosomiasis and surface
+brucellosis. The framework can't know the answer from incomplete, ungrounded inputs; it can
+tell you **exactly which input to ground first to find out.**
+
+## 5. Honest limitations
+
+- **The weights are model-proposed.** ADJ65 quantifies and audits them but does not ground
+  them — that is the spider's job, now prioritized. The primitive's value is precisely that
+  it refuses to launder assumed weights into trustworthy confidence.
+- **`grounded` is taken on the model's word here.** A weight tagged grounded should itself
+  carry a CAS-citable likelihood ratio that a deterministic check verifies (as `cite()`
+  does for source spans) — the next hardening, mirroring the layer-2 multi-verifier thread.
+- **Single decision, single level.** v1 audits one decision; propagating uncertainty across
+  a multi-step derivation (each step's margin feeding the next) is the larger build.
+
+## 6. Where this leaves the framework
+
+Four epistemic states, all byte-disciplined: a claim is **grounded**, a conclusion is
+**determined** or **underdetermined**, and now a determination carries a **robustness** —
+its margin, and whether that margin stands on grounded or assumed weights. The framework no
+longer reports confidence it cannot back; it reports confidence *and the provenance of that
+confidence*, and turns the gap into the next thing to fetch.

--- a/code/specs/data/adj57/CHANGELOG.md
+++ b/code/specs/data/adj57/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — adj57 byte-provenance pipeline
 
+## [0.8.0] — 2026-06-04
+
+### Added
+
+- **ADJ65 — uncertainty as a first-class primitive (weight of evidence + sensitivity).**
+  Makes the hypothesis competition first-class and answers *"if we make some probability
+  shift, how would the decision shift?"*
+  - **`pipeline/sensitivity.py`** — Good's weight of evidence (the math behind MYCIN
+    certainty factors): each fact contributes **decibans** (10·log10 LR) toward each
+    hypothesis; the **decision is argmax of the summed log-odds** (deterministic — softmax
+    is a display *view* only, no temperature knob). Reports the **margin** (robustness),
+    load-bearing evidence, one-out flips, per-weight tipping points, and — the honest part
+    — whether the margin **rests on `assumed` (ungrounded) weights**. 10 unit tests
+    (`pipeline/test_sensitivity.py`).
+  - **`pipeline/sensitivity.workflow.js`** — the model proposes hypotheses + a weight
+    matrix, each weight tagged grounded (cites a real LR) or assumed.
+    **`pipeline/run_sensitivity.py`** runs the engine + reports.
+  - **Run (neurobrucellosis):** the engine picked **East African trypanosomiasis at 99.7%
+    (+26 dB margin)** — **wrong** (truth neurobrucellosis, 4th). But it flagged that **every
+    load-bearing weight is `assumed`**; the only grounded weights contribute ~0 dB. The
+    99.7% is an artifact of four made-up numbers. ADJ65 doesn't make the model right — it
+    makes its **confidence auditable**, converting overconfidence into a prioritized
+    fetch-list. Spec: [ADJ65](../../ADJ65-uncertainty-primitive.md).
+
 ## [0.7.0] — 2026-06-04
 
 ### Added

--- a/code/specs/data/adj57/pipeline/run_sensitivity.py
+++ b/code/specs/data/adj57/pipeline/run_sensitivity.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""ADJ65 driver — report the weight-of-evidence decision and its sensitivity.
+
+Answers "if we make some probability shift, how would the decision shift?" by printing:
+the decision + posteriors (a view), the MARGIN (robustness, in decibans), the load-bearing
+evidence, which single facts would flip the call, how far one weight must move to flip it,
+and — the honest part — whether the margin rests on ungrounded (assumed) weights that should
+be fetched/grounded first.
+
+Run: python run_sensitivity.py <sensitivity-results.json>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sensitivity as s  # noqa: E402
+
+
+def main() -> None:
+    res = json.loads(Path(sys.argv[1]).read_text())
+    res = res.get("result", res)
+    hyps, evidence = res["hypotheses"], res["evidence"]
+    r = s.assess(hyps, evidence)
+
+    print("=" * 74)
+    print("  ADJ65 — uncertainty as a primitive (weight of evidence + sensitivity)")
+    print("=" * 74)
+
+    print("\n## Posterior view (softmax of the log-odds — a VIEW; the decision is argmax):")
+    for row in r["ranked"]:
+        h = row["hypothesis"]
+        bar = "#" * int(round(r["posteriors"][h] * 40))
+        print(f"   {h[:30]:30s} {r['posteriors'][h] * 100:5.1f}%  {row['score_db']:+6.1f} dB  {bar}")
+
+    print(f"\n## DECISION: {r['decision']}")
+    print(f"   runner-up: {r['runner_up']}")
+    print(f"   MARGIN: {r['margin_db']:+.1f} dB  (leader is ~{r['margin_odds']:.1f}x the runner-up's odds)")
+    print(f"   => the decision survives any single weight perturbation smaller than {r['margin_db']:.1f} dB")
+
+    print("\n## Load-bearing evidence (push of leader over runner-up, decibans):")
+    for c in r["load_bearing"][:8]:
+        tag = "" if c["push_for_leader"] <= 0 else (" [DECISIVE ALONE]" if c["decisive_alone"] else "")
+        src = "grounded" if c["source"] == "grounded" else "ASSUMED"
+        print(f"   {c['name'][:42]:42s} {c['push_for_leader']:+6.1f} dB  ({src}){tag}")
+
+    print("\n## What would flip the decision:")
+    if r["one_out_flips"]:
+        for f in r["one_out_flips"]:
+            print(f"   - remove '{f['remove']}' -> leader becomes {f['new_leader']}")
+    else:
+        print("   - no SINGLE fact's removal flips it")
+    print(f"   - minimum supporting facts that must fail to flip it: {r['min_facts_to_flip']}"
+          f"{'' if r['min_facts_to_flip'] else ' (no single-evidence erosion can flip it)'}")
+    if r["load_bearing"] and r["load_bearing"][0]["push_for_leader"] > 0:
+        top = r["load_bearing"][0]["name"]
+        t = s.tip(hyps, evidence, {}, top)
+        print(f"   - top lever '{top}': weight {t['current_weight_for_leader_db']:+.1f} dB; "
+              f"{'drop it by >' + str(t['flip_needs_drop_db']) + ' dB -> ' + str(t['flips_to']) if t['can_flip_alone'] else 'cannot flip the call alone'}")
+
+    print("\n## PROVENANCE OF THE MARGIN (the honest part):")
+    if r["margin_rests_on_assumed"]:
+        print("   ⚠ the decision's margin RESTS ON ASSUMED (ungrounded) weights:")
+        for n in r["assumed_load_bearing"][:8]:
+            print(f"       ? {n}  — fetch a real likelihood ratio for this before trusting the margin")
+    else:
+        print("   the load-bearing weights are grounded.")
+
+    out = {
+        "decision": r["decision"], "runner_up": r["runner_up"],
+        "margin_db": r["margin_db"], "margin_odds": r["margin_odds"],
+        "posteriors": r["posteriors"], "ranked": r["ranked"],
+        "load_bearing": r["load_bearing"], "one_out_flips": r["one_out_flips"],
+        "min_facts_to_flip": r["min_facts_to_flip"],
+        "margin_rests_on_assumed": r["margin_rests_on_assumed"],
+        "assumed_load_bearing": r["assumed_load_bearing"],
+        "ground_truth": res.get("ground_truth", ""),
+    }
+    (Path(__file__).resolve().parent.parent / "sensitivity.json").write_text(json.dumps(out, indent=2))
+    print(f"\n   ground truth (held aside): {res.get('ground_truth','')}")
+    print(f"\n   >>> decision={r['decision']}; margin={r['margin_db']:+.1f} dB; "
+          f"{'margin rests on assumed weights -> fetch LRs' if r['margin_rests_on_assumed'] else 'margin grounded'}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/sensitivity-results.json
+++ b/code/specs/data/adj57/pipeline/sensitivity-results.json
@@ -1,0 +1,202 @@
+{
+  "summary": "ADJ65 — uncertainty as a first-class primitive. Given a case and its grounded facts, the model proposes the competing hypotheses and a weight-of-evidence matrix (each fact contributes decibans toward each hypothesis, tagged grounded=cites a real likelihood ratio, or assumed=an estimate). The deterministic sensitivity engine then computes the decision, its margin, the load-bearing evidence, what would flip it, and — the honest part — whether the margin rests on ungrounded weights. Demonstrates \"if we make some probability shift, how would the decision shift\" on the neurobrucellosis case.",
+  "agentCount": 1,
+  "logs": [],
+  "result": {
+    "case_text": "A forty-year Indian traveled through Uganda, Tanzania and Kenya. He developed a swelling over the left ankle after an insect bite, then high grade fever with chills and rigors after 3-4 days. He took empirical antibiotics with only minor relief. He was febrile (102 F). Abdomen revealed hepatomegaly of 3 cm and splenomegaly of 3 cm. Blood smear for malaria parasite was negative. Cultures from blood and urine were sterile. Widal test showed normal titers. Testing for viral markers were negative. CSF was acellular with normal glucose; the proteins were raised. Bone biopsy showed a single ill defined granuloma. MRI of brain showed mild meningeal enhancement; few small lesions in pons, hyperintense on T2/FLAIR.",
+    "facts": [
+      "travel_to_east_africa",
+      "ankle_swelling_after_insect_bite",
+      "high_grade_fever_with_chills_rigors",
+      "partial_response_to_empirical_antibiotics",
+      "hepatosplenomegaly",
+      "malaria_smear_negative",
+      "blood_urine_cultures_sterile",
+      "widal_negative",
+      "viral_markers_negative",
+      "csf_acellular_normal_glucose_raised_protein",
+      "bone_granuloma",
+      "pontine_t2_flair_lesions_meningeal_enhancement"
+    ],
+    "hypotheses": [
+      "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)",
+      "Malaria",
+      "Enteric (typhoid) fever",
+      "Visceral leishmaniasis (kala-azar)",
+      "Tuberculosis (disseminated / CNS)",
+      "Brucellosis",
+      "Arboviral / other viral encephalitis"
+    ],
+    "evidence": [
+      {
+        "name": "travel_to_east_africa",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 12,
+          "Malaria": 6,
+          "Enteric (typhoid) fever": 2,
+          "Visceral leishmaniasis (kala-azar)": 5,
+          "Tuberculosis (disseminated / CNS)": 1,
+          "Brucellosis": 3,
+          "Arboviral / other viral encephalitis": 4
+        }
+      },
+      {
+        "name": "ankle_swelling_after_insect_bite",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 13,
+          "Malaria": 1,
+          "Enteric (typhoid) fever": -3,
+          "Visceral leishmaniasis (kala-azar)": 4,
+          "Tuberculosis (disseminated / CNS)": -2,
+          "Brucellosis": -2,
+          "Arboviral / other viral encephalitis": 3
+        }
+      },
+      {
+        "name": "high_grade_fever_with_chills_rigors",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 4,
+          "Malaria": 6,
+          "Enteric (typhoid) fever": 4,
+          "Visceral leishmaniasis (kala-azar)": 4,
+          "Tuberculosis (disseminated / CNS)": 2,
+          "Brucellosis": 4,
+          "Arboviral / other viral encephalitis": 2
+        }
+      },
+      {
+        "name": "partial_response_to_empirical_antibiotics",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 2,
+          "Malaria": 1,
+          "Enteric (typhoid) fever": -2,
+          "Visceral leishmaniasis (kala-azar)": 2,
+          "Tuberculosis (disseminated / CNS)": 1,
+          "Brucellosis": -1,
+          "Arboviral / other viral encephalitis": 2
+        }
+      },
+      {
+        "name": "hepatosplenomegaly",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 5,
+          "Malaria": 4,
+          "Enteric (typhoid) fever": 4,
+          "Visceral leishmaniasis (kala-azar)": 8,
+          "Tuberculosis (disseminated / CNS)": 3,
+          "Brucellosis": 4,
+          "Arboviral / other viral encephalitis": -1
+        }
+      },
+      {
+        "name": "malaria_smear_negative",
+        "source": "grounded",
+        "citation": "Thick blood film sensitivity for malaria ~90-95% per exam at standard parasitemia (WHO microscopy QA); a single negative reduces malaria odds ~10x",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 1,
+          "Malaria": -10,
+          "Enteric (typhoid) fever": 1,
+          "Visceral leishmaniasis (kala-azar)": 1,
+          "Tuberculosis (disseminated / CNS)": 1,
+          "Brucellosis": 1,
+          "Arboviral / other viral encephalitis": 1
+        }
+      },
+      {
+        "name": "blood_urine_cultures_sterile",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 2,
+          "Malaria": 1,
+          "Enteric (typhoid) fever": -6,
+          "Visceral leishmaniasis (kala-azar)": 2,
+          "Tuberculosis (disseminated / CNS)": 1,
+          "Brucellosis": -3,
+          "Arboviral / other viral encephalitis": 2
+        }
+      },
+      {
+        "name": "widal_negative",
+        "source": "grounded",
+        "citation": "Widal test sensitivity for typhoid ~60-80% (variable, poor); a negative modestly lowers typhoid odds. Olopoenia & King, Postgrad Med J 2000 review of Widal performance",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 1,
+          "Malaria": 0,
+          "Enteric (typhoid) fever": -5,
+          "Visceral leishmaniasis (kala-azar)": 1,
+          "Tuberculosis (disseminated / CNS)": 0,
+          "Brucellosis": 0,
+          "Arboviral / other viral encephalitis": 1
+        }
+      },
+      {
+        "name": "viral_markers_negative",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 2,
+          "Malaria": 1,
+          "Enteric (typhoid) fever": 1,
+          "Visceral leishmaniasis (kala-azar)": 2,
+          "Tuberculosis (disseminated / CNS)": 1,
+          "Brucellosis": 1,
+          "Arboviral / other viral encephalitis": -7
+        }
+      },
+      {
+        "name": "csf_acellular_normal_glucose_raised_protein",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 6,
+          "Malaria": -2,
+          "Enteric (typhoid) fever": -1,
+          "Visceral leishmaniasis (kala-azar)": 0,
+          "Tuberculosis (disseminated / CNS)": -2,
+          "Brucellosis": 1,
+          "Arboviral / other viral encephalitis": -3
+        }
+      },
+      {
+        "name": "bone_granuloma",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 1,
+          "Malaria": -2,
+          "Enteric (typhoid) fever": 0,
+          "Visceral leishmaniasis (kala-azar)": 4,
+          "Tuberculosis (disseminated / CNS)": 7,
+          "Brucellosis": 5,
+          "Arboviral / other viral encephalitis": -3
+        }
+      },
+      {
+        "name": "pontine_t2_flair_lesions_meningeal_enhancement",
+        "source": "assumed",
+        "citation": "",
+        "weights": {
+          "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 9,
+          "Malaria": 0,
+          "Enteric (typhoid) fever": -1,
+          "Visceral leishmaniasis (kala-azar)": -1,
+          "Tuberculosis (disseminated / CNS)": 5,
+          "Brucellosis": 3,
+          "Arboviral / other viral encephalitis": 5
+        }
+      }
+    ],
+    "ground_truth": "Neurobrucellosis (confirmed by Brucella serology + culture, held aside from the weighting)."
+  }
+}

--- a/code/specs/data/adj57/pipeline/sensitivity.py
+++ b/code/specs/data/adj57/pipeline/sensitivity.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""ADJ65 — uncertainty as a first-class primitive (weight of evidence + decision sensitivity).
+
+The gates so far answer YES/NO questions: is this claim grounded? is the conclusion
+determined? But a real decision is rarely a clean yes/no — it is a *competition* between
+hypotheses, each pushed on by the evidence with some strength. This module makes that
+competition first-class, and then asks the question Adhithya posed:
+
+    "If we make some probability shift, how would the decision shift?"
+
+THE MODEL (Good's weight of evidence, the formulation behind MYCIN's certainty factors).
+Each piece of grounded evidence E_j contributes, for each hypothesis H_i, a *weight* in
+**decibans** — ten times the log10 likelihood ratio:
+
+    w_ij = 10 · log10  P(E_j | H_i) / P(E_j | baseline)
+
+Decibans are additive log-odds: +10 dB means the evidence makes H_i ten times more likely;
+−10 dB, ten times less. The score of a hypothesis is its prior log-odds plus the evidence
+it has collected:
+
+    score_i = prior_i + Σ_j w_ij          (decibans)
+
+The DECISION is the argmax of the scores — deterministic, no temperature, no softmax. (We
+expose posteriors via softmax purely as a human-readable *view*; nothing downstream depends
+on them, so there is no entropy knob to tune — the past softmax mistake is not repeated.)
+
+THE PRIMITIVE WE ACTUALLY WANT IS SENSITIVITY. A single number for the winner is the least
+interesting output. What a decision-maker needs is:
+
+  - MARGIN  M = score(leader) − score(runner-up), in decibans. The decision survives any
+    single weight perturbation smaller than M. M *is* the robustness of the call.
+  - LOAD-BEARING evidence: ranked by how much each fact pushes leader-over-runner
+    (d_j = w_leader,j − w_runner,j). The fact with d_j closest to M is carrying the call.
+  - INDIVIDUALLY DECISIVE evidence: those whose removal alone flips the decision (d_j > M).
+  - TIPPING POINT: how far you must shift a weight (or the prior) to change the answer, and
+    WHICH hypothesis it changes to.
+  - PROVENANCE OF THE MARGIN: of the load-bearing weights, which are `grounded` (cite a real
+    likelihood ratio) and which are `assumed` (an ungrounded estimate). A decision whose
+    margin rests on an *assumed* weight is fragile in the one way that matters — go ground
+    that weight first (it is an ADJ64 hole, now prioritized by how much the decision depends
+    on it).
+
+This is why sensitivity, not a point probability, is the honest primitive: the weights are
+the soft underbelly (often interpretation, not byte-grounded), and the right response to
+soft inputs is not false precision — it is to report exactly how much the softness can move
+the answer.
+
+Usage (library): assess(hyps, evidence, prior=None) -> report.
+  evidence: [{"name","weights":{hyp: decibans}, "source":"grounded"|"assumed", "citation":""}]
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _scores(hyps: list[str], prior: dict, evidence: list[dict]) -> dict:
+    """score_i = prior_i + Σ_j w_ij, in decibans."""
+    s = {h: float(prior.get(h, 0.0)) for h in hyps}
+    for e in evidence:
+        for h, w in (e.get("weights") or {}).items():
+            if h in s:
+                s[h] += float(w)
+    return s
+
+
+def _rank(scores: dict) -> list[tuple]:
+    return sorted(scores.items(), key=lambda kv: -kv[1])
+
+
+def posteriors(scores: dict) -> dict:
+    """A human-readable VIEW only — softmax over the log-odds scores (decibans -> prob).
+    The decision never depends on this; it is argmax of `scores`."""
+    if not scores:
+        return {}
+    m = max(scores.values())
+    exps = {h: 10 ** ((v - m) / 10.0) for h, v in scores.items()}  # /10: decibans -> bans
+    z = sum(exps.values())
+    return {h: exps[h] / z for h in scores}
+
+
+def assess(hyps: list[str], evidence: list[dict], prior: dict | None = None) -> dict:
+    """Run the weight-of-evidence decision and its full sensitivity analysis."""
+    prior = prior or {}
+    scores = _scores(hyps, prior, evidence)
+    ranked = _rank(scores)
+    leader, s1 = ranked[0]
+    runner, s2 = ranked[1] if len(ranked) > 1 else (None, float("-inf"))
+    margin = s1 - s2  # decibans
+
+    # per-evidence push of leader over runner-up (load-bearing ranking)
+    contrib = []
+    for e in evidence:
+        w = e.get("weights") or {}
+        d = float(w.get(leader, 0.0)) - (float(w.get(runner, 0.0)) if runner else 0.0)
+        contrib.append({
+            "name": e.get("name", ""),
+            "push_for_leader": round(d, 2),          # decibans of leader-over-runner support
+            "decisive_alone": d > margin,            # removing this alone would flip the call
+            "source": e.get("source", "assumed"),
+            "citation": e.get("citation", ""),
+        })
+    contrib.sort(key=lambda c: -c["push_for_leader"])
+
+    # one-out: which single removals actually flip the leader
+    flips = []
+    for j, e in enumerate(evidence):
+        sub_leader = _rank(_scores(hyps, prior, evidence[:j] + evidence[j + 1:]))[0][0]
+        if sub_leader != leader:
+            flips.append({"remove": e.get("name", ""), "new_leader": sub_leader})
+
+    # minimal NUMBER of supporting facts that must fail to flip the decision (greedy on push)
+    pos = [c for c in contrib if c["push_for_leader"] > 0]
+    acc, k_to_flip, eroded = 0.0, None, []
+    for c in pos:
+        acc += c["push_for_leader"]
+        eroded.append(c["name"])
+        if acc > margin:
+            k_to_flip = len(eroded)
+            break
+
+    # provenance of the margin: is the call resting on ungrounded weights?
+    assumed_load = [c for c in pos if c["source"] != "grounded"]
+    margin_rests_on_assumed = bool(assumed_load) and (pos and pos[0]["source"] != "grounded")
+
+    return {
+        "hypotheses": hyps,
+        "scores": {h: round(v, 2) for h, v in scores.items()},
+        "posteriors": {h: round(p, 4) for h, p in posteriors(scores).items()},
+        "decision": leader,
+        "runner_up": runner,
+        "margin_db": round(margin, 2),
+        "margin_odds": round(10 ** (margin / 10.0), 1),   # leader is this-many times the runner-up
+        "ranked": [{"hypothesis": h, "score_db": round(v, 2)} for h, v in ranked],
+        "load_bearing": contrib,
+        "one_out_flips": flips,
+        "min_facts_to_flip": k_to_flip,                   # None if no single-evidence set can flip it
+        "would_flip_to": runner,
+        "assumed_load_bearing": [c["name"] for c in assumed_load],
+        "margin_rests_on_assumed": margin_rests_on_assumed,
+    }
+
+
+def tip(hyps: list[str], evidence: list[dict], prior: dict, evidence_name: str) -> dict:
+    """The literal "probability shift -> decision shift": sweep ONE evidence's leader-weight
+    downward and report the threshold at which the decision changes, and to what."""
+    prior = prior or {}
+    base = assess(hyps, evidence, prior)
+    leader, margin = base["decision"], base["margin_db"]
+    idx = next((i for i, e in enumerate(evidence) if e.get("name") == evidence_name), None)
+    if idx is None:
+        return {"error": f"no evidence named {evidence_name!r}"}
+    w0 = float((evidence[idx].get("weights") or {}).get(leader, 0.0))
+    # lowering this one weight by > margin flips the leader — but only possible if w0 > margin
+    return {
+        "evidence": evidence_name,
+        "current_weight_for_leader_db": round(w0, 2),
+        "flip_needs_drop_db": round(margin, 2),     # decibans this weight must lose to flip
+        "can_flip_alone": w0 > margin,
+        "flips_to": base["runner_up"] if w0 > margin else None,
+        "note": (f"dropping this weight below {round(w0 - margin, 2)} dB flips the decision to "
+                 f"{base['runner_up']!r}" if w0 > margin
+                 else "this single weight cannot flip the decision (its support is smaller than the margin)"),
+    }
+
+
+def main() -> None:
+    """CLI: python sensitivity.py <model.json>   (model: {hypotheses, prior?, evidence})"""
+    model = json.loads(Path(sys.argv[1]).read_text())
+    r = assess(model["hypotheses"], model["evidence"], model.get("prior"))
+    print(json.dumps(r, indent=2))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj57/pipeline/sensitivity.workflow.js
+++ b/code/specs/data/adj57/pipeline/sensitivity.workflow.js
@@ -1,0 +1,75 @@
+export const meta = {
+  name: 'adj65-sensitivity',
+  description: 'ADJ65 — uncertainty as a first-class primitive. Given a case and its grounded facts, the model proposes the competing hypotheses and a weight-of-evidence matrix (each fact contributes decibans toward each hypothesis, tagged grounded=cites a real likelihood ratio, or assumed=an estimate). The deterministic sensitivity engine then computes the decision, its margin, the load-bearing evidence, what would flip it, and — the honest part — whether the margin rests on ungrounded weights. Demonstrates "if we make some probability shift, how would the decision shift" on the neurobrucellosis case.',
+  phases: [{ title: 'WeighEvidence' }],
+}
+
+// The neurobrucellosis case + its grounded facts (the discriminating subset).
+const CASE_TEXT = `A forty-year Indian traveled through Uganda, Tanzania and Kenya. He developed a swelling over the left ankle after an insect bite, then high grade fever with chills and rigors after 3-4 days. He took empirical antibiotics with only minor relief. He was febrile (102 F). Abdomen revealed hepatomegaly of 3 cm and splenomegaly of 3 cm. Blood smear for malaria parasite was negative. Cultures from blood and urine were sterile. Widal test showed normal titers. Testing for viral markers were negative. CSF was acellular with normal glucose; the proteins were raised. Bone biopsy showed a single ill defined granuloma. MRI of brain showed mild meningeal enhancement; few small lesions in pons, hyperintense on T2/FLAIR.`
+const FACTS = [
+  'travel_to_east_africa',
+  'ankle_swelling_after_insect_bite',
+  'high_grade_fever_with_chills_rigors',
+  'partial_response_to_empirical_antibiotics',
+  'hepatosplenomegaly',
+  'malaria_smear_negative',
+  'blood_urine_cultures_sterile',
+  'widal_negative',
+  'viral_markers_negative',
+  'csf_acellular_normal_glucose_raised_protein',
+  'bone_granuloma',
+  'pontine_t2_flair_lesions_meningeal_enhancement',
+]
+
+const MODEL_SCHEMA = {
+  type: 'object',
+  required: ['hypotheses', 'evidence'],
+  properties: {
+    hypotheses: {
+      type: 'array', items: { type: 'string' },
+      description: 'the competing diagnoses a careful clinician would weigh for this presentation (4-7).',
+    },
+    evidence: {
+      type: 'array',
+      description: 'one entry per fact; its weight of evidence toward EACH hypothesis.',
+      items: {
+        type: 'object', required: ['name', 'weights', 'source', 'citation'],
+        properties: {
+          name: { type: 'string', description: 'the fact name' },
+          weights: {
+            type: 'object',
+            description: 'hypothesis -> weight in DECIBANS (10*log10 likelihood ratio). +10 = the fact makes this hypothesis 10x more likely; -10 = 10x less; 0 = no information. Use the SAME hypothesis keys as `hypotheses`.',
+            additionalProperties: { type: 'number' },
+          },
+          source: { type: 'string', enum: ['grounded', 'assumed'], description: 'grounded = you are citing a published/derivable likelihood ratio for this fact->hypothesis link; assumed = your own estimate with no specific source.' },
+          citation: { type: 'string', description: 'if grounded: the source of the likelihood ratio. if assumed: "".' },
+        },
+      },
+    },
+  },
+}
+
+const weighPrompt = `Build a weight-of-evidence model for this case so a decision engine can compute the diagnosis AND its sensitivity.
+
+CASE:
+${CASE_TEXT}
+
+GROUNDED FACTS (each is already byte-justified; weigh each one):
+${FACTS.map((f) => `  - ${f}`).join('\n')}
+
+1. List the competing HYPOTHESES (diagnoses) a careful clinician would weigh — 4 to 7 of them.
+2. For EACH fact, give its weight of evidence toward EACH hypothesis, in DECIBANS (10 * log10 of the likelihood ratio): +10 means the fact makes that hypothesis ~10x more likely, -10 means ~10x less, 0 means uninformative. A fact can support several hypotheses and argue against others (e.g. a negative malaria smear is strongly negative for malaria, ~neutral for the rest).
+3. Tag each fact's weighting honestly: source="grounded" ONLY if you are citing an actual published or derivable likelihood ratio (give the source in citation); otherwise source="assumed" with citation="". Be honest — most clinical LRs for a presentation like this are not precisely published, so most weights will be "assumed". That is the point: the engine will report how much the decision rests on those assumed weights.
+
+Do NOT pick the answer yourself; just supply the hypotheses and the weight matrix. The engine decides.`
+
+// ---- run ----
+const model = await agent(weighPrompt, { phase: 'WeighEvidence', label: 'weigh-evidence', agentType: 'general-purpose', schema: MODEL_SCHEMA })
+
+return {
+  case_text: CASE_TEXT,
+  facts: FACTS,
+  hypotheses: model.hypotheses,
+  evidence: model.evidence,
+  ground_truth: 'Neurobrucellosis (confirmed by Brucella serology + culture, held aside from the weighting).',
+}

--- a/code/specs/data/adj57/pipeline/test_sensitivity.py
+++ b/code/specs/data/adj57/pipeline/test_sensitivity.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for the sensitivity engine (sensitivity.py). Run: python test_sensitivity.py"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import sensitivity as s  # noqa: E402
+
+HYPS = ["brucellosis", "tuberculosis", "malaria"]
+
+
+def ev(name, weights, source="grounded", citation="x"):
+    return {"name": name, "weights": weights, "source": source, "citation": citation}
+
+
+def test_decision_is_argmax_of_summed_decibans():
+    e = [ev("granuloma", {"brucellosis": 5, "tuberculosis": 8, "malaria": -10}),
+         ev("travel", {"brucellosis": 4, "tuberculosis": 1, "malaria": 6})]
+    r = s.assess(HYPS, e)
+    # tb: 9, bruc: 9, mal: -4 -> tie at top; argmax picks the first max (brucellosis or tb)
+    assert r["scores"] == {"brucellosis": 9.0, "tuberculosis": 9.0, "malaria": -4.0}
+    assert r["decision"] in ("brucellosis", "tuberculosis")
+
+
+def test_margin_and_odds():
+    e = [ev("a", {"brucellosis": 10, "tuberculosis": 0, "malaria": 0})]
+    r = s.assess(HYPS, e)
+    assert r["decision"] == "brucellosis"
+    assert r["margin_db"] == 10.0 and r["margin_odds"] == 10.0  # +10 dB = 10x odds over runner-up
+
+
+def test_posteriors_are_a_view_and_sum_to_one():
+    raw = s.posteriors({"brucellosis": 10.0, "tuberculosis": 0.0, "malaria": 0.0})
+    assert abs(sum(raw.values()) - 1.0) < 1e-12          # the function is exact
+    r = s.assess(HYPS, [ev("a", {"brucellosis": 10, "tuberculosis": 0, "malaria": 0})])
+    assert abs(sum(r["posteriors"].values()) - 1.0) < 1e-3  # the report rounds for display
+    assert r["posteriors"]["brucellosis"] > r["posteriors"]["tuberculosis"]
+
+
+def test_load_bearing_and_decisive_alone():
+    e = [ev("big", {"brucellosis": 20, "tuberculosis": 0, "malaria": 0}),
+         ev("small", {"brucellosis": 2, "tuberculosis": 0, "malaria": 0})]
+    r = s.assess(HYPS, e)
+    # leader bruc=22, runner tb=0, margin=22. 'big' pushes 20 (< 22, not decisive alone here)
+    top = r["load_bearing"][0]
+    assert top["name"] == "big" and top["push_for_leader"] == 20.0
+
+
+def test_one_out_flip_detected():
+    e = [ev("decisive", {"brucellosis": 30, "tuberculosis": 0, "malaria": 0}),
+         ev("tb_lean", {"brucellosis": 0, "tuberculosis": 10, "malaria": 0})]
+    r = s.assess(HYPS, e)
+    assert r["decision"] == "brucellosis"
+    # removing 'decisive' -> tb wins
+    assert any(f["remove"] == "decisive" and f["new_leader"] == "tuberculosis" for f in r["one_out_flips"])
+
+
+def test_min_facts_to_flip():
+    e = [ev("a", {"brucellosis": 6, "tuberculosis": 0, "malaria": 0}),
+         ev("b", {"brucellosis": 6, "tuberculosis": 0, "malaria": 0}),
+         ev("c", {"brucellosis": 6, "tuberculosis": 0, "malaria": 0})]
+    r = s.assess(HYPS, e)  # bruc=18, margin=18; need to erode >18 -> all 3 (6+6+6=18 not >18)... 4th not exist
+    # eroding a(6)+b(6)+c(6)=18, not >18, so k stays None (cannot flip by removing supportive facts alone)
+    assert r["min_facts_to_flip"] is None
+
+
+def test_margin_rests_on_assumed_flagged():
+    e = [ev("ungrounded_big", {"brucellosis": 20, "tuberculosis": 0, "malaria": 0}, source="assumed"),
+         ev("grounded_small", {"brucellosis": 3, "tuberculosis": 0, "malaria": 0}, source="grounded")]
+    r = s.assess(HYPS, e)
+    assert r["margin_rests_on_assumed"] is True
+    assert "ungrounded_big" in r["assumed_load_bearing"]
+
+
+def test_tip_reports_threshold_and_target():
+    e = [ev("a", {"brucellosis": 30, "tuberculosis": 0, "malaria": 0}),
+         ev("b", {"brucellosis": 0, "tuberculosis": 10, "malaria": 0})]
+    t = s.tip(HYPS, e, {}, "a")
+    # bruc=30, tb=10, margin=20; weight 'a' for leader=30 > 20 -> can flip to tb
+    assert t["can_flip_alone"] is True and t["flips_to"] == "tuberculosis"
+    assert t["flip_needs_drop_db"] == 20.0
+
+
+def test_tip_cannot_flip_when_weight_below_margin():
+    e = [ev("a", {"brucellosis": 30, "tuberculosis": 0, "malaria": 0}),
+         ev("small", {"brucellosis": 5, "tuberculosis": 0, "malaria": 0})]
+    t = s.tip(HYPS, e, {}, "small")  # margin 35; small weight 5 < 35
+    assert t["can_flip_alone"] is False and t["flips_to"] is None
+
+
+def test_prior_shifts_the_decision():
+    e = [ev("a", {"brucellosis": 5, "tuberculosis": 0, "malaria": 0})]
+    r0 = s.assess(HYPS, e)
+    r1 = s.assess(HYPS, e, prior={"tuberculosis": 10})  # strong prior for tb overrides +5 evidence
+    assert r0["decision"] == "brucellosis" and r1["decision"] == "tuberculosis"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"  ok  {fn.__name__}")
+    print(f"\n{len(fns)} tests passed.")

--- a/code/specs/data/adj57/sensitivity.json
+++ b/code/specs/data/adj57/sensitivity.json
@@ -1,0 +1,141 @@
+{
+  "decision": "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)",
+  "runner_up": "Visceral leishmaniasis (kala-azar)",
+  "margin_db": 26.0,
+  "margin_odds": 398.1,
+  "posteriors": {
+    "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)": 0.9973,
+    "Malaria": 0.0,
+    "Enteric (typhoid) fever": 0.0,
+    "Visceral leishmaniasis (kala-azar)": 0.0025,
+    "Tuberculosis (disseminated / CNS)": 0.0001,
+    "Brucellosis": 0.0001,
+    "Arboviral / other viral encephalitis": 0.0
+  },
+  "ranked": [
+    {
+      "hypothesis": "East African trypanosomiasis (T. b. rhodesiense, meningoencephalitic stage)",
+      "score_db": 58.0
+    },
+    {
+      "hypothesis": "Visceral leishmaniasis (kala-azar)",
+      "score_db": 32.0
+    },
+    {
+      "hypothesis": "Tuberculosis (disseminated / CNS)",
+      "score_db": 18.0
+    },
+    {
+      "hypothesis": "Brucellosis",
+      "score_db": 16.0
+    },
+    {
+      "hypothesis": "Malaria",
+      "score_db": 6.0
+    },
+    {
+      "hypothesis": "Arboviral / other viral encephalitis",
+      "score_db": 6.0
+    },
+    {
+      "hypothesis": "Enteric (typhoid) fever",
+      "score_db": -6.0
+    }
+  ],
+  "load_bearing": [
+    {
+      "name": "pontine_t2_flair_lesions_meningeal_enhancement",
+      "push_for_leader": 10.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "ankle_swelling_after_insect_bite",
+      "push_for_leader": 9.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "travel_to_east_africa",
+      "push_for_leader": 7.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "csf_acellular_normal_glucose_raised_protein",
+      "push_for_leader": 6.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "high_grade_fever_with_chills_rigors",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "partial_response_to_empirical_antibiotics",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "malaria_smear_negative",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "grounded",
+      "citation": "Thick blood film sensitivity for malaria ~90-95% per exam at standard parasitemia (WHO microscopy QA); a single negative reduces malaria odds ~10x"
+    },
+    {
+      "name": "blood_urine_cultures_sterile",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "widal_negative",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "grounded",
+      "citation": "Widal test sensitivity for typhoid ~60-80% (variable, poor); a negative modestly lowers typhoid odds. Olopoenia & King, Postgrad Med J 2000 review of Widal performance"
+    },
+    {
+      "name": "viral_markers_negative",
+      "push_for_leader": 0.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "hepatosplenomegaly",
+      "push_for_leader": -3.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    },
+    {
+      "name": "bone_granuloma",
+      "push_for_leader": -3.0,
+      "decisive_alone": false,
+      "source": "assumed",
+      "citation": ""
+    }
+  ],
+  "one_out_flips": [],
+  "min_facts_to_flip": 4,
+  "margin_rests_on_assumed": true,
+  "assumed_load_bearing": [
+    "pontine_t2_flair_lesions_meningeal_enhancement",
+    "ankle_swelling_after_insect_bite",
+    "travel_to_east_africa",
+    "csf_acellular_normal_glucose_raised_protein"
+  ],
+  "ground_truth": "Neurobrucellosis (confirmed by Brucella serology + culture, held aside from the weighting)."
+}


### PR DESCRIPTION
Makes the hypothesis competition first-class and answers **"if we make some probability shift, how would the decision shift?"** In the MYCIN-2026 lineage (Good's weight of evidence — the math behind certainty factors). Builds on the merged ADJ60–64.

## The model
Each grounded fact contributes a weight in **decibans** (10·log10 LR) toward each hypothesis; scores add in log space; the **decision is `argmax`** — deterministic. Softmax appears *only* as a posterior display view (no temperature knob — the past softmax-entropy mistake is not repeated). Each weight is tagged **grounded** (cites a real likelihood ratio) or **assumed** (an estimate).

## The primitive is sensitivity, not a point probability
`sensitivity.py` reports the **margin** (the decision survives any single perturbation smaller than it), the **load-bearing** evidence, what would **flip** it (one-out, min-facts-to-flip, per-weight tipping point), and — the honest part — whether the **margin rests on `assumed` (ungrounded) weights**. 10 unit tests.

## The run — a confidently WRONG answer, correctly exposed
On the neurobrucellosis case the engine picked **East African trypanosomiasis at 99.7% (+26 dB margin ≈ 400×)** — **wrong** (held-aside truth: neurobrucellosis, ranked **4th**). A naive system stops at "99.7%." ADJ65 keeps going:

```
## What would flip it: no single fact; minimum that must fail: 4
## PROVENANCE OF THE MARGIN:
   ⚠ the margin RESTS ON ASSUMED weights:
       ? pontine_t2_flair_lesions_meningeal_enhancement (+10 dB)
       ? ankle_swelling_after_insect_bite               (+9 dB)
       ? travel_to_east_africa                          (+7 dB)
       ? csf_acellular_normal_glucose_raised_protein    (+6 dB)
```

**Every load-bearing weight is `assumed`.** The only *grounded* weights (negative malaria smear, negative Widal) contribute ~0 dB to the margin. The 99.7% is an artifact of four made-up numbers — the biggest, *insect-bite → trypanosomiasis +13 dB*, the very red herring ADJ60 fell for.

> ADJ65 doesn't make the model right. It makes the model's **confidence auditable** — and converts overconfidence into a *prioritized fetch-list*. It composes with ADJ64: the assumed load-bearing weight is the spider/CAS's top fetch priority.

## Honest limitations (in the spec)
- The weights are model-proposed; ADJ65 audits them, the spider grounds them (next).
- `grounded` is taken on the model's word — the next hardening is a deterministic check that a `grounded` weight carries a CAS-citable LR (mirrors the layer-2 multi-verifier thread).
- Single decision, single level; propagating uncertainty across a multi-step derivation is the larger build.

Security review: passed. 10 tests green. Spec: `code/specs/ADJ65-uncertainty-primitive.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)