### PR TITLE
Bring MACSYMA elementary assumptions to TS and Rust

### DIFF
--- a/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
+++ b/code/packages/python/macsyma-runtime/tests/test_cas_pipeline.py
@@ -379,6 +379,26 @@ def test_pipeline_totient() -> None:
     assert result == _int(4)
 
 
+def test_pipeline_assumptions_feed_elementary_abs_sqrt_log() -> None:
+    """Assumptions feed direct abs/sqrt/log evaluation, not only radcan."""
+    sqrt_result = _eval_seq("assume(x >= 0)", "sqrt(x^2)")
+    assert isinstance(sqrt_result, IRSymbol)
+    assert sqrt_result.name == "x"
+
+    log_result = _eval_seq("assume(x >= 0)", "log(x^3)")
+    assert isinstance(log_result, IRApply)
+    assert log_result.head.name == "Mul"
+    assert log_result.args[0] == IRInteger(3)
+    assert isinstance(log_result.args[1], IRApply)
+    assert log_result.args[1].head.name == "Log"
+    assert log_result.args[1].args == (IRSymbol("x"),)
+
+    abs_result = _eval_seq("assume(y < 0)", "abs(y)")
+    assert isinstance(abs_result, IRApply)
+    assert abs_result.head.name == "Neg"
+    assert abs_result.args == (IRSymbol("y"),)
+
+
 # ===========================================================================
 # Section L: Complex number operations (B2)
 # ===========================================================================

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Feed the Rust MACSYMA session assumption context into direct `abs`, `sqrt`,
+  and `log` evaluation, matching Python reference behavior for cases such as
+  `assume(x >= 0); sqrt(x^2)`, `log(x^3)`, and `abs(x)`.
+
 ## [0.3.0] — 2026-05-16
 
 **EllipticE (2nd kind) and EllipticPi (3rd kind) integration pipeline tests.**

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -22,8 +22,8 @@ use coding_adventures_macsyma_compiler::{
     SUPPRESS as COMPILER_SUPPRESS,
 };
 use symbolic_ir::{
-    apply, str_node, sym, IRApply, IRNode, ASSIGN, DEFINE, GREATER, GREATER_EQUAL, IF, LESS,
-    LESS_EQUAL, LIST, POW,
+    apply, flt, int, rat, str_node, sym, IRApply, IRNode, ASSIGN, DEFINE, EXP, GREATER,
+    GREATER_EQUAL, IF, LESS, LESS_EQUAL, LIST, LOG, MUL, NEG, POW, SQRT,
 };
 use symbolic_vm::backend::{handler_fn, Backend, Handler};
 use symbolic_vm::handlers::build_handler_table;
@@ -552,6 +552,21 @@ impl MacsymaBackend {
             PROP_VARS.to_string(),
             Arc::new(move |_vm, expr| propvars_handler(&propvars_state, expr)),
         );
+        let abs_state = state.clone();
+        handlers.insert(
+            "Abs".to_string(),
+            Arc::new(move |vm, expr| runtime_abs_handler(&abs_state, vm, expr)),
+        );
+        let sqrt_state = state.clone();
+        handlers.insert(
+            SQRT.to_string(),
+            Arc::new(move |vm, expr| runtime_sqrt_handler(&sqrt_state, vm, expr)),
+        );
+        let log_state = state.clone();
+        handlers.insert(
+            LOG.to_string(),
+            Arc::new(move |vm, expr| runtime_log_handler(&log_state, vm, expr)),
+        );
         handlers.insert(
             LENGTH.to_string(),
             list_handler(Some(1), |args| length(&args[0])),
@@ -649,6 +664,193 @@ impl Backend for MacsymaBackend {
 
     fn hold_heads(&self) -> &HashSet<String> {
         &self.held
+    }
+}
+
+fn runtime_abs_handler(
+    state: &Arc<Mutex<MacsymaBackendState>>,
+    vm: &mut VM,
+    expr: IRApply,
+) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let inner = vm.eval(expr.args[0].clone());
+    if let Some(numeric) = abs_numeric_node(&inner) {
+        return numeric;
+    }
+    if let IRNode::Symbol(name) = &inner {
+        let assumptions = &state.lock().expect("macsyma backend state poisoned").assumptions;
+        if assumptions.is_nonneg(name) == Some(true) {
+            return inner;
+        }
+        if assumptions.sign_of(name) == Some(0) {
+            return int(0);
+        }
+        if assumptions.is_negative(name) == Some(true) {
+            return apply(sym(NEG), vec![inner]);
+        }
+    }
+    if let IRNode::Apply(apply_node) = &inner {
+        if apply_node.head == sym("Abs") {
+            return inner;
+        }
+        if apply_node.head == sym(NEG) && apply_node.args.len() == 1 {
+            return vm.eval(apply(sym("Abs"), vec![apply_node.args[0].clone()]));
+        }
+        if apply_node.head == sym(MUL)
+            && apply_node.args.len() == 2
+            && apply_node.args[0] == int(-1)
+        {
+            return vm.eval(apply(sym("Abs"), vec![apply_node.args[1].clone()]));
+        }
+        if apply_node.head == sym(POW) && apply_node.args.len() == 2 {
+            if let IRNode::Integer(exp) = apply_node.args[1] {
+                if exp >= 2 && exp % 2 == 0 {
+                    return inner;
+                }
+            }
+        }
+    }
+    apply(expr.head, vec![inner])
+}
+
+fn runtime_sqrt_handler(
+    state: &Arc<Mutex<MacsymaBackendState>>,
+    vm: &mut VM,
+    expr: IRApply,
+) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let arg = vm.eval(expr.args[0].clone());
+    if let Some(numeric) = sqrt_numeric_node(&arg) {
+        return numeric;
+    }
+    if let IRNode::Apply(apply_node) = &arg {
+        if apply_node.head == sym(POW) && apply_node.args.len() == 2 {
+            let base = &apply_node.args[0];
+            if let IRNode::Integer(exp) = apply_node.args[1] {
+                if exp > 0 && exp % 2 == 0 {
+                    let k = exp / 2;
+                    if k == 1 {
+                        if let IRNode::Symbol(name) = base {
+                            let assumptions =
+                                &state.lock().expect("macsyma backend state poisoned").assumptions;
+                            if assumptions.is_nonneg(name) == Some(true) {
+                                return base.clone();
+                            }
+                        }
+                    }
+                    if k % 2 == 0 {
+                        return apply(sym(POW), vec![base.clone(), int(k)]);
+                    }
+                    if k == 1 {
+                        return apply(sym("Abs"), vec![base.clone()]);
+                    }
+                    return apply(
+                        sym("Abs"),
+                        vec![apply(sym(POW), vec![base.clone(), int(k)])],
+                    );
+                }
+            }
+        }
+    }
+    apply(expr.head, vec![arg])
+}
+
+fn runtime_log_handler(
+    state: &Arc<Mutex<MacsymaBackendState>>,
+    vm: &mut VM,
+    expr: IRApply,
+) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    let arg = vm.eval(expr.args[0].clone());
+    if let Some(numeric) = log_numeric_node(&arg) {
+        return numeric;
+    }
+    if let IRNode::Apply(apply_node) = &arg {
+        if apply_node.head == sym(EXP) && apply_node.args.len() == 1 {
+            return apply_node.args[0].clone();
+        }
+        if apply_node.head == sym(POW) && apply_node.args.len() == 2 {
+            let base = &apply_node.args[0];
+            if let IRNode::Symbol(name) = base {
+                let assumptions = &state.lock().expect("macsyma backend state poisoned").assumptions;
+                if assumptions.is_nonneg(name) == Some(true) {
+                    return apply(
+                        sym(MUL),
+                        vec![apply_node.args[1].clone(), apply(sym(LOG), vec![base.clone()])],
+                    );
+                }
+            }
+        }
+    }
+    apply(expr.head, vec![arg])
+}
+
+fn abs_numeric_node(node: &IRNode) -> Option<IRNode> {
+    match node {
+        IRNode::Integer(n) => Some(int(n.abs())),
+        IRNode::Rational(n, d) => Some(rat(n.abs(), *d)),
+        IRNode::Float(v) => Some(flt(v.abs())),
+        _ => None,
+    }
+}
+
+fn sqrt_numeric_node(node: &IRNode) -> Option<IRNode> {
+    match node {
+        IRNode::Integer(n) => {
+            if *n < 0 {
+                return None;
+            }
+            if let Some(root) = i64_sqrt_exact(*n) {
+                Some(int(root))
+            } else {
+                Some(flt((*n as f64).sqrt()))
+            }
+        }
+        IRNode::Rational(n, d) => {
+            if *n < 0 {
+                return None;
+            }
+            match (i64_sqrt_exact(*n), i64_sqrt_exact(*d)) {
+                (Some(n_root), Some(d_root)) => Some(rat(n_root, d_root)),
+                _ => Some(flt((*n as f64 / *d as f64).sqrt())),
+            }
+        }
+        IRNode::Float(v) if *v >= 0.0 => Some(flt(v.sqrt())),
+        _ => None,
+    }
+}
+
+fn log_numeric_node(node: &IRNode) -> Option<IRNode> {
+    let value = match node {
+        IRNode::Integer(n) => *n as f64,
+        IRNode::Rational(n, d) => *n as f64 / *d as f64,
+        IRNode::Float(v) => *v,
+        _ => return None,
+    };
+    if value == 1.0 {
+        return Some(int(0));
+    }
+    if value <= 0.0 {
+        return None;
+    }
+    Some(flt(value.ln()))
+}
+
+fn i64_sqrt_exact(n: i64) -> Option<i64> {
+    if n < 0 {
+        return None;
+    }
+    let root = (n as f64).sqrt().round() as i64;
+    if root.saturating_mul(root) == n {
+        Some(root)
+    } else {
+        None
     }
 }
 

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -6,7 +6,7 @@ use coding_adventures_macsyma_runtime::{
 use std::collections::HashMap;
 use symbolic_ir::{
     apply, int, rat, sym, ADD, AND, ASIN, COS, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, LESS,
-    LESS_EQUAL, LIST, LOG, MUL, POW, RULE, SIN, SQRT, SUB,
+    LESS_EQUAL, LIST, LOG, MUL, NEG, POW, RULE, SIN, SQRT, SUB,
 };
 
 const SUBST: &str = "Subst";
@@ -701,6 +701,29 @@ fn declared_positivity_feeds_radcan() {
         .unwrap();
 
     assert_eq!(results[1].output, sym("y"));
+}
+
+#[test]
+fn assumptions_feed_elementary_abs_sqrt_log_simplification() {
+    let mut session = MacsymaSession::new();
+    let results = session
+        .eval_source("assume(x >= 0); sqrt(x^2); log(x^3); abs(x);")
+        .unwrap();
+
+    assert_eq!(results[1].output, sym("x"));
+    assert_eq!(
+        results[2].output,
+        apply(sym(MUL), vec![int(3), apply(sym(LOG), vec![sym("x")])])
+    );
+    assert_eq!(results[3].output, sym("x"));
+}
+
+#[test]
+fn negative_assumptions_feed_abs() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("assume(y < 0); abs(y);").unwrap();
+
+    assert_eq!(results[1].output, apply(sym(NEG), vec![sym("y")]));
 }
 
 #[test]

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Feed the TypeScript MACSYMA session assumption context into direct
+  `abs`, `sqrt`, and `log` evaluation, matching Python reference behavior
+  for cases such as `assume(x >= 0); sqrt(x^2)`, `log(x^3)`, and `abs(x)`.
+
 ## [0.3.0] — 2026-05-14
 
 - Add TypeScript MACSYMA parity for EllipticE (second kind) integration:

--- a/code/packages/typescript/macsyma-runtime/src/index.ts
+++ b/code/packages/typescript/macsyma-runtime/src/index.ts
@@ -47,6 +47,7 @@ import {
   LIST,
   LOG,
   MUL,
+  NEG,
   POW,
   SIN,
   SINH,
@@ -62,11 +63,15 @@ import {
   equals,
   int,
   numberNode,
+  rational,
   stringNode,
   sym,
   toDisplayString,
   type IRApply,
+  type IRFloat,
+  type IRInteger,
   type IRNode,
+  type IRRational,
   type IRSymbol,
 } from "@coding-adventures/symbolic-ir";
 import { SymbolicBackend, VM, type Handler } from "@coding-adventures/symbolic-vm";
@@ -396,6 +401,9 @@ export class MacsymaBackend extends SymbolicBackend {
     table.set(DECLARE.name, declareHandler);
     table.set(PROPERTIES.name, propertiesHandler);
     table.set(PROP_VARS.name, propvarsHandler);
+    table.set("Abs", makeAbsHandler(this));
+    table.set(SQRT.name, makeSqrtHandler(this));
+    table.set(LOG.name, makeLogHandler(this));
     table.set(SOLVE.name, solveHandler);
     table.set(SUBST.name, substHandler);
     table.set(SIMPLIFY.name, unaryHandler((value) => simplifyCas(value)));
@@ -490,6 +498,145 @@ export class MacsymaBackend extends SymbolicBackend {
     this.bind("%i", sym("ImaginaryUnit"));
     this.bind("showtime", this.showtime ? TRUE : FALSE);
   }
+}
+
+function makeAbsHandler(backend: MacsymaBackend): Handler {
+  return (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const inner = vm.eval(expr.args[0]);
+    const numeric = numericNodeAbs(inner);
+    if (numeric !== undefined) return numeric;
+    if (inner.kind === "symbol") {
+      if (backend.assumptions.isNonneg(inner.name) === true) return inner;
+      if (backend.assumptions.signOf(inner.name) === 0) return int(0);
+      if (backend.assumptions.isNegative(inner.name) === true) return app(NEG, [inner]);
+    }
+    if (inner.kind === "apply") {
+      if (equals(inner.head, sym("Abs"))) return inner;
+      if (equals(inner.head, NEG) && inner.args.length === 1) {
+        return vm.eval(app(sym("Abs"), [inner.args[0]]));
+      }
+      if (
+        equals(inner.head, MUL) &&
+        inner.args.length === 2 &&
+        inner.args[0].kind === "integer" &&
+        inner.args[0].value === -1n
+      ) {
+        return vm.eval(app(sym("Abs"), [inner.args[1]]));
+      }
+      if (equals(inner.head, POW) && inner.args.length === 2) {
+        const expNode = inner.args[1];
+        if (expNode.kind === "integer" && expNode.value >= 2n && expNode.value % 2n === 0n) {
+          return inner;
+        }
+      }
+    }
+    return app(expr.head, [inner]);
+  };
+}
+
+function makeSqrtHandler(backend: MacsymaBackend): Handler {
+  return (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = vm.eval(expr.args[0]);
+    const numeric = sqrtNumericNode(arg);
+    if (numeric !== undefined) return numeric;
+    if (arg.kind === "apply" && equals(arg.head, POW) && arg.args.length === 2) {
+      const [base, expNode] = arg.args;
+      if (expNode.kind === "integer" && expNode.value > 0n && expNode.value % 2n === 0n) {
+        const k = expNode.value / 2n;
+        if (k === 1n && base.kind === "symbol" && backend.assumptions.isNonneg(base.name) === true) {
+          return base;
+        }
+        if (k % 2n === 0n) return app(POW, [base, int(k)]);
+        if (k === 1n) return app(sym("Abs"), [base]);
+        return app(sym("Abs"), [app(POW, [base, int(k)])]);
+      }
+    }
+    return app(expr.head, [arg]);
+  };
+}
+
+function makeLogHandler(backend: MacsymaBackend): Handler {
+  return (vm, expr) => {
+    if (expr.args.length !== 1) return expr;
+    const arg = vm.eval(expr.args[0]);
+    const numeric = logNumericNode(arg);
+    if (numeric !== undefined) return numeric;
+    if (arg.kind === "apply" && equals(arg.head, EXP) && arg.args.length === 1) {
+      return arg.args[0];
+    }
+    if (arg.kind === "apply" && equals(arg.head, POW) && arg.args.length === 2) {
+      const [base, expNode] = arg.args;
+      if (base.kind === "symbol" && backend.assumptions.isNonneg(base.name) === true) {
+        return app(MUL, [expNode, app(LOG, [base])]);
+      }
+    }
+    return app(expr.head, [arg]);
+  };
+}
+
+function numericNodeAbs(node: IRNode): IRInteger | IRRational | IRFloat | undefined {
+  if (node.kind === "integer") return int(node.value < 0n ? -node.value : node.value);
+  if (node.kind === "rational") {
+    const numer = node.numer < 0n ? -node.numer : node.numer;
+    return rational(numer, node.denom) as IRInteger | IRRational;
+  }
+  if (node.kind === "float") return numberNode(Math.abs(node.value));
+  return undefined;
+}
+
+function sqrtNumericNode(node: IRNode): IRNode | undefined {
+  if (node.kind === "integer") {
+    if (node.value < 0n) return undefined;
+    if (node.value === 0n) return int(0);
+    if (node.value === 1n) return int(1);
+    const root = bigIntSqrtExact(node.value);
+    if (root !== undefined) return int(root);
+    return numberNode(Math.sqrt(Number(node.value)));
+  }
+  if (node.kind === "rational") {
+    if (node.numer < 0n) return undefined;
+    if (node.numer === 0n) return int(0);
+    const numerRoot = bigIntSqrtExact(node.numer);
+    const denomRoot = bigIntSqrtExact(node.denom);
+    if (numerRoot !== undefined && denomRoot !== undefined) return rational(numerRoot, denomRoot);
+    return numberNode(Math.sqrt(Number(node.numer) / Number(node.denom)));
+  }
+  if (node.kind === "float") {
+    if (node.value < 0) return undefined;
+    return numberNode(Math.sqrt(node.value));
+  }
+  return undefined;
+}
+
+function logNumericNode(node: IRNode): IRNode | undefined {
+  const value = node.kind === "integer"
+    ? Number(node.value)
+    : node.kind === "rational"
+      ? Number(node.numer) / Number(node.denom)
+      : node.kind === "float"
+        ? node.value
+        : undefined;
+  if (value === undefined) return undefined;
+  if (value === 1) return int(0);
+  if (value <= 0) return undefined;
+  return numberNode(Math.log(value));
+}
+
+function bigIntSqrtExact(n: bigint): bigint | undefined {
+  if (n < 0n) return undefined;
+  if (n < 2n) return n;
+  let lo = 1n;
+  let hi = n;
+  while (lo <= hi) {
+    const mid = (lo + hi) / 2n;
+    const sq = mid * mid;
+    if (sq === n) return mid;
+    if (sq < n) lo = mid + 1n;
+    else hi = mid - 1n;
+  }
+  return undefined;
 }
 
 export class MacsymaSession {

--- a/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
+++ b/code/packages/typescript/macsyma-runtime/tests/runtime.test.ts
@@ -601,6 +601,24 @@ describe("macsyma-runtime", () => {
     expect(result.output).toEqual(sym("y"));
   });
 
+  it("feeds assumptions into elementary abs/sqrt/log simplification", () => {
+    const session = new MacsymaSession();
+    const [, sqrtResult, logResult, absResult] = session.evalSource(
+      "assume(x >= 0); sqrt(x^2); log(x^3); abs(x);",
+    );
+
+    expect(sqrtResult.output).toEqual(sym("x"));
+    expect(logResult.output).toEqual(app(MUL, [int(3), app(LOG, [sym("x")])]));
+    expect(absResult.output).toEqual(sym("x"));
+  });
+
+  it("uses negative assumptions for abs", () => {
+    const session = new MacsymaSession();
+    const [, result] = session.evalSource("assume(y < 0); abs(y);");
+
+    expect(result.output).toEqual(app(sym("Neg"), [sym("y")]));
+  });
+
   it("properties lists declared properties deterministically", () => {
     const session = new MacsymaSession();
     const [, result] = session.evalSource("declare(n, integer, n, positive); properties(n);");

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -388,6 +388,12 @@ numeric backend is unaffected).
 ports do not yet have an assumption system.  Python keeps those rules behind
 `is_nonneg(x)` checks.
 
+**Update (2026-06-06):** TS/Rust MACSYMA runtime sessions now feed their
+assumption context into direct `abs`, `sqrt`, and `log` evaluation, matching
+the Python reference for `assume(x >= 0); sqrt(x^2)`, `log(x^n)`, and
+`abs(x)`. The lower-level TS/Rust `symbolic-vm` packages remain
+assumption-free by design; the MACSYMA runtime layer owns session assumptions.
+
 **Pi-multiple detection** (Phase 33) covers both numeric (`IRFloat ≈ q·π`,
 denominators {1,2,3,4,6}) and structural IR (`%pi`, `Neg(%pi)`, `Mul(n,%pi)`,
 `Div(%pi,n)`, `Div(Mul(n,%pi),d)`) shapes, keyed via a reduced-fraction string


### PR DESCRIPTION
## Summary

- Adds TypeScript MACSYMA runtime handlers for assumption-aware `abs`, `sqrt`, and `log` simplification.
- Adds matching Rust MACSYMA runtime handlers wired to the existing session `AssumptionContext`.
- Pins Python reference behavior and adds TS/Rust parity tests for direct surface syntax, plus changelog/spec notes.

## Verification

- `python -m pytest code/packages/python/macsyma-runtime/tests -q --no-cov` — 477 passed
- `node node_modules/vitest/vitest.mjs run tests/runtime.test.ts` in `code/packages/typescript/macsyma-runtime` — 78 passed
- `node node_modules/typescript/bin/tsc --noEmit` in `code/packages/typescript/macsyma-runtime` — passed
- `cargo test --manifest-path code/packages/rust/macsyma-runtime/Cargo.toml` — 66 passed
- `git diff --check` — passed