### PR TITLE
Track browser ARIA live region descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -248,6 +248,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "command_elements", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_collections", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_ranges", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "aria_live_regions", errors)
     require_object_list(f"{case_path}.expected", expected, "links", errors)
     require_object_list(f"{case_path}.expected", expected, "images", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "image_maps", errors)

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -840,6 +840,7 @@ pub struct BrowserDocument {
     pub command_elements: Vec<BrowserCommandElement>,
     pub aria_collections: Vec<BrowserAriaCollection>,
     pub aria_ranges: Vec<BrowserAriaRange>,
+    pub aria_live_regions: Vec<BrowserAriaLiveRegion>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1603,6 +1604,25 @@ pub struct BrowserAriaRange {
     pub aria_required: Option<String>,
     pub tabindex: Option<String>,
     pub text_value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaLiveRegion {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub aria_live: Option<String>,
+    pub aria_busy: Option<String>,
+    pub aria_atomic: Option<String>,
+    pub aria_relevant: Vec<String>,
+    pub aria_hidden: bool,
+    pub update_kind: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9495,6 +9515,9 @@ fn collect_browser_facts(
         if let Some(aria_range) = browser_aria_range_element(element, id_texts) {
             summary.aria_ranges.push(aria_range);
         }
+        if let Some(aria_live_region) = browser_aria_live_region_element(element, id_texts) {
+            summary.aria_live_regions.push(aria_live_region);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -11374,12 +11397,7 @@ fn browser_aria_collection_element(
         .count();
     let checked_item_count = items
         .iter()
-        .filter(|item| {
-            matches!(
-                item.aria_checked.as_deref(),
-                Some("true") | Some("mixed")
-            )
-        })
+        .filter(|item| matches!(item.aria_checked.as_deref(), Some("true") | Some("mixed")))
         .count();
     let current_item_count = items
         .iter()
@@ -11536,6 +11554,68 @@ fn browser_authored_range_role(element: &Element) -> Option<String> {
         "meter" | "progressbar" | "scrollbar" | "separator" | "slider" | "spinbutton"
     )
     .then_some(role)
+}
+
+fn browser_aria_live_region_element(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaLiveRegion> {
+    let role = browser_aria_live_region_role(element)?;
+    let aria_live = browser_aria_state(element, "aria-live");
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    Some(BrowserAriaLiveRegion {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        accessible_name: browser_accessible_name(element, &role, &[], id_texts)
+            .or_else(|| (!text.is_empty()).then(|| text.clone())),
+        accessible_description: browser_accessible_description(element, id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
+        aria_live: aria_live.clone(),
+        aria_busy: browser_aria_state(element, "aria-busy"),
+        aria_atomic: browser_aria_state(element, "aria-atomic"),
+        aria_relevant: browser_aria_tokens(element, "aria-relevant"),
+        aria_hidden: browser_aria_hidden(element),
+        update_kind: browser_aria_live_update_kind(&role, aria_live.as_deref()),
+        role,
+        text,
+    })
+}
+
+fn browser_aria_live_region_role(element: &Element) -> Option<String> {
+    let authored_role = browser_authored_role(element).map(|role| role.to_ascii_lowercase());
+    if let Some(role) = authored_role.as_deref() {
+        if matches!(role, "alert" | "log" | "marquee" | "status" | "timer") {
+            return Some(role.to_string());
+        }
+    }
+
+    element
+        .attribute("aria-live")
+        .or_else(|| element.attribute("aria-busy"))
+        .or_else(|| element.attribute("aria-atomic"))
+        .or_else(|| element.attribute("aria-relevant"))
+        .map(|_| {
+            authored_role.unwrap_or_else(|| {
+                browser_content_role(&element.name)
+                    .unwrap_or(element.name.as_str())
+                    .to_string()
+            })
+        })
+}
+
+fn browser_aria_live_update_kind(role: &str, aria_live: Option<&str>) -> String {
+    if let Some(aria_live) = aria_live {
+        return aria_live.to_ascii_lowercase();
+    }
+    match role {
+        "alert" => "assertive",
+        "log" | "status" => "polite",
+        "marquee" | "timer" => "off",
+        _ => "implicit",
+    }
+    .to_string()
 }
 
 fn should_collect_browser_content_children(name: &str) -> bool {
@@ -12537,6 +12617,13 @@ fn browser_aria_state(element: &Element, name: &str) -> Option<String> {
         .attribute(name)
         .map(collapse_html_whitespace)
         .filter(|state| !state.is_empty())
+}
+
+fn browser_aria_tokens(element: &Element, name: &str) -> Vec<String> {
+    element
+        .attribute(name)
+        .map(split_html_classes)
+        .unwrap_or_default()
 }
 
 fn browser_aria_hidden(element: &Element) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,19 +1,19 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserAnchor, BrowserComponentHydrationTarget, BrowserDataAttribute,
-    BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
-    BrowserEmbeddedContext, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
-    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
-    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
-    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect,
-    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
-    BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserAriaCollection, BrowserAriaCollectionItem, BrowserAriaRange, BrowserCommandElement,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    parse_browser_document, BrowserAnchor, BrowserAriaCollection, BrowserAriaCollectionItem,
+    BrowserAriaLiveRegion, BrowserAriaRange, BrowserCommandElement,
+    BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDatalistOption,
+    BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
+    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
+    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
+    BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea,
+    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -77,6 +77,8 @@ struct ExpectedBrowserDocument {
     aria_collections: Vec<ExpectedAriaCollection>,
     #[serde(default)]
     aria_ranges: Vec<ExpectedAriaRange>,
+    #[serde(default)]
+    aria_live_regions: Vec<ExpectedAriaLiveRegion>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -705,6 +707,36 @@ struct ExpectedAriaRange {
     tabindex: Option<String>,
     #[serde(default)]
     text_value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaLiveRegion {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    aria_live: Option<String>,
+    #[serde(default)]
+    aria_busy: Option<String>,
+    #[serde(default)]
+    aria_atomic: Option<String>,
+    #[serde(default)]
+    aria_relevant: Vec<String>,
+    #[serde(default)]
+    aria_hidden: bool,
+    update_kind: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2043,6 +2075,26 @@ fn browser_aria_range_descriptor_metadata_tracks_value_widgets() {
 }
 
 #[test]
+fn browser_aria_live_region_descriptor_metadata_tracks_update_semantics() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-live-region-descriptor-page")
+        .expect("ARIA live-region fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA live-region fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.aria_live_regions, expected.aria_live_regions,
+        "ARIA live-region descriptors should preserve live politeness, busy/atomic/relevant flags, and implicit update semantics",
+    );
+}
+
+#[test]
 fn browser_form_validation_metadata_tracks_constraint_candidates() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3211,6 +3263,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedAriaRange::into_browser_aria_range)
                 .collect(),
+            aria_live_regions: self
+                .aria_live_regions
+                .into_iter()
+                .map(ExpectedAriaLiveRegion::into_browser_aria_live_region)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -3776,6 +3833,28 @@ impl ExpectedAriaRange {
             aria_required: self.aria_required,
             tabindex: self.tabindex,
             text_value: self.text_value,
+        }
+    }
+}
+
+impl ExpectedAriaLiveRegion {
+    fn into_browser_aria_live_region(self) -> BrowserAriaLiveRegion {
+        BrowserAriaLiveRegion {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            aria_live: self.aria_live,
+            aria_busy: self.aria_busy,
+            aria_atomic: self.aria_atomic,
+            aria_relevant: self.aria_relevant,
+            aria_hidden: self.aria_hidden,
+            update_kind: self.update_kind,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -980,6 +980,9 @@
           { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown"] },
           { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
         ],
+        "aria_live_regions": [
+          { "element": "section", "id": "panel", "role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "update_kind": "polite" }
+        ],
         "links": [],
         "images": [],
         "interactive_elements": [
@@ -1092,6 +1095,55 @@
           { "element": "div", "id": "stepper", "role": "block", "authored_role": "spinbutton", "text": "", "accessible_name": "Retries", "aria_label": "Retries", "aria_required": "true", "tabindex": "0", "focusable": true },
           { "element": "div", "id": "load", "role": "block", "authored_role": "progressbar", "text": "Loading", "accessible_name": "Load progress", "aria_label": "Load progress" },
           { "element": "div", "id": "scroll", "role": "block", "authored_role": "scrollbar", "text": "Scroll", "accessible_name": "Timeline", "aria_label": "Timeline", "aria_disabled": "true" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "aria-live-region-descriptor-page",
+      "description": "Browser document summaries expose implicit and explicit ARIA live-region update semantics.",
+      "input": "<body><h2 id=live-title>Updates</h2><p id=status-help>Sync status</p><div id=toast role=status aria-labelledby=live-title aria-describedby=status-help aria-atomic=true aria-relevant=\"additions text\">Saved</div><div id=alert role=alert aria-label=\"Error alert\" aria-busy=true>Network down</div><div id=feed role=log aria-live=polite aria-relevant=additions><p>First</p><p>Second</p></div><div id=ticker role=marquee aria-label=Ticker>Stocks</div><div id=clock role=timer aria-live=off>12:00</div><div id=custom role=region aria-label=Notifications aria-live=assertive aria-busy=false aria-atomic=false aria-relevant=\"removals all\">Custom</div><p id=hidden role=status aria-hidden=true>Muted</p></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Updates Sync status Saved Network down First Second Stocks 12:00 Custom Muted",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "live-title", "name": null, "text": "Updates" },
+          { "id": "status-help", "name": null, "text": "Sync status" },
+          { "id": "toast", "name": null, "text": "Saved" },
+          { "id": "alert", "name": null, "text": "Network down" },
+          { "id": "feed", "name": null, "text": "First Second" },
+          { "id": "ticker", "name": null, "text": "Stocks" },
+          { "id": "clock", "name": null, "text": "12:00" },
+          { "id": "custom", "name": null, "text": "Custom" },
+          { "id": "hidden", "name": null, "text": "Muted" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Updates" }
+        ],
+        "aria_live_regions": [
+          { "element": "div", "id": "toast", "role": "status", "text": "Saved", "accessible_name": "Updates", "accessible_description": "Sync status", "aria_labelledby": ["live-title"], "aria_describedby": ["status-help"], "aria_atomic": "true", "aria_relevant": ["additions", "text"], "update_kind": "polite" },
+          { "element": "div", "id": "alert", "role": "alert", "text": "Network down", "accessible_name": "Error alert", "aria_label": "Error alert", "aria_busy": "true", "update_kind": "assertive" },
+          { "element": "div", "id": "feed", "role": "log", "text": "First Second", "accessible_name": "First Second", "aria_live": "polite", "aria_relevant": ["additions"], "update_kind": "polite" },
+          { "element": "div", "id": "ticker", "role": "marquee", "text": "Stocks", "accessible_name": "Ticker", "aria_label": "Ticker", "update_kind": "off" },
+          { "element": "div", "id": "clock", "role": "timer", "text": "12:00", "accessible_name": "12:00", "aria_live": "off", "update_kind": "off" },
+          { "element": "div", "id": "custom", "role": "region", "text": "Custom", "accessible_name": "Notifications", "aria_label": "Notifications", "aria_live": "assertive", "aria_busy": "false", "aria_atomic": "false", "aria_relevant": ["removals", "all"], "update_kind": "assertive" },
+          { "element": "p", "id": "hidden", "role": "status", "text": "Muted", "accessible_name": "Muted", "aria_hidden": true, "update_kind": "polite" }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [
+          { "element": "div", "id": "toast", "role": "block", "authored_role": "status", "text": "Saved", "accessible_name": "Updates", "accessible_description": "Sync status", "aria_labelledby": ["live-title"], "aria_describedby": ["status-help"] },
+          { "element": "div", "id": "alert", "role": "block", "authored_role": "alert", "text": "Network down", "accessible_name": "Error alert", "aria_label": "Error alert", "aria_busy": "true" },
+          { "element": "div", "id": "feed", "role": "block", "authored_role": "log", "text": "First Second", "aria_live": "polite" },
+          { "element": "div", "id": "ticker", "role": "block", "authored_role": "marquee", "text": "Stocks", "accessible_name": "Ticker", "aria_label": "Ticker" },
+          { "element": "div", "id": "clock", "role": "block", "authored_role": "timer", "text": "12:00", "aria_live": "off" },
+          { "element": "div", "id": "custom", "role": "block", "authored_role": "region", "text": "Custom", "accessible_name": "Notifications", "aria_label": "Notifications", "aria_live": "assertive", "aria_busy": "false" },
+          { "element": "p", "id": "hidden", "role": "paragraph", "authored_role": "status", "text": "Muted", "aria_hidden": true }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
Summary:
- add BrowserAriaLiveRegion metadata to browser document extraction
- capture implicit and explicit ARIA live-region semantics, labels, descriptions, busy/atomic/relevant state, and update kind
- add fixture schema coverage plus browser-readiness fixture/test expectations

Tests:
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_aria_live_region_descriptor_metadata_tracks_update_semantics
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser