### PR TITLE
Add smart-home mDNS discovery scan path

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
+  preserving scan parse failures as per-source D23 worker failures.
 - Hue mDNS and cloud-fallback discovery normalization into D23
   `DiscoveryRecord` candidates, including bridge-candidate batches and
   discovery-record pairing-plan handoff.

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -36,6 +36,8 @@ packages a typed surface for:
   `DiscoveryRecord` bridge candidates
 - Hue discovery worker runs that bundle mDNS/cloud observations, per-source
   failures, and generic D23 worker metadata for runtime catalog ingest
+- Hue discovery worker runs from generic mDNS scan results, preserving
+  malformed datagram failures alongside valid bridge advertisements
 - discovery-record-to-pairing-plan handoff for local physical-presence Hue
   pairing flows
 - integration descriptor metadata for Chief of Staff discovery

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -15,7 +15,7 @@ use smart_home_core::{
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerFailure,
-    DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun, MdnsAdvertisement,
+    DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun, MdnsAdvertisement, MdnsScanResult,
     PairingRequirement,
 };
 use std::fmt;
@@ -818,6 +818,60 @@ pub fn hue_discovery_worker_run_from_observations<'a>(
                     .with_metadata("hue.discovery.internal_ip_address", internal_ip_address),
             ),
         }
+    }
+
+    Ok(run)
+}
+
+pub fn hue_discovery_worker_run_from_mdns_scan(
+    worker_id: impl Into<String>,
+    scan: &MdnsScanResult,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> Result<DiscoveryWorkerRun, HueError> {
+    let mut run = DiscoveryWorkerRun::new(
+        DiscoveryWorkerId::new(worker_id)?,
+        IntegrationId::trusted(HUE_INTEGRATION_ID),
+        DiscoveryWorkerKind::MdnsScan,
+        started_at_ms,
+        completed_at_ms,
+    )
+    .with_metadata("hue.discovery.worker", "true")
+    .with_metadata("hue.discovery.worker_version", env!("CARGO_PKG_VERSION"))
+    .with_metadata("hue.discovery.scan_service_type", &scan.service_type)
+    .with_metadata(
+        "hue.discovery.scan_datagram_count",
+        scan.datagram_count.to_string(),
+    )
+    .with_metadata(
+        "hue.discovery.scan_advertisement_count",
+        scan.advertisements.len().to_string(),
+    )
+    .with_metadata(
+        "hue.discovery.scan_failure_count",
+        scan.failures.len().to_string(),
+    );
+
+    for advertisement in &scan.advertisements {
+        match hue_discovery_record_from_mdns(advertisement) {
+            Ok(record) => run.push_record(record)?,
+            Err(error) => run.push_failure(
+                DiscoveryWorkerFailure::new(DiscoverySource::Mdns, error.to_string())?
+                    .with_metadata("hue.discovery.service_type", &advertisement.service_type)
+                    .with_metadata("hue.discovery.instance_name", &advertisement.instance_name)
+                    .with_metadata("hue.discovery.host_name", &advertisement.host_name),
+            ),
+        }
+    }
+
+    for failure in &scan.failures {
+        let mut worker_failure =
+            DiscoveryWorkerFailure::new(DiscoverySource::Mdns, failure.message.clone())?
+                .with_metadata("hue.discovery.scan_failure", "true");
+        if let Some(source) = &failure.source {
+            worker_failure = worker_failure.with_metadata("hue.discovery.scan_source", source);
+        }
+        run.push_failure(worker_failure);
     }
 
     Ok(run)
@@ -2425,6 +2479,65 @@ mod tests {
             1
         );
         assert_eq!(summary.signal_summary.fresh, 2);
+    }
+
+    #[test]
+    fn hue_discovery_worker_run_from_mdns_scan_keeps_scan_failures() {
+        let mdns = MdnsAdvertisement::new(
+            HUE_MDNS_SERVICE_TYPE,
+            "Philips Hue - ABCDEF",
+            "hue-bridge.local",
+            443,
+            1_000,
+        )
+        .unwrap()
+        .with_address("192.0.2.10")
+        .unwrap()
+        .with_txt("bridgeid", "001788fffeabcdef")
+        .unwrap();
+        let non_hue = MdnsAdvertisement::new(
+            "_matter._tcp.local",
+            "Matter Bridge",
+            "matter.local",
+            5540,
+            1_005,
+        )
+        .unwrap();
+        let scan = MdnsScanResult {
+            service_type: HUE_MDNS_SERVICE_TYPE.to_string(),
+            discovered_at_ms: 1_010,
+            datagram_count: 3,
+            advertisements: vec![mdns, non_hue],
+            failures: vec![smart_home_discovery::MdnsScanFailure {
+                source: Some("192.0.2.50:5353".to_string()),
+                message: "invalid mDNS message: DNS header is shorter than 12 bytes".to_string(),
+            }],
+        };
+
+        let run =
+            hue_discovery_worker_run_from_mdns_scan("hue-mdns-scan", &scan, 990, 1_020).unwrap();
+        let summary = run.summary_at(1_100, 500, 1, 0, 0);
+
+        assert_eq!(run.kind, DiscoveryWorkerKind::MdnsScan);
+        assert_eq!(run.status(), DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(run.len(), 1);
+        assert_eq!(run.failure_count(), 2);
+        assert_eq!(run.records[0].source, DiscoverySource::Mdns);
+        assert!(run
+            .failures
+            .iter()
+            .any(|failure| failure.message.contains("not a Hue bridge service")));
+        assert!(run.failures.iter().any(|failure| failure
+            .metadata
+            .iter()
+            .any(|metadata| metadata.key == "hue.discovery.scan_source"
+                && metadata.value == "192.0.2.50:5353")));
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.scan_datagram_count" && metadata.value == "3"
+        }));
+        assert_eq!(summary.record_count, 1);
+        assert_eq!(summary.failure_count, 2);
+        assert_eq!(summary.accepted_count(), 1);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Bounded IPv4/IPv6 mDNS scan helpers that build PTR queries, collect UDP
+  replies through `udp-client`, and return deterministic `MdnsScanResult`
+  envelopes.
+- mDNS/DNS-SD response parsing for PTR, SRV, TXT, A, and AAAA records,
+  including compressed DNS names and per-datagram scan failures for malformed
+  replies.
 - `DiscoveryRecordSummary` and `DiscoveryCatalog::record_summary_at` for
   aggregate discovery planning by source, confidence, pairing requirement,
   address coverage, and freshness status.

--- a/code/packages/rust/smart-home-discovery/Cargo.toml
+++ b/code/packages/rust/smart-home-discovery/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT"
 [dependencies]
 smart-home-core = { path = "../smart-home-core" }
 smart-home-integration-catalog = { path = "../smart-home-integration-catalog" }
+udp-client = { path = "../udp-client" }

--- a/code/packages/rust/smart-home-discovery/README.md
+++ b/code/packages/rust/smart-home-discovery/README.md
@@ -1,11 +1,16 @@
 # smart-home-discovery
 
-Pure discovery-record primitives for the D23 smart-home runtime.
+Discovery-record and mDNS scan primitives for the D23 smart-home runtime.
 
-This crate does not open sockets, send mDNS packets, call vendor cloud APIs, or
-write credentials. It gives discovery workers a shared shape for:
+Most of this crate is transport-neutral record shaping. Its LAN mDNS helpers use
+`udp-client` for bounded datagram collection, but still keep vendor-specific
+normalization, cloud APIs, credential storage, and actor supervision outside
+this package. It gives discovery workers a shared shape for:
 
 - mDNS/SSDP/BLE/USB/DHCP/MQTT/webhook/cloud/manual discovery sources
+- bounded IPv4/IPv6 mDNS scans that send PTR questions and collect replies
+- mDNS/DNS-SD PTR/SRV/TXT/A/AAAA response parsing into advertisements
+- per-datagram scan failures for malformed mDNS responses
 - bridge candidate records with stable integration/native identifiers
 - stable discovery fingerprints and freshness signals for supervisor loops
 - confidence, pairing requirement, interface, and expiry metadata for repeated
@@ -32,13 +37,14 @@ write credentials. It gives discovery workers a shared shape for:
 - freshness filtering for supervisor/discovery loops
 - projection into unpaired `smart-home-core::Bridge` records
 
-Network transports, Hue-specific discovery, Vault credential storage, and actor
-supervision live in later integration/runtime crates.
+Hue-specific discovery, Vault credential storage, and actor supervision live in
+later integration/runtime crates.
 
 ## Dependencies
 
 - smart-home-core
 - smart-home-integration-catalog
+- udp-client
 
 ## Development
 

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -1,9 +1,10 @@
-//! Transport-neutral discovery records for the D23 smart-home runtime.
+//! Discovery records and mDNS scan helpers for the D23 smart-home runtime.
 //!
 //! Discovery workers can use this crate to normalize LAN, radio, USB, MQTT,
 //! cloud, webhook, manual, or simulator findings before a runtime decides
-//! whether to pair, ignore, or supervise a bridge. The crate deliberately
-//! performs no I/O.
+//! whether to pair, ignore, or supervise a bridge. Most helpers are pure data
+//! shaping; the mDNS scan functions use `udp-client` for bounded datagram I/O
+//! while leaving vendor-specific interpretation to integration crates.
 
 #![forbid(unsafe_code)]
 
@@ -12,7 +13,8 @@ use smart_home_core::{
     ProtocolIdentifier,
 };
 use smart_home_integration_catalog::{AuthMode, DiscoveryMechanism, IntegrationCatalogEntry};
-use std::{cmp::Ordering, collections::BTreeMap, fmt};
+use std::{cmp::Ordering, collections::BTreeMap, fmt, net::Ipv6Addr, time::Duration};
+use udp_client::{send_to_and_collect, UdpDiscoveryEndpoint, UdpOptions};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveryError {
@@ -21,6 +23,16 @@ pub enum DiscoveryError {
     },
     DuplicateTxtKey {
         key: String,
+    },
+    InvalidMdnsMessage {
+        message: String,
+    },
+    InvalidMdnsScanOption {
+        field: &'static str,
+        message: String,
+    },
+    MdnsTransport {
+        message: String,
     },
     WorkerIntegrationMismatch {
         worker_integration_id: String,
@@ -35,6 +47,13 @@ impl fmt::Display for DiscoveryError {
             Self::DuplicateTxtKey { key } => {
                 write!(f, "mDNS TXT key `{key}` appears more than once")
             }
+            Self::InvalidMdnsMessage { message } => {
+                write!(f, "invalid mDNS message: {message}")
+            }
+            Self::InvalidMdnsScanOption { field, message } => {
+                write!(f, "invalid mDNS scan option `{field}`: {message}")
+            }
+            Self::MdnsTransport { message } => write!(f, "mDNS transport failed: {message}"),
             Self::WorkerIntegrationMismatch {
                 worker_integration_id,
                 record_integration_id,
@@ -1315,6 +1334,239 @@ impl ManualBridgeInput {
     }
 }
 
+pub const MDNS_DNS_CLASS_IN: u16 = 1;
+pub const MDNS_DNS_TYPE_A: u16 = 1;
+pub const MDNS_DNS_TYPE_PTR: u16 = 12;
+pub const MDNS_DNS_TYPE_TXT: u16 = 16;
+pub const MDNS_DNS_TYPE_AAAA: u16 = 28;
+pub const MDNS_DNS_TYPE_SRV: u16 = 33;
+pub const MDNS_DEFAULT_MAX_DATAGRAM_SIZE: usize = 1500;
+pub const MDNS_DEFAULT_MAX_RESPONSES: usize = 32;
+pub const MDNS_UNICAST_RESPONSE_CLASS_BIT: u16 = 0x8000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsQuestion {
+    pub service_type: String,
+    pub unicast_response: bool,
+}
+
+impl MdnsQuestion {
+    pub fn new(service_type: impl Into<String>) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            service_type: non_empty("mdns.service_type", service_type)?,
+            unicast_response: true,
+        })
+    }
+
+    pub fn multicast_response(mut self) -> Self {
+        self.unicast_response = false;
+        self
+    }
+
+    pub fn to_query_packet(&self) -> Result<Vec<u8>, DiscoveryError> {
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&0u16.to_be_bytes());
+        packet.extend_from_slice(&0u16.to_be_bytes());
+        packet.extend_from_slice(&1u16.to_be_bytes());
+        packet.extend_from_slice(&0u16.to_be_bytes());
+        packet.extend_from_slice(&0u16.to_be_bytes());
+        packet.extend_from_slice(&0u16.to_be_bytes());
+        encode_dns_name(&self.service_type, &mut packet)?;
+        packet.extend_from_slice(&MDNS_DNS_TYPE_PTR.to_be_bytes());
+        let class = if self.unicast_response {
+            MDNS_DNS_CLASS_IN | MDNS_UNICAST_RESPONSE_CLASS_BIT
+        } else {
+            MDNS_DNS_CLASS_IN
+        };
+        packet.extend_from_slice(&class.to_be_bytes());
+        Ok(packet)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsResponsePacket {
+    pub source: Option<String>,
+    pub payload: Vec<u8>,
+}
+
+impl MdnsResponsePacket {
+    pub fn new(payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            source: None,
+            payload: payload.into(),
+        }
+    }
+
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsScanFailure {
+    pub source: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsScanResult {
+    pub service_type: String,
+    pub discovered_at_ms: u64,
+    pub datagram_count: usize,
+    pub advertisements: Vec<MdnsAdvertisement>,
+    pub failures: Vec<MdnsScanFailure>,
+}
+
+impl MdnsScanResult {
+    pub fn from_packets(
+        service_type: impl Into<String>,
+        discovered_at_ms: u64,
+        packets: impl IntoIterator<Item = MdnsResponsePacket>,
+    ) -> Result<Self, DiscoveryError> {
+        let service_type = non_empty("mdns.service_type", service_type)?;
+        let mut result = Self {
+            service_type: service_type.clone(),
+            discovered_at_ms,
+            datagram_count: 0,
+            advertisements: Vec::new(),
+            failures: Vec::new(),
+        };
+
+        for packet in packets {
+            result.datagram_count += 1;
+            match mdns_advertisements_from_response(
+                &packet.payload,
+                &service_type,
+                discovered_at_ms,
+            ) {
+                Ok(mut advertisements) => result.advertisements.append(&mut advertisements),
+                Err(error) => result.failures.push(MdnsScanFailure {
+                    source: packet.source,
+                    message: error.to_string(),
+                }),
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn len(&self) -> usize {
+        self.advertisements.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.advertisements.is_empty()
+    }
+
+    pub fn failure_count(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn has_failures(&self) -> bool {
+        !self.failures.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsScanOptions {
+    pub service_type: String,
+    pub discovered_at_ms: u64,
+    pub timeout: Duration,
+    pub max_responses: usize,
+    pub max_datagram_size: usize,
+    pub unicast_response: bool,
+}
+
+impl MdnsScanOptions {
+    pub fn new(
+        service_type: impl Into<String>,
+        discovered_at_ms: u64,
+        timeout: Duration,
+    ) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            service_type: non_empty("mdns.service_type", service_type)?,
+            discovered_at_ms,
+            timeout,
+            max_responses: MDNS_DEFAULT_MAX_RESPONSES,
+            max_datagram_size: MDNS_DEFAULT_MAX_DATAGRAM_SIZE,
+            unicast_response: true,
+        })
+    }
+
+    pub fn with_max_responses(mut self, max_responses: usize) -> Self {
+        self.max_responses = max_responses;
+        self
+    }
+
+    pub fn with_max_datagram_size(mut self, max_datagram_size: usize) -> Self {
+        self.max_datagram_size = max_datagram_size;
+        self
+    }
+
+    pub fn multicast_response(mut self) -> Self {
+        self.unicast_response = false;
+        self
+    }
+
+    pub fn query_packet(&self) -> Result<Vec<u8>, DiscoveryError> {
+        let mut question = MdnsQuestion::new(self.service_type.clone())?;
+        if !self.unicast_response {
+            question = question.multicast_response();
+        }
+        question.to_query_packet()
+    }
+}
+
+pub fn run_mdns_ipv4_scan(options: MdnsScanOptions) -> Result<MdnsScanResult, DiscoveryError> {
+    validate_mdns_scan_options(&options)?;
+    let endpoint = UdpDiscoveryEndpoint::mdns_ipv4();
+    let query = options.query_packet()?;
+    let udp_options = endpoint.options(
+        options.max_datagram_size,
+        Some(options.timeout),
+        Some(options.timeout),
+    );
+    let datagrams = send_to_and_collect(
+        endpoint.destination,
+        &query,
+        udp_options,
+        options.max_responses,
+    )
+    .map_err(|error| DiscoveryError::MdnsTransport {
+        message: error.to_string(),
+    })?;
+    let packets = datagrams.into_iter().map(|datagram| {
+        MdnsResponsePacket::new(datagram.payload).with_source(datagram.source.to_string())
+    });
+    MdnsScanResult::from_packets(options.service_type, options.discovered_at_ms, packets)
+}
+
+pub fn run_mdns_ipv6_scan(options: MdnsScanOptions) -> Result<MdnsScanResult, DiscoveryError> {
+    validate_mdns_scan_options(&options)?;
+    let endpoint = UdpDiscoveryEndpoint::mdns_ipv6();
+    let query = options.query_packet()?;
+    let udp_options = UdpOptions {
+        bind_addr: Some(endpoint.bind_addr()),
+        max_datagram_size: options.max_datagram_size,
+        read_timeout: Some(options.timeout),
+        write_timeout: Some(options.timeout),
+    };
+    let datagrams = send_to_and_collect(
+        endpoint.destination,
+        &query,
+        udp_options,
+        options.max_responses,
+    )
+    .map_err(|error| DiscoveryError::MdnsTransport {
+        message: error.to_string(),
+    })?;
+    let packets = datagrams.into_iter().map(|datagram| {
+        MdnsResponsePacket::new(datagram.payload).with_source(datagram.source.to_string())
+    });
+    MdnsScanResult::from_packets(options.service_type, options.discovered_at_ms, packets)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdnsTxtEntry {
     pub key: String,
@@ -1729,6 +1981,341 @@ fn discovery_mechanism_name(mechanism: DiscoveryMechanism) -> &'static str {
     }
 }
 
+fn validate_mdns_scan_options(options: &MdnsScanOptions) -> Result<(), DiscoveryError> {
+    if options.timeout.is_zero() {
+        return Err(DiscoveryError::InvalidMdnsScanOption {
+            field: "timeout",
+            message: "must be greater than zero".to_string(),
+        });
+    }
+    if options.max_responses == 0 {
+        return Err(DiscoveryError::InvalidMdnsScanOption {
+            field: "max_responses",
+            message: "must be greater than zero".to_string(),
+        });
+    }
+    if options.max_datagram_size == 0 {
+        return Err(DiscoveryError::InvalidMdnsScanOption {
+            field: "max_datagram_size",
+            message: "must be greater than zero".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn encode_dns_name(name: &str, packet: &mut Vec<u8>) -> Result<(), DiscoveryError> {
+    let name = name.trim().trim_end_matches('.');
+    if name.is_empty() {
+        return Err(DiscoveryError::EmptyField { field: "dns.name" });
+    }
+    for label in name.split('.') {
+        if label.is_empty() {
+            return Err(DiscoveryError::InvalidMdnsMessage {
+                message: format!("DNS name `{name}` contains an empty label"),
+            });
+        }
+        if label.len() > 63 {
+            return Err(DiscoveryError::InvalidMdnsMessage {
+                message: format!("DNS label `{label}` is longer than 63 bytes"),
+            });
+        }
+        packet.push(label.len() as u8);
+        packet.extend_from_slice(label.as_bytes());
+    }
+    packet.push(0);
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedDnsRecord {
+    name: String,
+    record_type: u16,
+    data: ParsedDnsRecordData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParsedDnsRecordData {
+    Ptr(String),
+    Srv { port: u16, target: String },
+    Txt(Vec<MdnsTxtEntry>),
+    Address(String),
+    Ignored,
+}
+
+fn mdns_advertisements_from_response(
+    packet: &[u8],
+    service_type: &str,
+    discovered_at_ms: u64,
+) -> Result<Vec<MdnsAdvertisement>, DiscoveryError> {
+    let records = parse_dns_records(packet)?;
+    let service_key = normalize_dns_name(service_type);
+    let mut ptr_instances = Vec::new();
+    let mut srv_by_instance = BTreeMap::<String, (u16, String)>::new();
+    let mut txt_by_instance = BTreeMap::<String, Vec<MdnsTxtEntry>>::new();
+    let mut addresses_by_host = BTreeMap::<String, Vec<String>>::new();
+
+    for record in records {
+        match record.data {
+            ParsedDnsRecordData::Ptr(instance_name)
+                if normalize_dns_name(&record.name) == service_key =>
+            {
+                ptr_instances.push(instance_name);
+            }
+            ParsedDnsRecordData::Srv { port, target } => {
+                srv_by_instance.insert(normalize_dns_name(&record.name), (port, target));
+            }
+            ParsedDnsRecordData::Txt(txt) => {
+                txt_by_instance.insert(normalize_dns_name(&record.name), txt);
+            }
+            ParsedDnsRecordData::Address(address) => {
+                addresses_by_host
+                    .entry(normalize_dns_name(&record.name))
+                    .or_default()
+                    .push(address);
+            }
+            ParsedDnsRecordData::Ptr(_) | ParsedDnsRecordData::Ignored => {}
+        }
+    }
+
+    let mut advertisements = Vec::new();
+    for instance_fqdn in ptr_instances {
+        let instance_key = normalize_dns_name(&instance_fqdn);
+        let (port, host_name) = srv_by_instance
+            .get(&instance_key)
+            .cloned()
+            .unwrap_or_else(|| (0, instance_fqdn.clone()));
+        let txt = txt_by_instance.remove(&instance_key).unwrap_or_default();
+        let addresses = addresses_by_host
+            .get(&normalize_dns_name(&host_name))
+            .cloned()
+            .unwrap_or_default();
+        let mut advertisement = MdnsAdvertisement::new(
+            service_type.to_string(),
+            mdns_instance_display_name(&instance_fqdn, service_type),
+            trim_trailing_dot(&host_name),
+            port,
+            discovered_at_ms,
+        )?;
+        for address in addresses {
+            advertisement = advertisement.with_address(address)?;
+        }
+        for entry in txt {
+            advertisement = advertisement.with_txt(entry.key, entry.value)?;
+        }
+        advertisements.push(advertisement);
+    }
+
+    Ok(advertisements)
+}
+
+fn parse_dns_records(packet: &[u8]) -> Result<Vec<ParsedDnsRecord>, DiscoveryError> {
+    if packet.len() < 12 {
+        return Err(invalid_mdns_message("DNS header is shorter than 12 bytes"));
+    }
+
+    let question_count = read_u16(packet, 4)? as usize;
+    let answer_count = read_u16(packet, 6)? as usize;
+    let authority_count = read_u16(packet, 8)? as usize;
+    let additional_count = read_u16(packet, 10)? as usize;
+    let mut offset = 12;
+
+    for _ in 0..question_count {
+        let (_, next_offset) = parse_dns_name(packet, offset)?;
+        offset = next_offset;
+        offset = offset
+            .checked_add(4)
+            .filter(|next| *next <= packet.len())
+            .ok_or_else(|| invalid_mdns_message("question extends beyond packet"))?;
+    }
+
+    let record_count = answer_count
+        .checked_add(authority_count)
+        .and_then(|count| count.checked_add(additional_count))
+        .ok_or_else(|| invalid_mdns_message("record count overflow"))?;
+    let mut records = Vec::new();
+    for _ in 0..record_count {
+        let (name, next_offset) = parse_dns_name(packet, offset)?;
+        offset = next_offset;
+        let record_type = read_u16(packet, offset)?;
+        let _class = read_u16(packet, offset + 2)?;
+        let _ttl = read_u32(packet, offset + 4)?;
+        let data_len = read_u16(packet, offset + 8)? as usize;
+        let data_offset = offset + 10;
+        let data_end = data_offset
+            .checked_add(data_len)
+            .filter(|end| *end <= packet.len())
+            .ok_or_else(|| invalid_mdns_message("record data extends beyond packet"))?;
+        let data = parse_dns_record_data(packet, record_type, data_offset, data_end)?;
+        records.push(ParsedDnsRecord {
+            name,
+            record_type,
+            data,
+        });
+        offset = data_end;
+    }
+    Ok(records)
+}
+
+fn parse_dns_record_data(
+    packet: &[u8],
+    record_type: u16,
+    data_offset: usize,
+    data_end: usize,
+) -> Result<ParsedDnsRecordData, DiscoveryError> {
+    match record_type {
+        MDNS_DNS_TYPE_PTR => {
+            let (name, _) = parse_dns_name(packet, data_offset)?;
+            Ok(ParsedDnsRecordData::Ptr(name))
+        }
+        MDNS_DNS_TYPE_SRV => {
+            if data_end.saturating_sub(data_offset) < 7 {
+                return Err(invalid_mdns_message("SRV record is too short"));
+            }
+            let port = read_u16(packet, data_offset + 4)?;
+            let (target, _) = parse_dns_name(packet, data_offset + 6)?;
+            Ok(ParsedDnsRecordData::Srv { port, target })
+        }
+        MDNS_DNS_TYPE_TXT => parse_txt_record(packet, data_offset, data_end),
+        MDNS_DNS_TYPE_A => {
+            if data_end.saturating_sub(data_offset) != 4 {
+                return Err(invalid_mdns_message("A record must be exactly 4 bytes"));
+            }
+            Ok(ParsedDnsRecordData::Address(format!(
+                "{}.{}.{}.{}",
+                packet[data_offset],
+                packet[data_offset + 1],
+                packet[data_offset + 2],
+                packet[data_offset + 3]
+            )))
+        }
+        MDNS_DNS_TYPE_AAAA => {
+            if data_end.saturating_sub(data_offset) != 16 {
+                return Err(invalid_mdns_message("AAAA record must be exactly 16 bytes"));
+            }
+            let mut octets = [0u8; 16];
+            octets.copy_from_slice(&packet[data_offset..data_end]);
+            Ok(ParsedDnsRecordData::Address(
+                Ipv6Addr::from(octets).to_string(),
+            ))
+        }
+        _ => Ok(ParsedDnsRecordData::Ignored),
+    }
+}
+
+fn parse_txt_record(
+    packet: &[u8],
+    mut offset: usize,
+    data_end: usize,
+) -> Result<ParsedDnsRecordData, DiscoveryError> {
+    let mut entries = Vec::new();
+    while offset < data_end {
+        let len = packet[offset] as usize;
+        offset += 1;
+        let entry_end = offset
+            .checked_add(len)
+            .filter(|end| *end <= data_end)
+            .ok_or_else(|| invalid_mdns_message("TXT entry extends beyond record"))?;
+        if len > 0 {
+            let entry = String::from_utf8_lossy(&packet[offset..entry_end]).to_string();
+            let (key, value) = entry.split_once('=').unwrap_or((entry.as_str(), ""));
+            entries.push(MdnsTxtEntry::new(key, value)?);
+        }
+        offset = entry_end;
+    }
+    Ok(ParsedDnsRecordData::Txt(entries))
+}
+
+fn parse_dns_name(packet: &[u8], offset: usize) -> Result<(String, usize), DiscoveryError> {
+    let mut labels = Vec::new();
+    let mut cursor = offset;
+    let mut consumed_offset = None;
+    let mut jumps = 0usize;
+
+    loop {
+        if cursor >= packet.len() {
+            return Err(invalid_mdns_message("DNS name extends beyond packet"));
+        }
+        let len = packet[cursor];
+        if len & 0xC0 == 0xC0 {
+            if cursor + 1 >= packet.len() {
+                return Err(invalid_mdns_message(
+                    "compressed DNS name pointer is truncated",
+                ));
+            }
+            let pointer = (((len as usize & 0x3F) << 8) | packet[cursor + 1] as usize) as usize;
+            if pointer >= packet.len() {
+                return Err(invalid_mdns_message(
+                    "compressed DNS name pointer is out of range",
+                ));
+            }
+            consumed_offset.get_or_insert(cursor + 2);
+            cursor = pointer;
+            jumps += 1;
+            if jumps > 16 {
+                return Err(invalid_mdns_message("compressed DNS name pointer loop"));
+            }
+            continue;
+        }
+        if len & 0xC0 != 0 {
+            return Err(invalid_mdns_message("unsupported DNS name label encoding"));
+        }
+        cursor += 1;
+        if len == 0 {
+            let next_offset = consumed_offset.unwrap_or(cursor);
+            return Ok((labels.join("."), next_offset));
+        }
+        let label_len = len as usize;
+        let label_end = cursor
+            .checked_add(label_len)
+            .filter(|end| *end <= packet.len())
+            .ok_or_else(|| invalid_mdns_message("DNS label extends beyond packet"))?;
+        labels.push(String::from_utf8_lossy(&packet[cursor..label_end]).to_string());
+        cursor = label_end;
+    }
+}
+
+fn read_u16(packet: &[u8], offset: usize) -> Result<u16, DiscoveryError> {
+    let bytes = packet
+        .get(offset..offset + 2)
+        .ok_or_else(|| invalid_mdns_message("expected u16 beyond packet"))?;
+    Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+}
+
+fn read_u32(packet: &[u8], offset: usize) -> Result<u32, DiscoveryError> {
+    let bytes = packet
+        .get(offset..offset + 4)
+        .ok_or_else(|| invalid_mdns_message("expected u32 beyond packet"))?;
+    Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+fn mdns_instance_display_name(instance_fqdn: &str, service_type: &str) -> String {
+    let instance = trim_trailing_dot(instance_fqdn);
+    let service = trim_trailing_dot(service_type);
+    let suffix = format!(".{service}");
+    if instance
+        .to_ascii_lowercase()
+        .ends_with(&suffix.to_ascii_lowercase())
+    {
+        instance[..instance.len().saturating_sub(suffix.len())].to_string()
+    } else {
+        instance.to_string()
+    }
+}
+
+fn normalize_dns_name(name: &str) -> String {
+    trim_trailing_dot(name).to_ascii_lowercase()
+}
+
+fn trim_trailing_dot(name: &str) -> String {
+    name.trim().trim_end_matches('.').to_string()
+}
+
+fn invalid_mdns_message(message: impl Into<String>) -> DiscoveryError {
+    DiscoveryError::InvalidMdnsMessage {
+        message: message.into(),
+    }
+}
+
 fn non_empty(field: &'static str, value: impl Into<String>) -> Result<String, DiscoveryError> {
     let value = value.into();
     if value.trim().is_empty() {
@@ -2108,6 +2695,118 @@ mod tests {
             error,
             DiscoveryError::DuplicateTxtKey {
                 key: "bridgeid".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn mdns_questions_build_ptr_queries_with_unicast_response_class() {
+        let query = MdnsQuestion::new("_hue._tcp.local")
+            .unwrap()
+            .to_query_packet()
+            .unwrap();
+
+        assert_eq!(&query[0..2], &[0, 0]);
+        assert_eq!(&query[4..6], &[0, 1]);
+        assert!(query.windows(4).any(|window| window == b"_hue"));
+        assert_eq!(
+            &query[query.len() - 4..],
+            &[
+                (MDNS_DNS_TYPE_PTR >> 8) as u8,
+                MDNS_DNS_TYPE_PTR as u8,
+                ((MDNS_DNS_CLASS_IN | MDNS_UNICAST_RESPONSE_CLASS_BIT) >> 8) as u8,
+                (MDNS_DNS_CLASS_IN | MDNS_UNICAST_RESPONSE_CLASS_BIT) as u8,
+            ]
+        );
+
+        let multicast_query = MdnsQuestion::new("_hue._tcp.local")
+            .unwrap()
+            .multicast_response()
+            .to_query_packet()
+            .unwrap();
+        assert_eq!(
+            &multicast_query[multicast_query.len() - 2..],
+            &[(MDNS_DNS_CLASS_IN >> 8) as u8, MDNS_DNS_CLASS_IN as u8]
+        );
+    }
+
+    #[test]
+    fn mdns_scan_result_parses_dns_sd_hue_advertisements_with_compression() {
+        let packet = hue_mdns_response_packet();
+        let result = MdnsScanResult::from_packets(
+            "_hue._tcp.local",
+            5_000,
+            [MdnsResponsePacket::new(packet).with_source("192.0.2.10:5353")],
+        )
+        .unwrap();
+
+        assert_eq!(result.datagram_count, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.failure_count(), 0);
+
+        let advertisement = &result.advertisements[0];
+        assert_eq!(advertisement.service_type, "_hue._tcp.local");
+        assert_eq!(advertisement.instance_name, "Living Room Hue");
+        assert_eq!(advertisement.host_name, "hue-bridge.local");
+        assert_eq!(advertisement.port, 443);
+        assert_eq!(advertisement.addresses, vec!["192.0.2.10"]);
+        assert_eq!(
+            advertisement.txt_value("bridgeid"),
+            Some("001788fffeabcdef")
+        );
+        assert_eq!(advertisement.txt_value("modelid"), Some("BSB002"));
+        assert_eq!(advertisement.discovered_at_ms, 5_000);
+    }
+
+    #[test]
+    fn mdns_scan_result_preserves_malformed_datagram_failures() {
+        let result = MdnsScanResult::from_packets(
+            "_hue._tcp.local",
+            5_000,
+            [
+                MdnsResponsePacket::new([1, 2, 3]).with_source("192.0.2.20:5353"),
+                MdnsResponsePacket::new(hue_mdns_response_packet()).with_source("192.0.2.10:5353"),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(result.datagram_count, 2);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.failure_count(), 1);
+        assert_eq!(
+            result.failures[0].source.as_deref(),
+            Some("192.0.2.20:5353")
+        );
+        assert!(result.failures[0]
+            .message
+            .contains("DNS header is shorter than 12 bytes"));
+    }
+
+    #[test]
+    fn mdns_scan_options_validate_bounded_socket_scans() {
+        let error = run_mdns_ipv4_scan(
+            MdnsScanOptions::new("_hue._tcp.local", 1_000, Duration::ZERO).unwrap(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            DiscoveryError::InvalidMdnsScanOption {
+                field: "timeout",
+                message: "must be greater than zero".to_string()
+            }
+        );
+
+        let error = run_mdns_ipv4_scan(
+            MdnsScanOptions::new("_hue._tcp.local", 1_000, Duration::from_millis(1))
+                .unwrap()
+                .with_max_responses(0),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            DiscoveryError::InvalidMdnsScanOption {
+                field: "max_responses",
+                message: "must be greater than zero".to_string()
             }
         );
     }
@@ -2594,5 +3293,84 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, DiscoveryError::EmptyField { field: "address" });
+    }
+
+    fn hue_mdns_response_packet() -> Vec<u8> {
+        let mut packet = Vec::new();
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 0x8400);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 1);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 3);
+
+        let service_offset = packet.len();
+        encode_dns_name("_hue._tcp.local", &mut packet).unwrap();
+        push_record_fixed_header(&mut packet, MDNS_DNS_TYPE_PTR, 120);
+        let ptr_len_offset = reserve_rdlength(&mut packet);
+        let instance_offset = packet.len();
+        encode_dns_name("Living Room Hue._hue._tcp.local", &mut packet).unwrap();
+        fill_rdlength(&mut packet, ptr_len_offset);
+
+        push_name_pointer(&mut packet, instance_offset);
+        push_record_fixed_header(&mut packet, MDNS_DNS_TYPE_SRV, 120);
+        let srv_len_offset = reserve_rdlength(&mut packet);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 0);
+        push_u16(&mut packet, 443);
+        let host_offset = packet.len();
+        encode_dns_name("hue-bridge.local", &mut packet).unwrap();
+        fill_rdlength(&mut packet, srv_len_offset);
+
+        push_name_pointer(&mut packet, instance_offset);
+        push_record_fixed_header(&mut packet, MDNS_DNS_TYPE_TXT, 120);
+        let txt_len_offset = reserve_rdlength(&mut packet);
+        push_txt_entry(&mut packet, "bridgeid", "001788fffeabcdef");
+        push_txt_entry(&mut packet, "modelid", "BSB002");
+        fill_rdlength(&mut packet, txt_len_offset);
+
+        push_name_pointer(&mut packet, host_offset);
+        push_record_fixed_header(&mut packet, MDNS_DNS_TYPE_A, 120);
+        let a_len_offset = reserve_rdlength(&mut packet);
+        packet.extend_from_slice(&[192, 0, 2, 10]);
+        fill_rdlength(&mut packet, a_len_offset);
+
+        assert_eq!(service_offset, 12);
+        packet
+    }
+
+    fn push_record_fixed_header(packet: &mut Vec<u8>, record_type: u16, ttl: u32) {
+        push_u16(packet, record_type);
+        push_u16(packet, MDNS_DNS_CLASS_IN);
+        packet.extend_from_slice(&ttl.to_be_bytes());
+    }
+
+    fn reserve_rdlength(packet: &mut Vec<u8>) -> usize {
+        let offset = packet.len();
+        push_u16(packet, 0);
+        offset
+    }
+
+    fn fill_rdlength(packet: &mut [u8], len_offset: usize) {
+        let data_start = len_offset + 2;
+        let len = packet.len() - data_start;
+        packet[len_offset..len_offset + 2].copy_from_slice(&(len as u16).to_be_bytes());
+    }
+
+    fn push_name_pointer(packet: &mut Vec<u8>, offset: usize) {
+        assert!(offset <= 0x3FFF);
+        let pointer = 0xC000 | offset as u16;
+        push_u16(packet, pointer);
+    }
+
+    fn push_txt_entry(packet: &mut Vec<u8>, key: &str, value: &str) {
+        let entry = format!("{key}={value}");
+        assert!(entry.len() <= u8::MAX as usize);
+        packet.push(entry.len() as u8);
+        packet.extend_from_slice(entry.as_bytes());
+    }
+
+    fn push_u16(packet: &mut Vec<u8>, value: u16) {
+        packet.extend_from_slice(&value.to_be_bytes());
     }
 }

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Deterministic Hue mDNS scan fixtures, with discovery worker-run fixtures now
+  flowing through `MdnsScanResult` before seeding runtime discovery catalogs.
 - Deterministic fixture clock for freshness and supervisor tests.
 - Normalized Hue-like bridge, device, light entity, and sensor entity fixtures.
 - Deterministic Hue discovery record and discovery-runtime fixtures built

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -10,8 +10,8 @@ a shared way to build:
 - normalized bridge/device/entity fixtures
 - normalized Hue discovery records, built through `hue-core` mDNS mapping, and
   discovery-seeded runtime fixtures
-- deterministic Hue discovery worker-run fixtures that feed the runtime
-  discovery catalog without opening network sockets
+- deterministic Hue mDNS scan and discovery worker-run fixtures that feed the
+  runtime discovery catalog without opening network sockets
 - registry seeding helpers for installing fixture records into
   `smart-home-registry`
 - confirmed, stale, and optimistic state snapshots

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -7,8 +7,7 @@
 #![forbid(unsafe_code)]
 
 use hue_core::{
-    hue_discovery_record_from_mdns, hue_discovery_worker_run_from_observations,
-    HueCloudDiscoveryBridge, HUE_MDNS_SERVICE_TYPE,
+    hue_discovery_record_from_mdns, hue_discovery_worker_run_from_mdns_scan, HUE_MDNS_SERVICE_TYPE,
 };
 use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId, CommandResult,
@@ -17,7 +16,9 @@ use smart_home_core::{
     ProtocolFamily, ProtocolIdentifier, StateConfidence, StateDelta, StateSnapshot, StateSource,
     Value,
 };
-use smart_home_discovery::{DiscoveryRecord, DiscoveryWorkerRun, MdnsAdvertisement};
+use smart_home_discovery::{
+    DiscoveryRecord, DiscoveryWorkerRun, MdnsAdvertisement, MdnsScanResult,
+};
 use smart_home_event_streams::{
     EventStreamCheckpoint, EventStreamRestartReason, EventStreamSpec, EventStreamState,
     EventStreamStatus, MqttQos, MqttTopicError, MqttTopicFilter,
@@ -1019,16 +1020,28 @@ pub fn hue_bridge_mdns_advertisement(
     .expect("fixture Hue firmware TXT is valid")
 }
 
+pub fn hue_bridge_mdns_scan_result(
+    native_id: impl Into<String>,
+    discovered_at_ms: u64,
+) -> MdnsScanResult {
+    MdnsScanResult {
+        service_type: HUE_MDNS_SERVICE_TYPE.to_string(),
+        discovered_at_ms,
+        datagram_count: 1,
+        advertisements: vec![hue_bridge_mdns_advertisement(native_id, discovered_at_ms)],
+        failures: Vec::new(),
+    }
+}
+
 pub fn hue_bridge_discovery_worker_run(
     native_id: impl Into<String>,
     started_at_ms: u64,
     completed_at_ms: u64,
 ) -> DiscoveryWorkerRun {
-    let advertisement = hue_bridge_mdns_advertisement(native_id, completed_at_ms);
-    let mut run = hue_discovery_worker_run_from_observations(
+    let scan = hue_bridge_mdns_scan_result(native_id, completed_at_ms);
+    let mut run = hue_discovery_worker_run_from_mdns_scan(
         "fixture-hue-discovery-worker",
-        [&advertisement],
-        Vec::<HueCloudDiscoveryBridge>::new(),
+        &scan,
         started_at_ms,
         completed_at_ms,
     )
@@ -1752,6 +1765,24 @@ mod tests {
         assert!(run.metadata.iter().any(|metadata| {
             metadata.key == "fixture" && metadata.value == "hue_bridge_discovery_worker"
         }));
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.scan_datagram_count" && metadata.value == "1"
+        }));
+    }
+
+    #[test]
+    fn hue_mdns_scan_fixture_reports_canonical_advertisements() {
+        let scan = hue_bridge_mdns_scan_result("001788fffescan", 1_000);
+
+        assert_eq!(scan.service_type, HUE_MDNS_SERVICE_TYPE);
+        assert_eq!(scan.datagram_count, 1);
+        assert_eq!(scan.len(), 1);
+        assert!(!scan.has_failures());
+        assert_eq!(
+            scan.advertisements[0].txt_value("bridgeid"),
+            Some("001788fffescan")
+        );
+        assert_eq!(scan.advertisements[0].preferred_address(), "192.0.2.10");
     }
 
     #[test]

--- a/code/packages/rust/udp-client/CHANGELOG.md
+++ b/code/packages/rust/udp-client/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- `send_to_and_collect` for bounded unconnected discovery probes that gather
+  replies until the configured read timeout or response limit is reached.
 - mDNS and SSDP [`UdpDiscoveryEndpoint`] presets with matching unspecified
   bind-address helpers and option construction for local device-discovery
   probes.

--- a/code/packages/rust/udp-client/README.md
+++ b/code/packages/rust/udp-client/README.md
@@ -57,6 +57,8 @@ fn main() -> Result<(), udp_client::UdpError> {
 - `send(payload)` — send one datagram to the connected peer
 - `recv_from()` — receive one datagram plus source/destination metadata
 - `send_and_receive(destination, payload, options)` — simple one-shot request/response helper
+- `send_to_and_collect(destination, payload, options, max_responses)` — send an
+  unconnected probe and collect replies until timeout or limit
 - `UdpDiscoveryEndpoint` — mDNS/SSDP multicast destinations and matching bind
   options for local device discovery probes
 

--- a/code/packages/rust/udp-client/src/lib.rs
+++ b/code/packages/rust/udp-client/src/lib.rs
@@ -148,7 +148,9 @@ pub enum UdpError {
     ReceiveFailed(String),
     Timeout,
     NotConnected,
+    MissingReadTimeout,
     InvalidDatagramSize { size: usize, max: usize },
+    InvalidResponseLimit { max_responses: usize },
     TruncatedDatagram,
 }
 
@@ -161,8 +163,17 @@ impl fmt::Display for UdpError {
             Self::ReceiveFailed(message) => write!(f, "failed to receive UDP datagram: {message}"),
             Self::Timeout => write!(f, "UDP operation timed out"),
             Self::NotConnected => write!(f, "UDP socket has no connected peer"),
+            Self::MissingReadTimeout => {
+                write!(f, "UDP response collection requires a read timeout")
+            }
             Self::InvalidDatagramSize { size, max } => {
                 write!(f, "invalid UDP datagram size {size}; maximum is {max}")
+            }
+            Self::InvalidResponseLimit { max_responses } => {
+                write!(
+                    f,
+                    "invalid UDP response limit {max_responses}; maximum is 1 or more"
+                )
             }
             Self::TruncatedDatagram => write!(f, "UDP datagram exceeded receive buffer"),
         }
@@ -280,6 +291,38 @@ pub fn send_and_receive(
     client.connect(destination)?;
     client.send(payload)?;
     client.recv_from()
+}
+
+/// Send one datagram to a discovery endpoint and collect replies until the
+/// configured read timeout or response limit is reached.
+pub fn send_to_and_collect(
+    destination: SocketAddr,
+    payload: &[u8],
+    mut options: UdpOptions,
+    max_responses: usize,
+) -> Result<Vec<UdpDatagram>, UdpError> {
+    if max_responses == 0 {
+        return Err(UdpError::InvalidResponseLimit { max_responses });
+    }
+    if options.read_timeout.is_none() {
+        return Err(UdpError::MissingReadTimeout);
+    }
+    if options.bind_addr.is_none() {
+        options.bind_addr = Some(unspecified_addr_for(destination));
+    }
+
+    let client = UdpClient::bind(options)?;
+    client.send_to(payload, destination)?;
+
+    let mut datagrams = Vec::new();
+    while datagrams.len() < max_responses {
+        match client.recv_from() {
+            Ok(datagram) => datagrams.push(datagram),
+            Err(UdpError::Timeout) => break,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(datagrams)
 }
 
 fn validate_max_datagram_size(size: usize) -> Result<(), UdpError> {
@@ -423,8 +466,16 @@ mod tests {
             (UdpError::Timeout, "UDP operation timed out"),
             (UdpError::NotConnected, "UDP socket has no connected peer"),
             (
+                UdpError::MissingReadTimeout,
+                "UDP response collection requires a read timeout",
+            ),
+            (
                 UdpError::InvalidDatagramSize { size: 9, max: 8 },
                 "invalid UDP datagram size 9; maximum is 8",
+            ),
+            (
+                UdpError::InvalidResponseLimit { max_responses: 0 },
+                "invalid UDP response limit 0; maximum is 1 or more",
             ),
             (
                 UdpError::TruncatedDatagram,
@@ -449,6 +500,63 @@ mod tests {
 
         assert!(local.is_ipv4());
         assert_ne!(local.port(), 0);
+    }
+
+    #[test]
+    fn send_to_and_collect_gathers_unconnected_replies_until_timeout() {
+        let client = bind_test_client();
+        let client_addr = client.local_addr().unwrap();
+        drop(client);
+        let responder = UdpSocket::bind(localhost(0)).unwrap();
+        let responder_addr = responder.local_addr().unwrap();
+
+        let handle = thread::spawn(move || {
+            let mut buffer = [0u8; 32];
+            let (_, source) = responder.recv_from(&mut buffer).unwrap();
+            responder.send_to(b"one", source).unwrap();
+            responder.send_to(b"two", source).unwrap();
+        });
+
+        let replies = send_to_and_collect(
+            responder_addr,
+            b"probe",
+            UdpOptions {
+                bind_addr: Some(client_addr),
+                max_datagram_size: 16,
+                read_timeout: Some(Duration::from_millis(100)),
+                write_timeout: Some(Duration::from_millis(100)),
+            },
+            4,
+        )
+        .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(replies.len(), 2);
+        assert_eq!(replies[0].payload, b"one");
+        assert_eq!(replies[1].payload, b"two");
+        assert!(replies.iter().all(|reply| reply.source == responder_addr));
+    }
+
+    #[test]
+    fn send_to_and_collect_requires_timeout_and_positive_limit() {
+        let destination = localhost(9);
+
+        assert_eq!(
+            send_to_and_collect(destination, b"probe", test_options(), 0),
+            Err(UdpError::InvalidResponseLimit { max_responses: 0 })
+        );
+        assert_eq!(
+            send_to_and_collect(
+                destination,
+                b"probe",
+                UdpOptions {
+                    read_timeout: None,
+                    ..test_options()
+                },
+                1,
+            ),
+            Err(UdpError::MissingReadTimeout)
+        );
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -82,6 +82,25 @@ keeping the implementation testable and D23-owned:
   worker-run ingest path, so runtime and Chief bridge tests exercise the same
   platform handoff a future LAN scanner will use.
 
+## Current LAN mDNS Scan Slice
+
+This slice attaches real LAN mDNS scan primitives to that worker handoff while
+preserving the platform boundary:
+
+- `udp-client` can send an unconnected multicast discovery probe and collect
+  replies until a bounded read timeout or response limit is reached.
+- `smart-home-discovery` can build mDNS PTR questions, run IPv4/IPv6 mDNS
+  scans through the UDP transport, and parse DNS-SD PTR/SRV/TXT/A/AAAA replies
+  with compressed names into reusable `MdnsAdvertisement` records.
+- `smart-home-discovery` keeps malformed datagrams as per-packet scan failures,
+  which lets discovery workers report partial LAN results instead of dropping a
+  whole scan.
+- `hue-core` can convert a generic `MdnsScanResult` into the D23 Hue discovery
+  worker-run envelope.
+- `smart-home-testkit` now seeds deterministic Hue discovery worker fixtures
+  through the mDNS scan envelope, so runtime tests exercise the scanner handoff
+  shape without opening sockets.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -103,8 +122,8 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Attach actual LAN mDNS socket scanning to the D23 discovery worker-run
-  contract and feed those runs into the runtime discovery catalog.
+- Run the LAN mDNS scanner from a supervised discovery worker across selected
+  interfaces and feed scheduled runs into durable D23 runtime state.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers

--- a/code/specs/NET07-udp-client.md
+++ b/code/specs/NET07-udp-client.md
@@ -221,6 +221,19 @@ pub fn send_and_receive(
     payload: &[u8],
     options: UdpOptions,
 ) -> Result<UdpDatagram, UdpError>;
+
+/// Send one datagram to a discovery endpoint and collect replies until the
+/// configured read timeout or response limit is reached.
+///
+/// This is useful for multicast discovery protocols such as mDNS, where
+/// responses may arrive from several different hosts and should not be filtered
+/// to the multicast destination address.
+pub fn send_to_and_collect(
+    destination: SocketAddr,
+    payload: &[u8],
+    options: UdpOptions,
+    max_responses: usize,
+) -> Result<Vec<UdpDatagram>, UdpError>;
 ```
 
 ### Error Types
@@ -246,8 +259,14 @@ pub enum UdpError {
     /// Caller attempted `send()` without first calling `connect()`.
     NotConnected,
 
+    /// Response collection was requested without a bounded read timeout.
+    MissingReadTimeout,
+
     /// Payload or receive buffer size is invalid for this package.
     InvalidDatagramSize { size: usize, max: usize },
+
+    /// Response collection was requested with an invalid response limit.
+    InvalidResponseLimit { max_responses: usize },
 
     /// The OS reported that a datagram did not fit in the receive buffer.
     TruncatedDatagram,
@@ -275,6 +294,10 @@ variants while preserving enough detail in string fields to debug locally.
 
 `send_and_receive()` sends once and receives once. If receive times out, it
 returns `UdpError::Timeout`. Higher layers decide whether to retry.
+
+`send_to_and_collect()` also sends exactly once. It does not retry, join
+multicast groups, or parse payloads; it only keeps receiving unconnected
+datagrams until the read timeout fires or `max_responses` replies have arrived.
 
 ### 3. No Hostname Resolution
 


### PR DESCRIPTION
## Summary

- add bounded UDP multicast response collection for discovery probes
- add mDNS PTR query building plus DNS-SD PTR/SRV/TXT/A/AAAA response parsing into smart-home discovery scan results
- adapt Hue discovery worker runs and testkit fixtures to consume generic mDNS scan results while preserving malformed datagram failures

## Validation

- cargo test -p udp-client
- cargo test -p smart-home-discovery
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in code/packages/rust/udp-client
- sh BUILD in code/packages/rust/smart-home-discovery
- sh BUILD in code/packages/rust/hue-core
- sh BUILD in code/packages/rust/smart-home-runtime
- sh BUILD in code/packages/rust/smart-home-testkit
- git diff --check

No code/packages/rust/Cargo.lock is present after validation.