### PR TITLE
Add MACSYMA Phase 13 hyperbolic parity

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2134,6 +2134,10 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
             .or_else(|| try_trig_log_product(b, a, x))
             .or_else(|| try_asin_acos_poly_product(a, b, x))
             .or_else(|| try_asin_acos_poly_product(b, a, x))
+            .or_else(|| try_sinh_cosh_poly_product(a, b, x))
+            .or_else(|| try_sinh_cosh_poly_product(b, a, x))
+            .or_else(|| try_asinh_acosh_poly_product(a, b, x))
+            .or_else(|| try_asinh_acosh_poly_product(b, a, x))
             .or_else(|| try_log_poly_product(a, b, x))
             .or_else(|| try_log_poly_product(b, a, x))
             .or_else(|| try_atan_poly_product(a, b, x))
@@ -2151,6 +2155,12 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
                 .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
         (ASIN, [_]) | (ACOS, [_]) => try_asin_acos_poly_product(f, &IRNode::Integer(1), x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
+        (SINH, [_]) | (COSH, [_]) => try_sinh_cosh_poly_product(f, &IRNode::Integer(1), x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
+        (ASINH, [_]) | (ACOSH, [_]) => try_asinh_acosh_poly_product(f, &IRNode::Integer(1), x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
+        (TANH, [_]) | (ATANH, [_]) => try_tanh_atanh_linear(f, x)
             .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
     }
@@ -4108,6 +4118,289 @@ fn try_asin_acos_poly_product(
         );
     }
     Some(result)
+}
+
+fn linear_arg_coeffs(arg_ir: &IRNode, x: &str) -> Option<(RatC, RatC)> {
+    let arg_rp = rp_from_poly_vec(to_polynomial_coeffs(arg_ir, x)?)?;
+    if rp_deg(&arg_rp) != Some(1) {
+        return None;
+    }
+    let b = rp_coeff(&arg_rp, 0);
+    let a = rp_coeff(&arg_rp, 1);
+    if rc_is_zero(a) {
+        return None;
+    }
+    Some((a, b))
+}
+
+fn hyp_product_term(poly: &[RatC], head: &str, arg_ir: &IRNode, x: &str) -> Option<Option<IRNode>> {
+    if rp_is_zero(poly) {
+        return Some(None);
+    }
+    let hyp_ir = apply_node(head, vec![arg_ir.clone()]);
+    if rp_deg(poly) == Some(0) && rc_is_one(rp_coeff(poly, 0)) {
+        return Some(Some(hyp_ir));
+    }
+    Some(Some(apply_node(MUL, vec![rp_to_ir(poly, x)?, hyp_ir])))
+}
+
+fn add_terms(terms: Vec<Option<IRNode>>) -> Option<IRNode> {
+    let terms: Vec<IRNode> = terms.into_iter().flatten().collect();
+    match terms.len() {
+        0 => None,
+        1 => terms.into_iter().next(),
+        _ => terms.into_iter().reduce(|a, b| apply_node(ADD, vec![a, b])),
+    }
+}
+
+/// Phase 13: integrate P(x)*sinh(a*x+b) and P(x)*cosh(a*x+b).
+fn try_sinh_cosh_poly_product(
+    transcendental: &IRNode,
+    poly_candidate: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), SINH | COSH) || apply.args.len() != 1 {
+        return None;
+    }
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+    let (a, _) = linear_arg_coeffs(arg_ir, x)?;
+
+    let mut derivative = rp_from_poly_vec(to_polynomial_coeffs(poly_candidate, x)?)?;
+    if rp_is_zero(&derivative) {
+        return None;
+    }
+
+    let mut cosh_poly: RatPoly = vec![];
+    let mut sinh_poly: RatPoly = vec![];
+    let mut a_power = a;
+    let mut sign = RC_ONE;
+    let mut degree = 0usize;
+    while !rp_is_zero(&derivative) {
+        let scale = rc_div(sign, a_power)?;
+        let scaled = rp_mul_scalar(&derivative, scale)?;
+        if head.as_str() == SINH {
+            if degree % 2 == 0 {
+                cosh_poly = rp_add(&cosh_poly, &scaled)?;
+            } else {
+                sinh_poly = rp_add(&sinh_poly, &scaled)?;
+            }
+        } else if degree % 2 == 0 {
+            sinh_poly = rp_add(&sinh_poly, &scaled)?;
+        } else {
+            cosh_poly = rp_add(&cosh_poly, &scaled)?;
+        }
+
+        derivative = rp_deriv(&derivative)?;
+        a_power = rc_mul(a_power, a)?;
+        sign = rc_neg(sign);
+        degree += 1;
+    }
+
+    add_terms(vec![
+        hyp_product_term(&cosh_poly, COSH, arg_ir, x)?,
+        hyp_product_term(&sinh_poly, SINH, arg_ir, x)?,
+    ])
+}
+
+/// Phase 13: integrate P(x)*asinh(a*x+b) and P(x)*acosh(a*x+b).
+fn try_asinh_acosh_poly_product(
+    transcendental: &IRNode,
+    poly_candidate: &IRNode,
+    x: &str,
+) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), ASINH | ACOSH) || apply.args.len() != 1 {
+        return None;
+    }
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+    let (a, b) = linear_arg_coeffs(arg_ir, x)?;
+
+    let p_rp = rp_from_poly_vec(to_polynomial_coeffs(poly_candidate, x)?)?;
+    if rp_is_zero(&p_rp) {
+        return None;
+    }
+
+    let q_rp = rp_integrate(&p_rp)?;
+    let q_tilde = rp_compose_to_t(&q_rp, a, b)?;
+    let (a_t, b_t) = if head.as_str() == ASINH {
+        sqrt_t_plus_one_decompose(&q_tilde)?
+    } else {
+        sqrt_t_minus_one_decompose(&q_tilde)?
+    };
+    let a_x = rp_compose_linear(&a_t, a, b)?;
+    let b_x = rp_compose_linear(&b_t, a, b)?;
+
+    let q_ir = rp_to_ir(&q_rp, x)?;
+    let main_coef = if rp_is_zero(&b_x) {
+        q_ir
+    } else {
+        apply_node(SUB, vec![q_ir, rp_to_ir(&b_x, x)?])
+    };
+    let mut result = apply_node(MUL, vec![main_coef, transcendental.clone()]);
+
+    if !rp_is_zero(&a_x) {
+        let arg_sq = apply_node(POW, vec![arg_ir.clone(), IRNode::Integer(2)]);
+        let sqrt_inner = if head.as_str() == ASINH {
+            apply_node(ADD, vec![arg_sq, IRNode::Integer(1)])
+        } else {
+            apply_node(SUB, vec![arg_sq, IRNode::Integer(1)])
+        };
+        result = apply_node(
+            SUB,
+            vec![
+                result,
+                apply_node(
+                    MUL,
+                    vec![rp_to_ir(&a_x, x)?, apply_node(SQRT, vec![sqrt_inner])],
+                ),
+            ],
+        );
+    }
+    Some(result)
+}
+
+fn try_tanh_atanh_linear(transcendental: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), TANH | ATANH) || apply.args.len() != 1 {
+        return None;
+    }
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+    let (a, _) = linear_arg_coeffs(arg_ir, x)?;
+    let inv_a = rc_div(RC_ONE, a)?;
+
+    if head.as_str() == TANH {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(inv_a)?,
+                apply_node(LOG, vec![apply_node(COSH, vec![arg_ir.clone()])]),
+            ],
+        ));
+    }
+
+    let arg_over_a = apply_node(MUL, vec![rc_to_ir(inv_a)?, arg_ir.clone()]);
+    let log_coef = rc_div(RC_ONE, rc_mul((2, 1), a)?)?;
+    let log_arg = apply_node(
+        SUB,
+        vec![
+            IRNode::Integer(1),
+            apply_node(POW, vec![arg_ir.clone(), IRNode::Integer(2)]),
+        ],
+    );
+    Some(apply_node(
+        ADD,
+        vec![
+            apply_node(MUL, vec![arg_over_a, transcendental.clone()]),
+            apply_node(MUL, vec![rc_to_ir(log_coef)?, apply_node(LOG, vec![log_arg])]),
+        ],
+    ))
+}
+
+fn sqrt_t_plus_one_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {
+    fn monomial(n: usize, memo: &mut Vec<Option<(RatPoly, RatPoly)>>) -> Option<(RatPoly, RatPoly)> {
+        if n < memo.len() {
+            if let Some(cached) = memo[n].clone() {
+                return Some(cached);
+            }
+        } else {
+            memo.resize_with(n + 1, || None);
+        }
+
+        let result = if n == 0 {
+            (vec![], vec![RC_ONE])
+        } else if n == 1 {
+            (vec![RC_ONE], vec![])
+        } else {
+            let mut a_new = vec![RC_ZERO; n];
+            a_new[n - 1] = rc(1, n as i128)?;
+            let (a_rec, b_rec) = monomial(n - 2, memo)?;
+            let coef = rc(-((n - 1) as i128), n as i128)?;
+            (
+                rp_add(&a_new, &rp_mul_scalar(&a_rec, coef)?)?,
+                rp_mul_scalar(&b_rec, coef)?,
+            )
+        };
+
+        memo[n] = Some(result.clone());
+        Some(result)
+    }
+
+    decompose_by_monomial(q_tilde, monomial)
+}
+
+fn sqrt_t_minus_one_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {
+    fn monomial(n: usize, memo: &mut Vec<Option<(RatPoly, RatPoly)>>) -> Option<(RatPoly, RatPoly)> {
+        if n < memo.len() {
+            if let Some(cached) = memo[n].clone() {
+                return Some(cached);
+            }
+        } else {
+            memo.resize_with(n + 1, || None);
+        }
+
+        let result = if n == 0 {
+            (vec![], vec![RC_ONE])
+        } else if n == 1 {
+            (vec![RC_ONE], vec![])
+        } else {
+            let mut a_new = vec![RC_ZERO; n];
+            a_new[n - 1] = rc(1, n as i128)?;
+            let (a_rec, b_rec) = monomial(n - 2, memo)?;
+            let coef = rc((n - 1) as i128, n as i128)?;
+            (
+                rp_add(&a_new, &rp_mul_scalar(&a_rec, coef)?)?,
+                rp_mul_scalar(&b_rec, coef)?,
+            )
+        };
+
+        memo[n] = Some(result.clone());
+        Some(result)
+    }
+
+    decompose_by_monomial(q_tilde, monomial)
+}
+
+fn decompose_by_monomial(
+    q_tilde: &[RatC],
+    monomial: fn(usize, &mut Vec<Option<(RatPoly, RatPoly)>>) -> Option<(RatPoly, RatPoly)>,
+) -> Option<(RatPoly, RatPoly)> {
+    let mut memo: Vec<Option<(RatPoly, RatPoly)>> = Vec::new();
+    let mut a_total = vec![];
+    let mut b_total = vec![];
+    for (deg, &coef) in q_tilde.iter().enumerate() {
+        if rc_is_zero(coef) {
+            continue;
+        }
+        let (a_n, b_n) = monomial(deg, &mut memo)?;
+        a_total = rp_add(&a_total, &rp_mul_scalar(&a_n, coef)?)?;
+        b_total = rp_add(&b_total, &rp_mul_scalar(&b_n, coef)?)?;
+    }
+    Some((a_total, b_total))
 }
 
 fn sqrt_one_minus_t_squared_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -1798,6 +1798,90 @@ fn phase12_nonlinear_asin_falls_through() {
     assert_eq!(result, original);
 }
 
+#[test]
+fn phase13_x_sinh_x_derivative_matches() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(SINH), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close x*sinh(x); got {phi:?}");
+    assert!(contains_head(&phi, COSH), "expected Cosh term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.sinh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_x_cosh_x_derivative_matches() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(COSH), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close x*cosh(x); got {phi:?}");
+    assert!(contains_head(&phi, SINH), "expected Sinh term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.cosh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_asinh_x_derivative_matches() {
+    let phi = integrate(apply(sym(ASINH), vec![sym("x")]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close asinh(x); got {phi:?}");
+    assert!(contains_head(&phi, SQRT), "expected Sqrt term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val.asinh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_x_acosh_x_derivative_matches() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(ACOSH), vec![sym("x")])]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close x*acosh(x); got {phi:?}");
+    assert!(contains_head(&phi, SQRT), "expected Sqrt term in {phi:?}");
+    for &x_val in &[1.3_f64, 1.7, 2.2] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = x_val * x_val.acosh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_tanh_linear_derivative_matches() {
+    let arg = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)]);
+    let phi = integrate(apply(sym(TANH), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close tanh(2x+1); got {phi:?}");
+    assert!(contains_head(&phi, LOG), "expected Log term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.1, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = (2.0 * x_val + 1.0).tanh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_atanh_linear_derivative_matches() {
+    let arg = apply(sym(MUL), vec![rat(1, 2), sym("x")]);
+    let phi = integrate(apply(sym(ATANH), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 13 should close atanh(x/2); got {phi:?}");
+    assert!(contains_head(&phi, LOG), "expected Log term in {phi:?}");
+    for &x_val in &[-0.5_f64, 0.2, 0.7] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = (x_val / 2.0).atanh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase13_x_tanh_x_falls_through() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(TANH), vec![sym("x")])]);
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result), "x*tanh(x) should remain deferred; got {result:?}");
+}
+
 // ---------------------------------------------------------------------------
 // Phase 29: Abs and Sqrt algebraic rules
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -3118,6 +3118,10 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     // Phase 12: ∫ P(x)·asin/acos(ax+b) dx via IBP.
     const invTrig12 = tryAsinAcosPolyProduct(a, b, x) ?? tryAsinAcosPolyProduct(b, a, x);
     if (invTrig12 !== undefined) return invTrig12;
+    const hyp13 =
+      trySinhCoshPolyProduct(a, b, x) ?? trySinhCoshPolyProduct(b, a, x) ??
+      tryAsinhAcoshPolyProduct(a, b, x) ?? tryAsinhAcoshPolyProduct(b, a, x);
+    if (hyp13 !== undefined) return hyp13;
     const lp28 = tryLogPolyProduct(a, b, x) ?? tryLogPolyProduct(b, a, x);
     if (lp28 !== undefined) return lp28;
     const ap28 = tryAtanPolyProduct(a, b, x) ?? tryAtanPolyProduct(b, a, x);
@@ -3200,6 +3204,18 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   if (f.args.length === 1 && (equals(f.head, ASIN) || equals(f.head, ACOS))) {
     const invTrig12 = tryAsinAcosPolyProduct(f, int(1), x);
     if (invTrig12 !== undefined) return invTrig12;
+  }
+  if (f.args.length === 1 && (equals(f.head, SINH) || equals(f.head, COSH))) {
+    const hyp13 = trySinhCoshPolyProduct(f, int(1), x);
+    if (hyp13 !== undefined) return hyp13;
+  }
+  if (f.args.length === 1 && (equals(f.head, ASINH) || equals(f.head, ACOSH))) {
+    const invHyp13 = tryAsinhAcoshPolyProduct(f, int(1), x);
+    if (invHyp13 !== undefined) return invHyp13;
+  }
+  if (f.args.length === 1 && (equals(f.head, TANH) || equals(f.head, ATANH))) {
+    const tanh13 = tryTanhAtanhLinear(f, x);
+    if (tanh13 !== undefined) return tanh13;
   }
 
   return undefined;
@@ -5160,6 +5176,211 @@ function tryAsinAcosPolyProduct(
     result = app(ADD, [result, app(MUL, [rpToIR(B_x, x), app(ASIN, [arg])])]);
   }
   return result;
+}
+
+function linearArgCoeffs(arg: IRNode, x: IRNode): { readonly a: RatCoeff; readonly b: RatCoeff } | undefined {
+  const argMap = toPolynomialCoeffs(arg, x);
+  if (argMap === undefined) return undefined;
+  const argPoly = rpFromCoeffsMap(argMap);
+  if (argPoly === undefined || rpDeg(argPoly) !== 1) return undefined;
+  const a = rpCoeff(argPoly, 1);
+  if (rcIsZero(a)) return undefined;
+  return { a, b: rpCoeff(argPoly, 0) };
+}
+
+function hypProductTerm(poly: RatPoly, head: IRNode, arg: IRNode, x: IRNode): IRNode | undefined {
+  if (rpIsZero(poly)) return undefined;
+  const polyIr = rpToIR(poly, x);
+  const hypIr = app(head, [arg]);
+  return rpDeg(poly) === 0 && rcIsOne(rpCoeff(poly, 0)) ? hypIr : app(MUL, [polyIr, hypIr]);
+}
+
+function addDefinedTerms(terms: readonly (IRNode | undefined)[]): IRNode | undefined {
+  const present = terms.filter((term): term is IRNode => term !== undefined);
+  if (present.length === 0) return undefined;
+  return present.reduce((acc, term) => app(ADD, [acc, term]));
+}
+
+/**
+ * Phase 13: integrate P(x) * sinh(ax+b) and P(x) * cosh(ax+b).
+ *
+ * Tabular IBP terminates for polynomial P:
+ *   integral P*sinh(u) = P/a*cosh(u) - P'/a^2*sinh(u) + ...
+ *   integral P*cosh(u) = P/a*sinh(u) - P'/a^2*cosh(u) + ...
+ */
+function trySinhCoshPolyProduct(
+  transcendental: IRNode,
+  polyCandidate: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, SINH) && !equals(transcendental.head, COSH)) return undefined;
+  if (transcendental.args.length !== 1) return undefined;
+  const arg = transcendental.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+  const linear = linearArgCoeffs(arg, x);
+  if (linear === undefined) return undefined;
+
+  const Pmap = toPolynomialCoeffs(polyCandidate, x);
+  if (Pmap === undefined) return undefined;
+  let derivative = rpFromCoeffsMap(Pmap);
+  if (derivative === undefined || rpIsZero(derivative)) return undefined;
+
+  let coshPoly: RatPoly = [];
+  let sinhPoly: RatPoly = [];
+  let aPower = linear.a;
+  let sign = RC_ONE;
+  let degree = 0;
+  while (!rpIsZero(derivative)) {
+    const scale = rcDiv(sign, aPower);
+    if (equals(transcendental.head, SINH)) {
+      if (degree % 2 === 0) coshPoly = rpAdd(coshPoly, rpScale(derivative, scale));
+      else sinhPoly = rpAdd(sinhPoly, rpScale(derivative, scale));
+    } else {
+      if (degree % 2 === 0) sinhPoly = rpAdd(sinhPoly, rpScale(derivative, scale));
+      else coshPoly = rpAdd(coshPoly, rpScale(derivative, scale));
+    }
+    derivative = rpDeriv(derivative);
+    aPower = rcMul(aPower, linear.a);
+    sign = rc(0n - sign.numer, sign.denom);
+    degree += 1;
+  }
+
+  return addDefinedTerms([
+    hypProductTerm(coshPoly, COSH, arg, x),
+    hypProductTerm(sinhPoly, SINH, arg, x),
+  ]);
+}
+
+/**
+ * Phase 13: integrate P(x) * asinh(ax+b) and P(x) * acosh(ax+b).
+ *
+ * Mirrors Phase 12's IBP shape, replacing the inverse-trig residual with
+ * decompositions over sqrt(t^2 + 1) or sqrt(t^2 - 1).
+ */
+function tryAsinhAcoshPolyProduct(
+  transcendental: IRNode,
+  polyCandidate: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, ASINH) && !equals(transcendental.head, ACOSH)) return undefined;
+  if (transcendental.args.length !== 1) return undefined;
+  const arg = transcendental.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+  const linear = linearArgCoeffs(arg, x);
+  if (linear === undefined) return undefined;
+
+  const Pmap = toPolynomialCoeffs(polyCandidate, x);
+  if (Pmap === undefined) return undefined;
+  const P = rpFromCoeffsMap(Pmap);
+  if (P === undefined || rpIsZero(P)) return undefined;
+
+  const Q = rpIntegrate(P);
+  const Q_tilde = rpComposeToT(Q, linear.a, linear.b);
+  const [A_t, B_t] = equals(transcendental.head, ASINH)
+    ? sqrtTPlusOneDecompose(Q_tilde)
+    : sqrtTMinusOneDecompose(Q_tilde);
+  const A_x = rpComposeLinear(A_t, linear.a, linear.b);
+  const B_x = rpComposeLinear(B_t, linear.a, linear.b);
+
+  const Q_ir = rpToIR(Q, x);
+  const mainCoef = rpIsZero(B_x) ? Q_ir : app(SUB, [Q_ir, rpToIR(B_x, x)]);
+  let result: IRNode = app(MUL, [mainCoef, transcendental]);
+
+  if (!rpIsZero(A_x)) {
+    const argSquared = app(POW, [arg, int(2)]);
+    const sqrtInner = equals(transcendental.head, ASINH)
+      ? app(ADD, [argSquared, int(1)])
+      : app(SUB, [argSquared, int(1)]);
+    result = app(SUB, [result, app(MUL, [rpToIR(A_x, x), app(SQRT, [sqrtInner])])]);
+  }
+  return result;
+}
+
+function tryTanhAtanhLinear(transcendental: IRNode, x: IRNode): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, TANH) && !equals(transcendental.head, ATANH)) return undefined;
+  if (transcendental.args.length !== 1) return undefined;
+  const arg = transcendental.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+  const linear = linearArgCoeffs(arg, x);
+  if (linear === undefined) return undefined;
+
+  const invA = rcDiv(RC_ONE, linear.a);
+  if (equals(transcendental.head, TANH)) {
+    return app(MUL, [rcToIR(invA), app(LOG, [app(COSH, [arg])])]);
+  }
+
+  const argOverA = app(MUL, [rcToIR(invA), arg]);
+  const logCoef = rcDiv(RC_ONE, rcMul(rcFromBigInt(2n), linear.a));
+  const logArg = app(SUB, [int(1), app(POW, [arg, int(2)])]);
+  return app(ADD, [
+    app(MUL, [argOverA, transcendental]),
+    app(MUL, [rcToIR(logCoef), app(LOG, [logArg])]),
+  ]);
+}
+
+function sqrtTPlusOneDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {
+  const memo = new Map<number, [RatPoly, RatPoly]>();
+  const monomial = (n: number): [RatPoly, RatPoly] => {
+    const cached = memo.get(n);
+    if (cached !== undefined) return cached;
+    let result: [RatPoly, RatPoly];
+    if (n === 0) {
+      result = [[], [RC_ONE]];
+    } else if (n === 1) {
+      result = [[RC_ONE], []];
+    } else {
+      const aNew: RatCoeff[] = Array.from({ length: n }, () => RC_ZERO);
+      aNew[n - 1] = rc(1n, BigInt(n));
+      const [aRec, bRec] = monomial(n - 2);
+      const coef = rc(0n - BigInt(n - 1), BigInt(n));
+      result = [rpAdd(aNew, rpScale(aRec, coef)), rpScale(bRec, coef)];
+    }
+    memo.set(n, result);
+    return result;
+  };
+  return decomposeByMonomial(Q_tilde, monomial);
+}
+
+function sqrtTMinusOneDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {
+  const memo = new Map<number, [RatPoly, RatPoly]>();
+  const monomial = (n: number): [RatPoly, RatPoly] => {
+    const cached = memo.get(n);
+    if (cached !== undefined) return cached;
+    let result: [RatPoly, RatPoly];
+    if (n === 0) {
+      result = [[], [RC_ONE]];
+    } else if (n === 1) {
+      result = [[RC_ONE], []];
+    } else {
+      const aNew: RatCoeff[] = Array.from({ length: n }, () => RC_ZERO);
+      aNew[n - 1] = rc(1n, BigInt(n));
+      const [aRec, bRec] = monomial(n - 2);
+      const coef = rc(BigInt(n - 1), BigInt(n));
+      result = [rpAdd(aNew, rpScale(aRec, coef)), rpScale(bRec, coef)];
+    }
+    memo.set(n, result);
+    return result;
+  };
+  return decomposeByMonomial(Q_tilde, monomial);
+}
+
+function decomposeByMonomial(
+  Q_tilde: RatPoly,
+  monomial: (degree: number) => [RatPoly, RatPoly],
+): [RatPoly, RatPoly] {
+  let A: RatPoly = [];
+  let B: RatPoly = [];
+  for (let degree = 0; degree < Q_tilde.length; degree += 1) {
+    const coef = rpCoeff(Q_tilde, degree);
+    if (rcIsZero(coef)) continue;
+    const [aN, bN] = monomial(degree);
+    A = rpAdd(A, rpScale(aN, coef));
+    B = rpAdd(B, rpScale(bN, coef));
+  }
+  return [A, B];
 }
 
 function sqrtOneMinusTSquaredDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -992,6 +992,12 @@ describe("symbolic-vm", () => {
     if (h === "Asin") return Math.asin(evalIR28(args[0], xVal));
     if (h === "Acos") return Math.acos(evalIR28(args[0], xVal));
     if (h === "Atan") return Math.atan(evalIR28(args[0], xVal));
+    if (h === "Sinh") return Math.sinh(evalIR28(args[0], xVal));
+    if (h === "Cosh") return Math.cosh(evalIR28(args[0], xVal));
+    if (h === "Tanh") return Math.tanh(evalIR28(args[0], xVal));
+    if (h === "Asinh") return Math.asinh(evalIR28(args[0], xVal));
+    if (h === "Acosh") return Math.acosh(evalIR28(args[0], xVal));
+    if (h === "Atanh") return Math.atanh(evalIR28(args[0], xVal));
     throw new Error(`evalIR28: unsupported head: ${h}`);
   }
 
@@ -1000,6 +1006,11 @@ describe("symbolic-vm", () => {
     let total = 0.5 * (fn(a) + fn(b));
     for (let i = 1; i < n; i++) total += fn(a + i * h);
     return total * h;
+  }
+
+  function numericalDerivative28(node: ReturnType<typeof sym>, xVal: number): number {
+    const h = 1e-6;
+    return (evalIR28(node, xVal + h) - evalIR28(node, xVal - h)) / (2 * h);
   }
 
   it("Phase 28: ∫ log(x²+1) dx returns a closed form with LOG and ATAN", () => {
@@ -1206,6 +1217,90 @@ describe("symbolic-vm", () => {
     const vm = new VM(new SymbolicBackend());
     const x = sym("x");
     const result = vm.eval(app(INTEGRATE, [app(ASIN, [app(POW, [x, int(2)])]), x]));
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+  });
+
+  it("Phase 13: integrates x*sinh(x) and differentiates back", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(SINH, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Cosh")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - xVal * Math.sinh(xVal))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: integrates x*cosh(x) and differentiates back", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(COSH, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Sinh")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - xVal * Math.cosh(xVal))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: integrates asinh(x) and differentiates back", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const antideriv = vm.eval(app(INTEGRATE, [app(ASINH, [x]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Sqrt")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - Math.asinh(xVal))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: integrates x*acosh(x) on the real domain", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(MUL, [x, app(ACOSH, [x])]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Sqrt")).toBe(true);
+    for (const xVal of [1.3, 1.7, 2.2]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - xVal * Math.acosh(xVal))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: integrates tanh(2x+1) as log(cosh)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(ADD, [app(MUL, [int(2), x]), int(1)]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(TANH, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+    for (const xVal of [-0.4, 0.1, 0.5]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - Math.tanh(2 * xVal + 1))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: integrates atanh(x/2) and differentiates back", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(MUL, [rational(1, 2), x]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(ATANH, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+    for (const xVal of [-0.5, 0.2, 0.7]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - Math.atanh(xVal / 2))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 13: leaves x*tanh(x) deferred", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const result = vm.eval(app(INTEGRATE, [app(MUL, [x, app(TANH, [x])]), x]));
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- port MACSYMA Phase 13 hyperbolic integration support into TypeScript symbolic-vm
- add Rust parity for polynomial products with sinh/cosh, inverse hyperbolic IBP, and linear tanh/atanh
- add cross-runtime derivative-based regression tests plus deferred coverage for x*tanh(x)

## Local verification
- `node .\\node_modules\\typescript\\bin\\tsc --noEmit` from `code/packages/typescript/symbolic-vm`
- `node .\\node_modules\\vitest\\vitest.mjs run` from `code/packages/typescript/symbolic-vm` (4 files, 197 tests)
- `C:\\Users\\adhit\\.cargo\\bin\\cargo.exe test --manifest-path code/packages/rust/symbolic-vm/Cargo.toml`
- Python reference check: `test_phase13.py` core symbolic cases passed (49 passed); Macsyma-facing tail still needs more local parser package PYTHONPATH wiring in this Windows shell and was not a behavior failure in changed code.
- `git diff --check`