### PR TITLE
Track browser popover descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -246,6 +246,7 @@ def check_browser_readiness_case(
     require_optional_object_list(f"{case_path}.expected", expected, "navigation_groups", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "section_landmarks", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "command_elements", errors)
+    require_optional_object_list(f"{case_path}.expected", expected, "popovers", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_collections", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_ranges", errors)
     require_optional_object_list(f"{case_path}.expected", expected, "aria_live_regions", errors)
@@ -581,6 +582,37 @@ def check_browser_expected_lists(
             "disabled",
         ):
             require_optional_boolean(command_path, command, field, errors)
+
+    for index, popover in enumerate(object_list_items(expected, "popovers")):
+        popover_path = f"{case_path}.expected.popovers[{index}]"
+        for field in ("element", "role", "text", "popover"):
+            require_string(popover_path, popover, field, errors)
+        for field in (
+            "id",
+            "accessible_name",
+            "accessible_description",
+            "aria_label",
+        ):
+            require_optional_nullable_string(popover_path, popover, field, errors)
+        for field in ("aria_labelledby", "aria_describedby"):
+            require_optional_string_list(popover_path, popover, field, errors)
+        require_optional_object_list(popover_path, popover, "invokers", errors)
+        for invoker_index, invoker in enumerate(object_list_items(popover, "invokers")):
+            invoker_path = f"{popover_path}.invokers[{invoker_index}]"
+            for field in ("element", "text", "command_kind"):
+                require_string(invoker_path, invoker, field, errors)
+            for field in (
+                "id",
+                "accessible_name",
+                "command",
+                "command_for",
+                "popover_target",
+                "popover_target_action",
+                "aria_expanded",
+            ):
+                require_optional_nullable_string(invoker_path, invoker, field, errors)
+            require_optional_string_list(invoker_path, invoker, "aria_controls", errors)
+            require_optional_boolean(invoker_path, invoker, "focusable", errors)
 
     for index, collection in enumerate(object_list_items(expected, "aria_collections")):
         collection_path = f"{case_path}.expected.aria_collections[{index}]"

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -838,6 +838,7 @@ pub struct BrowserDocument {
     pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub command_elements: Vec<BrowserCommandElement>,
+    pub popovers: Vec<BrowserPopover>,
     pub aria_collections: Vec<BrowserAriaCollection>,
     pub aria_ranges: Vec<BrowserAriaRange>,
     pub aria_live_regions: Vec<BrowserAriaLiveRegion>,
@@ -1840,6 +1841,37 @@ pub struct BrowserInteractiveElement {
     pub command: Option<String>,
     pub command_for: Option<String>,
     pub disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserPopover {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub popover: String,
+    pub invokers: Vec<BrowserPopoverInvoker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserPopoverInvoker {
+    pub element: String,
+    pub id: Option<String>,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub command_kind: String,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub aria_controls: Vec<String>,
+    pub aria_expanded: Option<String>,
+    pub focusable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9546,6 +9578,9 @@ fn collect_browser_facts(
         ) {
             summary.command_elements.push(command_element);
         }
+        if let Some(popover) = browser_popover_element(element, labels, id_texts, body_root) {
+            summary.popovers.push(popover);
+        }
         if let Some(aria_collection) = browser_aria_collection_element(element, id_texts) {
             summary.aria_collections.push(aria_collection);
         }
@@ -11429,6 +11464,99 @@ fn browser_command_focusable(element: &Element) -> bool {
     }
 
     matches!(element.name.as_str(), "button" | "input" | "summary")
+}
+
+fn browser_popover_element(
+    element: &Element,
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+    body_root: &[Node],
+) -> Option<BrowserPopover> {
+    let popover = element.attribute("popover")?.to_string();
+    let role = browser_content_role(&element.name).unwrap_or(element.name.as_str());
+    let id = element.attribute("id").map(ToOwned::to_owned);
+    let invokers = id
+        .as_deref()
+        .map(|id| browser_popover_invokers(body_root, labels, id_texts, id))
+        .unwrap_or_default();
+
+    Some(BrowserPopover {
+        element: element.name.clone(),
+        id,
+        role: role.to_string(),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, role, &[], id_texts),
+        accessible_description: browser_accessible_description(element, id_texts),
+        aria_label: browser_aria_label(element),
+        aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
+        aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
+        popover,
+        invokers,
+    })
+}
+
+fn browser_popover_invokers(
+    nodes: &[Node],
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+    target_id: &str,
+) -> Vec<BrowserPopoverInvoker> {
+    let mut invokers = Vec::new();
+    collect_browser_popover_invokers(nodes, labels, id_texts, target_id, &mut invokers);
+    invokers
+}
+
+fn collect_browser_popover_invokers(
+    nodes: &[Node],
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+    target_id: &str,
+    invokers: &mut Vec<BrowserPopoverInvoker>,
+) {
+    for node in nodes {
+        let Node::Element(element) = node else {
+            continue;
+        };
+
+        if browser_popover_target(element).as_deref() == Some(target_id)
+            || browser_command_for(element).as_deref() == Some(target_id)
+        {
+            invokers.push(browser_popover_invoker(element, labels, id_texts));
+        }
+
+        collect_browser_popover_invokers(&element.children, labels, id_texts, target_id, invokers);
+    }
+}
+
+fn browser_popover_invoker(
+    element: &Element,
+    labels: &[(String, String)],
+    id_texts: &[(String, String)],
+) -> BrowserPopoverInvoker {
+    let role = browser_command_role(element);
+    let control_labels = browser_control_labels(element, labels, None);
+    let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+
+    BrowserPopoverInvoker {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        text: text.clone(),
+        accessible_name: browser_command_accessible_name(
+            element,
+            role.as_str(),
+            &control_labels,
+            id_texts,
+            &text,
+        ),
+        command_kind: browser_command_kind(element).unwrap_or_else(|| "command".to_string()),
+        command: browser_command(element),
+        command_for: browser_command_for(element),
+        popover_target: browser_popover_target(element),
+        popover_target_action: browser_popover_target_action(element),
+        aria_controls: browser_aria_idrefs(element, "aria-controls"),
+        aria_expanded: browser_aria_state(element, "aria-expanded"),
+        focusable: browser_command_focusable(element),
+    }
 }
 
 fn browser_aria_collection_element(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -11,10 +11,10 @@ use coding_adventures_html_parser::{
     BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover, BrowserPopoverInvoker,
+    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -74,6 +74,8 @@ struct ExpectedBrowserDocument {
     section_landmarks: Vec<ExpectedSectionLandmark>,
     #[serde(default)]
     command_elements: Vec<ExpectedCommandElement>,
+    #[serde(default)]
+    popovers: Vec<ExpectedPopover>,
     #[serde(default)]
     aria_collections: Vec<ExpectedAriaCollection>,
     #[serde(default)]
@@ -626,6 +628,53 @@ struct ExpectedCommandElement {
     focusable: bool,
     #[serde(default)]
     disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedPopover {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    popover: String,
+    #[serde(default)]
+    invokers: Vec<ExpectedPopoverInvoker>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedPopoverInvoker {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    command_kind: String,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    aria_controls: Vec<String>,
+    #[serde(default)]
+    aria_expanded: Option<String>,
+    #[serde(default)]
+    focusable: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2116,6 +2165,26 @@ fn browser_command_element_descriptor_metadata_tracks_activation_surfaces() {
 }
 
 #[test]
+fn browser_popover_descriptor_metadata_tracks_hosts_and_invokers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "popover-command-descriptor-page")
+        .expect("popover command fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("popover command fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.popovers, expected.popovers,
+        "popover descriptors should preserve host metadata and popovertarget/commandfor invoker relationships",
+    );
+}
+
+#[test]
 fn browser_aria_collection_descriptor_metadata_tracks_grouped_composites() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3356,6 +3425,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedCommandElement::into_browser_command_element)
                 .collect(),
+            popovers: self
+                .popovers
+                .into_iter()
+                .map(ExpectedPopover::into_browser_popover)
+                .collect(),
             aria_collections: self
                 .aria_collections
                 .into_iter()
@@ -3889,6 +3963,47 @@ impl ExpectedCommandElement {
             event_handlers: self.event_handlers,
             focusable: self.focusable,
             disabled: self.disabled,
+        }
+    }
+}
+
+impl ExpectedPopover {
+    fn into_browser_popover(self) -> BrowserPopover {
+        BrowserPopover {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            popover: self.popover,
+            invokers: self
+                .invokers
+                .into_iter()
+                .map(ExpectedPopoverInvoker::into_browser_popover_invoker)
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedPopoverInvoker {
+    fn into_browser_popover_invoker(self) -> BrowserPopoverInvoker {
+        BrowserPopoverInvoker {
+            element: self.element,
+            id: self.id,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            command_kind: self.command_kind,
+            command: self.command,
+            command_for: self.command_for,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            aria_controls: self.aria_controls,
+            aria_expanded: self.aria_expanded,
+            focusable: self.focusable,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1032,6 +1032,9 @@
           { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown"] },
           { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
         ],
+        "popovers": [
+          { "element": "div", "id": "action", "role": "block", "text": "Inline action", "popover": "manual" }
+        ],
         "aria_live_regions": [
           { "element": "section", "id": "panel", "role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "update_kind": "polite" }
         ],
@@ -1051,6 +1054,68 @@
         "disclosures": [
           { "element": "dialog", "id": "dialog", "text": "Dialog copy", "open": true, "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true" },
           { "element": "details", "id": "more", "text": "More Extra", "summary_text": "More", "open": true, "accessible_name": "More" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "popover-command-descriptor-page",
+      "description": "Browser document summaries expose popover hosts with their popovertarget and commandfor invoker relationships.",
+      "input": "<body><button id=open popovertarget=menu-pop popovertargetaction=show aria-controls=menu-pop aria-expanded=false>Open menu</button><button id=close command=hide-popover commandfor=menu-pop>Close menu</button><div id=menu-pop popover=manual aria-label=Actions><h2>Actions</h2><p>Archive</p></div><div id=note-pop popover=auto aria-labelledby=note-title><h3 id=note-title>Note</h3><p>Saved</p></div></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Open menu Close menu Actions Archive Note Saved",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "open", "name": null, "text": "Open menu" },
+          { "id": "close", "name": null, "text": "Close menu" },
+          { "id": "menu-pop", "name": null, "text": "Actions Archive" },
+          { "id": "note-pop", "name": null, "text": "Note Saved" },
+          { "id": "note-title", "name": null, "text": "Note" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Actions" },
+          { "level": 3, "text": "Note" }
+        ],
+        "command_elements": [
+          { "element": "button", "id": "open", "role": "control", "command_kind": "popover", "text": "Open menu", "accessible_name": "Open menu", "control_type": "submit", "popover_target": "menu-pop", "popover_target_action": "show", "aria_controls": ["menu-pop"], "aria_expanded": "false", "focusable": true },
+          { "element": "button", "id": "close", "role": "control", "command_kind": "command", "text": "Close menu", "accessible_name": "Close menu", "control_type": "submit", "command": "hide-popover", "command_for": "menu-pop", "focusable": true }
+        ],
+        "popovers": [
+          {
+            "element": "div",
+            "id": "menu-pop",
+            "role": "block",
+            "text": "Actions Archive",
+            "accessible_name": "Actions",
+            "aria_label": "Actions",
+            "popover": "manual",
+            "invokers": [
+              { "element": "button", "id": "open", "text": "Open menu", "accessible_name": "Open menu", "command_kind": "popover", "popover_target": "menu-pop", "popover_target_action": "show", "aria_controls": ["menu-pop"], "aria_expanded": "false", "focusable": true },
+              { "element": "button", "id": "close", "text": "Close menu", "accessible_name": "Close menu", "command_kind": "command", "command": "hide-popover", "command_for": "menu-pop", "focusable": true }
+            ]
+          },
+          {
+            "element": "div",
+            "id": "note-pop",
+            "role": "block",
+            "text": "Note Saved",
+            "accessible_name": "Note",
+            "aria_labelledby": ["note-title"],
+            "popover": "auto"
+          }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [
+          { "element": "button", "id": "open", "role": "control", "text": "Open menu", "accessible_name": "Open menu", "aria_controls": ["menu-pop"], "aria_expanded": "false", "popover_target": "menu-pop", "popover_target_action": "show" },
+          { "element": "button", "id": "close", "role": "control", "text": "Close menu", "accessible_name": "Close menu", "command": "hide-popover", "command_for": "menu-pop" },
+          { "element": "div", "id": "menu-pop", "role": "block", "text": "Actions Archive", "accessible_name": "Actions", "aria_label": "Actions", "popover": "manual" },
+          { "element": "div", "id": "note-pop", "role": "block", "text": "Note Saved", "accessible_name": "Note", "aria_labelledby": ["note-title"], "popover": "auto" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- add top-level BrowserDocument popover descriptors for elements with the popover attribute
- connect each popover host to popovertarget and commandfor invokers using existing command metadata helpers
- extend browser-readiness fixture expectations and schema governance for popovers and nested invokers

## Tests
- cargo test -p coding-adventures-html-parser browser_popover_descriptor_metadata_tracks_hosts_and_invokers
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser