### PR TITLE
Track browser image map descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -244,6 +244,7 @@ def check_browser_readiness_case(
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "media", errors)
     require_optional_object_list(
         f"{case_path}.expected", expected, "embedded_contexts", errors
@@ -506,6 +507,41 @@ def check_browser_expected_lists(
             source_path = f"{image_path}.sources[{source_index}]"
             for field in ("srcset", "resolved_srcset", "sizes", "media", "type_hint"):
                 require_optional_nullable_string(source_path, source, field, errors)
+
+    for index, image_map in enumerate(object_list_items(expected, "image_maps")):
+        image_map_path = f"{case_path}.expected.image_maps[{index}]"
+        for field in ("id", "name"):
+            require_optional_nullable_string(image_map_path, image_map, field, errors)
+        require_optional_object_list(image_map_path, image_map, "areas", errors)
+        for area_index, area in enumerate(object_list_items(image_map, "areas")):
+            area_path = f"{image_map_path}.areas[{area_index}]"
+            for field in (
+                "id",
+                "shape",
+                "coords",
+                "href",
+                "resolved_href",
+                "alt",
+                "target",
+                "effective_target",
+                "rel",
+                "download",
+                "hreflang",
+                "referrerpolicy",
+            ):
+                require_optional_nullable_string(area_path, area, field, errors)
+            require_optional_string_list(area_path, area, "rel_tokens", errors)
+            require_optional_string_list(area_path, area, "ping", errors)
+            require_optional_string_list(area_path, area, "resolved_ping", errors)
+            require_optional_string_list(area_path, area, "attributionsrc", errors)
+            require_optional_string_list(area_path, area, "resolved_attributionsrc", errors)
+            for field in (
+                "rel_external",
+                "rel_nofollow",
+                "rel_noopener",
+                "rel_noreferrer",
+            ):
+                require_optional_boolean(area_path, area, field, errors)
 
     for index, media in enumerate(object_list_items(expected, "media")):
         media_path = f"{case_path}.expected.media[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -836,6 +836,7 @@ pub struct BrowserDocument {
     pub headings: Vec<BrowserHeading>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
+    pub image_maps: Vec<BrowserImageMap>,
     pub media: Vec<BrowserMedia>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
     pub interactive_elements: Vec<BrowserInteractiveElement>,
@@ -1496,6 +1497,38 @@ pub struct BrowserImageSource {
     pub sizes: Option<String>,
     pub media: Option<String>,
     pub type_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImageMap {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub areas: Vec<BrowserImageMapArea>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImageMapArea {
+    pub id: Option<String>,
+    pub shape: String,
+    pub coords: Option<String>,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub alt: Option<String>,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub rel_external: bool,
+    pub rel_nofollow: bool,
+    pub rel_noopener: bool,
+    pub rel_noreferrer: bool,
+    pub ping: Vec<String>,
+    pub resolved_ping: Vec<String>,
+    pub attributionsrc: Vec<String>,
+    pub resolved_attributionsrc: Vec<String>,
+    pub download: Option<String>,
+    pub hreflang: Option<String>,
+    pub referrerpolicy: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9318,6 +9351,11 @@ fn collect_browser_facts(
                     picture_sources
                 },
             )),
+            "map" => summary.image_maps.push(browser_image_map_element(
+                element,
+                summary.base_href.as_deref(),
+                summary.base_target.as_deref(),
+            )),
             "audio" | "video" => summary
                 .media
                 .push(browser_media_element(element, summary.base_href.as_deref())),
@@ -11182,6 +11220,70 @@ fn resolve_browser_srcset_candidate(candidate: &str, base_href: Option<&str>) ->
         resolved_url
     } else {
         format!("{resolved_url} {descriptor}")
+    }
+}
+
+fn browser_image_map_element(
+    element: &Element,
+    base_href: Option<&str>,
+    base_target: Option<&str>,
+) -> BrowserImageMap {
+    BrowserImageMap {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        name: element.attribute("name").map(ToOwned::to_owned),
+        areas: element
+            .children
+            .iter()
+            .filter_map(|child| match child {
+                Node::Element(child_element) if child_element.name == "area" => Some(
+                    browser_image_map_area_element(child_element, base_href, base_target),
+                ),
+                _ => None,
+            })
+            .collect(),
+    }
+}
+
+fn browser_image_map_area_element(
+    element: &Element,
+    base_href: Option<&str>,
+    base_target: Option<&str>,
+) -> BrowserImageMapArea {
+    let rel_tokens = browser_rel_tokens(element);
+    let href = element.attribute("href").map(ToOwned::to_owned);
+    let target = element.attribute("target").map(ToOwned::to_owned);
+    BrowserImageMapArea {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        shape: browser_image_map_shape(element).unwrap_or_else(|| "rect".to_string()),
+        coords: browser_image_map_coords(element),
+        resolved_href: href
+            .as_deref()
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        href,
+        alt: element.attribute("alt").map(ToOwned::to_owned),
+        effective_target: target
+            .clone()
+            .or_else(|| base_target.map(ToOwned::to_owned)),
+        target,
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_external: browser_rel_tokens_contain(&rel_tokens, "external"),
+        rel_nofollow: browser_rel_tokens_contain(&rel_tokens, "nofollow"),
+        rel_noopener: browser_rel_tokens_contain(&rel_tokens, "noopener"),
+        rel_noreferrer: browser_rel_tokens_contain(&rel_tokens, "noreferrer"),
+        rel_tokens,
+        resolved_ping: browser_anchor_ping(element)
+            .into_iter()
+            .filter_map(|ping| resolve_browser_url(&ping, base_href))
+            .collect(),
+        ping: browser_anchor_ping(element),
+        resolved_attributionsrc: browser_anchor_attributionsrc(element)
+            .into_iter()
+            .filter_map(|attributionsrc| resolve_browser_url(&attributionsrc, base_href))
+            .collect(),
+        attributionsrc: browser_anchor_attributionsrc(element),
+        download: browser_anchor_download(element),
+        hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
     }
 }
 
@@ -15167,6 +15269,45 @@ mod tests {
         );
 
         let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.image_maps.len(), 1);
+        let image_map = &summary.image_maps[0];
+        assert_eq!(image_map.id.as_deref(), Some("map-node"));
+        assert_eq!(image_map.name.as_deref(), Some("hero-map"));
+        assert_eq!(image_map.areas.len(), 2);
+        assert_eq!(image_map.areas[0].id.as_deref(), Some("cta"));
+        assert_eq!(image_map.areas[0].shape, "rect");
+        assert_eq!(image_map.areas[0].coords.as_deref(), Some("0,0,120,60"));
+        assert_eq!(image_map.areas[0].href.as_deref(), Some("details.html"));
+        assert_eq!(
+            image_map.areas[0].resolved_href.as_deref(),
+            Some("https://example.test/gallery/details.html")
+        );
+        assert_eq!(image_map.areas[0].alt.as_deref(), Some("Details"));
+        assert_eq!(image_map.areas[0].target.as_deref(), Some("preview"));
+        assert_eq!(
+            image_map.areas[0].effective_target.as_deref(),
+            Some("preview")
+        );
+        assert_eq!(
+            image_map.areas[0].rel_tokens,
+            vec!["nofollow".to_string(), "external".to_string()]
+        );
+        assert!(image_map.areas[0].rel_nofollow);
+        assert!(image_map.areas[0].rel_external);
+        assert_eq!(image_map.areas[0].ping, vec!["track.html".to_string()]);
+        assert_eq!(
+            image_map.areas[0].resolved_ping,
+            vec!["https://example.test/gallery/track.html".to_string()]
+        );
+        assert_eq!(image_map.areas[0].hreflang.as_deref(), Some("en"));
+        assert_eq!(image_map.areas[1].shape, "rect");
+        assert_eq!(image_map.areas[1].coords.as_deref(), Some("10,10,40,40"));
+        assert_eq!(image_map.areas[1].href.as_deref(), Some("#logo"));
+        assert_eq!(
+            image_map.areas[1].resolved_href.as_deref(),
+            Some("https://example.test/gallery/index.html#logo")
+        );
+
         assert_eq!(summary.links.len(), 2);
         assert_eq!(summary.links[0].element, "area");
         assert_eq!(summary.links[0].id.as_deref(), Some("cta"));

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -7,10 +7,11 @@ use coding_adventures_html_parser::{
     BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect,
     BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
+    BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTemplate, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -64,6 +65,8 @@ struct ExpectedBrowserDocument {
     headings: Vec<ExpectedHeading>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
+    #[serde(default)]
+    image_maps: Vec<ExpectedImageMap>,
     #[serde(default)]
     media: Vec<ExpectedMedia>,
     #[serde(default)]
@@ -515,6 +518,62 @@ struct ExpectedImageSource {
     media: Option<String>,
     #[serde(default)]
     type_hint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedImageMap {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    areas: Vec<ExpectedImageMapArea>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedImageMapArea {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default = "default_image_map_area_shape")]
+    shape: String,
+    #[serde(default)]
+    coords: Option<String>,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    alt: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_external: bool,
+    #[serde(default)]
+    rel_nofollow: bool,
+    #[serde(default)]
+    rel_noopener: bool,
+    #[serde(default)]
+    rel_noreferrer: bool,
+    #[serde(default)]
+    ping: Vec<String>,
+    #[serde(default)]
+    resolved_ping: Vec<String>,
+    #[serde(default)]
+    attributionsrc: Vec<String>,
+    #[serde(default)]
+    resolved_attributionsrc: Vec<String>,
+    #[serde(default)]
+    download: Option<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1565,6 +1624,26 @@ fn browser_link_descriptor_metadata_tracks_icon_and_alternate_fields() {
     assert_eq!(
         actual.resources, expected.resources,
         "link resources should preserve icon sizes, mask colors, and alternate language descriptors",
+    );
+}
+
+#[test]
+fn browser_image_map_descriptor_metadata_tracks_area_navigation() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "responsive-image-metadata-page")
+        .expect("responsive image fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("responsive image fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.image_maps, expected.image_maps,
+        "image maps should preserve area geometry, link policy, and resolved navigation metadata",
     );
 }
 
@@ -2717,6 +2796,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedImage::into_browser_image)
                 .collect(),
+            image_maps: self
+                .image_maps
+                .into_iter()
+                .map(ExpectedImageMap::into_browser_image_map)
+                .collect(),
             media: self
                 .media
                 .into_iter()
@@ -3128,6 +3212,10 @@ fn default_track_kind() -> String {
     "subtitles".to_string()
 }
 
+fn default_image_map_area_shape() -> String {
+    "rect".to_string()
+}
+
 impl ExpectedImage {
     fn into_browser_image(self) -> BrowserImage {
         BrowserImage {
@@ -3163,6 +3251,48 @@ impl ExpectedImageSource {
             sizes: self.sizes,
             media: self.media,
             type_hint: self.type_hint,
+        }
+    }
+}
+
+impl ExpectedImageMap {
+    fn into_browser_image_map(self) -> BrowserImageMap {
+        BrowserImageMap {
+            id: self.id,
+            name: self.name,
+            areas: self
+                .areas
+                .into_iter()
+                .map(ExpectedImageMapArea::into_browser_image_map_area)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedImageMapArea {
+    fn into_browser_image_map_area(self) -> BrowserImageMapArea {
+        BrowserImageMapArea {
+            id: self.id,
+            shape: self.shape,
+            coords: self.coords,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            alt: self.alt,
+            target: self.target,
+            effective_target: self.effective_target,
+            rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            rel_external: self.rel_external,
+            rel_nofollow: self.rel_nofollow,
+            rel_noopener: self.rel_noopener,
+            rel_noreferrer: self.rel_noreferrer,
+            ping: self.ping,
+            resolved_ping: self.resolved_ping,
+            attributionsrc: self.attributionsrc,
+            resolved_attributionsrc: self.resolved_attributionsrc,
+            download: self.download,
+            hreflang: self.hreflang,
+            referrerpolicy: self.referrerpolicy,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -167,6 +167,31 @@
             ]
           }
         ],
+        "image_maps": [
+          {
+            "name": "hero-map",
+            "areas": [
+              {
+                "shape": "rect",
+                "coords": "0,0,120,60",
+                "href": "details.html",
+                "resolved_href": "https://example.test/gallery/details.html",
+                "alt": "Details",
+                "target": "preview",
+                "effective_target": "preview",
+                "rel": "nofollow external",
+                "rel_tokens": ["nofollow", "external"],
+                "rel_external": true,
+                "rel_nofollow": true,
+                "ping": ["track.html"],
+                "resolved_ping": ["https://example.test/gallery/track.html"],
+                "attributionsrc": ["area-attr.html"],
+                "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"],
+                "hreflang": "en"
+              }
+            ]
+          }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- Add document-level BrowserImageMap and BrowserImageMapArea descriptors for map/area metadata
- Preserve area geometry, resolved navigation, rel/ping/attribution, target, and language/referrer hints
- Extend browser-readiness fixture/schema coverage for image maps

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_image_map_metadata_tracks_map_areas_and_navigation
- cargo test -p coding-adventures-html-parser browser_image_map_descriptor_metadata_tracks_area_navigation
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser