### PR TITLE
Close Apart mixed irreducible residual gap

### DIFF
--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -143,6 +143,12 @@ from polynomial import (
 from polynomial import (
     rational_roots as _poly_rational_roots,
 )
+from polynomial import (
+    subtract as _poly_subtract,
+)
+from polynomial import (
+    multiply as _poly_multiply,
+)
 from symbolic_ir import (
     ACOS,
     ACOSH,
@@ -929,17 +935,14 @@ def _series_div(
     return tuple(q)
 
 
-def _root_multiplicities(
+def _root_multiplicities_and_residual(
     den: tuple[Fraction, ...], roots: list[Fraction]
-) -> dict[Fraction, int] | None:
-    """For each distinct rational root, count how many times ``(x − r)``
-    divides ``den``.
+) -> tuple[dict[Fraction, int], tuple[Fraction, ...]] | None:
+    """Return rational-root multiplicities and any residual factor.
 
-    Returns a dict ``{r: m}`` such that ``∏_r (x − r)^m`` equals ``den``
-    up to a nonzero constant factor.  If the multiplicities don't fully
-    account for ``deg(den)`` — i.e. ``den`` has an irreducible factor
-    on top of the rational roots — returns ``None`` so the caller can
-    fall back to the unevaluated ``Apart(...)`` form.
+    The residual is constant when ``den`` is fully split over Q.  If it has
+    positive degree, ``Apart`` keeps it as the proper irreducible residual
+    after subtracting the rational-pole terms.
     """
     multiplicities: dict[Fraction, int] = {}
     remaining: tuple[Fraction, ...] = den
@@ -955,17 +958,12 @@ def _root_multiplicities(
             else:
                 break
         if m == 0:
-            # Shouldn't happen — ``r`` was returned by rational_roots
+            # Shouldn't happen: ``r`` was returned by rational_roots
             # so (x − r) must divide ``den`` at least once.  Defensive
             # bail-out.
             return None
         multiplicities[r] = m
-    if sum(multiplicities.values()) != _poly_degree(den):
-        # ``remaining`` is a non-constant polynomial with no rational
-        # root — irreducible factor present.  Apart on rationals can't
-        # decompose this further.
-        return None
-    return multiplicities
+    return multiplicities, _poly_normalize(remaining)
 
 
 def _apart_proper(
@@ -991,36 +989,41 @@ def _apart_proper(
     ``Q(x) = den(x) / (x − r)^m``.  Then ``A_{r, m − j} = φ_j``
     (coefficient of ``t^j`` in ``φ``'s Taylor series).
 
-    Returns ``None`` when ``den`` has an irreducible residual on top
-    of the rational roots; that mixed-factor decomposition is still
-    pending.  Pure irreducible proper rationals are already apart and
-    return unchanged in canonical IR.
+    Mixed rational-root plus irreducible residual factors are decomposed into
+    rational-pole terms plus a proper residual rational term.  Pure
+    irreducible proper rationals are already apart and return unchanged in
+    canonical IR.
     """
     roots = _poly_rational_roots(den)
     if not roots:
         return _proper_rational_to_ir(num, den, x)
 
-    # Phase 48: compute each root's multiplicity, bail if irreducible
-    # factors remain on top.
-    multiplicities = _root_multiplicities(den, roots)
-    if multiplicities is None:
+    # Phase 48: compute each root's multiplicity and the residual factor.
+    split = _root_multiplicities_and_residual(den, roots)
+    if split is None:
         return None
+    multiplicities, residual_den = split
+    has_residual = _poly_degree(residual_den) >= 1
 
     # Phase 1 fast path — every root simple.  Reuses the residue
     # formula, which is cheaper than the generic Taylor expansion
     # and preserves the previous output shape for the regression
     # tests written against it.
-    if all(m == 1 for m in multiplicities.values()):
+    if not has_residual and all(m == 1 for m in multiplicities.values()):
         return _apart_simple_roots(num, den, roots, x)
 
     # Phase 48 generic path: Taylor + series-division per root.
     terms: list[IRNode] = []
+    linear_part: tuple[Fraction, ...] = (Fraction(1),)
+    residual_num: tuple[Fraction, ...] = num
     for r in roots:
         m = multiplicities[r]
         # Q(x) = den(x) / (x − r)^m.  Successive divisions are
         # exact (we verified the multiplicity above).
         q_poly: tuple[Fraction, ...] = den
         linear = (Fraction(-r), Fraction(1))
+        for _ in range(m):
+            linear_part = _poly_multiply(linear_part, linear)
         for _ in range(m):
             quotient, _rem = _poly_divmod(q_poly, linear)
             q_poly = quotient
@@ -1040,6 +1043,21 @@ def _apart_proper(
                 continue
             term = _build_apart_term(A, r, power, x)
             terms.append(term)
+            pole_denom: tuple[Fraction, ...] = (Fraction(1),)
+            for _ in range(power):
+                pole_denom = _poly_multiply(pole_denom, linear)
+            quotient, rem = _poly_divmod(den, pole_denom)
+            if _poly_normalize(rem):
+                return None
+            residual_num = _poly_subtract(residual_num, tuple(c * A for c in quotient))
+
+    if has_residual:
+        residual_quotient, residual_rem = _poly_divmod(residual_num, linear_part)
+        if _poly_normalize(residual_rem):
+            return None
+        residual_ir = _proper_rational_to_ir(residual_quotient, residual_den, x)
+        if not (isinstance(residual_ir, IRInteger) and residual_ir.value == 0):
+            terms.append(residual_ir)
 
     if not terms:
         return IRInteger(0)

--- a/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
+++ b/code/packages/python/symbolic-vm/tests/test_cas_handlers.py
@@ -1770,6 +1770,36 @@ def test_apart_already_polynomial() -> None:
     assert _subst_at(vm, result, 2) == IRInteger(5)
 
 
+def test_apart_mixed_irreducible_and_linear_residual() -> None:
+    """Apart(1/((x^2 + 1)(x - 1)), x) keeps the irreducible residual."""
+    from symbolic_ir import DIV, MUL, SUB
+
+    vm, _ = make_vm()
+    quad = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
+    lin = IRApply(SUB, (x, IRInteger(1)))
+    inner = IRApply(DIV, (IRInteger(1), IRApply(MUL, (quad, lin))))
+    result = vm.eval(IRApply(_APART, (inner, x)))
+
+    assert not (isinstance(result, IRApply) and result.head == _APART)
+    assert _subst_at(vm, result, 0) == IRInteger(-1)
+    assert _subst_at(vm, result, 2) == IRRational(1, 5)
+
+
+def test_apart_mixed_irreducible_and_repeated_root_residual() -> None:
+    """Apart(1/((x^2 + 1)(x - 1)^2), x) decomposes poles plus residual."""
+    from symbolic_ir import DIV, MUL, SUB
+
+    vm, _ = make_vm()
+    quad = IRApply(ADD, (IRApply(POW, (x, IRInteger(2))), IRInteger(1)))
+    lin_sq = IRApply(POW, (IRApply(SUB, (x, IRInteger(1))), IRInteger(2)))
+    inner = IRApply(DIV, (IRInteger(1), IRApply(MUL, (quad, lin_sq))))
+    result = vm.eval(IRApply(_APART, (inner, x)))
+
+    assert not (isinstance(result, IRApply) and result.head == _APART)
+    assert _subst_at(vm, result, 0) == IRInteger(1)
+    assert _subst_at(vm, result, 2) == IRRational(1, 5)
+
+
 def test_apart_wrong_arity_passthrough() -> None:
     """Apart(x) with only one arg → unevaluated."""
     vm, _ = make_vm()

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -5006,8 +5006,8 @@ fn try_bivariate_hensel_ir(inner: &IRNode) -> Option<IRNode> {
 //
 // Supports simple rational roots, repeated rational roots, and proper
 // irreducible denominators that are already apart.  Mixed rational-root plus
-// irreducible residual factors still leave the expression wrapped in
-// ``Apart(...)``.  This mirrors the Python
+// irreducible residual factors, emitted as rational-pole terms plus a
+// proper residual rational term.  This mirrors the Python
 // ``apart_handler`` / ``_apart_simple_roots`` / ``_apart_proper`` chain in
 // ``cas_handlers.py`` but stays inside the existing ``RatC`` / ``RatPoly``
 // machinery so we don't introduce a new arithmetic substrate.
@@ -5137,13 +5137,14 @@ fn rp_rational_roots(p: &[RatC]) -> Option<Vec<RatC>> {
 }
 
 /// For each rational root, count the multiplicity of ``(x − r)`` in ``den``.
-/// Returns ``None`` when the multiplicities don't sum to ``deg(den)``
-/// (irreducible factor present), so the caller can bail to the unevaluated
-/// form.
-fn rp_root_multiplicities(den: &[RatC], roots: &[RatC]) -> Option<Vec<(RatC, usize)>> {
+/// Returns the remaining factor after rational-root factors are removed.
+/// The residual is constant iff ``den`` fully splits over Q.
+fn rp_root_multiplicities_and_residual(
+    den: &[RatC],
+    roots: &[RatC],
+) -> Option<(Vec<(RatC, usize)>, RatPoly)> {
     let mut out: Vec<(RatC, usize)> = Vec::new();
     let mut remaining: RatPoly = rp_normalize(den);
-    let mut total = 0usize;
     for &r in roots {
         let linear: RatPoly = vec![rc_neg(r), RC_ONE]; // (x − r)
         let mut m: usize = 0;
@@ -5159,14 +5160,9 @@ fn rp_root_multiplicities(den: &[RatC], roots: &[RatC]) -> Option<Vec<(RatC, usi
         if m == 0 {
             return None;
         }
-        total += m;
         out.push((r, m));
     }
-    let deg_den = rp_deg(den)?;
-    if total != deg_den {
-        return None;
-    }
-    Some(out)
+    Some((out, rp_normalize(&remaining)))
 }
 
 /// Rational form of an IR sub-expression in variable ``x``.
@@ -5476,23 +5472,26 @@ fn build_apart_term(a: RatC, r: RatC, power: usize, x: &str) -> Option<IRNode> {
 /// ``t^(m − 1)``.  Then ``A_{r, m − j} = φ_j``.  Emits terms
 /// ``A / (x − r)^power`` for ``power = 1..=m`` in ascending order.
 ///
-/// Returns ``None`` when ``den`` has an irreducible residual on top of its
-/// rational roots; that mixed-factor decomposition is still pending.
+/// Mixed rational-root plus irreducible residual factors are decomposed into
+/// rational-pole terms plus a proper residual rational term.
 fn apart_proper(num: &[RatC], den: &[RatC], x: &str) -> Option<IRNode> {
     let roots = rp_rational_roots(den)?;
     if roots.is_empty() {
         return proper_rational_to_ir(num, den, x);
     }
-    let mults = rp_root_multiplicities(den, &roots)?;
+    let (mults, residual_den) = rp_root_multiplicities_and_residual(den, &roots)?;
+    let has_residual = rp_deg(&residual_den).is_some_and(|deg| deg >= 1);
 
     // Phase 1 fast path — preserves the existing output shape for the
     // regression tests written against B1.
-    if mults.iter().all(|(_, m)| *m == 1) {
+    if !has_residual && mults.iter().all(|(_, m)| *m == 1) {
         return apart_simple_roots(num, den, &roots, x);
     }
 
     // Phase 48 generic path: Taylor + series-division per root.
     let mut terms: Vec<IRNode> = Vec::new();
+    let mut linear_part: RatPoly = rp_one();
+    let mut residual_num: RatPoly = rp_normalize(num);
     for &r in &roots {
         let m = mults
             .iter()
@@ -5501,6 +5500,9 @@ fn apart_proper(num: &[RatC], den: &[RatC], x: &str) -> Option<IRNode> {
         // because we just verified the multiplicity above.
         let mut q_poly: RatPoly = rp_normalize(den);
         let linear: RatPoly = vec![rc_neg(r), RC_ONE];
+        for _ in 0..m {
+            linear_part = rp_mul(&linear_part, &linear)?;
+        }
         for _ in 0..m {
             let (q, _rem) = rp_div(&q_poly, &linear)?;
             q_poly = q;
@@ -5518,6 +5520,29 @@ fn apart_proper(num: &[RatC], den: &[RatC], x: &str) -> Option<IRNode> {
                 continue;
             }
             terms.push(build_apart_term(a, r, power, x)?);
+            let mut pole_denom: RatPoly = rp_one();
+            for _ in 0..power {
+                pole_denom = rp_mul(&pole_denom, &linear)?;
+            }
+            let (q, rem) = rp_div(den, &pole_denom)?;
+            if !rp_is_zero(&rem) {
+                return None;
+            }
+            let scaled: RatPoly = q
+                .iter()
+                .map(|&c| rc_mul(c, a))
+                .collect::<Option<Vec<_>>>()?;
+            residual_num = rp_sub_poly(&residual_num, &scaled)?;
+        }
+    }
+    if has_residual {
+        let (residual_quotient, residual_rem) = rp_div(&residual_num, &linear_part)?;
+        if !rp_is_zero(&residual_rem) {
+            return None;
+        }
+        let residual_ir = proper_rational_to_ir(&residual_quotient, &residual_den, x)?;
+        if residual_ir != IRNode::Integer(0) {
+            terms.push(residual_ir);
         }
     }
     if terms.is_empty() {

--- a/code/packages/rust/symbolic-vm/tests/apart.rs
+++ b/code/packages/rust/symbolic-vm/tests/apart.rs
@@ -270,16 +270,39 @@ fn apart_mixed_simple_plus_repeated() {
 }
 
 #[test]
-fn apart_irreducible_plus_repeated_stays_unevaluated() {
+fn apart_irreducible_plus_repeated_decomposes_poles_plus_residual() {
     let mut v = vm();
     // 1 / ((x^2 + 1) * (x - 1)^2)
     let quad = apply(sym(ADD), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]);
     let lin_sq = apply(sym(POW), vec![apply(sym(SUB), vec![sym("x"), int(1)]), int(2)]);
     let inner = apply(sym(DIV), vec![int(1), apply(sym(MUL), vec![quad, lin_sq])]);
     let result = v.eval(apart(inner.clone()));
-    // x^2 + 1 has no rational roots; only x = 1 (mult 2) is found.  Sum of
-    // multiplicities (2) ≠ deg(den) (4) → bail to unevaluated form.
-    assert_eq!(result, apply(sym("Apart"), vec![inner, sym("x")]));
+    let expected = apply(
+        sym(ADD),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(DIV), vec![rat(-1, 2), apply(sym(ADD), vec![int(-1), sym("x")])]),
+                    apply(
+                        sym(DIV),
+                        vec![
+                            rat(1, 2),
+                            apply(sym(POW), vec![apply(sym(ADD), vec![int(-1), sym("x")]), int(2)]),
+                        ],
+                    ),
+                ],
+            ),
+            apply(
+                sym(DIV),
+                vec![
+                    apply(sym(MUL), vec![rat(1, 2), sym("x")]),
+                    apply(sym(ADD), vec![int(1), apply(sym(POW), vec![sym("x"), int(2)])]),
+                ],
+            ),
+        ],
+    );
+    assert_eq!(result, expected);
 }
 
 #[test]

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -1828,8 +1828,8 @@ function nodeKey(node: IRNode): string {
 // Apart (Track B1) — partial-fraction decomposition over Q(x).
 //
 // Supports simple rational roots, repeated rational roots, and proper
-// irreducible denominators that are already apart.  Mixed rational-root plus
-// irreducible residual factors still bail to unevaluated ``Apart(...)``.
+// irreducible denominators that are already apart, and mixed rational-root
+// plus irreducible residual factors.
 //
 // Polynomials here use a coefficient-tuple representation indexed by power
 // (lowest degree first) — same convention as ``polynomial-bridge.py``:
@@ -2054,15 +2054,14 @@ function polyQRationalRoots(p: PolyQ): RatQ[] {
 }
 
 /** For each rational root r, count how many times (x − r) divides ``den``.
- *  Returns a Map keyed by RatQ string-key; returns ``undefined`` if the
- *  multiplicities don't sum to deg(den) (irreducible factor present). */
-function polyQRootMultiplicities(
+ *  Also returns the remaining factor, which is constant iff ``den`` fully
+ *  splits over Q. */
+function polyQRootMultiplicitiesAndResidual(
   den: PolyQ,
   roots: readonly RatQ[],
-): Map<string, { root: RatQ; mult: number }> | undefined {
+): { mults: Map<string, { root: RatQ; mult: number }>; residual: RatQ[] } | undefined {
   const out = new Map<string, { root: RatQ; mult: number }>();
   let remaining: RatQ[] = polyQNormalize(den);
-  let total = 0;
   for (const r of roots) {
     let m = 0;
     const linear: RatQ[] = [rqNeg(r), RQ_ONE]; // (x − r)
@@ -2080,10 +2079,8 @@ function polyQRootMultiplicities(
     /* eslint-enable no-constant-condition */
     if (m === 0) return undefined;
     out.set(`${r[0]}/${r[1]}`, { root: r, mult: m });
-    total += m;
   }
-  if (total !== polyQDegree(den)) return undefined;
-  return out;
+  return { mults: out, residual: polyQNormalize(remaining) };
 }
 
 // --- IR ↔ polynomial bridge -------------------------------------------------
@@ -2404,13 +2401,15 @@ function buildApartTerm(A: RatQ, r: RatQ, power: number, x: IRSymbol): IRNode {
  *  Then ``A_{r, m − j} = φ_j``.  Emits terms ``A / (x − r)^power`` for
  *  ``power = 1..m``.
  *
- *  Returns ``undefined`` when ``den`` has an irreducible residual on top of
- *  its rational roots — the mixed-factor decomposition is still pending. */
+ *  Mixed rational-root plus irreducible residual factors are decomposed into
+ *  rational-pole terms plus a proper residual rational term. */
 function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
   const roots = polyQRationalRoots(den);
   if (roots.length === 0) return properRationalToIr(num, den, x);
-  const mults = polyQRootMultiplicities(den, roots);
-  if (mults === undefined) return undefined;
+  const split = polyQRootMultiplicitiesAndResidual(den, roots);
+  if (split === undefined) return undefined;
+  const { mults, residual: residualDen } = split;
+  const hasResidual = polyQDegree(residualDen) >= 1;
 
   // Phase 1 fast path — preserves the existing output shape for the
   // regression tests written against B1.
@@ -2421,10 +2420,12 @@ function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
       break;
     }
   }
-  if (allSimple) return apartSimpleRoots(num, den, roots, x);
+  if (!hasResidual && allSimple) return apartSimpleRoots(num, den, roots, x);
 
   // Phase 48 generic path: Taylor + series-division per root.
   const terms: IRNode[] = [];
+  let linearPart: RatQ[] = [RQ_ONE];
+  let residualNum: RatQ[] = polyQNormalize(num);
   for (const r of roots) {
     const key = `${r[0]}/${r[1]}`;
     const entry = mults.get(key);
@@ -2434,6 +2435,9 @@ function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
     // we just verified the multiplicity above.
     let qPoly: RatQ[] = polyQNormalize(den);
     const linear: RatQ[] = [rqNeg(r), RQ_ONE];
+    for (let i = 0; i < m; i += 1) {
+      linearPart = polyQMul(linearPart, linear);
+    }
     for (let i = 0; i < m; i += 1) {
       const { q } = polyQDivmod(qPoly, linear);
       qPoly = q;
@@ -2450,6 +2454,24 @@ function apartProper(num: PolyQ, den: PolyQ, x: IRSymbol): IRNode | undefined {
       const A = phi[j];
       if (rqIsZero(A)) continue;
       terms.push(buildApartTerm(A, r, power, x));
+      let poleDenom: RatQ[] = [RQ_ONE];
+      for (let i = 0; i < power; i += 1) {
+        poleDenom = polyQMul(poleDenom, linear);
+      }
+      const { q, r: rem } = polyQDivmod(den, poleDenom);
+      if (polyQNormalize(rem).length !== 0) return undefined;
+      residualNum = polyQSub(
+        residualNum,
+        q.map((c) => rqMul(c, A)),
+      );
+    }
+  }
+  if (hasResidual) {
+    const { q: residualQuotient, r: residualRem } = polyQDivmod(residualNum, linearPart);
+    if (polyQNormalize(residualRem).length !== 0) return undefined;
+    const residualIr = properRationalToIr(residualQuotient, residualDen, x);
+    if (!(residualIr.kind === "integer" && residualIr.value === 0n)) {
+      terms.push(residualIr);
     }
   }
   if (terms.length === 0) return int(0);

--- a/code/packages/typescript/symbolic-vm/tests/apart.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/apart.test.ts
@@ -176,15 +176,24 @@ describe("Apart — Track B3 (Phase 48 repeated linear factors)", () => {
     );
   });
 
-  it("leaves 1/((x^2+1)(x-1)^2) unevaluated (irreducible factor + repeated root)", () => {
+  it("decomposes 1/((x^2+1)(x-1)^2) into poles plus irreducible residual", () => {
     const vm = new VM(new SymbolicBackend());
     const quad = app(ADD, [app(POW, [x, int(2)]), int(1)]);
     const linSq = app(POW, [app(SUB, [x, int(1)]), int(2)]);
     const inner = app(DIV, [int(1), app(MUL, [quad, linSq])]);
     const result = vm.eval(apart(inner));
-    // x^2 + 1 has no rational roots — the rational-roots theorem only
-    // finds x = 1 (mult 2), which doesn't sum to deg(den) = 4.  Bail.
-    expect(result).toEqual(app(APART, [inner, x]));
+    expect(result).toEqual(
+      app(ADD, [
+        app(ADD, [
+          app(DIV, [rational(-1, 2), app(ADD, [int(-1), x])]),
+          app(DIV, [rational(1, 2), app(POW, [app(ADD, [int(-1), x]), int(2)])]),
+        ]),
+        app(DIV, [
+          app(MUL, [rational(1, 2), x]),
+          app(ADD, [int(1), app(POW, [x, int(2)])]),
+        ]),
+      ]),
+    );
   });
 
   it("decomposes 1/(x-2)^2 to itself (single repeated root, Q(x) = 1)", () => {

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -22,6 +22,14 @@
 > repo.  New work is feature-driven (e.g. Maple frontend) rather than
 > gap-driven.
 
+> **MACSYMA parity audit follow-up (2026-06-06).** A fresh `Apart`
+> audit found one post-finish residual gap: mixed rational-root plus
+> irreducible-denominator factors still returned unevaluated
+> `Apart(...)` even though pure irreducible and fully split repeated
+> rational factors were handled. This PR closes that gap across Python,
+> TypeScript, and Rust by subtracting rational-pole terms and emitting
+> the remaining proper irreducible residual.
+
 > **SPICE completion follow-up inventory (2026-06-06).** The 2026-06-05
 > release cut closed the planned SPICE 1970s compatibility slice, but a live
 > follow-up audit found one real parity gap: Rust had advanced named-corner
@@ -39,8 +47,9 @@
 > accuracy beyond the Phase 8 executable footholds.
 
 > **Living document.** Updated each time a PR lands or new work is planned.
-> Last updated: 2026-06-06 (SPICE completion follow-up inventory, Python and
-> TypeScript advanced-corner parity, and explicit remaining roadmap).
+> Last updated: 2026-06-06 (MACSYMA `Apart` mixed residual parity, SPICE
+> completion follow-up inventory, Python and TypeScript advanced-corner
+> parity, and explicit remaining roadmap).
 >
 > **Phase 48 — Apart for repeated linear factors (Python only, so far):**
 > `symbolic-vm` 0.72.0 (PR #3927).  Extends ``Apart`` to decompose


### PR DESCRIPTION
## Summary
- Decompose `Apart` expressions that mix rational poles with irreducible residual denominator factors across Python, TypeScript, and Rust.
- Preserve the existing simple-root fast path when the denominator fully splits, while routing mixed residual cases through residual subtraction.
- Replace stale unevaluated mixed-factor tests with exact/residual-equivalence coverage and document the parity audit follow-up.

## Verification
- Python: `pytest code/packages/python/symbolic-vm/tests/test_cas_handlers.py -q --no-cov` (160 passed)
- TypeScript: `node node_modules/vitest/vitest.mjs run tests/apart.test.ts` (11 passed)
- TypeScript: `node node_modules/typescript/bin/tsc --noEmit`
- Rust: `cargo check --manifest-path code/packages/rust/symbolic-vm/Cargo.toml`
- `git diff --check`

## Notes
- A focused Python run without `--no-cov` also passed all 160 tests but failed the repository-wide coverage threshold because only one test file was run.
- `cargo test --test apart` reached the link step but this Windows environment is missing SDK libraries such as `kernel32.lib`; `cargo check` succeeds.