### PR TITLE
Add smart-home discovery execution handoff

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
+- Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`
+  envelopes, preserving per-interface scan failures and report metadata.
 - Hue mDNS and cloud-fallback discovery normalization into D23
   `DiscoveryRecord` candidates, including bridge-candidate batches and
   discovery-record pairing-plan handoff.

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -38,6 +38,8 @@ packages a typed surface for:
   failures, and generic D23 worker metadata for runtime catalog ingest
 - Hue discovery worker runs from generic mDNS scan results, preserving
   malformed datagram failures alongside valid bridge advertisements
+- Hue discovery worker runs from aggregate mDNS worker scan reports, preserving
+  interface-level scan failures without moving network I/O into Hue mapping code
 - discovery-record-to-pairing-plan handoff for local physical-presence Hue
   pairing flows
 - integration descriptor metadata for Chief of Staff discovery

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -16,7 +16,7 @@ use smart_home_core::{
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerFailure,
     DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun, MdnsAdvertisement, MdnsScanResult,
-    PairingRequirement,
+    MdnsWorkerScanReport, PairingRequirement,
 };
 use std::fmt;
 
@@ -874,6 +874,46 @@ pub fn hue_discovery_worker_run_from_mdns_scan(
         run.push_failure(worker_failure);
     }
 
+    Ok(run)
+}
+
+pub fn hue_discovery_worker_run_from_mdns_scan_report(
+    report: &MdnsWorkerScanReport,
+) -> Result<DiscoveryWorkerRun, HueError> {
+    if report.integration_id != IntegrationId::trusted(HUE_INTEGRATION_ID) {
+        return Err(DiscoveryError::WorkerIntegrationMismatch {
+            worker_integration_id: HUE_INTEGRATION_ID.to_string(),
+            record_integration_id: report.integration_id.as_str().to_string(),
+        }
+        .into());
+    }
+    if report.service_type != HUE_MDNS_SERVICE_TYPE {
+        return Err(HueError::UnsupportedDiscoveryService {
+            service_type: report.service_type.clone(),
+        });
+    }
+
+    let scan = report.aggregate_result();
+    let mut run = hue_discovery_worker_run_from_mdns_scan(
+        report.worker_id.as_str().to_string(),
+        &scan,
+        report.started_at_ms,
+        report.completed_at_ms,
+    )?
+    .with_metadata("hue.discovery.scan_report", "true")
+    .with_metadata(
+        "hue.discovery.scan_request_success_count",
+        report.completed_scan_count().to_string(),
+    )
+    .with_metadata(
+        "hue.discovery.scan_request_failure_count",
+        report.failed_scan_count().to_string(),
+    )
+    .with_metadata(
+        "hue.discovery.scan_packet_failure_count",
+        report.packet_failure_count().to_string(),
+    );
+    run.metadata.extend(report.metadata.iter().cloned());
     Ok(run)
 }
 
@@ -1985,7 +2025,10 @@ pub fn validate_brightness(value: u16) -> Result<u8, HueError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use smart_home_discovery::DiscoveryWorkerRunStatus;
+    use smart_home_discovery::{
+        DiscoveryWorkerRunStatus, MdnsScanNetwork, MdnsWorkerScanReport, MdnsWorkerScanRequest,
+    };
+    use std::time::Duration;
 
     #[test]
     fn resource_paths_match_clip_v2_shape() {
@@ -2538,6 +2581,95 @@ mod tests {
         assert_eq!(summary.record_count, 1);
         assert_eq!(summary.failure_count, 2);
         assert_eq!(summary.accepted_count(), 1);
+    }
+
+    #[test]
+    fn hue_discovery_worker_run_from_mdns_scan_report_keeps_interface_failures() {
+        let mdns = MdnsAdvertisement::new(
+            HUE_MDNS_SERVICE_TYPE,
+            "Philips Hue - ABCDEF",
+            "hue-bridge.local",
+            443,
+            1_000,
+        )
+        .unwrap()
+        .with_address("192.0.2.10")
+        .unwrap()
+        .with_txt("bridgeid", "001788fffeabcdef")
+        .unwrap();
+        let worker_id = DiscoveryWorkerId::trusted("hue-mdns-scan");
+        let integration_id = IntegrationId::trusted(HUE_INTEGRATION_ID);
+        let ipv4 = MdnsWorkerScanRequest::new(
+            worker_id.clone(),
+            integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv4,
+            HUE_MDNS_SERVICE_TYPE,
+            1_010,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let ipv6 = MdnsWorkerScanRequest::new(
+            worker_id.clone(),
+            integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv6,
+            HUE_MDNS_SERVICE_TYPE,
+            1_010,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let mut report = MdnsWorkerScanReport::new(
+            worker_id.clone(),
+            integration_id,
+            HUE_MDNS_SERVICE_TYPE,
+            990,
+            1_020,
+        )
+        .unwrap()
+        .with_metadata("fixture", "hue_mdns_scan_report");
+        report
+            .push_success(
+                ipv4,
+                MdnsScanResult {
+                    service_type: HUE_MDNS_SERVICE_TYPE.to_string(),
+                    discovered_at_ms: 1_010,
+                    datagram_count: 1,
+                    advertisements: vec![mdns],
+                    failures: Vec::new(),
+                },
+            )
+            .unwrap();
+        report
+            .push_failure(ipv6, "IPv6 multicast route is unavailable")
+            .unwrap();
+
+        let run = hue_discovery_worker_run_from_mdns_scan_report(&report).unwrap();
+
+        assert_eq!(run.worker_id, worker_id);
+        assert_eq!(run.kind, DiscoveryWorkerKind::MdnsScan);
+        assert_eq!(run.status(), DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(run.len(), 1);
+        assert_eq!(run.failure_count(), 1);
+        assert_eq!(run.failures[0].source, DiscoverySource::Mdns);
+        assert_eq!(
+            run.failures[0]
+                .metadata
+                .iter()
+                .find(|metadata| metadata.key == "hue.discovery.scan_source")
+                .map(|metadata| metadata.value.as_str()),
+            Some("en0/ipv6")
+        );
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.scan_report" && metadata.value == "true"
+        }));
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.scan_request_success_count" && metadata.value == "1"
+        }));
+        assert!(run
+            .metadata
+            .iter()
+            .any(|metadata| metadata.key == "fixture" && metadata.value == "hue_mdns_scan_report"));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this package will be documented in this file.
 - Bounded IPv4/IPv6 mDNS scan helpers that build PTR queries, collect UDP
   replies through `udp-client`, and return deterministic `MdnsScanResult`
   envelopes.
+- `MdnsWorkerScanRequest`, `MdnsWorkerScanPlan`, and `MdnsWorkerScanReport`
+  for handing scheduled mDNS work to supervised per-interface scan actors and
+  aggregating interface-level successes or failures.
 - mDNS/DNS-SD response parsing for PTR, SRV, TXT, A, and AAAA records,
   including compressed DNS names and per-datagram scan failures for malformed
   replies.

--- a/code/packages/rust/smart-home-discovery/README.md
+++ b/code/packages/rust/smart-home-discovery/README.md
@@ -9,6 +9,8 @@ this package. It gives discovery workers a shared shape for:
 
 - mDNS/SSDP/BLE/USB/DHCP/MQTT/webhook/cloud/manual discovery sources
 - bounded IPv4/IPv6 mDNS scans that send PTR questions and collect replies
+- per-interface IPv4/IPv6 mDNS worker scan requests, plans, and aggregate
+  reports for supervised discovery actors
 - mDNS/DNS-SD PTR/SRV/TXT/A/AAAA response parsing into advertisements
 - per-datagram scan failures for malformed mDNS responses
 - bridge candidate records with stable integration/native identifiers

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -1342,7 +1342,141 @@ pub const MDNS_DNS_TYPE_AAAA: u16 = 28;
 pub const MDNS_DNS_TYPE_SRV: u16 = 33;
 pub const MDNS_DEFAULT_MAX_DATAGRAM_SIZE: usize = 1500;
 pub const MDNS_DEFAULT_MAX_RESPONSES: usize = 32;
+pub const MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY: &str = "smart_home.discovery.service_type";
 pub const MDNS_UNICAST_RESPONSE_CLASS_BIT: u16 = 0x8000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MdnsScanNetwork {
+    Ipv4,
+    Ipv6,
+}
+
+impl MdnsScanNetwork {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ipv4 => "ipv4",
+            Self::Ipv6 => "ipv6",
+        }
+    }
+}
+
+impl fmt::Display for MdnsScanNetwork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsWorkerScanRequest {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub network_interface: String,
+    pub network: MdnsScanNetwork,
+    pub service_type: String,
+    pub discovered_at_ms: u64,
+    pub timeout: Duration,
+    pub max_responses: usize,
+    pub max_datagram_size: usize,
+    pub unicast_response: bool,
+    pub metadata: Vec<Metadata>,
+}
+
+impl MdnsWorkerScanRequest {
+    pub fn new(
+        worker_id: DiscoveryWorkerId,
+        integration_id: IntegrationId,
+        network_interface: impl Into<String>,
+        network: MdnsScanNetwork,
+        service_type: impl Into<String>,
+        discovered_at_ms: u64,
+        timeout: Duration,
+    ) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            worker_id,
+            integration_id,
+            network_interface: non_empty("mdns.network_interface", network_interface)?,
+            network,
+            service_type: non_empty("mdns.service_type", service_type)?,
+            discovered_at_ms,
+            timeout,
+            max_responses: MDNS_DEFAULT_MAX_RESPONSES,
+            max_datagram_size: MDNS_DEFAULT_MAX_DATAGRAM_SIZE,
+            unicast_response: true,
+            metadata: Vec::new(),
+        })
+    }
+
+    pub fn with_max_responses(mut self, max_responses: usize) -> Self {
+        self.max_responses = max_responses;
+        self
+    }
+
+    pub fn with_max_datagram_size(mut self, max_datagram_size: usize) -> Self {
+        self.max_datagram_size = max_datagram_size;
+        self
+    }
+
+    pub fn multicast_response(mut self) -> Self {
+        self.unicast_response = false;
+        self
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.push(Metadata::new(key, value));
+        self
+    }
+
+    pub fn options(&self) -> Result<MdnsScanOptions, DiscoveryError> {
+        let mut options = MdnsScanOptions::new(
+            self.service_type.clone(),
+            self.discovered_at_ms,
+            self.timeout,
+        )?
+        .with_max_responses(self.max_responses)
+        .with_max_datagram_size(self.max_datagram_size);
+        if !self.unicast_response {
+            options = options.multicast_response();
+        }
+        Ok(options)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsWorkerScanPlan {
+    pub generated_at_ms: u64,
+    pub requests: Vec<MdnsWorkerScanRequest>,
+}
+
+impl MdnsWorkerScanPlan {
+    pub fn new(generated_at_ms: u64) -> Self {
+        Self {
+            generated_at_ms,
+            requests: Vec::new(),
+        }
+    }
+
+    pub fn push_request(&mut self, request: MdnsWorkerScanRequest) {
+        self.requests.push(request);
+    }
+
+    pub fn len(&self) -> usize {
+        self.requests.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    pub fn requests_for_worker(
+        &self,
+        worker_id: &DiscoveryWorkerId,
+    ) -> Vec<&MdnsWorkerScanRequest> {
+        self.requests
+            .iter()
+            .filter(|request| &request.worker_id == worker_id)
+            .collect()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdnsQuestion {
@@ -1465,6 +1599,187 @@ impl MdnsScanResult {
 
     pub fn has_failures(&self) -> bool {
         !self.failures.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsWorkerScanSuccess {
+    pub request: MdnsWorkerScanRequest,
+    pub result: MdnsScanResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsWorkerScanFailure {
+    pub request: MdnsWorkerScanRequest,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MdnsWorkerScanReport {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub service_type: String,
+    pub started_at_ms: u64,
+    pub completed_at_ms: u64,
+    pub successes: Vec<MdnsWorkerScanSuccess>,
+    pub failures: Vec<MdnsWorkerScanFailure>,
+    pub metadata: Vec<Metadata>,
+}
+
+impl MdnsWorkerScanReport {
+    pub fn new(
+        worker_id: DiscoveryWorkerId,
+        integration_id: IntegrationId,
+        service_type: impl Into<String>,
+        started_at_ms: u64,
+        completed_at_ms: u64,
+    ) -> Result<Self, DiscoveryError> {
+        Ok(Self {
+            worker_id,
+            integration_id,
+            service_type: non_empty("mdns.service_type", service_type)?,
+            started_at_ms,
+            completed_at_ms,
+            successes: Vec::new(),
+            failures: Vec::new(),
+            metadata: Vec::new(),
+        })
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.push(Metadata::new(key, value));
+        self
+    }
+
+    pub fn push_success(
+        &mut self,
+        request: MdnsWorkerScanRequest,
+        result: MdnsScanResult,
+    ) -> Result<(), DiscoveryError> {
+        self.validate_request(&request)?;
+        if result.service_type != self.service_type {
+            return Err(DiscoveryError::InvalidMdnsScanOption {
+                field: "service_type",
+                message: format!(
+                    "expected `{}` result but received `{}`",
+                    self.service_type, result.service_type
+                ),
+            });
+        }
+        self.successes
+            .push(MdnsWorkerScanSuccess { request, result });
+        Ok(())
+    }
+
+    pub fn push_failure(
+        &mut self,
+        request: MdnsWorkerScanRequest,
+        message: impl Into<String>,
+    ) -> Result<(), DiscoveryError> {
+        self.validate_request(&request)?;
+        self.failures.push(MdnsWorkerScanFailure {
+            request,
+            message: non_empty("mdns.worker_scan_failure.message", message)?,
+        });
+        Ok(())
+    }
+
+    pub fn completed_scan_count(&self) -> usize {
+        self.successes.len()
+    }
+
+    pub fn failed_scan_count(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn datagram_count(&self) -> usize {
+        self.successes
+            .iter()
+            .map(|success| success.result.datagram_count)
+            .sum()
+    }
+
+    pub fn advertisement_count(&self) -> usize {
+        self.successes
+            .iter()
+            .map(|success| success.result.advertisements.len())
+            .sum()
+    }
+
+    pub fn packet_failure_count(&self) -> usize {
+        self.successes
+            .iter()
+            .map(|success| success.result.failures.len())
+            .sum()
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.failed_scan_count() > 0 || self.packet_failure_count() > 0
+    }
+
+    pub fn aggregate_result(&self) -> MdnsScanResult {
+        let mut result = MdnsScanResult {
+            service_type: self.service_type.clone(),
+            discovered_at_ms: self.completed_at_ms,
+            datagram_count: self.datagram_count(),
+            advertisements: Vec::new(),
+            failures: Vec::new(),
+        };
+
+        for success in &self.successes {
+            result
+                .advertisements
+                .extend(success.result.advertisements.iter().cloned());
+            for failure in &success.result.failures {
+                result.failures.push(MdnsScanFailure {
+                    source: Some(mdns_worker_scan_source(
+                        &success.request,
+                        failure.source.as_deref(),
+                    )),
+                    message: failure.message.clone(),
+                });
+            }
+        }
+
+        for failure in &self.failures {
+            result.failures.push(MdnsScanFailure {
+                source: Some(mdns_worker_scan_source(&failure.request, None)),
+                message: failure.message.clone(),
+            });
+        }
+
+        result
+    }
+
+    fn validate_request(&self, request: &MdnsWorkerScanRequest) -> Result<(), DiscoveryError> {
+        if request.worker_id != self.worker_id {
+            return Err(DiscoveryError::InvalidMdnsScanOption {
+                field: "worker_id",
+                message: format!(
+                    "expected `{}` request but received `{}`",
+                    self.worker_id, request.worker_id
+                ),
+            });
+        }
+        if request.integration_id != self.integration_id {
+            return Err(DiscoveryError::InvalidMdnsScanOption {
+                field: "integration_id",
+                message: format!(
+                    "expected `{}` request but received `{}`",
+                    self.integration_id, request.integration_id
+                ),
+            });
+        }
+        if request.service_type != self.service_type {
+            return Err(DiscoveryError::InvalidMdnsScanOption {
+                field: "service_type",
+                message: format!(
+                    "expected `{}` request but received `{}`",
+                    self.service_type, request.service_type
+                ),
+            });
+        }
+        Ok(())
     }
 }
 
@@ -2001,6 +2316,17 @@ fn validate_mdns_scan_options(options: &MdnsScanOptions) -> Result<(), Discovery
         });
     }
     Ok(())
+}
+
+fn mdns_worker_scan_source(request: &MdnsWorkerScanRequest, source: Option<&str>) -> String {
+    match source {
+        Some(source) => format!(
+            "{}/{}:{source}",
+            request.network_interface,
+            request.network.as_str()
+        ),
+        None => format!("{}/{}", request.network_interface, request.network.as_str()),
+    }
 }
 
 fn encode_dns_name(name: &str, packet: &mut Vec<u8>) -> Result<(), DiscoveryError> {
@@ -2808,6 +3134,121 @@ mod tests {
                 field: "max_responses",
                 message: "must be greater than zero".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn mdns_worker_scan_requests_project_socket_options_and_scope() {
+        let request = MdnsWorkerScanRequest::new(
+            DiscoveryWorkerId::trusted("hue-mdns-worker"),
+            IntegrationId::trusted("hue"),
+            "en0",
+            MdnsScanNetwork::Ipv6,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap()
+        .with_max_responses(8)
+        .with_max_datagram_size(512)
+        .multicast_response()
+        .with_metadata("fixture", "mdns_worker_scan_request");
+        let mut plan = MdnsWorkerScanPlan::new(4_990);
+        plan.push_request(request.clone());
+        let options = request.options().unwrap();
+
+        assert_eq!(plan.generated_at_ms, 4_990);
+        assert_eq!(plan.len(), 1);
+        assert_eq!(
+            plan.requests_for_worker(&DiscoveryWorkerId::trusted("hue-mdns-worker"))[0].network,
+            MdnsScanNetwork::Ipv6
+        );
+        assert_eq!(request.network_interface, "en0");
+        assert_eq!(request.network, MdnsScanNetwork::Ipv6);
+        assert_eq!(request.network.as_str(), "ipv6");
+        assert_eq!(options.service_type, "_hue._tcp.local");
+        assert_eq!(options.discovered_at_ms, 5_000);
+        assert_eq!(options.timeout, Duration::from_millis(250));
+        assert_eq!(options.max_responses, 8);
+        assert_eq!(options.max_datagram_size, 512);
+        assert!(!options.unicast_response);
+        assert!(request
+            .metadata
+            .iter()
+            .any(|metadata| metadata.key == "fixture"
+                && metadata.value == "mdns_worker_scan_request"));
+    }
+
+    #[test]
+    fn mdns_worker_scan_reports_aggregate_interface_results_and_failures() {
+        let worker_id = DiscoveryWorkerId::trusted("hue-mdns-worker");
+        let integration_id = IntegrationId::trusted("hue");
+        let ipv4 = MdnsWorkerScanRequest::new(
+            worker_id.clone(),
+            integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv4,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let ipv6 = MdnsWorkerScanRequest::new(
+            worker_id.clone(),
+            integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv6,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let result = MdnsScanResult::from_packets(
+            "_hue._tcp.local",
+            5_000,
+            [
+                MdnsResponsePacket::new(hue_mdns_response_packet()).with_source("192.0.2.10:5353"),
+                MdnsResponsePacket::new([1, 2, 3]).with_source("192.0.2.20:5353"),
+            ],
+        )
+        .unwrap();
+        let mut report = MdnsWorkerScanReport::new(
+            worker_id.clone(),
+            integration_id,
+            "_hue._tcp.local",
+            4_950,
+            5_050,
+        )
+        .unwrap()
+        .with_metadata("fixture", "mdns_worker_scan_report");
+
+        report.push_success(ipv4, result).unwrap();
+        report
+            .push_failure(ipv6, "IPv6 multicast route is unavailable")
+            .unwrap();
+        let aggregate = report.aggregate_result();
+
+        assert_eq!(report.completed_scan_count(), 1);
+        assert_eq!(report.failed_scan_count(), 1);
+        assert_eq!(report.datagram_count(), 2);
+        assert_eq!(report.advertisement_count(), 1);
+        assert_eq!(report.packet_failure_count(), 1);
+        assert!(report.has_failures());
+        assert_eq!(aggregate.service_type, "_hue._tcp.local");
+        assert_eq!(aggregate.datagram_count, 2);
+        assert_eq!(aggregate.len(), 1);
+        assert_eq!(aggregate.failure_count(), 2);
+        assert_eq!(
+            aggregate.failures[0].source.as_deref(),
+            Some("en0/ipv4:192.0.2.20:5353")
+        );
+        assert!(aggregate.failures[0]
+            .message
+            .contains("DNS header is shorter than 12 bytes"));
+        assert_eq!(aggregate.failures[1].source.as_deref(), Some("en0/ipv6"));
+        assert_eq!(
+            aggregate.failures[1].message,
+            "IPv6 multicast route is unavailable"
         );
     }
 

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to this package will be documented in this file.
 - `ScheduledDiscoveryWorker`, `RuntimeDiscoveryScheduler`, and scheduled
   discovery run-plan helpers for runtime-owned discovery cadence, selected
   network interfaces, and last-run status.
+- `DiscoveryWorkerRunPlan::mdns_scan_plan` and
+  `SmartHomeRuntime::discovery_mdns_scan_plan_at` for projecting due mDNS
+  schedules into per-interface IPv4/IPv6 scan requests.
 - `SmartHomeRuntime::record_scheduled_discovery_worker_run` for ingesting a
   registered worker run, reconciling discovery results, and advancing the next
   scheduled due time.

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -43,6 +43,8 @@ Included surfaces:
   catalog counts
 - runtime-owned discovery worker schedules with source/interface scope, due-run
   plans, run-status tracking, and cadence advancement after scheduled ingest
+- executable mDNS scan-plan projection from due discovery schedules into
+  per-interface IPv4/IPv6 scan requests without mutating runtime state
 - D18D-facing discover tool facade for authorized discovery reads, freshness
   filters, summaries, and bridge-candidate output
 - composed event-bus health summaries for replay history, stream coverage, and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -18,14 +18,15 @@ use smart_home_core::{
 use smart_home_discovery::{
     DiscoveryCatalog, DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary,
     DiscoverySource, DiscoveryUpsert, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-    DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary,
+    DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary, MdnsScanNetwork, MdnsWorkerScanPlan,
+    MdnsWorkerScanRequest, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
 };
 use smart_home_registry::{
     DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts, RegistryError, StateRefreshPlan,
     StateRefreshReason,
 };
 use std::collections::{BTreeMap, VecDeque};
-use std::fmt;
+use std::{fmt, time::Duration};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeError {
@@ -1792,6 +1793,16 @@ impl ScheduledDiscoveryWorker {
                 "mDNS schedules must name the selected interfaces",
             ));
         }
+        if self.sources.contains(&DiscoverySource::Mdns)
+            && metadata_value(&self.metadata, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY)
+                .is_none_or(str::is_empty)
+        {
+            return Err(invalid_discovery_worker_schedule(
+                &self.worker_id,
+                "metadata.smart_home.discovery.service_type",
+                "mDNS schedules must name the DNS-SD service type",
+            ));
+        }
         if self
             .network_interfaces
             .iter()
@@ -1827,6 +1838,56 @@ impl DiscoveryWorkerRunInstruction {
     pub fn overdue_by_ms(&self) -> u64 {
         self.planned_at_ms.saturating_sub(self.due_at_ms)
     }
+
+    pub fn mdns_service_type(&self) -> Option<&str> {
+        metadata_value(&self.metadata, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY)
+    }
+
+    pub fn mdns_scan_requests(&self) -> Result<Vec<MdnsWorkerScanRequest>, RuntimeError> {
+        if self.kind != DiscoveryWorkerKind::MdnsScan
+            || !self.sources.contains(&DiscoverySource::Mdns)
+        {
+            return Ok(Vec::new());
+        }
+        let service_type = self.mdns_service_type().ok_or_else(|| {
+            invalid_discovery_worker_schedule(
+                &self.worker_id,
+                "metadata.smart_home.discovery.service_type",
+                "mDNS schedules must name the DNS-SD service type",
+            )
+        })?;
+        let timeout = Duration::from_millis(self.run_timeout_ms);
+        let mut requests = Vec::new();
+        for network_interface in &self.network_interfaces {
+            for network in [MdnsScanNetwork::Ipv4, MdnsScanNetwork::Ipv6] {
+                requests.push(
+                    MdnsWorkerScanRequest::new(
+                        self.worker_id.clone(),
+                        self.integration_id.clone(),
+                        network_interface.clone(),
+                        network,
+                        service_type,
+                        self.planned_at_ms,
+                        timeout,
+                    )
+                    .map_err(|error| {
+                        invalid_discovery_worker_schedule(
+                            &self.worker_id,
+                            "network_interfaces",
+                            error.to_string(),
+                        )
+                    })?
+                    .with_metadata("smart_home.discovery.due_at_ms", self.due_at_ms.to_string())
+                    .with_metadata(
+                        "smart_home.discovery.planned_at_ms",
+                        self.planned_at_ms.to_string(),
+                    )
+                    .with_metadata("smart_home.discovery.worker_status", self.status.as_str()),
+                );
+            }
+        }
+        Ok(requests)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1852,6 +1913,16 @@ impl DiscoveryWorkerRunPlan {
             .iter()
             .filter(|instruction| &instruction.worker_id == worker_id)
             .collect()
+    }
+
+    pub fn mdns_scan_plan(&self) -> Result<MdnsWorkerScanPlan, RuntimeError> {
+        let mut plan = MdnsWorkerScanPlan::new(self.generated_at_ms);
+        for instruction in &self.instructions {
+            for request in instruction.mdns_scan_requests()? {
+                plan.push_request(request);
+            }
+        }
+        Ok(plan)
     }
 }
 
@@ -3307,6 +3378,13 @@ impl SmartHomeRuntime {
         self.discovery_scheduler.run_plan_at(now_ms)
     }
 
+    pub fn discovery_mdns_scan_plan_at(
+        &self,
+        now_ms: u64,
+    ) -> Result<MdnsWorkerScanPlan, RuntimeError> {
+        self.discovery_worker_run_plan_at(now_ms).mdns_scan_plan()
+    }
+
     pub fn mark_discovery_worker_started(
         &mut self,
         worker_id: &DiscoveryWorkerId,
@@ -4324,6 +4402,13 @@ fn invalid_discovery_worker_schedule(
         field,
         message: message.into(),
     }
+}
+
+fn metadata_value<'a>(metadata: &'a [Metadata], key: &str) -> Option<&'a str> {
+    metadata
+        .iter()
+        .find(|entry| entry.key == key)
+        .map(|entry| entry.value.as_str().trim())
 }
 
 fn scheduled_discovery_worker_matches_query(
@@ -5659,6 +5744,27 @@ mod tests {
                 && instruction.overdue_by_ms() == 25
                 && instruction.run_timeout_ms == 250
         ));
+        let mdns_scan_plan = plan.discovery_worker_run_plan.mdns_scan_plan().unwrap();
+        let runtime_mdns_scan_plan = runtime.discovery_mdns_scan_plan_at(1_125).unwrap();
+        assert_eq!(mdns_scan_plan, runtime_mdns_scan_plan);
+        assert_eq!(mdns_scan_plan.generated_at_ms, 1_125);
+        assert_eq!(mdns_scan_plan.len(), 4);
+        assert!(matches!(
+            mdns_scan_plan.requests.as_slice(),
+            [en0_ipv4, en0_ipv6, bridge0_ipv4, bridge0_ipv6]
+                if en0_ipv4.worker_id == worker_id
+                    && en0_ipv4.network_interface == "en0"
+                    && en0_ipv4.network == MdnsScanNetwork::Ipv4
+                    && en0_ipv4.service_type == "_hue._tcp.local"
+                    && en0_ipv4.discovered_at_ms == 1_125
+                    && en0_ipv4.timeout == Duration::from_millis(250)
+                    && en0_ipv6.network_interface == "en0"
+                    && en0_ipv6.network == MdnsScanNetwork::Ipv6
+                    && bridge0_ipv4.network_interface == "bridge0"
+                    && bridge0_ipv4.network == MdnsScanNetwork::Ipv4
+                    && bridge0_ipv6.network_interface == "bridge0"
+                    && bridge0_ipv6.network == MdnsScanNetwork::Ipv6
+        ));
         assert_eq!(summary.total_actions, 1);
         assert_eq!(summary.discovery_worker_run_count, 1);
         assert!(summary.has_discovery_worker_work());
@@ -5780,6 +5886,26 @@ mod tests {
             error,
             RuntimeError::InvalidDiscoveryWorkerSchedule {
                 field: "network_interfaces",
+                ..
+            }
+        ));
+
+        let missing_service_type = ScheduledDiscoveryWorker::new(
+            DiscoveryWorkerId::trusted("hue-mdns-worker"),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            5_000,
+            250,
+            1_100,
+        )
+        .with_source(DiscoverySource::Mdns)
+        .with_network_interface("en0");
+        assert!(matches!(
+            runtime
+                .register_discovery_worker_schedule(missing_service_type)
+                .unwrap_err(),
+            RuntimeError::InvalidDiscoveryWorkerSchedule {
+                field: "metadata.smart_home.discovery.service_type",
                 ..
             }
         ));

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
-- Deterministic Hue mDNS scan fixtures, with discovery worker-run fixtures now
-  flowing through `MdnsScanResult` before seeding runtime discovery catalogs.
+- Deterministic Hue mDNS scan-report fixtures, with discovery worker-run
+  fixtures now flowing through `MdnsWorkerScanReport` before seeding runtime
+  discovery catalogs.
 - Deterministic Hue discovery worker schedule fixtures, with discovery runtime
   seeding now flowing through `SmartHomeRuntime::record_scheduled_discovery_worker_run`.
 - Deterministic fixture clock for freshness and supervisor tests.

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -10,8 +10,8 @@ a shared way to build:
 - normalized bridge/device/entity fixtures
 - normalized Hue discovery records, built through `hue-core` mDNS mapping, and
   discovery-seeded runtime fixtures
-- deterministic Hue mDNS scan and discovery worker-run fixtures that feed the
-  runtime discovery catalog without opening network sockets
+- deterministic Hue mDNS scan, scan-report, and discovery worker-run fixtures
+  that feed the runtime discovery catalog without opening network sockets
 - deterministic Hue discovery worker schedules that exercise runtime due-run
   planning and scheduled ingest without opening network sockets
 - registry seeding helpers for installing fixture records into

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -7,7 +7,8 @@
 #![forbid(unsafe_code)]
 
 use hue_core::{
-    hue_discovery_record_from_mdns, hue_discovery_worker_run_from_mdns_scan, HUE_MDNS_SERVICE_TYPE,
+    hue_discovery_record_from_mdns, hue_discovery_worker_run_from_mdns_scan_report,
+    HUE_MDNS_SERVICE_TYPE,
 };
 use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId, CommandResult,
@@ -18,7 +19,8 @@ use smart_home_core::{
 };
 use smart_home_discovery::{
     DiscoveryRecord, DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-    MdnsAdvertisement, MdnsScanResult,
+    MdnsAdvertisement, MdnsScanNetwork, MdnsScanResult, MdnsWorkerScanReport,
+    MdnsWorkerScanRequest,
 };
 use smart_home_event_streams::{
     EventStreamCheckpoint, EventStreamRestartReason, EventStreamSpec, EventStreamState,
@@ -29,7 +31,7 @@ use smart_home_registry::{InMemorySmartHomeRegistry, RegistryError};
 use smart_home_runtime::{
     BridgeHealthReport, RuntimeError, ScheduledDiscoveryWorker, SmartHomeRuntime,
 };
-use std::collections::VecDeque;
+use std::{collections::VecDeque, time::Duration};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FixtureClock {
@@ -1036,20 +1038,51 @@ pub fn hue_bridge_mdns_scan_result(
     }
 }
 
+pub fn hue_bridge_mdns_scan_report(
+    native_id: impl Into<String>,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> MdnsWorkerScanReport {
+    let worker_id = DiscoveryWorkerId::trusted("fixture-hue-discovery-worker");
+    let integration_id = IntegrationId::trusted("hue");
+    let request = MdnsWorkerScanRequest::new(
+        worker_id.clone(),
+        integration_id.clone(),
+        "fixture-lan0",
+        MdnsScanNetwork::Ipv4,
+        HUE_MDNS_SERVICE_TYPE,
+        completed_at_ms,
+        Duration::from_millis(250),
+    )
+    .expect("fixture Hue mDNS scan request is valid")
+    .with_metadata("fixture", "hue_bridge_mdns_scan_report");
+    let mut report = MdnsWorkerScanReport::new(
+        worker_id,
+        integration_id,
+        HUE_MDNS_SERVICE_TYPE,
+        started_at_ms,
+        completed_at_ms,
+    )
+    .expect("fixture Hue mDNS scan report is valid")
+    .with_metadata("fixture", "hue_bridge_mdns_scan_report");
+    report
+        .push_success(
+            request,
+            hue_bridge_mdns_scan_result(native_id, completed_at_ms),
+        )
+        .expect("fixture Hue mDNS scan result matches its request");
+    report
+}
+
 pub fn hue_bridge_discovery_worker_run(
     native_id: impl Into<String>,
     started_at_ms: u64,
     completed_at_ms: u64,
 ) -> DiscoveryWorkerRun {
-    let scan = hue_bridge_mdns_scan_result(native_id, completed_at_ms);
-    let mut run = hue_discovery_worker_run_from_mdns_scan(
-        "fixture-hue-discovery-worker",
-        &scan,
-        started_at_ms,
-        completed_at_ms,
-    )
-    .expect("fixture Hue discovery worker run is valid")
-    .with_metadata("fixture", "hue_bridge_discovery_worker");
+    let report = hue_bridge_mdns_scan_report(native_id, started_at_ms, completed_at_ms);
+    let mut run = hue_discovery_worker_run_from_mdns_scan_report(&report)
+        .expect("fixture Hue discovery worker run is valid")
+        .with_metadata("fixture", "hue_bridge_discovery_worker");
     for record in &mut run.records {
         record
             .metadata
@@ -1804,6 +1837,32 @@ mod tests {
         assert!(run.metadata.iter().any(|metadata| {
             metadata.key == "hue.discovery.scan_datagram_count" && metadata.value == "1"
         }));
+        assert!(run.metadata.iter().any(|metadata| {
+            metadata.key == "hue.discovery.scan_report" && metadata.value == "true"
+        }));
+    }
+
+    #[test]
+    fn hue_mdns_scan_report_fixture_reports_interface_scope() {
+        let report = hue_bridge_mdns_scan_report("001788fffereport", 975, 1_000);
+        let aggregate = report.aggregate_result();
+
+        assert_eq!(report.worker_id.as_str(), "fixture-hue-discovery-worker");
+        assert_eq!(report.integration_id, IntegrationId::trusted("hue"));
+        assert_eq!(report.completed_scan_count(), 1);
+        assert_eq!(report.failed_scan_count(), 0);
+        assert_eq!(report.datagram_count(), 1);
+        assert_eq!(report.advertisement_count(), 1);
+        assert_eq!(aggregate.len(), 1);
+        assert_eq!(
+            report.successes[0].request.network_interface,
+            "fixture-lan0"
+        );
+        assert_eq!(report.successes[0].request.network, MdnsScanNetwork::Ipv4);
+        assert_eq!(
+            aggregate.advertisements[0].txt_value("bridgeid"),
+            Some("001788fffereport")
+        );
     }
 
     #[test]
@@ -1816,6 +1875,9 @@ mod tests {
 
         let idle = runtime.discovery_worker_run_plan_at(999);
         let due = runtime.discovery_worker_run_plan_at(1_000);
+        let mdns_scan_plan = runtime
+            .discovery_mdns_scan_plan_at(1_000)
+            .expect("fixture mDNS scan plan can be projected");
         let worker = runtime
             .discovery_worker_schedule(&DiscoveryWorkerId::trusted("fixture-hue-discovery-worker"))
             .unwrap();
@@ -1833,6 +1895,16 @@ mod tests {
                     metadata.key == "smart_home.discovery.service_type"
                         && metadata.value == HUE_MDNS_SERVICE_TYPE
                 })
+        ));
+        assert_eq!(mdns_scan_plan.len(), 2);
+        assert!(matches!(
+            mdns_scan_plan.requests.as_slice(),
+            [ipv4, ipv6] if ipv4.network_interface == "fixture-lan0"
+                && ipv4.network == MdnsScanNetwork::Ipv4
+                && ipv4.service_type == HUE_MDNS_SERVICE_TYPE
+                && ipv4.timeout == Duration::from_millis(250)
+                && ipv6.network_interface == "fixture-lan0"
+                && ipv6.network == MdnsScanNetwork::Ipv6
         ));
         assert_eq!(worker.interval_ms, 5_000);
         assert_eq!(worker.status, WorkerStatus::Starting);

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -122,6 +122,24 @@ moving socket work into the Chief bridge:
   runtime and integration tests can exercise the scheduled handoff without
   opening sockets or inventing another fake scheduler.
 
+## Current Discovery Execution Handoff Slice
+
+This slice gives a future supervised discovery actor an executable mDNS work
+contract while keeping socket execution and runtime mutation separate:
+
+- `smart-home-discovery` now has per-interface IPv4/IPv6 mDNS scan requests,
+  scan plans, and aggregate scan reports that preserve both packet-level parse
+  failures and interface-level transport failures.
+- `smart-home-runtime` can project due mDNS discovery worker schedules into
+  executable scan requests without mutating scheduler state, and mDNS schedules
+  must now name the DNS-SD service type they plan to scan.
+- `hue-core` can convert an aggregate mDNS worker scan report into the existing
+  Hue D23 discovery worker-run envelope, preserving interface failure context
+  as worker failure metadata.
+- `smart-home-testkit` now seeds Hue discovery worker fixtures through the scan
+  report path, so runtime and Chief-facing tests exercise the same handoff a
+  supervised worker will report back.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -143,9 +161,9 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Wire scheduled discovery run plans to a supervised actor or process that runs
-  per-interface LAN mDNS scans and persists schedules, results, and runtime
-  state across restarts.
+- Wire the mDNS execution handoff to a supervised actor or process that opens
+  sockets, runs the requested per-interface scans, and persists schedules,
+  results, and runtime state across restarts.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers


### PR DESCRIPTION
## Summary
- add generic per-interface IPv4/IPv6 mDNS worker scan requests, plans, and aggregate reports
- project due runtime discovery schedules into executable mDNS scan plans without mutating scheduler state
- route Hue/testkit fixtures through aggregate mDNS scan reports and update the D18/D23 completion inventory

## Validation
- cargo test -p smart-home-discovery
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-discovery
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- git diff --check