### PR TITLE
Expose Chief smart-home discovery route

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -12,3 +12,6 @@ All notable changes to this package will be documented in this file.
   `smart_home.pair_bridge`, `smart_home.describe_capabilities`, and
   `smart_home.get_health` so Chief of Staff jobs can reach the existing D23
   subscription, pairing, capability, and health runtime paths.
+- Added the `smart_home.discover` D18D handler over
+  `RuntimeDiscoverToolRequest`, including discovery filters, bridge-candidate
+  output, and end-to-end journal coverage.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding-adventures-json-value = { path = "../json-value" }
 smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 
 [dev-dependencies]

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -8,8 +8,7 @@ The crate is intentionally a thin adapter:
 - it publishes `smart_home.*` D18D tool definitions
 - it registers in-process handlers on `InMemoryToolRuntime`
 - handlers translate JSON arguments into `SmartHomeRuntime` read, subscribe,
-  pair, and command
-  requests
+  discover, pair, and command requests
 - `SmartHomeRuntime` still owns smart-home authorization, command validation,
   event subscriptions, pairing sessions, optimistic state, supervision, and
   audit decisions
@@ -21,8 +20,9 @@ fixture:
 
 ```text
 Chief of Staff job/session/agent
-  -> D18D smart_home.command tool call
+  -> D18D smart_home.discover / smart_home.command tool calls
   -> smart-home runtime authorization
+  -> discovery records and unpaired bridge candidates
   -> device command acceptance
   -> optimistic state update
   -> D18D trace and audit record
@@ -30,6 +30,7 @@ Chief of Staff job/session/agent
 
 ## Included Tools
 
+- `smart_home.discover`
 - `smart_home.list_bridges`
 - `smart_home.list_devices`
 - `smart_home.get_state`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -16,12 +16,15 @@ use chief_of_staff_tool_api::{
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, Capability, CapabilityId, CommandResult, CommandStatus, CommandType,
-    Device, EntityId, Health, Metadata, StateConfidence, StateSnapshot, StateSource, Value,
+    Device, EntityId, Health, IntegrationId, Metadata, StateConfidence, StateSnapshot, StateSource,
+    Value,
 };
+use smart_home_discovery::{DiscoveryRecord, DiscoverySource};
 use smart_home_runtime::{
-    PairingSessionStatus, RuntimeCommandToolRequest, RuntimeError, RuntimeEventCheckpoint,
-    RuntimeEventFilter, RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest,
-    RuntimePairingSession, RuntimePairingSessionId, RuntimeReadToolOutput, RuntimeReadToolRequest,
+    PairingSessionStatus, RuntimeCommandToolRequest, RuntimeDiscoverToolOutput,
+    RuntimeDiscoverToolRequest, RuntimeError, RuntimeEventCheckpoint, RuntimeEventFilter,
+    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingSession,
+    RuntimePairingSessionId, RuntimeReadToolOutput, RuntimeReadToolRequest,
     RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionId,
     SmartHomeRuntime,
 };
@@ -29,6 +32,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub const SMART_HOME_LIST_BRIDGES_TOOL_ID: &str = "smart_home.list_bridges";
+pub const SMART_HOME_DISCOVER_TOOL_ID: &str = "smart_home.discover";
 pub const SMART_HOME_LIST_DEVICES_TOOL_ID: &str = "smart_home.list_devices";
 pub const SMART_HOME_GET_STATE_TOOL_ID: &str = "smart_home.get_state";
 pub const SMART_HOME_COMMAND_TOOL_ID: &str = "smart_home.command";
@@ -87,6 +91,13 @@ impl SmartHomeToolBridge {
             let mut runtime = runtime.borrow_mut();
 
             match tool_id.as_str() {
+                SMART_HOME_DISCOVER_TOOL_ID => {
+                    let request = discover_request(&arguments)?;
+                    let output = runtime
+                        .execute_discover_tool(principal_id, request, now_ms)
+                        .map_err(runtime_error)?;
+                    Ok(discover_output_handler_output(output))
+                }
                 SMART_HOME_LIST_BRIDGES_TOOL_ID => {
                     let _ = expect_object(&arguments)?;
                     let output = runtime
@@ -197,6 +208,59 @@ impl SmartHomeToolBridge {
 /// Return the D18D definitions for the first smart-home runtime bridge tools.
 pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
     vec![
+        read_definition(
+            SMART_HOME_DISCOVER_TOOL_ID,
+            "Discover smart-home bridges",
+            "List normalized D23 discovery candidates recorded by the smart-home runtime.",
+            object_schema(
+                vec![
+                    SchemaProperty::new("integration_id", JsonSchema::String),
+                    SchemaProperty::new("source", JsonSchema::String),
+                    SchemaProperty::new("fresh_only", JsonSchema::Boolean),
+                    SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+                    SchemaProperty::new("limit", JsonSchema::Integer),
+                ],
+                vec![],
+                false,
+            ),
+            object_schema(
+                vec![
+                    SchemaProperty::new("generated_at_ms", JsonSchema::Integer),
+                    SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+                    SchemaProperty::new(
+                        "records",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new(
+                        "bridge_candidates",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("with_address_count", JsonSchema::Integer),
+                    SchemaProperty::new("fresh_count", JsonSchema::Integer),
+                    SchemaProperty::new("stale_count", JsonSchema::Integer),
+                    SchemaProperty::new("expired_count", JsonSchema::Integer),
+                    SchemaProperty::new("next_transition_at_ms", JsonSchema::Any),
+                ],
+                vec![
+                    "generated_at_ms",
+                    "ttl_ms",
+                    "records",
+                    "bridge_candidates",
+                    "count",
+                    "with_address_count",
+                    "fresh_count",
+                    "stale_count",
+                    "expired_count",
+                    "next_transition_at_ms",
+                ],
+                false,
+            ),
+        ),
         read_definition(
             SMART_HOME_LIST_BRIDGES_TOOL_ID,
             "List smart-home bridges",
@@ -502,6 +566,27 @@ fn command_definition() -> ToolDefinition {
     }
 }
 
+fn discover_request(arguments: &JsonValue) -> Result<RuntimeDiscoverToolRequest, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut request = RuntimeDiscoverToolRequest::new();
+    if let Some(integration_id) = optional_string(arguments, "integration_id")? {
+        request = request.for_integration(IntegrationId::trusted(integration_id));
+    }
+    if let Some(source) = optional_string(arguments, "source")? {
+        request = request.from_source(parse_discovery_source(&source)?);
+    }
+    if let Some(fresh_only) = optional_bool(arguments, "fresh_only")? {
+        request = request.fresh_only(fresh_only);
+    }
+    if let Some(ttl_ms) = optional_u64(arguments, "ttl_ms")? {
+        request = request.with_ttl_ms(ttl_ms);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        request = request.with_limit(limit as usize);
+    }
+    Ok(request)
+}
+
 fn list_devices_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest, ToolCallError> {
     Ok(RuntimeReadToolRequest::ListDevices {
         bridge_id: optional_string(arguments, "bridge_id")?.map(BridgeId::trusted),
@@ -557,6 +642,17 @@ fn pair_bridge_request(
         request = request.with_metadata(metadata);
     }
     Ok(request)
+}
+
+fn discover_output_handler_output(output: RuntimeDiscoverToolOutput) -> ToolHandlerOutput {
+    ToolHandlerOutput::new(discover_output_json(&output)).with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("discover")),
+            ("count", integer(output.len() as i64)),
+            ("fresh_count", integer(output.record_summary.fresh as i64)),
+        ]),
+    )
 }
 
 fn subscribe_output_handler_output(output: RuntimeSubscribeToolOutput) -> ToolHandlerOutput {
@@ -717,6 +813,82 @@ fn pair_bridge_output_json(output: &RuntimePairBridgeToolOutput) -> JsonValue {
     pairing_session_json(&output.session)
 }
 
+fn discover_output_json(output: &RuntimeDiscoverToolOutput) -> JsonValue {
+    object([
+        ("generated_at_ms", integer(output.generated_at_ms as i64)),
+        ("ttl_ms", integer(output.ttl_ms as i64)),
+        (
+            "records",
+            JsonValue::Array(output.records.iter().map(discovery_record_json).collect()),
+        ),
+        (
+            "bridge_candidates",
+            JsonValue::Array(output.bridge_candidates.iter().map(bridge_json).collect()),
+        ),
+        ("count", integer(output.record_summary.total as i64)),
+        (
+            "with_address_count",
+            integer(output.record_summary.with_address as i64),
+        ),
+        ("fresh_count", integer(output.record_summary.fresh as i64)),
+        ("stale_count", integer(output.record_summary.stale as i64)),
+        (
+            "expired_count",
+            integer(output.record_summary.expired as i64),
+        ),
+        (
+            "next_transition_at_ms",
+            output
+                .signal_summary
+                .next_transition_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+    ])
+}
+
+fn discovery_record_json(record: &DiscoveryRecord) -> JsonValue {
+    object([
+        ("fingerprint", string(record.fingerprint().as_str())),
+        ("bridge_id", string(record.bridge_id().as_str())),
+        ("integration_id", string(record.integration_id.as_str())),
+        ("native_bridge_id", string(&record.native_bridge_id)),
+        ("display_name", optional_string_json(&record.display_name)),
+        ("source", string(record.source.as_str())),
+        ("transport", string(record.transport.as_str())),
+        ("address", optional_string_json(&record.address)),
+        (
+            "network_interface",
+            optional_string_json(&record.network_interface),
+        ),
+        (
+            "hardware_model",
+            optional_string_json(&record.hardware_model),
+        ),
+        (
+            "firmware_version",
+            optional_string_json(&record.firmware_version),
+        ),
+        ("confidence", string(record.confidence.as_str())),
+        (
+            "pairing_requirement",
+            string(record.pairing_requirement.as_str()),
+        ),
+        ("discovered_at_ms", integer(record.discovered_at_ms as i64)),
+        (
+            "expires_at_ms",
+            record
+                .expires_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "metadata",
+            JsonValue::Array(record.metadata.iter().map(metadata_json).collect()),
+        ),
+    ])
+}
+
 fn pairing_session_json(session: &RuntimePairingSession) -> JsonValue {
     object([
         ("session_id", string(session.session_id.as_str())),
@@ -770,6 +942,10 @@ fn metadata_json(metadata: &Metadata) -> JsonValue {
         ("key", string(&metadata.key)),
         ("value", string(&metadata.value)),
     ])
+}
+
+fn optional_string_json(value: &Option<String>) -> JsonValue {
+    value.as_ref().map(string).unwrap_or(JsonValue::Null)
 }
 
 fn device_json(device: &Device) -> JsonValue {
@@ -1030,6 +1206,24 @@ fn parse_health(label: &str) -> Result<Health, ToolCallError> {
     }
 }
 
+fn parse_discovery_source(label: &str) -> Result<DiscoverySource, ToolCallError> {
+    match label {
+        "mdns" => Ok(DiscoverySource::Mdns),
+        "ssdp" => Ok(DiscoverySource::Ssdp),
+        "bluetooth" => Ok(DiscoverySource::Bluetooth),
+        "usb" => Ok(DiscoverySource::Usb),
+        "dhcp" => Ok(DiscoverySource::Dhcp),
+        "mqtt" => Ok(DiscoverySource::Mqtt),
+        "manual" => Ok(DiscoverySource::Manual),
+        "cloud_fallback" => Ok(DiscoverySource::CloudFallback),
+        "webhook" => Ok(DiscoverySource::Webhook),
+        "simulator" => Ok(DiscoverySource::Simulator),
+        _ => Err(validation_error(format!(
+            "unknown discovery source `{label}`"
+        ))),
+    }
+}
+
 fn health_label(health: Health) -> &'static str {
     match health {
         Health::Unknown => "unknown",
@@ -1148,6 +1342,14 @@ fn optional_string(value: &JsonValue, field: &str) -> Result<Option<String>, Too
         Some(JsonValue::String(value)) => Ok(Some(value.clone())),
         Some(JsonValue::Null) | None => Ok(None),
         Some(_) => Err(validation_error(format!("{field} must be a string"))),
+    }
+}
+
+fn optional_bool(value: &JsonValue, field: &str) -> Result<Option<bool>, ToolCallError> {
+    match optional_field(value, field) {
+        Some(JsonValue::Bool(value)) => Ok(Some(*value)),
+        Some(JsonValue::Null) | None => Ok(None),
+        Some(_) => Err(validation_error(format!("{field} must be a boolean"))),
     }
 }
 
@@ -1281,7 +1483,7 @@ mod tests {
         ToolValidationReport,
     };
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
-    use smart_home_testkit::hue_lighting_runtime;
+    use smart_home_testkit::{hue_bridge_discovery_record, hue_lighting_runtime};
 
     const AGENT_ID: &str = "agent:chief-smart-home";
 
@@ -1290,8 +1492,9 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 9);
+        assert_eq!(definitions.len(), 10);
         assert!(export.ok());
+        assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_COMMAND_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_PAIR_BRIDGE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_SUBSCRIBE_TOOL_ID));
@@ -1301,7 +1504,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            7
+            8
         );
         assert_eq!(
             export
@@ -1320,6 +1523,10 @@ mod tests {
     #[test]
     fn chief_of_staff_runtime_drives_smart_home_light_end_to_end() {
         let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        runtime
+            .borrow_mut()
+            .record_discovery(hue_bridge_discovery_record("001788fffediscovered", 1_000))
+            .unwrap();
         runtime.borrow_mut().registry_mut().upsert_capability_grant(
             CapabilityGrant::for_all_smart_home(
                 CapabilityGrantId::trusted("grant-smart-home"),
@@ -1346,6 +1553,41 @@ mod tests {
         assert_eq!(
             field(list_trace.result.output.as_ref().unwrap(), "count"),
             Some(&integer(1))
+        );
+
+        let discover_request = request(
+            "call-discover",
+            SMART_HOME_DISCOVER_TOOL_ID,
+            object([
+                ("integration_id", string("hue")),
+                ("source", string("mdns")),
+                ("fresh_only", JsonValue::Bool(true)),
+                ("ttl_ms", integer(1_000)),
+            ]),
+            1_005,
+        );
+        let discover_trace = tool_runtime.invoke_with_events(&discover_request);
+        assert!(discover_trace.result.ok);
+        assert_eq!(
+            field(discover_trace.result.output.as_ref().unwrap(), "count"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(
+                discover_trace.result.output.as_ref().unwrap(),
+                "with_address_count"
+            ),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            array_len(
+                field(
+                    discover_trace.result.output.as_ref().unwrap(),
+                    "bridge_candidates"
+                )
+                .unwrap()
+            ),
+            Some(1)
         );
 
         let capabilities_request = request(
@@ -1448,6 +1690,7 @@ mod tests {
 
         let mut journal = ToolExecutionJournal::new();
         journal.record_trace(list_request, list_trace);
+        journal.record_trace(discover_request, discover_trace);
         journal.record_trace(capabilities_request, capabilities_trace);
         journal.record_trace(health_request, health_trace);
         journal.record_trace(subscribe_request, subscribe_trace);
@@ -1456,9 +1699,9 @@ mod tests {
         journal.record_trace(state_request, state_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 7);
-        assert_eq!(journal_summary.completed_count, 7);
-        assert_eq!(journal.audit_records().len(), 7);
+        assert_eq!(journal_summary.invocation_count, 8);
+        assert_eq!(journal_summary.completed_count, 8);
+        assert_eq!(journal.audit_records().len(), 8);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -1472,7 +1715,7 @@ mod tests {
         );
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            8,
+            9,
             "read, subscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }
@@ -1566,6 +1809,22 @@ mod tests {
                 .map(|error| error.kind),
             Some(ToolErrorKind::ToolValidationError)
         );
+
+        let unsupported_source = tool_runtime.invoke_with_events(&request(
+            "call-invalid-discover",
+            SMART_HOME_DISCOVER_TOOL_ID,
+            object([("source", string("radio_magic"))]),
+            1_000,
+        ));
+        assert!(!unsupported_source.result.ok);
+        assert_eq!(
+            unsupported_source
+                .result
+                .error
+                .as_ref()
+                .map(|error| error.kind),
+            Some(ToolErrorKind::ToolValidationError)
+        );
     }
 
     fn request(
@@ -1596,5 +1855,12 @@ mod tests {
         fields
             .iter()
             .find_map(|(field_name, value)| (field_name == name).then_some(value))
+    }
+
+    fn array_len(value: &JsonValue) -> Option<usize> {
+        let JsonValue::Array(values) = value else {
+            return None;
+        };
+        Some(values.len())
     }
 }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this package will be documented in this file.
 - `RuntimePairingSessionInventorySummary` plus
   `pairing_session_inventory_summary_at()` for compact bridge-pairing status,
   expiry, and VaultRef completion counts.
+- Runtime discovery catalog recording plus `RuntimeDiscoverToolRequest` and
+  `RuntimeDiscoverToolOutput` for authorized discovery reads, freshness
+  filtering, and unpaired bridge-candidate projection.
 - `RuntimeSupervisionPlanSummary` plus plan/observation helpers for compact
   due-work counts over non-mutating supervision plans.
 - `SupervisionTickSummary` plus tick-report helpers for compact actual-work

--- a/code/packages/rust/smart-home-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime/Cargo.toml
@@ -7,4 +7,5 @@ license = "MIT"
 
 [dependencies]
 smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-registry = { path = "../smart-home-registry" }

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -36,6 +36,10 @@ Included surfaces:
   subscribers without draining their delivery queues
 - subscription inventory summaries for read-side event-stream filter coverage
   and queue pressure checks
+- runtime-owned discovery catalog recording that reconciles normalized
+  discovery results into unpaired bridge candidates
+- D18D-facing discover tool facade for authorized discovery reads, freshness
+  filters, summaries, and bridge-candidate output
 - composed event-bus health summaries for replay history, stream coverage, and
   current queue pressure checks
 - command validation against entity capabilities and command modes
@@ -85,6 +89,7 @@ Included surfaces:
 ## Dependencies
 
 - smart-home-core
+- smart-home-discovery
 - smart-home-registry
 
 ## Development

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -15,6 +15,10 @@ use smart_home_core::{
     SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
     VaultRef,
 };
+use smart_home_discovery::{
+    DiscoveryCatalog, DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary,
+    DiscoverySource, DiscoveryUpsert,
+};
 use smart_home_registry::{
     DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts, RegistryError, StateRefreshPlan,
     StateRefreshReason,
@@ -2234,6 +2238,86 @@ impl RuntimePendingWorkSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDiscoverToolRequest {
+    pub integration_id: Option<IntegrationId>,
+    pub source: Option<DiscoverySource>,
+    pub fresh_only: bool,
+    pub ttl_ms: u64,
+    pub limit: Option<usize>,
+}
+
+impl RuntimeDiscoverToolRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_integration(mut self, integration_id: IntegrationId) -> Self {
+        self.integration_id = Some(integration_id);
+        self
+    }
+
+    pub fn from_source(mut self, source: DiscoverySource) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    pub fn fresh_only(mut self, fresh_only: bool) -> Self {
+        self.fresh_only = fresh_only;
+        self
+    }
+
+    pub fn with_ttl_ms(mut self, ttl_ms: u64) -> Self {
+        self.ttl_ms = ttl_ms;
+        self
+    }
+
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    fn matches_record(&self, record: &DiscoveryRecord, now_ms: u64) -> bool {
+        self.integration_id
+            .as_ref()
+            .is_none_or(|integration_id| &record.integration_id == integration_id)
+            && self.source.is_none_or(|source| record.source == source)
+            && (!self.fresh_only || !record.is_stale_at(now_ms, self.ttl_ms))
+    }
+}
+
+impl Default for RuntimeDiscoverToolRequest {
+    fn default() -> Self {
+        Self {
+            integration_id: None,
+            source: None,
+            fresh_only: false,
+            ttl_ms: 60_000,
+            limit: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDiscoverToolOutput {
+    pub generated_at_ms: u64,
+    pub ttl_ms: u64,
+    pub records: Vec<DiscoveryRecord>,
+    pub bridge_candidates: Vec<Bridge>,
+    pub record_summary: DiscoveryRecordSummary,
+    pub signal_summary: DiscoverySignalSummary,
+}
+
+impl RuntimeDiscoverToolOutput {
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeReadToolRequest {
     ListBridges,
     ListDevices {
@@ -2419,6 +2503,7 @@ pub struct RuntimePairBridgeToolOutput {
 #[derive(Debug, Clone)]
 pub struct SmartHomeRuntime {
     registry: InMemorySmartHomeRegistry,
+    discovery: DiscoveryCatalog,
     event_bus: RuntimeEventBus,
     supervisor: RuntimeSupervisor,
     pairing_sessions: BTreeMap<RuntimePairingSessionId, RuntimePairingSession>,
@@ -2430,6 +2515,7 @@ impl SmartHomeRuntime {
     pub fn new() -> Self {
         Self {
             registry: InMemorySmartHomeRegistry::new(),
+            discovery: DiscoveryCatalog::new(),
             event_bus: RuntimeEventBus::new(),
             supervisor: RuntimeSupervisor::new(),
             pairing_sessions: BTreeMap::new(),
@@ -2444,6 +2530,14 @@ impl SmartHomeRuntime {
 
     pub fn registry_mut(&mut self) -> &mut InMemorySmartHomeRegistry {
         &mut self.registry
+    }
+
+    pub fn discovery(&self) -> &DiscoveryCatalog {
+        &self.discovery
+    }
+
+    pub fn discovery_mut(&mut self) -> &mut DiscoveryCatalog {
+        &mut self.discovery
     }
 
     pub fn event_bus(&self) -> &RuntimeEventBus {
@@ -2622,6 +2716,22 @@ impl SmartHomeRuntime {
 
     pub fn upsert_entity(&mut self, entity: Entity) -> Result<Option<Entity>, RuntimeError> {
         self.registry.upsert_entity(entity).map_err(Into::into)
+    }
+
+    pub fn record_discovery(
+        &mut self,
+        record: DiscoveryRecord,
+    ) -> Result<DiscoveryUpsert, RuntimeError> {
+        let bridge_candidate = record.to_bridge_candidate();
+        let upsert = self.discovery.record_preferred(record);
+        if !matches!(upsert, DiscoveryUpsert::Ignored(_)) {
+            self.registry.upsert_bridge(bridge_candidate)?;
+        }
+        Ok(upsert)
+    }
+
+    pub fn discovery_record_count(&self) -> usize {
+        self.discovery.len()
     }
 
     pub fn apply_device_event(&mut self, event: DeviceEvent) -> Result<(), RuntimeError> {
@@ -2824,6 +2934,59 @@ impl SmartHomeRuntime {
         self.registry
             .record_authorization_decision(decision.clone());
         decision
+    }
+
+    pub fn execute_discover_tool(
+        &mut self,
+        principal_id: AgentId,
+        request: RuntimeDiscoverToolRequest,
+        now_ms: u64,
+    ) -> Result<RuntimeDiscoverToolOutput, RuntimeError> {
+        let tool = SmartHomeTool::Discover;
+        let decision = self.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+        if !decision.missing_capabilities.is_empty() {
+            return Err(RuntimeError::UnauthorizedTool {
+                principal_id,
+                tool,
+                missing_capabilities: decision.missing_capabilities,
+            });
+        }
+
+        let mut records = self
+            .discovery
+            .records()
+            .filter(|record| request.matches_record(record, now_ms))
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| {
+            right
+                .discovered_at_ms
+                .cmp(&left.discovered_at_ms)
+                .then_with(|| left.integration_id.cmp(&right.integration_id))
+                .then_with(|| left.native_bridge_id.cmp(&right.native_bridge_id))
+        });
+        apply_limit(&mut records, request.limit);
+
+        let bridge_candidates = records
+            .iter()
+            .map(DiscoveryRecord::to_bridge_candidate)
+            .collect::<Vec<_>>();
+        let record_summary =
+            DiscoveryRecordSummary::from_records(records.iter(), now_ms, request.ttl_ms);
+        let signals = records
+            .iter()
+            .map(|record| record.signal(request.ttl_ms))
+            .collect::<Vec<_>>();
+        let signal_summary = DiscoverySignalSummary::from_signals(&signals, now_ms);
+
+        Ok(RuntimeDiscoverToolOutput {
+            generated_at_ms: now_ms,
+            ttl_ms: request.ttl_ms,
+            records,
+            bridge_candidates,
+            record_summary,
+            signal_summary,
+        })
     }
 
     pub fn execute_read_tool(
@@ -3660,6 +3823,9 @@ mod tests {
         AuthorizationOutcome, BridgeTransport, Capability, CapabilityGrantId, CommandId,
         CorrelationId, EntityKind, IntegrationId, ProtocolFamily, ProtocolIdentifier, StateDelta,
     };
+    use smart_home_discovery::{
+        DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert, PairingRequirement,
+    };
     use smart_home_registry::StateRefreshReason;
 
     fn bridge(id: &str) -> Bridge {
@@ -3735,6 +3901,21 @@ mod tests {
             observed_at_ms: at_ms,
             received_at_ms: at_ms,
         }
+    }
+
+    fn hue_discovery_record(native_bridge_id: &str, discovered_at_ms: u64) -> DiscoveryRecord {
+        DiscoveryRecord::new(
+            IntegrationId::trusted("hue"),
+            ProtocolFamily::Hue,
+            native_bridge_id,
+            DiscoverySource::Mdns,
+            BridgeTransport::Mdns,
+            discovered_at_ms,
+        )
+        .unwrap()
+        .with_address("https://192.0.2.10")
+        .with_confidence(DiscoveryConfidence::Verified)
+        .with_pairing_requirement(PairingRequirement::PhysicalPresence)
     }
 
     fn device_runtime_event(event_id: &str, at_ms: u64) -> RuntimeEvent {
@@ -4536,6 +4717,143 @@ mod tests {
         assert_eq!(decisions.len(), 1);
         assert_eq!(decisions[0].outcome, AuthorizationOutcome::Denied);
         assert!(runtime.event_bus().published().is_empty());
+    }
+
+    #[test]
+    fn discover_tool_requires_smart_home_read_grants() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:observer");
+        runtime
+            .record_discovery(hue_discovery_record("001788fffeabcdef", 1_000))
+            .unwrap();
+
+        let error = runtime
+            .execute_discover_tool(principal.clone(), RuntimeDiscoverToolRequest::new(), 1_500)
+            .unwrap_err();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert!(matches!(
+            error,
+            RuntimeError::UnauthorizedTool {
+                tool: SmartHomeTool::Discover,
+                missing_capabilities,
+                ..
+            } if missing_capabilities == vec![CapabilityId::trusted("smart_home.read")]
+        ));
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].outcome, AuthorizationOutcome::Denied);
+        assert_eq!(runtime.discovery_record_count(), 1);
+    }
+
+    #[test]
+    fn discovery_records_reconcile_unpaired_bridge_candidates_for_discover_tool() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:observer");
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            )
+            .with_expiry(2_000),
+        );
+        let record = hue_discovery_record("001788fffeabcdef", 1_100);
+        let bridge_id = record.bridge_id();
+
+        let upsert = runtime.record_discovery(record.clone()).unwrap();
+        let bridge = runtime.registry().bridge(&bridge_id).unwrap().clone();
+        let output = runtime
+            .execute_discover_tool(
+                principal.clone(),
+                RuntimeDiscoverToolRequest::new()
+                    .for_integration(IntegrationId::trusted("hue"))
+                    .from_source(DiscoverySource::Mdns)
+                    .with_ttl_ms(1_000),
+                1_500,
+            )
+            .unwrap();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert_eq!(upsert, DiscoveryUpsert::Inserted);
+        assert_eq!(runtime.discovery_record_count(), 1);
+        assert_eq!(bridge.bridge_id, bridge_id);
+        assert_eq!(bridge.health, Health::Unpaired);
+        assert_eq!(bridge.address.as_deref(), Some("https://192.0.2.10"));
+        assert_eq!(bridge.auth_ref, None);
+        assert!(bridge.metadata.iter().any(|metadata| {
+            metadata.key == "smart_home.discovery.source" && metadata.value == "mdns"
+        }));
+        assert_eq!(output.len(), 1);
+        assert_eq!(output.generated_at_ms, 1_500);
+        assert_eq!(output.ttl_ms, 1_000);
+        assert_eq!(output.records[0], record);
+        assert_eq!(output.bridge_candidates[0].bridge_id, bridge_id);
+        assert_eq!(output.record_summary.total, 1);
+        assert_eq!(output.record_summary.with_address, 1);
+        assert_eq!(output.record_summary.fresh, 1);
+        assert_eq!(
+            output
+                .record_summary
+                .count_for_source(DiscoverySource::Mdns),
+            1
+        );
+        assert_eq!(
+            output
+                .record_summary
+                .count_for_pairing_requirement(PairingRequirement::PhysicalPresence),
+            1
+        );
+        assert_eq!(output.signal_summary.fresh, 1);
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].outcome, AuthorizationOutcome::Allowed);
+    }
+
+    #[test]
+    fn discover_tool_filters_stale_records_and_limits_results() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:observer");
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            )
+            .with_expiry(3_000),
+        );
+        runtime
+            .record_discovery(hue_discovery_record("001788fffeold", 1_000))
+            .unwrap();
+        runtime
+            .record_discovery(hue_discovery_record("001788fffefresh", 1_900))
+            .unwrap();
+
+        let output = runtime
+            .execute_discover_tool(
+                principal,
+                RuntimeDiscoverToolRequest::new()
+                    .fresh_only(true)
+                    .with_ttl_ms(500)
+                    .with_limit(1),
+                2_000,
+            )
+            .unwrap();
+
+        assert_eq!(output.len(), 1);
+        assert_eq!(output.records[0].native_bridge_id, "001788fffefresh");
+        assert_eq!(output.record_summary.total, 1);
+        assert_eq!(output.record_summary.fresh, 1);
+        assert_eq!(output.record_summary.stale, 0);
+        assert_eq!(output.bridge_candidates[0].health, Health::Unpaired);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Deterministic fixture clock for freshness and supervisor tests.
 - Normalized Hue-like bridge, device, light entity, and sensor entity fixtures.
+- Deterministic Hue discovery record and discovery-runtime fixtures for testing
+  unpaired bridge candidates without network I/O.
 - Registry seeding helpers for installing normalized fixture records into the
   in-memory smart-home registry.
 - Helpers for confirmed, stale, and optimistic state snapshots.

--- a/code/packages/rust/smart-home-testkit/Cargo.toml
+++ b/code/packages/rust/smart-home-testkit/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [dependencies]
 smart-home-core = { path = "../smart-home-core" }
+smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-event-streams = { path = "../smart-home-event-streams" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-registry = { path = "../smart-home-registry" }

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -8,6 +8,7 @@ It gives future Hue, MQTT, Zigbee, Z-Wave, Thread, Matter, and runtime packages
 a shared way to build:
 
 - normalized bridge/device/entity fixtures
+- normalized Hue discovery records and discovery-seeded runtime fixtures
 - registry seeding helpers for installing fixture records into
   `smart-home-registry`
 - confirmed, stale, and optimistic state snapshots
@@ -31,6 +32,7 @@ a shared way to build:
 ## Dependencies
 
 - `smart-home-core`
+- `smart-home-discovery`
 - `smart-home-event-streams`
 - `smart-home-local-http`
 - `smart-home-registry`

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -13,6 +13,9 @@ use smart_home_core::{
     ProtocolFamily, ProtocolIdentifier, StateConfidence, StateDelta, StateSnapshot, StateSource,
     Value,
 };
+use smart_home_discovery::{
+    DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
+};
 use smart_home_event_streams::{
     EventStreamCheckpoint, EventStreamRestartReason, EventStreamSpec, EventStreamState,
     EventStreamStatus, MqttQos, MqttTopicError, MqttTopicFilter,
@@ -982,6 +985,28 @@ pub fn hue_bridge(id: &'static str, native_id: &'static str) -> Bridge {
     bridge
 }
 
+pub fn hue_bridge_discovery_record(
+    native_id: impl Into<String>,
+    discovered_at_ms: u64,
+) -> DiscoveryRecord {
+    DiscoveryRecord::new(
+        IntegrationId::trusted("hue"),
+        ProtocolFamily::Hue,
+        native_id,
+        DiscoverySource::Mdns,
+        BridgeTransport::Mdns,
+        discovered_at_ms,
+    )
+    .expect("fixture Hue discovery native ids are valid")
+    .with_display_name("Hue Bridge")
+    .with_address("https://192.0.2.10")
+    .with_hardware_model("BSB002")
+    .with_firmware_version("1.66.1960062030")
+    .with_confidence(DiscoveryConfidence::Verified)
+    .with_pairing_requirement(PairingRequirement::PhysicalPresence)
+    .with_metadata("fixture", "hue_bridge_discovery")
+}
+
 pub fn hue_device(id: &'static str, bridge_id: &BridgeId, native_id: &'static str) -> Device {
     Device {
         device_id: DeviceId::trusted(id),
@@ -1213,6 +1238,14 @@ pub fn runtime_with_fixture(fixture: &SmartHomeFixture) -> Result<SmartHomeRunti
 pub fn hue_lighting_runtime() -> SmartHomeRuntime {
     runtime_with_fixture(&SmartHomeFixture::hue_lighting())
         .expect("hue lighting fixture records are internally consistent")
+}
+
+pub fn hue_discovery_runtime() -> SmartHomeRuntime {
+    let mut runtime = SmartHomeRuntime::new();
+    runtime
+        .record_discovery(hue_bridge_discovery_record("001788fffeabcdef", 1_000))
+        .expect("Hue discovery fixture can be recorded");
+    runtime
 }
 
 pub fn hue_sse_stream_spec(fixture: &SmartHomeFixture) -> EventStreamSpec {
@@ -1640,6 +1673,30 @@ mod tests {
             registry.entity(&fixture.sensor.entity_id).unwrap().kind,
             EntityKind::Sensor
         );
+    }
+
+    #[test]
+    fn hue_discovery_fixture_records_unpaired_bridge_candidate() {
+        let runtime = hue_discovery_runtime();
+        let bridge_id = BridgeId::trusted("hue.bridge.001788fffeabcdef");
+        let bridge = runtime.registry().bridge(&bridge_id).unwrap();
+        let record = runtime
+            .discovery()
+            .get(&IntegrationId::trusted("hue"), "001788fffeabcdef")
+            .unwrap();
+
+        assert_eq!(runtime.discovery_record_count(), 1);
+        assert_eq!(bridge.health, Health::Unpaired);
+        assert_eq!(bridge.address.as_deref(), Some("https://192.0.2.10"));
+        assert_eq!(bridge.hardware_model.as_deref(), Some("BSB002"));
+        assert_eq!(record.source, DiscoverySource::Mdns);
+        assert_eq!(
+            record.pairing_requirement,
+            PairingRequirement::PhysicalPresence
+        );
+        assert!(bridge.metadata.iter().any(|metadata| {
+            metadata.key == "fixture" && metadata.value == "hue_bridge_discovery"
+        }));
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -31,17 +31,23 @@ The merged D18 and D23 work has the core local path in place:
 
 ## This Slice
 
-This slice completes the Chief-facing smart-home runtime surface that already
-exists in D23:
+This slice closes the Chief-facing discovery gap while keeping the platform
+boundary intact:
 
-- `smart_home.describe_capabilities`
-- `smart_home.get_health`
-- `smart_home.subscribe`
-- `smart_home.pair_bridge`
+- `smart-home-runtime` now owns a discovery catalog, records preferred
+  discovery results, reconciles them into unpaired bridge candidates, and
+  exposes an authorized `execute_discover_tool` read path.
+- `smart-home-testkit` now has deterministic Hue discovery fixtures so runtime,
+  integration, and Chief bridge tests share the same fake discovery primitive.
+- `chief-of-staff-smart-home-tools` now exposes D18D `smart_home.discover`
+  without owning discovery policy or smart-home state.
+- The bridge end-to-end test now covers list devices, discover, describe
+  capabilities, health, subscribe, pair, command, optimistic state, and D18D
+  journal/audit records.
 
-The one intentional gap is `smart_home.discover`, because D23 has the catalog
-descriptor but does not yet have a runtime discovery execution path. The bridge
-should expose discovery only after D23 owns actual discovery plans and results.
+This does not replace Home Assistant yet. It gives Chief of Staff a complete
+typed route into D23 discovery records; the remaining smart-home work is to run
+real network/radio/cloud discovery workers and persist the platform state.
 
 ## Chief Of Staff Remaining Work
 
@@ -64,7 +70,8 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Implement D23 discovery execution, starting with LAN and mDNS Hue discovery.
+- Implement real D23 discovery workers, starting with LAN and mDNS Hue
+  discovery, that feed the runtime discovery catalog.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers


### PR DESCRIPTION
## Summary

- add runtime-owned discovery catalog recording and `execute_discover_tool` over D23 discovery records
- add deterministic Hue discovery fixtures in `smart-home-testkit`
- expose D18D `smart_home.discover` through the Chief smart-home bridge, with filters, bridge-candidate output, and end-to-end journal coverage
- update the completion inventory to separate this Chief-facing discovery route from the remaining real smart-home platform work needed to retire Home Assistant

## Validation

- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p chief-of-staff-smart-home-tools`
- `sh BUILD` in `code/packages/rust/smart-home-runtime`
- `sh BUILD` in `code/packages/rust/smart-home-testkit`
- `sh BUILD` in `code/packages/rust/chief-of-staff-smart-home-tools`

Generated `code/packages/rust/Cargo.lock` was removed after validation.

## Remaining Direction

This PR makes discovery visible end to end through Chief, but the smart-home platform still needs real LAN/mDNS Hue discovery workers, real pairing, real Hue command/read/event workers, persistence, local API/dashboard, automations, and migration tooling before it can replace Home Assistant.