### PR TITLE
Track browser ARIA collection descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -246,6 +246,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "navigation_groups", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "section_landmarks", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "command_elements", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "aria_collections", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -574,6 +575,64 @@ def check_browser_expected_lists(
             "disabled",
         ):
             require_optional_boolean(command_path, command, field, errors)
+
+    for index, collection in enumerate(object_list_items(expected, "aria_collections")):
+        collection_path = f"{case_path}.expected.aria_collections[{index}]"
+        for field in (
+            "element",
+            "role",
+            "text",
+        ):
+            require_string(collection_path, collection, field, errors)
+        for field in (
+            "id",
+            "accessible_name",
+            "accessible_description",
+            "aria_label",
+            "aria_orientation",
+            "aria_multiselectable",
+            "aria_activedescendant",
+        ):
+            require_optional_nullable_string(collection_path, collection, field, errors)
+        for field in (
+            "aria_labelledby",
+            "aria_describedby",
+            "aria_owns",
+        ):
+            require_optional_string_list(collection_path, collection, field, errors)
+        for field in (
+            "item_count",
+            "selected_item_count",
+            "checked_item_count",
+            "current_item_count",
+            "disabled_item_count",
+        ):
+            require_optional_integer(collection_path, collection, field, errors)
+        require_optional_object_list(collection_path, collection, "items", errors)
+        for item_index, item in enumerate(object_list_items(collection, "items")):
+            item_path = f"{collection_path}.items[{item_index}]"
+            for field in (
+                "element",
+                "role",
+                "text",
+            ):
+                require_string(item_path, item, field, errors)
+            for field in (
+                "id",
+                "accessible_name",
+                "aria_selected",
+                "aria_checked",
+                "aria_current",
+                "aria_disabled",
+                "aria_expanded",
+                "aria_level",
+                "aria_posinset",
+                "aria_setsize",
+                "aria_rowindex",
+                "aria_colindex",
+            ):
+                require_optional_nullable_string(item_path, item, field, errors)
+            require_optional_string_list(item_path, item, "aria_controls", errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -838,6 +838,7 @@ pub struct BrowserDocument {
     pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub command_elements: Vec<BrowserCommandElement>,
+    pub aria_collections: Vec<BrowserAriaCollection>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1535,6 +1536,49 @@ pub struct BrowserCommandElement {
     pub event_handlers: Vec<String>,
     pub focusable: bool,
     pub disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaCollection {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub aria_orientation: Option<String>,
+    pub aria_multiselectable: Option<String>,
+    pub aria_activedescendant: Option<String>,
+    pub aria_owns: Vec<String>,
+    pub item_count: usize,
+    pub selected_item_count: usize,
+    pub checked_item_count: usize,
+    pub current_item_count: usize,
+    pub disabled_item_count: usize,
+    pub items: Vec<BrowserAriaCollectionItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaCollectionItem {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_selected: Option<String>,
+    pub aria_checked: Option<String>,
+    pub aria_current: Option<String>,
+    pub aria_disabled: Option<String>,
+    pub aria_expanded: Option<String>,
+    pub aria_level: Option<String>,
+    pub aria_posinset: Option<String>,
+    pub aria_setsize: Option<String>,
+    pub aria_rowindex: Option<String>,
+    pub aria_colindex: Option<String>,
+    pub aria_controls: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9421,6 +9465,9 @@ fn collect_browser_facts(
         ) {
             summary.command_elements.push(command_element);
         }
+        if let Some(aria_collection) = browser_aria_collection_element(element, id_texts) {
+            summary.aria_collections.push(aria_collection);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -11286,6 +11333,143 @@ fn browser_command_focusable(element: &Element) -> bool {
     }
 
     matches!(element.name.as_str(), "button" | "input" | "summary")
+}
+
+fn browser_aria_collection_element(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaCollection> {
+    let role = browser_authored_collection_role(element)?;
+    let items = browser_aria_collection_items(element, id_texts);
+    let selected_item_count = items
+        .iter()
+        .filter(|item| item.aria_selected.as_deref() == Some("true"))
+        .count();
+    let checked_item_count = items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item.aria_checked.as_deref(),
+                Some("true") | Some("mixed")
+            )
+        })
+        .count();
+    let current_item_count = items
+        .iter()
+        .filter(|item| {
+            item.aria_current
+                .as_deref()
+                .is_some_and(|current| !current.eq_ignore_ascii_case("false"))
+        })
+        .count();
+    let disabled_item_count = items
+        .iter()
+        .filter(|item| item.aria_disabled.as_deref() == Some("true"))
+        .count();
+
+    Some(BrowserAriaCollection {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, &role, &[], id_texts),
+        accessible_description: browser_accessible_description(element, id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
+        aria_orientation: browser_aria_state(element, "aria-orientation"),
+        aria_multiselectable: browser_aria_state(element, "aria-multiselectable"),
+        aria_activedescendant: browser_aria_idref(element, "aria-activedescendant"),
+        aria_owns: browser_aria_idrefs(element, "aria-owns"),
+        item_count: items.len(),
+        selected_item_count,
+        checked_item_count,
+        current_item_count,
+        disabled_item_count,
+        role,
+        items,
+    })
+}
+
+fn browser_authored_collection_role(element: &Element) -> Option<String> {
+    let role = browser_authored_role(element)?.to_ascii_lowercase();
+    matches!(
+        role.as_str(),
+        "grid" | "listbox" | "menu" | "menubar" | "radiogroup" | "tablist" | "tree" | "treegrid"
+    )
+    .then_some(role)
+}
+
+fn browser_aria_collection_items(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Vec<BrowserAriaCollectionItem> {
+    let mut items = Vec::new();
+    collect_browser_aria_collection_items(&element.children, id_texts, &mut items);
+    items
+}
+
+fn collect_browser_aria_collection_items(
+    nodes: &[Node],
+    id_texts: &[(String, String)],
+    items: &mut Vec<BrowserAriaCollectionItem>,
+) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        if let Some(item) = browser_aria_collection_item(element, id_texts) {
+            items.push(item);
+        }
+        if browser_authored_collection_role(element).is_none() {
+            collect_browser_aria_collection_items(&element.children, id_texts, items);
+        }
+    }
+}
+
+fn browser_aria_collection_item(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaCollectionItem> {
+    let role = browser_authored_collection_item_role(element)?;
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    Some(BrowserAriaCollectionItem {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        accessible_name: browser_accessible_name(element, &role, &[], id_texts)
+            .or_else(|| (!text.is_empty()).then(|| text.clone())),
+        role,
+        text,
+        aria_selected: browser_aria_state(element, "aria-selected"),
+        aria_checked: browser_aria_state(element, "aria-checked"),
+        aria_current: browser_aria_state(element, "aria-current"),
+        aria_disabled: browser_aria_state(element, "aria-disabled"),
+        aria_expanded: browser_aria_state(element, "aria-expanded"),
+        aria_level: browser_aria_state(element, "aria-level"),
+        aria_posinset: browser_aria_state(element, "aria-posinset"),
+        aria_setsize: browser_aria_state(element, "aria-setsize"),
+        aria_rowindex: browser_aria_state(element, "aria-rowindex"),
+        aria_colindex: browser_aria_state(element, "aria-colindex"),
+        aria_controls: browser_aria_idrefs(element, "aria-controls"),
+    })
+}
+
+fn browser_authored_collection_item_role(element: &Element) -> Option<String> {
+    let role = browser_authored_role(element)?.to_ascii_lowercase();
+    matches!(
+        role.as_str(),
+        "columnheader"
+            | "gridcell"
+            | "menuitem"
+            | "menuitemcheckbox"
+            | "menuitemradio"
+            | "option"
+            | "radio"
+            | "row"
+            | "rowheader"
+            | "tab"
+            | "treeitem"
+    )
+    .then_some(role)
 }
 
 fn should_collect_browser_content_children(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -9,9 +9,9 @@ use coding_adventures_html_parser::{
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserCommandElement, BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh,
-    BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
-    BrowserSelectOption,
+    BrowserAriaCollection, BrowserAriaCollectionItem, BrowserCommandElement,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
     BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
@@ -73,6 +73,8 @@ struct ExpectedBrowserDocument {
     section_landmarks: Vec<ExpectedSectionLandmark>,
     #[serde(default)]
     command_elements: Vec<ExpectedCommandElement>,
+    #[serde(default)]
+    aria_collections: Vec<ExpectedAriaCollection>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -590,6 +592,78 @@ struct ExpectedCommandElement {
     focusable: bool,
     #[serde(default)]
     disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaCollection {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    aria_orientation: Option<String>,
+    #[serde(default)]
+    aria_multiselectable: Option<String>,
+    #[serde(default)]
+    aria_activedescendant: Option<String>,
+    #[serde(default)]
+    aria_owns: Vec<String>,
+    #[serde(default)]
+    item_count: usize,
+    #[serde(default)]
+    selected_item_count: usize,
+    #[serde(default)]
+    checked_item_count: usize,
+    #[serde(default)]
+    current_item_count: usize,
+    #[serde(default)]
+    disabled_item_count: usize,
+    #[serde(default)]
+    items: Vec<ExpectedAriaCollectionItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaCollectionItem {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_selected: Option<String>,
+    #[serde(default)]
+    aria_checked: Option<String>,
+    #[serde(default)]
+    aria_current: Option<String>,
+    #[serde(default)]
+    aria_disabled: Option<String>,
+    #[serde(default)]
+    aria_expanded: Option<String>,
+    #[serde(default)]
+    aria_level: Option<String>,
+    #[serde(default)]
+    aria_posinset: Option<String>,
+    #[serde(default)]
+    aria_setsize: Option<String>,
+    #[serde(default)]
+    aria_rowindex: Option<String>,
+    #[serde(default)]
+    aria_colindex: Option<String>,
+    #[serde(default)]
+    aria_controls: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1888,6 +1962,26 @@ fn browser_command_element_descriptor_metadata_tracks_activation_surfaces() {
 }
 
 #[test]
+fn browser_aria_collection_descriptor_metadata_tracks_grouped_composites() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-collection-descriptor-page")
+        .expect("ARIA collection fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA collection fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.aria_collections, expected.aria_collections,
+        "ARIA collection descriptors should preserve composite roles, active descendants, item roles, and item states",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3046,6 +3140,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedCommandElement::into_browser_command_element)
                 .collect(),
+            aria_collections: self
+                .aria_collections
+                .into_iter()
+                .map(ExpectedAriaCollection::into_browser_aria_collection)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3532,6 +3631,59 @@ impl ExpectedCommandElement {
             event_handlers: self.event_handlers,
             focusable: self.focusable,
             disabled: self.disabled,
+        }
+    }
+}
+
+impl ExpectedAriaCollection {
+    fn into_browser_aria_collection(self) -> BrowserAriaCollection {
+        BrowserAriaCollection {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            aria_orientation: self.aria_orientation,
+            aria_multiselectable: self.aria_multiselectable,
+            aria_activedescendant: self.aria_activedescendant,
+            aria_owns: self.aria_owns,
+            item_count: self.item_count,
+            selected_item_count: self.selected_item_count,
+            checked_item_count: self.checked_item_count,
+            current_item_count: self.current_item_count,
+            disabled_item_count: self.disabled_item_count,
+            items: self
+                .items
+                .into_iter()
+                .map(ExpectedAriaCollectionItem::into_browser_aria_collection_item)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedAriaCollectionItem {
+    fn into_browser_aria_collection_item(self) -> BrowserAriaCollectionItem {
+        BrowserAriaCollectionItem {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_selected: self.aria_selected,
+            aria_checked: self.aria_checked,
+            aria_current: self.aria_current,
+            aria_disabled: self.aria_disabled,
+            aria_expanded: self.aria_expanded,
+            aria_level: self.aria_level,
+            aria_posinset: self.aria_posinset,
+            aria_setsize: self.aria_setsize,
+            aria_rowindex: self.aria_rowindex,
+            aria_colindex: self.aria_colindex,
+            aria_controls: self.aria_controls,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1002,6 +1002,62 @@
       }
     },
     {
+      "id": "aria-collection-descriptor-page",
+      "description": "Browser document summaries expose explicit ARIA collection roles and their owned item state as a flat descriptor inventory.",
+      "input": "<body><h2 id=tabs-title>Pages</h2><div id=tabs role=tablist aria-labelledby=tabs-title aria-orientation=horizontal aria-activedescendant=tab-settings><button id=tab-home role=tab aria-selected=true aria-controls=panel-home>Home</button><button id=tab-settings role=tab aria-selected=false aria-controls=panel-settings aria-disabled=true>Settings</button></div><div id=panel-home>Home panel</div><div id=panel-settings>Settings panel</div></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Pages Home Settings Home panel Settings panel",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "tabs-title", "name": null, "text": "Pages" },
+          { "id": "tabs", "name": null, "text": "Home Settings" },
+          { "id": "tab-home", "name": null, "text": "Home" },
+          { "id": "tab-settings", "name": null, "text": "Settings" },
+          { "id": "panel-home", "name": null, "text": "Home panel" },
+          { "id": "panel-settings", "name": null, "text": "Settings panel" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Pages" }
+        ],
+        "command_elements": [
+          { "element": "button", "id": "tab-home", "role": "tab", "authored_role": "tab", "command_kind": "tab", "text": "Home", "accessible_name": "Home", "control_type": "submit", "aria_controls": ["panel-home"], "focusable": true },
+          { "element": "button", "id": "tab-settings", "role": "tab", "authored_role": "tab", "command_kind": "tab", "text": "Settings", "accessible_name": "Settings", "control_type": "submit", "aria_controls": ["panel-settings"], "aria_disabled": "true", "focusable": true }
+        ],
+        "aria_collections": [
+          {
+            "element": "div",
+            "id": "tabs",
+            "role": "tablist",
+            "text": "Home Settings",
+            "accessible_name": "Pages",
+            "aria_labelledby": ["tabs-title"],
+            "aria_orientation": "horizontal",
+            "aria_activedescendant": "tab-settings",
+            "item_count": 2,
+            "selected_item_count": 1,
+            "disabled_item_count": 1,
+            "items": [
+              { "element": "button", "id": "tab-home", "role": "tab", "text": "Home", "accessible_name": "Home", "aria_selected": "true", "aria_controls": ["panel-home"] },
+              { "element": "button", "id": "tab-settings", "role": "tab", "text": "Settings", "accessible_name": "Settings", "aria_selected": "false", "aria_disabled": "true", "aria_controls": ["panel-settings"] }
+            ]
+          }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [
+          { "element": "div", "id": "tabs", "role": "block", "authored_role": "tablist", "text": "Home Settings", "accessible_name": "Pages", "aria_labelledby": ["tabs-title"], "aria_activedescendant": "tab-settings" },
+          { "element": "button", "id": "tab-home", "role": "control", "authored_role": "tab", "text": "Home", "accessible_name": "Home", "aria_controls": ["panel-home"], "aria_selected": "true" },
+          { "element": "button", "id": "tab-settings", "role": "control", "authored_role": "tab", "text": "Settings", "accessible_name": "Settings", "aria_controls": ["panel-settings"], "aria_selected": "false", "aria_disabled": "true" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "form-measurement-descriptor-page",
       "description": "Browser document form summaries expose in-form meter and progress descriptors without adding them to submission controls.",
       "input": "<form id=telemetry><label for=disk>Disk</label><meter id=disk value=0.72 min=0 max=1 low=0.25 high=0.9 optimum=0.7 aria-describedby=disk-help>72%</meter><p id=disk-help>Capacity used</p><label for=upload>Upload</label><progress id=upload value=30 max=100>30%</progress><progress id=sync max=1 aria-label=Sync>Loading</progress><input name=token value=ok></form><meter id=outside value=1>Outside</meter>",


### PR DESCRIPTION
## Summary
- Add browser ARIA collection descriptors for authored composite groups such as tablists, grids, menus, listboxes, trees, and radiogroups
- Capture collection labels, active descendants, owned refs, item roles, item states, and aggregate item counts
- Extend browser readiness fixture/schema coverage with a focused tablist case

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_aria_collection_descriptor_metadata_tracks_grouped_composites
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser