### PR TITLE
Track browser section landmark descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -244,6 +244,7 @@ def check_browser_readiness_case(
     require_object_list(f"{case_path}.expected", expected, "headings", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "text_semantics", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "navigation_groups", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "section_landmarks", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -502,6 +503,27 @@ def check_browser_expected_lists(
         require_optional_string_list(group_path, group, "aria_labelledby", errors)
         require_integer(group_path, group, "item_count", errors)
         require_optional_boolean(group_path, group, "list_reversed", errors)
+
+    for index, section in enumerate(object_list_items(expected, "section_landmarks")):
+        section_path = f"{case_path}.expected.section_landmarks[{index}]"
+        for field in (
+            "element",
+            "role",
+            "text",
+        ):
+            require_string(section_path, section, field, errors)
+        for field in (
+            "id",
+            "authored_role",
+            "accessible_name",
+            "aria_label",
+            "section_kind",
+            "landmark_kind",
+            "heading_text",
+        ):
+            require_optional_nullable_string(section_path, section, field, errors)
+        require_optional_string_list(section_path, section, "aria_labelledby", errors)
+        require_optional_integer(section_path, section, "heading_level", errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -836,6 +836,7 @@ pub struct BrowserDocument {
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
     pub navigation_groups: Vec<BrowserNavigationGroup>,
+    pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1479,6 +1480,22 @@ pub struct BrowserNavigationGroup {
     pub list_start: Option<String>,
     pub list_marker_type: Option<String>,
     pub list_reversed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserSectionLandmark {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub authored_role: Option<String>,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub section_kind: Option<String>,
+    pub landmark_kind: Option<String>,
+    pub heading_level: Option<u8>,
+    pub heading_text: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9353,6 +9370,9 @@ fn collect_browser_facts(
         if let Some(navigation_group) = browser_navigation_group_element(element, id_texts) {
             summary.navigation_groups.push(navigation_group);
         }
+        if let Some(section_landmark) = browser_section_landmark_element(element, id_texts) {
+            summary.section_landmarks.push(section_landmark);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -10998,6 +11018,59 @@ fn browser_direct_list_item_count(element: &Element) -> usize {
         .iter()
         .filter(|node| matches!(node, Node::Element(child) if child.name == "li"))
         .count()
+}
+
+fn browser_section_landmark_element(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserSectionLandmark> {
+    let section_kind = browser_section_kind(element);
+    let landmark_kind = browser_landmark_kind(element);
+    if section_kind.is_none() && landmark_kind.is_none() {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name).unwrap_or(element.name.as_str());
+    let heading = browser_first_heading(element);
+
+    Some(BrowserSectionLandmark {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        role: role.to_string(),
+        authored_role: browser_authored_role(element),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, role, &[], id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        section_kind,
+        landmark_kind,
+        heading_level: heading.as_ref().map(|(level, _)| *level),
+        heading_text: heading.map(|(_, text)| text),
+    })
+}
+
+fn browser_first_heading(element: &Element) -> Option<(u8, String)> {
+    find_first_heading_in_nodes(&element.children).map(|heading| {
+        (
+            heading_level(&heading.name).expect("heading helper only returns heading elements"),
+            visible_text_for_nodes(&heading.children),
+        )
+    })
+}
+
+fn find_first_heading_in_nodes(nodes: &[Node]) -> Option<&Element> {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if heading_level(&element.name).is_some() {
+            return Some(element);
+        }
+        if let Some(heading) = find_first_heading_in_nodes(&element.children) {
+            return Some(heading);
+        }
+    }
+    None
 }
 
 fn should_collect_browser_content_children(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -10,9 +10,9 @@ use coding_adventures_html_parser::{
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
     BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSelectOption, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserTable, BrowserTemplate,
-    BrowserTextSemantic, BrowserThemeColor,
+    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -68,6 +68,8 @@ struct ExpectedBrowserDocument {
     text_semantics: Vec<ExpectedTextSemantic>,
     #[serde(default)]
     navigation_groups: Vec<ExpectedNavigationGroup>,
+    #[serde(default)]
+    section_landmarks: Vec<ExpectedSectionLandmark>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -492,6 +494,31 @@ struct ExpectedNavigationGroup {
     list_marker_type: Option<String>,
     #[serde(default)]
     list_reversed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedSectionLandmark {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    #[serde(default)]
+    authored_role: Option<String>,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    section_kind: Option<String>,
+    #[serde(default)]
+    landmark_kind: Option<String>,
+    #[serde(default)]
+    heading_level: Option<u8>,
+    #[serde(default)]
+    heading_text: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1750,6 +1777,26 @@ fn browser_navigation_group_descriptor_metadata_tracks_lists_and_landmarks() {
 }
 
 #[test]
+fn browser_section_landmark_descriptor_metadata_tracks_outline_roles_and_names() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "document-outline-landmark-page")
+        .expect("document outline fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("document outline fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.section_landmarks, expected.section_landmarks,
+        "section landmarks should preserve roles, accessible names, landmark kinds, and first headings",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -2898,6 +2945,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedNavigationGroup::into_browser_navigation_group)
                 .collect(),
+            section_landmarks: self
+                .section_landmarks
+                .into_iter()
+                .map(ExpectedSectionLandmark::into_browser_section_landmark)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3324,6 +3376,25 @@ impl ExpectedNavigationGroup {
             list_start: self.list_start,
             list_marker_type: self.list_marker_type,
             list_reversed: self.list_reversed,
+        }
+    }
+}
+
+impl ExpectedSectionLandmark {
+    fn into_browser_section_landmark(self) -> BrowserSectionLandmark {
+        BrowserSectionLandmark {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            authored_role: self.authored_role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            section_kind: self.section_kind,
+            landmark_kind: self.landmark_kind,
+            heading_level: self.heading_level,
+            heading_text: self.heading_text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -712,6 +712,9 @@
           { "element": "menu", "id": "actions", "role": "list", "text": "Open Save", "accessible_name": "Actions", "aria_label": "Actions", "list_kind": "menu", "item_count": 2 },
           { "element": "ol", "id": "steps", "role": "list", "text": "Review Ship", "list_kind": "ordered", "item_count": 2, "list_start": "2", "list_marker_type": "A", "list_reversed": true }
         ],
+        "section_landmarks": [
+          { "element": "nav", "id": "site-nav", "role": "navigation", "text": "Home Docs API", "accessible_name": "Site", "aria_labelledby": ["nav-title"], "section_kind": "navigation", "landmark_kind": "navigation" }
+        ],
         "links": [
           { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
         ],
@@ -744,6 +747,15 @@
         "navigation_groups": [
           { "element": "nav", "role": "navigation", "text": "Nav Home", "landmark_kind": "navigation", "item_count": 0 }
         ],
+        "section_landmarks": [
+          { "element": "header", "role": "header", "text": "Site", "section_kind": "header", "landmark_kind": "header", "heading_level": 1, "heading_text": "Site" },
+          { "element": "nav", "role": "navigation", "text": "Nav Home", "section_kind": "navigation", "landmark_kind": "navigation", "heading_level": 2, "heading_text": "Nav" },
+          { "element": "main", "role": "main", "text": "Post Chapter Related", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Post" },
+          { "element": "article", "id": "post", "role": "article", "text": "Post Chapter", "section_kind": "article", "heading_level": 2, "heading_text": "Post" },
+          { "element": "section", "role": "section", "text": "Chapter", "accessible_name": "Chapter", "aria_label": "Chapter", "section_kind": "section", "heading_level": 3, "heading_text": "Chapter" },
+          { "element": "aside", "role": "aside", "text": "Related", "section_kind": "aside", "landmark_kind": "complementary", "heading_level": 2, "heading_text": "Related" },
+          { "element": "footer", "role": "footer", "text": "Fine print", "section_kind": "footer", "landmark_kind": "footer" }
+        ],
         "links": [
           { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
         ],
@@ -775,6 +787,9 @@
         "text_semantics": [
           { "element": "data", "role": "data", "text": "Widget SKU", "data_value": "WID-001" },
           { "element": "time", "role": "time", "text": "today", "datetime": "2026-05-25" }
+        ],
+        "section_landmarks": [
+          { "element": "article", "id": "product", "role": "article", "text": "Widget Pro Product page Widget SKU today 19.99", "section_kind": "article", "heading_level": 2, "heading_text": "Widget Pro" }
         ],
         "links": [
           { "href": "../products/widget", "resolved_href": "https://example.test/products/widget", "name": null, "target": null, "rel": null, "title": null, "text": "Product page" }
@@ -907,6 +922,9 @@
           { "id": "app", "name": null, "text": "Save" }
         ],
         "headings": [],
+        "section_landmarks": [
+          { "element": "main", "id": "app", "role": "main", "text": "Save", "section_kind": "main", "landmark_kind": "main" }
+        ],
         "links": [],
         "images": [
           { "src": "hero.jpg", "resolved_src": null, "alt": "Hero" }
@@ -952,6 +970,10 @@
         ],
         "headings": [
           { "level": 2, "text": "Settings" }
+        ],
+        "section_landmarks": [
+          { "element": "main", "id": "app", "role": "main", "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative", "accessible_name": "App shell", "aria_label": "App shell", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Settings" },
+          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "aria_labelledby": ["panel-title"], "section_kind": "section", "heading_level": 2, "heading_text": "Settings" }
         ],
         "links": [],
         "images": [],
@@ -1136,6 +1158,9 @@
           { "id": "chart", "name": null, "text": "Chart fallback" }
         ],
         "headings": [],
+        "section_landmarks": [
+          { "element": "article", "role": "article", "text": "Untitled Body", "section_kind": "article" }
+        ],
         "links": [],
         "images": [],
         "templates": [


### PR DESCRIPTION
## Summary
- Add browser section/landmark descriptors for sectioning roots and landmark-like elements.
- Capture roles, accessible-name sources, landmark/section kinds, and first heading metadata in browser readiness fixtures.
- Extend fixture schema governance and focused browser readiness coverage.

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_section_landmark_descriptor_metadata_tracks_outline_roles_and_names
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser