### PR TITLE
Track browser table cell descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -268,6 +268,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
     require_object_list(f"{case_path}.expected", expected, "forms", errors)
     require_object_list(f"{case_path}.expected", expected, "tables", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "table_cells", errors)
     check_browser_expected_lists(case_path, expected, errors)
 
     return errors
@@ -1272,6 +1273,27 @@ def check_browser_expected_lists(
             "header_cell_count",
         ):
             require_integer(table_path, table, field, errors)
+
+    for index, cell in enumerate(object_list_items(expected, "table_cells")):
+        cell_path = f"{case_path}.expected.table_cells[{index}]"
+        for field in ("table_index", "row_index", "column_index"):
+            require_integer(cell_path, cell, field, errors)
+        require_string(cell_path, cell, "element", errors)
+        require_string(cell_path, cell, "text", errors)
+        for field in (
+            "table_id",
+            "table_caption",
+            "section_kind",
+            "id",
+            "accessible_name",
+            "scope",
+            "abbr",
+            "rowspan",
+            "colspan",
+        ):
+            require_optional_nullable_string(cell_path, cell, field, errors)
+        require_optional_boolean(cell_path, cell, "header", errors)
+        require_optional_string_list(cell_path, cell, "headers", errors)
 
 
 def check_browser_content_tree_case(

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -853,6 +853,7 @@ pub struct BrowserDocument {
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
     pub tables: Vec<BrowserTable>,
+    pub table_cells: Vec<BrowserTableCell>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -2265,6 +2266,26 @@ pub struct BrowserTable {
     pub column_hint_count: usize,
     pub cell_count: usize,
     pub header_cell_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTableCell {
+    pub table_index: usize,
+    pub table_id: Option<String>,
+    pub table_caption: Option<String>,
+    pub section_kind: Option<String>,
+    pub row_index: usize,
+    pub column_index: usize,
+    pub element: String,
+    pub id: Option<String>,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub header: bool,
+    pub scope: Option<String>,
+    pub headers: Vec<String>,
+    pub abbr: Option<String>,
+    pub rowspan: Option<String>,
+    pub colspan: Option<String>,
 }
 
 impl BrowserDocument {
@@ -9585,15 +9606,21 @@ fn collect_browser_facts(
                 summary.base_href.as_deref(),
                 summary.base_target.as_deref(),
             )),
-            "table" => summary.tables.push(BrowserTable {
-                caption: find_first_element_in_nodes(&element.children, "caption")
-                    .map(element_text),
-                row_count: browser_table_rows(element).len(),
-                column_count: browser_table_column_count(element),
-                column_hint_count: browser_table_column_hint_count(element),
-                cell_count: browser_table_cell_count(element),
-                header_cell_count: browser_table_header_cell_count(element),
-            }),
+            "table" => {
+                let table_index = summary.tables.len() + 1;
+                summary.tables.push(BrowserTable {
+                    caption: find_first_element_in_nodes(&element.children, "caption")
+                        .map(element_text),
+                    row_count: browser_table_rows(element).len(),
+                    column_count: browser_table_column_count(element),
+                    column_hint_count: browser_table_column_hint_count(element),
+                    cell_count: browser_table_cell_count(element),
+                    header_cell_count: browser_table_header_cell_count(element),
+                });
+                summary
+                    .table_cells
+                    .extend(browser_table_cells(element, table_index, id_texts));
+            }
             name if heading_level(name).is_some() => summary.headings.push(BrowserHeading {
                 level: heading_level(name).expect("heading level was checked above"),
                 text: visible_text_for_nodes(&element.children),
@@ -15431,6 +15458,74 @@ fn browser_table_rows(table: &Element) -> Vec<&Element> {
     rows
 }
 
+fn browser_table_cells(
+    table: &Element,
+    table_index: usize,
+    id_texts: &[(String, String)],
+) -> Vec<BrowserTableCell> {
+    let table_id = table.attribute("id").map(ToOwned::to_owned);
+    let table_caption = find_first_element_in_nodes(&table.children, "caption").map(element_text);
+    let mut rows = Vec::new();
+    collect_browser_table_rows_with_sections(&table.children, None, &mut rows);
+
+    let mut cells = Vec::new();
+    let mut occupied_until: Vec<usize> = Vec::new();
+    for (row_index, (section_kind, row)) in rows.into_iter().enumerate() {
+        let mut column_index = 0;
+        for child in &row.children {
+            let Node::Element(cell) = child else {
+                continue;
+            };
+            if !matches!(cell.name.as_str(), "td" | "th") {
+                continue;
+            }
+
+            while occupied_until
+                .get(column_index)
+                .map(|occupied| *occupied > row_index)
+                .unwrap_or(false)
+            {
+                column_index += 1;
+            }
+
+            let rowspan = html_positive_integer_attribute(cell, "rowspan");
+            let colspan = html_positive_integer_attribute(cell, "colspan");
+            if rowspan > 1 {
+                for occupied_column in column_index..column_index + colspan {
+                    if occupied_until.len() <= occupied_column {
+                        occupied_until.resize(occupied_column + 1, 0);
+                    }
+                    occupied_until[occupied_column] =
+                        occupied_until[occupied_column].max(row_index + rowspan);
+                }
+            }
+
+            cells.push(BrowserTableCell {
+                table_index,
+                table_id: table_id.clone(),
+                table_caption: table_caption.clone(),
+                section_kind: section_kind.clone(),
+                row_index: row_index + 1,
+                column_index: column_index + 1,
+                element: cell.name.clone(),
+                id: cell.attribute("id").map(ToOwned::to_owned),
+                text: visible_text_for_nodes(&cell.children),
+                accessible_name: browser_accessible_name(cell, "", &[], id_texts),
+                header: cell.name == "th",
+                scope: cell.attribute("scope").map(ToOwned::to_owned),
+                headers: browser_aria_idrefs(cell, "headers"),
+                abbr: cell.attribute("abbr").map(ToOwned::to_owned),
+                rowspan: cell.attribute("rowspan").map(ToOwned::to_owned),
+                colspan: cell.attribute("colspan").map(ToOwned::to_owned),
+            });
+
+            column_index += colspan;
+        }
+    }
+
+    cells
+}
+
 fn collect_browser_table_rows<'a>(nodes: &'a [Node], rows: &mut Vec<&'a Element>) {
     for node in nodes {
         let Node::Element(element) = node else {
@@ -15440,6 +15535,32 @@ fn collect_browser_table_rows<'a>(nodes: &'a [Node], rows: &mut Vec<&'a Element>
             rows.push(element);
         } else if element.name != "table" {
             collect_browser_table_rows(&element.children, rows);
+        }
+    }
+}
+
+fn collect_browser_table_rows_with_sections<'a>(
+    nodes: &'a [Node],
+    current_section: Option<String>,
+    rows: &mut Vec<(Option<String>, &'a Element)>,
+) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+        match element.name.as_str() {
+            "tr" => rows.push((current_section.clone(), element)),
+            "thead" | "tbody" | "tfoot" => collect_browser_table_rows_with_sections(
+                &element.children,
+                Some(element.name.clone()),
+                rows,
+            ),
+            "table" => {}
+            _ => collect_browser_table_rows_with_sections(
+                &element.children,
+                current_section.clone(),
+                rows,
+            ),
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -13,7 +13,7 @@ use coding_adventures_html_parser::{
     BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
     BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
     BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -99,6 +99,8 @@ struct ExpectedBrowserDocument {
     templates: Vec<ExpectedTemplate>,
     forms: Vec<ExpectedForm>,
     tables: Vec<ExpectedTable>,
+    #[serde(default)]
+    table_cells: Vec<ExpectedTableCell>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1828,6 +1830,37 @@ struct ExpectedTable {
     header_cell_count: usize,
 }
 
+#[derive(Debug, Deserialize)]
+struct ExpectedTableCell {
+    table_index: usize,
+    #[serde(default)]
+    table_id: Option<String>,
+    #[serde(default)]
+    table_caption: Option<String>,
+    #[serde(default)]
+    section_kind: Option<String>,
+    row_index: usize,
+    column_index: usize,
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    header: bool,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    headers: Vec<String>,
+    #[serde(default)]
+    abbr: Option<String>,
+    #[serde(default)]
+    rowspan: Option<String>,
+    #[serde(default)]
+    colspan: Option<String>,
+}
+
 #[test]
 fn browser_readiness_cases_extract_browser_document_facts() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
@@ -1848,6 +1881,26 @@ fn browser_readiness_cases_extract_browser_document_facts() {
             case.id
         );
     }
+}
+
+#[test]
+fn browser_table_cell_descriptor_metadata_tracks_headers_spans_and_sections() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "table-cell-descriptor-page")
+        .expect("table cell descriptor fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("table cell descriptor fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.table_cells, expected.table_cells,
+        "table cell descriptors should preserve table context, sections, spans, headers, and grid positions",
+    );
 }
 
 #[test]
@@ -3328,6 +3381,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedTable::into_browser_table)
                 .collect(),
+            table_cells: self
+                .table_cells
+                .into_iter()
+                .map(ExpectedTableCell::into_browser_table_cell)
+                .collect(),
         }
     }
 }
@@ -4708,6 +4766,29 @@ impl ExpectedTable {
             column_hint_count: self.column_hint_count,
             cell_count: self.cell_count,
             header_cell_count: self.header_cell_count,
+        }
+    }
+}
+
+impl ExpectedTableCell {
+    fn into_browser_table_cell(self) -> BrowserTableCell {
+        BrowserTableCell {
+            table_index: self.table_index,
+            table_id: self.table_id,
+            table_caption: self.table_caption,
+            section_kind: self.section_kind,
+            row_index: self.row_index,
+            column_index: self.column_index,
+            element: self.element,
+            id: self.id,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            header: self.header,
+            scope: self.scope,
+            headers: self.headers,
+            abbr: self.abbr,
+            rowspan: self.rowspan,
+            colspan: self.colspan,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -126,6 +126,12 @@
         ],
         "tables": [
           { "caption": "Results", "row_count": 2, "column_count": 2, "column_hint_count": 0, "cell_count": 4, "header_cell_count": 2 }
+        ],
+        "table_cells": [
+          { "table_index": 1, "table_caption": "Results", "section_kind": "tbody", "row_index": 1, "column_index": 1, "element": "th", "text": "Name", "header": true },
+          { "table_index": 1, "table_caption": "Results", "section_kind": "tbody", "row_index": 1, "column_index": 2, "element": "th", "text": "Kind", "header": true },
+          { "table_index": 1, "table_caption": "Results", "section_kind": "tbody", "row_index": 2, "column_index": 1, "element": "td", "text": "Mosaic" },
+          { "table_index": 1, "table_caption": "Results", "section_kind": "tbody", "row_index": 2, "column_index": 2, "element": "td", "text": "Browser" }
         ]
       }
     },
@@ -682,6 +688,52 @@
         "forms": [],
         "tables": [
           { "caption": "Prices", "row_count": 2, "column_count": 3, "column_hint_count": 3, "cell_count": 4, "header_cell_count": 3 }
+        ],
+        "table_cells": [
+          { "table_index": 1, "table_caption": "Prices", "section_kind": "thead", "row_index": 1, "column_index": 1, "element": "th", "id": "item", "text": "Name", "header": true, "scope": "col", "abbr": "Item" },
+          { "table_index": 1, "table_caption": "Prices", "section_kind": "thead", "row_index": 1, "column_index": 2, "element": "th", "id": "price", "text": "Price", "header": true, "scope": "col" },
+          { "table_index": 1, "table_caption": "Prices", "section_kind": "tbody", "row_index": 2, "column_index": 1, "element": "th", "text": "Basic", "header": true, "scope": "row", "headers": ["item"] },
+          { "table_index": 1, "table_caption": "Prices", "section_kind": "tbody", "row_index": 2, "column_index": 2, "element": "td", "text": "$1", "headers": ["item", "price"], "colspan": "2" }
+        ]
+      }
+    },
+    {
+      "id": "table-cell-descriptor-page",
+      "description": "Browser document summaries expose table cell descriptors with section context, header associations, spans, and grid positions.",
+      "input": "<body><table id=matrix aria-label=Schedule><caption>Schedule</caption><thead><tr><th id=day scope=col abbr=Day>Day<th id=morning scope=col>Morning<th id=evening scope=col>Evening<tbody><tr><th id=mon scope=row rowspan=2 headers=day>Mon<td headers=\"mon morning\">Standup<td headers=\"mon evening\" colspan=2>Review<tr><td headers=\"mon morning\">Focus<td headers=\"mon evening\">Wrap<tfoot><tr><th scope=row>Totals<td headers=morning>3<td headers=evening>2</table>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Schedule Day Morning Evening Mon Standup Review Focus Wrap Totals 3 2",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "matrix", "name": null, "text": "Schedule Day Morning Evening Mon Standup Review Focus Wrap Totals 3 2" },
+          { "id": "day", "name": null, "text": "Day" },
+          { "id": "morning", "name": null, "text": "Morning" },
+          { "id": "evening", "name": null, "text": "Evening" },
+          { "id": "mon", "name": null, "text": "Mon" }
+        ],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": [
+          { "caption": "Schedule", "row_count": 4, "column_count": 4, "column_hint_count": 0, "cell_count": 11, "header_cell_count": 5 }
+        ],
+        "table_cells": [
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "thead", "row_index": 1, "column_index": 1, "element": "th", "id": "day", "text": "Day", "header": true, "scope": "col", "abbr": "Day" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "thead", "row_index": 1, "column_index": 2, "element": "th", "id": "morning", "text": "Morning", "header": true, "scope": "col" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "thead", "row_index": 1, "column_index": 3, "element": "th", "id": "evening", "text": "Evening", "header": true, "scope": "col" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tbody", "row_index": 2, "column_index": 1, "element": "th", "id": "mon", "text": "Mon", "header": true, "scope": "row", "headers": ["day"], "rowspan": "2" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tbody", "row_index": 2, "column_index": 2, "element": "td", "text": "Standup", "headers": ["mon", "morning"] },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tbody", "row_index": 2, "column_index": 3, "element": "td", "text": "Review", "headers": ["mon", "evening"], "colspan": "2" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tbody", "row_index": 3, "column_index": 2, "element": "td", "text": "Focus", "headers": ["mon", "morning"] },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tbody", "row_index": 3, "column_index": 3, "element": "td", "text": "Wrap", "headers": ["mon", "evening"] },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 1, "element": "th", "text": "Totals", "header": true, "scope": "row" },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 2, "element": "td", "text": "3", "headers": ["morning"] },
+          { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 3, "element": "td", "text": "2", "headers": ["evening"] }
         ]
       }
     },


### PR DESCRIPTION
Summary:
- add BrowserTableCell descriptors to browser document extraction
- capture table/caption context, section kind, 1-based grid positions, header state, scope, headers, abbr, rowspan, and colspan
- add browser-readiness fixture schema validation plus focused fixture/test coverage

Tests:
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_table_cell_descriptor_metadata_tracks_headers_spans_and_sections
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser