### PR TITLE
Track browser ARIA relation descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,8 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness ARIA relation descriptors now expose details, error-message,
+  and flow target metadata with resolved target text.
 - Browser-readiness global-state descriptors now include shell-level `html` and
   `body` states such as hidden, inert, accesskey, editing, spellcheck, and
   translate metadata.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -842,6 +842,7 @@ pub struct BrowserDocument {
     pub aria_collections: Vec<BrowserAriaCollection>,
     pub aria_ranges: Vec<BrowserAriaRange>,
     pub aria_live_regions: Vec<BrowserAriaLiveRegion>,
+    pub aria_relation_descriptors: Vec<BrowserAriaRelationDescriptor>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
@@ -1112,6 +1113,19 @@ pub struct BrowserGlobalStateDescriptor {
     pub spellcheck: Option<String>,
     pub translate: Option<String>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaRelationDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub text: String,
+    pub aria_details: Vec<String>,
+    pub details_text: Vec<String>,
+    pub aria_errormessage: Vec<String>,
+    pub errormessage_text: Vec<String>,
+    pub aria_flowto: Vec<String>,
+    pub flowto_text: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -9620,6 +9634,9 @@ fn collect_browser_facts(
         if let Some(aria_live_region) = browser_aria_live_region_element(element, id_texts) {
             summary.aria_live_regions.push(aria_live_region);
         }
+        if let Some(aria_relation) = browser_aria_relation_descriptor(element, id_texts) {
+            summary.aria_relation_descriptors.push(aria_relation);
+        }
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
@@ -12086,6 +12103,31 @@ fn browser_global_state_descriptor(element: &Element) -> Option<BrowserGlobalSta
     })
 }
 
+fn browser_aria_relation_descriptor(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaRelationDescriptor> {
+    let aria_details = browser_aria_idrefs(element, "aria-details");
+    let aria_errormessage = browser_aria_idrefs(element, "aria-errormessage");
+    let aria_flowto = browser_aria_idrefs(element, "aria-flowto");
+
+    if aria_details.is_empty() && aria_errormessage.is_empty() && aria_flowto.is_empty() {
+        return None;
+    }
+
+    Some(BrowserAriaRelationDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        text: visible_text_for_nodes(&element.children),
+        details_text: browser_idref_texts(&aria_details, id_texts),
+        aria_details,
+        errormessage_text: browser_idref_texts(&aria_errormessage, id_texts),
+        aria_errormessage,
+        flowto_text: browser_idref_texts(&aria_flowto, id_texts),
+        aria_flowto,
+    })
+}
+
 fn browser_slot_assignment(element: &Element) -> Option<String> {
     element.attribute("slot").map(ToOwned::to_owned)
 }
@@ -13257,12 +13299,7 @@ fn browser_accessible_name(
 ) -> Option<String> {
     let labelledby = browser_aria_idrefs(element, "aria-labelledby");
     if !labelledby.is_empty() {
-        let mut parts = Vec::new();
-        for id in labelledby {
-            if let Some((_, text)) = id_texts.iter().find(|(candidate, _)| candidate == &id) {
-                push_unique_string(&mut parts, collapse_html_whitespace(text));
-            }
-        }
+        let parts = browser_idref_texts(&labelledby, id_texts);
         if !parts.is_empty() {
             return Some(parts.join(" "));
         }
@@ -13305,17 +13342,18 @@ fn browser_accessible_description(
     id_texts: &[(String, String)],
 ) -> Option<String> {
     let describedby = browser_aria_idrefs(element, "aria-describedby");
-    if describedby.is_empty() {
-        return None;
-    }
+    let parts = browser_idref_texts(&describedby, id_texts);
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
 
-    let mut parts = Vec::new();
-    for id in describedby {
-        if let Some((_, text)) = id_texts.iter().find(|(candidate, _)| candidate == &id) {
-            push_unique_string(&mut parts, collapse_html_whitespace(text));
+fn browser_idref_texts(idrefs: &[String], id_texts: &[(String, String)]) -> Vec<String> {
+    let mut texts = Vec::new();
+    for id in idrefs {
+        if let Some((_, text)) = id_texts.iter().find(|(candidate, _)| candidate == id) {
+            push_unique_string(&mut texts, collapse_html_whitespace(text));
         }
     }
-    (!parts.is_empty()).then(|| parts.join(" "))
+    texts
 }
 
 fn browser_form_owner(element: &Element) -> Option<String> {
@@ -18024,6 +18062,30 @@ mod tests {
         assert_eq!(body_shell.spellcheck.as_deref(), Some("true"));
         assert_eq!(body_shell.translate.as_deref(), Some("yes"));
         assert_eq!(body_shell.text, "Ready");
+    }
+
+    #[test]
+    fn browser_aria_relation_metadata_tracks_details_errors_and_flow() {
+        let document = parse_html(
+            "<body><div id=source aria-details=\"details extra\" aria-errormessage=error aria-flowto=next>Source</div>\
+             <p id=details>Detailed help</p><p id=extra>Extra notes</p>\
+             <p id=error>Required value</p><p id=next>Next step</p></body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.aria_relation_descriptors.len(), 1);
+
+        let relation = &summary.aria_relation_descriptors[0];
+        assert_eq!(relation.element, "div");
+        assert_eq!(relation.id.as_deref(), Some("source"));
+        assert_eq!(relation.text, "Source");
+        assert_eq!(relation.aria_details, vec!["details", "extra"]);
+        assert_eq!(relation.details_text, vec!["Detailed help", "Extra notes"]);
+        assert_eq!(relation.aria_errormessage, vec!["error"]);
+        assert_eq!(relation.errormessage_text, vec!["Required value"]);
+        assert_eq!(relation.aria_flowto, vec!["next"]);
+        assert_eq!(relation.flowto_text, vec!["Next step"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,6 +1,6 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserAriaCollection, BrowserAriaCollectionItem,
-    BrowserAriaLiveRegion, BrowserAriaRange, BrowserCommandElement,
+    BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
     BrowserEmbeddedContext, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
@@ -83,6 +83,8 @@ struct ExpectedBrowserDocument {
     aria_ranges: Vec<ExpectedAriaRange>,
     #[serde(default)]
     aria_live_regions: Vec<ExpectedAriaLiveRegion>,
+    #[serde(default)]
+    aria_relation_descriptors: Vec<ExpectedAriaRelationDescriptor>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
     #[serde(default)]
@@ -366,6 +368,27 @@ struct ExpectedGlobalStateDescriptor {
     translate: Option<String>,
     #[serde(default)]
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaRelationDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    aria_details: Vec<String>,
+    #[serde(default)]
+    details_text: Vec<String>,
+    #[serde(default)]
+    aria_errormessage: Vec<String>,
+    #[serde(default)]
+    errormessage_text: Vec<String>,
+    #[serde(default)]
+    aria_flowto: Vec<String>,
+    #[serde(default)]
+    flowto_text: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3511,6 +3534,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedAriaLiveRegion::into_browser_aria_live_region)
                 .collect(),
+            aria_relation_descriptors: self
+                .aria_relation_descriptors
+                .into_iter()
+                .map(ExpectedAriaRelationDescriptor::into_browser_aria_relation_descriptor)
+                .collect(),
             links: self
                 .links
                 .into_iter()
@@ -4181,6 +4209,22 @@ impl ExpectedAriaRange {
             aria_required: self.aria_required,
             tabindex: self.tabindex,
             text_value: self.text_value,
+        }
+    }
+}
+
+impl ExpectedAriaRelationDescriptor {
+    fn into_browser_aria_relation_descriptor(self) -> BrowserAriaRelationDescriptor {
+        BrowserAriaRelationDescriptor {
+            element: self.element,
+            id: self.id,
+            text: self.text,
+            aria_details: self.aria_details,
+            details_text: self.details_text,
+            aria_errormessage: self.aria_errormessage,
+            errormessage_text: self.errormessage_text,
+            aria_flowto: self.aria_flowto,
+            flowto_text: self.flowto_text,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -24,6 +24,8 @@ placeholder/autocomplete hints, and required/readonly/multiple control state.
 Global-state descriptor cases pin document/body shell state plus non-form
 inert/hidden, editing, drag, spellcheck, translate, accesskey, autofocus, and
 related focus metadata.
+ARIA descriptor cases pin collection/range/live-region semantics plus details,
+error-message, and flow relationship target text.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1324,6 +1324,44 @@
       }
     },
     {
+      "id": "aria-relation-descriptor-page",
+      "description": "Browser document summaries expose ARIA details, error-message, and flow relationships with resolved target text.",
+      "input": "<body><div id=source aria-details=\"details extra\" aria-errormessage=error aria-flowto=next>Source</div><p id=details>Detailed help</p><p id=extra>Extra notes</p><p id=error>Required value</p><p id=next>Next step</p></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Source Detailed help Extra notes Required value Next step",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "source", "name": null, "text": "Source" },
+          { "id": "details", "name": null, "text": "Detailed help" },
+          { "id": "extra", "name": null, "text": "Extra notes" },
+          { "id": "error", "name": null, "text": "Required value" },
+          { "id": "next", "name": null, "text": "Next step" }
+        ],
+        "headings": [],
+        "aria_relation_descriptors": [
+          {
+            "element": "div",
+            "id": "source",
+            "text": "Source",
+            "aria_details": ["details", "extra"],
+            "details_text": ["Detailed help", "Extra notes"],
+            "aria_errormessage": ["error"],
+            "errormessage_text": ["Required value"],
+            "aria_flowto": ["next"],
+            "flowto_text": ["Next step"]
+          }
+        ],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "form-measurement-descriptor-page",
       "description": "Browser document form summaries expose in-form meter and progress descriptors without adding them to submission controls.",
       "input": "<form id=telemetry><label for=disk>Disk</label><meter id=disk value=0.72 min=0 max=1 low=0.25 high=0.9 optimum=0.7 aria-describedby=disk-help>72%</meter><p id=disk-help>Capacity used</p><label for=upload>Upload</label><progress id=upload value=30 max=100>30%</progress><progress id=sync max=1 aria-label=Sync>Loading</progress><input name=token value=ok></form><meter id=outside value=1>Outside</meter>",


### PR DESCRIPTION
## Summary
- add browser ARIA relation descriptors for aria-details, aria-errormessage, and aria-flowto
- resolve relation targets back to visible target text in BrowserDocument summaries
- add fixture coverage, fixture inventory notes, and changelog entry

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_aria_relation_metadata_tracks_details_errors_and_flow
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_shell_global_state_metadata_tracks_document_and_body_attributes
- cargo test -p coding-adventures-html-parser browser_text_semantic_descriptor_metadata_tracks_inline_annotations
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser