### PR TITLE
Add smart-home discovery observability

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -15,3 +15,6 @@ All notable changes to this package will be documented in this file.
 - Added the `smart_home.discover` D18D handler over
   `RuntimeDiscoverToolRequest`, including discovery filters, bridge-candidate
   output, and end-to-end journal coverage.
+- Added scheduled discovery worker observability to
+  `smart_home.observe_supervision`, including worker status, due time, last run
+  counts, and failure pressure from the D23 runtime.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -10,8 +10,8 @@ The crate is intentionally a thin adapter:
 - handlers translate JSON arguments into `SmartHomeRuntime` read, subscribe,
   discover, pair, and command requests
 - `SmartHomeRuntime` still owns smart-home authorization, command validation,
-  event subscriptions, pairing sessions, optimistic state, supervision, and
-  audit decisions
+  event subscriptions, pairing sessions, optimistic state, discovery scheduler
+  observability, supervision, and audit decisions
 - D18D still owns tool validation, policy decisions, event streams, terminal
   results, and execution journals
 
@@ -23,6 +23,7 @@ Chief of Staff job/session/agent
   -> D18D smart_home.discover / smart_home.command tool calls
   -> smart-home runtime authorization
   -> discovery records and unpaired bridge candidates
+  -> discovery worker health in smart_home.observe_supervision
   -> device command acceptance
   -> optimistic state update
   -> D18D trace and audit record

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -26,7 +26,7 @@ use smart_home_runtime::{
     RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingSession,
     RuntimePairingSessionId, RuntimeReadToolOutput, RuntimeReadToolRequest,
     RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionId,
-    SmartHomeRuntime,
+    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -354,6 +354,20 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
                     SchemaProperty::new("state_refresh_count", JsonSchema::Integer),
                     SchemaProperty::new("desired_state_drift_count", JsonSchema::Integer),
                     SchemaProperty::new("worker_restart_count", JsonSchema::Integer),
+                    SchemaProperty::new("discovery_worker_count", JsonSchema::Integer),
+                    SchemaProperty::new("discovery_worker_run_count", JsonSchema::Integer),
+                    SchemaProperty::new("unhealthy_discovery_worker_count", JsonSchema::Integer),
+                    SchemaProperty::new(
+                        "discovery_workers_with_failures_count",
+                        JsonSchema::Integer,
+                    ),
+                    SchemaProperty::new("next_discovery_worker_due_at_ms", JsonSchema::Any),
+                    SchemaProperty::new(
+                        "discovery_workers",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
                     SchemaProperty::new("due_worker_deadline_count", JsonSchema::Integer),
                     SchemaProperty::new("next_worker_heartbeat_due_at_ms", JsonSchema::Any),
                 ],
@@ -365,6 +379,12 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
                     "state_refresh_count",
                     "desired_state_drift_count",
                     "worker_restart_count",
+                    "discovery_worker_count",
+                    "discovery_worker_run_count",
+                    "unhealthy_discovery_worker_count",
+                    "discovery_workers_with_failures_count",
+                    "next_discovery_worker_due_at_ms",
+                    "discovery_workers",
                     "due_worker_deadline_count",
                     "next_worker_heartbeat_due_at_ms",
                 ],
@@ -780,6 +800,39 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
                 integer(observation.worker_restart_count() as i64),
             ),
             (
+                "discovery_worker_count",
+                integer(observation.discovery_worker_count() as i64),
+            ),
+            (
+                "discovery_worker_run_count",
+                integer(observation.discovery_worker_run_count() as i64),
+            ),
+            (
+                "unhealthy_discovery_worker_count",
+                integer(observation.unhealthy_discovery_worker_count() as i64),
+            ),
+            (
+                "discovery_workers_with_failures_count",
+                integer(observation.discovery_workers_with_failures_count() as i64),
+            ),
+            (
+                "next_discovery_worker_due_at_ms",
+                observation
+                    .next_discovery_worker_due_at_ms()
+                    .map(|value| integer(value as i64))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "discovery_workers",
+                JsonValue::Array(
+                    observation
+                        .discovery_workers
+                        .iter()
+                        .map(discovery_worker_snapshot_json)
+                        .collect(),
+                ),
+            ),
+            (
                 "due_worker_deadline_count",
                 integer(observation.due_worker_deadline_count() as i64),
             ),
@@ -941,6 +994,80 @@ fn metadata_json(metadata: &Metadata) -> JsonValue {
     object([
         ("key", string(&metadata.key)),
         ("value", string(&metadata.value)),
+    ])
+}
+
+fn discovery_worker_snapshot_json(snapshot: &ScheduledDiscoveryWorkerSnapshot) -> JsonValue {
+    object([
+        ("worker_id", string(snapshot.worker_id.as_str())),
+        ("integration_id", string(snapshot.integration_id.as_str())),
+        ("kind", string(snapshot.kind.as_str())),
+        ("status", string(snapshot.status.as_str())),
+        (
+            "sources",
+            JsonValue::Array(
+                snapshot
+                    .sources
+                    .iter()
+                    .map(|source| string(source.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "network_interfaces",
+            JsonValue::Array(snapshot.network_interfaces.iter().map(string).collect()),
+        ),
+        ("is_due", JsonValue::Bool(snapshot.is_due)),
+        ("overdue_by_ms", integer(snapshot.overdue_by_ms as i64)),
+        ("next_due_at_ms", integer(snapshot.next_due_at_ms as i64)),
+        ("interval_ms", integer(snapshot.interval_ms as i64)),
+        ("run_timeout_ms", integer(snapshot.run_timeout_ms as i64)),
+        (
+            "last_started_at_ms",
+            snapshot
+                .last_started_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "last_completed_at_ms",
+            snapshot
+                .last_completed_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "last_run_status",
+            snapshot
+                .last_run_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "last_record_count",
+            integer(snapshot.last_record_count as i64),
+        ),
+        (
+            "last_failure_count",
+            integer(snapshot.last_failure_count as i64),
+        ),
+        (
+            "last_catalog_change_count",
+            integer(snapshot.last_catalog_change_count as i64),
+        ),
+        ("total_run_count", integer(snapshot.total_run_count as i64)),
+        (
+            "consecutive_failure_count",
+            integer(snapshot.consecutive_failure_count as i64),
+        ),
+        (
+            "has_failure_pressure",
+            JsonValue::Bool(snapshot.has_failure_pressure()),
+        ),
+        (
+            "metadata",
+            JsonValue::Array(snapshot.metadata.iter().map(metadata_json).collect()),
+        ),
     ])
 }
 
@@ -1483,6 +1610,10 @@ mod tests {
         ToolValidationReport,
     };
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use smart_home_discovery::{
+        DiscoveryWorkerId, DiscoveryWorkerKind, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
+    };
+    use smart_home_runtime::ScheduledDiscoveryWorker;
     use smart_home_testkit::{hue_bridge_discovery_record, hue_lighting_runtime};
 
     const AGENT_ID: &str = "agent:chief-smart-home";
@@ -1526,6 +1657,22 @@ mod tests {
         runtime
             .borrow_mut()
             .record_discovery(hue_bridge_discovery_record("001788fffediscovered", 1_000))
+            .unwrap();
+        runtime
+            .borrow_mut()
+            .register_discovery_worker_schedule(
+                ScheduledDiscoveryWorker::new(
+                    DiscoveryWorkerId::trusted("hue-mdns-worker"),
+                    IntegrationId::trusted("hue"),
+                    DiscoveryWorkerKind::MdnsScan,
+                    5_000,
+                    250,
+                    1_050,
+                )
+                .with_source(DiscoverySource::Mdns)
+                .with_network_interface("en0")
+                .with_metadata(MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY, "_hue._tcp.local"),
+            )
             .unwrap();
         runtime.borrow_mut().registry_mut().upsert_capability_grant(
             CapabilityGrant::for_all_smart_home(
@@ -1616,6 +1763,36 @@ mod tests {
             Some(&integer(1))
         );
 
+        let supervision_request = request(
+            "call-observe-supervision",
+            SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID,
+            object([]),
+            1_060,
+        );
+        let supervision_trace = tool_runtime.invoke_with_events(&supervision_request);
+        assert!(supervision_trace.result.ok);
+        let supervision_output = supervision_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(supervision_output, "discovery_worker_count"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(supervision_output, "discovery_worker_run_count"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(supervision_output, "unhealthy_discovery_worker_count"),
+            Some(&integer(0))
+        );
+        assert_eq!(
+            field(supervision_output, "next_discovery_worker_due_at_ms"),
+            Some(&integer(1_050))
+        );
+        assert_eq!(
+            array_len(field(supervision_output, "discovery_workers").unwrap()),
+            Some(1)
+        );
+
         let subscribe_request = request(
             "call-subscribe",
             SMART_HOME_SUBSCRIBE_TOOL_ID,
@@ -1693,15 +1870,16 @@ mod tests {
         journal.record_trace(discover_request, discover_trace);
         journal.record_trace(capabilities_request, capabilities_trace);
         journal.record_trace(health_request, health_trace);
+        journal.record_trace(supervision_request, supervision_trace);
         journal.record_trace(subscribe_request, subscribe_trace);
         journal.record_trace(pair_request, pair_trace);
         journal.record_trace(command_request, command_trace);
         journal.record_trace(state_request, state_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 8);
-        assert_eq!(journal_summary.completed_count, 8);
-        assert_eq!(journal.audit_records().len(), 8);
+        assert_eq!(journal_summary.invocation_count, 9);
+        assert_eq!(journal_summary.completed_count, 9);
+        assert_eq!(journal.audit_records().len(), 9);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -1715,7 +1893,7 @@ mod tests {
         );
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            9,
+            10,
             "read, subscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this package will be documented in this file.
   `MdnsDiscoveryRunAdapter` for supervised mDNS discovery passes that execute
   due scan plans through injectable runners, record scheduled run summaries,
   and convert adapter failures into deterministic failed worker runs.
+- `ScheduledDiscoveryWorkerSnapshot` and discovery scheduler details on
+  `RuntimeSupervisionObservation` for read-side inspection of due workers, last
+  run status, record/failure counts, catalog changes, and consecutive failure
+  pressure.
 - `RuntimeSupervisionPlanSummary` plus plan/observation helpers for compact
   due-work counts over non-mutating supervision plans.
 - `SupervisionTickSummary` plus tick-report helpers for compact actual-work

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -48,6 +48,9 @@ Included surfaces:
 - supervised mDNS discovery runs that mark due workers started, execute scan
   plans through an injectable runner, adapt reports into worker runs, and
   record scheduler/catalog outcomes
+- read-side scheduled discovery worker snapshots for supervision observations,
+  including due status, last run status, record/failure counts, catalog changes,
+  and consecutive failure pressure
 - D18D-facing discover tool facade for authorized discovery reads, freshness
   filters, summaries, and bridge-candidate output
 - composed event-bus health summaries for replay history, stream coverage, and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -1829,6 +1829,63 @@ impl ScheduledDiscoveryWorker {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduledDiscoveryWorkerSnapshot {
+    pub worker_id: DiscoveryWorkerId,
+    pub integration_id: IntegrationId,
+    pub kind: DiscoveryWorkerKind,
+    pub sources: Vec<DiscoverySource>,
+    pub network_interfaces: Vec<String>,
+    pub status: WorkerStatus,
+    pub interval_ms: u64,
+    pub run_timeout_ms: u64,
+    pub next_due_at_ms: u64,
+    pub is_due: bool,
+    pub overdue_by_ms: u64,
+    pub last_started_at_ms: Option<u64>,
+    pub last_completed_at_ms: Option<u64>,
+    pub last_run_status: Option<DiscoveryWorkerRunStatus>,
+    pub last_record_count: usize,
+    pub last_failure_count: usize,
+    pub last_catalog_change_count: usize,
+    pub total_run_count: u64,
+    pub consecutive_failure_count: u32,
+    pub metadata: Vec<Metadata>,
+}
+
+impl ScheduledDiscoveryWorkerSnapshot {
+    pub fn from_worker_at(worker: &ScheduledDiscoveryWorker, now_ms: u64) -> Self {
+        Self {
+            worker_id: worker.worker_id.clone(),
+            integration_id: worker.integration_id.clone(),
+            kind: worker.kind,
+            sources: worker.sources.clone(),
+            network_interfaces: worker.network_interfaces.clone(),
+            status: worker.status,
+            interval_ms: worker.interval_ms,
+            run_timeout_ms: worker.run_timeout_ms,
+            next_due_at_ms: worker.next_due_at_ms,
+            is_due: worker.is_due_at(now_ms),
+            overdue_by_ms: worker.overdue_by_ms_at(now_ms),
+            last_started_at_ms: worker.last_started_at_ms,
+            last_completed_at_ms: worker.last_completed_at_ms,
+            last_run_status: worker.last_run_status,
+            last_record_count: worker.last_record_count,
+            last_failure_count: worker.last_failure_count,
+            last_catalog_change_count: worker.last_catalog_change_count,
+            total_run_count: worker.total_run_count,
+            consecutive_failure_count: worker.consecutive_failure_count,
+            metadata: worker.metadata.clone(),
+        }
+    }
+
+    pub fn has_failure_pressure(&self) -> bool {
+        self.status == WorkerStatus::Unhealthy
+            || self.last_failure_count > 0
+            || self.consecutive_failure_count > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveryWorkerRunInstruction {
     pub worker_id: DiscoveryWorkerId,
     pub integration_id: IntegrationId,
@@ -2222,6 +2279,13 @@ impl RuntimeDiscoveryScheduler {
         }
         apply_limit(&mut workers, query.limit);
         workers
+    }
+
+    pub fn worker_snapshots_at(&self, now_ms: u64) -> Vec<ScheduledDiscoveryWorkerSnapshot> {
+        self.query_workers(&DiscoveryWorkerQuery::new().sorted_by(DiscoveryWorkerSort::NextDueAt))
+            .into_iter()
+            .map(|worker| ScheduledDiscoveryWorkerSnapshot::from_worker_at(worker, now_ms))
+            .collect()
     }
 
     pub fn run_plan_at(&self, now_ms: u64) -> DiscoveryWorkerRunPlan {
@@ -2709,6 +2773,8 @@ pub struct RuntimeSupervisionObservation {
     pub generated_at_ms: u64,
     pub plan: RuntimeSupervisionPlan,
     pub heartbeat_schedule: WorkerHeartbeatSchedule,
+    pub discovery_scheduler: DiscoveryWorkerSchedulerSnapshot,
+    pub discovery_workers: Vec<ScheduledDiscoveryWorkerSnapshot>,
 }
 
 impl RuntimeSupervisionObservation {
@@ -2738,6 +2804,25 @@ impl RuntimeSupervisionObservation {
 
     pub fn discovery_worker_run_count(&self) -> usize {
         self.plan.discovery_worker_run_plan.len()
+    }
+
+    pub fn discovery_worker_count(&self) -> usize {
+        self.discovery_scheduler.worker_count
+    }
+
+    pub fn unhealthy_discovery_worker_count(&self) -> usize {
+        self.discovery_scheduler.unhealthy_count
+    }
+
+    pub fn discovery_workers_with_failures_count(&self) -> usize {
+        self.discovery_scheduler.workers_with_failures
+    }
+
+    pub fn next_discovery_worker_due_at_ms(&self) -> Option<u64> {
+        self.discovery_workers
+            .iter()
+            .map(|worker| worker.next_due_at_ms)
+            .min()
     }
 
     pub fn due_worker_deadline_count(&self) -> usize {
@@ -4244,6 +4329,8 @@ impl SmartHomeRuntime {
             generated_at_ms: now_ms,
             plan: self.supervision_plan_at(now_ms)?,
             heartbeat_schedule: self.supervisor.heartbeat_schedule_at(now_ms),
+            discovery_scheduler: self.discovery_scheduler.snapshot_at(now_ms),
+            discovery_workers: self.discovery_scheduler.worker_snapshots_at(now_ms),
         })
     }
 
@@ -6043,6 +6130,23 @@ mod tests {
         assert_eq!(summary.discovery_worker_run_count, 1);
         assert!(summary.has_discovery_worker_work());
         assert_eq!(observation.discovery_worker_run_count(), 1);
+        assert_eq!(observation.discovery_worker_count(), 1);
+        assert_eq!(observation.unhealthy_discovery_worker_count(), 0);
+        assert_eq!(observation.discovery_workers_with_failures_count(), 0);
+        assert_eq!(observation.next_discovery_worker_due_at_ms(), Some(1_100));
+        assert!(matches!(
+            observation.discovery_workers.as_slice(),
+            [snapshot] if snapshot.worker_id == worker_id
+                && snapshot.integration_id == IntegrationId::trusted("hue")
+                && snapshot.kind == DiscoveryWorkerKind::MdnsScan
+                && snapshot.status == WorkerStatus::Starting
+                && snapshot.is_due
+                && snapshot.overdue_by_ms == 25
+                && snapshot.next_due_at_ms == 1_100
+                && snapshot.last_run_status.is_none()
+                && snapshot.total_run_count == 0
+                && !snapshot.has_failure_pressure()
+        ));
         assert_eq!(scheduled.status, WorkerStatus::Starting);
         assert_eq!(scheduled.total_run_count, 0);
         assert_eq!(snapshot.discovery_scheduler.worker_count, 1);
@@ -6243,6 +6347,25 @@ mod tests {
         assert_eq!(scheduled.last_failure_count, 1);
         assert_eq!(scheduled.consecutive_failure_count, 1);
         assert_eq!(scheduled.next_due_at_ms, 6_180);
+
+        let observation = runtime.observe_supervision_at(1_181).unwrap();
+        assert_eq!(observation.discovery_worker_count(), 1);
+        assert_eq!(observation.discovery_worker_run_count(), 0);
+        assert_eq!(observation.unhealthy_discovery_worker_count(), 1);
+        assert_eq!(observation.discovery_workers_with_failures_count(), 1);
+        assert_eq!(observation.next_discovery_worker_due_at_ms(), Some(6_180));
+        assert!(matches!(
+            observation.discovery_workers.as_slice(),
+            [snapshot] if snapshot.worker_id == worker_id
+                && snapshot.status == WorkerStatus::Unhealthy
+                && !snapshot.is_due
+                && snapshot.last_run_status == Some(DiscoveryWorkerRunStatus::Failed)
+                && snapshot.last_record_count == 0
+                && snapshot.last_failure_count == 1
+                && snapshot.total_run_count == 1
+                && snapshot.consecutive_failure_count == 1
+                && snapshot.has_failure_pressure()
+        ));
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -176,6 +176,23 @@ turning runtime into a Hue integration or process manager:
   path using local fake runners, without opening sockets or moving the Chief
   bridge boundary.
 
+## Current Discovery Observability Slice
+
+This slice makes supervised discovery runs inspectable through the existing
+D23 runtime and D18D bridge surfaces:
+
+- `smart-home-runtime` now snapshots scheduled discovery workers with due
+  status, next due time, last run status, record/failure counts, catalog change
+  counts, total run count, and consecutive failure pressure.
+- `RuntimeSupervisionObservation` now carries discovery scheduler counts and
+  per-worker snapshots alongside the existing non-mutating supervision plan and
+  bridge-worker heartbeat schedule.
+- `chief-of-staff-smart-home-tools` now includes those discovery worker details
+  in `smart_home.observe_supervision`, so Chief jobs and dashboards can triage
+  scheduled discovery health without owning D23 scheduler policy.
+- The bridge end-to-end test now proves the D18D handler can surface scheduled
+  Hue mDNS worker health while the runtime remains the source of truth.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:


### PR DESCRIPTION
## Summary
- add scheduled discovery worker snapshots to `RuntimeSupervisionObservation`
- expose discovery worker status, due timing, last-run counts, catalog changes, and failure pressure through `smart_home.observe_supervision`
- update the D18-D23 inventory and crate docs for the discovery observability slice

## Validation
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-discovery`
- `cargo test -p smart-home-testkit`
- `cargo test -p hue-core`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-discovery`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, and `chief-of-staff-smart-home-tools`
- `git diff --check`