### PR TITLE
Fix arithmetic deploy TypeScript build

### DIFF
--- a/code/packages/typescript/paint-vm-canvas/src/index.ts
+++ b/code/packages/typescript/paint-vm-canvas/src/index.ts
@@ -63,7 +63,6 @@ export const VERSION = "0.1.0";
 
 import { PaintVM, ExportNotSupportedError } from "@coding-adventures/paint-vm";
 import type {
-  PaintInstruction,
   PaintRect,
   PaintEllipse,
   PaintPath,


### PR DESCRIPTION
## Summary

- Remove an unused `PaintInstruction` type import from `@coding-adventures/paint-vm-canvas`.
- This addresses the Arithmetic Visualizer deploy failure where TypeScript reported `'PaintInstruction' is declared but never used.`

## Verification

- `git diff --check` passed locally.
- Could not run `npm run build` locally because this environment does not have `npm` available on `PATH` or in the bundled Node runtime.

## Failure Context

Job: https://github.com/adhithyan15/coding-adventures/actions/runs/26873332192/job/79254003424
