### PR TITLE
Add smart-home discovery worker ingest

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 - Hue mDNS and cloud-fallback discovery normalization into D23
   `DiscoveryRecord` candidates, including bridge-candidate batches and
   discovery-record pairing-plan handoff.
+- Hue discovery worker-run projection that keeps mDNS/cloud records and
+  per-observation failures in a generic D23 discovery-worker envelope.
 - Hue application registration request and discovered-bridge pairing plan
   helpers for local physical-presence pairing flows.
 - Hue command summaries and command-plan rollups for payload-free write-surface

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -34,6 +34,8 @@ packages a typed surface for:
   ids such as `light.on_off` and `light.brightness`
 - Hue mDNS and cloud-fallback discovery observations normalized into D23
   `DiscoveryRecord` bridge candidates
+- Hue discovery worker runs that bundle mDNS/cloud observations, per-source
+  failures, and generic D23 worker metadata for runtime catalog ingest
 - discovery-record-to-pairing-plan handoff for local physical-presence Hue
   pairing flows
 - integration descriptor metadata for Chief of Staff discovery

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -14,7 +14,8 @@ use smart_home_core::{
     StateDelta, StateSnapshot, StateSource, Value,
 };
 use smart_home_discovery::{
-    DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource, MdnsAdvertisement,
+    DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerFailure,
+    DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun, MdnsAdvertisement,
     PairingRequirement,
 };
 use std::fmt;
@@ -772,6 +773,62 @@ impl HueDiscoveryBatch {
             .iter()
             .map(DiscoveryRecord::to_bridge_candidate)
             .collect()
+    }
+}
+
+pub fn hue_discovery_worker_run_from_observations<'a>(
+    worker_id: impl Into<String>,
+    mdns_advertisements: impl IntoIterator<Item = &'a MdnsAdvertisement>,
+    cloud_bridges: impl IntoIterator<Item = HueCloudDiscoveryBridge>,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> Result<DiscoveryWorkerRun, HueError> {
+    let mdns_advertisements = mdns_advertisements.into_iter().collect::<Vec<_>>();
+    let cloud_bridges = cloud_bridges.into_iter().collect::<Vec<_>>();
+    let mut run = DiscoveryWorkerRun::new(
+        DiscoveryWorkerId::new(worker_id)?,
+        IntegrationId::trusted(HUE_INTEGRATION_ID),
+        hue_discovery_worker_kind(!mdns_advertisements.is_empty(), !cloud_bridges.is_empty()),
+        started_at_ms,
+        completed_at_ms,
+    )
+    .with_metadata("hue.discovery.worker", "true")
+    .with_metadata("hue.discovery.worker_version", env!("CARGO_PKG_VERSION"));
+
+    for advertisement in mdns_advertisements {
+        match hue_discovery_record_from_mdns(advertisement) {
+            Ok(record) => run.push_record(record)?,
+            Err(error) => run.push_failure(
+                DiscoveryWorkerFailure::new(DiscoverySource::Mdns, error.to_string())?
+                    .with_metadata("hue.discovery.service_type", &advertisement.service_type)
+                    .with_metadata("hue.discovery.instance_name", &advertisement.instance_name)
+                    .with_metadata("hue.discovery.host_name", &advertisement.host_name),
+            ),
+        }
+    }
+
+    for bridge in cloud_bridges {
+        let bridge_id = bridge.bridge_id.clone();
+        let internal_ip_address = bridge.internal_ip_address.clone();
+        match bridge.into_record() {
+            Ok(record) => run.push_record(record)?,
+            Err(error) => run.push_failure(
+                DiscoveryWorkerFailure::new(DiscoverySource::CloudFallback, error.to_string())?
+                    .with_metadata("hue.discovery.bridge_id", bridge_id)
+                    .with_metadata("hue.discovery.internal_ip_address", internal_ip_address),
+            ),
+        }
+    }
+
+    Ok(run)
+}
+
+fn hue_discovery_worker_kind(has_mdns: bool, has_cloud: bool) -> DiscoveryWorkerKind {
+    match (has_mdns, has_cloud) {
+        (true, true) => DiscoveryWorkerKind::Composite,
+        (true, false) => DiscoveryWorkerKind::MdnsScan,
+        (false, true) => DiscoveryWorkerKind::CloudFallback,
+        (false, false) => DiscoveryWorkerKind::Composite,
     }
 }
 
@@ -1874,6 +1931,7 @@ pub fn validate_brightness(value: u16) -> Result<u8, HueError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use smart_home_discovery::DiscoveryWorkerRunStatus;
 
     #[test]
     fn resource_paths_match_clip_v2_shape() {
@@ -2300,6 +2358,73 @@ mod tests {
             batch.bridge_candidates()[0].bridge_id.as_str(),
             "hue.bridge.001788fffeabcdef"
         );
+    }
+
+    #[test]
+    fn hue_discovery_worker_run_preserves_records_and_partial_failures() {
+        let mdns = MdnsAdvertisement::new(
+            HUE_MDNS_SERVICE_TYPE,
+            "Philips Hue - ABCDEF",
+            "hue-bridge.local",
+            443,
+            1_000,
+        )
+        .unwrap()
+        .with_address("192.0.2.10")
+        .unwrap()
+        .with_txt("bridgeid", "001788fffeabcdef")
+        .unwrap();
+        let non_hue = MdnsAdvertisement::new(
+            "_matter._tcp.local",
+            "Matter Bridge",
+            "matter.local",
+            5540,
+            1_005,
+        )
+        .unwrap();
+        let cloud = HueCloudDiscoveryBridge::new("001788fffecloud", "192.0.2.11", 1_010).unwrap();
+
+        let run = hue_discovery_worker_run_from_observations(
+            "hue-discovery-worker",
+            [&mdns, &non_hue],
+            [cloud],
+            990,
+            1_020,
+        )
+        .unwrap();
+        let summary = run.summary_at(1_100, 500, 2, 0, 0);
+
+        assert_eq!(
+            run.worker_id,
+            DiscoveryWorkerId::trusted("hue-discovery-worker")
+        );
+        assert_eq!(run.kind, DiscoveryWorkerKind::Composite);
+        assert_eq!(run.status(), DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(run.len(), 2);
+        assert_eq!(run.failure_count(), 1);
+        assert_eq!(run.duration_ms(), 30);
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.worker" && metadata.value == "true"
+        }));
+        assert_eq!(run.records[0].source, DiscoverySource::Mdns);
+        assert_eq!(run.records[1].source, DiscoverySource::CloudFallback);
+        assert_eq!(run.failures[0].source, DiscoverySource::Mdns);
+        assert!(run.failures[0].message.contains("not a Hue bridge service"));
+        assert_eq!(summary.record_count, 2);
+        assert_eq!(summary.failure_count, 1);
+        assert_eq!(
+            summary
+                .record_summary
+                .count_for_source(DiscoverySource::Mdns),
+            1
+        );
+        assert_eq!(
+            summary
+                .record_summary
+                .count_for_source(DiscoverySource::CloudFallback),
+            1
+        );
+        assert_eq!(summary.signal_summary.fresh, 2);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 - `DiscoveryRecordSummary` and `DiscoveryCatalog::record_summary_at` for
   aggregate discovery planning by source, confidence, pairing requirement,
   address coverage, and freshness status.
+- `DiscoveryWorkerRun`, worker failure records, worker run status, and
+  `DiscoveryWorkerRunSummary` for deterministic discovery-worker handoff into
+  catalog ingest.
 - `DiscoveryPairingPlanSummary`, `DiscoveryPairingPlan::summary`, and
   `DiscoveryCatalog::pairing_plan_summary_at` for host-facing pairing queue
   rollups by actionability, human action, freshness, source, requirement,

--- a/code/packages/rust/smart-home-discovery/README.md
+++ b/code/packages/rust/smart-home-discovery/README.md
@@ -13,6 +13,8 @@ write credentials. It gives discovery workers a shared shape for:
 - manual bridge address normalization
 - mDNS advertisement endpoint helpers
 - deterministic candidate catalogs
+- first-class discovery worker runs with per-source failures, durations, and
+  catalog-ingest summaries
 - catalog-backed scan and pairing hints derived from first-party integration
   metadata
 - pairing plans that rank discovered bridges and identify the next pairing
@@ -25,6 +27,8 @@ write credentials. It gives discovery workers a shared shape for:
 - catalog-level fresh/stale/expired signal summaries with next transition time
 - catalog-level discovery record summaries by source, confidence, pairing
   requirement, address coverage, and freshness
+- worker-run summaries that separate reported records from inserted, replaced,
+  and ignored catalog outcomes
 - freshness filtering for supervisor/discovery loops
 - projection into unpaired `smart-home-core::Bridge` records
 

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -16,8 +16,16 @@ use std::{cmp::Ordering, collections::BTreeMap, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveryError {
-    EmptyField { field: &'static str },
-    DuplicateTxtKey { key: String },
+    EmptyField {
+        field: &'static str,
+    },
+    DuplicateTxtKey {
+        key: String,
+    },
+    WorkerIntegrationMismatch {
+        worker_integration_id: String,
+        record_integration_id: String,
+    },
 }
 
 impl fmt::Display for DiscoveryError {
@@ -27,6 +35,13 @@ impl fmt::Display for DiscoveryError {
             Self::DuplicateTxtKey { key } => {
                 write!(f, "mDNS TXT key `{key}` appears more than once")
             }
+            Self::WorkerIntegrationMismatch {
+                worker_integration_id,
+                record_integration_id,
+            } => write!(
+                f,
+                "discovery worker for `{worker_integration_id}` cannot report `{record_integration_id}` records"
+            ),
         }
     }
 }
@@ -328,6 +343,270 @@ impl DiscoveryRecordSummary {
 
     pub fn is_empty(&self) -> bool {
         self.total == 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DiscoveryWorkerId(String);
+
+impl DiscoveryWorkerId {
+    pub fn new(value: impl Into<String>) -> Result<Self, DiscoveryError> {
+        Ok(Self(non_empty("discovery_worker_id", value)?))
+    }
+
+    pub fn trusted(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DiscoveryWorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiscoveryWorkerKind {
+    MdnsScan,
+    CloudFallback,
+    ManualSeed,
+    Composite,
+    Simulator,
+}
+
+impl DiscoveryWorkerKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MdnsScan => "mdns_scan",
+            Self::CloudFallback => "cloud_fallback",
+            Self::ManualSeed => "manual_seed",
+            Self::Composite => "composite",
+            Self::Simulator => "simulator",
+        }
+    }
+}
+
+impl fmt::Display for DiscoveryWorkerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiscoveryWorkerRunStatus {
+    Completed,
+    Partial,
+    Failed,
+}
+
+impl DiscoveryWorkerRunStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl fmt::Display for DiscoveryWorkerRunStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryWorkerFailure {
+    pub source: DiscoverySource,
+    pub message: String,
+    pub metadata: Vec<Metadata>,
+}
+
+impl DiscoveryWorkerFailure {
+    pub fn new(
+        source: DiscoverySource,
+        message: impl Into<String>,
+    ) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            source,
+            message: non_empty("discovery_worker_failure.message", message)?,
+            metadata: Vec::new(),
+        })
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.push(Metadata::new(key, value));
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryWorkerRun {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub kind: DiscoveryWorkerKind,
+    pub started_at_ms: u64,
+    pub completed_at_ms: u64,
+    pub records: Vec<DiscoveryRecord>,
+    pub failures: Vec<DiscoveryWorkerFailure>,
+    pub metadata: Vec<Metadata>,
+}
+
+impl DiscoveryWorkerRun {
+    pub fn new(
+        worker_id: DiscoveryWorkerId,
+        integration_id: IntegrationId,
+        kind: DiscoveryWorkerKind,
+        started_at_ms: u64,
+        completed_at_ms: u64,
+    ) -> Self {
+        Self {
+            worker_id,
+            integration_id,
+            kind,
+            started_at_ms,
+            completed_at_ms,
+            records: Vec::new(),
+            failures: Vec::new(),
+            metadata: Vec::new(),
+        }
+    }
+
+    pub fn push_record(&mut self, record: DiscoveryRecord) -> Result<(), DiscoveryError> {
+        if record.integration_id != self.integration_id {
+            return Err(DiscoveryError::WorkerIntegrationMismatch {
+                worker_integration_id: self.integration_id.as_str().to_string(),
+                record_integration_id: record.integration_id.as_str().to_string(),
+            });
+        }
+        self.records.push(record);
+        Ok(())
+    }
+
+    pub fn push_failure(&mut self, failure: DiscoveryWorkerFailure) {
+        self.failures.push(failure);
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.push(Metadata::new(key, value));
+        self
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn failure_count(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn has_failures(&self) -> bool {
+        !self.failures.is_empty()
+    }
+
+    pub fn duration_ms(&self) -> u64 {
+        self.completed_at_ms.saturating_sub(self.started_at_ms)
+    }
+
+    pub fn status(&self) -> DiscoveryWorkerRunStatus {
+        match (self.records.is_empty(), self.failures.is_empty()) {
+            (false, true) | (true, true) => DiscoveryWorkerRunStatus::Completed,
+            (false, false) => DiscoveryWorkerRunStatus::Partial,
+            (true, false) => DiscoveryWorkerRunStatus::Failed,
+        }
+    }
+
+    pub fn summary_at(
+        &self,
+        now_ms: u64,
+        ttl_ms: u64,
+        inserted_count: usize,
+        replaced_count: usize,
+        ignored_count: usize,
+    ) -> DiscoveryWorkerRunSummary {
+        DiscoveryWorkerRunSummary::from_run_at(
+            self,
+            now_ms,
+            ttl_ms,
+            inserted_count,
+            replaced_count,
+            ignored_count,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryWorkerRunSummary {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub kind: DiscoveryWorkerKind,
+    pub status: DiscoveryWorkerRunStatus,
+    pub started_at_ms: u64,
+    pub completed_at_ms: u64,
+    pub duration_ms: u64,
+    pub record_count: usize,
+    pub failure_count: usize,
+    pub inserted_count: usize,
+    pub replaced_count: usize,
+    pub ignored_count: usize,
+    pub record_summary: DiscoveryRecordSummary,
+    pub signal_summary: DiscoverySignalSummary,
+}
+
+impl DiscoveryWorkerRunSummary {
+    pub fn from_run_at(
+        run: &DiscoveryWorkerRun,
+        now_ms: u64,
+        ttl_ms: u64,
+        inserted_count: usize,
+        replaced_count: usize,
+        ignored_count: usize,
+    ) -> Self {
+        let signals = run
+            .records
+            .iter()
+            .map(|record| record.signal(ttl_ms))
+            .collect::<Vec<_>>();
+        Self {
+            worker_id: run.worker_id.clone(),
+            integration_id: run.integration_id.clone(),
+            kind: run.kind,
+            status: run.status(),
+            started_at_ms: run.started_at_ms,
+            completed_at_ms: run.completed_at_ms,
+            duration_ms: run.duration_ms(),
+            record_count: run.records.len(),
+            failure_count: run.failures.len(),
+            inserted_count,
+            replaced_count,
+            ignored_count,
+            record_summary: DiscoveryRecordSummary::from_records(
+                run.records.iter(),
+                now_ms,
+                ttl_ms,
+            ),
+            signal_summary: DiscoverySignalSummary::from_signals(&signals, now_ms),
+        }
+    }
+
+    pub fn accepted_count(&self) -> usize {
+        self.inserted_count + self.replaced_count
+    }
+
+    pub fn has_catalog_changes(&self) -> bool {
+        self.accepted_count() > 0
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.failure_count > 0
     }
 }
 
@@ -1831,6 +2110,98 @@ mod tests {
                 key: "bridgeid".to_string()
             }
         );
+    }
+
+    #[test]
+    fn discovery_worker_runs_summarize_records_failures_and_catalog_outcomes() {
+        let record = ManualBridgeInput {
+            integration_id: IntegrationId::trusted("hue"),
+            protocol_family: ProtocolFamily::Hue,
+            native_bridge_id: "001788fffeabcdef".to_string(),
+            address: "https://192.0.2.10".to_string(),
+            transport: BridgeTransport::LanHttp,
+            discovered_at_ms: 1_900,
+        }
+        .into_record()
+        .unwrap()
+        .with_confidence(DiscoveryConfidence::Verified)
+        .with_pairing_requirement(PairingRequirement::PhysicalPresence);
+        let mut run = DiscoveryWorkerRun::new(
+            DiscoveryWorkerId::trusted("hue-mdns-scan"),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            1_800,
+            1_950,
+        )
+        .with_metadata("scan", "lan");
+
+        run.push_record(record).unwrap();
+        run.push_failure(
+            DiscoveryWorkerFailure::new(DiscoverySource::Mdns, "ignored malformed TXT").unwrap(),
+        );
+        let summary = run.summary_at(2_000, 500, 1, 0, 0);
+
+        assert_eq!(run.status(), DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(run.duration_ms(), 150);
+        assert_eq!(run.len(), 1);
+        assert!(run.has_failures());
+        assert_eq!(
+            summary.worker_id,
+            DiscoveryWorkerId::trusted("hue-mdns-scan")
+        );
+        assert_eq!(summary.kind, DiscoveryWorkerKind::MdnsScan);
+        assert_eq!(summary.status, DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(summary.record_count, 1);
+        assert_eq!(summary.failure_count, 1);
+        assert_eq!(summary.inserted_count, 1);
+        assert_eq!(summary.accepted_count(), 1);
+        assert!(summary.has_catalog_changes());
+        assert_eq!(summary.record_summary.fresh, 1);
+        assert_eq!(summary.signal_summary.fresh, 1);
+        assert_eq!(
+            summary
+                .record_summary
+                .count_for_source(DiscoverySource::Manual),
+            1
+        );
+        assert_eq!(
+            summary
+                .record_summary
+                .count_for_pairing_requirement(PairingRequirement::PhysicalPresence),
+            1
+        );
+    }
+
+    #[test]
+    fn discovery_worker_runs_reject_records_from_another_integration() {
+        let mut run = DiscoveryWorkerRun::new(
+            DiscoveryWorkerId::trusted("hue-mdns-scan"),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            1_000,
+            1_100,
+        );
+        let mqtt_record = ManualBridgeInput {
+            integration_id: IntegrationId::trusted("mqtt"),
+            protocol_family: ProtocolFamily::Mqtt,
+            native_bridge_id: "broker-1".to_string(),
+            address: "mqtt://192.0.2.20".to_string(),
+            transport: BridgeTransport::LocalProcess,
+            discovered_at_ms: 1_050,
+        }
+        .into_record()
+        .unwrap();
+
+        let error = run.push_record(mqtt_record).unwrap_err();
+
+        assert_eq!(
+            error,
+            DiscoveryError::WorkerIntegrationMismatch {
+                worker_integration_id: "hue".to_string(),
+                record_integration_id: "mqtt".to_string()
+            }
+        );
+        assert!(run.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this package will be documented in this file.
 - Runtime discovery catalog recording plus `RuntimeDiscoverToolRequest` and
   `RuntimeDiscoverToolOutput` for authorized discovery reads, freshness
   filtering, and unpaired bridge-candidate projection.
+- `SmartHomeRuntime::record_discovery_worker_run` for ingesting reported
+  discovery-worker batches with inserted, replaced, and ignored catalog counts.
 - `RuntimeSupervisionPlanSummary` plus plan/observation helpers for compact
   due-work counts over non-mutating supervision plans.
 - `SupervisionTickSummary` plus tick-report helpers for compact actual-work

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -38,6 +38,9 @@ Included surfaces:
   and queue pressure checks
 - runtime-owned discovery catalog recording that reconciles normalized
   discovery results into unpaired bridge candidates
+- discovery worker-run ingest that records preferred batch results, reconciles
+  accepted candidates into the registry, and returns inserted/replaced/ignored
+  catalog counts
 - D18D-facing discover tool facade for authorized discovery reads, freshness
   filters, summaries, and bridge-candidate output
 - composed event-bus health summaries for replay history, stream coverage, and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -17,7 +17,7 @@ use smart_home_core::{
 };
 use smart_home_discovery::{
     DiscoveryCatalog, DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary,
-    DiscoverySource, DiscoveryUpsert,
+    DiscoverySource, DiscoveryUpsert, DiscoveryWorkerRun, DiscoveryWorkerRunSummary,
 };
 use smart_home_registry::{
     DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts, RegistryError, StateRefreshPlan,
@@ -2730,6 +2730,33 @@ impl SmartHomeRuntime {
         Ok(upsert)
     }
 
+    pub fn record_discovery_worker_run(
+        &mut self,
+        run: &DiscoveryWorkerRun,
+        now_ms: u64,
+        ttl_ms: u64,
+    ) -> Result<DiscoveryWorkerRunSummary, RuntimeError> {
+        let mut inserted_count = 0;
+        let mut replaced_count = 0;
+        let mut ignored_count = 0;
+
+        for record in &run.records {
+            match self.record_discovery(record.clone())? {
+                DiscoveryUpsert::Inserted => inserted_count += 1,
+                DiscoveryUpsert::Replaced(_) => replaced_count += 1,
+                DiscoveryUpsert::Ignored(_) => ignored_count += 1,
+            }
+        }
+
+        Ok(run.summary_at(
+            now_ms,
+            ttl_ms,
+            inserted_count,
+            replaced_count,
+            ignored_count,
+        ))
+    }
+
     pub fn discovery_record_count(&self) -> usize {
         self.discovery.len()
     }
@@ -3824,7 +3851,9 @@ mod tests {
         CorrelationId, EntityKind, IntegrationId, ProtocolFamily, ProtocolIdentifier, StateDelta,
     };
     use smart_home_discovery::{
-        DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert, PairingRequirement,
+        DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert,
+        DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
+        DiscoveryWorkerRunStatus, PairingRequirement,
     };
     use smart_home_registry::StateRefreshReason;
 
@@ -3915,6 +3944,24 @@ mod tests {
         .unwrap()
         .with_address("https://192.0.2.10")
         .with_confidence(DiscoveryConfidence::Verified)
+        .with_pairing_requirement(PairingRequirement::PhysicalPresence)
+    }
+
+    fn hue_cloud_discovery_record(
+        native_bridge_id: &str,
+        discovered_at_ms: u64,
+    ) -> DiscoveryRecord {
+        DiscoveryRecord::new(
+            IntegrationId::trusted("hue"),
+            ProtocolFamily::Hue,
+            native_bridge_id,
+            DiscoverySource::CloudFallback,
+            BridgeTransport::Cloud,
+            discovered_at_ms,
+        )
+        .unwrap()
+        .with_address("https://192.0.2.20")
+        .with_confidence(DiscoveryConfidence::Candidate)
         .with_pairing_requirement(PairingRequirement::PhysicalPresence)
     }
 
@@ -4854,6 +4901,76 @@ mod tests {
         assert_eq!(output.record_summary.fresh, 1);
         assert_eq!(output.record_summary.stale, 0);
         assert_eq!(output.bridge_candidates[0].health, Health::Unpaired);
+    }
+
+    #[test]
+    fn runtime_ingests_discovery_worker_runs_as_preferred_bridge_candidates() {
+        let mut runtime = SmartHomeRuntime::new();
+        let replace_bridge_id = BridgeId::trusted("hue.bridge.001788fffereplace");
+        let ignored_bridge_id = BridgeId::trusted("hue.bridge.001788fffeignored");
+        runtime
+            .record_discovery(hue_cloud_discovery_record("001788fffereplace", 1_000))
+            .unwrap();
+        runtime
+            .record_discovery(hue_discovery_record("001788fffeignored", 1_900))
+            .unwrap();
+
+        let mut run = DiscoveryWorkerRun::new(
+            DiscoveryWorkerId::trusted("hue-composite-worker"),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::Composite,
+            1_800,
+            1_950,
+        );
+        run.push_record(hue_discovery_record("001788fffereplace", 1_900))
+            .unwrap();
+        run.push_record(hue_cloud_discovery_record("001788fffeignored", 1_950))
+            .unwrap();
+        run.push_failure(
+            DiscoveryWorkerFailure::new(DiscoverySource::Mdns, "ignored malformed packet").unwrap(),
+        );
+
+        let summary = runtime
+            .record_discovery_worker_run(&run, 2_000, 500)
+            .unwrap();
+
+        assert_eq!(summary.status, DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(summary.record_count, 2);
+        assert_eq!(summary.failure_count, 1);
+        assert_eq!(summary.inserted_count, 0);
+        assert_eq!(summary.replaced_count, 1);
+        assert_eq!(summary.ignored_count, 1);
+        assert_eq!(summary.accepted_count(), 1);
+        assert!(summary.has_catalog_changes());
+        assert_eq!(summary.record_summary.total, 2);
+        assert_eq!(summary.signal_summary.fresh, 2);
+        assert_eq!(runtime.discovery_record_count(), 2);
+        assert_eq!(
+            runtime
+                .discovery()
+                .get(&IntegrationId::trusted("hue"), "001788fffereplace")
+                .unwrap()
+                .source,
+            DiscoverySource::Mdns
+        );
+        assert_eq!(
+            runtime
+                .registry()
+                .bridge(&replace_bridge_id)
+                .unwrap()
+                .address
+                .as_deref(),
+            Some("https://192.0.2.10")
+        );
+        assert_eq!(
+            runtime
+                .registry()
+                .bridge(&ignored_bridge_id)
+                .unwrap()
+                .address
+                .as_deref(),
+            Some("https://192.0.2.10")
+        );
     }
 
     #[test]

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this package will be documented in this file.
 - Deterministic Hue discovery record and discovery-runtime fixtures built
   through `hue-core` mDNS normalization for testing unpaired bridge candidates
   without network I/O.
+- Deterministic Hue discovery worker-run fixtures that seed discovery runtime
+  candidates through `SmartHomeRuntime::record_discovery_worker_run`.
 - Registry seeding helpers for installing normalized fixture records into the
   in-memory smart-home registry.
 - Helpers for confirmed, stale, and optimistic state snapshots.

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -10,6 +10,8 @@ a shared way to build:
 - normalized bridge/device/entity fixtures
 - normalized Hue discovery records, built through `hue-core` mDNS mapping, and
   discovery-seeded runtime fixtures
+- deterministic Hue discovery worker-run fixtures that feed the runtime
+  discovery catalog without opening network sockets
 - registry seeding helpers for installing fixture records into
   `smart-home-registry`
 - confirmed, stale, and optimistic state snapshots

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -6,7 +6,10 @@
 
 #![forbid(unsafe_code)]
 
-use hue_core::{hue_discovery_record_from_mdns, HUE_MDNS_SERVICE_TYPE};
+use hue_core::{
+    hue_discovery_record_from_mdns, hue_discovery_worker_run_from_observations,
+    HueCloudDiscoveryBridge, HUE_MDNS_SERVICE_TYPE,
+};
 use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId, CommandResult,
     CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType,
@@ -14,7 +17,7 @@ use smart_home_core::{
     ProtocolFamily, ProtocolIdentifier, StateConfidence, StateDelta, StateSnapshot, StateSource,
     Value,
 };
-use smart_home_discovery::{DiscoveryRecord, MdnsAdvertisement};
+use smart_home_discovery::{DiscoveryRecord, DiscoveryWorkerRun, MdnsAdvertisement};
 use smart_home_event_streams::{
     EventStreamCheckpoint, EventStreamRestartReason, EventStreamSpec, EventStreamState,
     EventStreamStatus, MqttQos, MqttTopicError, MqttTopicFilter,
@@ -988,8 +991,17 @@ pub fn hue_bridge_discovery_record(
     native_id: impl Into<String>,
     discovered_at_ms: u64,
 ) -> DiscoveryRecord {
+    hue_discovery_record_from_mdns(&hue_bridge_mdns_advertisement(native_id, discovered_at_ms))
+        .expect("fixture Hue mDNS advertisement maps to a discovery record")
+        .with_metadata("fixture", "hue_bridge_discovery")
+}
+
+pub fn hue_bridge_mdns_advertisement(
+    native_id: impl Into<String>,
+    discovered_at_ms: u64,
+) -> MdnsAdvertisement {
     let native_id = native_id.into();
-    let advertisement = MdnsAdvertisement::new(
+    MdnsAdvertisement::new(
         HUE_MDNS_SERVICE_TYPE,
         "Hue Bridge",
         "hue-bridge.local",
@@ -1004,10 +1016,30 @@ pub fn hue_bridge_discovery_record(
     .with_txt("modelid", "BSB002")
     .expect("fixture Hue model TXT is valid")
     .with_txt("swversion", "1.66.1960062030")
-    .expect("fixture Hue firmware TXT is valid");
-    hue_discovery_record_from_mdns(&advertisement)
-        .expect("fixture Hue mDNS advertisement maps to a discovery record")
-        .with_metadata("fixture", "hue_bridge_discovery")
+    .expect("fixture Hue firmware TXT is valid")
+}
+
+pub fn hue_bridge_discovery_worker_run(
+    native_id: impl Into<String>,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> DiscoveryWorkerRun {
+    let advertisement = hue_bridge_mdns_advertisement(native_id, completed_at_ms);
+    let mut run = hue_discovery_worker_run_from_observations(
+        "fixture-hue-discovery-worker",
+        [&advertisement],
+        Vec::<HueCloudDiscoveryBridge>::new(),
+        started_at_ms,
+        completed_at_ms,
+    )
+    .expect("fixture Hue discovery worker run is valid")
+    .with_metadata("fixture", "hue_bridge_discovery_worker");
+    for record in &mut run.records {
+        record
+            .metadata
+            .push(Metadata::new("fixture", "hue_bridge_discovery"));
+    }
+    run
 }
 
 pub fn hue_device(id: &'static str, bridge_id: &BridgeId, native_id: &'static str) -> Device {
@@ -1245,9 +1277,10 @@ pub fn hue_lighting_runtime() -> SmartHomeRuntime {
 
 pub fn hue_discovery_runtime() -> SmartHomeRuntime {
     let mut runtime = SmartHomeRuntime::new();
+    let run = hue_bridge_discovery_worker_run("001788fffeabcdef", 950, 1_000);
     runtime
-        .record_discovery(hue_bridge_discovery_record("001788fffeabcdef", 1_000))
-        .expect("Hue discovery fixture can be recorded");
+        .record_discovery_worker_run(&run, 1_000, 1_000)
+        .expect("Hue discovery fixture worker run can be recorded");
     runtime
 }
 
@@ -1701,6 +1734,23 @@ mod tests {
         );
         assert!(bridge.metadata.iter().any(|metadata| {
             metadata.key == "fixture" && metadata.value == "hue_bridge_discovery"
+        }));
+    }
+
+    #[test]
+    fn hue_discovery_worker_fixture_reports_canonical_mdns_records() {
+        let run = hue_bridge_discovery_worker_run("001788fffediscovered", 975, 1_000);
+
+        assert_eq!(run.worker_id.as_str(), "fixture-hue-discovery-worker");
+        assert_eq!(run.len(), 1);
+        assert!(!run.has_failures());
+        assert_eq!(run.records[0].native_bridge_id, "001788fffediscovered");
+        assert_eq!(run.records[0].source, DiscoverySource::Mdns);
+        assert!(run.records[0].metadata.iter().any(|metadata| {
+            metadata.key == "fixture" && metadata.value == "hue_bridge_discovery"
+        }));
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "fixture" && metadata.value == "hue_bridge_discovery_worker"
         }));
     }
 

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -64,6 +64,24 @@ This slice moves the smart-home platform side forward:
 - `smart-home-testkit` now builds its deterministic Hue discovery runtime
   fixture through the canonical Hue mDNS normalization path.
 
+## Current Discovery Worker Slice
+
+This slice turns the discovery ingest shape into a worker handoff contract while
+keeping the implementation testable and D23-owned:
+
+- `smart-home-discovery` now has generic discovery worker-run envelopes with
+  worker id/kind/status, per-source failures, run duration, and ingest summary
+  counts.
+- `smart-home-runtime` can ingest a full discovery worker run, record preferred
+  catalog results, reconcile accepted records into unpaired bridge candidates,
+  and report inserted/replaced/ignored outcomes.
+- `hue-core` can wrap Hue mDNS and cloud-fallback observations into the generic
+  D23 worker-run envelope, preserving malformed or non-Hue observations as
+  worker failures instead of losing the whole scan.
+- `smart-home-testkit` now seeds its Hue discovery runtime fixture through the
+  worker-run ingest path, so runtime and Chief bridge tests exercise the same
+  platform handoff a future LAN scanner will use.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -85,8 +103,8 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Bind real D23 discovery workers to the Hue mDNS/cloud-fallback ingest path,
-  starting with LAN mDNS scanning that feeds the runtime discovery catalog.
+- Attach actual LAN mDNS socket scanning to the D23 discovery worker-run
+  contract and feed those runs into the runtime discovery catalog.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers


### PR DESCRIPTION
## Summary

- add generic D23 discovery worker-run, failure, status, and ingest summary primitives
- let smart-home-runtime ingest a full worker run and reconcile accepted records into unpaired bridge candidates with inserted/replaced/ignored counts
- wrap Hue mDNS/cloud observations in the generic worker-run envelope and route smart-home-testkit Hue discovery fixtures through that runtime handoff
- update package docs and the D18/D23 inventory to mark the remaining step as real LAN mDNS socket scanning against this worker contract

## Validation

- cargo test -p smart-home-discovery
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-discovery
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- git diff --check
- removed generated code/packages/rust/Cargo.lock
