### PR TITLE
Add reciprocal hyperbolic integration parity

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2160,6 +2160,8 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
             .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         (ASINH, [_]) | (ACOSH, [_]) => try_asinh_acosh_poly_product(f, &IRNode::Integer(1), x)
             .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
+        (COTH, [_]) | (SECH, [_]) | (CSCH, [_]) => try_recip_hyp_linear(f, x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         (TANH, [_]) | (ATANH, [_]) => try_tanh_atanh_linear(f, x)
             .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
@@ -4319,6 +4321,43 @@ fn try_tanh_atanh_linear(transcendental: &IRNode, x: &str) -> Option<IRNode> {
             apply_node(MUL, vec![rc_to_ir(log_coef)?, apply_node(LOG, vec![log_arg])]),
         ],
     ))
+}
+
+fn try_recip_hyp_linear(transcendental: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(apply) = transcendental else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), COTH | SECH | CSCH) || apply.args.len() != 1 {
+        return None;
+    }
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+    let (a, _) = linear_arg_coeffs(arg_ir, x)?;
+    let inv_a = rc_to_ir(rc_div(RC_ONE, a)?)?;
+
+    match head.as_str() {
+        COTH => Some(apply_node(
+            MUL,
+            vec![inv_a, apply_node(LOG, vec![apply_node(SINH, vec![arg_ir.clone()])])],
+        )),
+        SECH => Some(apply_node(
+            MUL,
+            vec![inv_a, apply_node(ATAN, vec![apply_node(SINH, vec![arg_ir.clone()])])],
+        )),
+        CSCH => {
+            let half_arg = apply_node(MUL, vec![IRNode::Rational(1, 2), arg_ir.clone()]);
+            Some(apply_node(
+                MUL,
+                vec![inv_a, apply_node(LOG, vec![apply_node(TANH, vec![half_arg])])],
+            ))
+        }
+        _ => None,
+    }
 }
 
 fn sqrt_t_plus_one_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -1455,6 +1455,15 @@ fn eval_at(node: &symbolic_ir::IRNode, xval: f64) -> f64 {
                 ("Asin", [v]) => eval_at(v, xval).asin(),
                 ("Acos", [v]) => eval_at(v, xval).acos(),
                 ("Atan", [v]) => eval_at(v, xval).atan(),
+                ("Sinh", [v]) => eval_at(v, xval).sinh(),
+                ("Cosh", [v]) => eval_at(v, xval).cosh(),
+                ("Tanh", [v]) => eval_at(v, xval).tanh(),
+                ("Coth", [v]) => {
+                    let u = eval_at(v, xval);
+                    u.cosh() / u.sinh()
+                }
+                ("Sech", [v]) => 1.0 / eval_at(v, xval).cosh(),
+                ("Csch", [v]) => 1.0 / eval_at(v, xval).sinh(),
                 _ => panic!("eval_at: unsupported head {h}"),
             }
         }
@@ -1880,6 +1889,56 @@ fn phase13_x_tanh_x_falls_through() {
     let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(TANH), vec![sym("x")])]);
     let result = integrate(integrand);
     assert!(is_unevaluated_integrate(&result), "x*tanh(x) should remain deferred; got {result:?}");
+}
+
+#[test]
+fn phase15_coth_linear_derivative_matches() {
+    let arg = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)]);
+    let phi = integrate(apply(sym(COTH), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 15 should close coth(2x+1); got {phi:?}");
+    assert!(contains_head(&phi, LOG), "expected Log term in {phi:?}");
+    assert!(contains_head(&phi, SINH), "expected Sinh term in {phi:?}");
+    for &x_val in &[0.2_f64, 0.6, 1.0] {
+        let u = 2.0 * x_val + 1.0;
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = u.cosh() / u.sinh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase15_sech_linear_derivative_matches() {
+    let arg = apply(sym(MUL), vec![int(3), sym("x")]);
+    let phi = integrate(apply(sym(SECH), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 15 should close sech(3x); got {phi:?}");
+    assert!(contains_head(&phi, ATAN), "expected Atan term in {phi:?}");
+    assert!(contains_head(&phi, SINH), "expected Sinh term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (3.0 * x_val).cosh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase15_csch_linear_derivative_matches() {
+    let arg = apply(sym(MUL), vec![rat(1, 2), sym("x")]);
+    let phi = integrate(apply(sym(CSCH), vec![arg]));
+    assert!(!is_unevaluated_integrate(&phi), "Phase 15 should close csch(x/2); got {phi:?}");
+    assert!(contains_head(&phi, LOG), "expected Log term in {phi:?}");
+    assert!(contains_head(&phi, TANH), "expected Tanh term in {phi:?}");
+    for &x_val in &[0.6_f64, 1.2, 2.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (x_val / 2.0).sinh();
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase15_x_coth_x_falls_through() {
+    let integrand = apply(sym(MUL), vec![sym("x"), apply(sym(COTH), vec![sym("x")])]);
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result), "x*coth(x) should remain deferred; got {result:?}");
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -3213,6 +3213,10 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     const invHyp13 = tryAsinhAcoshPolyProduct(f, int(1), x);
     if (invHyp13 !== undefined) return invHyp13;
   }
+  if (f.args.length === 1 && (equals(f.head, COTH) || equals(f.head, SECH) || equals(f.head, CSCH))) {
+    const recipHyp15 = tryRecipHypLinear(f, x);
+    if (recipHyp15 !== undefined) return recipHyp15;
+  }
   if (f.args.length === 1 && (equals(f.head, TANH) || equals(f.head, ATANH))) {
     const tanh13 = tryTanhAtanhLinear(f, x);
     if (tanh13 !== undefined) return tanh13;
@@ -5319,6 +5323,29 @@ function tryTanhAtanhLinear(transcendental: IRNode, x: IRNode): IRNode | undefin
     app(MUL, [argOverA, transcendental]),
     app(MUL, [rcToIR(logCoef), app(LOG, [logArg])]),
   ]);
+}
+
+function tryRecipHypLinear(transcendental: IRNode, x: IRNode): IRNode | undefined {
+  if (transcendental.kind !== "apply") return undefined;
+  if (!equals(transcendental.head, COTH) && !equals(transcendental.head, SECH) && !equals(transcendental.head, CSCH)) {
+    return undefined;
+  }
+  if (transcendental.args.length !== 1) return undefined;
+  const arg = transcendental.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+  const linear = linearArgCoeffs(arg, x);
+  if (linear === undefined) return undefined;
+
+  const invA = rcToIR(rcDiv(RC_ONE, linear.a));
+  if (equals(transcendental.head, COTH)) {
+    return app(MUL, [invA, app(LOG, [app(SINH, [arg])])]);
+  }
+  if (equals(transcendental.head, SECH)) {
+    return app(MUL, [invA, app(ATAN, [app(SINH, [arg])])]);
+  }
+
+  const halfArg = app(MUL, [rational(1, 2), arg]);
+  return app(MUL, [invA, app(LOG, [app(TANH, [halfArg])])]);
 }
 
 function sqrtTPlusOneDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -995,6 +995,12 @@ describe("symbolic-vm", () => {
     if (h === "Sinh") return Math.sinh(evalIR28(args[0], xVal));
     if (h === "Cosh") return Math.cosh(evalIR28(args[0], xVal));
     if (h === "Tanh") return Math.tanh(evalIR28(args[0], xVal));
+    if (h === "Coth") {
+      const v = evalIR28(args[0], xVal);
+      return Math.cosh(v) / Math.sinh(v);
+    }
+    if (h === "Sech") return 1 / Math.cosh(evalIR28(args[0], xVal));
+    if (h === "Csch") return 1 / Math.sinh(evalIR28(args[0], xVal));
     if (h === "Asinh") return Math.asinh(evalIR28(args[0], xVal));
     if (h === "Acosh") return Math.acosh(evalIR28(args[0], xVal));
     if (h === "Atanh") return Math.atanh(evalIR28(args[0], xVal));
@@ -1301,6 +1307,56 @@ describe("symbolic-vm", () => {
     const vm = new VM(new SymbolicBackend());
     const x = sym("x");
     const result = vm.eval(app(INTEGRATE, [app(MUL, [x, app(TANH, [x])]), x]));
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+  });
+
+  it("Phase 15: integrates coth(2x+1) as log(sinh)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(ADD, [app(MUL, [int(2), x]), int(1)]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(COTH, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Sinh")).toBe(true);
+    for (const xVal of [0.2, 0.6, 1.0]) {
+      const u = 2 * xVal + 1;
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - Math.cosh(u) / Math.sinh(u))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 15: integrates sech(3x) as atan(sinh)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(MUL, [int(3), x]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(SECH, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Atan")).toBe(true);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Sinh")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.cosh(3 * xVal))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 15: integrates csch(x/2) as log(tanh half-argument)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(MUL, [rational(1, 2), x]);
+    const antideriv = vm.eval(app(INTEGRATE, [app(CSCH, [arg]), x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Tanh")).toBe(true);
+    for (const xVal of [0.6, 1.2, 2.0]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.sinh(xVal / 2))).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 15: leaves x*coth(x) deferred", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const result = vm.eval(app(INTEGRATE, [app(MUL, [x, app(COTH, [x])]), x]));
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add TypeScript integration for linear `coth`, `sech`, and `csch` reciprocal hyperbolic forms.
- Add Rust integration parity for the same Phase 15 forms.
- Add TypeScript and Rust numeric derivative tests plus deferred `x*coth(x)` guards.

## Local verification
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\typescript\bin\tsc --noEmit`
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\vitest\vitest.mjs run`
- `C:\Users\adhit\.cargo\bin\cargo.exe test --manifest-path code/packages/rust/symbolic-vm/Cargo.toml`
- `git diff --check`