### PR TITLE
Close decaying exponential telescope parity

### DIFF
--- a/code/packages/python/cas-summation/CHANGELOG.md
+++ b/code/packages/python/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.26.0 - 2026-06-06
+
+### Added
+
+- Infinite telescope limits now recognise direct decaying exponential terms:
+  ``exp(-k)`` and ``b^(-k)`` with ``|b| > 1`` are treated as vanishing at
+  infinity. This closes structurally telescoping sums such as
+  ``sum(exp(-(k+1)) - exp(-k), k, 1, inf)`` without requiring a rational
+  denominator wrapper.
+- The recogniser is conservative: growing exponentials, ambiguous exponent
+  signs, and unrecognised transcendental factors still fall through to the
+  unevaluated ``Sum`` form.
+
 ## 2.24.0 — 2026-05-28
 
 **Track A2 cleanup — delete 27 grid helpers superseded by Phase 86 generic.**

--- a/code/packages/python/cas-summation/pyproject.toml
+++ b/code/packages/python/cas-summation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-summation"
-version = "2.24.0"
+version = "2.26.0"
 description = "Symbolic summation: closed-form evaluation of sum(f,k,a,b) and product(f,k,a,b) — polynomial (Faulhaber), geometric, classic series."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-summation/src/cas_summation/summation.py
+++ b/code/packages/python/cas-summation/src/cas_summation/summation.py
@@ -631,6 +631,57 @@ def _is_bounded_in_k(node: IRNode, k: IRSymbol) -> bool:
     return False
 
 
+def _vanishes_at_infinity(node: IRNode, k: IRSymbol) -> bool:
+    """Return True for non-rational shapes that provably tend to zero.
+
+    This complements :func:`_g_vanishes_at_infinity`, which handles rational
+    quotients like ``1/k`` and ``log(k)/k²``.  The telescope rule also needs to
+    recognise direct decaying exponentials such as ``exp(-k)`` and ``2^(-k)``.
+    """
+    if _is_constant_in(node, k):
+        val = _ir_rational_val(node)
+        return val == 0
+    if not isinstance(node, IRApply):
+        return False
+    if node.head == NEG and len(node.args) == 1:
+        return _vanishes_at_infinity(node.args[0], k)
+    if node.head == ADD:
+        return all(_vanishes_at_infinity(arg, k) for arg in node.args)
+    if node.head == EXP and len(node.args) == 1:
+        inner = node.args[0]
+        degree = _polynomial_degree_in_k(inner, k)
+        return (
+            degree is not None
+            and degree > 0
+            and _polynomial_leading_coeff_sign_in_k(inner, k) == -1
+        )
+    if node.head == POW and len(node.args) == 2:
+        base, exp = node.args
+        base_val = _ir_rational_val(base) if _is_constant_in(base, k) else None
+        if base_val is not None and abs(base_val) > 1:
+            degree = _polynomial_degree_in_k(exp, k)
+            return (
+                degree is not None
+                and degree > 0
+                and _polynomial_leading_coeff_sign_in_k(exp, k) == -1
+            )
+    if node.head == MUL:
+        has_vanishing = False
+        for arg in node.args:
+            if _is_constant_in(arg, k):
+                if _ir_rational_val(arg) == 0:
+                    return True
+                continue
+            if _is_bounded_in_k(arg, k):
+                continue
+            if _vanishes_at_infinity(arg, k):
+                has_vanishing = True
+                continue
+            return False
+        return has_vanishing
+    return False
+
+
 def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     """Return True when ``g(k)`` provably tends to 0 as ``k → ∞``.
 
@@ -673,6 +724,8 @@ def _g_vanishes_at_infinity(g: IRNode, k: IRSymbol) -> bool:
     - ``k/(k+1)`` → False (deg 1 = deg 1; limit is 1, not 0).
     - ``k²/(k+1)`` → False (improper; limit is ∞).
     """
+    if _vanishes_at_infinity(g, k):
+        return True
     if not isinstance(g, IRApply) or g.head != DIV or len(g.args) != 2:
         return False
     num, den = g.args

--- a/code/packages/python/cas-summation/tests/test_summation.py
+++ b/code/packages/python/cas-summation/tests/test_summation.py
@@ -5,11 +5,14 @@
 from symbolic_ir import (
     ADD,
     DIV,
+    EXP,
     GAMMA_FUNC,
     LOG,
     MUL,
+    NEG,
     POW,
     PRODUCT,
+    SUB,
     SUM,
     IRApply,
     IRInteger,
@@ -446,6 +449,31 @@ class TestEvaluateSumPhase41InfiniteTelescope:
         )
         result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
         assert isinstance(result, IRInteger) and result.value == 1
+
+    def test_standard_exp_negative_k_telescope_closes(self):
+        """``exp(-k)`` itself vanishes, so standard orientation closes."""
+        g_k = IRApply(EXP, (IRApply(NEG, (_k,)),))
+        g_kp1 = IRApply(EXP, (IRApply(NEG, (IRApply(ADD, (_k, IRInteger(1))),)),))
+        f = IRApply(SUB, (g_kp1, g_k))
+
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+
+        expected = IRApply(NEG, (IRApply(EXP, (IRInteger(-1),)),))
+        assert result == expected
+
+    def test_antisymmetric_pow_two_negative_k_telescope_closes(self):
+        """``2^(-k)`` has magnitude tending to zero, so antisymmetric closes."""
+        g_k = IRApply(POW, (IRInteger(2), IRApply(NEG, (_k,))))
+        g_kp1 = IRApply(
+            POW,
+            (IRInteger(2), IRApply(NEG, (IRApply(ADD, (_k, IRInteger(1))),))),
+        )
+        f = IRApply(SUB, (g_k, g_kp1))
+
+        result = evaluate_sum(f, _k, IRInteger(1), IRSymbol("%inf"), _VM)
+
+        expected = IRApply(POW, (IRInteger(2), IRInteger(-1)))
+        assert result == expected
 
     def test_constant_g_falls_through(self):
         """``∑_{k=1}^∞ [c − c] = ∑ 0`` — the SUB folds to 0 first (step 1

--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.26.0 - 2026-06-06
+
+### Added
+
+- Infinite telescope limits now recognise direct decaying exponential terms:
+  ``exp(-k)`` and ``b^(-k)`` with ``|b| > 1`` are treated as vanishing at
+  infinity. This closes structurally telescoping sums such as
+  ``sum(exp(-(k+1)) - exp(-k), k, 1, inf)`` without requiring a rational
+  denominator wrapper.
+- The recogniser is conservative: growing exponentials, ambiguous exponent
+  signs, and unrecognised transcendental factors still fall through to the
+  unevaluated ``Sum`` form.
+
 ## 2.25.0 — 2026-05-28
 
 ### Added — Track B2 (Apart-retry telescope chain port: Phase 40 + Phase 46)

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.25.0"
+version = "2.26.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -1536,7 +1536,73 @@ fn log_sqrt_poly_effective_x2_generic(node: &IRNode, k: &IRNode) -> Option<i64> 
     Some(sqrt_inner_deg_x2_sum + 2 * poly_deg_sum)
 }
 
+fn vanishes_at_infinity(node: &IRNode, k: &IRNode) -> bool {
+    if is_constant_in(node, k) {
+        return rational_value(node).is_some_and(|value| value.numer == 0);
+    }
+    let apply_node = match node {
+        IRNode::Apply(a) => a,
+        _ => return false,
+    };
+    let head_name = match &apply_node.head {
+        IRNode::Symbol(s) => s.as_str(),
+        _ => return false,
+    };
+    if head_name == NEG && apply_node.args.len() == 1 {
+        return vanishes_at_infinity(&apply_node.args[0], k);
+    }
+    if head_name == ADD {
+        return apply_node
+            .args
+            .iter()
+            .all(|arg| vanishes_at_infinity(arg, k));
+    }
+    if head_name == EXP && apply_node.args.len() == 1 {
+        let inner = &apply_node.args[0];
+        return polynomial_degree_in_k(inner, k).is_some_and(|degree| degree > 0)
+            && polynomial_leading_coeff_sign_in_k(inner, k) == Some(-1);
+    }
+    if head_name == POW && apply_node.args.len() == 2 {
+        let base = &apply_node.args[0];
+        let exp = &apply_node.args[1];
+        if is_constant_in(base, k) {
+            if let Some(base_val) = rational_value(base) {
+                let abs_numer: u64 = base_val.numer.unsigned_abs();
+                let denom_u: u64 = base_val.denom as u64;
+                if abs_numer > denom_u {
+                    return polynomial_degree_in_k(exp, k).is_some_and(|degree| degree > 0)
+                        && polynomial_leading_coeff_sign_in_k(exp, k) == Some(-1);
+                }
+            }
+        }
+    }
+    if head_name == MUL {
+        let mut has_vanishing = false;
+        for arg in &apply_node.args {
+            if is_constant_in(arg, k) {
+                if rational_value(arg).is_some_and(|value| value.numer == 0) {
+                    return true;
+                }
+                continue;
+            }
+            if is_bounded_in_k(arg, k) {
+                continue;
+            }
+            if vanishes_at_infinity(arg, k) {
+                has_vanishing = true;
+                continue;
+            }
+            return false;
+        }
+        return has_vanishing;
+    }
+    false
+}
+
 fn g_vanishes_at_infinity(g: &IRNode, k: &IRNode) -> bool {
+    if vanishes_at_infinity(g, k) {
+        return true;
+    }
     let apply_node = match g {
         IRNode::Apply(a) => a,
         _ => return false,

--- a/code/packages/rust/cas-summation/tests/tests.rs
+++ b/code/packages/rust/cas-summation/tests/tests.rs
@@ -393,6 +393,40 @@ fn phase41_quadratic_denominator() {
 }
 
 #[test]
+fn phase41_exp_negative_k_telescope_closes() {
+    // exp(-k) itself vanishes, so standard orientation emits -g(1).
+    let k = sym("k");
+    let g_k = apply(sym(EXP), vec![apply(sym(NEG), vec![k.clone()])]);
+    let g_kp1 = apply(
+        sym(EXP),
+        vec![apply(
+            sym(NEG),
+            vec![apply(sym(ADD), vec![k.clone(), int(1)])],
+        )],
+    );
+    let f = apply(sym(SUB), vec![g_kp1, g_k]);
+    let expected = apply(sym(NEG), vec![apply(sym(EXP), vec![int(-1)])]);
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), expected);
+}
+
+#[test]
+fn phase41_pow_two_negative_k_telescope_closes() {
+    // 2^(-k) has magnitude tending to zero, so antisymmetric emits g(1).
+    let k = sym("k");
+    let g_k = apply(sym(POW), vec![int(2), apply(sym(NEG), vec![k.clone()])]);
+    let g_kp1 = apply(
+        sym(POW),
+        vec![
+            int(2),
+            apply(sym(NEG), vec![apply(sym(ADD), vec![k.clone(), int(1)])]),
+        ],
+    );
+    let f = apply(sym(SUB), vec![g_k, g_kp1]);
+    let expected = apply(sym(POW), vec![int(2), int(-1)]);
+    assert_eq!(evaluate_sum(f, k, int(1), sym("%inf"), eval), expected);
+}
+
+#[test]
 fn phase42_proper_rational_k_over_k_squared_plus_1() {
     // ∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = g(1) = 1/2.
     let k = sym("k");

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.26.0 - 2026-06-06
+
+### Added
+
+- Infinite telescope limits now recognise direct decaying exponential terms:
+  ``exp(-k)`` and ``b^(-k)`` with ``|b| > 1`` are treated as vanishing at
+  infinity. This closes structurally telescoping sums such as
+  ``sum(exp(-(k+1)) - exp(-k), k, 1, inf)`` without requiring a rational
+  denominator wrapper.
+- The recogniser is conservative: growing exponentials, ambiguous exponent
+  signs, and unrecognised transcendental factors still fall through to the
+  unevaluated ``Sum`` form.
+
 ## 2.25.0 — 2026-05-28
 
 ### Added — Track B2 (Apart-retry telescope chain port: Phase 40 + Phase 46)

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -1217,7 +1217,66 @@ function logSqrtPolyEffectiveDegGeneric(
   return sqrtHalfDegSum + polyDegSum;
 }
 
+function vanishesAtInfinity(node: IRNode, k: IRNode): boolean {
+  if (isConstantIn(node, k)) {
+    const value = rationalValue(node);
+    return value !== undefined && value.numer === 0n;
+  }
+  if (node.kind !== "apply") return false;
+  if (equals(node.head, NEG) && node.args.length === 1) {
+    return vanishesAtInfinity(node.args[0], k);
+  }
+  if (equals(node.head, ADD)) {
+    return node.args.every((arg) => vanishesAtInfinity(arg, k));
+  }
+  if (equals(node.head, EXP) && node.args.length === 1) {
+    const inner = node.args[0];
+    const degree = polynomialDegreeInK(inner, k);
+    return (
+      degree !== undefined &&
+      degree > 0 &&
+      polynomialLeadingCoeffSignInK(inner, k) === -1
+    );
+  }
+  if (equals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    if (isConstantIn(base, k)) {
+      const baseVal = rationalValue(base);
+      if (baseVal !== undefined) {
+        const absNumer = baseVal.numer < 0n ? -baseVal.numer : baseVal.numer;
+        if (absNumer > baseVal.denom) {
+          const degree = polynomialDegreeInK(exp, k);
+          return (
+            degree !== undefined &&
+            degree > 0 &&
+            polynomialLeadingCoeffSignInK(exp, k) === -1
+          );
+        }
+      }
+    }
+  }
+  if (equals(node.head, MUL)) {
+    let hasVanishing = false;
+    for (const arg of node.args) {
+      if (isConstantIn(arg, k)) {
+        const value = rationalValue(arg);
+        if (value !== undefined && value.numer === 0n) return true;
+        continue;
+      }
+      if (isBoundedInK(arg, k)) continue;
+      if (vanishesAtInfinity(arg, k)) {
+        hasVanishing = true;
+        continue;
+      }
+      return false;
+    }
+    return hasVanishing;
+  }
+  return false;
+}
+
 function gVanishesAtInfinity(g: IRNode, k: IRNode): boolean {
+  if (vanishesAtInfinity(g, k)) return true;
   if (g.kind !== "apply" || !equals(g.head, DIV) || g.args.length !== 2) {
     return false;
   }

--- a/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
+++ b/code/packages/typescript/cas-summation/tests/cas-summation.test.ts
@@ -312,6 +312,26 @@ describe("summation: Phase 41+42 limit-aware infinite telescope", () => {
     expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(int(1));
   });
 
+  it("standard exp(-k) telescope closes because exp(-k) vanishes", () => {
+    const k = sym("k");
+    const gK = app(EXP, [app(NEG, [k])]);
+    const gKp1 = app(EXP, [app(NEG, [app(ADD, [k, int(1)])])]);
+    const f = app(SUB, [gKp1, gK]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(
+      app(NEG, [app(EXP, [int(-1)])]),
+    );
+  });
+
+  it("antisymmetric 2^(-k) telescope closes because the magnitude vanishes", () => {
+    const k = sym("k");
+    const gK = app(POW, [int(2), app(NEG, [k])]);
+    const gKp1 = app(POW, [int(2), app(NEG, [app(ADD, [k, int(1)])])]);
+    const f = app(SUB, [gK, gKp1]);
+    expect(evaluateSum(f, k, int(1), sym("%inf"), evalNode)).toEqual(
+      app(POW, [int(2), int(-1)]),
+    );
+  });
+
   it("Phase 42 proper rational ∑_{k=1}^∞ [k/(k²+1) − (k+1)/((k+1)²+1)] = 1/2", () => {
     const k = sym("k");
     const gK = app(DIV, [k, app(ADD, [app(POW, [k, int(2)]), int(1)])]);

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -30,6 +30,13 @@
 > TypeScript, and Rust by subtracting rational-pole terms and emitting
 > the remaining proper irreducible residual.
 
+> **MACSYMA summation audit follow-up (2026-06-06).** Infinite telescope
+> limits now recognise direct decaying exponential terms, not only rational
+> quotients with diverging denominators. Across Python, TypeScript, and Rust,
+> `exp(-k)` and `b^(-k)` with `|b| > 1` are treated as vanishing at infinity,
+> closing structurally telescoping exponential tails while preserving
+> conservative fallthrough for growing or sign-ambiguous exponentials.
+
 > **SPICE completion follow-up inventory (2026-06-06).** The 2026-06-05
 > release cut closed the planned SPICE 1970s compatibility slice, but a live
 > follow-up audit found one real parity gap: Rust had advanced named-corner


### PR DESCRIPTION
## Summary

- Teach the Python, TypeScript, and Rust `cas-summation` telescope recognizers that direct decaying exponentials vanish at infinity.
- Cover `exp(-k)` and `b^(-k)` with `|b| > 1`, including standard and antisymmetric infinite telescope orientations.
- Bump `cas-summation` package versions to `2.26.0` and record the MACSYMA parity follow-up in the pending-work plan.

## Validation

- `PYTHONPATH='...symbolic-ir/src;...cas-summation/src;...cas-substitution/src;...cas-pattern-matching/src' python -m pytest code/packages/python/cas-summation/tests -q --no-cov` -> `153 passed`
- `node ./node_modules/vitest/vitest.mjs run` -> `91 passed`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `cargo test --manifest-path code/packages/rust/cas-summation/Cargo.toml` -> `89 passed`
- `git diff --check`