### PR TITLE
[codex] Port linear atan integration to symbolic VMs

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2137,14 +2137,14 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
             .or_else(|| try_atan_poly_product(a, b, x))
             .or_else(|| try_atan_poly_product(b, a, x))
             .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
-        // Phase 28: bare ∫ log(Q(x)) dx and ∫ atan(Q(x)) dx for non-linear Q.
-        // The simple arms (LOG, [inner]) and (ATAN, [inner]) above already captured
-        // the x-equals-inner case; these arms fire when Q depends on x but is non-linear.
+        // Phase 28: bare ∫ log(Q(x)) dx for non-linear Q, plus bare
+        // ∫ atan(Q(x)) dx for linear (Phase 11) and non-linear (Phase 28) Q.
+        // The simple LOG arm above already captured the x-equals-inner case.
         (LOG, [q_ir]) if depends_on(q_ir, x) && !is_linear_in(q_ir, x) => {
             try_log_poly_product(f, &IRNode::Integer(1), x)
                 .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
-        (ATAN, [q_ir]) if depends_on(q_ir, x) && !is_linear_in(q_ir, x) => {
+        (ATAN, [q_ir]) if depends_on(q_ir, x) => {
             try_atan_poly_product(f, &IRNode::Integer(1), x)
                 .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
@@ -3717,8 +3717,9 @@ fn is_linear_in(expr: &IRNode, x: &str) -> bool {
 /// Phase 28 residuals:
 ///
 /// - **Case A**: R = c·D′  →  c·log(D)
-/// - **Case B**: R is a constant, D = a₂x²+a₀ (no odd-degree terms),
-///              √(a₀/a₂) is rational  →  r₀/(a₂√(a₀/a₂))·atan(x/√(a₀/a₂))
+/// - **Case B**: R is linear, D = a₂x²+a₁x+a₀, and √(4a₂a₀-a₁²)
+///              is rational. Split off the D′ log term, then close the
+///              remaining constant-over-quadratic term with atan.
 ///
 /// Returns `None` if neither case applies (signals that Phase 28 falls through).
 fn close_remainder_over_d(
@@ -3741,56 +3742,86 @@ fn close_remainder_over_d(
         }
     }
 
-    // Case B: constant remainder over quadratic denominator with rational √
-    if rp_deg(r) != Some(0) {
+    // Case B: linear remainder over a positive shifted quadratic.
+    if rp_deg(d) != Some(2) {
         return None;
     }
-    if rp_deg(d) != Some(2) {
+    if !matches!(rp_deg(r), Some(0) | Some(1)) {
         return None;
     }
 
     let a2 = rp_coeff(d, 2);
     let a1 = rp_coeff(d, 1);
     let a0 = rp_coeff(d, 0);
-
-    // No linear term (otherwise denominator has a real root and we'd need
-    // partial fractions with irrational roots)
-    if !rc_is_zero(a1) {
+    if rc_is_zero(a2) || a2.0 <= 0 {
         return None;
     }
 
-    // a₀/a₂ must be a positive rational perfect square
-    let ba = rc_div(a0, a2)?;
-    if ba.0 <= 0 {
-        return None;
-    }
-    let sqrt_ba = rc_sqrt(ba)?;
-    if rc_is_zero(sqrt_ba) {
-        return None;
-    }
-
-    // ∫ r₀/(a₂x²+a₀) dx = r₀/(a₂·√(a₀/a₂)) · atan(x/√(a₀/a₂))
+    // R = r1*x + r0 = c*D' + k, with c = r1/(2*a2).
+    let two = (2, 1);
+    let four = (4, 1);
+    let r1 = rp_coeff(r, 1);
     let r0 = rp_coeff(r, 0);
-    let denom_coef = rc_mul(a2, sqrt_ba)?;
-    let coef = rc_div(r0, denom_coef)?;
+    let c = rc_div(r1, rc_mul(two, a2)?)?;
+    let k = rc_sub(r0, rc_mul(c, a1)?)?;
 
-    let coef_ir = rc_to_ir(coef)?;
-    let sqrt_ba_ir = rc_to_ir(sqrt_ba)?;
-    let x_sym = IRNode::Symbol(x.to_string());
+    // delta = 4*a2*a0 - a1^2 must have a positive rational square root.
+    let delta = rc_sub(
+        rc_mul(four, rc_mul(a2, a0)?)?,
+        rc_mul(a1, a1)?,
+    )?;
+    if delta.0 <= 0 {
+        return None;
+    }
+    let sqrt_delta = rc_sqrt(delta)?;
+    if rc_is_zero(sqrt_delta) {
+        return None;
+    }
 
-    // Build atan(x / √(a₀/a₂)).  If √(a₀/a₂) = 1, simplify to atan(x).
-    let atan_arg = if rc_is_one(sqrt_ba) {
-        x_sym
-    } else {
-        apply_node(DIV, vec![x_sym, sqrt_ba_ir])
-    };
-    let atan_node = apply_node(ATAN, vec![atan_arg]);
+    let mut terms = Vec::new();
+    if !rc_is_zero(c) {
+        let c_ir = rc_to_ir(c)?;
+        let log_d = apply_node(LOG, vec![d_ir.clone()]);
+        terms.push(if rc_is_one(c) {
+            log_d
+        } else {
+            apply_node(MUL, vec![c_ir, log_d])
+        });
+    }
 
-    Some(if rc_is_one(coef) {
-        atan_node
-    } else {
-        apply_node(MUL, vec![coef_ir, atan_node])
-    })
+    if !rc_is_zero(k) {
+        // ∫ k/D dx = (2k/sqrt(delta)) * atan((2*a2*x+a1)/sqrt(delta)).
+        let coef = rc_div(rc_mul(two, k)?, sqrt_delta)?;
+
+        let x_sym = IRNode::Symbol(x.to_string());
+        let atan_numer = apply_node(
+            ADD,
+            vec![
+                apply_node(MUL, vec![rc_to_ir(rc_mul(two, a2)?)?, x_sym]),
+                rc_to_ir(a1)?,
+            ],
+        );
+        let atan_arg = if rc_is_one(sqrt_delta) {
+            atan_numer
+        } else {
+            apply_node(DIV, vec![atan_numer, rc_to_ir(sqrt_delta)?])
+        };
+        let atan_node = apply_node(ATAN, vec![atan_arg]);
+
+        terms.push(if rc_is_one(coef) {
+            atan_node
+        } else {
+            apply_node(MUL, vec![rc_to_ir(coef)?, atan_node])
+        });
+    }
+
+    match terms.len() {
+        0 => None,
+        1 => terms.into_iter().next(),
+        _ => terms
+            .into_iter()
+            .reduce(|a, b| apply_node(ADD, vec![a, b])),
+    }
 }
 
 /// Core rational function integrator (Phase 28 residuals).
@@ -3903,7 +3934,7 @@ fn try_log_poly_product(
     Some(apply_node(SUB, vec![main_term, residual]))
 }
 
-/// Phase 28: ``∫ P(x) · atan(Q(x)) dx`` for non-linear polynomial Q.
+/// Phase 11/28: ``∫ P(x) · atan(Q(x)) dx`` for polynomial Q.
 ///
 /// IBP (u = atan Q, dv = P dx):
 ///   ∫ P·atan(Q) dx  =  R·atan(Q) − ∫ R·Q′/(1+Q²) dx
@@ -3924,8 +3955,9 @@ fn try_atan_poly_product(
     }
     let q_ir = &apply.args[0];
 
-    // Q must depend on x and be non-linear (linear Q left to future Phase 11)
-    if !depends_on(q_ir, x) || is_linear_in(q_ir, x) {
+    // Q must depend on x. Linear Q covers MACSYMA Phase 11; non-linear Q
+    // covers Phase 28.
+    if !depends_on(q_ir, x) {
         return None;
     }
 

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -1661,15 +1661,47 @@ fn phase28_regression_log_x_still_phase3() {
 }
 
 #[test]
-fn phase28_regression_atan_x_stays_unevaluated() {
-    // ∫ atan(x) dx — linear Q, Phase 28 must NOT intercept this.
-    // TypeScript has no Phase 11 so the result stays unevaluated.
+fn phase11_atan_x_is_closed() {
+    // ∫ atan(x) dx = x*atan(x) - 1/2*log(1+x^2).
     let result = integrate(apply(sym(ATAN), vec![sym("x")]));
-    let original = apply(
-        sym(INTEGRATE),
-        vec![apply(sym(ATAN), vec![sym("x")]), sym("x")],
+    assert!(
+        !is_unevaluated_integrate(&result),
+        "Phase 11 should close ∫ atan(x) dx; got {result:?}"
     );
-    assert_eq!(result, original, "Phase 28 must not intercept linear atan(x)");
+    assert!(contains_head(&result, ATAN), "Expected Atan in {result:?}");
+    assert!(contains_head(&result, LOG), "Expected Log in {result:?}");
+}
+
+#[test]
+fn phase11_shifted_atan_derivative_matches() {
+    // The shifted case exercises the shifted-quadratic residual closure:
+    // D = 1 + (x+1)^2.
+    let integrand = apply(sym(ATAN), vec![apply(sym(ADD), vec![sym("x"), int(1)])]);
+    let phi = integrate(integrand);
+    assert!(
+        !is_unevaluated_integrate(&phi),
+        "Phase 11 should close ∫ atan(x+1) dx; got {phi:?}"
+    );
+    for &x_val in &[-0.5_f64, 0.0, 0.5, 1.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = (x_val + 1.0).atan();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase11_x_atan_x_derivative_matches() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(ATAN), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(
+        !is_unevaluated_integrate(&phi),
+        "Phase 11 should close ∫ x*atan(x) dx; got {phi:?}"
+    );
+    for &x_val in &[-1.0_f64, -0.25, 0.25, 1.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.atan();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -4838,8 +4838,9 @@ function isLinearIn(expr: IRNode, x: IRNode): boolean {
  *   1. The polynomial quotient Q is integrated term-by-term.
  *   2. For the remainder R (deg R < deg D), two patterns are tried:
  *      Case A: R = c · D′  →  c · log(D)
- *      Case B: R is a constant and D = a₂x² + a₀ with rational √(a₀/a₂)
- *              →  R/(a₂·√(a₀/a₂)) · atan(x / √(a₀/a₂))
+ *      Case B: R is linear and D = a₂x² + a₁x + a₀ with rational
+ *              √(4a₂a₀-a₁²). Split off the D′ log term, then close the
+ *              remaining constant-over-quadratic term with atan.
  *
  * Returns ``undefined`` when no pattern matches (caller falls through).
  */
@@ -4901,28 +4902,44 @@ function closeRemainderOverD(
     }
   }
 
-  // Case B: R is a non-zero constant and D is a quadratic a₂x² + a₀ (no linear
-  // term) with a₂, a₀ > 0 and √(a₀/a₂) rational.
+  // Case B: linear remainder over a positive shifted quadratic.
+  //
+  // Let R = r1*x + r0 and D = a2*x^2 + a1*x + a0.  Split
+  // R = c*D' + k, where c = r1/(2*a2) and k = r0 - c*a1. Then:
+  //   ∫ R/D dx = c*log(D) + (2k/sqrt(4*a2*a0-a1^2))
+  //              * atan((2*a2*x+a1)/sqrt(4*a2*a0-a1^2)).
   const dR = rpDeg(R);
   const dD = rpDeg(D);
-  if (dR === 0 && dD === 2) {
+  if ((dR === 0 || dR === 1) && dD === 2) {
+    const r1 = rpCoeff(R, 1);
     const r0 = rpCoeff(R, 0);
     const a2 = rpCoeff(D, 2);
     const a1 = rpCoeff(D, 1);
     const a0 = rpCoeff(D, 0);
-    if (
-      !rcIsZero(r0) &&
-      !rcIsZero(a2) && a2.numer > 0n &&
-      !rcIsZero(a0) && a0.numer > 0n &&
-      rcIsZero(a1)
-    ) {
-      // ∫ r₀/(a₂x² + a₀) dx = r₀/(a₂·√(a₀/a₂)) · atan(x / √(a₀/a₂))
-      const ba = rcDiv(a0, a2);
-      const sqBa = rcSqrt(ba);
-      if (sqBa !== undefined && !rcIsZero(sqBa)) {
-        const coeff = rcDiv(r0, rcMul(a2, sqBa));
-        const arg: IRNode = rcIsOne(sqBa) ? x : app(DIV, [x, rcToIR(sqBa)]);
-        return app(MUL, [rcToIR(coeff), app(ATAN, [arg])]);
+    const two = rcFromBigInt(2n);
+    const four = rcFromBigInt(4n);
+    if (!rcIsZero(a2) && a2.numer > 0n) {
+      const c = rcDiv(r1, rcMul(two, a2));
+      const k = rcSub(r0, rcMul(c, a1));
+      const delta = rcSub(rcMul(four, rcMul(a2, a0)), rcMul(a1, a1));
+      const sqrtDelta = delta.numer > 0n ? rcSqrt(delta) : undefined;
+      if (sqrtDelta !== undefined && !rcIsZero(sqrtDelta)) {
+        const terms: IRNode[] = [];
+        if (!rcIsZero(c)) {
+          terms.push(app(MUL, [rcToIR(c), app(LOG, [D_ir])]));
+        }
+        if (!rcIsZero(k)) {
+          const atanCoeff = rcDiv(rcMul(two, k), sqrtDelta);
+          const atanNumer = app(ADD, [
+            app(MUL, [rcToIR(rcMul(two, a2)), x]),
+            rcToIR(a1),
+          ]);
+          const atanArg = rcIsOne(sqrtDelta) ? atanNumer : app(DIV, [atanNumer, rcToIR(sqrtDelta)]);
+          const atanTerm = app(MUL, [rcToIR(atanCoeff), app(ATAN, [atanArg])]);
+          terms.push(atanTerm);
+        }
+        if (terms.length === 0) return null;
+        return terms.reduce((acc, term) => app(ADD, [acc, term]));
       }
     }
   }
@@ -4996,7 +5013,8 @@ function tryLogPolyProduct(
  * IBP formula (u = atan(Q), dv = P dx):
  *   ∫ P·atan(Q) dx  =  R·atan(Q) − ∫ R·Q′/(1+Q²) dx
  *
- * Linear Q is skipped so that Phase 11 handles it instead.
+ * Handles both linear and non-linear polynomial Q.  Linear Q covers MACSYMA
+ * Phase 11; non-linear Q covers Phase 28.
  */
 function tryAtanPolyProduct(
   transcendental: IRNode,
@@ -5009,7 +5027,6 @@ function tryAtanPolyProduct(
   const Q_ir = transcendental.args[0]!;
 
   if (!dependsOn(Q_ir, x)) return undefined;
-  if (isLinearIn(Q_ir, x)) return undefined; // Phase 11 handles atan(ax+b)
 
   const Qmap = toPolynomialCoeffs(Q_ir, x);
   if (Qmap === undefined) return undefined;

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1111,16 +1111,38 @@ describe("symbolic-vm", () => {
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
   });
 
-  it("Phase 28: regression — ∫ atan(x) dx is not intercepted by Phase 28", () => {
-    // Phase 28 checks isLinearIn(Q, x); for atan(x), Q = x is linear (degree 1),
-    // so Phase 28 skips it.  TypeScript does not yet have Phase 11, so atan(x)
-    // remains unevaluated.  This test verifies that Phase 28 does NOT accidentally
-    // intercept or corrupt it.
+  it("Phase 11: ∫ atan(x) dx returns a closed form with ATAN and LOG", () => {
     const vm = new VM(new SymbolicBackend());
     const x = sym("x");
     const result = vm.eval(app(INTEGRATE, [app(ATAN, [x]), x]));
-    // Should remain unevaluated (Phase 11 is not implemented in TypeScript yet).
-    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Atan")).toBe(true);
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+  });
+
+  it("Phase 11: ∫ atan(x+1) dx numerical correctness", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(ATAN, [app(ADD, [x, int(1)])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, 1)
+      - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
+    const numerical = trapezoid28((t) => Math.atan(t + 1), 0, 1);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 11: ∫ x·atan(x) dx numerical correctness", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(ATAN, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, 1)
+      - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
+    const numerical = trapezoid28((t) => t * Math.atan(t), 0, 1);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
   });
 });
 


### PR DESCRIPTION
## Summary

Ports MACSYMA Phase 11 linear `atan` integration behavior into the TypeScript and Rust symbolic VMs by reusing the existing IBP/rational residual route.

- Allows `atan(Q(x))` integration to handle linear polynomial `Q`, not only non-linear Phase 28 cases.
- Extends the exact rational residual closure for shifted positive quadratics, covering denominators like `1 + (a*x+b)^2`.
- Replaces the old `atan(x)` fallthrough regression with closed-form and numerical parity tests for `atan(x)`, `atan(x+1)`, and `x*atan(x)`.

## Validation

- TypeScript: `node ./node_modules/typescript/bin/tsc --noEmit`
- TypeScript: `node ./node_modules/vitest/vitest.mjs run` (185 passed)
- Rust: `cargo test --manifest-path code/packages/rust/symbolic-vm/Cargo.toml` (200 integration tests + doctests passed)
- Python reference: `pytest code/packages/python/symbolic-vm/tests/test_phase9.py code/packages/python/symbolic-vm/tests/test_phase11.py -q --no-cov` (86 passed)
- `git diff --check`