### PR TITLE
Track browser loading hint descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,8 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness loading-hint descriptors now expose lazy/eager loading,
+  decoding, fetch priority, blocking, and media preload scheduling metadata.
 - Browser-readiness ARIA relation descriptors now expose details, error-message,
   and flow target metadata with resolved target text.
 - Browser-readiness global-state descriptors now include shell-level `html` and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -832,6 +832,7 @@ pub struct BrowserDocument {
     pub resources: Vec<BrowserResource>,
     pub scripts: Vec<BrowserScript>,
     pub stylesheets: Vec<BrowserStylesheet>,
+    pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
@@ -1018,6 +1019,22 @@ pub struct BrowserStylesheet {
     pub blocking: Option<String>,
     pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserLoadingHintDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub url: Option<String>,
+    pub resolved_url: Option<String>,
+    pub loading: Option<String>,
+    pub decoding: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
+    pub preload: Option<String>,
+    pub as_hint: Option<String>,
+    pub media: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9593,6 +9610,11 @@ fn collect_browser_facts(
 
         collect_anchor_target(element, summary);
         collect_body_resource(element, summary);
+        if let Some(descriptor) =
+            browser_loading_hint_descriptor(element, summary.base_href.as_deref())
+        {
+            summary.loading_hint_descriptors.push(descriptor);
+        }
         if let Some(context) = browser_embedded_context(element, summary.base_href.as_deref()) {
             summary.embedded_contexts.push(context);
         }
@@ -9751,6 +9773,12 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
         let Node::Element(element) = node else {
             continue;
         };
+
+        if let Some(descriptor) =
+            browser_loading_hint_descriptor(element, summary.base_href.as_deref())
+        {
+            summary.loading_hint_descriptors.push(descriptor);
+        }
 
         match element.name.as_str() {
             "meta" => summary.metas.push(BrowserMeta {
@@ -12260,6 +12288,68 @@ fn browser_browsing_context_fetchpriority(element: &Element) -> Option<String> {
     } else {
         None
     }
+}
+
+fn browser_loading_hint_descriptor(
+    element: &Element,
+    base_href: Option<&str>,
+) -> Option<BrowserLoadingHintDescriptor> {
+    let loading = match element.name.as_str() {
+        "img" => element.attribute("loading").map(ToOwned::to_owned),
+        _ => browser_browsing_context_loading(element),
+    };
+    let decoding = (element.name == "img")
+        .then(|| element.attribute("decoding").map(ToOwned::to_owned))
+        .flatten();
+    let fetchpriority = match element.name.as_str() {
+        "img" | "iframe" | "frame" | "link" | "script" => {
+            element.attribute("fetchpriority").map(ToOwned::to_owned)
+        }
+        _ => None,
+    };
+    let blocking = match element.name.as_str() {
+        "link" | "script" | "style" => element.attribute("blocking").map(ToOwned::to_owned),
+        _ => None,
+    };
+    let preload = browser_media_preload(element);
+
+    if loading.is_none()
+        && decoding.is_none()
+        && fetchpriority.is_none()
+        && blocking.is_none()
+        && preload.is_none()
+    {
+        return None;
+    }
+
+    let url = browser_loading_hint_url(element);
+    let resolved_url = url
+        .as_deref()
+        .and_then(|url| resolve_browser_url(url, base_href));
+
+    Some(BrowserLoadingHintDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        url,
+        resolved_url,
+        loading,
+        decoding,
+        fetchpriority,
+        blocking,
+        blocking_tokens: browser_blocking_tokens(element),
+        preload,
+        as_hint: element.attribute("as").map(ToOwned::to_owned),
+        media: element.attribute("media").map(ToOwned::to_owned),
+    })
+}
+
+fn browser_loading_hint_url(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "link" => element.attribute("href"),
+        "audio" | "frame" | "iframe" | "img" | "script" | "video" => element.attribute("src"),
+        _ => None,
+    }
+    .map(ToOwned::to_owned)
 }
 
 fn browser_browsing_context_csp(element: &Element) -> Option<String> {
@@ -18247,6 +18337,63 @@ mod tests {
         );
         assert_eq!(stylesheet_preload.fetchpriority.as_deref(), Some("high"));
         assert_eq!(stylesheet_preload.blocking.as_deref(), Some("render"));
+    }
+
+    #[test]
+    fn browser_loading_hint_descriptors_track_head_and_body_scheduling_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/\">\
+             <link rel=preload href=fonts/site.woff2 as=font fetchpriority=high blocking=render>\
+             <style id=critical blocking=render media=screen>body{color:black}</style>\
+             <script id=boot src=scripts/app.js fetchpriority=low blocking=render></script>\
+             <body><img id=hero src=hero.jpg loading=lazy decoding=async fetchpriority=high>\
+             <iframe id=frame src=frame.html loading=eager fetchpriority=low></iframe>\
+             <video id=movie src=movie.mp4 preload=metadata></video></body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.loading_hint_descriptors.len(), 6);
+
+        let preload = &summary.loading_hint_descriptors[0];
+        assert_eq!(preload.element, "link");
+        assert_eq!(preload.url.as_deref(), Some("fonts/site.woff2"));
+        assert_eq!(
+            preload.resolved_url.as_deref(),
+            Some("https://example.test/app/fonts/site.woff2")
+        );
+        assert_eq!(preload.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(preload.blocking.as_deref(), Some("render"));
+        assert_eq!(preload.blocking_tokens, vec!["render"]);
+        assert_eq!(preload.as_hint.as_deref(), Some("font"));
+
+        let style = &summary.loading_hint_descriptors[1];
+        assert_eq!(style.element, "style");
+        assert_eq!(style.id.as_deref(), Some("critical"));
+        assert_eq!(style.blocking.as_deref(), Some("render"));
+        assert_eq!(style.media.as_deref(), Some("screen"));
+
+        let script = &summary.loading_hint_descriptors[2];
+        assert_eq!(script.element, "script");
+        assert_eq!(script.id.as_deref(), Some("boot"));
+        assert_eq!(script.url.as_deref(), Some("scripts/app.js"));
+        assert_eq!(script.fetchpriority.as_deref(), Some("low"));
+        assert_eq!(script.blocking.as_deref(), Some("render"));
+
+        let image = &summary.loading_hint_descriptors[3];
+        assert_eq!(image.element, "img");
+        assert_eq!(image.loading.as_deref(), Some("lazy"));
+        assert_eq!(image.decoding.as_deref(), Some("async"));
+        assert_eq!(image.fetchpriority.as_deref(), Some("high"));
+
+        let frame = &summary.loading_hint_descriptors[4];
+        assert_eq!(frame.element, "iframe");
+        assert_eq!(frame.loading.as_deref(), Some("eager"));
+        assert_eq!(frame.fetchpriority.as_deref(), Some("low"));
+
+        let video = &summary.loading_hint_descriptors[5];
+        assert_eq!(video.element, "video");
+        assert_eq!(video.preload.as_deref(), Some("metadata"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -10,12 +10,12 @@ use coding_adventures_html_parser::{
     BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
     BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
     BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
-    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
-    BrowserThemeColor,
+    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaSource, BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective,
+    BrowserNavigationGroup, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
+    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -65,6 +65,8 @@ struct ExpectedBrowserDocument {
     scripts: Vec<ExpectedScript>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
+    #[serde(default)]
+    loading_hint_descriptors: Vec<ExpectedLoadingHintDescriptor>,
     anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
     #[serde(default)]
@@ -389,6 +391,33 @@ struct ExpectedAriaRelationDescriptor {
     aria_flowto: Vec<String>,
     #[serde(default)]
     flowto_text: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedLoadingHintDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    decoding: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
+    preload: Option<String>,
+    #[serde(default)]
+    as_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3484,6 +3513,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedStylesheet::into_browser_stylesheet)
                 .collect(),
+            loading_hint_descriptors: self
+                .loading_hint_descriptors
+                .into_iter()
+                .map(ExpectedLoadingHintDescriptor::into_browser_loading_hint_descriptor)
+                .collect(),
             anchors: self
                 .anchors
                 .into_iter()
@@ -3952,6 +3986,27 @@ impl ExpectedStylesheet {
             blocking: self.blocking,
             blocking_tokens,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedLoadingHintDescriptor {
+    fn into_browser_loading_hint_descriptor(self) -> BrowserLoadingHintDescriptor {
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
+        BrowserLoadingHintDescriptor {
+            element: self.element,
+            id: self.id,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            loading: self.loading,
+            decoding: self.decoding,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            blocking_tokens,
+            preload: self.preload,
+            as_hint: self.as_hint,
+            media: self.media,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -26,6 +26,8 @@ inert/hidden, editing, drag, spellcheck, translate, accesskey, autofocus, and
 related focus metadata.
 ARIA descriptor cases pin collection/range/live-region semantics plus details,
 error-message, and flow relationship target text.
+Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
+decoding, fetch priority, blocking, and media preload metadata.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -150,6 +150,9 @@
         ],
         "anchors": [],
         "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "img", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "loading": "lazy", "decoding": "async", "fetchpriority": "high" }
+        ],
         "links": [
           { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "attributionsrc": ["area-attr.html"], "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"], "hreflang": "en", "text": "Details" }
         ],
@@ -442,6 +445,11 @@
         ],
         "anchors": [],
         "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "link", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "fetchpriority": "high", "as_hint": "font" },
+          { "element": "link", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "blocking": "render", "blocking_tokens": ["render"] },
+          { "element": "link", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "fetchpriority": "high", "as_hint": "image" }
+        ],
         "links": [],
         "images": [],
         "forms": [],
@@ -506,6 +514,9 @@
         ],
         "anchors": [],
         "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "loading": "lazy", "fetchpriority": "high" }
+        ],
         "links": [],
         "images": [],
         "media": [
@@ -546,6 +557,10 @@
           { "id": "hero", "name": null, "text": "" }
         ],
         "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "video", "id": "hero", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "preload": "metadata" },
+          { "element": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "preload": "none" }
+        ],
         "links": [],
         "images": [],
         "media": [
@@ -667,6 +682,10 @@
         ],
         "anchors": [],
         "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "link", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"], "as_hint": null, "media": "screen" },
+          { "element": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "fetchpriority": "low", "blocking": "render", "blocking_tokens": ["render"] }
+        ],
         "links": [],
         "images": [],
         "forms": [],
@@ -1357,6 +1376,50 @@
         ],
         "links": [],
         "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
+      "id": "loading-hint-descriptor-page",
+      "description": "Browser document summaries expose image, frame, and media loading hints as a flat scheduling descriptor inventory.",
+      "input": "<base href=\"https://example.test/assets/\"><body><img id=hero src=hero.jpg alt=Hero loading=lazy decoding=async fetchpriority=high><iframe id=frame src=frame.html loading=eager fetchpriority=low title=Frame></iframe><video id=movie src=movie.mp4 preload=metadata></video><audio id=sound src=sound.ogg preload=none></audio></body>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/assets/",
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "image", "url": "hero.jpg", "resolved_url": "https://example.test/assets/hero.jpg", "rel": null, "type_hint": null, "media": null, "title": null, "fetchpriority": "high", "async_script": false, "defer_script": false },
+          { "kind": "frame", "url": "frame.html", "resolved_url": "https://example.test/assets/frame.html", "rel": null, "type_hint": null, "media": null, "title": "Frame", "fetchpriority": "low", "loading": "eager", "async_script": false, "defer_script": false },
+          { "kind": "video", "url": "movie.mp4", "resolved_url": "https://example.test/assets/movie.mp4", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false },
+          { "kind": "audio", "url": "sound.ogg", "resolved_url": "https://example.test/assets/sound.ogg", "rel": null, "type_hint": null, "media": null, "title": null, "async_script": false, "defer_script": false }
+        ],
+        "anchors": [
+          { "id": "hero", "name": null, "text": "" },
+          { "id": "frame", "name": null, "text": "" },
+          { "id": "movie", "name": null, "text": "" },
+          { "id": "sound", "name": null, "text": "" }
+        ],
+        "headings": [],
+        "loading_hint_descriptors": [
+          { "element": "img", "id": "hero", "url": "hero.jpg", "resolved_url": "https://example.test/assets/hero.jpg", "loading": "lazy", "decoding": "async", "fetchpriority": "high" },
+          { "element": "iframe", "id": "frame", "url": "frame.html", "resolved_url": "https://example.test/assets/frame.html", "loading": "eager", "fetchpriority": "low" },
+          { "element": "video", "id": "movie", "url": "movie.mp4", "resolved_url": "https://example.test/assets/movie.mp4", "preload": "metadata" },
+          { "element": "audio", "id": "sound", "url": "sound.ogg", "resolved_url": "https://example.test/assets/sound.ogg", "preload": "none" }
+        ],
+        "links": [],
+        "images": [
+          { "src": "hero.jpg", "resolved_src": "https://example.test/assets/hero.jpg", "alt": "Hero", "loading": "lazy", "decoding": "async", "fetchpriority": "high" }
+        ],
+        "media": [
+          { "kind": "video", "src": "movie.mp4", "resolved_src": "https://example.test/assets/movie.mp4", "preload": "metadata" },
+          { "kind": "audio", "src": "sound.ogg", "resolved_src": "https://example.test/assets/sound.ogg", "preload": "none" }
+        ],
+        "embedded_contexts": [
+          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/assets/frame.html", "title": "Frame", "loading": "eager", "fetchpriority": "low", "fallback_text": "" }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add flat browser loading hint descriptors for loading, decoding, fetch priority, blocking, and media preload scheduling hints
- wire descriptor fixture expectations into browser-readiness governance
- document the new loading-hint descriptor fixture coverage

## Verification
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_loading_hint_descriptors_track_head_and_body_scheduling_hints
- cargo test -p coding-adventures-html-parser browser_aria_relation_metadata_tracks_details_errors_and_flow
- cargo test -p coding-adventures-html-parser browser_shell_global_state_metadata_tracks_document_and_body_attributes
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_text_semantic_descriptor_metadata_tracks_inline_annotations
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser