### PR TITLE
Track browser navigation group descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -243,6 +243,7 @@ def check_browser_readiness_case(
     require_object_list(f"{case_path}.expected", expected, "anchors", errors)
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "text_semantics", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "navigation_groups", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -479,6 +480,28 @@ def check_browser_expected_lists(
             "bidi_kind",
         ):
             require_optional_nullable_string(semantic_path, semantic, field, errors)
+
+    for index, group in enumerate(object_list_items(expected, "navigation_groups")):
+        group_path = f"{case_path}.expected.navigation_groups[{index}]"
+        for field in (
+            "element",
+            "role",
+            "text",
+        ):
+            require_string(group_path, group, field, errors)
+        for field in (
+            "id",
+            "accessible_name",
+            "aria_label",
+            "landmark_kind",
+            "list_kind",
+            "list_start",
+            "list_marker_type",
+        ):
+            require_optional_nullable_string(group_path, group, field, errors)
+        require_optional_string_list(group_path, group, "aria_labelledby", errors)
+        require_integer(group_path, group, "item_count", errors)
+        require_optional_boolean(group_path, group, "list_reversed", errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -835,6 +835,7 @@ pub struct BrowserDocument {
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
+    pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1461,6 +1462,23 @@ pub struct BrowserTextSemantic {
     pub edit_datetime: Option<String>,
     pub ruby_kind: Option<String>,
     pub bidi_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserNavigationGroup {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub landmark_kind: Option<String>,
+    pub list_kind: Option<String>,
+    pub item_count: usize,
+    pub list_start: Option<String>,
+    pub list_marker_type: Option<String>,
+    pub list_reversed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9332,6 +9350,9 @@ fn collect_browser_facts(
         {
             summary.text_semantics.push(text_semantic);
         }
+        if let Some(navigation_group) = browser_navigation_group_element(element, id_texts) {
+            summary.navigation_groups.push(navigation_group);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -10941,6 +10962,42 @@ fn browser_content_role(name: &str) -> Option<&'static str> {
         name if is_browser_block_element(name) => Some("block"),
         _ => Some("inline"),
     }
+}
+
+fn browser_navigation_group_element(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserNavigationGroup> {
+    if !matches!(element.name.as_str(), "nav" | "ul" | "ol" | "menu" | "dir") {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name).unwrap_or(element.name.as_str());
+    let aria_labelledby = browser_aria_idrefs(element, "aria-labelledby");
+
+    Some(BrowserNavigationGroup {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        role: role.to_string(),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, role, &[], id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby,
+        landmark_kind: browser_landmark_kind(element),
+        list_kind: browser_list_kind(element),
+        item_count: browser_direct_list_item_count(element),
+        list_start: browser_list_start(element),
+        list_marker_type: browser_list_marker_type(element),
+        list_reversed: element.name == "ol" && element.attribute("reversed").is_some(),
+    })
+}
+
+fn browser_direct_list_item_count(element: &Element) -> usize {
+    element
+        .children
+        .iter()
+        .filter(|node| matches!(node, Node::Element(child) if child.name == "li"))
+        .count()
 }
 
 fn should_collect_browser_content_children(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -9,9 +9,10 @@ use coding_adventures_html_parser::{
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate,
+    BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -65,6 +66,8 @@ struct ExpectedBrowserDocument {
     headings: Vec<ExpectedHeading>,
     #[serde(default)]
     text_semantics: Vec<ExpectedTextSemantic>,
+    #[serde(default)]
+    navigation_groups: Vec<ExpectedNavigationGroup>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -463,6 +466,32 @@ struct ExpectedTextSemantic {
     ruby_kind: Option<String>,
     #[serde(default)]
     bidi_kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedNavigationGroup {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    landmark_kind: Option<String>,
+    #[serde(default)]
+    list_kind: Option<String>,
+    item_count: usize,
+    #[serde(default)]
+    list_start: Option<String>,
+    #[serde(default)]
+    list_marker_type: Option<String>,
+    #[serde(default)]
+    list_reversed: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1701,6 +1730,26 @@ fn browser_text_semantic_descriptor_metadata_tracks_inline_annotations() {
 }
 
 #[test]
+fn browser_navigation_group_descriptor_metadata_tracks_lists_and_landmarks() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "navigation-menu-descriptor-page")
+        .expect("navigation menu fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("navigation menu fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.navigation_groups, expected.navigation_groups,
+        "navigation groups should preserve list/menu landmark names, item counts, and ordered list metadata",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -2844,6 +2893,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedTextSemantic::into_browser_text_semantic)
                 .collect(),
+            navigation_groups: self
+                .navigation_groups
+                .into_iter()
+                .map(ExpectedNavigationGroup::into_browser_navigation_group)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3250,6 +3304,26 @@ impl ExpectedTextSemantic {
             edit_datetime: self.edit_datetime,
             ruby_kind: self.ruby_kind,
             bidi_kind: self.bidi_kind,
+        }
+    }
+}
+
+impl ExpectedNavigationGroup {
+    fn into_browser_navigation_group(self) -> BrowserNavigationGroup {
+        BrowserNavigationGroup {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            landmark_kind: self.landmark_kind,
+            list_kind: self.list_kind,
+            item_count: self.item_count,
+            list_start: self.list_start,
+            list_marker_type: self.list_marker_type,
+            list_reversed: self.list_reversed,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -29,6 +29,9 @@
         "headings": [
           { "level": 1, "text": "Example Directory" }
         ],
+        "navigation_groups": [
+          { "element": "ul", "role": "list", "text": "One Two", "list_kind": "unordered", "item_count": 2 }
+        ],
         "links": [
           { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "attributionsrc": ["attr/register", "https://ad.example/register"], "resolved_attributionsrc": ["https://example.test/docs/attr/register", "https://ad.example/register"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
         ],
@@ -683,6 +686,41 @@
       }
     },
     {
+      "id": "navigation-menu-descriptor-page",
+      "description": "Browser document summaries expose navigation landmarks, menus, and ordered/unordered lists as a flat group inventory.",
+      "input": "<body><h2 id=nav-title>Site</h2><nav id=site-nav aria-labelledby=nav-title><a href=/home>Home</a><ul id=primary><li>Docs<li>API</ul></nav><menu id=actions aria-label=\"Actions\"><li value=3>Open<li>Save</menu><ol id=steps start=2 reversed type=A><li value=4>Review<li>Ship</ol>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Site Home Docs API Open Save Review Ship",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "nav-title", "name": null, "text": "Site" },
+          { "id": "site-nav", "name": null, "text": "Home Docs API" },
+          { "id": "primary", "name": null, "text": "Docs API" },
+          { "id": "actions", "name": null, "text": "Open Save" },
+          { "id": "steps", "name": null, "text": "Review Ship" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Site" }
+        ],
+        "navigation_groups": [
+          { "element": "nav", "id": "site-nav", "role": "navigation", "text": "Home Docs API", "accessible_name": "Site", "aria_labelledby": ["nav-title"], "landmark_kind": "navigation", "item_count": 0 },
+          { "element": "ul", "id": "primary", "role": "list", "text": "Docs API", "list_kind": "unordered", "item_count": 2 },
+          { "element": "menu", "id": "actions", "role": "list", "text": "Open Save", "accessible_name": "Actions", "aria_label": "Actions", "list_kind": "menu", "item_count": 2 },
+          { "element": "ol", "id": "steps", "role": "list", "text": "Review Ship", "list_kind": "ordered", "item_count": 2, "list_start": "2", "list_marker_type": "A", "list_reversed": true }
+        ],
+        "links": [
+          { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
+        ],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "document-outline-landmark-page",
       "description": "Browser document summaries keep heading order across sectioning and landmark elements.",
       "input": "<body><header><h1>Site</h1></header><nav><h2>Nav</h2><a href=/home>Home</a></nav><main><article id=post><h2>Post</h2><section aria-label=Chapter><h3>Chapter</h3></section></article><aside><h2>Related</h2></aside></main><footer>Fine print</footer>",
@@ -702,6 +740,9 @@
           { "level": 2, "text": "Post" },
           { "level": 3, "text": "Chapter" },
           { "level": 2, "text": "Related" }
+        ],
+        "navigation_groups": [
+          { "element": "nav", "role": "navigation", "text": "Nav Home", "landmark_kind": "navigation", "item_count": 0 }
         ],
         "links": [
           { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
@@ -792,6 +833,9 @@
         "text_semantics": [
           { "element": "blockquote", "role": "quote_block", "text": "Quote part", "quote_cite": "notes/ref.html", "resolved_quote_cite": "https://example.test/docs/notes/ref.html" },
           { "element": "q", "role": "quote", "text": "part", "quote_cite": "#part", "resolved_quote_cite": "https://example.test/docs/page.html#part" }
+        ],
+        "navigation_groups": [
+          { "element": "ol", "role": "list", "text": "Seven Eight", "list_kind": "ordered", "item_count": 2, "list_start": "3", "list_marker_type": "A", "list_reversed": true }
         ],
         "links": [],
         "images": [],


### PR DESCRIPTION
## Summary
- add document-level browser navigation group descriptors for nav/list/menu elements
- expose ARIA naming, landmark/list kind, item counts, and ordered-list marker hints
- extend browser-readiness fixtures and schema validation for the new flat inventory

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_navigation_group_descriptor_metadata_tracks_lists_and_landmarks
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser

Note: `cargo fmt -p coding-adventures-html-parser --check` reports pre-existing rustfmt drift in unrelated WHATWG audit test files; touched Rust files remain scoped and tests pass.