### PR TITLE
Close csc/sec Weierstrass log branch across CAS ports

### DIFF
--- a/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/integrate.py
@@ -1043,6 +1043,10 @@ def _parse_a_plus_b_sincos(
     trig function of a linear-in-``x`` argument.  Phase 38 supersedes
     the bare-``x``-only predecessor.
     """
+    trig_parse = _parse_const_times_trig_linear(node, x)
+    if trig_parse is not None:
+        b, head, alpha, beta = trig_parse
+        return Fraction(0), b, head, alpha, beta
     if not isinstance(node, IRApply) or len(node.args) != 2:
         return None
     if node.head == ADD:
@@ -1187,7 +1191,10 @@ def _try_weierstrass_log_form(
 
         a·u² + 2b·u + a = a·(u − u₁)·(u − u₂)
 
-    Partial fractions give
+    When ``a = 0``, the integrand is the csc form
+    ``c/(b·sin x)`` and closes directly to ``(c/b)·log|tan(x/2)|``.
+
+    For ``a ≠ 0``, partial fractions give
 
         ∫ 2/(a·(u−u₁)(u−u₂)) du
           =  (1/D) · log| (a·u + b − D) / (a·u + b + D) | + C
@@ -1225,7 +1232,7 @@ def _try_weierstrass_log_form(
     ``b > |a|`` strictly.
 
     Returns ``None`` when the matched shape doesn't satisfy the
-    above sign preconditions (``a ≠ 0`` for sin; ``b > |a|`` for cos).
+    above sign preconditions.
     """
     # b² − a² > 0 must hold (caller passes disc = a² − b² < 0).
     disc_sq = b * b - a * a
@@ -1236,9 +1243,11 @@ def _try_weierstrass_log_form(
     abs_head = IRSymbol("Abs")
     if trig_head == SIN:
         if a == 0:
-            # Integrand reduces to c/(b·sin x); special-cased elsewhere or
-            # left for the elementary table.  Defer.
-            return None
+            # ∫ c/(b·sin u) dx = (c/b)·log|tan(u/2)|, with any linear
+            # argument scaling already absorbed into c by the dispatcher.
+            coef_ir = _frac_ir(c / b)
+            log_arg = IRApply(abs_head, (tan_half,))
+            return IRApply(MUL, (coef_ir, IRApply(LOG, (log_arg,))))
         # log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
         a_tan = IRApply(MUL, (_frac_ir(a), tan_half))
         a_tan_plus_b = IRApply(ADD, (a_tan, _frac_ir(b)))

--- a/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
+++ b/code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py
@@ -31,6 +31,7 @@ from symbolic_ir import (
     COS,
     DIV,
     INTEGRATE,
+    LOG,
     MUL,
     NEG,
     SIN,
@@ -737,20 +738,41 @@ def test_regression_pure_sin_still_works(vm: VM) -> None:
     assert result in (neg_cos, mul_neg), f"Got {result!r}"
 
 
-def test_regression_one_over_cos_unchanged(vm: VM) -> None:
-    """``∫ 1/cos(x) dx`` (i.e. ∫ sec(x) dx) is NOT a Weierstrass case.
-
-    The denominator is bare ``cos(x)`` without an additive constant, so
-    ``_parse_a_plus_b_sincos`` returns None and Phase 34 does not engage.
-    The result therefore stays as ``Integrate(...)`` (∫sec x dx has no
-    elementary closed form in our pipeline yet).
-    """
+def test_regression_one_over_cos_now_closes(vm: VM) -> None:
+    """``∫ 1/cos(x) dx`` closes as the ``a = 0`` cosine log branch."""
     integrand = IRApply(DIV, (IRInteger(1), IRApply(COS, (X,))))
     result = vm.eval(_integrate(integrand))
-    # Either unevaluated, or some elementary fold the VM applies — but
-    # specifically MUST NOT be a Phase 34 arctan-of-tan(x/2) artefact.
-    if isinstance(result, IRApply) and result.head == ATAN:
-        pytest.fail(f"Phase 34 incorrectly fired on ∫ 1/cos(x) dx: got {result!r}")
+    assert not (isinstance(result, IRApply) and result.head == INTEGRATE)
+    assert _contains_head(result, LOG)
+    for x_val in (-1.0, -0.4, 0.0, 0.4, 1.0):
+        got = _numerical_derivative(vm, result, x_val)
+        expected = 1.0 / math.cos(x_val)
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase36_one_over_sin_now_closes(vm: VM) -> None:
+    """``∫ 1/sin(x) dx`` closes as ``log|tan(x/2)|``."""
+    integrand = IRApply(DIV, (IRInteger(1), IRApply(SIN, (X,))))
+    result = vm.eval(_integrate(integrand))
+    assert not (isinstance(result, IRApply) and result.head == INTEGRATE)
+    assert _contains_head(result, LOG)
+    for x_val in (0.4, 0.8, 1.2, 1.6, 2.0):
+        got = _numerical_derivative(vm, result, x_val)
+        expected = 1.0 / math.sin(x_val)
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
+
+
+def test_phase38_scaled_csc_branch_closes(vm: VM) -> None:
+    """``∫ 3/(2·sin(2x+1)) dx`` preserves numerator, b, and alpha scaling."""
+    arg = IRApply(ADD, (IRApply(MUL, (IRInteger(2), X)), IRInteger(1)))
+    denominator = IRApply(MUL, (IRInteger(2), IRApply(SIN, (arg,))))
+    result = vm.eval(_integrate(IRApply(DIV, (IRInteger(3), denominator))))
+    assert not (isinstance(result, IRApply) and result.head == INTEGRATE)
+    assert _contains_head(result, LOG)
+    for x_val in (0.0, 0.2, 0.5, 0.8):
+        got = _numerical_derivative(vm, result, x_val)
+        expected = 3.0 / (2.0 * math.sin(2.0 * x_val + 1.0))
+        assert math.isclose(got, expected, abs_tol=1e-3, rel_tol=1e-3)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -1733,6 +1733,9 @@ fn weierstrass_parse_a_plus_b_sincos(
     node: &IRNode,
     x: &str,
 ) -> Option<(RatC, RatC, &'static str, RatC, RatC)> {
+    if let Some((b, head, alpha, beta)) = weierstrass_parse_const_times_trig_linear(node, x) {
+        return Some(((0, 1), b, head, alpha, beta));
+    }
     let IRNode::Apply(apply) = node else {
         return None;
     };
@@ -1843,9 +1846,9 @@ fn try_weierstrass_degenerate(
 }
 
 /// Phase 36: Weierstrass log form for `a² < b²`.  Returns the closed
-/// form with `log|·|` instead of `arctan(·)`.  Sin branch handles any
-/// nonzero `a`; cos branch requires `b > |a|` strictly (the symmetric
-/// `b < −|a|` case has the opposite sign pattern and is deferred).
+/// form with `log|·|` instead of `arctan(·)`.  The `a = 0` sin/csc
+/// subcase closes as `(c/b)·log|tan(x/2)|`; the cos branch handles both
+/// sign regimes via the Abs-wrapped Phase 37 form.
 fn try_weierstrass_log_form(
     c: RatC,
     a: RatC,
@@ -1869,8 +1872,11 @@ fn try_weierstrass_log_form(
     );
     if trig_head == SIN {
         if a.0 == 0 {
-            // 1/(b·sin x) — defer to the elementary table.
-            return None;
+            // ∫ c/(b·sin u) dx = (c/b)·log|tan(u/2)|.  Any linear argument
+            // scaling has already been absorbed into c by the dispatcher.
+            let coef_ir = rc_to_ir(rc_div(c, b)?)?;
+            let log_arg = apply_node("Abs", vec![tan_half]);
+            return Some(apply_node(MUL, vec![coef_ir, apply_node(LOG, vec![log_arg])]));
         }
         // log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
         let a_tan = apply_node(MUL, vec![rc_to_ir(a)?, tan_half]);

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2702,21 +2702,36 @@ fn phase34_regression_pure_sin_unchanged() {
 }
 
 #[test]
-fn phase34_regression_one_over_cos_not_misinterpreted() {
-    // ∫ 1/cos(x) dx — denominator has no additive constant; Phase 34 must NOT
-    // fire and produce a spurious arctan of tan(x/2).
+fn phase34_regression_one_over_cos_now_closes() {
+    // ∫ 1/cos(x) dx — a = 0 cosine log branch.
     let integrand = apply(sym(DIV), vec![int(1), apply(sym(COS), vec![sym("x")])]);
     let result = integrate(integrand);
-    if let symbolic_ir::IRNode::Apply(apply) = &result {
-        if apply.head == symbolic_ir::IRNode::Symbol(ATAN.to_string()) {
-            panic!("Phase 34 incorrectly fired on ∫ 1/cos(x) dx: {result:?}");
-        }
+    assert!(!is_unevaluated_integrate(&result));
+    assert!(contains_head(&result, LOG), "Expected Log in {result:?}");
+    for &x_val in &[-1.0_f64, -0.4, 0.0, 0.4, 1.0] {
+        let got = phase34_numerical_derivative(&result, x_val);
+        let expected = 1.0 / x_val.cos();
+        assert!((got - expected).abs() < 1e-3, "x={x_val}: got={got}, expected={expected}");
     }
 }
 
 // ---------------------------------------------------------------------------
 // Phase 36 — Weierstrass log form for a² < b² (cos + edge cases)
 // ---------------------------------------------------------------------------
+
+#[test]
+fn phase36_one_over_sin_now_closes() {
+    // ∫ 1/sin(x) dx = log|tan(x/2)|.
+    let integrand = apply(sym(DIV), vec![int(1), apply(sym(SIN), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi));
+    assert!(contains_head(&phi, LOG), "Expected Log in {phi:?}");
+    for &x_val in &[0.4_f64, 0.8, 1.2, 1.6, 2.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / x_val.sin();
+        assert!((got - expected).abs() < 1e-3, "x={x_val}: got={got}, expected={expected}");
+    }
+}
 
 #[test]
 fn phase36_a_less_than_b_cos_now_closes() {
@@ -2888,6 +2903,21 @@ fn phase38_sin_two_x_closes() {
         let got = phase34_numerical_derivative(&phi, x_val);
         let expected = 1.0 / (2.0 + (2.0 * x_val).sin());
         assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase38_scaled_csc_branch_closes() {
+    // ∫ 3/(2·sin(2x+1)) dx — c, b, and alpha scaling.
+    let arg = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)]);
+    let denominator = apply(sym(MUL), vec![int(2), apply(sym(SIN), vec![arg])]);
+    let phi = integrate(apply(sym(DIV), vec![int(3), denominator]));
+    assert!(!is_unevaluated_integrate(&phi));
+    assert!(contains_head(&phi, LOG), "Expected Log in {phi:?}");
+    for &x_val in &[0.0_f64, 0.2, 0.5, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 3.0 / (2.0 * (2.0 * x_val + 1.0).sin());
+        assert!((got - expected).abs() < 1e-3, "x={x_val}: got={got}, expected={expected}");
     }
 }
 

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -2753,6 +2753,16 @@ function weierstrassParseAPlusBSincos(
       readonly beta: Numeric;
     }
   | undefined {
+  const bareTrig = weierstrassParseConstTimesTrigLinear(node, x);
+  if (bareTrig !== undefined) {
+    return {
+      a: { kind: "int", value: 0n },
+      b: bareTrig.c,
+      trigHead: bareTrig.head,
+      alpha: bareTrig.alpha,
+      beta: bareTrig.beta,
+    };
+  }
   if (node.kind !== "apply" || node.args.length !== 2) return undefined;
   if (equals(node.head, ADD)) {
     const [left, right] = node.args;
@@ -2961,9 +2971,9 @@ function absNumeric(v: Numeric): Numeric {
  *   ∫ c/(a + b·sin x) dx  =  (c/D)·log|(a·tan(x/2)+b−D)/(a·tan(x/2)+b+D)| + C
  *   ∫ c/(a + b·cos x) dx  =  (c/D)·log|(D+(b−a)·tan(x/2))/(D−(b−a)·tan(x/2))| + C
  *
- * with ``D = √(b²−a²) > 0``.  Sin branch handles any nonzero ``a``;
- * cos branch requires ``b > |a|`` strictly (the symmetric ``b < −|a|``
- * case has a different sign pattern and is deferred).
+ * with ``D = √(b²−a²) > 0``.  The ``a = 0`` sin/csc subcase closes as
+ * ``(c/b)·log|tan(x/2)|``.  The cos branch handles both sign regimes via
+ * the Abs-wrapped Phase 37 form.
  */
 function tryWeierstrassLogForm(
   c: Numeric,
@@ -2981,7 +2991,13 @@ function tryWeierstrassLogForm(
   const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
   const absHead = sym("Abs");
   if (equals(trigHead, SIN)) {
-    if (isZeroNumeric(a)) return undefined; // 1/(b·sin x) deferred
+    if (isZeroNumeric(a)) {
+      // ∫ c/(b·sin u) dx = (c/b)·log|tan(u/2)|.  Any linear argument
+      // scaling has already been absorbed into c by the dispatcher.
+      const coefIR = fromNumeric(divNumeric(c, b));
+      const logArg = app(absHead, [tanHalf]);
+      return app(MUL, [coefIR, app(LOG, [logArg])]);
+    }
     // log|(a·tan(x/2) + b − D) / (a·tan(x/2) + b + D)|
     const aTan = app(MUL, [fromNumeric(a), tanHalf]);
     const aTanPlusB = app(ADD, [aTan, fromNumeric(b)]);

--- a/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/phase34-weierstrass.test.ts
@@ -15,6 +15,7 @@ import {
   DIV,
   INTEGRATE,
   IRNode,
+  LOG,
   MUL,
   NEG,
   SIN,
@@ -251,14 +252,16 @@ describe("Phase 34: regression — must not interfere with existing rules", () =
     expect(equals(result, negCos) || equals(result, mulNeg)).toBe(true);
   });
 
-  it("∫ 1/cos(x) dx is NOT misinterpreted as Weierstrass (no additive constant)", () => {
+  it("∫ 1/cos(x) dx closes as the a = 0 cosine log branch", () => {
     const vm = makeVM();
     const integrand = app(DIV, [int(1), app(COS, [X])]);
     const result = vm.eval(integrate(integrand));
-    // Either unevaluated, or some elementary fold — but specifically MUST NOT be
-    // a top-level Atan (which would only come from Phase 34).
-    if (result.kind === "apply" && equals(result.head, ATAN)) {
-      throw new Error(`Phase 34 incorrectly fired on ∫ 1/cos(x) dx: got ${JSON.stringify(result)}`);
+    expect(isUnevaluatedIntegrate(result)).toBe(false);
+    expect(containsHead(result, LOG)).toBe(true);
+    for (const xVal of [-1.0, -0.4, 0.0, 0.4, 1.0]) {
+      const got = numericalDerivative(vm, result, xVal);
+      const expected = 1 / Math.cos(xVal);
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
     }
   });
 });
@@ -337,6 +340,19 @@ describe("Phase 35: degenerate a² = b² cases", () => {
 // ---------------------------------------------------------------------------
 
 describe("Phase 36: log form for a² < b²", () => {
+  it("∫ 1/sin(x) dx closes as log|tan(x/2)|", () => {
+    const vm = makeVM();
+    const integrand = app(DIV, [int(1), app(SIN, [X])]);
+    const phi = vm.eval(integrate(integrand));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    expect(containsHead(phi, LOG)).toBe(true);
+    for (const xVal of [0.4, 0.8, 1.2, 1.6, 2.0]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 1 / Math.sin(xVal);
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
+    }
+  });
+
   it("∫ 1/(1 + 2·cos x) dx — cos branch with b > |a|", () => {
     const vm = makeVM();
     const integrand = app(DIV, [int(1), app(ADD, [int(1), app(MUL, [int(2), app(COS, [X])])])]);
@@ -452,6 +468,20 @@ describe("Phase 38: linear-argument substitution lifts Weierstrass", () => {
       const got = numericalDerivative(vm, phi, xVal);
       const expected = 1.0 / (2.0 + Math.sin(2.0 * xVal));
       expect(Math.abs(got - expected)).toBeLessThan(1e-4);
+    }
+  });
+
+  it("scaled csc branch closes for ∫ 3/(2·sin(2x+1)) dx", () => {
+    const vm = makeVM();
+    const arg = app(ADD, [app(MUL, [int(2), X]), int(1)]);
+    const denominator = app(MUL, [int(2), app(SIN, [arg])]);
+    const phi = vm.eval(integrate(app(DIV, [int(3), denominator])));
+    expect(isUnevaluatedIntegrate(phi)).toBe(false);
+    expect(containsHead(phi, LOG)).toBe(true);
+    for (const xVal of [0.0, 0.2, 0.5, 0.8]) {
+      const got = numericalDerivative(vm, phi, xVal);
+      const expected = 3 / (2 * Math.sin(2 * xVal + 1));
+      expect(Math.abs(got - expected)).toBeLessThan(1e-3);
     }
   });
 


### PR DESCRIPTION
## Summary

Continues the MACSYMA parity closure loop after #5081 merged. The next concrete cross-port gap was the `a = 0` Weierstrass log branch: bare `1/sin(u)` and `1/cos(u)` denominators were not parsed as `a + b·trig(u)` with `a = 0`, and the sin/csc subcase explicitly deferred.

This PR closes that gap across all three symbolic-vm ports:

- Python reference implementation: parses bare `b·sin/cos(αx+β)` as `a = 0` and emits `(c/b)·log|tan(u/2)|` for the csc branch.
- TypeScript/Web implementation: mirrors the parser widening and csc closed form.
- Rust speed implementation: mirrors the same rational branch and parser widening.
- Existing sec/cos `a = 0` cases now close through the existing Abs-wrapped cos log formula.
- Adds derivative-based regression coverage for `1/sin(x)`, `1/cos(x)`, and `3/(2·sin(2x+1))` across the ports.

## Validation

- `python -m pytest code/packages/python/symbolic-vm/tests/test_phase34_weierstrass.py -q --no-cov` -> 38 passed
- `npm test --prefix code/packages/typescript/symbolic-vm -- phase34-weierstrass.test.ts` -> 38 passed
- `cargo check` in `code/packages/rust/symbolic-vm` -> passed
- `git diff --check` -> clean

Rust note: local `cargo test` still cannot link on this workstation because the Windows MSVC/SDK linker libraries are missing (`lld-link` / `link.exe` prerequisites), but `cargo check` type-checks the Rust port and CI should run the configured runner.