### PR TITLE
Close bounded limit-at-infinity parity

### DIFF
--- a/code/packages/python/cas-limit-series/CHANGELOG.md
+++ b/code/packages/python/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.2 - 2026-06-06
+
+### Added
+
+- Limits at infinity now recognise bounded numerators divided by diverging
+  denominators. This closes MACSYMA-style cases such as `limit(sin(x)/x, x,
+  inf)` and `limit(cos(x)/(x^2+1), x, minf)` to exact `0` instead of falling
+  through to an unevaluated `Limit(...)`.
+
 ## 0.2.1 — 2026-05-14
 
 **Bug fix: `ZeroDivisionError` from direct substitution now routes to L'Hôpital.**

--- a/code/packages/python/cas-limit-series/pyproject.toml
+++ b/code/packages/python/cas-limit-series/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-limit-series"
-version = "0.2.1"
+version = "0.2.2"
 description = "Limit and Taylor series on symbolic IR: direct substitution, L'Hôpital, ±∞, all indeterminate forms, one-sided limits."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
@@ -484,6 +484,25 @@ def _pow_exp_log(
     return result
 
 
+def _is_bounded_at_infinity(node: IRNode, var: IRSymbol) -> bool:
+    """Return True for shapes known to stay bounded at infinity."""
+    if isinstance(node, (IRInteger, IRRational, IRFloat)):
+        return True
+    if isinstance(node, IRSymbol):
+        return node != var
+    if not isinstance(node, IRApply):
+        return False
+    if node.head == NEG and len(node.args) == 1:
+        return _is_bounded_at_infinity(node.args[0], var)
+    if node.head == ADD:
+        return all(_is_bounded_at_infinity(arg, var) for arg in node.args)
+    if node.head == MUL:
+        return all(_is_bounded_at_infinity(arg, var) for arg in node.args)
+    if node.head in {SIN, COS, TANH, ATAN} and len(node.args) == 1:
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Section 6 — Indeterminate form dispatcher
 # ---------------------------------------------------------------------------
@@ -530,6 +549,10 @@ def _handle_form(
         is_inf_inf = (math.isinf(n_val) or abs(n_val) > _INF_THRESHOLD) and (
             math.isinf(d_val) or abs(d_val) > _INF_THRESHOLD
         )
+        if (math.isinf(d_val) or abs(d_val) > _INF_THRESHOLD) and (
+            _is_bounded_at_infinity(numer, var)
+        ):
+            return IRInteger(0)
         if (is_zero_zero or is_inf_inf) and diff_fn is not None:
             return _lhopital_step(
                 numer, denom, var, point, direction, diff_fn, eval_fn, depth

--- a/code/packages/python/cas-limit-series/tests/test_phase20.py
+++ b/code/packages/python/cas-limit-series/tests/test_phase20.py
@@ -684,19 +684,20 @@ class TestLimitsAtInfinity:
         out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
         assert _close(out, 0.0, tol=1e-6)
 
-    def test_sin_over_x_at_inf_is_zero_or_unevaluated(self):
-        """lim_{x→∞} sin(x)/x: sin(∞) is NaN but overall limit is 0.
-
-        Our numeric evaluator gives nan for sin(∞), so this either:
-        - Falls through to unevaluated (no diff_fn path finds 0)
-        - OR the system returns unevaluated Limit(…)
-        This test just verifies no exception is raised.
-        """
+    def test_sin_over_x_at_inf_is_zero(self):
+        """lim_{x→∞} sin(x)/x = 0 by bounded-over-diverging recognition."""
         x = _sym("x")
         expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
         out = limit_advanced(expr, x, INF, diff_fn=_DIFF, eval_fn=_EVAL)
-        # Either unevaluated or 0 — both acceptable
-        assert out is not None
+        assert isinstance(out, IRInteger) and out.value == 0
+
+    def test_cos_over_quadratic_at_neg_inf_is_zero(self):
+        """lim_{x→-∞} cos(x)/(x^2+1) = 0."""
+        x = _sym("x")
+        denom = IRApply(ADD, (IRApply(POW, (x, _i(2))), _i(1)))
+        expr = IRApply(DIV, (IRApply(COS, (x,)), denom))
+        out = limit_advanced(expr, x, MINF, diff_fn=_DIFF, eval_fn=_EVAL)
+        assert isinstance(out, IRInteger) and out.value == 0
 
 
 # ===========================================================================

--- a/code/packages/rust/cas-limit-series/CHANGELOG.md
+++ b/code/packages/rust/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — cas-limit-series (Rust)
 
+## [0.2.2] - 2026-06-06
+
+### Added
+
+- Add bounded-over-diverging limit recognition at infinity, closing
+  `limit(sin(x)/x, x, inf)` and `limit(cos(x)/(x^2+1), x, minf)` to exact
+  `0` instead of returning an unevaluated `Limit(...)`.
+
 ## [0.1.0] — 2026-04-27
 
 ### Added

--- a/code/packages/rust/cas-limit-series/Cargo.toml
+++ b/code/packages/rust/cas-limit-series/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-limit-series"
-version = "0.1.0"
+version = "0.2.2"
 edition = "2021"
 description = "Limit (direct substitution) and polynomial Taylor series for symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-limit-series/src/limit_advanced.rs
+++ b/code/packages/rust/cas-limit-series/src/limit_advanced.rs
@@ -129,6 +129,9 @@ fn handle_form(
             let d_val = eval_at_float(denom, var, exact_pt);
             let zero_zero = n_val == 0.0 && d_val == 0.0;
             let inf_inf = is_effectively_inf(n_val) && is_effectively_inf(d_val);
+            if is_effectively_inf(d_val) && is_bounded_at_infinity(numer, var) {
+                return int(0);
+            }
             if zero_zero || inf_inf {
                 if let Some(diff_fn) = options.diff_fn {
                     return lhopital_step(
@@ -271,6 +274,27 @@ fn pow_exp_log(
         result = eval_fn(result);
     }
     Some(result)
+}
+
+fn is_bounded_at_infinity(node: &IRNode, var: &IRNode) -> bool {
+    match node {
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_) => true,
+        IRNode::Symbol(_) => node != var,
+        IRNode::Str(_) => false,
+        IRNode::Apply(a) if a.head == sym(NEG) && a.args.len() == 1 => {
+            is_bounded_at_infinity(&a.args[0], var)
+        }
+        IRNode::Apply(a) if a.head == sym(ADD) => {
+            a.args.iter().all(|arg| is_bounded_at_infinity(arg, var))
+        }
+        IRNode::Apply(a) if a.head == sym(MUL) => {
+            a.args.iter().all(|arg| is_bounded_at_infinity(arg, var))
+        }
+        IRNode::Apply(a) if a.args.len() == 1 => {
+            a.head == sym(SIN) || a.head == sym(COS) || a.head == sym(TANH) || a.head == sym(ATAN)
+        }
+        _ => false,
+    }
 }
 
 fn build_unevaluated(

--- a/code/packages/rust/cas-limit-series/tests/tests.rs
+++ b/code/packages/rust/cas-limit-series/tests/tests.rs
@@ -7,7 +7,7 @@ use cas_limit_series::{
     limit_advanced, limit_direct, taylor_polynomial, LimitAdvancedOptions, LimitDirection,
     PolynomialError, LIMIT,
 };
-use symbolic_ir::{apply, int, sym, IRNode, ADD, DIV, EXP, LOG, MUL, POW, SUB};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, POW, SIN, SUB};
 
 // ---------------------------------------------------------------------------
 // limit_direct
@@ -291,6 +291,44 @@ fn limit_advanced_power_rewrite_falls_back_inside_exp() {
         ],
     );
     assert_eq!(out, apply(sym(EXP), vec![expected_inner]));
+}
+
+#[test]
+fn limit_advanced_bounded_oscillatory_over_diverging_at_infinity() {
+    let x = sym("x");
+    let expr = apply(sym(DIV), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    let out = limit_advanced(
+        expr,
+        &x,
+        sym("inf"),
+        LimitAdvancedOptions {
+            diff_fn: Some(&test_diff),
+            eval_fn: Some(&test_eval),
+            ..Default::default()
+        },
+    );
+    assert_eq!(out, int(0));
+}
+
+#[test]
+fn limit_advanced_bounded_oscillatory_over_quadratic_at_negative_infinity() {
+    let x = sym("x");
+    let denom = apply(
+        sym(ADD),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)],
+    );
+    let expr = apply(sym(DIV), vec![apply(sym(COS), vec![x.clone()]), denom]);
+    let out = limit_advanced(
+        expr,
+        &x,
+        sym("minf"),
+        LimitAdvancedOptions {
+            diff_fn: Some(&test_diff),
+            eval_fn: Some(&test_eval),
+            ..Default::default()
+        },
+    );
+    assert_eq!(out, int(0));
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-limit-series/CHANGELOG.md
+++ b/code/packages/typescript/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2 - 2026-06-06
+
+- Add bounded-over-diverging limit recognition at infinity, closing
+  `limit(sin(x)/x, x, inf)` and `limit(cos(x)/(x^2+1), x, minf)` to exact
+  `0` instead of returning an unevaluated `Limit(...)`.
+
 ## 0.1.0
 
 - Add pure TypeScript parity for Rust `cas-limit-series` direct limits and

--- a/code/packages/typescript/cas-limit-series/package-lock.json
+++ b/code/packages/typescript/cas-limit-series/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-limit-series",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-limit-series",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-substitution": "file:../cas-substitution",

--- a/code/packages/typescript/cas-limit-series/package.json
+++ b/code/packages/typescript/cas-limit-series/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-limit-series",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Pure TypeScript direct limits and polynomial Taylor expansion over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-limit-series/src/index.ts
+++ b/code/packages/typescript/cas-limit-series/src/index.ts
@@ -225,6 +225,9 @@ function handleIndeterminateForm(
     const denomValue = evalAtNumber(denom, variable, exactPoint);
     const zeroZero = numerValue === 0 && denomValue === 0;
     const infInf = isInfiniteLike(numerValue) && isInfiniteLike(denomValue);
+    if (isInfiniteLike(denomValue) && isBoundedAtInfinity(numer, variable)) {
+      return int(0);
+    }
     if ((zeroZero || infInf) && options.differentiate !== undefined) {
       return lhopital(numer, denom, variable, point, options, depth);
     }
@@ -318,6 +321,16 @@ function rewriteIndeterminatePower(
     return buildUnevaluatedLimit(app(POW, [base, exponent]), variable, point, options.direction);
   }
   return applyLimitCallbacks(app(EXP, [exponentLimit]), options);
+}
+
+function isBoundedAtInfinity(node: IRNode, variable: IRNode): boolean {
+  if (node.kind === "integer" || node.kind === "rational" || node.kind === "float") return true;
+  if (node.kind === "symbol") return !equals(node, variable);
+  if (node.kind !== "apply") return false;
+  if (equals(node.head, NEG) && node.args.length === 1) return isBoundedAtInfinity(node.args[0], variable);
+  if (equals(node.head, ADD)) return node.args.every((arg) => isBoundedAtInfinity(arg, variable));
+  if (equals(node.head, MUL)) return node.args.every((arg) => isBoundedAtInfinity(arg, variable));
+  return [SIN.name, COS.name, TANH.name, ATAN.name].includes(headName(node.head)) && node.args.length === 1;
 }
 
 function applyLimitCallbacks(node: IRNode, options: LimitAdvancedOptions): IRNode {

--- a/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
+++ b/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ADD, DIV, MUL, NEG, POW, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, COS, DIV, MUL, NEG, POW, SIN, SUB, app, equals, int, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 import { LIMIT, PolynomialError, limitAdvanced, limitDirect, taylorPolynomial } from "../src/index";
 
 function expectEqual(actual: IRNode, expected: IRNode): void {
@@ -171,6 +171,23 @@ describe("limitAdvanced", () => {
     const x = sym("x");
     const expr = app(POW, [x, x]);
     expectEqual(limitAdvanced(expr, x, int(0), { direction: "plus" }), app(sym(LIMIT), [expr, x, int(0), sym("plus")]));
+  });
+
+  it("resolves bounded oscillatory numerator over diverging denominator at infinity", () => {
+    const x = sym("x");
+    expectEqual(limitAdvanced(app(DIV, [app(SIN, [x]), x]), x, sym("inf"), {
+      differentiate: differentiateFixture,
+      evaluate: evaluateFixture,
+    }), int(0));
+  });
+
+  it("resolves bounded oscillatory numerator over quadratic denominator at negative infinity", () => {
+    const x = sym("x");
+    const denom = app(ADD, [app(POW, [x, int(2)]), int(1)]);
+    expectEqual(limitAdvanced(app(DIV, [app(COS, [x]), denom]), x, sym("minf"), {
+      differentiate: differentiateFixture,
+      evaluate: evaluateFixture,
+    }), int(0));
   });
 });
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -37,6 +37,13 @@
 > closing structurally telescoping exponential tails while preserving
 > conservative fallthrough for growing or sign-ambiguous exponentials.
 
+> **MACSYMA limit audit follow-up (2026-06-06).** Advanced limits at infinity
+> now recognise bounded numerators over diverging denominators across Python,
+> TypeScript, and Rust. This closes `limit(sin(x)/x, x, inf)` and
+> `limit(cos(x)/(x^2+1), x, minf)` to exact `0`, rather than accepting the
+> oscillatory numerator's direct `sin(inf)` / `cos(inf)` classification as an
+> unevaluated `Limit(...)`.
+
 > **SPICE completion follow-up inventory (2026-06-06).** The 2026-06-05
 > release cut closed the planned SPICE 1970s compatibility slice, but a live
 > follow-up audit found one real parity gap: Rust had advanced named-corner


### PR DESCRIPTION
## Summary

- Teach Python, TypeScript, and Rust `cas-limit-series` that bounded numerators over diverging denominators vanish at infinity.
- Close MACSYMA-style limits such as `limit(sin(x)/x, x, inf)` and `limit(cos(x)/(x^2+1), x, minf)` to exact `0` instead of returning an unevaluated `Limit(...)`.
- Bump `cas-limit-series` package metadata to `0.2.2` and record the audit closure in the living MACSYMA/SPICE work plan.

## Validation

- `PYTHONPATH='...symbolic-ir/src;...cas-substitution/src;...cas-pattern-matching/src;...cas-limit-series/src' python -m pytest code/packages/python/cas-limit-series/tests -q --no-cov` -> `60 passed, 7 skipped`
- `node ./node_modules/vitest/vitest.mjs run` -> `23 passed`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `cargo fmt --manifest-path code/packages/rust/cas-limit-series/Cargo.toml -- --check`
- `cargo test --manifest-path code/packages/rust/cas-limit-series/Cargo.toml` -> `26 passed` plus `4` doc-tests
- `git diff --check`