### PR TITLE
Track browser shell global states

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness global-state descriptors now include shell-level `html` and
+  `body` states such as hidden, inert, accesskey, editing, spellcheck, and
+  translate metadata.
 - Browser-readiness text semantic summaries now include phrase-level semantics
   for abbreviation, definition, citation, code, keyboard input, sample output,
   variables, subscript/superscript, emphasis, importance, small print,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -2410,6 +2410,11 @@ impl BrowserDocument {
         if let Some(head) = head {
             collect_head_browser_facts(&head.children, &mut summary);
         }
+        for element in [html, body].into_iter().flatten() {
+            if let Some(descriptor) = browser_global_state_descriptor(element) {
+                summary.global_state_descriptors.push(descriptor);
+            }
+        }
         let labels = collect_label_texts_by_control_id(body_children);
         let id_texts = collect_element_texts_by_id(body_children);
         collect_browser_facts(
@@ -17979,6 +17984,46 @@ mod tests {
         );
         assert!(render_tree.children[0].children[2].open);
         assert!(render_tree.children[0].children[3].open);
+    }
+
+    #[test]
+    fn browser_shell_global_state_metadata_tracks_document_and_body_attributes() {
+        let document = parse_html(
+            "<html lang=en dir=ltr hidden accesskey=\"h ?\" spellcheck=false translate=no>\
+             <body id=app-shell class=\"app hydrated\" title=\"App shell\" inert contenteditable=plaintext-only draggable=true spellcheck=true translate=yes>\
+             <main><p>Ready</p></main></body></html>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.global_state_descriptors.len(), 2);
+
+        let document_shell = &summary.global_state_descriptors[0];
+        assert_eq!(document_shell.element, "html");
+        assert_eq!(document_shell.lang.as_deref(), Some("en"));
+        assert_eq!(document_shell.dir.as_deref(), Some("ltr"));
+        assert!(document_shell.hidden);
+        assert_eq!(document_shell.accesskey, vec!["h", "?"]);
+        assert_eq!(document_shell.spellcheck.as_deref(), Some("false"));
+        assert_eq!(document_shell.translate.as_deref(), Some("no"));
+        assert_eq!(document_shell.text, "Ready");
+
+        let body_shell = &summary.global_state_descriptors[1];
+        assert_eq!(body_shell.element, "body");
+        assert_eq!(body_shell.id.as_deref(), Some("app-shell"));
+        assert_eq!(body_shell.classes, vec!["app", "hydrated"]);
+        assert_eq!(body_shell.title.as_deref(), Some("App shell"));
+        assert!(body_shell.inert);
+        assert_eq!(
+            body_shell.contenteditable.as_deref(),
+            Some("plaintext-only")
+        );
+        assert_eq!(body_shell.editing_mode.as_deref(), Some("plaintext"));
+        assert_eq!(body_shell.draggable.as_deref(), Some("true"));
+        assert_eq!(body_shell.draggable_state.as_deref(), Some("true"));
+        assert_eq!(body_shell.spellcheck.as_deref(), Some("true"));
+        assert_eq!(body_shell.translate.as_deref(), Some("yes"));
+        assert_eq!(body_shell.text, "Ready");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -21,8 +21,9 @@ viewport, description, application name, referrer/robots/color-scheme policy,
 theme colors, refresh URL resolution, and canonical/manifest URLs. Form cases
 also pin labels, derived accessible names, owner references,
 placeholder/autocomplete hints, and required/readonly/multiple control state.
-Global-state descriptor cases pin non-form inert/hidden, editing, drag,
-spellcheck, translate, accesskey, autofocus, and related focus metadata.
+Global-state descriptor cases pin document/body shell state plus non-form
+inert/hidden, editing, drag, spellcheck, translate, accesskey, autofocus, and
+related focus metadata.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1087,6 +1087,36 @@
       }
     },
     {
+      "id": "document-shell-global-state-page",
+      "description": "Browser document summaries expose html/body shell global-state descriptors alongside document identity metadata.",
+      "input": "<html lang=en dir=ltr hidden accesskey=\"h ?\" spellcheck=false translate=no><body id=app-shell class=\"app hydrated\" title=\"App shell\" inert contenteditable=plaintext-only draggable=true spellcheck=true translate=yes><main><p>Ready</p></main></body></html>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "document_lang": "en",
+        "document_dir": "ltr",
+        "body_id": "app-shell",
+        "body_classes": ["app", "hydrated"],
+        "body_text": "Ready",
+        "metas": [],
+        "resources": [],
+        "anchors": [],
+        "headings": [],
+        "section_landmarks": [
+          { "element": "main", "role": "main", "text": "Ready", "section_kind": "main", "landmark_kind": "main" }
+        ],
+        "links": [],
+        "images": [],
+        "global_state_descriptors": [
+          { "element": "html", "lang": "en", "dir": "ltr", "hidden": true, "accesskey": ["h", "?"], "spellcheck": "false", "translate": "no", "text": "Ready" },
+          { "element": "body", "id": "app-shell", "classes": ["app", "hydrated"], "title": "App shell", "inert": true, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "true", "draggable_state": "true", "spellcheck": "true", "translate": "yes", "text": "Ready" }
+        ],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "popover-command-descriptor-page",
       "description": "Browser document summaries expose popover hosts with their popovertarget and commandfor invoker relationships.",
       "input": "<body><button id=open popovertarget=menu-pop popovertargetaction=show aria-controls=menu-pop aria-expanded=false>Open menu</button><button id=close command=hide-popover commandfor=menu-pop>Close menu</button><div id=menu-pop popover=manual aria-label=Actions><h2>Actions</h2><p>Archive</p></div><div id=note-pop popover=auto aria-labelledby=note-title><h3 id=note-title>Note</h3><p>Saved</p></div></body>",


### PR DESCRIPTION
## Summary
- include html/body shell elements in browser-readiness global-state descriptors when they carry global state
- add a browser-readiness fixture for document/body hidden, inert, accesskey, editing, drag, spellcheck, and translate metadata
- update fixture notes and changelog

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_shell_global_state_metadata_tracks_document_and_body_attributes
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_text_semantic_descriptor_metadata_tracks_inline_annotations
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser