### PR TITLE
Add smart-home discovery runner handoff

### DIFF
--- a/code/packages/rust/smart-home-discovery/CHANGELOG.md
+++ b/code/packages/rust/smart-home-discovery/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this package will be documented in this file.
 - `MdnsWorkerScanRequest`, `MdnsWorkerScanPlan`, and `MdnsWorkerScanReport`
   for handing scheduled mDNS work to supervised per-interface scan actors and
   aggregating interface-level successes or failures.
+- `MdnsWorkerScanExecutor`, default UDP execution helpers, and grouped plan
+  runners for turning scheduled mDNS requests into worker scan reports while
+  keeping socket I/O injectable for tests and supervision.
 - mDNS/DNS-SD response parsing for PTR, SRV, TXT, A, and AAAA records,
   including compressed DNS names and per-datagram scan failures for malformed
   replies.

--- a/code/packages/rust/smart-home-discovery/README.md
+++ b/code/packages/rust/smart-home-discovery/README.md
@@ -11,6 +11,8 @@ this package. It gives discovery workers a shared shape for:
 - bounded IPv4/IPv6 mDNS scans that send PTR questions and collect replies
 - per-interface IPv4/IPv6 mDNS worker scan requests, plans, and aggregate
   reports for supervised discovery actors
+- injectable mDNS worker scan executors that run request/report and grouped
+  plan handoffs without coupling runtime mutation to socket I/O
 - mDNS/DNS-SD PTR/SRV/TXT/A/AAAA response parsing into advertisements
 - per-datagram scan failures for malformed mDNS responses
 - bridge candidate records with stable integration/native identifiers

--- a/code/packages/rust/smart-home-discovery/src/lib.rs
+++ b/code/packages/rust/smart-home-discovery/src/lib.rs
@@ -1783,6 +1783,126 @@ impl MdnsWorkerScanReport {
     }
 }
 
+pub trait MdnsWorkerScanExecutor {
+    fn run_request(
+        &mut self,
+        request: &MdnsWorkerScanRequest,
+    ) -> Result<MdnsScanResult, DiscoveryError>;
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UdpMdnsWorkerScanExecutor;
+
+impl MdnsWorkerScanExecutor for UdpMdnsWorkerScanExecutor {
+    fn run_request(
+        &mut self,
+        request: &MdnsWorkerScanRequest,
+    ) -> Result<MdnsScanResult, DiscoveryError> {
+        run_mdns_worker_scan_request(request)
+    }
+}
+
+pub fn run_mdns_worker_scan_request(
+    request: &MdnsWorkerScanRequest,
+) -> Result<MdnsScanResult, DiscoveryError> {
+    match request.network {
+        MdnsScanNetwork::Ipv4 => run_mdns_ipv4_scan(request.options()?),
+        MdnsScanNetwork::Ipv6 => run_mdns_ipv6_scan(request.options()?),
+    }
+}
+
+pub fn run_mdns_worker_scan_report_with_executor<E>(
+    requests: &[MdnsWorkerScanRequest],
+    started_at_ms: u64,
+    completed_at_ms: u64,
+    executor: &mut E,
+) -> Result<MdnsWorkerScanReport, DiscoveryError>
+where
+    E: MdnsWorkerScanExecutor + ?Sized,
+{
+    let first = requests
+        .first()
+        .ok_or_else(|| DiscoveryError::InvalidMdnsScanOption {
+            field: "requests",
+            message: "must include at least one mDNS scan request".to_string(),
+        })?;
+    let mut report = MdnsWorkerScanReport::new(
+        first.worker_id.clone(),
+        first.integration_id.clone(),
+        first.service_type.clone(),
+        started_at_ms,
+        completed_at_ms,
+    )?;
+
+    for request in requests {
+        report.validate_request(request)?;
+        match executor.run_request(request) {
+            Ok(result) => report.push_success(request.clone(), result)?,
+            Err(error) => report.push_failure(request.clone(), error.to_string())?,
+        }
+    }
+
+    Ok(report)
+}
+
+pub fn run_mdns_worker_scan_report(
+    requests: &[MdnsWorkerScanRequest],
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> Result<MdnsWorkerScanReport, DiscoveryError> {
+    let mut executor = UdpMdnsWorkerScanExecutor;
+    run_mdns_worker_scan_report_with_executor(
+        requests,
+        started_at_ms,
+        completed_at_ms,
+        &mut executor,
+    )
+}
+
+pub fn run_mdns_worker_scan_plan_with_executor<E>(
+    plan: &MdnsWorkerScanPlan,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+    executor: &mut E,
+) -> Result<Vec<MdnsWorkerScanReport>, DiscoveryError>
+where
+    E: MdnsWorkerScanExecutor + ?Sized,
+{
+    let mut groups: Vec<Vec<MdnsWorkerScanRequest>> = Vec::new();
+    'requests: for request in &plan.requests {
+        for group in &mut groups {
+            if group
+                .first()
+                .is_some_and(|existing| mdns_worker_scan_same_scope(existing, request))
+            {
+                group.push(request.clone());
+                continue 'requests;
+            }
+        }
+        groups.push(vec![request.clone()]);
+    }
+
+    let mut reports = Vec::with_capacity(groups.len());
+    for group in groups {
+        reports.push(run_mdns_worker_scan_report_with_executor(
+            &group,
+            started_at_ms,
+            completed_at_ms,
+            executor,
+        )?);
+    }
+    Ok(reports)
+}
+
+pub fn run_mdns_worker_scan_plan(
+    plan: &MdnsWorkerScanPlan,
+    started_at_ms: u64,
+    completed_at_ms: u64,
+) -> Result<Vec<MdnsWorkerScanReport>, DiscoveryError> {
+    let mut executor = UdpMdnsWorkerScanExecutor;
+    run_mdns_worker_scan_plan_with_executor(plan, started_at_ms, completed_at_ms, &mut executor)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdnsScanOptions {
     pub service_type: String,
@@ -2318,6 +2438,15 @@ fn validate_mdns_scan_options(options: &MdnsScanOptions) -> Result<(), Discovery
     Ok(())
 }
 
+fn mdns_worker_scan_same_scope(
+    left: &MdnsWorkerScanRequest,
+    right: &MdnsWorkerScanRequest,
+) -> bool {
+    left.worker_id == right.worker_id
+        && left.integration_id == right.integration_id
+        && left.service_type == right.service_type
+}
+
 fn mdns_worker_scan_source(request: &MdnsWorkerScanRequest, source: Option<&str>) -> String {
     match source {
         Some(source) => format!(
@@ -2654,6 +2783,35 @@ fn non_empty(field: &'static str, value: impl Into<String>) -> Result<String, Di
 mod tests {
     use super::*;
     use smart_home_integration_catalog::first_party_catalog;
+
+    #[derive(Debug)]
+    struct ScriptedMdnsWorkerScanExecutor {
+        outcomes: std::collections::VecDeque<Result<MdnsScanResult, DiscoveryError>>,
+        requests: Vec<MdnsWorkerScanRequest>,
+    }
+
+    impl ScriptedMdnsWorkerScanExecutor {
+        fn new(outcomes: impl IntoIterator<Item = Result<MdnsScanResult, DiscoveryError>>) -> Self {
+            Self {
+                outcomes: outcomes.into_iter().collect(),
+                requests: Vec::new(),
+            }
+        }
+    }
+
+    impl MdnsWorkerScanExecutor for ScriptedMdnsWorkerScanExecutor {
+        fn run_request(
+            &mut self,
+            request: &MdnsWorkerScanRequest,
+        ) -> Result<MdnsScanResult, DiscoveryError> {
+            self.requests.push(request.clone());
+            self.outcomes.pop_front().unwrap_or_else(|| {
+                Err(DiscoveryError::MdnsTransport {
+                    message: "missing scripted mDNS outcome".to_string(),
+                })
+            })
+        }
+    }
 
     #[test]
     fn catalog_hints_project_hue_discovery_and_pairing_shape() {
@@ -3250,6 +3408,139 @@ mod tests {
             aggregate.failures[1].message,
             "IPv6 multicast route is unavailable"
         );
+    }
+
+    #[test]
+    fn mdns_worker_scan_report_runner_collects_transport_failures() {
+        let worker_id = DiscoveryWorkerId::trusted("hue-mdns-worker");
+        let integration_id = IntegrationId::trusted("hue");
+        let ipv4 = MdnsWorkerScanRequest::new(
+            worker_id.clone(),
+            integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv4,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let ipv6 = MdnsWorkerScanRequest::new(
+            worker_id,
+            integration_id,
+            "en0",
+            MdnsScanNetwork::Ipv6,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let success = MdnsScanResult::from_packets(
+            "_hue._tcp.local",
+            5_000,
+            [MdnsResponsePacket::new(hue_mdns_response_packet()).with_source("192.0.2.10:5353")],
+        )
+        .unwrap();
+        let mut executor = ScriptedMdnsWorkerScanExecutor::new([
+            Ok(success),
+            Err(DiscoveryError::MdnsTransport {
+                message: "IPv6 multicast route is unavailable".to_string(),
+            }),
+        ]);
+
+        let report = run_mdns_worker_scan_report_with_executor(
+            &[ipv4.clone(), ipv6.clone()],
+            4_950,
+            5_050,
+            &mut executor,
+        )
+        .unwrap();
+        let aggregate = report.aggregate_result();
+
+        assert_eq!(executor.requests, vec![ipv4, ipv6]);
+        assert_eq!(report.completed_scan_count(), 1);
+        assert_eq!(report.failed_scan_count(), 1);
+        assert_eq!(report.datagram_count(), 1);
+        assert_eq!(report.advertisement_count(), 1);
+        assert_eq!(aggregate.failure_count(), 1);
+        assert_eq!(aggregate.failures[0].source.as_deref(), Some("en0/ipv6"));
+        assert_eq!(
+            aggregate.failures[0].message,
+            "mDNS transport failed: IPv6 multicast route is unavailable"
+        );
+    }
+
+    #[test]
+    fn mdns_worker_scan_plan_runner_groups_reports_by_worker_scope() {
+        let hue_worker_id = DiscoveryWorkerId::trusted("hue-mdns-worker");
+        let hue_integration_id = IntegrationId::trusted("hue");
+        let matter_worker_id = DiscoveryWorkerId::trusted("matter-mdns-worker");
+        let matter_integration_id = IntegrationId::trusted("matter");
+        let hue_ipv4 = MdnsWorkerScanRequest::new(
+            hue_worker_id.clone(),
+            hue_integration_id.clone(),
+            "en0",
+            MdnsScanNetwork::Ipv4,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let matter_ipv4 = MdnsWorkerScanRequest::new(
+            matter_worker_id.clone(),
+            matter_integration_id,
+            "bridge0",
+            MdnsScanNetwork::Ipv4,
+            "_matter._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let hue_ipv6 = MdnsWorkerScanRequest::new(
+            hue_worker_id.clone(),
+            hue_integration_id,
+            "en0",
+            MdnsScanNetwork::Ipv6,
+            "_hue._tcp.local",
+            5_000,
+            Duration::from_millis(250),
+        )
+        .unwrap();
+        let mut plan = MdnsWorkerScanPlan::new(4_990);
+        plan.push_request(hue_ipv4.clone());
+        plan.push_request(matter_ipv4.clone());
+        plan.push_request(hue_ipv6.clone());
+        let mut executor = ScriptedMdnsWorkerScanExecutor::new([
+            MdnsScanResult::from_packets(
+                "_hue._tcp.local",
+                5_000,
+                Vec::<MdnsResponsePacket>::new(),
+            ),
+            MdnsScanResult::from_packets(
+                "_hue._tcp.local",
+                5_000,
+                Vec::<MdnsResponsePacket>::new(),
+            ),
+            MdnsScanResult::from_packets(
+                "_matter._tcp.local",
+                5_000,
+                Vec::<MdnsResponsePacket>::new(),
+            ),
+        ]);
+
+        let reports =
+            run_mdns_worker_scan_plan_with_executor(&plan, 4_950, 5_050, &mut executor).unwrap();
+
+        assert_eq!(
+            executor.requests,
+            vec![hue_ipv4.clone(), hue_ipv6.clone(), matter_ipv4.clone()]
+        );
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].worker_id, hue_worker_id);
+        assert_eq!(reports[0].service_type, "_hue._tcp.local");
+        assert_eq!(reports[0].completed_scan_count(), 2);
+        assert_eq!(reports[1].worker_id, matter_worker_id);
+        assert_eq!(reports[1].service_type, "_matter._tcp.local");
+        assert_eq!(reports[1].completed_scan_count(), 1);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Scripted mDNS worker scan executor fixtures that can run runtime-produced
+  scan plans into deterministic reports without opening network sockets.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -14,6 +14,8 @@ a shared way to build:
   that feed the runtime discovery catalog without opening network sockets
 - deterministic Hue discovery worker schedules that exercise runtime due-run
   planning and scheduled ingest without opening network sockets
+- scripted mDNS worker scan executors that run runtime-produced scan plans into
+  deterministic reports without opening network sockets
 - registry seeding helpers for installing fixture records into
   `smart-home-registry`
 - confirmed, stale, and optimistic state snapshots

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -18,9 +18,9 @@ use smart_home_core::{
     Value,
 };
 use smart_home_discovery::{
-    DiscoveryRecord, DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-    MdnsAdvertisement, MdnsScanNetwork, MdnsScanResult, MdnsWorkerScanReport,
-    MdnsWorkerScanRequest,
+    DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind,
+    DiscoveryWorkerRun, MdnsAdvertisement, MdnsScanNetwork, MdnsScanResult, MdnsWorkerScanExecutor,
+    MdnsWorkerScanReport, MdnsWorkerScanRequest,
 };
 use smart_home_event_streams::{
     EventStreamCheckpoint, EventStreamRestartReason, EventStreamSpec, EventStreamState,
@@ -1038,6 +1038,52 @@ pub fn hue_bridge_mdns_scan_result(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ScriptedMdnsWorkerScanExecutor {
+    outcomes: VecDeque<Result<MdnsScanResult, DiscoveryError>>,
+    observed_requests: Vec<MdnsWorkerScanRequest>,
+}
+
+impl ScriptedMdnsWorkerScanExecutor {
+    pub fn new(outcomes: impl IntoIterator<Item = Result<MdnsScanResult, DiscoveryError>>) -> Self {
+        Self {
+            outcomes: outcomes.into_iter().collect(),
+            observed_requests: Vec::new(),
+        }
+    }
+
+    pub fn push_outcome(mut self, outcome: Result<MdnsScanResult, DiscoveryError>) -> Self {
+        self.outcomes.push_back(outcome);
+        self
+    }
+
+    pub fn record_outcome(&mut self, outcome: Result<MdnsScanResult, DiscoveryError>) {
+        self.outcomes.push_back(outcome);
+    }
+
+    pub fn observed_requests(&self) -> &[MdnsWorkerScanRequest] {
+        &self.observed_requests
+    }
+
+    pub fn pending_outcome_count(&self) -> usize {
+        self.outcomes.len()
+    }
+}
+
+impl MdnsWorkerScanExecutor for ScriptedMdnsWorkerScanExecutor {
+    fn run_request(
+        &mut self,
+        request: &MdnsWorkerScanRequest,
+    ) -> Result<MdnsScanResult, DiscoveryError> {
+        self.observed_requests.push(request.clone());
+        self.outcomes.pop_front().unwrap_or_else(|| {
+            Err(DiscoveryError::MdnsTransport {
+                message: "missing scripted mDNS scan outcome".to_string(),
+            })
+        })
+    }
+}
+
 pub fn hue_bridge_mdns_scan_report(
     native_id: impl Into<String>,
     started_at_ms: u64,
@@ -1908,6 +1954,58 @@ mod tests {
         ));
         assert_eq!(worker.interval_ms, 5_000);
         assert_eq!(worker.status, WorkerStatus::Starting);
+    }
+
+    #[test]
+    fn scripted_mdns_worker_executor_runs_runtime_scan_plan() {
+        let schedule = hue_bridge_discovery_worker_schedule(1_000, 5_000, 250);
+        let worker_id = DiscoveryWorkerId::trusted("fixture-hue-discovery-worker");
+        let mut runtime = SmartHomeRuntime::new();
+        runtime
+            .register_discovery_worker_schedule(schedule)
+            .expect("fixture schedule can be registered");
+        let plan = runtime
+            .discovery_mdns_scan_plan_at(1_000)
+            .expect("fixture mDNS scan plan can be projected");
+        let mut executor = ScriptedMdnsWorkerScanExecutor::new([
+            Ok(hue_bridge_mdns_scan_result("001788fffescripted", 1_000)),
+            Err(DiscoveryError::MdnsTransport {
+                message: "IPv6 multicast route is unavailable".to_string(),
+            }),
+        ]);
+
+        let reports = smart_home_discovery::run_mdns_worker_scan_plan_with_executor(
+            &plan,
+            1_000,
+            1_030,
+            &mut executor,
+        )
+        .expect("scripted executor can run the fixture mDNS scan plan");
+        let run = hue_discovery_worker_run_from_mdns_scan_report(&reports[0])
+            .expect("scripted Hue report can be converted to a worker run");
+        let summary = runtime
+            .record_scheduled_discovery_worker_run(&run, 1_030, 500)
+            .expect("scripted discovery worker run can be recorded");
+        let worker = runtime.discovery_worker_schedule(&worker_id).unwrap();
+
+        assert_eq!(executor.pending_outcome_count(), 0);
+        assert_eq!(executor.observed_requests().len(), 2);
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].completed_scan_count(), 1);
+        assert_eq!(reports[0].failed_scan_count(), 1);
+        assert_eq!(reports[0].advertisement_count(), 1);
+        assert_eq!(summary.status, DiscoveryWorkerRunStatus::Partial);
+        assert_eq!(summary.record_count, 1);
+        assert_eq!(summary.failure_count, 1);
+        assert_eq!(summary.inserted_count, 1);
+        assert_eq!(runtime.discovery_record_count(), 1);
+        assert_eq!(worker.status, WorkerStatus::Unhealthy);
+        assert_eq!(
+            worker.last_run_status,
+            Some(DiscoveryWorkerRunStatus::Partial)
+        );
+        assert_eq!(worker.consecutive_failure_count, 1);
+        assert_eq!(worker.next_due_at_ms, 6_030);
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -140,6 +140,23 @@ contract while keeping socket execution and runtime mutation separate:
   report path, so runtime and Chief-facing tests exercise the same handoff a
   supervised worker will report back.
 
+## Current Discovery Runner Slice
+
+This slice wires the mDNS execution contract into a reusable runner boundary
+without moving platform state or socket supervision into the Chief bridge:
+
+- `smart-home-discovery` now has an injectable `MdnsWorkerScanExecutor`,
+  default UDP-backed request execution, and grouped scan-plan runners that turn
+  runtime-produced mDNS requests into worker scan reports.
+- The runner preserves per-interface successes, packet parse failures, and
+  transport failures while grouping reports by worker, integration, and DNS-SD
+  service type.
+- `smart-home-testkit` now provides a scripted mDNS worker executor that can run
+  scheduled runtime scan plans deterministically without opening sockets.
+- The fixture path now proves schedule projection, scan execution, Hue report
+  conversion, and scheduled runtime ingest end to end while keeping Chief of
+  Staff on the existing thin `smart_home.*` tool bridge.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -161,9 +178,9 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Wire the mDNS execution handoff to a supervised actor or process that opens
-  sockets, runs the requested per-interface scans, and persists schedules,
-  results, and runtime state across restarts.
+- Wire the mDNS runner to a supervised actor or process that manages lifecycle,
+  retries, OS interface binding, and persistence for schedules, results, and
+  runtime state across restarts.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers


### PR DESCRIPTION
## Summary
- add an injectable smart-home mDNS worker scan executor and default UDP-backed request/plan runner in `smart-home-discovery`
- add deterministic scripted mDNS scan execution fixtures in `smart-home-testkit`
- document the new discovery runner slice and narrow the remaining smart-home work to supervised lifecycle, OS interface binding, and persistence

## Validation
- `cargo test -p smart-home-discovery`
- `cargo test -p smart-home-testkit`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `code/packages/rust/smart-home-discovery`
- `sh BUILD` in `code/packages/rust/hue-core`
- `sh BUILD` in `code/packages/rust/smart-home-runtime`
- `sh BUILD` in `code/packages/rust/smart-home-testkit`
- `git diff --check`