### PR TITLE
Add smart-home discovery supervisor run

### DIFF
--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -33,6 +33,10 @@ All notable changes to this package will be documented in this file.
 - `SmartHomeRuntime::record_scheduled_discovery_worker_run` for ingesting a
   registered worker run, reconciling discovery results, and advancing the next
   scheduled due time.
+- `SmartHomeRuntime::run_due_mdns_discovery_workers_with_executor` and
+  `MdnsDiscoveryRunAdapter` for supervised mDNS discovery passes that execute
+  due scan plans through injectable runners, record scheduled run summaries,
+  and convert adapter failures into deterministic failed worker runs.
 - `RuntimeSupervisionPlanSummary` plus plan/observation helpers for compact
   due-work counts over non-mutating supervision plans.
 - `SupervisionTickSummary` plus tick-report helpers for compact actual-work

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -45,6 +45,9 @@ Included surfaces:
   plans, run-status tracking, and cadence advancement after scheduled ingest
 - executable mDNS scan-plan projection from due discovery schedules into
   per-interface IPv4/IPv6 scan requests without mutating runtime state
+- supervised mDNS discovery runs that mark due workers started, execute scan
+  plans through an injectable runner, adapt reports into worker runs, and
+  record scheduler/catalog outcomes
 - D18D-facing discover tool facade for authorized discovery reads, freshness
   filters, summaries, and bridge-candidate output
 - composed event-bus health summaries for replay history, stream coverage, and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -16,10 +16,12 @@ use smart_home_core::{
     VaultRef,
 };
 use smart_home_discovery::{
-    DiscoveryCatalog, DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary,
-    DiscoverySource, DiscoveryUpsert, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-    DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary, MdnsScanNetwork, MdnsWorkerScanPlan,
-    MdnsWorkerScanRequest, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
+    run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError, DiscoveryRecord,
+    DiscoveryRecordSummary, DiscoverySignalSummary, DiscoverySource, DiscoveryUpsert,
+    DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
+    DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary, MdnsScanNetwork, MdnsWorkerScanExecutor,
+    MdnsWorkerScanPlan, MdnsWorkerScanReport, MdnsWorkerScanRequest, UdpMdnsWorkerScanExecutor,
+    MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
 };
 use smart_home_registry::{
     DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts, RegistryError, StateRefreshPlan,
@@ -32,6 +34,7 @@ use std::{fmt, time::Duration};
 pub enum RuntimeError {
     Registry(Box<RegistryError>),
     Core(Box<SmartHomeError>),
+    Discovery(Box<DiscoveryError>),
     UnknownBridge(BridgeId),
     UnknownDevice(DeviceId),
     UnknownEntity(EntityId),
@@ -91,6 +94,7 @@ impl fmt::Display for RuntimeError {
         match self {
             Self::Registry(error) => write!(f, "{error}"),
             Self::Core(error) => write!(f, "{error}"),
+            Self::Discovery(error) => write!(f, "{error}"),
             Self::UnknownBridge(id) => write!(f, "unknown runtime bridge {id}"),
             Self::UnknownDevice(id) => write!(f, "unknown runtime device {id}"),
             Self::UnknownEntity(id) => write!(f, "unknown runtime entity {id}"),
@@ -172,6 +176,12 @@ impl fmt::Display for RuntimeError {
 }
 
 impl std::error::Error for RuntimeError {}
+
+impl From<DiscoveryError> for RuntimeError {
+    fn from(error: DiscoveryError) -> Self {
+        Self::Discovery(Box::new(error))
+    }
+}
 
 impl From<RegistryError> for RuntimeError {
     fn from(error: RegistryError) -> Self {
@@ -1926,6 +1936,103 @@ impl DiscoveryWorkerRunPlan {
     }
 }
 
+pub trait MdnsDiscoveryRunAdapter {
+    type Error: fmt::Display;
+
+    fn worker_run_from_mdns_scan_report(
+        &mut self,
+        report: &MdnsWorkerScanReport,
+    ) -> Result<DiscoveryWorkerRun, Self::Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoverySupervisorRunFailure {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub kind: DiscoveryWorkerKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoverySupervisorRunReport {
+    pub started_at_ms: u64,
+    pub completed_at_ms: u64,
+    pub ttl_ms: u64,
+    pub planned_instruction_count: usize,
+    pub mdns_request_count: usize,
+    pub mdns_report_count: usize,
+    pub summaries: Vec<DiscoveryWorkerRunSummary>,
+    pub failures: Vec<DiscoverySupervisorRunFailure>,
+}
+
+impl DiscoverySupervisorRunReport {
+    pub fn new(
+        started_at_ms: u64,
+        completed_at_ms: u64,
+        ttl_ms: u64,
+        planned_instruction_count: usize,
+        mdns_request_count: usize,
+        mdns_report_count: usize,
+    ) -> Self {
+        Self {
+            started_at_ms,
+            completed_at_ms,
+            ttl_ms,
+            planned_instruction_count,
+            mdns_request_count,
+            mdns_report_count,
+            summaries: Vec::new(),
+            failures: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.planned_instruction_count == 0
+            && self.mdns_request_count == 0
+            && self.recorded_run_count() == 0
+    }
+
+    pub fn recorded_run_count(&self) -> usize {
+        self.summaries.len()
+    }
+
+    pub fn completed_run_count(&self) -> usize {
+        self.summaries
+            .iter()
+            .filter(|summary| summary.status == DiscoveryWorkerRunStatus::Completed)
+            .count()
+    }
+
+    pub fn partial_run_count(&self) -> usize {
+        self.summaries
+            .iter()
+            .filter(|summary| summary.status == DiscoveryWorkerRunStatus::Partial)
+            .count()
+    }
+
+    pub fn failed_run_count(&self) -> usize {
+        self.summaries
+            .iter()
+            .filter(|summary| summary.status == DiscoveryWorkerRunStatus::Failed)
+            .count()
+    }
+
+    pub fn catalog_change_count(&self) -> usize {
+        self.summaries
+            .iter()
+            .map(DiscoveryWorkerRunSummary::accepted_count)
+            .sum()
+    }
+
+    pub fn has_failures(&self) -> bool {
+        !self.failures.is_empty()
+            || self
+                .summaries
+                .iter()
+                .any(|summary| summary.status != DiscoveryWorkerRunStatus::Completed)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiscoveryWorkerSort {
     WorkerId,
@@ -3418,6 +3525,99 @@ impl SmartHomeRuntime {
         Ok(summary)
     }
 
+    pub fn run_due_mdns_discovery_workers_with_executor<E, A>(
+        &mut self,
+        started_at_ms: u64,
+        completed_at_ms: u64,
+        ttl_ms: u64,
+        executor: &mut E,
+        adapter: &mut A,
+    ) -> Result<DiscoverySupervisorRunReport, RuntimeError>
+    where
+        E: MdnsWorkerScanExecutor + ?Sized,
+        A: MdnsDiscoveryRunAdapter,
+    {
+        let instructions = self
+            .discovery_worker_run_plan_at(started_at_ms)
+            .instructions
+            .into_iter()
+            .filter(|instruction| {
+                instruction.kind == DiscoveryWorkerKind::MdnsScan
+                    && instruction.sources.contains(&DiscoverySource::Mdns)
+            })
+            .collect::<Vec<_>>();
+        for instruction in &instructions {
+            self.mark_discovery_worker_started(&instruction.worker_id, started_at_ms)?;
+        }
+
+        let planned_instruction_count = instructions.len();
+        let mdns_scan_plan = DiscoveryWorkerRunPlan {
+            generated_at_ms: started_at_ms,
+            instructions,
+        }
+        .mdns_scan_plan()?;
+        let mdns_request_count = mdns_scan_plan.len();
+        let scan_reports = run_mdns_worker_scan_plan_with_executor(
+            &mdns_scan_plan,
+            started_at_ms,
+            completed_at_ms,
+            executor,
+        )?;
+        let mut report = DiscoverySupervisorRunReport::new(
+            started_at_ms,
+            completed_at_ms,
+            ttl_ms,
+            planned_instruction_count,
+            mdns_request_count,
+            scan_reports.len(),
+        );
+
+        for scan_report in &scan_reports {
+            let worker_run = match adapter.worker_run_from_mdns_scan_report(scan_report) {
+                Ok(run) => run,
+                Err(error) => {
+                    let message = error.to_string();
+                    report.failures.push(DiscoverySupervisorRunFailure {
+                        worker_id: scan_report.worker_id.clone(),
+                        integration_id: scan_report.integration_id.clone(),
+                        kind: DiscoveryWorkerKind::MdnsScan,
+                        message: message.clone(),
+                    });
+                    failed_mdns_discovery_worker_run_from_report(scan_report, message)?
+                }
+            };
+            report
+                .summaries
+                .push(self.record_scheduled_discovery_worker_run(
+                    &worker_run,
+                    completed_at_ms,
+                    ttl_ms,
+                )?);
+        }
+
+        Ok(report)
+    }
+
+    pub fn run_due_mdns_discovery_workers<A>(
+        &mut self,
+        started_at_ms: u64,
+        completed_at_ms: u64,
+        ttl_ms: u64,
+        adapter: &mut A,
+    ) -> Result<DiscoverySupervisorRunReport, RuntimeError>
+    where
+        A: MdnsDiscoveryRunAdapter,
+    {
+        let mut executor = UdpMdnsWorkerScanExecutor;
+        self.run_due_mdns_discovery_workers_with_executor(
+            started_at_ms,
+            completed_at_ms,
+            ttl_ms,
+            &mut executor,
+            adapter,
+        )
+    }
+
     pub fn discovery_record_count(&self) -> usize {
         self.discovery.len()
     }
@@ -4404,6 +4604,21 @@ fn invalid_discovery_worker_schedule(
     }
 }
 
+fn failed_mdns_discovery_worker_run_from_report(
+    report: &MdnsWorkerScanReport,
+    message: impl Into<String>,
+) -> Result<DiscoveryWorkerRun, RuntimeError> {
+    let mut run = DiscoveryWorkerRun::new(
+        report.worker_id.clone(),
+        report.integration_id.clone(),
+        DiscoveryWorkerKind::MdnsScan,
+        report.started_at_ms,
+        report.completed_at_ms,
+    );
+    run.push_failure(DiscoveryWorkerFailure::new(DiscoverySource::Mdns, message)?);
+    Ok(run)
+}
+
 fn metadata_value<'a>(metadata: &'a [Metadata], key: &str) -> Option<&'a str> {
     metadata
         .iter()
@@ -4564,9 +4779,68 @@ mod tests {
     use smart_home_discovery::{
         DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert,
         DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-        DiscoveryWorkerRunStatus, PairingRequirement,
+        DiscoveryWorkerRunStatus, MdnsResponsePacket, MdnsScanResult, MdnsWorkerScanRequest,
+        PairingRequirement,
     };
     use smart_home_registry::StateRefreshReason;
+
+    #[derive(Debug)]
+    struct ScriptedMdnsExecutor {
+        outcomes: std::collections::VecDeque<Result<MdnsScanResult, DiscoveryError>>,
+        requests: Vec<MdnsWorkerScanRequest>,
+    }
+
+    impl ScriptedMdnsExecutor {
+        fn new(outcomes: impl IntoIterator<Item = Result<MdnsScanResult, DiscoveryError>>) -> Self {
+            Self {
+                outcomes: outcomes.into_iter().collect(),
+                requests: Vec::new(),
+            }
+        }
+    }
+
+    impl MdnsWorkerScanExecutor for ScriptedMdnsExecutor {
+        fn run_request(
+            &mut self,
+            request: &MdnsWorkerScanRequest,
+        ) -> Result<MdnsScanResult, DiscoveryError> {
+            self.requests.push(request.clone());
+            self.outcomes.pop_front().unwrap_or_else(|| {
+                Err(DiscoveryError::MdnsTransport {
+                    message: "missing scripted mDNS outcome".to_string(),
+                })
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct ScriptedMdnsRunAdapter {
+        outcomes: std::collections::VecDeque<Result<DiscoveryWorkerRun, String>>,
+        reports: Vec<MdnsWorkerScanReport>,
+    }
+
+    impl ScriptedMdnsRunAdapter {
+        fn new(outcomes: impl IntoIterator<Item = Result<DiscoveryWorkerRun, String>>) -> Self {
+            Self {
+                outcomes: outcomes.into_iter().collect(),
+                reports: Vec::new(),
+            }
+        }
+    }
+
+    impl MdnsDiscoveryRunAdapter for ScriptedMdnsRunAdapter {
+        type Error = String;
+
+        fn worker_run_from_mdns_scan_report(
+            &mut self,
+            report: &MdnsWorkerScanReport,
+        ) -> Result<DiscoveryWorkerRun, Self::Error> {
+            self.reports.push(report.clone());
+            self.outcomes
+                .pop_front()
+                .unwrap_or_else(|| Err("missing scripted discovery worker run".to_string()))
+        }
+    }
 
     fn bridge(id: &str) -> Bridge {
         let mut bridge = Bridge::new(
@@ -5864,6 +6138,111 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn runtime_supervised_mdns_discovery_run_executes_and_records_due_workers() {
+        let mut runtime = SmartHomeRuntime::new();
+        let worker_id = DiscoveryWorkerId::trusted("hue-mdns-worker");
+        runtime
+            .register_discovery_worker_schedule(hue_mdns_discovery_worker(1_100))
+            .unwrap();
+        let outcomes = (0..4).map(|_| {
+            MdnsScanResult::from_packets("_hue._tcp.local", 1_125, Vec::<MdnsResponsePacket>::new())
+        });
+        let mut executor = ScriptedMdnsExecutor::new(outcomes);
+        let mut run = DiscoveryWorkerRun::new(
+            worker_id.clone(),
+            IntegrationId::trusted("hue"),
+            DiscoveryWorkerKind::MdnsScan,
+            1_125,
+            1_180,
+        );
+        run.push_record(hue_discovery_record("001788fffesupervised", 1_175))
+            .unwrap();
+        let mut adapter = ScriptedMdnsRunAdapter::new([Ok(run)]);
+
+        let report = runtime
+            .run_due_mdns_discovery_workers_with_executor(
+                1_125,
+                1_180,
+                500,
+                &mut executor,
+                &mut adapter,
+            )
+            .unwrap();
+        let scheduled = runtime.discovery_worker_schedule(&worker_id).unwrap();
+
+        assert_eq!(executor.requests.len(), 4);
+        assert_eq!(adapter.reports.len(), 1);
+        assert_eq!(adapter.reports[0].completed_scan_count(), 4);
+        assert_eq!(report.planned_instruction_count, 1);
+        assert_eq!(report.mdns_request_count, 4);
+        assert_eq!(report.mdns_report_count, 1);
+        assert_eq!(report.recorded_run_count(), 1);
+        assert_eq!(report.completed_run_count(), 1);
+        assert_eq!(report.partial_run_count(), 0);
+        assert_eq!(report.failed_run_count(), 0);
+        assert_eq!(report.catalog_change_count(), 1);
+        assert!(!report.has_failures());
+        assert_eq!(runtime.discovery_record_count(), 1);
+        assert_eq!(scheduled.status, WorkerStatus::Running);
+        assert_eq!(scheduled.last_started_at_ms, Some(1_125));
+        assert_eq!(scheduled.last_completed_at_ms, Some(1_180));
+        assert_eq!(
+            scheduled.last_run_status,
+            Some(DiscoveryWorkerRunStatus::Completed)
+        );
+        assert_eq!(scheduled.next_due_at_ms, 6_180);
+    }
+
+    #[test]
+    fn runtime_supervised_mdns_discovery_run_records_adapter_failures() {
+        let mut runtime = SmartHomeRuntime::new();
+        let worker_id = DiscoveryWorkerId::trusted("hue-mdns-worker");
+        runtime
+            .register_discovery_worker_schedule(hue_mdns_discovery_worker(1_100))
+            .unwrap();
+        let outcomes = (0..4).map(|_| {
+            MdnsScanResult::from_packets("_hue._tcp.local", 1_125, Vec::<MdnsResponsePacket>::new())
+        });
+        let mut executor = ScriptedMdnsExecutor::new(outcomes);
+        let mut adapter =
+            ScriptedMdnsRunAdapter::new([Err("unsupported mDNS service type".to_string())]);
+
+        let report = runtime
+            .run_due_mdns_discovery_workers_with_executor(
+                1_125,
+                1_180,
+                500,
+                &mut executor,
+                &mut adapter,
+            )
+            .unwrap();
+        let scheduled = runtime.discovery_worker_schedule(&worker_id).unwrap();
+
+        assert_eq!(executor.requests.len(), 4);
+        assert_eq!(adapter.reports.len(), 1);
+        assert_eq!(report.planned_instruction_count, 1);
+        assert_eq!(report.mdns_request_count, 4);
+        assert_eq!(report.mdns_report_count, 1);
+        assert_eq!(report.recorded_run_count(), 1);
+        assert_eq!(report.completed_run_count(), 0);
+        assert_eq!(report.failed_run_count(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].worker_id, worker_id);
+        assert_eq!(report.failures[0].message, "unsupported mDNS service type");
+        assert!(report.has_failures());
+        assert_eq!(runtime.discovery_record_count(), 0);
+        assert_eq!(scheduled.status, WorkerStatus::Unhealthy);
+        assert_eq!(
+            scheduled.last_run_status,
+            Some(DiscoveryWorkerRunStatus::Failed)
+        );
+        assert_eq!(scheduled.last_record_count, 0);
+        assert_eq!(scheduled.last_failure_count, 1);
+        assert_eq!(scheduled.consecutive_failure_count, 1);
+        assert_eq!(scheduled.next_due_at_ms, 6_180);
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -157,6 +157,25 @@ without moving platform state or socket supervision into the Chief bridge:
   conversion, and scheduled runtime ingest end to end while keeping Chief of
   Staff on the existing thin `smart_home.*` tool bridge.
 
+## Current Discovery Supervisor Run Slice
+
+This slice lets D23 coordinate one deterministic supervised mDNS pass without
+turning runtime into a Hue integration or process manager:
+
+- `smart-home-runtime` now has a supervised mDNS discovery run helper that
+  marks due workers started, executes due scan plans through an injectable mDNS
+  runner, adapts reports into discovery worker runs, records scheduled ingest,
+  and returns compact run/catalog outcome counts.
+- Runtime keeps vendor-specific interpretation outside the scheduler through an
+  injected `MdnsDiscoveryRunAdapter`, so Hue report conversion stays in
+  `hue-core` or callers that compose Hue.
+- Adapter failures are converted into deterministic failed discovery-worker
+  runs, which advances schedule state and preserves failure pressure for
+  supervisor status instead of leaving workers stuck as running.
+- The new tests prove both a completed supervised mDNS pass and a failed adapter
+  path using local fake runners, without opening sockets or moving the Chief
+  bridge boundary.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -178,9 +197,9 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 These items move toward retiring an existing Home Assistant install:
 
-- Wire the mDNS runner to a supervised actor or process that manages lifecycle,
-  retries, OS interface binding, and persistence for schedules, results, and
-  runtime state across restarts.
+- Connect the supervised mDNS runtime pass to an actor or process that manages
+  lifecycle, retries/backoff, OS interface binding, and persistence for
+  schedules, results, and runtime state across restarts.
 - Complete real Hue pairing: start session, user presence/link button, vault
   credential write, bridge health update, and no-secret audit trail.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers


### PR DESCRIPTION
## Summary
- add runtime-supervised mDNS discovery passes that mark due workers started, execute scan plans through injectable runners, and record scheduled run summaries
- add `MdnsDiscoveryRunAdapter` so runtime stays generic while vendor report conversion remains outside the scheduler
- record adapter conversion failures as deterministic failed discovery-worker runs and update the completion inventory

## Validation
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-discovery`
- `cargo test -p smart-home-testkit`
- `cargo test -p hue-core`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `code/packages/rust/smart-home-discovery`
- `sh BUILD` in `code/packages/rust/hue-core`
- `sh BUILD` in `code/packages/rust/smart-home-runtime`
- `sh BUILD` in `code/packages/rust/smart-home-testkit`
- `git diff --check`