### PR TITLE
Close negative cosine Weierstrass branch across CAS ports

### DIFF
--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1329,6 +1329,7 @@ def _try_weierstrass_one_over_linear_trig(
         return None
     sqrt_disc_ir = _sqrt_fraction_ir(disc)
     tan_half = IRApply(TAN, (IRApply(DIV, (arg_node, TWO)),))
+    coef_sign = Fraction(1)
     if trig_head == SIN:
         # arctan argument: (a·tan(x/2) + b) / √(a²−b²)
         atan_arg_top = IRApply(
@@ -1338,20 +1339,19 @@ def _try_weierstrass_one_over_linear_trig(
         atan_arg = IRApply(DIV, (atan_arg_top, sqrt_disc_ir))
     else:  # COS
         # arctan argument: √((a−b)/(a+b)) · tan(x/2)
-        # Since a² > b², we have a+b ≠ 0; sign of (a−b)/(a+b) is positive
-        # iff a > 0 (and both numerator and denominator share the sign).
-        # When a < 0 the standard form needs adjustment; rather than chase
-        # branch issues, require a > 0 here and defer the a < 0 case.
-        if a <= 0:
-            return None
+        # Since a² > b², a-b and a+b share sign(a), so the ratio is positive.
+        # When a < 0, flip the outer coefficient to account for the negative
+        # factor introduced by the tangent-half-angle denominator quadratic.
+        if a < 0:
+            coef_sign = Fraction(-1)
         ratio = (a - b) / (a + b)
         if ratio <= 0:
-            # Cannot happen when a² > b² and a > 0, but defensive.
+            # Cannot happen when a² > b² with nonzero a, but defensive.
             return None
         sqrt_ratio_ir = _sqrt_fraction_ir(ratio)
         atan_arg = IRApply(MUL, (sqrt_ratio_ir, tan_half))
     # Final result: (2c/√(a²−b²)) · arctan(...)
-    coef_frac = c * 2
+    coef_frac = c * 2 * coef_sign
     coef_ir = IRApply(DIV, (_frac_ir(coef_frac), sqrt_disc_ir))
     return IRApply(MUL, (coef_ir, IRApply(ATAN, (atan_arg,))))
 

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -201,6 +201,22 @@ def test_cos_five_plus_three_cos(vm: VM) -> None:
         assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4)
 
 
+def test_cos_negative_a_arctan_branch_closes(vm: VM) -> None:
+    """``∫ 1/(-2 + cos(x)) dx`` closes with the sign-correct atan form."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(ADD, (IRInteger(-2), IRApply(COS, (X,))))))
+    phi = vm.eval(_integrate(integrand))
+    assert not (isinstance(phi, IRApply) and phi.head == INTEGRATE), (
+        f"Phase 34 should close ∫ 1/(-2+cos x) dx; got {phi!r}"
+    )
+    assert _contains_head(phi, ATAN)
+    for x_val in (-1.5, -0.4, 0.0, 0.4, 1.5):
+        got = _numerical_derivative(vm, phi, x_val)
+        expected = 1.0 / (-2.0 + math.cos(x_val))
+        assert math.isclose(got, expected, abs_tol=1e-4, rel_tol=1e-4), (
+            f"At x={x_val}: derivative={got!r}, expected={expected!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Operand-order robustness
 # ---------------------------------------------------------------------------

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1512,15 +1512,15 @@ fn derivative_handler() -> Handler {
 
 // ---------------------------------------------------------------------------
 // Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
-// ∫ c/(a + b·cos(x)) dx with rational a, b satisfying a² > b² (a > 0 for cos).
+// ∫ c/(a + b·cos(x)) dx with rational a, b satisfying a² > b².
 // Mirrors Python symbolic-vm 0.59.0 and TypeScript symbolic-vm 0.7.0.
 //
 // Closed forms:
 //   ∫ 1/(a + b·sin x) dx = (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
 //   ∫ 1/(a + b·cos x) dx = (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
 //
-// Discriminant cases a² ≤ b² and a ≤ 0 for cos are deferred — they need
-// sign analysis the assumption-free port cannot perform symbolically.
+// Symbolic-coefficient discriminant cases are deferred — they need sign
+// analysis the assumption-free port cannot perform symbolically.
 // ---------------------------------------------------------------------------
 
 /// Convert an IRNode to a `RatC` rational if it's an Integer or Rational
@@ -1940,6 +1940,7 @@ fn try_weierstrass_one_over_linear_trig(
         TAN,
         vec![apply_node(DIV, vec![arg_node.clone(), IRNode::Integer(2)])],
     );
+    let mut coef_sign: RatC = (1, 1);
     let atan_arg = if trig_head == SIN {
         // (a·tan(x/2) + b) / √disc
         let a_ir = rc_to_ir(a_rc)?;
@@ -1950,9 +1951,10 @@ fn try_weierstrass_one_over_linear_trig(
         );
         apply_node(DIV, vec![top, sqrt_disc_ir.clone()])
     } else {
-        // cos branch — require a > 0 to avoid sign-flip.
-        if a_rc.0 <= 0 {
-            return None;
+        // cos branch — a < 0 uses the same atan argument, but the
+        // denominator quadratic has an overall negative factor.
+        if a_rc.0 < 0 {
+            coef_sign = (-1, 1);
         }
         let ratio = rc_div(rc_sub(a_rc, b_rc)?, rc_add(a_rc, b_rc)?)?;
         if ratio.0 <= 0 {
@@ -1962,7 +1964,7 @@ fn try_weierstrass_one_over_linear_trig(
         apply_node(MUL, vec![sqrt_ratio_ir, tan_half])
     };
     // Outer coefficient: 2c / √disc
-    let two_c = rc_mul(c_rc, (2, 1))?;
+    let two_c = rc_mul(rc_mul(c_rc, (2, 1))?, coef_sign)?;
     let coef_ir = apply_node(DIV, vec![rc_to_ir(two_c)?, sqrt_disc_ir]);
     Some(apply_node(MUL, vec![coef_ir, apply_node(ATAN, vec![atan_arg])]))
 }

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2502,6 +2502,28 @@ fn phase34_cos_five_plus_three_cos_sqrt_free() {
 }
 
 #[test]
+fn phase34_cos_negative_a_arctan_branch_closes() {
+    let integrand = apply(
+        sym(DIV),
+        vec![int(1), apply(sym(ADD), vec![int(-2), apply(sym(COS), vec![sym("x")])])],
+    );
+    let phi = integrate(integrand);
+    assert!(
+        !is_unevaluated_integrate(&phi),
+        "Phase 34 should close 1/(-2 + cos x); got {phi:?}"
+    );
+    assert!(contains_head(&phi, ATAN), "Expected Atan in {phi:?}");
+    for &x_val in &[-1.5_f64, -0.4, 0.0, 0.4, 1.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (-2.0 + x_val.cos());
+        assert!(
+            (got - expected).abs() < 1e-4,
+            "At x={x_val}: derivative={got}, expected={expected}"
+        );
+    }
+}
+
+#[test]
 fn phase34_sin_operand_order_swapped() {
     // ∫ 1/(sin x + 2) dx — constant on the right.  Must still close.
     let integrand = apply(

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -2535,16 +2535,16 @@ function integrate(): Handler {
 
 // ---------------------------------------------------------------------------
 // Phase 34 — Weierstrass substitution for ∫ c/(a + b·sin(x)) dx and
-// ∫ c/(a + b·cos(x)) dx with numeric a, b satisfying a² > b² (and a > 0
-// for the cos branch).  Mirrors the Python port at symbolic-vm 0.59.0.
+// ∫ c/(a + b·cos(x)) dx with numeric a, b satisfying a² > b².
+// Mirrors the Python port at symbolic-vm 0.59.0.
 //
 // Closed forms:
 //   ∫ 1/(a + b·sin x) dx = (2/√(a²−b²)) · arctan((a·tan(x/2) + b)/√(a²−b²))
 //   ∫ 1/(a + b·cos x) dx = (2/√(a²−b²)) · arctan(√((a−b)/(a+b)) · tan(x/2))
 //
 // Numerator constants c scale the result.  Discriminant cases a² ≤ b² and
-// the a ≤ 0 cos branch are deliberately deferred — they need sign analysis
-// that the assumption-free TS port cannot perform symbolically.
+// symbolic-coefficient discriminant cases are deliberately deferred — they
+// need sign analysis that the assumption-free TS port cannot perform.
 // ---------------------------------------------------------------------------
 
 /**
@@ -2844,14 +2844,16 @@ function tryWeierstrassOneOverLinearTrig(
   }
   const sqrtDiscIR = weierstrassSqrtFractionIR(disc);
   const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
+  let coefSign: Numeric = { kind: "int", value: 1n };
   let atanArg: IRNode;
   if (equals(trigHead, SIN)) {
     // (a·tan(arg/2) + b) / √(a²−b²)
     const top = app(ADD, [app(MUL, [fromNumeric(a), tanHalf]), fromNumeric(b)]);
     atanArg = app(DIV, [top, sqrtDiscIR]);
   } else {
-    // COS branch: requires a > 0 to avoid sign-flip; defers otherwise.
-    if (!isPositiveNumeric(a)) return undefined;
+    // COS branch: a < 0 uses the same atan argument, but the denominator
+    // quadratic has an overall negative factor.
+    if (!isPositiveNumeric(a)) coefSign = { kind: "int", value: -1n };
     // ratio = (a − b) / (a + b)
     const ratio = divNumeric(subNumeric(a, b), addNumeric(a, b));
     if (!isPositiveNumeric(ratio)) return undefined;
@@ -2859,7 +2861,7 @@ function tryWeierstrassOneOverLinearTrig(
     atanArg = app(MUL, [sqrtRatioIR, tanHalf]);
   }
   // Outer coefficient: 2c / √(a²−b²)
-  const coefFrac = mulNumeric(c, { kind: "int", value: 2n });
+  const coefFrac = mulNumeric(mulNumeric(c, { kind: "int", value: 2n }), coefSign);
   const coefIR = app(DIV, [fromNumeric(coefFrac), sqrtDiscIR]);
   return app(MUL, [coefIR, app(ATAN, [atanArg])]);
 }

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -166,6 +166,19 @@ describe("Phase 34: ∫ 1/(a + b·cos x) dx (Weierstrass arctan form)", () => {
       expect(Math.abs(got - expected)).toBeLessThan(1e-4);
     }
   });
+
+  it("negative a in the cosine arctan branch closes with the correct sign", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(ADD, [int(-2), app(COS, [X])])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    expect(containsHead(phi, ATAN)).toBe(true);
+    for (const xVal of [-1.5, -0.4, 0.0, 0.4, 1.5]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / (-2 + Math.cos(xVal));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fresh MACSYMA parity pass found that the Phase 34 Weierstrass arctan implementation handled `c/(a + b*cos(x))` only for the positive-`a` branch even when the numeric discriminant satisfied `a^2 > b^2`. That left cases such as `integrate(1/(-2 + cos(x)), x)` unevaluated despite the same tangent-half-angle form being valid with an outer sign flip.

This PR closes that gap across the three maintained ports:

- Python reference implementation: accepts the negative-`a` cosine arctan branch and flips the outer coefficient.
- TypeScript/Web implementation: mirrors the sign handling and updates the parity comments.
- Rust speed implementation: mirrors the same rational sign handling.
- Adds derivative-based regression tests in all three ports for `1/(-2 + cos(x))`.

## MACSYMA Closure Plan Context

I treated this as the first work item from a fresh parity audit rather than a tiny isolated cleanup. The current repository already has broad MACSYMA work landed, but the remaining risk is branch/completeness drift between the Python reference, TS/Web port, and Rust port. The working plan is:

1. Audit parity claims against executable behavior, especially assumption-sensitive branches.
2. Close each real gap in Python first, then mirror TypeScript and Rust in the same PR where feasible.
3. Require derivative/evaluation-style regression coverage across all three ports for every symbolic integration gap.
4. Monitor CI and merge state before moving to the next parity item.

## Validation

- `python -m pytest code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py -q --no-cov` -> 36 passed
- `npm ci` in `code/packages/typescript/symbolic-vm` using a portable Node/npm install
- `npm test -- phase34-weierstrass.test.ts` -> 36 passed
- `git diff --check`

Rust note: `cargo test phase34_cos_negative_a_arctan_branch_closes` compiles source crates but local linking is blocked by missing Windows MSVC/SDK libraries (`kernel32.lib`, `ntdll.lib`, etc.). CI should validate this lane on the configured runner.