### PR TITLE
Add smart-home scene read tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -27,3 +27,5 @@ All notable changes to this package will be documented in this file.
 - Added `smart_home.poll_events` and `smart_home.unsubscribe` handlers so Chief
   of Staff jobs can drain, peek, summarize, and retire runtime event
   subscriptions without bypassing D23 authorization.
+- Added `smart_home.list_scenes` and `smart_home.describe_scene` handlers over
+  the D23 runtime scene read facade, including Hue-style fixture coverage.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -26,6 +26,7 @@ Chief of Staff job/session/agent
   -> D18D smart_home.discover / smart_home.command tool calls
   -> smart-home runtime authorization
   -> discovery records and unpaired bridge candidates
+  -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
   -> device command acceptance
   -> optimistic state update
@@ -41,6 +42,8 @@ Chief of Staff job/session/agent
 - `smart_home.discover`
 - `smart_home.list_bridges`
 - `smart_home.list_devices`
+- `smart_home.list_scenes`
+- `smart_home.describe_scene`
 - `smart_home.get_state`
 - `smart_home.describe_capabilities`
 - `smart_home.get_health`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -17,8 +17,8 @@ use coding_adventures_json_value::{JsonNumber, JsonValue};
 use smart_home_core::{
     AgentId, Bridge, BridgeId, Capability, CapabilityId, CommandResult, CommandStatus, CommandType,
     Device, DeviceEvent, DeviceEventType, EntityId, EntityKind, Health, IntegrationId, Metadata,
-    PrivilegeTier, ProtocolFamily, RuntimeKind, StateConfidence, StateDelta, StateSnapshot,
-    StateSource, Value,
+    PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId,
+    SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
 };
 use smart_home_discovery::{DiscoveryRecord, DiscoverySource};
 use smart_home_integration_catalog::{
@@ -49,6 +49,8 @@ use std::rc::Rc;
 pub const SMART_HOME_LIST_BRIDGES_TOOL_ID: &str = "smart_home.list_bridges";
 pub const SMART_HOME_DISCOVER_TOOL_ID: &str = "smart_home.discover";
 pub const SMART_HOME_LIST_DEVICES_TOOL_ID: &str = "smart_home.list_devices";
+pub const SMART_HOME_LIST_SCENES_TOOL_ID: &str = "smart_home.list_scenes";
+pub const SMART_HOME_DESCRIBE_SCENE_TOOL_ID: &str = "smart_home.describe_scene";
 pub const SMART_HOME_GET_STATE_TOOL_ID: &str = "smart_home.get_state";
 pub const SMART_HOME_COMMAND_TOOL_ID: &str = "smart_home.command";
 pub const SMART_HOME_SUBSCRIBE_TOOL_ID: &str = "smart_home.subscribe";
@@ -149,6 +151,24 @@ impl SmartHomeToolBridge {
                         .execute_read_tool(principal_id, request, now_ms)
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "list_devices"))
+                }
+                SMART_HOME_LIST_SCENES_TOOL_ID => {
+                    let request = list_scenes_request(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(principal_id, request, now_ms)
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "list_scenes"))
+                }
+                SMART_HOME_DESCRIBE_SCENE_TOOL_ID => {
+                    let scene_id = SceneId::trusted(required_string(&arguments, "scene_id")?);
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::DescribeScene { scene_id },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "describe_scene"))
                 }
                 SMART_HOME_GET_STATE_TOOL_ID => {
                     let entity_id = required_string(&arguments, "entity_id")?;
@@ -465,6 +485,39 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
                 false,
             ),
             collection_output_schema("devices"),
+        ),
+        read_definition(
+            SMART_HOME_LIST_SCENES_TOOL_ID,
+            "List smart-home scenes",
+            "List normalized D23 smart-home scenes, optionally filtered by scope, target entity, or target capability.",
+            object_schema(
+                vec![
+                    SchemaProperty::new("scope", JsonSchema::String),
+                    SchemaProperty::new("entity_id", JsonSchema::String),
+                    SchemaProperty::new("capability_id", JsonSchema::String),
+                ],
+                vec![],
+                false,
+            ),
+            collection_output_schema("scenes"),
+        ),
+        read_definition(
+            SMART_HOME_DESCRIBE_SCENE_TOOL_ID,
+            "Describe smart-home scene",
+            "Read one normalized D23 smart-home scene and its target actions.",
+            object_schema(
+                vec![SchemaProperty::new("scene_id", JsonSchema::String)],
+                vec!["scene_id"],
+                false,
+            ),
+            object_schema(
+                vec![
+                    SchemaProperty::new("scene_id", JsonSchema::String),
+                    SchemaProperty::new("scene", JsonSchema::Any),
+                ],
+                vec!["scene_id", "scene"],
+                false,
+            ),
         ),
         read_definition(
             SMART_HOME_GET_STATE_TOOL_ID,
@@ -891,6 +944,16 @@ fn list_devices_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest,
     })
 }
 
+fn list_scenes_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest, ToolCallError> {
+    Ok(RuntimeReadToolRequest::ListScenes {
+        scope: optional_string(arguments, "scope")?
+            .map(|value| parse_scene_scope(&value))
+            .transpose()?,
+        entity_id: optional_string(arguments, "entity_id")?.map(EntityId::trusted),
+        capability_id: optional_string(arguments, "capability_id")?.map(CapabilityId::trusted),
+    })
+}
+
 fn command_request(arguments: &JsonValue) -> Result<RuntimeCommandToolRequest, ToolCallError> {
     let entity_id = EntityId::trusted(required_string(arguments, "entity_id")?);
     let command_type = parse_command_type(&required_string(arguments, "command_type")?)?;
@@ -1216,6 +1279,17 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
                 JsonValue::Array(devices.iter().map(device_json).collect()),
             ),
             ("count", integer(devices.len() as i64)),
+        ]),
+        RuntimeReadToolOutput::Scenes(scenes) => object([
+            (
+                "scenes",
+                JsonValue::Array(scenes.iter().map(scene_json).collect()),
+            ),
+            ("count", integer(scenes.len() as i64)),
+        ]),
+        RuntimeReadToolOutput::Scene { scene_id, scene } => object([
+            ("scene_id", string(scene_id.as_str())),
+            ("scene", scene_json(&scene)),
         ]),
         RuntimeReadToolOutput::State {
             entity_id,
@@ -2024,6 +2098,14 @@ fn metadata_json(metadata: &Metadata) -> JsonValue {
     ])
 }
 
+fn protocol_identifier_json(identifier: &ProtocolIdentifier) -> JsonValue {
+    object([
+        ("family", string(protocol_family_label(&identifier.family))),
+        ("kind", string(&identifier.kind)),
+        ("value", string(&identifier.value)),
+    ])
+}
+
 fn discovery_worker_snapshot_json(snapshot: &ScheduledDiscoveryWorkerSnapshot) -> JsonValue {
     object([
         ("worker_id", string(snapshot.worker_id.as_str())),
@@ -2134,6 +2216,37 @@ fn device_json(device: &Device) -> JsonValue {
                 .map(|value| string(value))
                 .unwrap_or(JsonValue::Null),
         ),
+    ])
+}
+
+fn scene_json(scene: &Scene) -> JsonValue {
+    object([
+        ("scene_id", string(scene.scene_id.as_str())),
+        ("scope", string(scene_scope_label(scene.scope))),
+        (
+            "native_ref",
+            scene
+                .native_ref
+                .as_ref()
+                .map(protocol_identifier_json)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "actions",
+            JsonValue::Array(scene.actions.iter().map(scene_action_json).collect()),
+        ),
+        ("action_count", integer(scene.actions.len() as i64)),
+        (
+            "metadata",
+            JsonValue::Array(scene.metadata.iter().map(metadata_json).collect()),
+        ),
+    ])
+}
+
+fn scene_action_json(action: &SceneAction) -> JsonValue {
+    object([
+        ("entity_id", string(action.entity_id.as_str())),
+        ("desired_state", smart_value_to_json(&action.desired_state)),
     ])
 }
 
@@ -2549,6 +2662,17 @@ fn parse_health(label: &str) -> Result<Health, ToolCallError> {
     }
 }
 
+fn parse_scene_scope(label: &str) -> Result<SceneScope, ToolCallError> {
+    match label {
+        "room" => Ok(SceneScope::Room),
+        "zone" => Ok(SceneScope::Zone),
+        "home" => Ok(SceneScope::Home),
+        "bridge" => Ok(SceneScope::Bridge),
+        "custom" => Ok(SceneScope::Custom),
+        _ => Err(validation_error(format!("unknown scene scope `{label}`"))),
+    }
+}
+
 fn parse_discovery_source(label: &str) -> Result<DiscoverySource, ToolCallError> {
     match label {
         "mdns" => Ok(DiscoverySource::Mdns),
@@ -2722,6 +2846,18 @@ fn parse_protocol_family(label: &str) -> Result<ProtocolFamily, ToolCallError> {
     }
 }
 
+fn protocol_family_label(family: &ProtocolFamily) -> String {
+    match family {
+        ProtocolFamily::Hue => "hue".to_string(),
+        ProtocolFamily::Zigbee => "zigbee".to_string(),
+        ProtocolFamily::ZWave => "zwave".to_string(),
+        ProtocolFamily::Thread => "thread".to_string(),
+        ProtocolFamily::Matter => "matter".to_string(),
+        ProtocolFamily::Mqtt => "mqtt".to_string(),
+        ProtocolFamily::Vendor(value) => format!("vendor:{value}"),
+    }
+}
+
 fn parse_integration_catalog_sort(label: &str) -> Result<IntegrationCatalogSort, ToolCallError> {
     match label {
         "priority_then_name" => Ok(IntegrationCatalogSort::PriorityThenName),
@@ -2808,6 +2944,16 @@ fn runtime_kind_label(kind: RuntimeKind) -> &'static str {
     match kind {
         RuntimeKind::InProcessRust => "in_process_rust",
         RuntimeKind::RustWorkerProcess => "rust_worker_process",
+    }
+}
+
+fn scene_scope_label(scope: SceneScope) -> &'static str {
+    match scope {
+        SceneScope::Room => "room",
+        SceneScope::Zone => "zone",
+        SceneScope::Home => "home",
+        SceneScope::Bridge => "bridge",
+        SceneScope::Custom => "custom",
     }
 }
 
@@ -3298,7 +3444,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 16);
+        assert_eq!(definitions.len(), 18);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -3313,6 +3459,10 @@ mod tests {
             .tool_ids()
             .contains(&SMART_HOME_DESCRIBE_PRIMITIVE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
+        assert!(export.tool_ids().contains(&SMART_HOME_LIST_SCENES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_DESCRIBE_SCENE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_COMMAND_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_PAIR_BRIDGE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_SUBSCRIBE_TOOL_ID));
@@ -3324,7 +3474,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            14
+            16
         );
         assert_eq!(
             export
@@ -3337,6 +3487,8 @@ mod tests {
             1
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_LIST_SCENES_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_DESCRIBE_SCENE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition("smart_home.unknown").is_none());
     }
 
@@ -3490,6 +3642,49 @@ mod tests {
         assert_eq!(
             field(list_trace.result.output.as_ref().unwrap(), "count"),
             Some(&integer(1))
+        );
+
+        let list_scenes_request = request(
+            "call-list-scenes",
+            SMART_HOME_LIST_SCENES_TOOL_ID,
+            object([
+                ("scope", string("room")),
+                ("capability_id", string("light.on_off")),
+            ]),
+            1_001,
+        );
+        let list_scenes_trace = tool_runtime.invoke_with_events(&list_scenes_request);
+        assert!(list_scenes_trace.result.ok);
+        let list_scenes_output = list_scenes_trace.result.output.as_ref().unwrap();
+        assert_eq!(field(list_scenes_output, "count"), Some(&integer(1)));
+        let scene_summary = array_item(field(list_scenes_output, "scenes").unwrap(), 0).unwrap();
+        assert_eq!(
+            field(scene_summary, "scene_id"),
+            Some(&string("scene-kitchen-bright"))
+        );
+        assert_eq!(field(scene_summary, "scope"), Some(&string("room")));
+
+        let describe_scene_request = request(
+            "call-describe-scene",
+            SMART_HOME_DESCRIBE_SCENE_TOOL_ID,
+            object([("scene_id", string("scene-kitchen-bright"))]),
+            1_002,
+        );
+        let describe_scene_trace = tool_runtime.invoke_with_events(&describe_scene_request);
+        assert!(describe_scene_trace.result.ok);
+        let describe_scene_output = describe_scene_trace.result.output.as_ref().unwrap();
+        let scene = field(describe_scene_output, "scene").unwrap();
+        assert_eq!(
+            field(describe_scene_output, "scene_id"),
+            Some(&string("scene-kitchen-bright"))
+        );
+        assert_eq!(field(scene, "action_count"), Some(&integer(1)));
+        assert_eq!(
+            field(
+                array_item(field(scene, "actions").unwrap(), 0).unwrap(),
+                "entity_id"
+            ),
+            Some(&string("entity-light-1"))
         );
 
         let discover_request = request(
@@ -3724,6 +3919,8 @@ mod tests {
         journal.record_trace(list_primitives_request, list_primitives_trace);
         journal.record_trace(describe_primitive_request, describe_primitive_trace);
         journal.record_trace(list_request, list_trace);
+        journal.record_trace(list_scenes_request, list_scenes_trace);
+        journal.record_trace(describe_scene_request, describe_scene_trace);
         journal.record_trace(discover_request, discover_trace);
         journal.record_trace(capabilities_request, capabilities_trace);
         journal.record_trace(health_request, health_trace);
@@ -3736,9 +3933,9 @@ mod tests {
         journal.record_trace(unsubscribe_request, unsubscribe_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 15);
-        assert_eq!(journal_summary.completed_count, 15);
-        assert_eq!(journal.audit_records().len(), 15);
+        assert_eq!(journal_summary.invocation_count, 17);
+        assert_eq!(journal_summary.completed_count, 17);
+        assert_eq!(journal.audit_records().len(), 17);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -3751,7 +3948,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            12,
+            14,
             "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this package will be documented in this file.
   describe-capabilities views over entity capability surfaces.
 - `IntegrationSurfaceSummary` and `IntegrationDescriptor::surface_summary()`
   for payload-free adapter capability, discovery, and pairing introspection.
+- `smart_home.list_scenes` and `smart_home.describe_scene` tool descriptors for
+  read-only scene inventory and detail surfaces.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -46,6 +46,7 @@ Current scope:
 - command risk tier helpers
 - state freshness helpers
 - D18D-style smart-home tool descriptors
+- D18D scene inventory/read tool descriptors for model-facing scene lookup
 - D18D event lifecycle tool descriptors for subscribing, polling, and
   unsubscribing from runtime event streams
 - compact smart-home tool catalog summaries for read-side inspection

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1449,6 +1449,8 @@ pub enum SmartHomeTool {
     PairBridge,
     ListBridges,
     ListDevices,
+    ListScenes,
+    DescribeScene,
     GetState,
     Command,
     Subscribe,
@@ -1476,6 +1478,8 @@ impl SmartHomeTool {
             },
             Self::ListBridges => read_tool("smart_home.list_bridges"),
             Self::ListDevices => read_tool("smart_home.list_devices"),
+            Self::ListScenes => read_tool("smart_home.list_scenes"),
+            Self::DescribeScene => read_tool("smart_home.describe_scene"),
             Self::GetState => read_tool("smart_home.get_state"),
             Self::Command => ToolDescriptor {
                 tool_id: "smart_home.command",
@@ -1930,6 +1934,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::PairBridge,
         SmartHomeTool::ListBridges,
         SmartHomeTool::ListDevices,
+        SmartHomeTool::ListScenes,
+        SmartHomeTool::DescribeScene,
         SmartHomeTool::GetState,
         SmartHomeTool::Command,
         SmartHomeTool::Subscribe,
@@ -2733,7 +2739,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 12);
+        assert_eq!(catalog.len(), 14);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2742,6 +2748,16 @@ mod tests {
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.observe_supervision"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_scenes"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.describe_scene"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -2761,15 +2777,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 12);
-        assert_eq!(summary.read_tools, 10);
+        assert_eq!(summary.total_tools, 14);
+        assert_eq!(summary.read_tools, 12);
         assert_eq!(summary.write_tools, 0);
         assert_eq!(summary.external_tools, 2);
-        assert_eq!(summary.read_only_tier_tools, 10);
+        assert_eq!(summary.read_only_tier_tools, 12);
         assert_eq!(summary.low_risk_tier_tools, 1);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 12);
+        assert_eq!(summary.total_required_capabilities, 14);
         assert_eq!(summary.risky_tool_count(), 2);
         assert_eq!(summary.approval_gated_tool_count(), 1);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this package will be documented in this file.
   due-work counts over non-mutating supervision plans.
 - `SupervisionTickSummary` plus tick-report helpers for compact actual-work
   counts after supervision ticks mutate runtime state.
+- `RuntimeReadToolRequest::ListScenes` and
+  `RuntimeReadToolRequest::DescribeScene` for authorized D18D reads over the
+  registry-backed scene inventory.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -62,9 +62,9 @@ Included surfaces:
 - registry-backed authorization decision auditing for accepted and rejected
   authorized commands
 - registry-backed tool authorization decisions for Chief of Staff tool calls
-- D18D-facing read tool facade for listing bridges/devices, reading entity
-  state, describing capabilities, inspecting bridge health, and observing
-  supervision status without invoking integrations
+- D18D-facing read tool facade for listing bridges/devices/scenes, describing
+  scenes, reading entity state, describing capabilities, inspecting bridge
+  health, and observing supervision status without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and
   registers filtered replay subscriptions with checkpoints
 - D18D-facing poll and unsubscribe tool facades that authorize event-stream

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -11,9 +11,9 @@ use smart_home_core::{
     tier_for_command, AgentId, AuthorizationDecision, Bridge, BridgeId, Capability,
     CapabilityGrant, CapabilityGrantScope, CapabilityId, CapabilityMode, CommandId, CommandResult,
     CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType,
-    DeviceId, Entity, EntityId, EventId, Health, IntegrationId, Metadata, PrivilegeTier,
-    SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
-    VaultRef,
+    DeviceId, Entity, EntityId, EventId, Health, IntegrationId, Metadata, PrivilegeTier, Scene,
+    SceneId, SceneScope, SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot,
+    StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError, DiscoveryRecord,
@@ -38,6 +38,7 @@ pub enum RuntimeError {
     UnknownBridge(BridgeId),
     UnknownDevice(DeviceId),
     UnknownEntity(EntityId),
+    UnknownScene(SceneId),
     UnknownPairingSession(RuntimePairingSessionId),
     UnknownSubscription(RuntimeSubscriptionId),
     UnknownDiscoveryWorker(DiscoveryWorkerId),
@@ -98,6 +99,7 @@ impl fmt::Display for RuntimeError {
             Self::UnknownBridge(id) => write!(f, "unknown runtime bridge {id}"),
             Self::UnknownDevice(id) => write!(f, "unknown runtime device {id}"),
             Self::UnknownEntity(id) => write!(f, "unknown runtime entity {id}"),
+            Self::UnknownScene(id) => write!(f, "unknown runtime scene {id}"),
             Self::UnknownPairingSession(id) => write!(f, "unknown runtime pairing session {id}"),
             Self::UnknownSubscription(id) => write!(f, "unknown runtime subscription {id}"),
             Self::UnknownDiscoveryWorker(id) => write!(f, "unknown discovery worker {id}"),
@@ -3182,6 +3184,14 @@ pub enum RuntimeReadToolRequest {
         health: Option<Health>,
         capability_id: Option<CapabilityId>,
     },
+    ListScenes {
+        scope: Option<SceneScope>,
+        entity_id: Option<EntityId>,
+        capability_id: Option<CapabilityId>,
+    },
+    DescribeScene {
+        scene_id: SceneId,
+    },
     GetState {
         entity_id: EntityId,
     },
@@ -3199,6 +3209,8 @@ impl RuntimeReadToolRequest {
         match self {
             Self::ListBridges => SmartHomeTool::ListBridges,
             Self::ListDevices { .. } => SmartHomeTool::ListDevices,
+            Self::ListScenes { .. } => SmartHomeTool::ListScenes,
+            Self::DescribeScene { .. } => SmartHomeTool::DescribeScene,
             Self::GetState { .. } => SmartHomeTool::GetState,
             Self::DescribeCapabilities { .. } => SmartHomeTool::DescribeCapabilities,
             Self::GetHealth { .. } => SmartHomeTool::GetHealth,
@@ -3378,6 +3390,11 @@ impl BridgeHealthSnapshot {
 pub enum RuntimeReadToolOutput {
     Bridges(Vec<Bridge>),
     Devices(Vec<Device>),
+    Scenes(Vec<Scene>),
+    Scene {
+        scene_id: SceneId,
+        scene: Scene,
+    },
     State {
         entity_id: EntityId,
         snapshot: Option<StateSnapshot>,
@@ -3669,6 +3686,10 @@ impl SmartHomeRuntime {
 
     pub fn upsert_entity(&mut self, entity: Entity) -> Result<Option<Entity>, RuntimeError> {
         self.registry.upsert_entity(entity).map_err(Into::into)
+    }
+
+    pub fn upsert_scene(&mut self, scene: Scene) -> Result<Option<Scene>, RuntimeError> {
+        self.registry.upsert_scene(scene).map_err(Into::into)
     }
 
     pub fn record_discovery(
@@ -4189,6 +4210,35 @@ impl SmartHomeRuntime {
                         .collect(),
                 ))
             }
+            RuntimeReadToolRequest::ListScenes {
+                scope,
+                entity_id,
+                capability_id,
+            } => Ok(RuntimeReadToolOutput::Scenes(
+                self.registry
+                    .scenes()
+                    .filter(|scene| scope.is_none_or(|scope| scene.scope == scope))
+                    .filter(|scene| {
+                        entity_id
+                            .as_ref()
+                            .is_none_or(|entity_id| scene_has_action_for_entity(scene, entity_id))
+                    })
+                    .filter(|scene| {
+                        capability_id.as_ref().is_none_or(|capability_id| {
+                            scene_has_action_for_capability(&self.registry, scene, capability_id)
+                        })
+                    })
+                    .cloned()
+                    .collect(),
+            )),
+            RuntimeReadToolRequest::DescribeScene { scene_id } => {
+                let scene = self
+                    .registry
+                    .scene(&scene_id)
+                    .ok_or_else(|| RuntimeError::UnknownScene(scene_id.clone()))?
+                    .clone();
+                Ok(RuntimeReadToolOutput::Scene { scene_id, scene })
+            }
             RuntimeReadToolRequest::GetState { entity_id } => {
                 if self.registry.entity(&entity_id).is_none() {
                     return Err(RuntimeError::UnknownEntity(entity_id));
@@ -4695,6 +4745,28 @@ pub fn health_name(health: Health) -> &'static str {
         Health::Unsupported => "unsupported",
         Health::Removed => "removed",
     }
+}
+
+fn scene_has_action_for_entity(scene: &Scene, entity_id: &EntityId) -> bool {
+    scene
+        .actions
+        .iter()
+        .any(|action| &action.entity_id == entity_id)
+}
+
+fn scene_has_action_for_capability(
+    registry: &InMemorySmartHomeRegistry,
+    scene: &Scene,
+    capability_id: &CapabilityId,
+) -> bool {
+    scene.actions.iter().any(|action| {
+        registry.entity(&action.entity_id).is_some_and(|entity| {
+            entity
+                .capabilities
+                .iter()
+                .any(|capability| &capability.capability_id == capability_id)
+        })
+    })
 }
 
 fn validate_command_capabilities(
@@ -7544,6 +7616,18 @@ mod tests {
                 confidence: StateConfidence::Confirmed,
             })
             .unwrap();
+        runtime
+            .upsert_scene(Scene {
+                scene_id: SceneId::trusted("scene-1"),
+                scope: SceneScope::Room,
+                native_ref: None,
+                actions: vec![smart_home_core::SceneAction {
+                    entity_id: EntityId::trusted("entity-1"),
+                    desired_state: Value::Bool(true),
+                }],
+                metadata: vec![Metadata::new("fixture", "runtime_read_tool_scene")],
+            })
+            .unwrap();
 
         let bridges = runtime
             .execute_read_tool(
@@ -7563,13 +7647,33 @@ mod tests {
                 1_501,
             )
             .unwrap();
+        let scenes = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::ListScenes {
+                    scope: Some(SceneScope::Room),
+                    entity_id: Some(EntityId::trusted("entity-1")),
+                    capability_id: Some(CapabilityId::trusted("light.on_off")),
+                },
+                1_502,
+            )
+            .unwrap();
+        let scene = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::DescribeScene {
+                    scene_id: SceneId::trusted("scene-1"),
+                },
+                1_503,
+            )
+            .unwrap();
         let state = runtime
             .execute_read_tool(
                 principal.clone(),
                 RuntimeReadToolRequest::GetState {
                     entity_id: EntityId::trusted("entity-1"),
                 },
-                1_502,
+                1_504,
             )
             .unwrap();
         let capabilities = runtime
@@ -7578,7 +7682,7 @@ mod tests {
                 RuntimeReadToolRequest::DescribeCapabilities {
                     entity_id: EntityId::trusted("entity-1"),
                 },
-                1_503,
+                1_505,
             )
             .unwrap();
         let health = runtime
@@ -7587,11 +7691,11 @@ mod tests {
                 RuntimeReadToolRequest::GetHealth {
                     bridge_id: Some(BridgeId::trusted("bridge-1")),
                 },
-                1_504,
+                1_506,
             )
             .unwrap();
         let observation = runtime
-            .execute_read_tool(principal, RuntimeReadToolRequest::ObserveSupervision, 1_505)
+            .execute_read_tool(principal, RuntimeReadToolRequest::ObserveSupervision, 1_507)
             .unwrap();
 
         assert!(matches!(
@@ -7603,6 +7707,19 @@ mod tests {
             devices,
             RuntimeReadToolOutput::Devices(devices) if devices.len() == 1
                 && devices[0].device_id == DeviceId::trusted("device-1")
+        ));
+        assert!(matches!(
+            scenes,
+            RuntimeReadToolOutput::Scenes(scenes) if scenes.len() == 1
+                && scenes[0].scene_id == SceneId::trusted("scene-1")
+        ));
+        assert!(matches!(
+            scene,
+            RuntimeReadToolOutput::Scene {
+                scene_id,
+                scene,
+            } if scene_id == SceneId::trusted("scene-1")
+                && scene.actions.len() == 1
         ));
         assert!(matches!(
             state,
@@ -7632,12 +7749,12 @@ mod tests {
         assert!(matches!(
             observation,
             RuntimeReadToolOutput::SupervisionObservation(observation)
-                if observation.generated_at_ms == 1_505
+                if observation.generated_at_ms == 1_507
                     && observation.worker_restart_count() == 1
                     && observation.due_worker_deadline_count() == 1
                     && observation.next_worker_heartbeat_due_at_ms() == Some(1_100)
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 6);
+        assert_eq!(runtime.registry().counts().authorization_decisions, 8);
         assert!(runtime
             .registry()
             .authorization_decisions()

--- a/code/packages/rust/smart-home-testkit/CHANGELOG.md
+++ b/code/packages/rust/smart-home-testkit/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this package will be documented in this file.
 - A Hue pairing fixture path that matches the application registration HTTP
   plan, parses the scripted Hue response, simulates Vault storage, and completes
   the runtime pairing session without raw secret values in audit metadata.
+- A normalized Hue-style room scene fixture seeded into registry and runtime
+  helpers for scene inventory/read tests.
 
 ## [0.1.0] - 2026-05-08
 

--- a/code/packages/rust/smart-home-testkit/README.md
+++ b/code/packages/rust/smart-home-testkit/README.md
@@ -7,7 +7,7 @@ This crate does not open sockets, touch radios, read files, or call cloud APIs.
 It gives future Hue, MQTT, Zigbee, Z-Wave, Thread, Matter, and runtime packages
 a shared way to build:
 
-- normalized bridge/device/entity fixtures
+- normalized bridge/device/entity/scene fixtures
 - normalized Hue discovery records, built through `hue-core` mDNS mapping, and
   discovery-seeded runtime fixtures
 - deterministic Hue mDNS scan, scan-report, and discovery worker-run fixtures

--- a/code/packages/rust/smart-home-testkit/src/lib.rs
+++ b/code/packages/rust/smart-home-testkit/src/lib.rs
@@ -14,8 +14,8 @@ use smart_home_core::{
     Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId, CommandResult,
     CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType,
     DeviceId, Entity, EntityId, EntityKind, EventId, Health, IntegrationId, Metadata,
-    ProtocolFamily, ProtocolIdentifier, StateConfidence, StateDelta, StateSnapshot, StateSource,
-    Value,
+    ProtocolFamily, ProtocolIdentifier, Scene, SceneAction, SceneId, SceneScope, StateConfidence,
+    StateDelta, StateSnapshot, StateSource, Value,
 };
 use smart_home_discovery::{
     DiscoveryError, DiscoveryRecord, DiscoverySource, DiscoveryWorkerId, DiscoveryWorkerKind,
@@ -65,6 +65,7 @@ pub struct SmartHomeFixture {
     pub device: Device,
     pub light: Entity,
     pub sensor: Entity,
+    pub scene: Scene,
 }
 
 impl SmartHomeFixture {
@@ -73,17 +74,23 @@ impl SmartHomeFixture {
         let device = hue_device("device-1", &bridge.bridge_id, "device-native-1");
         let light = light_entity("entity-light-1", &device.device_id);
         let sensor = occupancy_sensor_entity("entity-sensor-1", &device.device_id);
+        let scene = room_scene("scene-kitchen-bright", &light.entity_id);
 
         Self {
             bridge,
             device,
             light,
             sensor,
+            scene,
         }
     }
 
     pub fn entities(&self) -> [&Entity; 2] {
         [&self.light, &self.sensor]
+    }
+
+    pub fn scenes(&self) -> [&Scene; 1] {
+        [&self.scene]
     }
 
     pub fn install_in_registry(
@@ -1201,6 +1208,25 @@ pub fn occupancy_sensor_entity(id: &'static str, device_id: &DeviceId) -> Entity
     }
 }
 
+pub fn room_scene(id: &'static str, entity_id: &EntityId) -> Scene {
+    Scene {
+        scene_id: SceneId::trusted(id),
+        scope: SceneScope::Room,
+        native_ref: Some(protocol_id(ProtocolFamily::Hue, "scene", id)),
+        actions: vec![SceneAction {
+            entity_id: entity_id.clone(),
+            desired_state: Value::Object(vec![
+                ("light.on_off".to_string(), Value::Bool(true)),
+                ("light.brightness".to_string(), Value::Percentage(80)),
+            ]),
+        }],
+        metadata: vec![
+            Metadata::new("fixture", "room_scene"),
+            Metadata::new("fixture.room_id", "kitchen"),
+        ],
+    }
+}
+
 pub fn turn_on_command(
     command_id: &'static str,
     entity_id: &EntityId,
@@ -1357,6 +1383,9 @@ pub fn install_fixture_in_registry(
     for entity in fixture.entities() {
         registry.upsert_entity(entity.clone())?;
     }
+    for scene in fixture.scenes() {
+        registry.upsert_scene(scene.clone())?;
+    }
     Ok(())
 }
 
@@ -1380,6 +1409,9 @@ pub fn runtime_with_fixture(fixture: &SmartHomeFixture) -> Result<SmartHomeRunti
     runtime.upsert_device(fixture.device.clone())?;
     for entity in fixture.entities() {
         runtime.upsert_entity(entity.clone())?;
+    }
+    for scene in fixture.scenes() {
+        runtime.upsert_scene(scene.clone())?;
     }
     Ok(runtime)
 }
@@ -1812,7 +1844,7 @@ mod tests {
         assert_eq!(registry.counts().bridges, 1);
         assert_eq!(registry.counts().devices, 1);
         assert_eq!(registry.counts().entities, 2);
-        assert_eq!(registry.counts().protocol_identifiers, 2);
+        assert_eq!(registry.counts().protocol_identifiers, 3);
         assert_eq!(
             registry
                 .bridge(&fixture.bridge.bridge_id)


### PR DESCRIPTION
## Summary
- add shared smart-home tool descriptors for scene inventory and scene detail reads
- expose registry-backed scene reads through smart-home-runtime with scope/entity/capability filtering
- add Chief D18D handlers plus Hue-style fixture coverage for list/describe scene flows

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools