### PR TITLE
Wire MACSYMA radcan through session assumptions

### DIFF
--- a/code/packages/python/cas-simplify/src/cas_simplify/radcan.py
+++ b/code/packages/python/cas-simplify/src/cas_simplify/radcan.py
@@ -24,11 +24,11 @@ Rules
 2. **Perfect-square extraction** — ``√(x² · b) = x · √b``
 
    When a Sqrt radicand is a Mul containing ``Pow(x, 2)`` for a
-   positive ``x`` (from context), pull ``x`` outside.
+   non-negative ``x`` (from context), pull ``x`` outside.
    For a positive integer radicand that is a perfect square, return
    the integer square root directly.
 
-3. **Sqrt(x²) → x** — ``√(x²) = x`` when x > 0
+3. **Sqrt(x²) → x** — ``√(x²) = x`` when x >= 0
 
    Handled as a special case of rule 2 with no remaining factor.
 
@@ -95,7 +95,7 @@ def radcan(
 
     Applies the five rules described in the module docstring in a single
     bottom-up pass.  The optional ``ctx`` parameter supplies sign facts
-    needed for rule 2 (``√(x²·b) = x·√b`` requires ``x > 0``).
+    needed for rule 2 (``√(x²·b) = x·√b`` requires ``x >= 0``).
 
     Parameters
     ----------
@@ -228,13 +228,13 @@ def _rule_sqrt(expr: IRApply, ctx: AssumptionContext | None) -> IRNode:
         if root is not None:
             return IRInteger(root)
 
-    # Sqrt(x²) → |x|, or → x when x > 0.
+    # Sqrt(x²) → x when x >= 0; otherwise leave sign-sensitive form intact.
     if _is_square_power(arg):
         base = _base_of(arg)
         if base is not None:
             return _abs_or_pos(base, ctx)
 
-    # Sqrt(Mul(...)) — extract Pow(x,2) factors when x > 0.
+    # Sqrt(Mul(...)) — extract Pow(x,2) factors when x >= 0.
     if isinstance(arg, IRApply) and arg.head == MUL:
         outer: list[IRNode] = []
         inner: list[IRNode] = []
@@ -262,21 +262,21 @@ def _try_extract_from_sqrt(
     """Return what to pull outside Sqrt(factor * ...), or None if not extractable.
 
     A factor is extractable when:
-    - It is ``Pow(x, 2)`` and either x is a positive integer literal or
-      x is a symbol known positive from ctx.
+    - It is ``Pow(x, 2)`` and either x is a non-negative integer literal or
+      x is a symbol known non-negative from ctx.
     - It is a positive integer that is a perfect square.
     """
-    # Pow(symbol, 2) with x > 0 from ctx.
+    # Pow(symbol, 2) with x >= 0 from ctx.
     if _is_square_power(factor):
         base = _base_of(factor)
         if base is None:
             return None
-        if isinstance(base, IRInteger) and base.value > 0:
+        if isinstance(base, IRInteger) and base.value >= 0:
             return base
         if (
             isinstance(base, IRSymbol)
             and ctx is not None
-            and ctx.is_positive(base.name) is True
+            and ctx.is_nonneg(base.name) is True
         ):
             return base
         return None
@@ -301,18 +301,18 @@ def _is_square_power(node: IRNode) -> bool:
 
 
 def _abs_or_pos(base: IRNode, ctx: AssumptionContext | None) -> IRNode:
-    """Return base when known positive, or Sqrt(base²) otherwise (leave unevaluated).
+    """Return base when known non-negative, or Sqrt(base²) otherwise.
 
-    Since we don't have an Abs head, we just return base when positivity is
+    Since we don't have an Abs head, we just return base when non-negativity is
     confirmed and leave the original Sqrt intact otherwise — the function's
     caller handles that case.
     """
-    if isinstance(base, IRInteger) and base.value > 0:
+    if isinstance(base, IRInteger) and base.value >= 0:
         return base
     if (
         isinstance(base, IRSymbol)
         and ctx is not None
-        and ctx.is_positive(base.name) is True
+        and ctx.is_nonneg(base.name) is True
     ):
         return base
     # Unknown sign — return the Sqrt unevaluated (caller returns expr as-is).

--- a/code/packages/python/cas-simplify/tests/test_phase21.py
+++ b/code/packages/python/cas-simplify/tests/test_phase21.py
@@ -65,6 +65,11 @@ def _greater_zero(sym: IRSymbol) -> IRApply:
     return IRApply(GREATER, (sym, IRInteger(0)))
 
 
+def _greater_equal_zero(sym: IRSymbol) -> IRApply:
+    """Build GreaterEqual(sym, 0)."""
+    return IRApply(GREATER_EQUAL, (sym, IRInteger(0)))
+
+
 def _less_zero(sym: IRSymbol) -> IRApply:
     """Build Less(sym, 0)."""
     return IRApply(LESS, (sym, IRInteger(0)))
@@ -80,6 +85,14 @@ def _ctx_pos(*syms: IRSymbol) -> AssumptionContext:
     ctx = _fresh_ctx()
     for s in syms:
         ctx.assume_relation(_greater_zero(s))
+    return ctx
+
+
+def _ctx_nonneg(*syms: IRSymbol) -> AssumptionContext:
+    """Return a context in which all given symbols are assumed non-negative."""
+    ctx = _fresh_ctx()
+    for s in syms:
+        ctx.assume_relation(_greater_equal_zero(s))
     return ctx
 
 
@@ -238,6 +251,11 @@ class TestRadcan:
         expr = IRApply(SQRT, (IRApply(POW, (x, IRInteger(2))),))
         assert radcan(expr, ctx) == x
 
+    def test_sqrt_x_squared_nonnegative(self) -> None:
+        ctx = _ctx_nonneg(x)
+        expr = IRApply(SQRT, (IRApply(POW, (x, IRInteger(2))),))
+        assert radcan(expr, ctx) == x
+
     def test_sqrt_x_squared_no_ctx(self) -> None:
         """Sqrt(x²) stays unevaluated without positivity context."""
         expr = IRApply(SQRT, (IRApply(POW, (x, IRInteger(2))),))
@@ -252,6 +270,16 @@ class TestRadcan:
         expr = IRApply(SQRT, (inner,))
         result = radcan(expr, ctx)
         # Should produce Mul(x, Sqrt(y))
+        assert isinstance(result, IRApply)
+        assert result.head == MUL
+        assert x in result.args
+        assert IRApply(SQRT, (y,)) in result.args
+
+    def test_sqrt_mul_nonnegative_perfect_square_factor(self) -> None:
+        ctx = _ctx_nonneg(x)
+        inner = IRApply(MUL, (IRApply(POW, (x, IRInteger(2))), y))
+        expr = IRApply(SQRT, (inner,))
+        result = radcan(expr, ctx)
         assert isinstance(result, IRApply)
         assert result.head == MUL
         assert x in result.args

--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -1460,6 +1460,13 @@ def test_pipeline_radcan_sqrt_squared() -> None:
     )
 
 
+def test_pipeline_radcan_uses_nonnegative_assumption() -> None:
+    """assume(x >= 0); radcan(sqrt(x^2)) -> x."""
+    result = _eval_seq("assume(x >= 0)", "radcan(sqrt(x^2))")
+    assert isinstance(result, IRSymbol)
+    assert result.name == "x"
+
+
 # ===========================================================================
 # Section DD — Fourier transforms (cas-fourier, Phase 33)
 # ===========================================================================

--- a/code/packages/rust/cas-simplify/src/radcan.rs
+++ b/code/packages/rust/cas-simplify/src/radcan.rs
@@ -136,11 +136,11 @@ fn rule_sqrt(args: &[IRNode], ctx: Option<&AssumptionContext>) -> IRNode {
 fn try_extract_from_sqrt(factor: &IRNode, ctx: Option<&AssumptionContext>) -> Option<IRNode> {
     if is_square_power(factor) {
         let base = base_of(factor)?;
-        if matches!(base, IRNode::Integer(n) if *n > 0) {
+        if matches!(base, IRNode::Integer(n) if *n >= 0) {
             return Some(base.clone());
         }
         if let IRNode::Symbol(name) = base {
-            if ctx.is_some_and(|ctx| ctx.is_positive(name) == Some(true)) {
+            if ctx.is_some_and(|ctx| ctx.is_nonneg(name) == Some(true)) {
                 return Some(base.clone());
             }
         }
@@ -192,11 +192,11 @@ fn is_square_power(node: &IRNode) -> bool {
 }
 
 fn abs_or_pos(base: &IRNode, ctx: Option<&AssumptionContext>) -> IRNode {
-    if matches!(base, IRNode::Integer(n) if *n > 0) {
+    if matches!(base, IRNode::Integer(n) if *n >= 0) {
         return base.clone();
     }
     if let IRNode::Symbol(name) = base {
-        if ctx.is_some_and(|ctx| ctx.is_positive(name) == Some(true)) {
+        if ctx.is_some_and(|ctx| ctx.is_nonneg(name) == Some(true)) {
             return base.clone();
         }
     }

--- a/code/packages/rust/cas-simplify/tests/tests.rs
+++ b/code/packages/rust/cas-simplify/tests/tests.rs
@@ -35,6 +35,12 @@ fn b() -> IRNode {
 fn c() -> IRNode {
     sym("c")
 }
+fn greater_zero(node: IRNode) -> IRNode {
+    apply(sym(GREATER), vec![node, int(0)])
+}
+fn greater_equal_zero(node: IRNode) -> IRNode {
+    apply(sym(GREATER_EQUAL), vec![node, int(0)])
+}
 fn zero() -> IRNode {
     int(0)
 }
@@ -510,7 +516,7 @@ fn radcan_simplifies_square_roots_and_exp_log_pairs() {
     );
 
     let mut ctx = AssumptionContext::new();
-    ctx.assume_relation(&apply(sym(GREATER), vec![x(), int(0)]));
+    ctx.assume_relation(&greater_zero(x()));
     let x_sq = apply(sym(POW), vec![x(), int(2)]);
     assert_eq!(
         radcan(apply(sym(SQRT), vec![x_sq.clone()]), Some(&ctx)),
@@ -518,8 +524,24 @@ fn radcan_simplifies_square_roots_and_exp_log_pairs() {
     );
     assert_ne!(radcan(apply(sym(SQRT), vec![x_sq]), None), x());
 
+    let mut nonneg_ctx = AssumptionContext::new();
+    nonneg_ctx.assume_relation(&greater_equal_zero(x()));
+    let x_sq = apply(sym(POW), vec![x(), int(2)]);
+    assert_eq!(radcan(apply(sym(SQRT), vec![x_sq]), Some(&nonneg_ctx)), x());
+
     let inner = apply(sym(MUL), vec![apply(sym(POW), vec![x(), int(2)]), y()]);
     let result = radcan(apply(sym(SQRT), vec![inner]), Some(&ctx));
+    match result {
+        IRNode::Apply(ap) => {
+            assert_eq!(ap.head, sym(MUL));
+            assert!(ap.args.contains(&x()));
+            assert!(ap.args.contains(&apply(sym(SQRT), vec![y()])));
+        }
+        other => panic!("expected Mul, got {other:?}"),
+    }
+
+    let inner = apply(sym(MUL), vec![apply(sym(POW), vec![x(), int(2)]), y()]);
+    let result = radcan(apply(sym(SQRT), vec![inner]), Some(&nonneg_ctx));
     match result {
         IRNode::Apply(ap) => {
             assert_eq!(ap.head, sym(MUL));

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -13,7 +13,7 @@ use cas_list_operations::{
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
 };
 use cas_pretty_printer::{pretty, pretty_2d, MacsymaDialect};
-use cas_simplify::{simplify, AssumptionContext};
+use cas_simplify::{radcan, simplify, AssumptionContext};
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_substitution::subst;
 use cas_trig::{expand_trig, trig_reduce, trig_simplify};
@@ -58,6 +58,7 @@ const FLOAT_FUNC: &str = "Float";
 const FORGET: &str = "Forget";
 const IS: &str = "Is";
 const RAT_SIMPLIFY: &str = "RatSimplify";
+const RADCAN: &str = "Radcan";
 const SIMPLIFY: &str = "Simplify";
 const SUBST: &str = "Subst";
 const TRIG_EXPAND: &str = "TrigExpand";
@@ -512,6 +513,11 @@ impl MacsymaBackend {
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
         handlers.insert(SUBST.to_string(), handler_fn(subst_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
+        let radcan_state = state.clone();
+        handlers.insert(
+            RADCAN.to_string(),
+            Arc::new(move |_vm, expr| radcan_handler(&radcan_state, expr)),
+        );
         handlers.insert(TRIG_SIMPLIFY.to_string(), handler_fn(trig_simplify_handler));
         handlers.insert(TRIG_EXPAND.to_string(), handler_fn(trig_expand_handler));
         handlers.insert(TRIG_REDUCE.to_string(), handler_fn(trig_reduce_handler));
@@ -598,7 +604,7 @@ impl MacsymaBackend {
 
         let held = [
             ASSIGN, DEFINE, IF, KILL, EV, ASSUME, FORGET, IS, DECLARE, PROPERTIES, PROP_VARS,
-            SOLVE, SUBST,
+            SOLVE, SUBST, RADCAN,
         ]
         .into_iter()
         .map(str::to_string)
@@ -959,6 +965,14 @@ fn simplify_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
         return IRNode::Apply(Box::new(expr));
     }
     simplify(expr.args[0].clone(), 50)
+}
+
+fn radcan_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let state = state.lock().expect("macsyma backend state poisoned");
+    radcan(expr.args[0].clone(), Some(&state.assumptions))
 }
 
 fn trig_simplify_handler(_vm: &mut VM, expr: IRApply) -> IRNode {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -6,7 +6,7 @@ use coding_adventures_macsyma_runtime::{
 use std::collections::HashMap;
 use symbolic_ir::{
     apply, int, rat, sym, ADD, AND, ASIN, COS, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS,
-    LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SUB,
+    LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SQRT, SUB,
 };
 
 const SUBST: &str = "Subst";
@@ -671,6 +671,36 @@ fn declare_feeds_properties_into_is_queries() {
     );
     assert_eq!(results[0].output, sym("done"));
     assert_eq!(results[1].output, sym("True"));
+}
+
+#[test]
+fn nonnegative_session_assumptions_feed_radcan() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("assume(x >= 0); radcan(sqrt(x^2));")
+        .unwrap();
+
+    assert_eq!(
+        results[1].input,
+        apply(
+            sym("Radcan"),
+            vec![apply(
+                sym(SQRT),
+                vec![apply(sym(POW), vec![sym("x"), int(2)])]
+            )]
+        )
+    );
+    assert_eq!(results[1].output, sym("x"));
+}
+
+#[test]
+fn declared_positivity_feeds_radcan() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("declare(y, positive); radcan(sqrt(y^2));")
+        .unwrap();
+
+    assert_eq!(results[1].output, sym("y"));
 }
 
 #[test]

--- a/code/packages/typescript/cas-simplify/src/radcan.ts
+++ b/code/packages/typescript/cas-simplify/src/radcan.ts
@@ -110,8 +110,8 @@ function ruleSqrt(expr: IRNode, ctx: AssumptionContext | undefined): IRNode {
 function tryExtractFromSqrt(factor: IRNode, ctx: AssumptionContext | undefined): IRNode | undefined {
   if (isSquarePower(factor)) {
     const base = baseOf(factor);
-    if (base?.kind === "integer" && base.value > 0n) return base;
-    if (base?.kind === "symbol" && ctx?.isPositive(base.name) === true) return base;
+    if (base?.kind === "integer" && base.value >= 0n) return base;
+    if (base?.kind === "symbol" && ctx?.isNonneg(base.name) === true) return base;
     return undefined;
   }
 
@@ -151,8 +151,8 @@ function isSquarePower(node: IRNode): boolean {
 }
 
 function absOrPositive(base: IRNode, ctx: AssumptionContext | undefined): IRNode {
-  if (base.kind === "integer" && base.value > 0n) return base;
-  if (base.kind === "symbol" && ctx?.isPositive(base.name) === true) return base;
+  if (base.kind === "integer" && base.value >= 0n) return base;
+  if (base.kind === "symbol" && ctx?.isNonneg(base.name) === true) return base;
   return app(SQRT, [app(POW, [base, int(2)])]);
 }
 

--- a/code/packages/typescript/cas-simplify/tests/phase21.test.ts
+++ b/code/packages/typescript/cas-simplify/tests/phase21.test.ts
@@ -45,9 +45,19 @@ function greaterZero(node: IRNode): IRNode {
   return app(GREATER, [node, int(0)]);
 }
 
+function greaterEqualZero(node: IRNode): IRNode {
+  return app(GREATER_EQUAL, [node, int(0)]);
+}
+
 function positiveContext(...nodes: readonly IRNode[]): AssumptionContext {
   const ctx = new AssumptionContext();
   for (const node of nodes) ctx.assumeRelation(greaterZero(node));
+  return ctx;
+}
+
+function nonnegativeContext(...nodes: readonly IRNode[]): AssumptionContext {
+  const ctx = new AssumptionContext();
+  for (const node of nodes) ctx.assumeRelation(greaterEqualZero(node));
   return ctx;
 }
 
@@ -110,11 +120,14 @@ describe("radcan", () => {
   it("uses positivity when simplifying Sqrt(x^2)", () => {
     expect(radcan(app(SQRT, [app(POW, [x, int(2)])]))).toEqual(app(SQRT, [app(POW, [x, int(2)])]));
     expect(radcan(app(SQRT, [app(POW, [x, int(2)])]), positiveContext(x))).toEqual(x);
+    expect(radcan(app(SQRT, [app(POW, [x, int(2)])]), nonnegativeContext(x))).toEqual(x);
   });
 
   it("extracts and merges square-root products", () => {
     const extracted = radcan(app(SQRT, [app(MUL, [app(POW, [x, int(2)]), y])]), positiveContext(x));
     expect(extracted).toEqual(app(MUL, [x, app(SQRT, [y])]));
+    const nonnegativeExtracted = radcan(app(SQRT, [app(MUL, [app(POW, [x, int(2)]), y])]), nonnegativeContext(x));
+    expect(nonnegativeExtracted).toEqual(app(MUL, [x, app(SQRT, [y])]));
 
     const merged = radcan(app(MUL, [app(SQRT, [a]), app(SQRT, [b])]));
     expect(merged).toEqual(app(SQRT, [app(MUL, [a, b])]));

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -13,7 +13,11 @@ import {
   reverse,
   sortList,
 } from "@coding-adventures/cas-list-operations";
-import { AssumptionContext, simplify as simplifyCas } from "@coding-adventures/cas-simplify";
+import {
+  AssumptionContext,
+  radcan as radcanCas,
+  simplify as simplifyCas,
+} from "@coding-adventures/cas-simplify";
 import { MacsymaDialect, pretty } from "@coding-adventures/cas-pretty-printer";
 import { solveLinearSystem, trySolveInequality, trySolveTranscendental } from "@coding-adventures/cas-solve";
 import { subst } from "@coding-adventures/cas-substitution";
@@ -79,6 +83,7 @@ export const PROP_VARS = sym("PropVars");
 export const SIMPLIFY = sym("Simplify");
 export const EXPAND = sym("Expand");
 export const RAT_SIMPLIFY = sym("RatSimplify");
+export const RADCAN = sym("Radcan");
 export const TRIG_SIMPLIFY = sym("TrigSimplify");
 export const TRIG_EXPAND = sym("TrigExpand");
 export const TRIG_REDUCE = sym("TrigReduce");
@@ -395,6 +400,7 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(SUBST.name, substHandler);
     table.set(SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
     table.set(RAT_SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
+    table.set(RADCAN.name, unaryHandler((value) => radcanCas(value, this.assumptions)));
     table.set(TRIG_SIMPLIFY.name, unaryHandler((value) => simplifyCas(trigSimplify(value))));
     table.set(TRIG_EXPAND.name, unaryHandler((value) => expandTrig(value)));
     table.set(TRIG_REDUCE.name, unaryHandler((value) => trigReduce(value)));
@@ -424,6 +430,7 @@ export class MacsymaBackend extends SymbolicBackend {
       PROP_VARS.name,
       SOLVE.name,
       SUBST.name,
+      RADCAN.name,
       FACTOR.name,
     ]);
   }

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -19,6 +19,7 @@ import {
   RULE,
   SIN,
   SOLVE,
+  SQRT,
   SUB,
   SUBST,
   TRUE,
@@ -51,6 +52,7 @@ import {
   PART,
   PROP_VARS,
   PROPERTIES,
+  RADCAN,
   RAT_SIMPLIFY,
   RANGE,
   REST,
@@ -582,6 +584,21 @@ describe("macsyma-runtime", () => {
     expect(declareResult.input).toEqual(app(DECLARE, [sym("x"), sym("positive")]));
     expect(declareResult.output).toEqual(sym("done"));
     expect(query.output).toEqual(TRUE);
+  });
+
+  it("feeds nonnegative session assumptions into radcan", () => {
+    const session = new MacsymaSession();
+    const [, result] = session.evalSource("assume(x >= 0); radcan(sqrt(x^2));");
+
+    expect(result.input).toEqual(app(RADCAN, [app(SQRT, [app(POW, [sym("x"), int(2)])])]));
+    expect(result.output).toEqual(sym("x"));
+  });
+
+  it("feeds declared positivity into radcan", () => {
+    const session = new MacsymaSession();
+    const [, result] = session.evalSource("declare(y, positive); radcan(sqrt(y^2));");
+
+    expect(result.output).toEqual(sym("y"));
   });
 
   it("properties lists declared properties deterministically", () => {


### PR DESCRIPTION
## Summary
- Extend Python/TypeScript/Rust `radcan` to use nonnegative assumptions for `sqrt(x^2)` and square-factor extraction.
- Wire TypeScript and Rust MACSYMA runtime `Radcan` handlers to session-owned assumptions and hold the head so raw radical input is preserved.
- Add parity tests for direct simplifier behavior and MACSYMA session behavior across Python, TypeScript, and Rust.

## Verification
- `python -m pytest code/packages/python/cas-simplify/tests/test_phase21.py -q --no-cov` — 75 passed
- `python -m pytest code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py -q --no-cov` — 182 passed
- `node node_modules/vitest/vitest.mjs run` in `code/packages/typescript/cas-simplify` — 21 passed
- `node node_modules/vitest/vitest.mjs run` in `code/packages/typescript/macsyma-runtime` — 76 passed
- `node node_modules/typescript/bin/tsc --noEmit` in `code/packages/typescript/cas-simplify`
- `node node_modules/typescript/bin/tsc --noEmit` in `code/packages/typescript/macsyma-runtime`
- `cargo test --manifest-path code/packages/rust/cas-simplify/Cargo.toml` — 51 integration/unit tests plus 2 doctests passed
- `cargo test --manifest-path code/packages/rust/macsyma-runtime/Cargo.toml` — 64 integration/unit tests passed
- `git diff --check`

## Notes
- Installed Node.js/npm and Visual Studio Build Tools/Windows SDK locally so TypeScript package installs/typechecks and Rust MSVC test binaries can run on this machine.