### PR TITLE
Track browser data attribute descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -263,6 +263,9 @@ def check_browser_readiness_case(
         f"{case_path}.expected", expected, "component_hydration_targets", errors
     )
     require_optional_object_list(
+        f"{case_path}.expected", expected, "data_attribute_descriptors", errors
+    )
+    require_optional_object_list(
         f"{case_path}.expected", expected, "structured_items", errors
     )
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
@@ -887,6 +890,25 @@ def check_browser_expected_lists(
             object_list_items(target, "data_attributes")
         ):
             data_path = f"{target_path}.data_attributes[{data_index}]"
+            require_string(data_path, data_attribute, "name", errors)
+            require_optional_nullable_string(data_path, data_attribute, "value", errors)
+
+    for index, descriptor in enumerate(
+        object_list_items(expected, "data_attribute_descriptors")
+    ):
+        descriptor_path = f"{case_path}.expected.data_attribute_descriptors[{index}]"
+        require_string(descriptor_path, descriptor, "element", errors)
+        for field in ("id", "custom_element_name", "custom_element_is", "slot", "slot_name"):
+            require_optional_nullable_string(descriptor_path, descriptor, field, errors)
+        for field in ("classes", "part"):
+            require_optional_string_list(descriptor_path, descriptor, field, errors)
+        require_optional_boolean(descriptor_path, descriptor, "custom_element", errors)
+        require_optional_string(descriptor_path, descriptor, "text", errors)
+        require_optional_object_list(descriptor_path, descriptor, "data_attributes", errors)
+        for data_index, data_attribute in enumerate(
+            object_list_items(descriptor, "data_attributes")
+        ):
+            data_path = f"{descriptor_path}.data_attributes[{data_index}]"
             require_string(data_path, data_attribute, "name", errors)
             require_optional_nullable_string(data_path, data_attribute, "value", errors)
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -849,6 +849,7 @@ pub struct BrowserDocument {
     pub interactive_elements: Vec<BrowserInteractiveElement>,
     pub disclosures: Vec<BrowserDisclosure>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
+    pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
     pub structured_items: Vec<BrowserStructuredItem>,
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
@@ -1072,6 +1073,21 @@ pub struct BrowserComponentHydrationTarget {
 pub struct BrowserDataAttribute {
     pub name: String,
     pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserDataAttributeDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub custom_element: bool,
+    pub custom_element_name: Option<String>,
+    pub custom_element_is: Option<String>,
+    pub slot: Option<String>,
+    pub slot_name: Option<String>,
+    pub part: Vec<String>,
+    pub data_attributes: Vec<BrowserDataAttribute>,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -9542,6 +9558,9 @@ fn collect_browser_facts(
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
+        if let Some(descriptor) = browser_data_attribute_descriptor(element) {
+            summary.data_attribute_descriptors.push(descriptor);
+        }
         if element.name == "template" {
             summary.templates.push(browser_template(element));
         }
@@ -11778,6 +11797,34 @@ fn browser_component_hydration_target(
         exportparts,
         data_attributes,
         canvas_fallback_text: is_canvas.then(|| visible_text_for_nodes(&element.children)),
+        text: visible_text_for_nodes(&element.children),
+    })
+}
+
+fn browser_data_attribute_descriptor(element: &Element) -> Option<BrowserDataAttributeDescriptor> {
+    let data_attributes = browser_data_attributes(element);
+    if data_attributes.is_empty() {
+        return None;
+    }
+
+    let custom_element_name = browser_custom_element_name(element);
+    let custom_element_is = browser_custom_element_is(element);
+    let custom_element = custom_element_name.is_some() || custom_element_is.is_some();
+
+    Some(BrowserDataAttributeDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        custom_element,
+        custom_element_name,
+        custom_element_is,
+        slot: browser_slot_assignment(element),
+        slot_name: browser_slot_name(element),
+        part: browser_part_tokens(element),
+        data_attributes,
         text: visible_text_for_nodes(&element.children),
     })
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,19 +1,20 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserAriaCollection, BrowserAriaCollectionItem,
     BrowserAriaLiveRegion, BrowserAriaRange, BrowserCommandElement,
-    BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDatalistOption,
-    BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata, BrowserEmbeddedContext,
-    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
-    BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserHeading, BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea,
-    BrowserImageSource, BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
+    BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
+    BrowserEmbeddedContext, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
+    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
+    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
+    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
+    BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -93,6 +94,8 @@ struct ExpectedBrowserDocument {
     disclosures: Vec<ExpectedDisclosure>,
     #[serde(default)]
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
+    #[serde(default)]
+    data_attribute_descriptors: Vec<ExpectedDataAttributeDescriptor>,
     #[serde(default)]
     structured_items: Vec<ExpectedStructuredItem>,
     #[serde(default)]
@@ -294,6 +297,31 @@ struct ExpectedDataAttribute {
     name: String,
     #[serde(default)]
     value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDataAttributeDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    custom_element: bool,
+    #[serde(default)]
+    custom_element_name: Option<String>,
+    #[serde(default)]
+    custom_element_is: Option<String>,
+    #[serde(default)]
+    slot: Option<String>,
+    #[serde(default)]
+    slot_name: Option<String>,
+    #[serde(default)]
+    part: Vec<String>,
+    #[serde(default)]
+    data_attributes: Vec<ExpectedDataAttribute>,
+    #[serde(default)]
+    text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3240,6 +3268,28 @@ fn browser_component_hydration_metadata_tracks_custom_elements_slots_parts_and_d
     );
 }
 
+#[test]
+fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_elements() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "component-template-page")
+        .expect("component template fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("component template fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.data_attribute_descriptors,
+        case.expected
+            .into_browser_document()
+            .data_attribute_descriptors,
+        "data attribute descriptors should preserve custom element, slot, part, and visible-text context for all data-* carriers",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         BrowserDocument {
@@ -3360,6 +3410,11 @@ impl ExpectedBrowserDocument {
                 .component_hydration_targets
                 .into_iter()
                 .map(ExpectedComponentHydrationTarget::into_browser_component_hydration_target)
+                .collect(),
+            data_attribute_descriptors: self
+                .data_attribute_descriptors
+                .into_iter()
+                .map(ExpectedDataAttributeDescriptor::into_browser_data_attribute_descriptor)
                 .collect(),
             structured_items: self
                 .structured_items
@@ -3577,6 +3632,28 @@ impl ExpectedDataAttribute {
         BrowserDataAttribute {
             name: self.name,
             value: self.value,
+        }
+    }
+}
+
+impl ExpectedDataAttributeDescriptor {
+    fn into_browser_data_attribute_descriptor(self) -> BrowserDataAttributeDescriptor {
+        BrowserDataAttributeDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            custom_element: self.custom_element,
+            custom_element_name: self.custom_element_name,
+            custom_element_is: self.custom_element_is,
+            slot: self.slot,
+            slot_name: self.slot_name,
+            part: self.part,
+            data_attributes: self
+                .data_attributes
+                .into_iter()
+                .map(ExpectedDataAttribute::into_browser_data_attribute)
+                .collect(),
+            text: self.text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1389,6 +1389,13 @@
           { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "text": "Save" },
           { "element": "slot", "slot_name": "footer", "part": ["footer"], "text": "Fallback footer" }
         ],
+        "data_attribute_descriptors": [
+          { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "text": "Untitled Body" },
+          { "element": "product-card", "id": "card", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "data_attributes": [{ "name": "data-controller", "value": "product" }, { "name": "data-state", "value": "ready" }], "text": "Widget Chart fallback Save Fallback footer" },
+          { "element": "span", "slot": "title", "part": ["title"], "data_attributes": [{ "name": "data-field", "value": "name" }], "text": "Widget" },
+          { "element": "canvas", "id": "chart", "part": ["chart"], "data_attributes": [{ "name": "data-renderer", "value": "canvas" }], "text": "Chart fallback" },
+          { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "text": "Save" }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add top-level BrowserDocument data attribute descriptors using the existing parsed data-* attribute primitive
- expose element identity, custom-element hints, slot/part context, and visible text for each data-* carrier
- extend browser-readiness fixture expectations and schema governance for the new descriptor inventory

## Tests
- cargo test -p coding-adventures-html-parser browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_elements
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser