### PR TITLE
Add reciprocal hyperbolic power integration parity

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -2123,6 +2123,8 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
                 _ => apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]),
             }
         }
+        (POW, [base, exponent]) => try_recip_hyp_power(base, exponent, x)
+            .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())])),
         // Phase 27: ∫ sin(log(x)) dx and ∫ cos(log(x)) dx (k=0 direct forms).
         (SIN, [inner]) if is_log_of_x(inner, x) => trig_log_integral(SIN, 0, x),
         (COS, [inner]) if is_log_of_x(inner, x) => trig_log_integral(COS, 0, x),
@@ -4358,6 +4360,154 @@ fn try_recip_hyp_linear(transcendental: &IRNode, x: &str) -> Option<IRNode> {
         }
         _ => None,
     }
+}
+
+fn try_recip_hyp_power(base: &IRNode, exponent: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(apply) = base else {
+        return None;
+    };
+    let IRNode::Symbol(head) = &apply.head else {
+        return None;
+    };
+    if !matches!(head.as_str(), SECH | CSCH | COTH) || apply.args.len() != 1 {
+        return None;
+    }
+    let n = match to_numeric(exponent) {
+        Some(Numeric::Int(n)) if n >= 0 => usize::try_from(n).ok()?,
+        _ => return None,
+    };
+    let arg_ir = &apply.args[0];
+    if !depends_on(arg_ir, x) {
+        return None;
+    }
+    let (a, _) = linear_arg_coeffs(arg_ir, x)?;
+
+    match head.as_str() {
+        SECH => sech_power_integral(n, arg_ir, a, x),
+        CSCH => csch_power_integral(n, arg_ir, a, x),
+        COTH => coth_power_integral(n, arg_ir, a, x),
+        _ => None,
+    }
+}
+
+fn pow_if_needed(base: IRNode, exponent: usize) -> IRNode {
+    if exponent == 1 {
+        base
+    } else {
+        apply_node(POW, vec![base, IRNode::Integer(exponent as i64)])
+    }
+}
+
+fn recip_hyp_coeff(numer: i128, denom: i128, a: RatC) -> Option<IRNode> {
+    rc_to_ir(rc_div(rc(numer, denom)?, a)?)
+}
+
+fn sech_power_integral(n: usize, arg_ir: &IRNode, a: RatC, x: &str) -> Option<IRNode> {
+    if n == 0 {
+        return Some(IRNode::Symbol(x.to_string()));
+    }
+    if n == 1 {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(RC_ONE, a)?)?,
+                apply_node(ATAN, vec![apply_node(SINH, vec![arg_ir.clone()])]),
+            ],
+        ));
+    }
+    if n == 2 {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(RC_ONE, a)?)?,
+                apply_node(TANH, vec![arg_ir.clone()]),
+            ],
+        ));
+    }
+
+    let sech_pow = pow_if_needed(apply_node(SECH, vec![arg_ir.clone()]), n - 2);
+    let main_term = apply_node(
+        MUL,
+        vec![
+            recip_hyp_coeff(1, (n - 1) as i128, a)?,
+            apply_node(MUL, vec![sech_pow, apply_node(TANH, vec![arg_ir.clone()])]),
+        ],
+    );
+    let tail = sech_power_integral(n - 2, arg_ir, a, x)?;
+    Some(apply_node(
+        ADD,
+        vec![
+            main_term,
+            apply_node(MUL, vec![IRNode::Rational((n - 2) as i64, (n - 1) as i64), tail]),
+        ],
+    ))
+}
+
+fn csch_power_integral(n: usize, arg_ir: &IRNode, a: RatC, x: &str) -> Option<IRNode> {
+    if n == 0 {
+        return Some(IRNode::Symbol(x.to_string()));
+    }
+    if n == 1 {
+        let half_arg = apply_node(MUL, vec![IRNode::Rational(1, 2), arg_ir.clone()]);
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(RC_ONE, a)?)?,
+                apply_node(LOG, vec![apply_node(TANH, vec![half_arg])]),
+            ],
+        ));
+    }
+    if n == 2 {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(rc(-1, 1)?, a)?)?,
+                apply_node(COTH, vec![arg_ir.clone()]),
+            ],
+        ));
+    }
+
+    let csch_pow = pow_if_needed(apply_node(CSCH, vec![arg_ir.clone()]), n - 2);
+    let main_term = apply_node(
+        MUL,
+        vec![
+            recip_hyp_coeff(-1, (n - 1) as i128, a)?,
+            apply_node(MUL, vec![csch_pow, apply_node(COTH, vec![arg_ir.clone()])]),
+        ],
+    );
+    let tail = csch_power_integral(n - 2, arg_ir, a, x)?;
+    Some(apply_node(
+        SUB,
+        vec![
+            main_term,
+            apply_node(MUL, vec![IRNode::Rational((n - 2) as i64, (n - 1) as i64), tail]),
+        ],
+    ))
+}
+
+fn coth_power_integral(n: usize, arg_ir: &IRNode, a: RatC, x: &str) -> Option<IRNode> {
+    if n == 0 {
+        return Some(IRNode::Symbol(x.to_string()));
+    }
+    if n == 1 {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(RC_ONE, a)?)?,
+                apply_node(LOG, vec![apply_node(SINH, vec![arg_ir.clone()])]),
+            ],
+        ));
+    }
+
+    let coth_pow = pow_if_needed(apply_node(COTH, vec![arg_ir.clone()]), n - 1);
+    let power_term = apply_node(
+        MUL,
+        vec![recip_hyp_coeff(1, (n - 1) as i128, a)?, coth_pow],
+    );
+    Some(apply_node(
+        SUB,
+        vec![coth_power_integral(n - 2, arg_ir, a, x)?, power_term],
+    ))
 }
 
 fn sqrt_t_plus_one_decompose(q_tilde: &[RatC]) -> Option<(RatPoly, RatPoly)> {

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -1941,6 +1941,83 @@ fn phase15_x_coth_x_falls_through() {
     assert!(is_unevaluated_integrate(&result), "x*coth(x) should remain deferred; got {result:?}");
 }
 
+#[test]
+fn phase16_sech_squared_linear_derivative_matches() {
+    let arg = apply(sym(MUL), vec![int(3), sym("x")]);
+    let integrand = apply(sym(POW), vec![apply(sym(SECH), vec![arg]), int(2)]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 16 should close sech^2(3x); got {phi:?}");
+    assert!(contains_head(&phi, TANH), "expected Tanh term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (3.0 * x_val).cosh().powi(2);
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase16_sech_cubed_derivative_matches() {
+    let integrand = apply(sym(POW), vec![apply(sym(SECH), vec![sym("x")]), int(3)]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 16 should close sech^3(x); got {phi:?}");
+    assert!(contains_head(&phi, ATAN), "expected Atan term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.2, 0.8] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / x_val.cosh().powi(3);
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase16_csch_squared_linear_derivative_matches() {
+    let arg = apply(sym(MUL), vec![rat(1, 2), sym("x")]);
+    let integrand = apply(sym(POW), vec![apply(sym(CSCH), vec![arg]), int(2)]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 16 should close csch^2(x/2); got {phi:?}");
+    assert!(contains_head(&phi, COTH), "expected Coth term in {phi:?}");
+    for &x_val in &[0.6_f64, 1.2, 2.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / (x_val / 2.0).sinh().powi(2);
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase16_csch_cubed_derivative_matches() {
+    let integrand = apply(sym(POW), vec![apply(sym(CSCH), vec![sym("x")]), int(3)]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 16 should close csch^3(x); got {phi:?}");
+    assert!(contains_head(&phi, LOG), "expected Log term in {phi:?}");
+    for &x_val in &[0.6_f64, 1.2, 2.0] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = 1.0 / x_val.sinh().powi(3);
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase16_coth_powers_derivative_match() {
+    for power in [2_i64, 3] {
+        let integrand = apply(sym(POW), vec![apply(sym(COTH), vec![sym("x")]), int(power)]);
+        let phi = integrate(integrand);
+        assert!(!is_unevaluated_integrate(&phi), "Phase 16 should close coth^{power}(x); got {phi:?}");
+        for &x_val in &[0.6_f64, 1.2, 2.0] {
+            let coth = x_val.cosh() / x_val.sinh();
+            let got = phase34_numerical_derivative(&phi, x_val);
+            let expected = coth.powi(power as i32);
+            assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+        }
+    }
+}
+
+#[test]
+fn phase16_nonlinear_sech_power_falls_through() {
+    let nonlinear_arg = apply(sym(POW), vec![sym("x"), int(2)]);
+    let integrand = apply(sym(POW), vec![apply(sym(SECH), vec![nonlinear_arg]), int(2)]);
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result), "sech^2(x^2) should remain deferred; got {result:?}");
+}
+
 // ---------------------------------------------------------------------------
 // Phase 29: Abs and Sqrt algebraic rules
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -3164,6 +3164,8 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
         return polyLogPowerTerm(0, Number(n26.numer), x);
       }
     }
+    const recipHyp16 = tryRecipHypPower(base, exponent, x);
+    if (recipHyp16 !== undefined) return recipHyp16;
     return undefined;
   }
 
@@ -5346,6 +5348,81 @@ function tryRecipHypLinear(transcendental: IRNode, x: IRNode): IRNode | undefine
 
   const halfArg = app(MUL, [rational(1, 2), arg]);
   return app(MUL, [invA, app(LOG, [app(TANH, [halfArg])])]);
+}
+
+function tryRecipHypPower(base: IRNode, exponent: IRNode, x: IRNode): IRNode | undefined {
+  if (base.kind !== "apply" || base.args.length !== 1) return undefined;
+  if (!equals(base.head, SECH) && !equals(base.head, CSCH) && !equals(base.head, COTH)) return undefined;
+  const nRat = exactRational(exponent);
+  if (nRat === undefined || nRat.denom !== 1n || nRat.numer < 0n || nRat.numer > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return undefined;
+  }
+  const arg = base.args[0]!;
+  if (!dependsOn(arg, x)) return undefined;
+  const linear = linearArgCoeffs(arg, x);
+  if (linear === undefined) return undefined;
+
+  const n = Number(nRat.numer);
+  if (equals(base.head, SECH)) return sechPowerIntegral(n, arg, linear.a, x);
+  if (equals(base.head, CSCH)) return cschPowerIntegral(n, arg, linear.a, x);
+  return cothPowerIntegral(n, arg, linear.a, x);
+}
+
+function powIfNeeded(base: IRNode, exponent: number): IRNode {
+  return exponent === 1 ? base : app(POW, [base, int(BigInt(exponent))]);
+}
+
+function recipHypCoeff(numer: bigint, denom: bigint, a: RatCoeff): IRNode {
+  return rcToIR(rcDiv(rc(numer, denom), a));
+}
+
+function sechPowerIntegral(n: number, arg: IRNode, a: RatCoeff, x: IRNode): IRNode {
+  if (n === 0) return x;
+  if (n === 1) return app(MUL, [rcToIR(rcDiv(RC_ONE, a)), app(ATAN, [app(SINH, [arg])])]);
+  if (n === 2) return app(MUL, [rcToIR(rcDiv(RC_ONE, a)), app(TANH, [arg])]);
+
+  const sechPow = powIfNeeded(app(SECH, [arg]), n - 2);
+  const mainTerm = app(MUL, [
+    recipHypCoeff(1n, BigInt(n - 1), a),
+    app(MUL, [sechPow, app(TANH, [arg])]),
+  ]);
+  const tail = sechPowerIntegral(n - 2, arg, a, x);
+  return app(ADD, [
+    mainTerm,
+    app(MUL, [rational(BigInt(n - 2), BigInt(n - 1)), tail]),
+  ]);
+}
+
+function cschPowerIntegral(n: number, arg: IRNode, a: RatCoeff, x: IRNode): IRNode {
+  if (n === 0) return x;
+  if (n === 1) {
+    const halfArg = app(MUL, [rational(1, 2), arg]);
+    return app(MUL, [rcToIR(rcDiv(RC_ONE, a)), app(LOG, [app(TANH, [halfArg])])]);
+  }
+  if (n === 2) {
+    const negInvA = rcToIR(rcDiv(rc(-1n, 1n), a));
+    return app(MUL, [negInvA, app(COTH, [arg])]);
+  }
+
+  const cschPow = powIfNeeded(app(CSCH, [arg]), n - 2);
+  const mainTerm = app(MUL, [
+    recipHypCoeff(-1n, BigInt(n - 1), a),
+    app(MUL, [cschPow, app(COTH, [arg])]),
+  ]);
+  const tail = cschPowerIntegral(n - 2, arg, a, x);
+  return app(SUB, [
+    mainTerm,
+    app(MUL, [rational(BigInt(n - 2), BigInt(n - 1)), tail]),
+  ]);
+}
+
+function cothPowerIntegral(n: number, arg: IRNode, a: RatCoeff, x: IRNode): IRNode {
+  if (n === 0) return x;
+  if (n === 1) return app(MUL, [rcToIR(rcDiv(RC_ONE, a)), app(LOG, [app(SINH, [arg])])]);
+
+  const cothPow = powIfNeeded(app(COTH, [arg]), n - 1);
+  const powerTerm = app(MUL, [recipHypCoeff(1n, BigInt(n - 1), a), cothPow]);
+  return app(SUB, [cothPowerIntegral(n - 2, arg, a, x), powerTerm]);
 }
 
 function sqrtTPlusOneDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1359,6 +1359,83 @@ describe("symbolic-vm", () => {
     const result = vm.eval(app(INTEGRATE, [app(MUL, [x, app(COTH, [x])]), x]));
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
   });
+
+  it("Phase 16: integrates sech^2(3x) as tanh(3x)/3", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(MUL, [int(3), x]);
+    const integrand = app(POW, [app(SECH, [arg]), int(2)]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Tanh")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.cosh(3 * xVal) ** 2)).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 16: integrates sech^3(x) via the odd-power recurrence", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(POW, [app(SECH, [x]), int(3)]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Atan")).toBe(true);
+    for (const xVal of [-0.4, 0.2, 0.8]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.cosh(xVal) ** 3)).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 16: integrates csch^2(x/2) as -2*coth(x/2)", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(MUL, [rational(1, 2), x]);
+    const integrand = app(POW, [app(CSCH, [arg]), int(2)]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Coth")).toBe(true);
+    for (const xVal of [0.6, 1.2, 2.0]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.sinh(xVal / 2) ** 2)).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 16: integrates csch^3(x) via the odd-power recurrence", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(POW, [app(CSCH, [x]), int(3)]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Log")).toBe(true);
+    for (const xVal of [0.6, 1.2, 2.0]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - 1 / Math.sinh(xVal) ** 3)).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 16: integrates coth powers through identity reduction", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    for (const power of [2, 3]) {
+      const integrand = app(POW, [app(COTH, [x]), int(power)]);
+      const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+      expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+      for (const xVal of [0.6, 1.2, 2.0]) {
+        const u = Math.cosh(xVal) / Math.sinh(xVal);
+        const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+        expect(Math.abs(got - u ** power)).toBeLessThan(1e-5);
+      }
+    }
+  });
+
+  it("Phase 16: leaves sech^2(x^2) deferred", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(POW, [app(SECH, [app(POW, [x, int(2)])]), int(2)]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add TypeScript Phase 16 integration for `sech^n`, `csch^n`, and `coth^n` with linear arguments.
- Add Rust parity for the same reciprocal-hyperbolic power recurrence formulas.
- Add numeric derivative coverage for squared and odd-power reductions, plus non-linear argument fallthrough guards.

## Local verification
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\typescript\bin\tsc --noEmit`
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\vitest\vitest.mjs run`
- `C:\Users\adhit\.cargo\bin\cargo.exe test --manifest-path code/packages/rust/symbolic-vm/Cargo.toml`
- `git diff --check`