### PR TITLE
Add Hue command plan audit primitive

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this package will be documented in this file.
   telemetry.
 - Hue command planning from normalized D23 `StateDelta` records for direct and
   grouped light writes.
+- `HueCommandPlan` for bundling generated Hue commands, request projections,
+  and ignored D23 capabilities from reconciliation passes.
 - Hue scene summaries for recall planning and read-model telemetry, including
   room/zone scope and projected action coverage.
 - Hue state update summaries for read models and event-stream telemetry across

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -10,6 +10,8 @@ packages a typed surface for:
 - event stream path constants
 - structured Hue command intents
 - Hue command planning from normalized D23 state deltas
+- Hue command plans that retain generated requests and ignored capabilities for
+  reconciliation telemetry
 - Hue command summaries for payload-free command planning and read-model
   telemetry
 - Hue application registration requests and discovered-bridge pairing plans

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -392,6 +392,66 @@ pub fn hue_commands_from_state_deltas<'a>(
     Ok(commands)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct HueCommandPlan {
+    pub target: HueResourceRef,
+    pub commands: Vec<HueCommand>,
+    pub ignored_capability_ids: Vec<CapabilityId>,
+}
+
+impl HueCommandPlan {
+    pub fn empty(target: HueResourceRef) -> Self {
+        Self {
+            target,
+            commands: Vec::new(),
+            ignored_capability_ids: Vec::new(),
+        }
+    }
+
+    pub fn from_state_deltas<'a>(
+        target: &HueResourceRef,
+        deltas: impl IntoIterator<Item = &'a StateDelta>,
+    ) -> Result<Self, HueError> {
+        hue_command_plan_from_state_deltas(target, deltas)
+    }
+
+    pub fn summary(&self) -> HueCommandPlanSummary {
+        HueCommandPlanSummary::from_commands(&self.commands)
+    }
+
+    pub fn requests(&self) -> Vec<HueRequest> {
+        self.commands.iter().map(HueCommand::to_request).collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
+    pub fn has_ignored_deltas(&self) -> bool {
+        !self.ignored_capability_ids.is_empty()
+    }
+
+    pub fn ignored_delta_count(&self) -> usize {
+        self.ignored_capability_ids.len()
+    }
+}
+
+pub fn hue_command_plan_from_state_deltas<'a>(
+    target: &HueResourceRef,
+    deltas: impl IntoIterator<Item = &'a StateDelta>,
+) -> Result<HueCommandPlan, HueError> {
+    let mut plan = HueCommandPlan::empty(target.clone());
+    for delta in deltas {
+        if let Some(command) = hue_command_from_state_delta(target, delta)? {
+            plan.commands.push(command);
+        } else {
+            plan.ignored_capability_ids
+                .push(delta.capability_id.clone());
+        }
+    }
+    Ok(plan)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HueCommandTarget {
     Light,
@@ -1720,6 +1780,76 @@ mod tests {
                 HueCommand::SetGroupedLightBrightness {
                     grouped_light_id: HueResourceId::trusted("grouped-light-1"),
                     brightness: 20,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn hue_command_plans_keep_requests_and_ignored_capabilities() {
+        let light = HueResourceRef::new(HueResourceType::Light, HueResourceId::trusted("light-1"));
+        let deltas = vec![
+            StateDelta {
+                capability_id: CapabilityId::trusted("light.on_off"),
+                value: Value::Bool(true),
+            },
+            StateDelta {
+                capability_id: CapabilityId::trusted("sensor.occupancy"),
+                value: Value::Bool(false),
+            },
+            StateDelta {
+                capability_id: CapabilityId::trusted("light.brightness"),
+                value: Value::Percentage(25),
+            },
+        ];
+
+        let plan = HueCommandPlan::from_state_deltas(&light, &deltas).unwrap();
+
+        assert_eq!(plan.target, light);
+        assert_eq!(
+            plan.commands,
+            vec![
+                HueCommand::SetLightOn {
+                    light_id: HueResourceId::trusted("light-1"),
+                    on: true,
+                },
+                HueCommand::SetLightBrightness {
+                    light_id: HueResourceId::trusted("light-1"),
+                    brightness: 25,
+                },
+            ]
+        );
+        assert_eq!(
+            plan.ignored_capability_ids,
+            vec![CapabilityId::trusted("sensor.occupancy")]
+        );
+        assert!(plan.has_ignored_deltas());
+        assert_eq!(plan.ignored_delta_count(), 1);
+        assert_eq!(
+            plan.summary(),
+            HueCommandPlanSummary {
+                total_commands: 2,
+                light_commands: 2,
+                grouped_light_commands: 0,
+                scene_commands: 0,
+                on_off_commands: 1,
+                brightness_commands: 1,
+                color_temperature_commands: 0,
+                scene_recall_commands: 0,
+            }
+        );
+        assert_eq!(
+            plan.requests(),
+            vec![
+                HueRequest {
+                    method: HueMethod::Put,
+                    path: "/clip/v2/resource/light/light-1".to_string(),
+                    body: Some(HueRequestBody::SetOn { on: true }),
+                },
+                HueRequest {
+                    method: HueMethod::Put,
+                    path: "/clip/v2/resource/light/light-1".to_string(),
+                    body: Some(HueRequestBody::SetBrightness { brightness: 25 }),
                 },
             ]
         );


### PR DESCRIPTION
## Summary
- add HueCommandPlan for bundling generated Hue commands with ignored D23 capability ids
- expose request and summary helpers for reconciliation telemetry
- document the new Hue planning surface

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml
- CARGO_TARGET_DIR=C:\\tmp\\codex-hue-command-plan-target cargo test --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml -- --nocapture