### PR TITLE
Add Hue pairing exchange handoff

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this package will be documented in this file.
   per-observation failures in a generic D23 discovery-worker envelope.
 - Hue application registration request and discovered-bridge pairing plan
   helpers for local physical-presence pairing flows.
+- Hue pairing exchange helpers that build local HTTP registration plans, parse
+  Hue success and link-button error responses, produce Vault secret payloads,
+  and hand off only non-secret completion metadata.
 - Hue command summaries and command-plan rollups for payload-free write-surface
   telemetry.
 - Hue command planning from normalized D23 `StateDelta` records for direct and

--- a/code/packages/rust/hue-core/Cargo.toml
+++ b/code/packages/rust/hue-core/Cargo.toml
@@ -6,5 +6,7 @@ description = "Philips Hue CLIP v2 resource and mapping primitives for the smart
 license = "MIT"
 
 [dependencies]
+serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
 smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-local-http = { path = "../smart-home-local-http" }

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -15,6 +15,8 @@ packages a typed surface for:
 - Hue command summaries for payload-free command planning and read-model
   telemetry
 - Hue application registration requests and discovered-bridge pairing plans
+- Hue application registration local-HTTP request plans, response parsing, and
+  no-secret Vault handoff metadata for physical-presence pairing
 - typed Hue bridge resources for paired bridge identity/health refresh
 - typed Hue device resources and service references
 - typed Hue grouped-light resources for room/zone aggregate lights
@@ -46,8 +48,10 @@ packages a typed surface for:
 
 ## Dependencies
 
+- `serde_json`
 - `smart-home-core`
 - `smart-home-discovery`
+- `smart-home-local-http`
 
 ## Development
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -11,12 +11,16 @@ use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, Device, DeviceId, Entity,
     EntityId, EntityKind, Health, IntegrationDescriptor, IntegrationId, Metadata, ProtocolFamily,
     ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope, StateConfidence,
-    StateDelta, StateSnapshot, StateSource, Value,
+    StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerFailure,
     DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun, MdnsAdvertisement, MdnsScanResult,
     MdnsWorkerScanReport, PairingRequirement,
+};
+use smart_home_local_http::{
+    LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
+    LocalHttpRequestTemplate,
 };
 use std::fmt;
 
@@ -44,10 +48,28 @@ pub enum HueError {
     MissingDiscoveryField {
         field: &'static str,
     },
+    MissingPairingCredential {
+        field: &'static str,
+    },
+    EmptyPairingCredential {
+        field: &'static str,
+    },
+    InvalidPairingResponse {
+        reason: String,
+    },
+    PairingRejected {
+        error_type: Option<i64>,
+        description: String,
+    },
+    PairingBridgeMismatch {
+        plan_bridge_id: BridgeId,
+        endpoint_bridge_id: BridgeId,
+    },
     UnsupportedDiscoveryService {
         service_type: String,
     },
     Discovery(DiscoveryError),
+    LocalHttp(LocalHttpError),
 }
 
 impl fmt::Display for HueError {
@@ -71,6 +93,32 @@ impl fmt::Display for HueError {
             Self::MissingDiscoveryField { field } => {
                 write!(f, "Hue discovery field {field} is required")
             }
+            Self::MissingPairingCredential { field } => {
+                write!(f, "Hue pairing credential field {field} is required")
+            }
+            Self::EmptyPairingCredential { field } => {
+                write!(f, "Hue pairing credential field {field} must not be empty")
+            }
+            Self::InvalidPairingResponse { reason } => {
+                write!(f, "Hue pairing response is invalid: {reason}")
+            }
+            Self::PairingRejected {
+                error_type,
+                description,
+            } => match error_type {
+                Some(error_type) => write!(
+                    f,
+                    "Hue pairing was rejected with error {error_type}: {description}"
+                ),
+                None => write!(f, "Hue pairing was rejected: {description}"),
+            },
+            Self::PairingBridgeMismatch {
+                plan_bridge_id,
+                endpoint_bridge_id,
+            } => write!(
+                f,
+                "Hue pairing plan bridge {plan_bridge_id} does not match local HTTP endpoint bridge {endpoint_bridge_id}"
+            ),
             Self::UnsupportedDiscoveryService { service_type } => {
                 write!(
                     f,
@@ -78,6 +126,7 @@ impl fmt::Display for HueError {
                 )
             }
             Self::Discovery(error) => write!(f, "{error}"),
+            Self::LocalHttp(error) => write!(f, "{error}"),
         }
     }
 }
@@ -87,6 +136,12 @@ impl std::error::Error for HueError {}
 impl From<DiscoveryError> for HueError {
     fn from(error: DiscoveryError) -> Self {
         Self::Discovery(error)
+    }
+}
+
+impl From<LocalHttpError> for HueError {
+    fn from(error: LocalHttpError) -> Self {
+        Self::LocalHttp(error)
     }
 }
 
@@ -219,6 +274,21 @@ pub enum HueMethod {
     Delete,
 }
 
+impl HueMethod {
+    pub fn as_local_http_method(self) -> LocalHttpMethod {
+        match self {
+            Self::Get => LocalHttpMethod::Get,
+            Self::Post => LocalHttpMethod::Post,
+            Self::Put => LocalHttpMethod::Put,
+            Self::Delete => LocalHttpMethod::Delete,
+        }
+    }
+
+    pub fn is_idempotent_by_default(self) -> bool {
+        matches!(self, Self::Get | Self::Put | Self::Delete)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum HueRequestBody {
     RegisterApplication {
@@ -244,6 +314,18 @@ pub enum HueRequestBodyKind {
     SetBrightness,
     SetColorTemperature,
     RecallScene,
+}
+
+impl HueRequestBodyKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RegisterApplication => "register_application",
+            Self::SetOn => "set_on",
+            Self::SetBrightness => "set_brightness",
+            Self::SetColorTemperature => "set_color_temperature",
+            Self::RecallScene => "recall_scene",
+        }
+    }
 }
 
 impl HueRequestBody {
@@ -941,6 +1023,91 @@ impl HueBridgePairingPlan {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HueApplicationCredentials {
+    pub application_key: String,
+    pub client_key: Option<String>,
+}
+
+impl HueApplicationCredentials {
+    pub fn new(
+        application_key: impl Into<String>,
+        client_key: Option<String>,
+    ) -> Result<Self, HueError> {
+        let application_key = application_key.into();
+        if application_key.trim().is_empty() {
+            return Err(HueError::EmptyPairingCredential { field: "username" });
+        }
+
+        Ok(Self {
+            application_key,
+            client_key,
+        })
+    }
+
+    pub fn has_client_key(&self) -> bool {
+        self.client_key.is_some()
+    }
+
+    pub fn vault_secret_json(&self) -> Vec<u8> {
+        let mut object = serde_json::Map::new();
+        object.insert(
+            "application_key".to_string(),
+            serde_json::Value::String(self.application_key.clone()),
+        );
+        if let Some(client_key) = &self.client_key {
+            object.insert(
+                "client_key".to_string(),
+                serde_json::Value::String(client_key.clone()),
+            );
+        }
+        serde_json::to_vec(&serde_json::Value::Object(object))
+            .expect("Hue credential vault payload is valid JSON")
+    }
+
+    pub fn vault_handoff(
+        &self,
+        plan: &HueBridgePairingPlan,
+        vault_ref: VaultRef,
+        stored_at_ms: u64,
+    ) -> HuePairingVaultHandoff {
+        HuePairingVaultHandoff {
+            bridge_id: plan.bridge_id().clone(),
+            vault_ref,
+            stored_at_ms,
+            application_key_header: plan.application_key_header.clone(),
+            event_stream_path: plan.event_stream_path.clone(),
+            metadata: vec![
+                Metadata::new("hue.pairing.phase", "credential_stored"),
+                Metadata::new("hue.pairing.credential_kind", "application_key"),
+                Metadata::new(
+                    "hue.pairing.application_key_header",
+                    plan.application_key_header.as_str(),
+                ),
+                Metadata::new(
+                    "hue.pairing.client_key_present",
+                    self.has_client_key().to_string(),
+                ),
+                Metadata::new(
+                    "hue.pairing.event_stream_path",
+                    plan.event_stream_path.as_str(),
+                ),
+                Metadata::new("hue.pairing.stored_at_ms", stored_at_ms.to_string()),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HuePairingVaultHandoff {
+    pub bridge_id: BridgeId,
+    pub vault_ref: VaultRef,
+    pub stored_at_ms: u64,
+    pub application_key_header: String,
+    pub event_stream_path: String,
+    pub metadata: Vec<Metadata>,
+}
+
 pub fn hue_integration_descriptor() -> IntegrationDescriptor {
     IntegrationDescriptor {
         integration_id: IntegrationId::trusted(HUE_INTEGRATION_ID),
@@ -969,6 +1136,118 @@ pub fn hue_registration_request(
             instance_name: instance_name.into(),
         }),
     }
+}
+
+pub fn hue_request_body_json(body: &HueRequestBody) -> serde_json::Value {
+    match body {
+        HueRequestBody::RegisterApplication {
+            app_name,
+            instance_name,
+        } => serde_json::json!({
+            "devicetype": format!("{app_name}#{instance_name}"),
+            "generateclientkey": true,
+        }),
+        HueRequestBody::SetOn { on } => serde_json::json!({
+            "on": { "on": on },
+        }),
+        HueRequestBody::SetBrightness { brightness } => serde_json::json!({
+            "dimming": { "brightness": brightness },
+        }),
+        HueRequestBody::SetColorTemperature { mirek } => serde_json::json!({
+            "color_temperature": { "mirek": mirek },
+        }),
+        HueRequestBody::RecallScene => serde_json::json!({
+            "recall": { "action": "active" },
+        }),
+    }
+}
+
+pub fn hue_request_body_json_bytes(body: &HueRequestBody) -> Vec<u8> {
+    serde_json::to_vec(&hue_request_body_json(body)).expect("Hue request body is valid JSON")
+}
+
+pub fn hue_request_to_local_http_plan(
+    request: &HueRequest,
+    endpoint: &LocalHttpEndpoint,
+) -> Result<LocalHttpRequestPlan, HueError> {
+    let body = request
+        .body
+        .as_ref()
+        .map(hue_request_body_json_bytes)
+        .unwrap_or_default();
+    let mut template =
+        LocalHttpRequestTemplate::new(request.method.as_local_http_method(), request.path.clone())?
+            .with_accept("application/json")
+            .with_timeout_ms(5_000)
+            .with_idempotent(request.method.is_idempotent_by_default())
+            .with_metadata(Metadata::new("hue.request.path", request.path.as_str()));
+
+    if let Some(body) = &request.body {
+        template = template
+            .with_content_type("application/json")
+            .with_metadata(Metadata::new("hue.request.body_kind", body.kind().as_str()));
+    }
+
+    Ok(template.plan(endpoint, body)?)
+}
+
+pub fn hue_pairing_registration_request_plan(
+    plan: &HueBridgePairingPlan,
+    endpoint: &LocalHttpEndpoint,
+) -> Result<LocalHttpRequestPlan, HueError> {
+    if plan.bridge_id() != &endpoint.bridge_id {
+        return Err(HueError::PairingBridgeMismatch {
+            plan_bridge_id: plan.bridge_id().clone(),
+            endpoint_bridge_id: endpoint.bridge_id.clone(),
+        });
+    }
+
+    let mut request_plan = hue_request_to_local_http_plan(&plan.registration_request, endpoint)?;
+    request_plan
+        .metadata
+        .push(Metadata::new("hue.pairing.phase", "registration"));
+    request_plan.metadata.push(Metadata::new(
+        "hue.pairing.requires_user_presence",
+        plan.requires_user_presence.to_string(),
+    ));
+    Ok(request_plan)
+}
+
+pub fn hue_application_credentials_from_registration_response(
+    body: &[u8],
+) -> Result<HueApplicationCredentials, HueError> {
+    let value: serde_json::Value =
+        serde_json::from_slice(body).map_err(|error| HueError::InvalidPairingResponse {
+            reason: error.to_string(),
+        })?;
+    let entries = value
+        .as_array()
+        .ok_or_else(|| HueError::InvalidPairingResponse {
+            reason: "expected top-level response array".to_string(),
+        })?;
+
+    for entry in entries {
+        if let Some(error) = entry.get("error") {
+            return Err(HueError::PairingRejected {
+                error_type: json_i64_field(error, "type"),
+                description: json_string_field(error, "description")
+                    .unwrap_or("unknown Hue pairing error")
+                    .to_string(),
+            });
+        }
+
+        if let Some(success) = entry.get("success") {
+            let application_key = json_string_field(success, "username")
+                .or_else(|| json_string_field(success, "application_key"))
+                .ok_or(HueError::MissingPairingCredential { field: "username" })?;
+            let client_key = json_string_field(success, "clientkey")
+                .or_else(|| json_string_field(success, "client_key"))
+                .map(str::to_string);
+            return HueApplicationCredentials::new(application_key, client_key);
+        }
+    }
+
+    Err(HueError::MissingPairingCredential { field: "success" })
 }
 
 pub fn hue_pairing_plan_for_discovered_bridge(
@@ -2015,6 +2294,14 @@ fn hue_entity_id_for_resource_ref(bridge_id: &BridgeId, resource: &HueResourceRe
     ))
 }
 
+fn json_string_field<'a>(value: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    value.get(field).and_then(serde_json::Value::as_str)
+}
+
+fn json_i64_field(value: &serde_json::Value, field: &str) -> Option<i64> {
+    value.get(field).and_then(serde_json::Value::as_i64)
+}
+
 pub fn validate_brightness(value: u16) -> Result<u8, HueError> {
     if value > 100 {
         return Err(HueError::InvalidBrightness { value });
@@ -2720,6 +3007,90 @@ mod tests {
                     app_name: "chief-of-staff".to_string(),
                     instance_name: "desk".to_string(),
                 }),
+            }
+        );
+    }
+
+    #[test]
+    fn hue_pairing_registration_builds_local_http_plan_and_parses_credentials() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        let endpoint = LocalHttpEndpoint::hue_bridge(plan.bridge_id().clone(), "192.0.2.10")
+            .unwrap()
+            .accept_invalid_certs(true);
+
+        let request_plan = hue_pairing_registration_request_plan(&plan, &endpoint).unwrap();
+
+        assert_eq!(request_plan.method, LocalHttpMethod::Post);
+        assert_eq!(request_plan.url, "https://192.0.2.10/api");
+        assert_eq!(
+            request_plan.header("Content-Type"),
+            Some("application/json")
+        );
+        assert_eq!(request_plan.header("Accept"), Some("application/json"));
+        assert!(!request_plan.idempotent);
+        assert!(request_plan.required_vault_ref().is_none());
+        assert!(request_plan.metadata.iter().any(|metadata| {
+            metadata.key == "hue.pairing.phase" && metadata.value == "registration"
+        }));
+        let body: serde_json::Value = serde_json::from_slice(&request_plan.body).unwrap();
+        assert_eq!(body["devicetype"], "chief-of-staff#desk");
+        assert_eq!(body["generateclientkey"], true);
+
+        let credentials = hue_application_credentials_from_registration_response(
+            br#"[{"success":{"username":"raw-hue-application-key","clientkey":"client-key-1"}}]"#,
+        )
+        .unwrap();
+        assert_eq!(credentials.application_key, "raw-hue-application-key");
+        assert_eq!(credentials.client_key.as_deref(), Some("client-key-1"));
+
+        let vault_payload = credentials.vault_secret_json();
+        let vault_payload_json: serde_json::Value = serde_json::from_slice(&vault_payload).unwrap();
+        assert_eq!(
+            vault_payload_json["application_key"],
+            "raw-hue-application-key"
+        );
+        assert_eq!(vault_payload_json["client_key"], "client-key-1");
+
+        let handoff = credentials.vault_handoff(
+            &plan,
+            VaultRef::trusted("vault://smart-home/hue/001788fffeabcdef/application-key"),
+            1_300,
+        );
+        assert_eq!(
+            handoff.bridge_id,
+            BridgeId::trusted("hue.bridge.001788fffeabcdef")
+        );
+        assert_eq!(handoff.application_key_header, HUE_APPLICATION_KEY_HEADER);
+        assert!(handoff.metadata.iter().any(|metadata| {
+            metadata.key == "hue.pairing.client_key_present" && metadata.value == "true"
+        }));
+        assert!(handoff.metadata.iter().all(|metadata| {
+            !metadata.value.contains("raw-hue-application-key")
+                && !metadata.value.contains("client-key-1")
+        }));
+    }
+
+    #[test]
+    fn hue_pairing_registration_surfaces_link_button_errors() {
+        let error = hue_application_credentials_from_registration_response(
+            br#"[{"error":{"type":101,"address":"/","description":"link button not pressed"}}]"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            HueError::PairingRejected {
+                error_type: Some(101),
+                description: "link button not pressed".to_string(),
             }
         );
     }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this package will be documented in this file.
 - `RuntimePairingSessionInventorySummary` plus
   `pairing_session_inventory_summary_at()` for compact bridge-pairing status,
   expiry, and VaultRef completion counts.
+- `RuntimePairingCompletion` for completing pending pairing sessions with a
+  VaultRef plus non-secret completion metadata that is copied into the session
+  and bridge-health audit event.
 - Runtime discovery catalog recording plus `RuntimeDiscoverToolRequest` and
   `RuntimeDiscoverToolOutput` for authorized discovery reads, freshness
   filtering, and unpaired bridge-candidate projection.

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -68,7 +68,7 @@ Included surfaces:
 - D18D-facing subscribe tool facade that authorizes event-stream access and
   registers filtered replay subscriptions with checkpoints
 - D18D-facing pair-bridge facade with short-lived pairing sessions that complete
-  only to Vault references, never raw credentials
+  only to Vault references and non-secret audit metadata, never raw credentials
 - read-side queries for pairing sessions and desired-state supervision targets
 - pairing-session inventory summaries for bridge-pairing status, expiry, and
   VaultRef completion counts

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -3357,6 +3357,34 @@ pub struct RuntimePairBridgeToolOutput {
     pub session: RuntimePairingSession,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePairingCompletion {
+    pub session_id: RuntimePairingSessionId,
+    pub vault_ref: VaultRef,
+    pub completed_at_ms: u64,
+    pub metadata: Vec<Metadata>,
+}
+
+impl RuntimePairingCompletion {
+    pub fn new(
+        session_id: RuntimePairingSessionId,
+        vault_ref: VaultRef,
+        completed_at_ms: u64,
+    ) -> Self {
+        Self {
+            session_id,
+            vault_ref,
+            completed_at_ms,
+            metadata: Vec::new(),
+        }
+    }
+
+    pub fn with_metadata(mut self, metadata: Vec<Metadata>) -> Self {
+        self.metadata = metadata;
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SmartHomeRuntime {
     registry: InMemorySmartHomeRegistry,
@@ -3904,24 +3932,40 @@ impl SmartHomeRuntime {
         vault_ref: VaultRef,
         completed_at_ms: u64,
     ) -> Result<RuntimePairingSession, RuntimeError> {
+        self.complete_pairing_session_with(RuntimePairingCompletion::new(
+            session_id.clone(),
+            vault_ref,
+            completed_at_ms,
+        ))
+    }
+
+    pub fn complete_pairing_session_with(
+        &mut self,
+        completion: RuntimePairingCompletion,
+    ) -> Result<RuntimePairingSession, RuntimeError> {
+        let RuntimePairingCompletion {
+            session_id,
+            vault_ref,
+            completed_at_ms,
+            metadata,
+        } = completion;
         let session = self
             .pairing_sessions
-            .get(session_id)
+            .get(&session_id)
             .cloned()
             .ok_or_else(|| RuntimeError::UnknownPairingSession(session_id.clone()))?;
         if session.status != PairingSessionStatus::PendingUserPresence {
             return Err(RuntimeError::PairingSessionNotPending {
-                session_id: session_id.clone(),
+                session_id,
                 status: session.status,
             });
         }
         if completed_at_ms >= session.expires_at_ms {
             let mut expired = session.clone();
             expired.status = PairingSessionStatus::Expired;
-            self.pairing_sessions
-                .insert(session_id.clone(), expired.clone());
+            self.pairing_sessions.insert(session_id.clone(), expired);
             return Err(RuntimeError::PairingSessionExpired {
-                session_id: session_id.clone(),
+                session_id,
                 expired_at_ms: session.expires_at_ms,
                 now_ms: completed_at_ms,
             });
@@ -3930,6 +3974,7 @@ impl SmartHomeRuntime {
         let mut completed = session;
         completed.status = PairingSessionStatus::Completed;
         completed.vault_ref = Some(vault_ref.clone());
+        completed.metadata.extend(metadata.iter().cloned());
         self.pairing_sessions
             .insert(session_id.clone(), completed.clone());
 
@@ -3942,6 +3987,11 @@ impl SmartHomeRuntime {
         bridge.health = Health::Online;
         bridge.last_seen_at_ms = Some(completed_at_ms);
         self.registry.upsert_bridge(bridge)?;
+        let mut event_metadata = vec![Metadata::new(
+            "smart_home.pairing_session",
+            completed.session_id.as_str(),
+        )];
+        event_metadata.extend(metadata);
         self.apply_bridge_health(BridgeHealthReport {
             event_id: EventId::trusted(format!(
                 "pairing.completed.health:{}:{completed_at_ms}",
@@ -3951,10 +4001,7 @@ impl SmartHomeRuntime {
             health: Health::Online,
             observed_at_ms: completed_at_ms,
             received_at_ms: completed_at_ms,
-            metadata: vec![Metadata::new(
-                "smart_home.pairing_session",
-                completed.session_id.as_str(),
-            )],
+            metadata: event_metadata,
         })?;
 
         Ok(completed)

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this package will be documented in this file.
 
 - Scripted mDNS worker scan executor fixtures that can run runtime-produced
   scan plans into deterministic reports without opening network sockets.
+- A Hue pairing fixture path that matches the application registration HTTP
+  plan, parses the scripted Hue response, simulates Vault storage, and completes
+  the runtime pairing session without raw secret values in audit metadata.
 
 ## [0.1.0] - 2026-05-08
 

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -26,6 +26,8 @@ a shared way to build:
   scripts to both event-stream supervision state and `smart-home-runtime`
 - fake command buses with queued command/result pairs
 - fake local HTTP responses that can match planned requests without sockets
+- a deterministic Hue pairing fixture path from fake local HTTP response to
+  runtime pairing completion without raw secrets in audit metadata
 - non-consuming fake local HTTP server summaries for response-shape assertions
 - fake MQTT broker publications with retained-message and metadata markers
 - non-consuming fake MQTT broker summaries for publication-shape assertions

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -1571,8 +1571,18 @@ fn protocol_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hue_core::{
+        hue_application_credentials_from_registration_response,
+        hue_pairing_plan_for_discovered_bridge, hue_pairing_registration_request_plan,
+        DiscoveredHueBridge,
+    };
+    use smart_home_core::{AgentId, VaultRef};
     use smart_home_discovery::{DiscoverySource, DiscoveryWorkerRunStatus, PairingRequirement};
-    use smart_home_runtime::WorkerStatus;
+    use smart_home_local_http::LocalHttpEndpoint;
+    use smart_home_runtime::{
+        PairingSessionStatus, RuntimeEvent, RuntimePairingCompletion, RuntimePairingSession,
+        RuntimePairingSessionId, WorkerStatus,
+    };
 
     #[test]
     fn hue_fixture_projects_normalized_bridge_device_and_entities() {
@@ -2277,6 +2287,101 @@ mod tests {
         assert_eq!(matched, response);
         assert_eq!(matched.body_utf8(), Some(r#"{"data":[]}"#));
         assert!(server.is_empty());
+    }
+
+    #[test]
+    fn hue_pairing_fixture_completes_runtime_session_without_secret_metadata() {
+        let pairing_plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.66.1960062030".to_string()),
+            },
+            "chief-of-staff",
+            "desktop",
+        );
+        let endpoint =
+            LocalHttpEndpoint::hue_bridge(pairing_plan.bridge_id().clone(), "192.0.2.10")
+                .unwrap()
+                .accept_invalid_certs(true);
+        let request_plan = hue_pairing_registration_request_plan(&pairing_plan, &endpoint).unwrap();
+        let response = ScriptedLocalHttpResponse::ok_json(
+            LocalHttpMethod::Post,
+            request_plan.url.clone(),
+            br#"[{"success":{"username":"raw-hue-application-key","clientkey":"client-key-1"}}]"#
+                .to_vec(),
+            1_250,
+        );
+        let mut server = FakeLocalHttpServer::new().push_response(response);
+
+        let matched = server.respond_to_plan(&request_plan).unwrap();
+        let credentials =
+            hue_application_credentials_from_registration_response(&matched.body).unwrap();
+        let vault_payload = credentials.vault_secret_json();
+        let vault_payload_text = std::str::from_utf8(&vault_payload).unwrap();
+        assert!(vault_payload_text.contains("raw-hue-application-key"));
+
+        let handoff = credentials.vault_handoff(
+            &pairing_plan,
+            VaultRef::trusted("vault://smart-home/hue/001788fffeabcdef/application-key"),
+            matched.observed_at_ms,
+        );
+        assert!(handoff.metadata.iter().all(|metadata| {
+            !metadata.value.contains("raw-hue-application-key")
+                && !metadata.value.contains("client-key-1")
+        }));
+
+        let mut runtime = SmartHomeRuntime::new();
+        let mut unpaired_bridge = pairing_plan.bridge.clone();
+        unpaired_bridge.health = Health::Unpaired;
+        runtime.upsert_bridge(unpaired_bridge).unwrap();
+        let session_id = RuntimePairingSessionId::trusted("hue-pairing-1");
+        runtime
+            .start_pairing_session(RuntimePairingSession::pending(
+                session_id.clone(),
+                &pairing_plan.bridge,
+                AgentId::trusted("chief-agent"),
+                1_200,
+                2_000,
+                vec![Metadata::new("pairing_kind", "hue_link_button")],
+            ))
+            .unwrap();
+
+        let completed = runtime
+            .complete_pairing_session_with(
+                RuntimePairingCompletion::new(
+                    session_id.clone(),
+                    handoff.vault_ref.clone(),
+                    matched.observed_at_ms,
+                )
+                .with_metadata(handoff.metadata.clone()),
+            )
+            .unwrap();
+        let bridge = runtime.registry().bridge(pairing_plan.bridge_id()).unwrap();
+
+        assert_eq!(completed.status, PairingSessionStatus::Completed);
+        assert_eq!(completed.vault_ref, Some(handoff.vault_ref.clone()));
+        assert!(completed.metadata.iter().any(|metadata| {
+            metadata.key == "hue.pairing.credential_kind" && metadata.value == "application_key"
+        }));
+        assert_eq!(bridge.health, Health::Online);
+        assert_eq!(bridge.auth_ref.as_ref(), Some(&handoff.vault_ref));
+        assert!(matches!(
+            runtime.event_bus().published(),
+            [RuntimeEvent::Device(event), RuntimeEvent::BridgeHealth { bridge_id, health, .. }]
+                if event.event_type == DeviceEventType::Health
+                    && bridge_id == pairing_plan.bridge_id()
+                    && *health == Health::Online
+                    && event.metadata.iter().any(|metadata| {
+                        metadata.key == "hue.pairing.phase"
+                            && metadata.value == "credential_stored"
+                    })
+                    && event.metadata.iter().all(|metadata| {
+                        !metadata.value.contains("raw-hue-application-key")
+                            && !metadata.value.contains("client-key-1")
+                    })
+        ));
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -211,6 +211,28 @@ the resulting state through existing read-side surfaces:
   the Chief end-to-end fixture proves the D18D tool output includes the policy
   fields.
 
+## Current Hue Pairing Exchange Slice
+
+This slice connects the existing D23 pairing session model to Hue's local
+physical-presence registration exchange without moving Vault ownership or
+network I/O into the Chief bridge:
+
+- `hue-core` can turn a discovered-bridge pairing plan into a local HTTP
+  registration request plan for `/api`, including the Hue `devicetype` payload
+  and user-presence metadata.
+- `hue-core` can parse Hue registration success responses into application-key
+  credentials, parse link-button rejection responses as structured errors, and
+  produce a Vault secret payload for the component that owns secret storage.
+- `hue-core` then projects only a `VaultRef` and non-secret metadata into a
+  pairing handoff; raw Hue application keys and client keys are not copied into
+  runtime audit metadata.
+- `smart-home-runtime` now accepts metadata-bearing pairing completions, stores
+  the `VaultRef`, marks the bridge online, and includes the non-secret metadata
+  in the bridge-health audit event.
+- `smart-home-testkit` proves the no-socket path end to end with a fake local
+  HTTP response, simulated Vault handoff, runtime session completion, and an
+  assertion that raw Hue credentials are absent from audit metadata.
+
 ## Chief Of Staff Remaining Work
 
 These items are Chief of Staff architecture, not smart-home platform work:
@@ -237,8 +259,10 @@ These items move toward retiring an existing Home Assistant install:
   runtime state across restarts. Retry/backoff policy now exists in the runtime
   scheduler, but an external actor still needs to drive durable process
   lifecycle.
-- Complete real Hue pairing: start session, user presence/link button, vault
-  credential write, bridge health update, and no-secret audit trail.
+- Finish production Hue pairing by connecting the local HTTP registration plan
+  to the worker that presses through real LAN I/O and durable Vault writes. The
+  typed request/response/VaultRef handoff and runtime no-secret audit trail now
+  exist.
 - Add real Hue local HTTP command/read workers and Hue event-stream workers
   behind the existing runtime surfaces.
 - Persist registry, state cache, event history, command history, pairing


### PR DESCRIPTION
## Summary
- add Hue local HTTP registration request planning and Hue registration response parsing
- add VaultRef pairing handoff metadata so raw Hue app/client keys stay out of runtime audit surfaces
- add a testkit fixture proving fake local HTTP registration through runtime pairing completion and bridge online health

## Validation
- cargo fmt -p hue-core -p smart-home-runtime -p smart-home-testkit
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in code/packages/rust/hue-core
- sh BUILD in code/packages/rust/smart-home-runtime
- sh BUILD in code/packages/rust/smart-home-testkit
- sh BUILD in code/packages/rust/smart-home-local-http
- sh BUILD in code/packages/rust/smart-home-discovery
- sh BUILD in code/packages/rust/chief-of-staff-smart-home-tools
- git diff --check
