### PR TITLE
Track browser text semantic descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -242,6 +242,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "stylesheets", errors)
     require_object_list(f"{case_path}.expected", expected, "anchors", errors)
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "text_semantics", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -454,6 +455,30 @@ def check_browser_expected_lists(
         heading_path = f"{case_path}.expected.headings[{index}]"
         require_integer(heading_path, heading, "level", errors)
         require_string(heading_path, heading, "text", errors)
+
+    for index, semantic in enumerate(object_list_items(expected, "text_semantics")):
+        semantic_path = f"{case_path}.expected.text_semantics[{index}]"
+        for field in (
+            "element",
+            "role",
+            "text",
+        ):
+            require_string(semantic_path, semantic, field, errors)
+        for field in (
+            "id",
+            "lang",
+            "dir",
+            "quote_cite",
+            "resolved_quote_cite",
+            "data_value",
+            "datetime",
+            "edit_cite",
+            "resolved_edit_cite",
+            "edit_datetime",
+            "ruby_kind",
+            "bidi_kind",
+        ):
+            require_optional_nullable_string(semantic_path, semantic, field, errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -834,6 +834,7 @@ pub struct BrowserDocument {
     pub stylesheets: Vec<BrowserStylesheet>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
+    pub text_semantics: Vec<BrowserTextSemantic>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1441,6 +1442,25 @@ pub struct BrowserRenderNode {
 pub struct BrowserHeading {
     pub level: u8,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTextSemantic {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub lang: Option<String>,
+    pub dir: Option<String>,
+    pub quote_cite: Option<String>,
+    pub resolved_quote_cite: Option<String>,
+    pub data_value: Option<String>,
+    pub datetime: Option<String>,
+    pub edit_cite: Option<String>,
+    pub resolved_edit_cite: Option<String>,
+    pub edit_datetime: Option<String>,
+    pub ruby_kind: Option<String>,
+    pub bidi_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9307,6 +9327,11 @@ fn collect_browser_facts(
         if let Some(disclosure) = browser_disclosure_element(element, id_texts) {
             summary.disclosures.push(disclosure);
         }
+        if let Some(text_semantic) =
+            browser_text_semantic_element(element, summary.base_href.as_deref())
+        {
+            summary.text_semantics.push(text_semantic);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -9776,6 +9801,61 @@ fn browser_link_text(element: &Element) -> String {
     } else {
         text
     }
+}
+
+fn browser_text_semantic_element(
+    element: &Element,
+    base_href: Option<&str>,
+) -> Option<BrowserTextSemantic> {
+    if !is_browser_text_semantic_element(element) {
+        return None;
+    }
+
+    let quote_cite = browser_quote_cite(element);
+    let edit_cite = browser_edit_cite(element);
+    Some(BrowserTextSemantic {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        role: browser_content_role(&element.name)
+            .unwrap_or("inline")
+            .to_string(),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        lang: element.attribute("lang").map(ToOwned::to_owned),
+        dir: element.attribute("dir").map(ToOwned::to_owned),
+        resolved_quote_cite: quote_cite
+            .as_deref()
+            .and_then(|cite| resolve_browser_url(cite, base_href)),
+        quote_cite,
+        data_value: browser_data_value(element),
+        datetime: browser_datetime(element),
+        resolved_edit_cite: edit_cite
+            .as_deref()
+            .and_then(|cite| resolve_browser_url(cite, base_href)),
+        edit_cite,
+        edit_datetime: browser_edit_datetime(element),
+        ruby_kind: browser_ruby_kind(element),
+        bidi_kind: browser_bidi_kind(element),
+    })
+}
+
+fn is_browser_text_semantic_element(element: &Element) -> bool {
+    matches!(
+        element.name.as_str(),
+        "blockquote"
+            | "q"
+            | "data"
+            | "time"
+            | "mark"
+            | "ins"
+            | "del"
+            | "ruby"
+            | "rb"
+            | "rt"
+            | "rp"
+            | "rtc"
+            | "bdi"
+            | "bdo"
+    )
 }
 
 fn browser_link_resource_hint_kind(rel: Option<&str>) -> Option<String> {
@@ -15496,6 +15576,40 @@ mod tests {
         )
         .unwrap();
 
+        let summary = BrowserDocument::from_document(&document);
+        let semantic_ids: Vec<&str> = summary
+            .text_semantics
+            .iter()
+            .filter_map(|semantic| semantic.id.as_deref())
+            .collect();
+        assert_eq!(
+            semantic_ids,
+            vec!["version", "date", "add", "remove", "highlight"]
+        );
+        assert_eq!(summary.text_semantics[0].role, "data");
+        assert_eq!(summary.text_semantics[0].data_value.as_deref(), Some("2.1"));
+        assert_eq!(summary.text_semantics[1].role, "time");
+        assert_eq!(
+            summary.text_semantics[1].datetime.as_deref(),
+            Some("2026-05-25")
+        );
+        assert_eq!(summary.text_semantics[2].role, "inserted");
+        assert_eq!(
+            summary.text_semantics[2].resolved_edit_cite.as_deref(),
+            Some("https://example.test/docs/changes.html")
+        );
+        assert_eq!(
+            summary.text_semantics[2].edit_datetime.as_deref(),
+            Some("2026-05-25T06:00:00Z")
+        );
+        assert_eq!(summary.text_semantics[3].role, "deleted");
+        assert_eq!(
+            summary.text_semantics[3].resolved_edit_cite.as_deref(),
+            Some("https://example.test/docs/page.html#old")
+        );
+        assert_eq!(summary.text_semantics[4].role, "mark");
+        assert_eq!(summary.text_semantics[4].text, "Important");
+
         let content_tree = BrowserContentTree::from_document(&document);
         let paragraph = &content_tree.children[0];
 
@@ -15802,6 +15916,37 @@ mod tests {
              and <bdo id=rtl dir=rtl>abc</bdo>",
         )
         .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        let semantics: Vec<(&str, &str, Option<&str>)> = summary
+            .text_semantics
+            .iter()
+            .map(|semantic| {
+                (
+                    semantic.element.as_str(),
+                    semantic.role.as_str(),
+                    semantic
+                        .ruby_kind
+                        .as_deref()
+                        .or(semantic.bidi_kind.as_deref()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            semantics,
+            vec![
+                ("ruby", "ruby", Some("ruby")),
+                ("rb", "ruby_base", Some("base")),
+                ("rt", "ruby_text", Some("text")),
+                ("rp", "ruby_fallback", Some("fallback")),
+                ("rtc", "ruby_text_container", Some("text_container")),
+                ("rt", "ruby_text", Some("text")),
+                ("bdi", "bidi_isolate", Some("isolate")),
+                ("bdo", "bidi_override", Some("override")),
+            ]
+        );
+        assert_eq!(summary.text_semantics[6].dir.as_deref(), Some("auto"));
+        assert_eq!(summary.text_semantics[7].dir.as_deref(), Some("rtl"));
 
         let content_tree = BrowserContentTree::from_document(&document);
         let ruby = &content_tree.children[0];

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -11,7 +11,7 @@ use coding_adventures_html_parser::{
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
     BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
     BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserThemeColor,
+    BrowserTable, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -63,6 +63,8 @@ struct ExpectedBrowserDocument {
     stylesheets: Vec<ExpectedStylesheet>,
     anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
+    #[serde(default)]
+    text_semantics: Vec<ExpectedTextSemantic>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -430,6 +432,37 @@ struct ExpectedAnchor {
 struct ExpectedHeading {
     level: u8,
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedTextSemantic {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
+    #[serde(default)]
+    quote_cite: Option<String>,
+    #[serde(default)]
+    resolved_quote_cite: Option<String>,
+    #[serde(default)]
+    data_value: Option<String>,
+    #[serde(default)]
+    datetime: Option<String>,
+    #[serde(default)]
+    edit_cite: Option<String>,
+    #[serde(default)]
+    resolved_edit_cite: Option<String>,
+    #[serde(default)]
+    edit_datetime: Option<String>,
+    #[serde(default)]
+    ruby_kind: Option<String>,
+    #[serde(default)]
+    bidi_kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1648,6 +1681,26 @@ fn browser_image_map_descriptor_metadata_tracks_area_navigation() {
 }
 
 #[test]
+fn browser_text_semantic_descriptor_metadata_tracks_inline_annotations() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "inline-semantic-metadata-page")
+        .expect("inline semantic fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("inline semantic fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.text_semantics, expected.text_semantics,
+        "text semantics should preserve machine-readable values, edits, quotes, ruby annotations, and bidi metadata",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -2786,6 +2839,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedHeading::into_browser_heading)
                 .collect(),
+            text_semantics: self
+                .text_semantics
+                .into_iter()
+                .map(ExpectedTextSemantic::into_browser_text_semantic)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3170,6 +3228,28 @@ impl ExpectedHeading {
         BrowserHeading {
             level: self.level,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedTextSemantic {
+    fn into_browser_text_semantic(self) -> BrowserTextSemantic {
+        BrowserTextSemantic {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            lang: self.lang,
+            dir: self.dir,
+            quote_cite: self.quote_cite,
+            resolved_quote_cite: self.resolved_quote_cite,
+            data_value: self.data_value,
+            datetime: self.datetime,
+            edit_cite: self.edit_cite,
+            resolved_edit_cite: self.resolved_edit_cite,
+            edit_datetime: self.edit_datetime,
+            ruby_kind: self.ruby_kind,
+            bidi_kind: self.bidi_kind,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -731,6 +731,10 @@
         "headings": [
           { "level": 2, "text": "Widget Pro" }
         ],
+        "text_semantics": [
+          { "element": "data", "role": "data", "text": "Widget SKU", "data_value": "WID-001" },
+          { "element": "time", "role": "time", "text": "today", "datetime": "2026-05-25" }
+        ],
         "links": [
           { "href": "../products/widget", "resolved_href": "https://example.test/products/widget", "name": null, "target": null, "rel": null, "title": null, "text": "Product page" }
         ],
@@ -785,6 +789,55 @@
         "resources": [],
         "anchors": [],
         "headings": [],
+        "text_semantics": [
+          { "element": "blockquote", "role": "quote_block", "text": "Quote part", "quote_cite": "notes/ref.html", "resolved_quote_cite": "https://example.test/docs/notes/ref.html" },
+          { "element": "q", "role": "quote", "text": "part", "quote_cite": "#part", "resolved_quote_cite": "https://example.test/docs/page.html#part" }
+        ],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "inline-semantic-metadata-page",
+      "description": "Browser document summaries expose machine-readable text, edit annotations, inline quotes, ruby annotations, and bidi overrides as a flat text semantic inventory.",
+      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Version <data id=version value=\"2.1\">two point one</data> shipped <time id=date datetime=\"2026-05-25\">today</time>. <q id=quote cite=notes/ref.html>quoted</q> <ins id=add cite=changes.html datetime=\"2026-05-25T06:00:00Z\">Added</ins> <del id=remove cite=\"#old\" datetime=\"2026-05-24\">Removed</del> <mark id=highlight>Important</mark></p><ruby id=term><rb>kanji</rb><rt>kan</rt><rp>(</rp><rtc><rt>group</rt></rtc></ruby> then <bdi id=name dir=auto lang=ja>Name</bdi> and <bdo id=rtl dir=rtl>abc</bdo>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/docs/page.html",
+        "base_target": null,
+        "body_text": "Version two point one shipped today. quoted Added Removed Important kanji kan ( group then Name and abc",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "version", "name": null, "text": "two point one" },
+          { "id": "date", "name": null, "text": "today" },
+          { "id": "quote", "name": null, "text": "quoted" },
+          { "id": "add", "name": null, "text": "Added" },
+          { "id": "remove", "name": null, "text": "Removed" },
+          { "id": "highlight", "name": null, "text": "Important" },
+          { "id": "term", "name": null, "text": "kanji kan ( group" },
+          { "id": "name", "name": null, "text": "Name" },
+          { "id": "rtl", "name": null, "text": "abc" }
+        ],
+        "headings": [],
+        "text_semantics": [
+          { "element": "data", "id": "version", "role": "data", "text": "two point one", "data_value": "2.1" },
+          { "element": "time", "id": "date", "role": "time", "text": "today", "datetime": "2026-05-25" },
+          { "element": "q", "id": "quote", "role": "quote", "text": "quoted", "quote_cite": "notes/ref.html", "resolved_quote_cite": "https://example.test/docs/notes/ref.html" },
+          { "element": "ins", "id": "add", "role": "inserted", "text": "Added", "edit_cite": "changes.html", "resolved_edit_cite": "https://example.test/docs/changes.html", "edit_datetime": "2026-05-25T06:00:00Z" },
+          { "element": "del", "id": "remove", "role": "deleted", "text": "Removed", "edit_cite": "#old", "resolved_edit_cite": "https://example.test/docs/page.html#old", "edit_datetime": "2026-05-24" },
+          { "element": "mark", "id": "highlight", "role": "mark", "text": "Important" },
+          { "element": "ruby", "id": "term", "role": "ruby", "text": "kanji kan ( group", "ruby_kind": "ruby" },
+          { "element": "rb", "role": "ruby_base", "text": "kanji", "ruby_kind": "base" },
+          { "element": "rt", "role": "ruby_text", "text": "kan", "ruby_kind": "text" },
+          { "element": "rp", "role": "ruby_fallback", "text": "(", "ruby_kind": "fallback" },
+          { "element": "rtc", "role": "ruby_text_container", "text": "group", "ruby_kind": "text_container" },
+          { "element": "rt", "role": "ruby_text", "text": "group", "ruby_kind": "text" },
+          { "element": "bdi", "id": "name", "role": "bidi_isolate", "text": "Name", "lang": "ja", "dir": "auto", "bidi_kind": "isolate" },
+          { "element": "bdo", "id": "rtl", "role": "bidi_override", "text": "abc", "dir": "rtl", "bidi_kind": "override" }
+        ],
         "links": [],
         "images": [],
         "forms": [],


### PR DESCRIPTION
## Summary
- add document-level BrowserTextSemantic descriptors for data/time/quote/edit/ruby/bidi inline semantics
- validate the new text_semantics fixture shape in browser readiness fixtures
- update existing readiness expectations for microdata and quote cases now covered by text semantics

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_text_semantic_descriptor_metadata_tracks_inline_annotations
- cargo test -p coding-adventures-html-parser browser_inline_semantic_metadata_tracks_machine_readable_annotations
- cargo test -p coding-adventures-html-parser browser_ruby_bidi_metadata_tracks_annotation_and_direction_nodes
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser