### PR TITLE
Track browser command element descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -245,6 +245,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "text_semantics", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "navigation_groups", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "section_landmarks", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "command_elements", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -524,6 +525,55 @@ def check_browser_expected_lists(
             require_optional_nullable_string(section_path, section, field, errors)
         require_optional_string_list(section_path, section, "aria_labelledby", errors)
         require_optional_integer(section_path, section, "heading_level", errors)
+
+    for index, command in enumerate(object_list_items(expected, "command_elements")):
+        command_path = f"{case_path}.expected.command_elements[{index}]"
+        for field in (
+            "element",
+            "role",
+            "command_kind",
+            "text",
+        ):
+            require_string(command_path, command, field, errors)
+        for field in (
+            "id",
+            "authored_role",
+            "accessible_name",
+            "accessible_description",
+            "href",
+            "resolved_href",
+            "target",
+            "effective_target",
+            "control_type",
+            "form_owner",
+            "form_action",
+            "resolved_form_action",
+            "form_method",
+            "form_target",
+            "command",
+            "command_for",
+            "popover_target",
+            "popover_target_action",
+            "aria_expanded",
+            "aria_haspopup",
+            "aria_pressed",
+            "aria_current",
+            "aria_disabled",
+            "tabindex",
+        ):
+            require_optional_nullable_string(command_path, command, field, errors)
+        for field in (
+            "aria_controls",
+            "accesskey",
+            "event_handlers",
+        ):
+            require_optional_string_list(command_path, command, field, errors)
+        for field in (
+            "form_novalidate",
+            "focusable",
+            "disabled",
+        ):
+            require_optional_boolean(command_path, command, field, errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -837,6 +837,7 @@ pub struct BrowserDocument {
     pub text_semantics: Vec<BrowserTextSemantic>,
     pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
+    pub command_elements: Vec<BrowserCommandElement>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1496,6 +1497,44 @@ pub struct BrowserSectionLandmark {
     pub landmark_kind: Option<String>,
     pub heading_level: Option<u8>,
     pub heading_text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserCommandElement {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub authored_role: Option<String>,
+    pub command_kind: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub control_type: Option<String>,
+    pub form_owner: Option<String>,
+    pub form_action: Option<String>,
+    pub resolved_form_action: Option<String>,
+    pub form_method: Option<String>,
+    pub form_target: Option<String>,
+    pub form_novalidate: bool,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub aria_controls: Vec<String>,
+    pub aria_expanded: Option<String>,
+    pub aria_haspopup: Option<String>,
+    pub aria_pressed: Option<String>,
+    pub aria_current: Option<String>,
+    pub aria_disabled: Option<String>,
+    pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
+    pub event_handlers: Vec<String>,
+    pub focusable: bool,
+    pub disabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9373,6 +9412,15 @@ fn collect_browser_facts(
         if let Some(section_landmark) = browser_section_landmark_element(element, id_texts) {
             summary.section_landmarks.push(section_landmark);
         }
+        if let Some(command_element) = browser_command_element(
+            element,
+            labels,
+            id_texts,
+            summary.base_href.as_deref(),
+            summary.base_target.as_deref(),
+        ) {
+            summary.command_elements.push(command_element);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -11071,6 +11119,173 @@ fn find_first_heading_in_nodes(nodes: &[Node]) -> Option<&Element> {
         }
     }
     None
+}
+
+fn browser_command_element(
+    element: &Element,
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+    base_href: Option<&str>,
+    base_target: Option<&str>,
+) -> Option<BrowserCommandElement> {
+    let command_kind = browser_command_kind(element)?;
+    let role = browser_command_role(element);
+    let control_labels = browser_control_labels(element, labels, None);
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    let form_action = browser_control_form_action(element);
+    let target = browser_anchor_target(element).or_else(|| browser_control_form_target(element));
+
+    Some(BrowserCommandElement {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        accessible_name: browser_command_accessible_name(
+            element,
+            role.as_str(),
+            &control_labels,
+            id_texts,
+            &text,
+        ),
+        accessible_description: browser_accessible_description(element, id_texts),
+        role,
+        authored_role: browser_authored_role(element),
+        command_kind,
+        text,
+        href: element.attribute("href").map(ToOwned::to_owned),
+        resolved_href: element
+            .attribute("href")
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        effective_target: target
+            .clone()
+            .or_else(|| base_target.map(ToOwned::to_owned)),
+        target,
+        control_type: browser_content_control_type(element),
+        form_owner: browser_form_owner(element),
+        resolved_form_action: form_action
+            .as_deref()
+            .and_then(|action| resolve_browser_url(action, base_href)),
+        form_action,
+        form_method: browser_control_form_method(element),
+        form_target: browser_control_form_target(element),
+        form_novalidate: browser_control_form_novalidate(element),
+        command: browser_command(element),
+        command_for: browser_command_for(element),
+        popover_target: browser_popover_target(element),
+        popover_target_action: browser_popover_target_action(element),
+        aria_controls: browser_aria_idrefs(element, "aria-controls"),
+        aria_expanded: browser_aria_state(element, "aria-expanded"),
+        aria_haspopup: browser_aria_state(element, "aria-haspopup"),
+        aria_pressed: browser_aria_state(element, "aria-pressed"),
+        aria_current: browser_aria_state(element, "aria-current"),
+        aria_disabled: browser_aria_state(element, "aria-disabled"),
+        tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        accesskey: browser_accesskey(element),
+        event_handlers: browser_event_handlers(element),
+        focusable: browser_command_focusable(element),
+        disabled: element.attribute("disabled").is_some(),
+    })
+}
+
+fn browser_command_role(element: &Element) -> String {
+    browser_authored_role(element).unwrap_or_else(|| {
+        browser_content_role(&element.name)
+            .unwrap_or(element.name.as_str())
+            .to_string()
+    })
+}
+
+fn browser_command_kind(element: &Element) -> Option<String> {
+    if element.attribute("command").is_some() || element.attribute("commandfor").is_some() {
+        return Some("command".to_string());
+    }
+    if element.attribute("popovertarget").is_some() {
+        return Some("popover".to_string());
+    }
+    if let Some(role) = browser_authored_command_role(element) {
+        return Some(role);
+    }
+    if element.name == "summary" {
+        return Some("disclosure".to_string());
+    }
+
+    match (
+        element.name.as_str(),
+        browser_content_control_type(element).as_deref(),
+    ) {
+        ("button", Some("submit")) | ("input", Some("submit" | "image"))
+            if browser_has_command_state(element) =>
+        {
+            Some("submit".to_string())
+        }
+        ("button", Some("reset")) | ("input", Some("reset"))
+            if browser_has_command_state(element) =>
+        {
+            Some("reset".to_string())
+        }
+        ("button", Some("button")) | ("input", Some("button"))
+            if browser_has_command_state(element) =>
+        {
+            Some("button".to_string())
+        }
+        _ => None,
+    }
+}
+
+fn browser_has_command_state(element: &Element) -> bool {
+    element.attribute("aria-controls").is_some()
+        || element.attribute("aria-expanded").is_some()
+        || element.attribute("aria-haspopup").is_some()
+        || element.attribute("aria-pressed").is_some()
+        || element.attribute("aria-current").is_some()
+        || element.attribute("aria-disabled").is_some()
+}
+
+fn browser_authored_command_role(element: &Element) -> Option<String> {
+    let role = browser_authored_role(element)?.to_ascii_lowercase();
+    matches!(
+        role.as_str(),
+        "button"
+            | "link"
+            | "menuitem"
+            | "menuitemcheckbox"
+            | "menuitemradio"
+            | "option"
+            | "tab"
+            | "treeitem"
+    )
+    .then_some(role)
+}
+
+fn browser_command_accessible_name(
+    element: &Element,
+    role: &str,
+    control_labels: &[String],
+    id_texts: &[(String, String)],
+    text: &str,
+) -> Option<String> {
+    browser_accessible_name(element, role, control_labels, id_texts)
+        .or_else(|| browser_content_value(element).map(|value| collapse_html_whitespace(&value)))
+        .or_else(|| element.attribute("alt").map(collapse_html_whitespace))
+        .or_else(|| (!text.is_empty()).then(|| text.to_string()))
+        .filter(|name| !name.is_empty())
+}
+
+fn browser_command_focusable(element: &Element) -> bool {
+    if let Some(focusable) = browser_focusable(element) {
+        return focusable;
+    }
+    if element.attribute("disabled").is_some()
+        || browser_hidden(element)
+        || browser_inert(element)
+        || browser_aria_hidden(element)
+    {
+        return false;
+    }
+
+    if is_browser_document_link(element) {
+        return true;
+    }
+
+    matches!(element.name.as_str(), "button" | "input" | "summary")
 }
 
 fn should_collect_browser_content_children(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -9,8 +9,9 @@ use coding_adventures_html_parser::{
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserCommandElement, BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh,
+    BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
+    BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
     BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
@@ -70,6 +71,8 @@ struct ExpectedBrowserDocument {
     navigation_groups: Vec<ExpectedNavigationGroup>,
     #[serde(default)]
     section_landmarks: Vec<ExpectedSectionLandmark>,
+    #[serde(default)]
+    command_elements: Vec<ExpectedCommandElement>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -519,6 +522,74 @@ struct ExpectedSectionLandmark {
     heading_level: Option<u8>,
     #[serde(default)]
     heading_text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedCommandElement {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    #[serde(default)]
+    authored_role: Option<String>,
+    command_kind: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    control_type: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    form_action: Option<String>,
+    #[serde(default)]
+    resolved_form_action: Option<String>,
+    #[serde(default)]
+    form_method: Option<String>,
+    #[serde(default)]
+    form_target: Option<String>,
+    #[serde(default)]
+    form_novalidate: bool,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    aria_controls: Vec<String>,
+    #[serde(default)]
+    aria_expanded: Option<String>,
+    #[serde(default)]
+    aria_haspopup: Option<String>,
+    #[serde(default)]
+    aria_pressed: Option<String>,
+    #[serde(default)]
+    aria_current: Option<String>,
+    #[serde(default)]
+    aria_disabled: Option<String>,
+    #[serde(default)]
+    tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    focusable: bool,
+    #[serde(default)]
+    disabled: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1797,6 +1868,26 @@ fn browser_section_landmark_descriptor_metadata_tracks_outline_roles_and_names()
 }
 
 #[test]
+fn browser_command_element_descriptor_metadata_tracks_activation_surfaces() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive element fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive element fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.command_elements, expected.command_elements,
+        "command descriptors should preserve routed, ARIA, popover, and disclosure activation metadata",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -2950,6 +3041,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedSectionLandmark::into_browser_section_landmark)
                 .collect(),
+            command_elements: self
+                .command_elements
+                .into_iter()
+                .map(ExpectedCommandElement::into_browser_command_element)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3395,6 +3491,47 @@ impl ExpectedSectionLandmark {
             landmark_kind: self.landmark_kind,
             heading_level: self.heading_level,
             heading_text: self.heading_text,
+        }
+    }
+}
+
+impl ExpectedCommandElement {
+    fn into_browser_command_element(self) -> BrowserCommandElement {
+        BrowserCommandElement {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            authored_role: self.authored_role,
+            command_kind: self.command_kind,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            target: self.target,
+            effective_target: self.effective_target,
+            control_type: self.control_type,
+            form_owner: self.form_owner,
+            form_action: self.form_action,
+            resolved_form_action: self.resolved_form_action,
+            form_method: self.form_method,
+            form_target: self.form_target,
+            form_novalidate: self.form_novalidate,
+            command: self.command,
+            command_for: self.command_for,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            aria_controls: self.aria_controls,
+            aria_expanded: self.aria_expanded,
+            aria_haspopup: self.aria_haspopup,
+            aria_pressed: self.aria_pressed,
+            aria_current: self.aria_current,
+            aria_disabled: self.aria_disabled,
+            tabindex: self.tabindex,
+            accesskey: self.accesskey,
+            event_handlers: self.event_handlers,
+            focusable: self.focusable,
+            disabled: self.disabled,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -975,6 +975,11 @@
           { "element": "main", "id": "app", "role": "main", "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative", "accessible_name": "App shell", "aria_label": "App shell", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Settings" },
           { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "aria_labelledby": ["panel-title"], "section_kind": "section", "heading_level": 2, "heading_text": "Settings" }
         ],
+        "command_elements": [
+          { "element": "button", "id": "menu", "role": "control", "command_kind": "command", "text": "Menu", "accessible_name": "Menu", "control_type": "submit", "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "focusable": true },
+          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown"] },
+          { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
+        ],
         "links": [],
         "images": [],
         "interactive_elements": [


### PR DESCRIPTION
## Summary
- Add a flat browser command element descriptor inventory for explicit activation surfaces.
- Capture routed command/popover metadata, ARIA command roles/states, disclosure summaries, focusability, and accessible-name/description details.
- Extend browser readiness fixtures and schema governance for command descriptors.

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_command_element_descriptor_metadata_tracks_activation_surfaces
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser