### PR TITLE
ADJ69 — defensible output on a contested question (Jason's maternal great-grandfather)

### DIFF
--- a/code/specs/ADJ69-contested-question-worked-example.md
+++ b/code/specs/ADJ69-contested-question-worked-example.md
@@ -1,0 +1,71 @@
+# ADJ69 — Defensible Output on a Contested Question (worked example)
+
+> **Status (2026-06-04):** A worked example of the ADJ68 open-book defensibility pipeline
+> on a *user-chosen* question whose honest answer is **"there isn't a single one."**
+> *"In Greek mythology, who was Jason's maternal great-grandfather?"* — a question where
+> bare recall confidently hallucinates and the framework produces a cited, branch-aware,
+> auditable map of the genuine answer space. Implementation:
+> [`pipeline/jason.workflow.js`](data/adj57/pipeline/jason.workflow.js); result:
+> [`pipeline/jason-results.json`](data/adj57/pipeline/jason-results.json). Demonstrates
+> both paper pillars at once on a fresh case.
+
+## 1. Why this question is the cleanest test
+
+Two independent ambiguities make a single confident name a *hallucination*:
+1. **Definitional:** "maternal great-grandfather" can mean the father of the maternal
+   *grandfather* **or** of the maternal *grandmother* — two different people.
+2. **Source disagreement:** ancient authors disagree on Jason's *mother* (Apollonius:
+   Alcimede, daughter of Phylacus; Apollodorus: Polymede, daughter of Autolycus).
+
+So the correct answer is a *set with branch points*, not a name. A correctness-only metric
+is impoverished here; **defensibility** is the right axis.
+
+## 2. The run (open-book; grounded trace vs bare recall; adversarial audit)
+
+### Bare recall (closed-book) — confidently hallucinated
+Headline answer: **"Cretheus"** — who is Jason's **paternal grandfather** (his father Aeson's
+father): wrong on *both* axes (paternal, not maternal; grandfather, not great-grandfather).
+It then contradicted its own headline in the reasoning, waffling toward Hermes/Deion. **Zero
+citations** on any of its ~6 genealogical links. Auditor: **NOT_DEFENSIBLE** (6/6 links
+unsupported; led with a wrong-side ancestor; never surfaced the grandmother-line ambiguity).
+
+### Framework (open-book, grounded) — defensible
+A cited map of the answer space, refusing to collapse:
+
+| tradition / line | maternal great-grandfather | source |
+|---|---|---|
+| Apollonius (mother Alcimede → Phylacus → …) | **Deion** | theoi.com, *Argonautica* I / Apollodorus I |
+| Apollodorus (mother Polymede → Autolycus → …) | **Hermes** | theoi.com, *Bibliotheca* I |
+| maternal **grandmother** line (Alcimede born of Clymene → …) | **Minyas** | theoi.com, *Argonautica* I |
+
+Answer: *"No single answer. A: Deion. B: Hermes. Grandmother reading: Minyas. Do not collapse
+Deion and Hermes."* All **6/6 links cited**; the contested mother flagged `contested=true`
+and split per source; both ambiguities surfaced. Auditor: **DEFENSIBLE**.
+
+## 3. Both paper pillars, on one fresh case
+
+- **Accounting (no unaccounted bytes):** bare recall committed *commission* (asserted
+  "Cretheus," a relationship not on the maternal line) and *omission* (dropped the
+  grandmother branch). The grounded run did neither — no unsourced link, no swallowed
+  ambiguity.
+- **Correctability (auditable, editable):** every branch is a citable, editable node. A
+  classicist who disagrees traces to the exact source and corrects *that link*. And there is
+  a real one to correct: the grounded link *"Aeson had wedded his sister Alcimede"* is
+  suspect ("his sister" is likely an imprecision — Alcimede is his wife, not sister). The
+  framework made that error **findable**; bare recall buried six errors silently. This is the
+  edit-and-correct loop in miniature.
+
+## 4. Honest limitation
+
+The auditor flagged the one real weakness: citations are at **document granularity** (the
+theoi.com page), not line-level. Every link is checkable, but pinning each claim to the exact
+passage is the **citation-precision verifier** (the named next build) — the same 6/7 → 7/7
+upgrade ADJ68 needs, here too.
+
+## 5. Takeaway
+
+On a contested question with no single correct answer, the framework converted a
+confidently-wrong single name into a **cited, branch-aware, auditable, correctable** answer —
+which is what an expert actually wants, and what a correctness-only score cannot reward. The
+value is not "got the answer"; it is *"here is the answer space, mapped and cited, with every
+disagreement surfaced and every link a human can check and fix."*

--- a/code/specs/data/adj57/CHANGELOG.md
+++ b/code/specs/data/adj57/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — adj57 byte-provenance pipeline
 
+## [0.12.0] — 2026-06-04
+
+### Added
+
+- **ADJ69 — defensible output on a contested question (worked example).** Runs the ADJ68
+  open-book defensibility pipeline on a user-chosen question whose honest answer is *not a
+  single name*: *"who was Jason's maternal great-grandfather?"* — two independent ambiguities
+  (definitional: father of the maternal grandfather vs grandmother; source: Apollonius'
+  Alcimede vs Apollodorus' Polymede).
+  - **`pipeline/jason.workflow.js`** — spider+ground each genealogical link in a verbatim
+    source, flag contested links, surface both ambiguities; vs a bare closed-book recall
+    answer; adversarial auditor scores defensibility (every link sourced AND ambiguities
+    surfaced — not single-name correctness).
+  - **Result** (`pipeline/jason-results.json`): **bare recall hallucinated** — led with
+    "Cretheus" (Jason's *paternal* grandfather: wrong side AND wrong generation), zero
+    citations → **NOT_DEFENSIBLE** (6/6 links unsupported). **The grounded trace** produced a
+    cited map — Deion (Apollonius), Hermes (Apollodorus), Minyas (grandmother line) — 6/6
+    links cited, contested mother split per source, both ambiguities surfaced →
+    **DEFENSIBLE**, refusing to collapse.
+  - **Both pillars on one case:** accounting (bare committed commission "Cretheus" + omission
+    of the grandmother branch; grounded did neither) and correctability (every branch a
+    citable editable node — incl. a real findable imprecision, "his sister Alcimede", for a
+    human to correct). **Honest limit:** document-granularity citations (citation-precision
+    verifier is the next build). Spec: [ADJ69](../../ADJ69-contested-question-worked-example.md).
+
 ## [0.11.0] — 2026-06-04
 
 ### Added

--- a/code/specs/data/adj57/pipeline/jason-results.json
+++ b/code/specs/data/adj57/pipeline/jason-results.json
@@ -1,0 +1,80 @@
+{
+  "summary": "Open-book defensibility run on a contested genealogy question: \"who was Jason's maternal great-grandfather?\" The framework spiders + grounds each link of the maternal lineage in a verbatim source, EXPLICITLY surfacing (a) the definitional ambiguity of \"maternal great-grandfather\" and (b) the source disagreement over Jason's mother — vs a bare closed-book recall answer. An adversarial auditor scores whether every link is sourced AND whether the ambiguities are surfaced rather than papered over.",
+  "agentCount": 3,
+  "logs": [],
+  "result": {
+    "question": "In Greek mythology, who was Jason's (the Argonaut's) maternal great-grandfather?",
+    "grounded": {
+      "interpretation_note": "Father of the maternal grandfather (default) versus father of the maternal grandmother (gives Minyas). Mother contested.",
+      "answer": "No single answer. A (Apollonius): Deion. B (Apollodorus): Hermes. Grandmother reading: Minyas. Do not collapse Deion and Hermes.",
+      "links": [
+        {
+          "claim": "Mother contested: Alcimede vs Polymede",
+          "source_url": "https://www.theoi.com/Text/ApolloniusRhodius1.html",
+          "quote": "the son of Alcimede who was born of Clymene the daughter of Minyas",
+          "contested": true,
+          "note": "B: Apollodorus, Polymede dau Autolycus."
+        },
+        {
+          "claim": "A grandfather: Alcimede daughter of Phylacus",
+          "source_url": "https://www.theoi.com/Text/ApolloniusRhodius1.html",
+          "quote": "Aeson had wedded his sister Alcimede, daughter of Phylacus",
+          "contested": false,
+          "note": ""
+        },
+        {
+          "claim": "A great-grandfather: Phylacus son of Deion",
+          "source_url": "https://www.theoi.com/Text/Apollodorus1.html",
+          "quote": "sons, Aenetus, Actor, Phylacus, and Cephalus",
+          "contested": false,
+          "note": "Deion son of Aeolus."
+        },
+        {
+          "claim": "A grandmother: Clymene daughter of Minyas",
+          "source_url": "https://www.theoi.com/Text/ApolloniusRhodius1.html",
+          "quote": "born of Clymene the daughter of Minyas",
+          "contested": false,
+          "note": ""
+        },
+        {
+          "claim": "B grandfather: Polymede daughter of Autolycus",
+          "source_url": "https://www.theoi.com/Text/Apollodorus1.html",
+          "quote": "a son Jason by Polymede, daughter of Autolycus",
+          "contested": true,
+          "note": ""
+        },
+        {
+          "claim": "B great-grandfather: Autolycus son of Hermes",
+          "source_url": "https://www.theoi.com/Text/Apollodorus1.html",
+          "quote": "Autolycus, son of Hermes",
+          "contested": false,
+          "note": ""
+        }
+      ]
+    },
+    "bare_recall": {
+      "answer": "Cretheus (king and founder of Iolcus).\n\nJason's mother was a woman commonly named Alcimede (daughter of Phylacus, in one tradition) or, in some accounts, Polymede. The cleanest and most standard line traces through his father Aeson, but the question asks specifically about the *maternal* line. In the most widely cited genealogy, Jason's father Aeson was the son of Cretheus and Tyro. Following the maternal great-grandfather strictly: Jason → mother Alcimede → her father Phylacus → his father Deion (or, in the Polymede tradition, the line leads back to Autolycus). Because the maternal genealogy is variant and inconsistent across sources, the most reliable named answer in the dominant tradition is **Cretheus**, with **Autolycus** appearing in the version where Jason's mother is Polymede, daughter of Autolycus.",
+      "reasoning": "Jason's genealogy is recorded inconsistently in ancient sources. His father Aeson is consistently the son of Cretheus (founder of Iolcus) and Tyro. His mother is named variously: Alcimede (daughter of Phylacus), Polymede (daughter of Autolycus), Polypheme, or Amphinome. In the most prominent variant where his mother is Polymede, daughter of Autolycus, son of Hermes — the maternal grandfather is Autolycus, making the maternal great-grandfather Hermes. In the Alcimede-daughter-of-Phylacus tradition, the maternal grandfather is Phylacus and the great-grandfather is Deion. Given the variant traditions, the single best-supported named maternal great-grandfather is Autolycus's father Hermes (via Polymede), or Deion (via Alcimede). I flagged Cretheus but corrected to the maternal line in reasoning."
+    },
+    "audit": [
+      {
+        "label": "Answer 1",
+        "links_total": 6,
+        "links_unsupported": 6,
+        "surfaces_source_disagreement": true,
+        "surfaces_definitional_ambiguity": false,
+        "verdict": "NOT_DEFENSIBLE",
+        "note": "Bare recall with zero citations on any of its ~6 genealogical links (Jason->Alcimede, Alcimede->Phylacus, Phylacus->Deion, Polymede->Autolycus, Autolycus->Hermes, Aeson->Cretheus). It does surface mother-disagreement, naming Alcimede/Polymede/Polypheme/Amphinome, but undercuts itself: the headline answer field says 'Cretheus' (the PATERNAL grandfather, not on the maternal line at all), then the reasoning contradicts it and tries to land on a single 'best-supported' name (Hermes or Deion), papering over the dispute. It captures the mother/great-grandfather variant split but never raises the grandfather-vs-grandmother definitional ambiguity (Clymene/Minyas branch). Not defensible: every link is unsupported and one ambiguity is unsurfaced."
+      },
+      {
+        "label": "Answer 2",
+        "links_total": 6,
+        "links_unsupported": 0,
+        "surfaces_source_disagreement": true,
+        "surfaces_definitional_ambiguity": true,
+        "verdict": "DEFENSIBLE",
+        "note": "Grounded trace: all 6 links carry a checkable cited source (theoi.com Apollonius Rhodius 1 and Apollodorus 1), with the contested mother links explicitly flagged contested=true and split into A (Apollonius)/B (Apollodorus) traditions. Surfaces source disagreement on the mother directly (Alcimede vs Polymede, attributed per-source). Surfaces the definitional ambiguity explicitly in the interpretation field: 'Father of the maternal grandfather (default) versus father of the maternal grandmother (gives Minyas)', and refuses to collapse the divergent answers ('Do not collapse Deion and Hermes'; 'No single answer'). This is the defensible shape: it declines a single confident name and attributes each branch to a specific citable source. Note: citations are at source-document granularity (not line-level), but every link is checkable, satisfying the criterion."
+      }
+    ]
+  }
+}

--- a/code/specs/data/adj57/pipeline/jason.workflow.js
+++ b/code/specs/data/adj57/pipeline/jason.workflow.js
@@ -1,0 +1,89 @@
+export const meta = {
+  name: 'adj-jason-genealogy',
+  description: 'Open-book defensibility run on a contested genealogy question: "who was Jason\'s maternal great-grandfather?" The framework spiders + grounds each link of the maternal lineage in a verbatim source, EXPLICITLY surfacing (a) the definitional ambiguity of "maternal great-grandfather" and (b) the source disagreement over Jason\'s mother — vs a bare closed-book recall answer. An adversarial auditor scores whether every link is sourced AND whether the ambiguities are surfaced rather than papered over.',
+  phases: [{ title: 'Ground' }, { title: 'ChainVsBare' }, { title: 'Audit' }],
+}
+
+const QUESTION = 'In Greek mythology, who was Jason\'s (the Argonaut\'s) maternal great-grandfather?'
+
+const GROUND_SCHEMA = {
+  type: 'object',
+  required: ['interpretation_note', 'links', 'answer'],
+  properties: {
+    interpretation_note: { type: 'string', description: 'note the definitional ambiguity: "maternal great-grandfather" could be the father of the maternal GRANDFATHER or of the maternal GRANDMOTHER — state which line(s) you trace.' },
+    links: {
+      type: 'array',
+      description: 'each genealogical link, grounded in a verbatim source quote. Mark contested links where ancient sources disagree.',
+      items: {
+        type: 'object', required: ['claim', 'source_url', 'quote', 'contested'],
+        properties: {
+          claim: { type: 'string', description: 'e.g. "Jason\'s mother is Alcimede" or "Phylacus is the son of Deion"' },
+          source_url: { type: 'string' },
+          quote: { type: 'string', description: 'verbatim passage establishing the link' },
+          contested: { type: 'boolean', description: 'true if ancient sources disagree on this link' },
+          note: { type: 'string', description: 'for contested links: the competing variants + their sources' },
+        },
+      },
+    },
+    answer: { type: 'string', description: 'the defensible answer: name the branch points and the maternal great-grandfather under EACH tradition; do NOT collapse a contested lineage into a single name.' },
+  },
+}
+
+const BARE_SCHEMA = { type: 'object', required: ['answer', 'reasoning'], properties: { answer: { type: 'string' }, reasoning: { type: 'string' } } }
+
+const AUDIT_SCHEMA = {
+  type: 'object', required: ['audits'],
+  properties: {
+    audits: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['label', 'links_total', 'links_unsupported', 'surfaces_source_disagreement', 'surfaces_definitional_ambiguity', 'verdict', 'note'],
+        properties: {
+          label: { type: 'string' },
+          links_total: { type: 'integer' },
+          links_unsupported: { type: 'integer', description: 'genealogical links asserted with no checkable citation' },
+          surfaces_source_disagreement: { type: 'boolean', description: 'does it surface that ancient sources disagree on Jason\'s mother, rather than papering over it?' },
+          surfaces_definitional_ambiguity: { type: 'boolean', description: 'does it note the maternal-great-grandfather definitional ambiguity?' },
+          verdict: { type: 'string', enum: ['DEFENSIBLE', 'NOT_DEFENSIBLE'], description: 'DEFENSIBLE = every link sourced AND ambiguities surfaced; NOT_DEFENSIBLE otherwise. Correctness of a single name is NOT the criterion.' },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const groundPrompt = `Use web search and web fetch (open-book). Answer this question with FULL traceability — every genealogical link grounded in a verbatim source, and every ambiguity surfaced, not hidden.
+
+QUESTION: ${QUESTION}
+
+1. State the DEFINITIONAL ambiguity of "maternal great-grandfather" (father of the maternal grandfather vs father of the maternal grandmother) and which line(s) you will trace.
+2. Trace Jason's maternal lineage. Ground EACH link (Jason's mother; her father = maternal grandfather; his father = maternal great-grandfather) in a verbatim quote from a real source (Apollonius' Argonautica, Apollodorus' Bibliotheca, Hyginus, Tzetzes, theoi.com, etc.).
+3. CRUCIAL: ancient sources DISAGREE on who Jason's mother was. Do NOT pick one silently — mark that link contested and list the competing traditions (e.g. Alcimede daughter of Phylacus vs Polymede daughter of Autolycus) each with its source, and carry each forward to its own great-grandfather.
+4. Give a defensible answer that names the branch points and the maternal great-grandfather UNDER EACH tradition. Do not collapse a contested lineage into a single confident name.`
+
+const barePrompt = `You are taking a closed-book quiz. Use ONLY your own knowledge — no tools, no web. Answer concisely and give brief reasoning.
+
+QUESTION: ${QUESTION}`
+
+const auditPrompt = (bare, ground) => `You are an adversarial AUDITOR judging DEFENSIBILITY, not whether a single name is "right". Two answers to a contested mythological-genealogy question are below.
+
+For EACH answer assess: (a) is every genealogical link backed by a checkable cited source? count unsupported links; (b) does it SURFACE that ancient sources disagree on Jason's mother (vs papering it over with one confident name)? (c) does it note the "maternal great-grandfather" definitional ambiguity? Verdict DEFENSIBLE only if every link is sourced AND both ambiguities are surfaced.
+
+--- Answer 1 (bare recall) ---
+answer: ${bare.answer}
+reasoning: ${bare.reasoning}
+
+--- Answer 2 (grounded trace) ---
+interpretation: ${ground.interpretation_note}
+links:
+${(ground.links || []).map((l, i) => `  ${i + 1}. ${l.claim}  [contested=${l.contested}]  src: ${l.source_url}`).join('\n')}
+answer: ${ground.answer}
+
+Audit both (label "Answer 1" and "Answer 2").`
+
+// ---- run ----
+const ground = await agent(groundPrompt, { phase: 'Ground', label: 'spider-genealogy', agentType: 'general-purpose', schema: GROUND_SCHEMA })
+const bare = await agent(barePrompt, { phase: 'ChainVsBare', label: 'bare-recall', agentType: 'general-purpose', schema: BARE_SCHEMA })
+const audit = await agent(auditPrompt(bare, ground), { phase: 'Audit', label: 'adversarial-audit', agentType: 'general-purpose', schema: AUDIT_SCHEMA })
+
+return { question: QUESTION, grounded: ground, bare_recall: bare, audit: audit.audits }


### PR DESCRIPTION
A worked example of the ADJ68 open-book defensibility pipeline on a **user-chosen** question whose honest answer is *"there isn't a single one"*: **"In Greek mythology, who was Jason's maternal great-grandfather?"**

## Why this question is the cleanest test
Two independent ambiguities make a confident single name a *hallucination*:
1. **Definitional** — "maternal great-grandfather" = father of the maternal *grandfather* **or** of the maternal *grandmother* (two different people).
2. **Source disagreement** — ancient authors disagree on Jason's *mother* (Apollonius: Alcimede daughter of Phylacus; Apollodorus: Polymede daughter of Autolycus).

So the answer is a *set with branch points*, not a name — a correctness-only metric is impoverished here; **defensibility** is the right axis.

## The run
**Bare recall (closed-book) — confidently hallucinated.** Headline: **"Cretheus"** — Jason's *paternal* grandfather, so wrong on *both* axes (paternal not maternal; grandfather not great-grandfather). Then contradicted its own headline, zero citations. Auditor: **NOT_DEFENSIBLE** (6/6 links unsupported; never surfaced the grandmother-line ambiguity).

**Framework (open-book, grounded) — defensible.** A cited map, refusing to collapse:
| line / tradition | answer | source |
|---|---|---|
| Apollonius (Alcimede → Phylacus → …) | **Deion** | theoi.com *Argonautica* I |
| Apollodorus (Polymede → Autolycus → …) | **Hermes** | theoi.com *Bibliotheca* I |
| maternal **grandmother** line (Clymene → …) | **Minyas** | theoi.com *Argonautica* I |

6/6 links cited, contested mother flagged + split per source, both ambiguities surfaced. Auditor: **DEFENSIBLE** (*"No single answer. Do not collapse Deion and Hermes."*).

## Both paper pillars, one fresh case
- **Accounting:** bare recall committed *commission* ("Cretheus", a relationship not on the maternal line) and *omission* (dropped the grandmother branch). The grounded run did neither.
- **Correctability:** every branch is a citable, editable node — including a real *findable* imprecision (the grounded link "Aeson had wedded his **sister** Alcimede" is suspect — likely wife, not sister), exactly the kind of node a human auditor traces and corrects. The framework made the error findable; bare recall buried six silently.

## Honest limitation
Citations are at **document granularity** (the theoi.com page), not line-level — the auditor flagged it. Every link is checkable, but pinning each claim to the exact passage is the **citation-precision verifier** (the named next build), here too.

## Takeaway
On a contested question with no single correct answer, the framework converted a confidently-wrong single name into a **cited, branch-aware, auditable, correctable** answer — what an expert actually wants, and what a correctness-only score cannot reward.

Security review: passed. Builds on the merged ADJ68. Spec: `code/specs/ADJ69-contested-question-worked-example.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)