### PR TITLE
Add 6LoWPAN IPHC inline field lengths

### DIFF
--- a/code/packages/rust/sixlowpan/CHANGELOG.md
+++ b/code/packages/rust/sixlowpan/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 - Payload-free reassembly buffer and table summaries for received/missing bytes,
   pending datagrams, contiguous ranges, and largest pending datagram size.
 - LOWPAN_IPHC context identifier extension parsing and encoding helpers.
+- LOWPAN_IPHC inline field length accounting and payload splitting helpers for
+  compressed IPv6 field parsing.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/sixlowpan/README.md
+++ b/code/packages/rust/sixlowpan/README.md
@@ -8,6 +8,7 @@ This crate starts D27 below Thread MLE:
 - mesh header hop-limit and short/extended address parsing
 - LOWPAN_IPHC first/second byte parsing
 - LOWPAN_IPHC optional context identifier extension parsing
+- LOWPAN_IPHC inline field length accounting for compressed IPv6 fields
 - LOWPAN_NHC UDP port compression and checksum-elision parsing
 - fragment first/next header parse and encode
 - fragment payload parsing and deterministic reassembly buffers

--- a/code/packages/rust/sixlowpan/src/lib.rs
+++ b/code/packages/rust/sixlowpan/src/lib.rs
@@ -175,6 +175,15 @@ impl IphcTrafficClassFlowLabel {
             Self::Elided => 3,
         }
     }
+
+    pub fn inline_len(self) -> usize {
+        match self {
+            Self::Inline => 4,
+            Self::FlowLabelInline => 3,
+            Self::TrafficClassInline => 1,
+            Self::Elided => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,6 +211,10 @@ impl IphcHopLimit {
             Self::SixtyFour => 2,
             Self::TwoHundredFiftyFive => 3,
         }
+    }
+
+    pub fn inline_len(self) -> usize {
+        usize::from(matches!(self, Self::Inline))
     }
 }
 
@@ -279,6 +292,44 @@ impl IphcEncoding {
                 | self.destination_address_mode.bits(),
         ]
     }
+
+    pub fn fixed_inline_fields_len(self) -> usize {
+        self.traffic_class_flow_label.inline_len()
+            + usize::from(!self.next_header_compressed)
+            + self.hop_limit.inline_len()
+    }
+
+    pub fn source_address_inline_len(self) -> usize {
+        iphc_unicast_address_inline_len(
+            self.source_address_compression,
+            self.source_address_mode,
+            true,
+        )
+        .expect("all IPHC source address modes have a deterministic inline length")
+    }
+
+    pub fn destination_address_inline_len(self) -> Option<usize> {
+        if self.multicast_destination {
+            iphc_multicast_address_inline_len(
+                self.destination_address_compression,
+                self.destination_address_mode,
+            )
+        } else {
+            iphc_unicast_address_inline_len(
+                self.destination_address_compression,
+                self.destination_address_mode,
+                false,
+            )
+        }
+    }
+
+    pub fn inline_fields_len(self) -> Option<usize> {
+        Some(
+            self.fixed_inline_fields_len()
+                + self.source_address_inline_len()
+                + self.destination_address_inline_len()?,
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -318,6 +369,12 @@ pub struct IphcHeader {
     pub payload: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IphcPayloadSlices<'a> {
+    pub inline_fields: &'a [u8],
+    pub carried_payload: &'a [u8],
+}
+
 impl IphcHeader {
     pub fn parse(bytes: &[u8]) -> Result<Self, SixlowpanError> {
         if bytes.len() < 2 {
@@ -344,6 +401,26 @@ impl IphcHeader {
         2 + usize::from(self.context_identifier.is_some())
     }
 
+    pub fn inline_fields_len(&self) -> Option<usize> {
+        self.encoding.inline_fields_len()
+    }
+
+    pub fn split_payload(&self) -> Result<Option<IphcPayloadSlices<'_>>, SixlowpanError> {
+        let Some(inline_len) = self.inline_fields_len() else {
+            return Ok(None);
+        };
+        if self.payload.len() < inline_len {
+            return Err(SixlowpanError::Truncated {
+                needed: inline_len,
+                remaining: self.payload.len(),
+            });
+        }
+        Ok(Some(IphcPayloadSlices {
+            inline_fields: &self.payload[..inline_len],
+            carried_payload: &self.payload[inline_len..],
+        }))
+    }
+
     pub fn encode_prefix(&self) -> Result<Vec<u8>, SixlowpanError> {
         let mut out = Vec::with_capacity(self.encoded_header_len());
         let mut encoding = self.encoding;
@@ -359,6 +436,40 @@ impl IphcHeader {
         let mut out = self.encode_prefix()?;
         out.extend_from_slice(&self.payload);
         Ok(out)
+    }
+}
+
+fn iphc_unicast_address_inline_len(
+    stateful_context: bool,
+    mode: IphcAddressMode,
+    source: bool,
+) -> Option<usize> {
+    match (stateful_context, mode, source) {
+        (false, IphcAddressMode::Inline128, _) => Some(16),
+        (false, IphcAddressMode::Compressed64, _) => Some(8),
+        (false, IphcAddressMode::Compressed16, _) => Some(2),
+        (false, IphcAddressMode::Elided, _) => Some(0),
+        (true, IphcAddressMode::Inline128, true) => Some(0),
+        (true, IphcAddressMode::Inline128, false) => None,
+        (true, IphcAddressMode::Compressed64, _) => Some(8),
+        (true, IphcAddressMode::Compressed16, _) => Some(2),
+        (true, IphcAddressMode::Elided, _) => Some(0),
+    }
+}
+
+fn iphc_multicast_address_inline_len(
+    stateful_context: bool,
+    mode: IphcAddressMode,
+) -> Option<usize> {
+    match (stateful_context, mode) {
+        (false, IphcAddressMode::Inline128) => Some(16),
+        (false, IphcAddressMode::Compressed64) => Some(6),
+        (false, IphcAddressMode::Compressed16) => Some(4),
+        (false, IphcAddressMode::Elided) => Some(1),
+        (true, IphcAddressMode::Inline128) => Some(6),
+        (true, IphcAddressMode::Compressed64)
+        | (true, IphcAddressMode::Compressed16)
+        | (true, IphcAddressMode::Elided) => None,
     }
 }
 
@@ -1182,6 +1293,94 @@ mod tests {
         assert_eq!(
             IphcContextIdentifier::new(16, 0),
             Err(SixlowpanError::InvalidContextIdentifier(16))
+        );
+    }
+
+    #[test]
+    fn iphc_encoding_reports_inline_field_lengths() {
+        let encoding = IphcEncoding {
+            traffic_class_flow_label: IphcTrafficClassFlowLabel::TrafficClassInline,
+            next_header_compressed: false,
+            hop_limit: IphcHopLimit::Inline,
+            context_identifier_extension: false,
+            source_address_compression: false,
+            source_address_mode: IphcAddressMode::Compressed16,
+            multicast_destination: true,
+            destination_address_compression: false,
+            destination_address_mode: IphcAddressMode::Elided,
+        };
+
+        assert_eq!(encoding.fixed_inline_fields_len(), 3);
+        assert_eq!(encoding.source_address_inline_len(), 2);
+        assert_eq!(encoding.destination_address_inline_len(), Some(1));
+        assert_eq!(encoding.inline_fields_len(), Some(6));
+    }
+
+    #[test]
+    fn iphc_header_splits_inline_fields_from_carried_payload() {
+        let header = IphcHeader {
+            encoding: IphcEncoding {
+                traffic_class_flow_label: IphcTrafficClassFlowLabel::TrafficClassInline,
+                next_header_compressed: false,
+                hop_limit: IphcHopLimit::Inline,
+                context_identifier_extension: false,
+                source_address_compression: false,
+                source_address_mode: IphcAddressMode::Compressed16,
+                multicast_destination: true,
+                destination_address_compression: false,
+                destination_address_mode: IphcAddressMode::Elided,
+            },
+            context_identifier: None,
+            payload: vec![0x00, 0x11, 0x40, 0xaa, 0xbb, 0x02, 0xf0, 0x12],
+        };
+
+        let split = header.split_payload().unwrap().unwrap();
+
+        assert_eq!(split.inline_fields, &[0x00, 0x11, 0x40, 0xaa, 0xbb, 0x02]);
+        assert_eq!(split.carried_payload, &[0xf0, 0x12]);
+    }
+
+    #[test]
+    fn iphc_inline_lengths_flag_reserved_address_modes() {
+        let encoding = IphcEncoding {
+            traffic_class_flow_label: IphcTrafficClassFlowLabel::Elided,
+            next_header_compressed: true,
+            hop_limit: IphcHopLimit::SixtyFour,
+            context_identifier_extension: false,
+            source_address_compression: true,
+            source_address_mode: IphcAddressMode::Elided,
+            multicast_destination: false,
+            destination_address_compression: true,
+            destination_address_mode: IphcAddressMode::Inline128,
+        };
+        let truncated = IphcHeader {
+            encoding: IphcEncoding {
+                destination_address_compression: false,
+                destination_address_mode: IphcAddressMode::Inline128,
+                ..encoding
+            },
+            context_identifier: None,
+            payload: vec![0xaa],
+        };
+
+        assert_eq!(encoding.destination_address_inline_len(), None);
+        assert_eq!(encoding.inline_fields_len(), None);
+        assert_eq!(
+            IphcHeader {
+                encoding,
+                context_identifier: None,
+                payload: Vec::new()
+            }
+            .split_payload()
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            truncated.split_payload(),
+            Err(SixlowpanError::Truncated {
+                needed: 16,
+                remaining: 1
+            })
         );
     }
 


### PR DESCRIPTION
Summary:
- add IPHC inline field length accounting for traffic class/flow label, next header, hop limit, and address modes
- add payload splitting for compressed IPv6 inline fields versus carried payload bytes
- document reserved IPHC destination address combinations as indeterminate length instead of guessing

Tests:
- cargo test --manifest-path code/packages/rust/sixlowpan/Cargo.toml -- --nocapture