### PR TITLE
Track browser ARIA range descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -247,6 +247,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "section_landmarks", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "command_elements", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_collections", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "aria_ranges", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)
@@ -633,6 +634,37 @@ def check_browser_expected_lists(
             ):
                 require_optional_nullable_string(item_path, item, field, errors)
             require_optional_string_list(item_path, item, "aria_controls", errors)
+
+    for index, aria_range in enumerate(object_list_items(expected, "aria_ranges")):
+        range_path = f"{case_path}.expected.aria_ranges[{index}]"
+        for field in (
+            "element",
+            "role",
+            "text",
+        ):
+            require_string(range_path, aria_range, field, errors)
+        for field in (
+            "id",
+            "accessible_name",
+            "accessible_description",
+            "aria_label",
+            "aria_valuenow",
+            "aria_valuemin",
+            "aria_valuemax",
+            "aria_valuetext",
+            "aria_orientation",
+            "aria_disabled",
+            "aria_readonly",
+            "aria_required",
+            "tabindex",
+            "text_value",
+        ):
+            require_optional_nullable_string(range_path, aria_range, field, errors)
+        for field in (
+            "aria_labelledby",
+            "aria_describedby",
+        ):
+            require_optional_string_list(range_path, aria_range, field, errors)
 
     for index, link in enumerate(object_list_items(expected, "links")):
         link_path = f"{case_path}.expected.links[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -839,6 +839,7 @@ pub struct BrowserDocument {
     pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub command_elements: Vec<BrowserCommandElement>,
     pub aria_collections: Vec<BrowserAriaCollection>,
+    pub aria_ranges: Vec<BrowserAriaRange>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1579,6 +1580,29 @@ pub struct BrowserAriaCollectionItem {
     pub aria_rowindex: Option<String>,
     pub aria_colindex: Option<String>,
     pub aria_controls: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaRange {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub aria_valuenow: Option<String>,
+    pub aria_valuemin: Option<String>,
+    pub aria_valuemax: Option<String>,
+    pub aria_valuetext: Option<String>,
+    pub aria_orientation: Option<String>,
+    pub aria_disabled: Option<String>,
+    pub aria_readonly: Option<String>,
+    pub aria_required: Option<String>,
+    pub tabindex: Option<String>,
+    pub text_value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9468,6 +9492,9 @@ fn collect_browser_facts(
         if let Some(aria_collection) = browser_aria_collection_element(element, id_texts) {
             summary.aria_collections.push(aria_collection);
         }
+        if let Some(aria_range) = browser_aria_range_element(element, id_texts) {
+            summary.aria_ranges.push(aria_range);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -11468,6 +11495,45 @@ fn browser_authored_collection_item_role(element: &Element) -> Option<String> {
             | "rowheader"
             | "tab"
             | "treeitem"
+    )
+    .then_some(role)
+}
+
+fn browser_aria_range_element(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaRange> {
+    let role = browser_authored_range_role(element)?;
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    Some(BrowserAriaRange {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        accessible_name: browser_accessible_name(element, &role, &[], id_texts)
+            .or_else(|| (!text.is_empty()).then(|| text.clone())),
+        accessible_description: browser_accessible_description(element, id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
+        aria_valuenow: browser_aria_state(element, "aria-valuenow"),
+        aria_valuemin: browser_aria_state(element, "aria-valuemin"),
+        aria_valuemax: browser_aria_state(element, "aria-valuemax"),
+        aria_valuetext: browser_aria_state(element, "aria-valuetext"),
+        aria_orientation: browser_aria_state(element, "aria-orientation"),
+        aria_disabled: browser_aria_state(element, "aria-disabled"),
+        aria_readonly: browser_aria_state(element, "aria-readonly"),
+        aria_required: browser_aria_state(element, "aria-required"),
+        tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        text_value: (!text.is_empty()).then(|| text.clone()),
+        role,
+        text,
+    })
+}
+
+fn browser_authored_range_role(element: &Element) -> Option<String> {
+    let role = browser_authored_role(element)?.to_ascii_lowercase();
+    matches!(
+        role.as_str(),
+        "meter" | "progressbar" | "scrollbar" | "separator" | "slider" | "spinbutton"
     )
     .then_some(role)
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -9,7 +9,7 @@ use coding_adventures_html_parser::{
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserAriaCollection, BrowserAriaCollectionItem, BrowserCommandElement,
+    BrowserAriaCollection, BrowserAriaCollectionItem, BrowserAriaRange, BrowserCommandElement,
     BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
     BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
@@ -75,6 +75,8 @@ struct ExpectedBrowserDocument {
     command_elements: Vec<ExpectedCommandElement>,
     #[serde(default)]
     aria_collections: Vec<ExpectedAriaCollection>,
+    #[serde(default)]
+    aria_ranges: Vec<ExpectedAriaRange>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -664,6 +666,45 @@ struct ExpectedAriaCollectionItem {
     aria_colindex: Option<String>,
     #[serde(default)]
     aria_controls: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaRange {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    aria_valuenow: Option<String>,
+    #[serde(default)]
+    aria_valuemin: Option<String>,
+    #[serde(default)]
+    aria_valuemax: Option<String>,
+    #[serde(default)]
+    aria_valuetext: Option<String>,
+    #[serde(default)]
+    aria_orientation: Option<String>,
+    #[serde(default)]
+    aria_disabled: Option<String>,
+    #[serde(default)]
+    aria_readonly: Option<String>,
+    #[serde(default)]
+    aria_required: Option<String>,
+    #[serde(default)]
+    tabindex: Option<String>,
+    #[serde(default)]
+    text_value: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1982,6 +2023,26 @@ fn browser_aria_collection_descriptor_metadata_tracks_grouped_composites() {
 }
 
 #[test]
+fn browser_aria_range_descriptor_metadata_tracks_value_widgets() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-range-descriptor-page")
+        .expect("ARIA range fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA range fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.aria_ranges, expected.aria_ranges,
+        "ARIA range descriptors should preserve value bounds, value text, orientation, and value widget states",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3145,6 +3206,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedAriaCollection::into_browser_aria_collection)
                 .collect(),
+            aria_ranges: self
+                .aria_ranges
+                .into_iter()
+                .map(ExpectedAriaRange::into_browser_aria_range)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3684,6 +3750,32 @@ impl ExpectedAriaCollectionItem {
             aria_rowindex: self.aria_rowindex,
             aria_colindex: self.aria_colindex,
             aria_controls: self.aria_controls,
+        }
+    }
+}
+
+impl ExpectedAriaRange {
+    fn into_browser_aria_range(self) -> BrowserAriaRange {
+        BrowserAriaRange {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            aria_valuenow: self.aria_valuenow,
+            aria_valuemin: self.aria_valuemin,
+            aria_valuemax: self.aria_valuemax,
+            aria_valuetext: self.aria_valuetext,
+            aria_orientation: self.aria_orientation,
+            aria_disabled: self.aria_disabled,
+            aria_readonly: self.aria_readonly,
+            aria_required: self.aria_required,
+            tabindex: self.tabindex,
+            text_value: self.text_value,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1058,6 +1058,46 @@
       }
     },
     {
+      "id": "aria-range-descriptor-page",
+      "description": "Browser document summaries expose authored ARIA range value widgets with value bounds, labels, and state hints.",
+      "input": "<body><h2 id=range-title>Settings</h2><p id=volume-help>Loud</p><div id=volume role=slider aria-labelledby=range-title aria-describedby=volume-help aria-valuemin=0 aria-valuemax=10 aria-valuenow=7 aria-valuetext=\"7 of 10\" aria-orientation=vertical tabindex=0></div><div id=stepper role=spinbutton aria-label=Retries aria-valuemin=1 aria-valuemax=5 aria-valuenow=2 aria-required=true tabindex=0></div><div id=load role=progressbar aria-label=\"Load progress\" aria-valuemin=0 aria-valuemax=100 aria-valuenow=40>Loading</div><div id=scroll role=scrollbar aria-label=Timeline aria-valuemin=0 aria-valuemax=300 aria-valuenow=120 aria-disabled=true aria-readonly=true>Scroll</div></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Settings Loud Loading Scroll",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "range-title", "name": null, "text": "Settings" },
+          { "id": "volume-help", "name": null, "text": "Loud" },
+          { "id": "volume", "name": null, "text": "" },
+          { "id": "stepper", "name": null, "text": "" },
+          { "id": "load", "name": null, "text": "Loading" },
+          { "id": "scroll", "name": null, "text": "Scroll" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Settings" }
+        ],
+        "aria_ranges": [
+          { "element": "div", "id": "volume", "role": "slider", "text": "", "accessible_name": "Settings", "accessible_description": "Loud", "aria_labelledby": ["range-title"], "aria_describedby": ["volume-help"], "aria_valuenow": "7", "aria_valuemin": "0", "aria_valuemax": "10", "aria_valuetext": "7 of 10", "aria_orientation": "vertical", "tabindex": "0" },
+          { "element": "div", "id": "stepper", "role": "spinbutton", "text": "", "accessible_name": "Retries", "aria_label": "Retries", "aria_valuenow": "2", "aria_valuemin": "1", "aria_valuemax": "5", "aria_required": "true", "tabindex": "0" },
+          { "element": "div", "id": "load", "role": "progressbar", "text": "Loading", "accessible_name": "Load progress", "aria_label": "Load progress", "aria_valuenow": "40", "aria_valuemin": "0", "aria_valuemax": "100", "text_value": "Loading" },
+          { "element": "div", "id": "scroll", "role": "scrollbar", "text": "Scroll", "accessible_name": "Timeline", "aria_label": "Timeline", "aria_valuenow": "120", "aria_valuemin": "0", "aria_valuemax": "300", "aria_disabled": "true", "aria_readonly": "true", "text_value": "Scroll" }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [
+          { "element": "div", "id": "volume", "role": "block", "authored_role": "slider", "text": "", "accessible_name": "Settings", "accessible_description": "Loud", "aria_labelledby": ["range-title"], "aria_describedby": ["volume-help"], "tabindex": "0", "focusable": true },
+          { "element": "div", "id": "stepper", "role": "block", "authored_role": "spinbutton", "text": "", "accessible_name": "Retries", "aria_label": "Retries", "aria_required": "true", "tabindex": "0", "focusable": true },
+          { "element": "div", "id": "load", "role": "block", "authored_role": "progressbar", "text": "Loading", "accessible_name": "Load progress", "aria_label": "Load progress" },
+          { "element": "div", "id": "scroll", "role": "block", "authored_role": "scrollbar", "text": "Scroll", "accessible_name": "Timeline", "aria_label": "Timeline", "aria_disabled": "true" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "form-measurement-descriptor-page",
       "description": "Browser document form summaries expose in-form meter and progress descriptors without adding them to submission controls.",
       "input": "<form id=telemetry><label for=disk>Disk</label><meter id=disk value=0.72 min=0 max=1 low=0.25 high=0.9 optimum=0.7 aria-describedby=disk-help>72%</meter><p id=disk-help>Capacity used</p><label for=upload>Upload</label><progress id=upload value=30 max=100>30%</progress><progress id=sync max=1 aria-label=Sync>Loading</progress><input name=token value=ok></form><meter id=outside value=1>Outside</meter>",


### PR DESCRIPTION
## Summary
- Add browser ARIA range descriptors for authored value widgets like sliders, spinbuttons, progressbars, scrollbars, meters, and separators
- Capture range labels, descriptions, value bounds, value text, orientation, disabled/readonly/required state, tabindex, and visible text values
- Extend browser readiness fixture/schema coverage with a focused ARIA range case

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_aria_range_descriptor_metadata_tracks_value_widgets
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser