### PR TITLE
Track browser phrase text semantics

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
@@ -480,6 +480,7 @@ def check_browser_expected_lists(
             require_string(semantic_path, semantic, field, errors)
         for field in (
             "id",
+            "title",
             "lang",
             "dir",
             "quote_cite",
@@ -491,6 +492,7 @@ def check_browser_expected_lists(
             "edit_datetime",
             "ruby_kind",
             "bidi_kind",
+            "phrase_kind",
         ):
             require_optional_nullable_string(semantic_path, semantic, field, errors)
 

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness text semantic summaries now include phrase-level semantics
+  for abbreviation, definition, citation, code, keyboard input, sample output,
+  variables, subscript/superscript, emphasis, importance, small print,
+  strikethrough, and unarticulated annotation elements.
 - Browser-readiness document summaries now include global-state descriptors for
   non-form elements with inert/hidden, editing, drag, spellcheck, translate,
   accesskey, autofocus, and related focus metadata.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1495,6 +1495,7 @@ pub struct BrowserHeading {
 pub struct BrowserTextSemantic {
     pub element: String,
     pub id: Option<String>,
+    pub title: Option<String>,
     pub role: String,
     pub text: String,
     pub lang: Option<String>,
@@ -1508,6 +1509,7 @@ pub struct BrowserTextSemantic {
     pub edit_datetime: Option<String>,
     pub ruby_kind: Option<String>,
     pub bidi_kind: Option<String>,
+    pub phrase_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10109,9 +10111,8 @@ fn browser_text_semantic_element(
     Some(BrowserTextSemantic {
         element: element.name.clone(),
         id: element.attribute("id").map(ToOwned::to_owned),
-        role: browser_content_role(&element.name)
-            .unwrap_or("inline")
-            .to_string(),
+        title: element.attribute("title").map(ToOwned::to_owned),
+        role: browser_text_semantic_role(element).to_string(),
         text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
         lang: element.attribute("lang").map(ToOwned::to_owned),
         dir: element.attribute("dir").map(ToOwned::to_owned),
@@ -10128,27 +10129,66 @@ fn browser_text_semantic_element(
         edit_datetime: browser_edit_datetime(element),
         ruby_kind: browser_ruby_kind(element),
         bidi_kind: browser_bidi_kind(element),
+        phrase_kind: browser_phrase_kind(element),
     })
 }
 
 fn is_browser_text_semantic_element(element: &Element) -> bool {
     matches!(
         element.name.as_str(),
-        "blockquote"
-            | "q"
+        "abbr"
+            | "b"
+            | "blockquote"
+            | "cite"
+            | "code"
             | "data"
-            | "time"
-            | "mark"
-            | "ins"
             | "del"
-            | "ruby"
+            | "dfn"
+            | "em"
+            | "i"
+            | "ins"
+            | "kbd"
+            | "mark"
+            | "q"
             | "rb"
-            | "rt"
             | "rp"
+            | "rt"
+            | "ruby"
             | "rtc"
+            | "s"
+            | "samp"
+            | "small"
+            | "strong"
+            | "sub"
+            | "sup"
+            | "time"
+            | "u"
+            | "var"
             | "bdi"
             | "bdo"
     )
+}
+
+fn browser_text_semantic_role(element: &Element) -> &'static str {
+    match element.name.as_str() {
+        "abbr" => "abbreviation",
+        "b" => "bring_attention",
+        "cite" => "citation",
+        "code" => "code",
+        "dfn" => "definition",
+        "em" => "emphasis",
+        "i" => "idiomatic",
+        "kbd" => "keyboard_input",
+        "s" => "struck",
+        "samp" => "sample_output",
+        "small" => "small_print",
+        "strong" => "strong_importance",
+        "sub" => "subscript",
+        "sup" => "superscript",
+        "u" => "unarticulated_annotation",
+        "var" => "variable",
+        _ => browser_content_role(&element.name).unwrap_or("inline"),
+    }
 }
 
 fn browser_link_resource_hint_kind(rel: Option<&str>) -> Option<String> {
@@ -12721,6 +12761,28 @@ fn browser_bidi_kind(element: &Element) -> Option<String> {
     match element.name.as_str() {
         "bdi" => Some("isolate".to_string()),
         "bdo" => Some("override".to_string()),
+        _ => None,
+    }
+}
+
+fn browser_phrase_kind(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "abbr" => Some("abbreviation".to_string()),
+        "b" => Some("bring_attention".to_string()),
+        "cite" => Some("citation".to_string()),
+        "code" => Some("code".to_string()),
+        "dfn" => Some("definition".to_string()),
+        "em" => Some("emphasis".to_string()),
+        "i" => Some("idiomatic".to_string()),
+        "kbd" => Some("keyboard_input".to_string()),
+        "s" => Some("struck".to_string()),
+        "samp" => Some("sample_output".to_string()),
+        "small" => Some("small_print".to_string()),
+        "strong" => Some("strong_importance".to_string()),
+        "sub" => Some("subscript".to_string()),
+        "sup" => Some("superscript".to_string()),
+        "u" => Some("unarticulated_annotation".to_string()),
+        "var" => Some("variable".to_string()),
         _ => None,
     }
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -527,6 +527,8 @@ struct ExpectedTextSemantic {
     element: String,
     #[serde(default)]
     id: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
     role: String,
     text: String,
     #[serde(default)]
@@ -551,6 +553,8 @@ struct ExpectedTextSemantic {
     ruby_kind: Option<String>,
     #[serde(default)]
     bidi_kind: Option<String>,
+    #[serde(default)]
+    phrase_kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2142,7 +2146,7 @@ fn browser_text_semantic_descriptor_metadata_tracks_inline_annotations() {
 
     assert_eq!(
         actual.text_semantics, expected.text_semantics,
-        "text semantics should preserve machine-readable values, edits, quotes, ruby annotations, and bidi metadata",
+        "text semantics should preserve machine-readable values, edits, quotes, phrase semantics, ruby annotations, and bidi metadata",
     );
 }
 
@@ -3962,6 +3966,7 @@ impl ExpectedTextSemantic {
         BrowserTextSemantic {
             element: self.element,
             id: self.id,
+            title: self.title,
             role: self.role,
             text: self.text,
             lang: self.lang,
@@ -3975,6 +3980,7 @@ impl ExpectedTextSemantic {
             edit_datetime: self.edit_datetime,
             ruby_kind: self.ruby_kind,
             bidi_kind: self.bidi_kind,
+            phrase_kind: self.phrase_kind,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -23,6 +23,8 @@ also pin labels, derived accessible names, owner references,
 placeholder/autocomplete hints, and required/readonly/multiple control state.
 Global-state descriptor cases pin non-form inert/hidden, editing, drag,
 spellcheck, translate, accesskey, autofocus, and related focus metadata.
+Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
+annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.
 Script/style cases pin module/classic script kind, async/defer/nomodule flags,
 inline script/style text, and loading-policy hints such as integrity,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -473,6 +473,12 @@
         "headings": [
           { "level": 3, "text": "Archive" }
         ],
+        "text_semantics": [
+          { "element": "b", "role": "bring_attention", "text": "bold", "phrase_kind": "bring_attention" },
+          { "element": "b", "role": "bring_attention", "text": "Beta italic", "phrase_kind": "bring_attention" },
+          { "element": "i", "role": "idiomatic", "text": "italic", "phrase_kind": "idiomatic" },
+          { "element": "i", "role": "idiomatic", "text": "tail", "phrase_kind": "idiomatic" }
+        ],
         "links": [
           { "href": null, "resolved_href": null, "name": "top", "target": null, "rel": null, "title": null, "text": "" },
           { "href": "#top", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Back" }
@@ -912,13 +918,13 @@
     },
     {
       "id": "inline-semantic-metadata-page",
-      "description": "Browser document summaries expose machine-readable text, edit annotations, inline quotes, ruby annotations, and bidi overrides as a flat text semantic inventory.",
-      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Version <data id=version value=\"2.1\">two point one</data> shipped <time id=date datetime=\"2026-05-25\">today</time>. <q id=quote cite=notes/ref.html>quoted</q> <ins id=add cite=changes.html datetime=\"2026-05-25T06:00:00Z\">Added</ins> <del id=remove cite=\"#old\" datetime=\"2026-05-24\">Removed</del> <mark id=highlight>Important</mark></p><ruby id=term><rb>kanji</rb><rt>kan</rt><rp>(</rp><rtc><rt>group</rt></rtc></ruby> then <bdi id=name dir=auto lang=ja>Name</bdi> and <bdo id=rtl dir=rtl>abc</bdo>",
+      "description": "Browser document summaries expose machine-readable text, edit annotations, inline quotes, phrase semantics, ruby annotations, and bidi overrides as a flat text semantic inventory.",
+      "input": "<base href=\"https://example.test/docs/page.html\"><body><p>Version <data id=version value=\"2.1\">two point one</data> shipped <time id=date datetime=\"2026-05-25\">today</time>. <q id=quote cite=notes/ref.html>quoted</q> <ins id=add cite=changes.html datetime=\"2026-05-25T06:00:00Z\">Added</ins> <del id=remove cite=\"#old\" datetime=\"2026-05-24\">Removed</del> <mark id=highlight>Important</mark></p><p><abbr title=\"HyperText Markup Language\">HTML</abbr> <dfn title=Parser>parser</dfn> <cite>Spec</cite> <code>token</code> <kbd>Enter</kbd> <samp>ok</samp> <var>x</var> <sub>2</sub> <sup>n</sup> <em>care</em> <strong>must</strong> <small>note</small> <s>old</s> <u>term</u></p><ruby id=term><rb>kanji</rb><rt>kan</rt><rp>(</rp><rtc><rt>group</rt></rtc></ruby> then <bdi id=name dir=auto lang=ja>Name</bdi> and <bdo id=rtl dir=rtl>abc</bdo>",
       "expected": {
         "title": null,
         "base_href": "https://example.test/docs/page.html",
         "base_target": null,
-        "body_text": "Version two point one shipped today. quoted Added Removed Important kanji kan ( group then Name and abc",
+        "body_text": "Version two point one shipped today. quoted Added Removed Important HTML parser Spec token Enter ok x 2 n care must note old term kanji kan ( group then Name and abc",
         "metas": [],
         "resources": [],
         "anchors": [
@@ -940,6 +946,20 @@
           { "element": "ins", "id": "add", "role": "inserted", "text": "Added", "edit_cite": "changes.html", "resolved_edit_cite": "https://example.test/docs/changes.html", "edit_datetime": "2026-05-25T06:00:00Z" },
           { "element": "del", "id": "remove", "role": "deleted", "text": "Removed", "edit_cite": "#old", "resolved_edit_cite": "https://example.test/docs/page.html#old", "edit_datetime": "2026-05-24" },
           { "element": "mark", "id": "highlight", "role": "mark", "text": "Important" },
+          { "element": "abbr", "role": "abbreviation", "title": "HyperText Markup Language", "text": "HTML", "phrase_kind": "abbreviation" },
+          { "element": "dfn", "role": "definition", "title": "Parser", "text": "parser", "phrase_kind": "definition" },
+          { "element": "cite", "role": "citation", "text": "Spec", "phrase_kind": "citation" },
+          { "element": "code", "role": "code", "text": "token", "phrase_kind": "code" },
+          { "element": "kbd", "role": "keyboard_input", "text": "Enter", "phrase_kind": "keyboard_input" },
+          { "element": "samp", "role": "sample_output", "text": "ok", "phrase_kind": "sample_output" },
+          { "element": "var", "role": "variable", "text": "x", "phrase_kind": "variable" },
+          { "element": "sub", "role": "subscript", "text": "2", "phrase_kind": "subscript" },
+          { "element": "sup", "role": "superscript", "text": "n", "phrase_kind": "superscript" },
+          { "element": "em", "role": "emphasis", "text": "care", "phrase_kind": "emphasis" },
+          { "element": "strong", "role": "strong_importance", "text": "must", "phrase_kind": "strong_importance" },
+          { "element": "small", "role": "small_print", "text": "note", "phrase_kind": "small_print" },
+          { "element": "s", "role": "struck", "text": "old", "phrase_kind": "struck" },
+          { "element": "u", "role": "unarticulated_annotation", "text": "term", "phrase_kind": "unarticulated_annotation" },
           { "element": "ruby", "id": "term", "role": "ruby", "text": "kanji kan ( group", "ruby_kind": "ruby" },
           { "element": "rb", "role": "ruby_base", "text": "kanji", "ruby_kind": "base" },
           { "element": "rt", "role": "ruby_text", "text": "kan", "ruby_kind": "text" },


### PR DESCRIPTION
## Summary
- extend BrowserTextSemantic with title and phrase_kind metadata
- expose phrase-level text semantics for abbr, dfn, cite, code, kbd, samp, var, sub/sup, emphasis, importance, small print, struck, and unarticulated annotation elements
- update browser-readiness fixtures, schema governance, fixture README, and changelog

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- cargo test -p coding-adventures-html-parser browser_text_semantic_descriptor_metadata_tracks_inline_annotations
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser