### PR TITLE
Track browser global state descriptors

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -267,6 +267,9 @@ def check_browser_readiness_case(
         f"{case_path}.expected", expected, "data_attribute_descriptors", errors
     )
     require_optional_object_list(
+        f"{case_path}.expected", expected, "global_state_descriptors", errors
+    )
+    require_optional_object_list(
         f"{case_path}.expected", expected, "structured_items", errors
     )
     require_optional_object_list(f"{case_path}.expected", expected, "templates", errors)
@@ -943,6 +946,29 @@ def check_browser_expected_lists(
             data_path = f"{descriptor_path}.data_attributes[{data_index}]"
             require_string(data_path, data_attribute, "name", errors)
             require_optional_nullable_string(data_path, data_attribute, "value", errors)
+
+    for index, state in enumerate(object_list_items(expected, "global_state_descriptors")):
+        state_path = f"{case_path}.expected.global_state_descriptors[{index}]"
+        require_string(state_path, state, "element", errors)
+        for field in (
+            "id",
+            "title",
+            "lang",
+            "dir",
+            "tabindex",
+            "contenteditable",
+            "editing_mode",
+            "draggable",
+            "draggable_state",
+            "spellcheck",
+            "translate",
+        ):
+            require_optional_nullable_string(state_path, state, field, errors)
+        for field in ("classes", "accesskey"):
+            require_optional_string_list(state_path, state, field, errors)
+        for field in ("hidden", "inert", "autofocus"):
+            require_optional_boolean(state_path, state, field, errors)
+        require_optional_string(state_path, state, "text", errors)
 
     for index, item in enumerate(object_list_items(expected, "structured_items")):
         item_path = f"{case_path}.expected.structured_items[{index}]"

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -5,6 +5,11 @@ documented in this file.
 
 ## Unreleased
 
+### Added
+- Browser-readiness document summaries now include global-state descriptors for
+  non-form elements with inert/hidden, editing, drag, spellcheck, translate,
+  accesskey, autofocus, and related focus metadata.
+
 ### Fixed
 - Test fixture generators: `COMMENT_MARKUP` regex accepts both `-->` and
   `--!>` comment end forms, and tag-axis classifier scans pass `re.I` even

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -851,6 +851,7 @@ pub struct BrowserDocument {
     pub disclosures: Vec<BrowserDisclosure>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
     pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
+    pub global_state_descriptors: Vec<BrowserGlobalStateDescriptor>,
     pub structured_items: Vec<BrowserStructuredItem>,
     pub templates: Vec<BrowserTemplate>,
     pub forms: Vec<BrowserForm>,
@@ -1088,6 +1089,28 @@ pub struct BrowserDataAttributeDescriptor {
     pub slot_name: Option<String>,
     pub part: Vec<String>,
     pub data_attributes: Vec<BrowserDataAttribute>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserGlobalStateDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub title: Option<String>,
+    pub lang: Option<String>,
+    pub dir: Option<String>,
+    pub hidden: bool,
+    pub inert: bool,
+    pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
+    pub autofocus: bool,
+    pub contenteditable: Option<String>,
+    pub editing_mode: Option<String>,
+    pub draggable: Option<String>,
+    pub draggable_state: Option<String>,
+    pub spellcheck: Option<String>,
+    pub translate: Option<String>,
     pub text: String,
 }
 
@@ -9596,6 +9619,9 @@ fn collect_browser_facts(
         if let Some(descriptor) = browser_data_attribute_descriptor(element) {
             summary.data_attribute_descriptors.push(descriptor);
         }
+        if let Some(descriptor) = browser_global_state_descriptor(element) {
+            summary.global_state_descriptors.push(descriptor);
+        }
         if element.name == "template" {
             summary.templates.push(browser_template(element));
         }
@@ -11953,6 +11979,64 @@ fn browser_data_attribute_descriptor(element: &Element) -> Option<BrowserDataAtt
         slot_name: browser_slot_name(element),
         part: browser_part_tokens(element),
         data_attributes,
+        text: visible_text_for_nodes(&element.children),
+    })
+}
+
+fn browser_global_state_descriptor(element: &Element) -> Option<BrowserGlobalStateDescriptor> {
+    if matches!(
+        element.name.as_str(),
+        "button"
+            | "fieldset"
+            | "form"
+            | "input"
+            | "label"
+            | "meter"
+            | "object"
+            | "option"
+            | "output"
+            | "progress"
+            | "select"
+            | "textarea"
+    ) {
+        return None;
+    }
+
+    let accesskey = browser_accesskey(element);
+    let has_global_state = browser_hidden(element)
+        || browser_inert(element)
+        || !accesskey.is_empty()
+        || browser_autofocus(element)
+        || element.attribute("contenteditable").is_some()
+        || element.attribute("draggable").is_some()
+        || element.attribute("spellcheck").is_some()
+        || element.attribute("translate").is_some();
+
+    if !has_global_state {
+        return None;
+    }
+
+    Some(BrowserGlobalStateDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        lang: element.attribute("lang").map(ToOwned::to_owned),
+        dir: element.attribute("dir").map(ToOwned::to_owned),
+        hidden: browser_hidden(element),
+        inert: browser_inert(element),
+        tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        accesskey,
+        autofocus: browser_autofocus(element),
+        contenteditable: element.attribute("contenteditable").map(ToOwned::to_owned),
+        editing_mode: browser_editing_mode(element),
+        draggable: element.attribute("draggable").map(ToOwned::to_owned),
+        draggable_state: browser_draggable_state(element),
+        spellcheck: browser_spellcheck_state(element),
+        translate: browser_translate_state(element),
         text: visible_text_for_nodes(&element.children),
     })
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -8,13 +8,14 @@ use coding_adventures_html_parser::{
     BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
     BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect,
     BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
-    BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover, BrowserPopoverInvoker,
-    BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
+    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
+    BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -98,6 +99,8 @@ struct ExpectedBrowserDocument {
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
     #[serde(default)]
     data_attribute_descriptors: Vec<ExpectedDataAttributeDescriptor>,
+    #[serde(default)]
+    global_state_descriptors: Vec<ExpectedGlobalStateDescriptor>,
     #[serde(default)]
     structured_items: Vec<ExpectedStructuredItem>,
     #[serde(default)]
@@ -322,6 +325,45 @@ struct ExpectedDataAttributeDescriptor {
     part: Vec<String>,
     #[serde(default)]
     data_attributes: Vec<ExpectedDataAttribute>,
+    #[serde(default)]
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedGlobalStateDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    lang: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
+    #[serde(default)]
+    hidden: bool,
+    #[serde(default)]
+    inert: bool,
+    #[serde(default)]
+    tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
+    #[serde(default)]
+    autofocus: bool,
+    #[serde(default)]
+    contenteditable: Option<String>,
+    #[serde(default)]
+    editing_mode: Option<String>,
+    #[serde(default)]
+    draggable: Option<String>,
+    #[serde(default)]
+    draggable_state: Option<String>,
+    #[serde(default)]
+    spellcheck: Option<String>,
+    #[serde(default)]
+    translate: Option<String>,
     #[serde(default)]
     text: String,
 }
@@ -3209,6 +3251,26 @@ fn browser_interactive_element_metadata_tracks_focus_editing_and_commands() {
 }
 
 #[test]
+fn browser_global_state_descriptor_metadata_tracks_non_form_global_states() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive global-state fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive global-state fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.global_state_descriptors,
+        case.expected.into_browser_document().global_state_descriptors,
+        "global-state descriptors should preserve inert, hidden, focus, editing, drag, spellcheck, translate, and accesskey metadata outside form-specific summaries",
+    );
+}
+
+#[test]
 fn browser_accessible_description_metadata_tracks_describedby_text() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -3490,6 +3552,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedDataAttributeDescriptor::into_browser_data_attribute_descriptor)
                 .collect(),
+            global_state_descriptors: self
+                .global_state_descriptors
+                .into_iter()
+                .map(ExpectedGlobalStateDescriptor::into_browser_global_state_descriptor)
+                .collect(),
             structured_items: self
                 .structured_items
                 .into_iter()
@@ -3727,6 +3794,31 @@ impl ExpectedDataAttributeDescriptor {
                 .into_iter()
                 .map(ExpectedDataAttribute::into_browser_data_attribute)
                 .collect(),
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedGlobalStateDescriptor {
+    fn into_browser_global_state_descriptor(self) -> BrowserGlobalStateDescriptor {
+        BrowserGlobalStateDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            title: self.title,
+            lang: self.lang,
+            dir: self.dir,
+            hidden: self.hidden,
+            inert: self.inert,
+            tabindex: self.tabindex,
+            accesskey: self.accesskey,
+            autofocus: self.autofocus,
+            contenteditable: self.contenteditable,
+            editing_mode: self.editing_mode,
+            draggable: self.draggable,
+            draggable_state: self.draggable_state,
+            spellcheck: self.spellcheck,
+            translate: self.translate,
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -21,6 +21,8 @@ viewport, description, application name, referrer/robots/color-scheme policy,
 theme colors, refresh URL resolution, and canonical/manifest URLs. Form cases
 also pin labels, derived accessible names, owner references,
 placeholder/autocomplete hints, and required/readonly/multiple control state.
+Global-state descriptor cases pin non-form inert/hidden, editing, drag,
+spellcheck, translate, accesskey, autofocus, and related focus metadata.
 Media cases pin audio/video playback flags and preload/poster metadata.
 Script/style cases pin module/classic script kind, async/defer/nomodule flags,
 inline script/style text, and loading-policy hints such as integrity,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1055,6 +1055,13 @@
           { "element": "dialog", "id": "dialog", "text": "Dialog copy", "open": true, "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true" },
           { "element": "details", "id": "more", "text": "More Extra", "summary_text": "More", "open": true, "accessible_name": "More" }
         ],
+        "global_state_descriptors": [
+          { "element": "section", "id": "panel", "inert": true, "text": "Settings Choose options Inline action Editable copy" },
+          { "element": "div", "id": "action", "tabindex": "-1", "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "text": "Inline action" },
+          { "element": "p", "id": "editable", "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes", "text": "Editable copy" },
+          { "element": "dialog", "id": "dialog", "accesskey": ["d", "x"], "text": "Dialog copy" },
+          { "element": "p", "id": "secret", "hidden": true, "text": "Hidden copy" }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add BrowserGlobalStateDescriptor facts to BrowserDocument for non-form hidden/inert/editing/drag/spellcheck/translate/accesskey state
- wire the browser-readiness fixture expectations and schema checks for global_state_descriptors
- document the new descriptor coverage in the fixture README and html-parser changelog

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_global_state_descriptor_metadata_tracks_non_form_global_states
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser