### PR TITLE
[codex] Port Phase 12 asin/acos parity

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2132,6 +2132,8 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
             .or_else(|| try_log_power_product(b, a, x))
             .or_else(|| try_trig_log_product(a, b, x))
             .or_else(|| try_trig_log_product(b, a, x))
+            .or_else(|| try_asin_acos_poly_product(a, b, x))
+            .or_else(|| try_asin_acos_poly_product(b, a, x))
             .or_else(|| try_log_poly_product(a, b, x))
             .or_else(|| try_log_poly_product(b, a, x))
             .or_else(|| try_atan_poly_product(a, b, x))
@@ -2148,6 +2150,8 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
             try_atan_poly_product(f, &IRNode::Integer(1), x)
                 .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
+        (ASIN, [_]) | (ACOS, [_]) => try_asin_acos_poly_product(f, &IRNode::Integer(1), x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
     }
 }
@@ -3564,6 +3568,24 @@ fn rp_mul(a: &[RatC], b: &[RatC]) -> Option<RatPoly> {
     Some(result)
 }
 
+/// Horner composition p(a*x+b).
+fn rp_compose_linear(p: &[RatC], a: RatC, b: RatC) -> Option<RatPoly> {
+    let Some(deg) = rp_deg(p) else {
+        return Some(vec![]);
+    };
+    let sub = vec![b, a];
+    let mut result = vec![rp_coeff(p, deg)];
+    for i in (0..deg).rev() {
+        result = rp_add(&rp_mul(&result, &sub)?, &[rp_coeff(p, i)])?;
+    }
+    Some(result)
+}
+
+/// Compose Q((t-b)/a), represented as a t-polynomial.
+fn rp_compose_to_t(q: &[RatC], a: RatC, b: RatC) -> Option<RatPoly> {
+    rp_compose_linear(q, rc_div(RC_ONE, a)?, rc_div(rc_neg(b), a)?)
+}
+
 /// Formal derivative of a polynomial (drops the constant term's contribution).
 fn rp_deriv(p: &[RatC]) -> Option<RatPoly> {
     if p.len() <= 1 {
@@ -3997,6 +4019,140 @@ fn try_atan_poly_product(
     Some(apply_node(SUB, vec![main_term, residual]))
 }
 
+/// Phase 12: ``∫ P(x) · asin(a*x+b) dx`` and ``∫ P(x) · acos(a*x+b) dx``.
+fn try_asin_acos_poly_product(
+    transcendental: &IRNode,
+    poly_candidate: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), ASIN | ACOS) || apply.args.len() != 1 {
+        return None;
+    }
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+
+    let arg_rp = rp_from_poly_vec(to_polynomial_coeffs(arg_ir, x)?)?;
+    if rp_deg(&arg_rp) != Some(1) {
+        return None;
+    }
+    let b = rp_coeff(&arg_rp, 0);
+    let a = rp_coeff(&arg_rp, 1);
+    if rc_is_zero(a) {
+        return None;
+    }
+
+    let p_rp = rp_from_poly_vec(to_polynomial_coeffs(poly_candidate, x)?)?;
+    if rp_is_zero(&p_rp) {
+        return None;
+    }
+
+    let q_rp = rp_integrate(&p_rp)?;
+    let q_tilde = rp_compose_to_t(&q_rp, a, b)?;
+    let (a_t, b_t) = sqrt_one_minus_t_squared_decompose(&q_tilde)?;
+    let a_x = rp_compose_linear(&a_t, a, b)?;
+    let b_x = rp_compose_linear(&b_t, a, b)?;
+
+    let q_ir = rp_to_ir(&q_rp, x)?;
+    let sqrt_ir = apply_node(
+        SQRT,
+        vec![apply_node(
+            SUB,
+            vec![
+                IRNode::Integer(1),
+                apply_node(POW, vec![arg_ir.clone(), IRNode::Integer(2)]),
+            ],
+        )],
+    );
+
+    if head.as_str() == ASIN {
+        let asin_coef = if rp_is_zero(&b_x) {
+            q_ir
+        } else {
+            apply_node(SUB, vec![q_ir, rp_to_ir(&b_x, x)?])
+        };
+        let mut result = apply_node(MUL, vec![asin_coef, transcendental.clone()]);
+        if !rp_is_zero(&a_x) {
+            result = apply_node(
+                SUB,
+                vec![result, apply_node(MUL, vec![rp_to_ir(&a_x, x)?, sqrt_ir])],
+            );
+        }
+        return Some(result);
+    }
+
+    let mut result = apply_node(MUL, vec![q_ir, transcendental.clone()]);
+    if !rp_is_zero(&a_x) {
+        result = apply_node(
+            ADD,
+            vec![result, apply_node(MUL, vec![rp_to_ir(&a_x, x)?, sqrt_ir])],
+        );
+    }
+    if !rp_is_zero(&b_x) {
+        result = apply_node(
+            ADD,
+            vec![
+                result,
+                apply_node(
+                    MUL,
+                    vec![rp_to_ir(&b_x, x)?, apply_node(ASIN, vec![arg_ir.clone()])],
+                ),
+            ],
+        );
+    }
+    Some(result)
+}
+
+fn sqrt_one_minus_t_squared_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {
+    fn monomial(n: usize, memo: &mut Vec<Option<(RatPoly, RatPoly)>>) -> Option<(RatPoly, RatPoly)> {
+        if n < memo.len() {
+            if let Some(cached) = memo[n].clone() {
+                return Some(cached);
+            }
+        } else {
+            memo.resize_with(n + 1, || None);
+        }
+
+        let result = if n == 0 {
+            (vec![], vec![RC_ONE])
+        } else if n == 1 {
+            (vec![(-1, 1)], vec![])
+        } else {
+            let mut a_new = vec![RC_ZERO; n];
+            a_new[n - 1] = rc(-1, n as i128)?;
+            let (a_rec, b_rec) = monomial(n - 2, memo)?;
+            let coef = rc((n - 1) as i128, n as i128)?;
+            (
+                rp_add(&a_new, &rp_mul_scalar(&a_rec, coef)?)?,
+                rp_mul_scalar(&b_rec, coef)?,
+            )
+        };
+
+        memo[n] = Some(result.clone());
+        Some(result)
+    }
+
+    let mut memo: Vec<Option<(RatPoly, RatPoly)>> = Vec::new();
+    let mut a_total = vec![];
+    let mut b_total = vec![];
+    for (deg, &coef) in q_tilde.iter().enumerate() {
+        if rc_is_zero(coef) {
+            continue;
+        }
+        let (a_n, b_n) = monomial(deg, &mut memo)?;
+        a_total = rp_add(&a_total, &rp_mul_scalar(&a_n, coef)?)?;
+        b_total = rp_add(&b_total, &rp_mul_scalar(&b_n, coef)?)?;
+    }
+    Some((a_total, b_total))
+}
+
 fn integrate_power_of_x(exponent: &IRNode, x: &str) -> IRNode {
     let Some(n) = to_numeric(exponent) else {
         return apply_node(
@@ -4098,6 +4254,32 @@ fn diff(f: &IRNode, x: &str) -> IRNode {
                 ),
             ],
         ),
+        (ASIN, [inner]) => {
+            let denom = apply_node(
+                SQRT,
+                vec![apply_node(
+                    SUB,
+                    vec![
+                        IRNode::Integer(1),
+                        apply_node(POW, vec![inner.clone(), IRNode::Integer(2)]),
+                    ],
+                )],
+            );
+            apply_node(DIV, vec![diff(inner, x), denom])
+        }
+        (ACOS, [inner]) => {
+            let denom = apply_node(
+                SQRT,
+                vec![apply_node(
+                    SUB,
+                    vec![
+                        IRNode::Integer(1),
+                        apply_node(POW, vec![inner.clone(), IRNode::Integer(2)]),
+                    ],
+                )],
+            );
+            apply_node(NEG, vec![apply_node(DIV, vec![diff(inner, x), denom])])
+        }
         (SINH, [inner]) => chain(COSH, inner, x),
         (COSH, [inner]) => chain(SINH, inner, x),
         (TANH, [inner]) => apply_node(

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -987,6 +987,41 @@ fn derivative_elementary_chain_rules() {
             ],
         )
     );
+    assert_eq!(
+        d(apply(sym(ASIN), vec![sym("x")])),
+        apply(
+            sym(DIV),
+            vec![
+                int(1),
+                apply(
+                    sym(SQRT),
+                    vec![apply(
+                        sym(SUB),
+                        vec![int(1), apply(sym(POW), vec![sym("x"), int(2)])],
+                    )],
+                ),
+            ],
+        )
+    );
+    assert_eq!(
+        d(apply(sym(ACOS), vec![sym("x")])),
+        apply(
+            sym(NEG),
+            vec![apply(
+                sym(DIV),
+                vec![
+                    int(1),
+                    apply(
+                        sym(SQRT),
+                        vec![apply(
+                            sym(SUB),
+                            vec![int(1), apply(sym(POW), vec![sym("x"), int(2)])],
+                        )],
+                    ),
+                ],
+            )],
+        )
+    );
 
     assert_eq!(
         d(apply(
@@ -1414,8 +1449,11 @@ fn eval_at(node: &symbolic_ir::IRNode, xval: f64) -> f64 {
                 ("Neg", [v]) => -eval_at(v, xval),
                 ("Pow", [b, e]) => eval_at(b, xval).powf(eval_at(e, xval)),
                 ("Log", [v]) => eval_at(v, xval).ln(),
+                ("Sqrt", [v]) => eval_at(v, xval).sqrt(),
                 ("Sin", [v]) => eval_at(v, xval).sin(),
                 ("Cos", [v]) => eval_at(v, xval).cos(),
+                ("Asin", [v]) => eval_at(v, xval).asin(),
+                ("Acos", [v]) => eval_at(v, xval).acos(),
                 ("Atan", [v]) => eval_at(v, xval).atan(),
                 _ => panic!("eval_at: unsupported head {h}"),
             }
@@ -1702,6 +1740,62 @@ fn phase11_x_atan_x_derivative_matches() {
         let expected = x_val * x_val.atan();
         assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
     }
+}
+
+#[test]
+fn phase12_asin_x_derivative_matches() {
+    let phi = integrate(apply(sym(ASIN), vec![sym("x")]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 12 should close ∫ asin(x) dx; got {phi:?}");
+    for &x_val in &[0.0_f64, 0.25, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val.asin();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase12_x_asin_x_derivative_matches() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(ASIN), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 12 should close ∫ x*asin(x) dx; got {phi:?}");
+    for &x_val in &[0.0_f64, 0.25, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.asin();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase12_x_acos_x_derivative_matches_and_keeps_asin_residual() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(ACOS), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 12 should close ∫ x*acos(x) dx; got {phi:?}");
+    assert!(contains_head(&phi, ASIN), "expected Asin residual in {phi:?}");
+    for &x_val in &[0.0_f64, 0.25, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.acos();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase12_shifted_linear_asin_derivative_matches() {
+    let arg = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)]);
+    let phi = integrate(apply(sym(ASIN), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 12 should close ∫ asin(2x+1) dx; got {phi:?}");
+    for &x_val in &[-0.4_f64, -0.25, -0.1] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = (2.0 * x_val + 1.0).asin();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase12_nonlinear_asin_falls_through() {
+    let integrand = apply(sym(ASIN), vec![apply(sym(POW), vec![sym("x"), int(2)])]);
+    let result = integrate(integrand.clone());
+    let original = apply(sym(INTEGRATE), vec![integrand, sym("x")]);
+    assert_eq!(result, original);
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -3115,6 +3115,9 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
       tryTrigLogProduct(a, b, x) ?? tryTrigLogProduct(b, a, x);
     if (tl27 !== undefined) return tl27;
     // Phase 28: ∫ P(x)·log(Q(x)) dx  and  ∫ P(x)·atan(Q(x)) dx  (non-linear Q)
+    // Phase 12: ∫ P(x)·asin/acos(ax+b) dx via IBP.
+    const invTrig12 = tryAsinAcosPolyProduct(a, b, x) ?? tryAsinAcosPolyProduct(b, a, x);
+    if (invTrig12 !== undefined) return invTrig12;
     const lp28 = tryLogPolyProduct(a, b, x) ?? tryLogPolyProduct(b, a, x);
     if (lp28 !== undefined) return lp28;
     const ap28 = tryAtanPolyProduct(a, b, x) ?? tryAtanPolyProduct(b, a, x);
@@ -3192,6 +3195,11 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   if (f.args.length === 1 && equals(f.head, ATAN)) {
     const ap28 = tryAtanPolyProduct(f, int(1), x);
     if (ap28 !== undefined) return ap28;
+  }
+  // Phase 12: bare ∫ asin/acos(ax+b) dx.
+  if (f.args.length === 1 && (equals(f.head, ASIN) || equals(f.head, ACOS))) {
+    const invTrig12 = tryAsinAcosPolyProduct(f, int(1), x);
+    if (invTrig12 !== undefined) return invTrig12;
   }
 
   return undefined;
@@ -4221,6 +4229,14 @@ function diff(f: IRNode, x: IRNode): IRNode {
     if (equals(f.head, SQRT)) {
       return app(DIV, [innerDiff, app(MUL, [int(2), app(SQRT, [inner])])]);
     }
+    if (equals(f.head, ASIN)) {
+      return app(DIV, [innerDiff, app(SQRT, [app(SUB, [int(1), app(POW, [inner, int(2)])])])]);
+    }
+    if (equals(f.head, ACOS)) {
+      return app(NEG, [
+        app(DIV, [innerDiff, app(SQRT, [app(SUB, [int(1), app(POW, [inner, int(2)])])])]),
+      ]);
+    }
     if (equals(f.head, SINH)) {
       return app(MUL, [app(COSH, [inner]), innerDiff]);
     }
@@ -4606,6 +4622,11 @@ function rpAdd(a: RatPoly, b: RatPoly): RatPoly {
   return Array.from({ length: len }, (_, i) => rcAdd(rpCoeff(a, i), rpCoeff(b, i)));
 }
 
+function rpScale(p: RatPoly, c: RatCoeff): RatPoly {
+  if (rcIsZero(c)) return [];
+  return p.map((coef) => rcMul(coef, c));
+}
+
 function rpMul(a: RatPoly, b: RatPoly): RatPoly {
   const da = rpDeg(a);
   const db = rpDeg(b);
@@ -4618,6 +4639,22 @@ function rpMul(a: RatPoly, b: RatPoly): RatPoly {
     }
   }
   return result;
+}
+
+/** Horner composition p(a*x+b). */
+function rpComposeLinear(p: RatPoly, a: RatCoeff, b: RatCoeff): RatPoly {
+  if (rpIsZero(p)) return [];
+  const sub: RatPoly = [b, a];
+  let result: RatPoly = [rpCoeff(p, rpDeg(p))];
+  for (let i = rpDeg(p) - 1; i >= 0; i--) {
+    result = rpAdd(rpMul(result, sub), [rpCoeff(p, i)]);
+  }
+  return result;
+}
+
+/** Compose Q((t-b)/a), represented as a t-polynomial. */
+function rpComposeToT(Q: RatPoly, a: RatCoeff, b: RatCoeff): RatPoly {
+  return rpComposeLinear(Q, rcDiv(RC_ONE, a), rcDiv(rc(0n - b.numer, b.denom), a));
 }
 
 /** Formal derivative: d/dx P(x). */
@@ -5062,6 +5099,100 @@ function tryAtanPolyProduct(
 
   // ∫ P·atan(Q) dx = R·atan(Q) − ∫ R·Q′/(1+Q²) dx.
   return app(SUB, [app(MUL, [R_ir, transcendental]), residual]);
+}
+
+/**
+ * Phase 12: integrate P(x) · asin(ax+b) and P(x) · acos(ax+b).
+ *
+ * Uses the Python reference formula:
+ *   asin: [Q(x)-B(ax+b)]·asin(ax+b) - A(ax+b)·sqrt(1-(ax+b)^2)
+ *   acos: Q(x)·acos(ax+b) + A(ax+b)·sqrt(1-(ax+b)^2) + B(ax+b)·asin(ax+b)
+ * where Q = ∫P dx and ∫Q((t-b)/a)/sqrt(1-t^2) dt = A(t)·sqrt(1-t^2)+B(t)·asin(t).
+ */
+function tryAsinAcosPolyProduct(
+  transcendental: IRNode,
+  polyCandidate: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, ASIN) && !equals(transcendental.head, ACOS)) return undefined;
+  if (transcendental.args.length !== 1) return undefined;
+  const arg = transcendental.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+
+  const argMap = toPolynomialCoeffs(arg, x);
+  if (argMap === undefined) return undefined;
+  const argPoly = rpFromCoeffsMap(argMap);
+  if (argPoly === undefined || rpDeg(argPoly) !== 1) return undefined;
+  const b = rpCoeff(argPoly, 0);
+  const a = rpCoeff(argPoly, 1);
+  if (rcIsZero(a)) return undefined;
+
+  const Pmap = toPolynomialCoeffs(polyCandidate, x);
+  if (Pmap === undefined) return undefined;
+  const P = rpFromCoeffsMap(Pmap);
+  if (P === undefined || rpIsZero(P)) return undefined;
+
+  const Q = rpIntegrate(P);
+  const Q_tilde = rpComposeToT(Q, a, b);
+  const [A_t, B_t] = sqrtOneMinusTSquaredDecompose(Q_tilde);
+  const A_x = rpComposeLinear(A_t, a, b);
+  const B_x = rpComposeLinear(B_t, a, b);
+
+  const Q_ir = rpToIR(Q, x);
+  const argSquared = app(POW, [arg, int(2)]);
+  const sqrtIr = app(SQRT, [app(SUB, [int(1), argSquared])]);
+
+  if (equals(transcendental.head, ASIN)) {
+    const asinCoef = rpIsZero(B_x) ? Q_ir : app(SUB, [Q_ir, rpToIR(B_x, x)]);
+    let result: IRNode = app(MUL, [asinCoef, transcendental]);
+    if (!rpIsZero(A_x)) {
+      result = app(SUB, [result, app(MUL, [rpToIR(A_x, x), sqrtIr])]);
+    }
+    return result;
+  }
+
+  let result: IRNode = app(MUL, [Q_ir, transcendental]);
+  if (!rpIsZero(A_x)) {
+    result = app(ADD, [result, app(MUL, [rpToIR(A_x, x), sqrtIr])]);
+  }
+  if (!rpIsZero(B_x)) {
+    result = app(ADD, [result, app(MUL, [rpToIR(B_x, x), app(ASIN, [arg])])]);
+  }
+  return result;
+}
+
+function sqrtOneMinusTSquaredDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {
+  const memo = new Map<number, [RatPoly, RatPoly]>();
+  const monomial = (n: number): [RatPoly, RatPoly] => {
+    const cached = memo.get(n);
+    if (cached !== undefined) return cached;
+    let result: [RatPoly, RatPoly];
+    if (n === 0) {
+      result = [[], [RC_ONE]];
+    } else if (n === 1) {
+      result = [[rcFromBigInt(-1n)], []];
+    } else {
+      const aNew: RatCoeff[] = Array.from({ length: n }, () => RC_ZERO);
+      aNew[n - 1] = rc(-1n, BigInt(n));
+      const [aRec, bRec] = monomial(n - 2);
+      const coef = rc(BigInt(n - 1), BigInt(n));
+      result = [rpAdd(aNew, rpScale(aRec, coef)), rpScale(bRec, coef)];
+    }
+    memo.set(n, result);
+    return result;
+  };
+
+  let A: RatPoly = [];
+  let B: RatPoly = [];
+  for (let degree = 0; degree < Q_tilde.length; degree += 1) {
+    const coef = rpCoeff(Q_tilde, degree);
+    if (rcIsZero(coef)) continue;
+    const [aN, bN] = monomial(degree);
+    A = rpAdd(A, rpScale(aN, coef));
+    B = rpAdd(B, rpScale(bN, coef));
+  }
+  return [A, B];
 }
 
 function gcd(a: bigint, b: bigint): bigint {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -427,6 +427,12 @@ describe("symbolic-vm", () => {
     expect(vm.eval(app(D, [app(SQRT, [sym("x")]), sym("x")]))).toEqual(
       app(DIV, [int(1), app(MUL, [int(2), app(SQRT, [sym("x")])])]),
     );
+    expect(vm.eval(app(D, [app(ASIN, [sym("x")]), sym("x")]))).toEqual(
+      app(DIV, [int(1), app(SQRT, [app(SUB, [int(1), app(POW, [sym("x"), int(2)])])])]),
+    );
+    expect(vm.eval(app(D, [app(ACOS, [sym("x")]), sym("x")]))).toEqual(
+      app(NEG, [app(DIV, [int(1), app(SQRT, [app(SUB, [int(1), app(POW, [sym("x"), int(2)])])])])]),
+    );
   });
 
   it("applies hyperbolic and inverse hyperbolic chain rules", () => {
@@ -980,8 +986,11 @@ describe("symbolic-vm", () => {
     if (h === "Neg") return -evalIR28(args[0], xVal);
     if (h === "Pow") return Math.pow(evalIR28(args[0], xVal), evalIR28(args[1], xVal));
     if (h === "Log") return Math.log(evalIR28(args[0], xVal));
+    if (h === "Sqrt") return Math.sqrt(evalIR28(args[0], xVal));
     if (h === "Sin") return Math.sin(evalIR28(args[0], xVal));
     if (h === "Cos") return Math.cos(evalIR28(args[0], xVal));
+    if (h === "Asin") return Math.asin(evalIR28(args[0], xVal));
+    if (h === "Acos") return Math.acos(evalIR28(args[0], xVal));
     if (h === "Atan") return Math.atan(evalIR28(args[0], xVal));
     throw new Error(`evalIR28: unsupported head: ${h}`);
   }
@@ -1143,6 +1152,61 @@ describe("symbolic-vm", () => {
       - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
     const numerical = trapezoid28((t) => t * Math.atan(t), 0, 1);
     expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 12: ∫ asin(x) dx closes and matches numerically", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const antideriv = vm.eval(app(INTEGRATE, [app(ASIN, [x]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0.5)
+               - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
+    const numerical = trapezoid28((t) => Math.asin(t), 0, 0.5);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 12: ∫ x·asin(x) dx closes and matches numerically", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(ASIN, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0.5)
+               - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
+    const numerical = trapezoid28((t) => t * Math.asin(t), 0, 0.5);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 12: ∫ x·acos(x) dx closes and includes the asin residual", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(ACOS, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Asin")).toBe(true);
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0.5)
+               - evalIR28(antideriv as unknown as ReturnType<typeof sym>, 0);
+    const numerical = trapezoid28((t) => t * Math.acos(t), 0, 0.5);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 12: ∫ asin(2x+1) dx handles linear arguments", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(ADD, [app(MUL, [int(2), x]), int(1)]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(ASIN, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    const diff = evalIR28(antideriv as unknown as ReturnType<typeof sym>, -0.1)
+               - evalIR28(antideriv as unknown as ReturnType<typeof sym>, -0.4);
+    const numerical = trapezoid28((t) => Math.asin(2 * t + 1), -0.4, -0.1);
+    expect(Math.abs(diff - numerical)).toBeLessThan(1e-5);
+  });
+
+  it("Phase 12: ∫ asin(x²) dx stays unevaluated", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const result = vm.eval(app(INTEGRATE, [app(ASIN, [app(POW, [x, int(2)])]), x]));
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Port MACSYMA Phase 12 asin/acos(linear) polynomial integration to the TypeScript symbolic VM.
- Port the same Phase 12 path to the Rust symbolic VM.
- Add asin/acos derivative rules needed to locally validate the generated antiderivatives.
- Add TS and Rust regression coverage for bare, polynomial-product, linear-argument, acos residual, and nonlinear fallthrough cases.

## Validation
- `node ./node_modules/typescript/bin/tsc --noEmit` in `code/packages/typescript/symbolic-vm`
- `node ./node_modules/vitest/vitest.mjs run` in `code/packages/typescript/symbolic-vm`
- `C:\Users\adhit\.cargo\bin\cargo.exe test --manifest-path code/packages/rust/symbolic-vm/Cargo.toml`
- `python -m pytest code/packages/python/symbolic-vm/tests/test_phase12.py -q --no-cov` with local monorepo `PYTHONPATH`
- `git diff --check`