### PR TITLE
Add tanh power integration parity

### DIFF
--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -4369,7 +4369,7 @@ fn try_recip_hyp_power(base: &IRNode, exponent: &IRNode, x: &str) -> Option<IRNo
     let IRNode::Symbol(head) = &apply.head else {
         return None;
     };
-    if !matches!(head.as_str(), SECH | CSCH | COTH) || apply.args.len() != 1 {
+    if !matches!(head.as_str(), SECH | CSCH | COTH | TANH) || apply.args.len() != 1 {
         return None;
     }
     let n = match to_numeric(exponent) {
@@ -4386,6 +4386,7 @@ fn try_recip_hyp_power(base: &IRNode, exponent: &IRNode, x: &str) -> Option<IRNo
         SECH => sech_power_integral(n, arg_ir, a, x),
         CSCH => csch_power_integral(n, arg_ir, a, x),
         COTH => coth_power_integral(n, arg_ir, a, x),
+        TANH => tanh_power_integral(n, arg_ir, a, x),
         _ => None,
     }
 }
@@ -4507,6 +4508,31 @@ fn coth_power_integral(n: usize, arg_ir: &IRNode, a: RatC, x: &str) -> Option<IR
     Some(apply_node(
         SUB,
         vec![coth_power_integral(n - 2, arg_ir, a, x)?, power_term],
+    ))
+}
+
+fn tanh_power_integral(n: usize, arg_ir: &IRNode, a: RatC, x: &str) -> Option<IRNode> {
+    if n == 0 {
+        return Some(IRNode::Symbol(x.to_string()));
+    }
+    if n == 1 {
+        return Some(apply_node(
+            MUL,
+            vec![
+                rc_to_ir(rc_div(RC_ONE, a)?)?,
+                apply_node(LOG, vec![apply_node(COSH, vec![arg_ir.clone()])]),
+            ],
+        ));
+    }
+
+    let tanh_pow = pow_if_needed(apply_node(TANH, vec![arg_ir.clone()]), n - 1);
+    let power_term = apply_node(
+        MUL,
+        vec![recip_hyp_coeff(1, (n - 1) as i128, a)?, tanh_pow],
+    );
+    Some(apply_node(
+        SUB,
+        vec![tanh_power_integral(n - 2, arg_ir, a, x)?, power_term],
     ))
 }
 

--- a/code/packages/rust/symbolic-vm/tests/test_vm.rs
+++ b/code/packages/rust/symbolic-vm/tests/test_vm.rs
@@ -2018,6 +2018,42 @@ fn phase16_nonlinear_sech_power_falls_through() {
     assert!(is_unevaluated_integrate(&result), "sech^2(x^2) should remain deferred; got {result:?}");
 }
 
+#[test]
+fn phase17_tanh_powers_derivative_match() {
+    for power in [2_i64, 3, 4] {
+        let integrand = apply(sym(POW), vec![apply(sym(TANH), vec![sym("x")]), int(power)]);
+        let phi = integrate(integrand);
+        assert!(!is_unevaluated_integrate(&phi), "Phase 17 should close tanh^{power}(x); got {phi:?}");
+        for &x_val in &[-0.4_f64, 0.2, 0.8] {
+            let got = phase34_numerical_derivative(&phi, x_val);
+            let expected = x_val.tanh().powi(power as i32);
+            assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+        }
+    }
+}
+
+#[test]
+fn phase17_tanh_squared_linear_derivative_matches() {
+    let arg = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), sym("x")]), int(1)]);
+    let integrand = apply(sym(POW), vec![apply(sym(TANH), vec![arg]), int(2)]);
+    let phi = integrate(integrand);
+    assert!(!is_unevaluated_integrate(&phi), "Phase 17 should close tanh^2(2x+1); got {phi:?}");
+    assert!(contains_head(&phi, TANH), "expected Tanh term in {phi:?}");
+    for &x_val in &[-0.4_f64, 0.1, 0.5] {
+        let got = phase34_numerical_derivative(&phi, x_val);
+        let expected = (2.0 * x_val + 1.0).tanh().powi(2);
+        assert!((got - expected).abs() < 1e-4, "x={x_val}: got={got}, expected={expected}");
+    }
+}
+
+#[test]
+fn phase17_nonlinear_tanh_power_falls_through() {
+    let nonlinear_arg = apply(sym(POW), vec![sym("x"), int(2)]);
+    let integrand = apply(sym(POW), vec![apply(sym(TANH), vec![nonlinear_arg]), int(2)]);
+    let result = integrate(integrand);
+    assert!(is_unevaluated_integrate(&result), "tanh^2(x^2) should remain deferred; got {result:?}");
+}
+
 // ---------------------------------------------------------------------------
 // Phase 29: Abs and Sqrt algebraic rules
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -5352,7 +5352,9 @@ function tryRecipHypLinear(transcendental: IRNode, x: IRNode): IRNode | undefine
 
 function tryRecipHypPower(base: IRNode, exponent: IRNode, x: IRNode): IRNode | undefined {
   if (base.kind !== "apply" || base.args.length !== 1) return undefined;
-  if (!equals(base.head, SECH) && !equals(base.head, CSCH) && !equals(base.head, COTH)) return undefined;
+  if (!equals(base.head, SECH) && !equals(base.head, CSCH) && !equals(base.head, COTH) && !equals(base.head, TANH)) {
+    return undefined;
+  }
   const nRat = exactRational(exponent);
   if (nRat === undefined || nRat.denom !== 1n || nRat.numer < 0n || nRat.numer > BigInt(Number.MAX_SAFE_INTEGER)) {
     return undefined;
@@ -5365,6 +5367,7 @@ function tryRecipHypPower(base: IRNode, exponent: IRNode, x: IRNode): IRNode | u
   const n = Number(nRat.numer);
   if (equals(base.head, SECH)) return sechPowerIntegral(n, arg, linear.a, x);
   if (equals(base.head, CSCH)) return cschPowerIntegral(n, arg, linear.a, x);
+  if (equals(base.head, TANH)) return tanhPowerIntegral(n, arg, linear.a, x);
   return cothPowerIntegral(n, arg, linear.a, x);
 }
 
@@ -5423,6 +5426,15 @@ function cothPowerIntegral(n: number, arg: IRNode, a: RatCoeff, x: IRNode): IRNo
   const cothPow = powIfNeeded(app(COTH, [arg]), n - 1);
   const powerTerm = app(MUL, [recipHypCoeff(1n, BigInt(n - 1), a), cothPow]);
   return app(SUB, [cothPowerIntegral(n - 2, arg, a, x), powerTerm]);
+}
+
+function tanhPowerIntegral(n: number, arg: IRNode, a: RatCoeff, x: IRNode): IRNode {
+  if (n === 0) return x;
+  if (n === 1) return app(MUL, [rcToIR(rcDiv(RC_ONE, a)), app(LOG, [app(COSH, [arg])])]);
+
+  const tanhPow = powIfNeeded(app(TANH, [arg]), n - 1);
+  const powerTerm = app(MUL, [recipHypCoeff(1n, BigInt(n - 1), a), tanhPow]);
+  return app(SUB, [tanhPowerIntegral(n - 2, arg, a, x), powerTerm]);
 }
 
 function sqrtTPlusOneDecompose(Q_tilde: RatPoly): [RatPoly, RatPoly] {

--- a/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/symbolic-vm.test.ts
@@ -1436,6 +1436,42 @@ describe("symbolic-vm", () => {
     const result = vm.eval(app(INTEGRATE, [integrand, x]));
     expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
   });
+
+  it("Phase 17: integrates tanh powers through identity reduction", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    for (const power of [2, 3, 4]) {
+      const integrand = app(POW, [app(TANH, [x]), int(power)]);
+      const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+      expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+      for (const xVal of [-0.4, 0.2, 0.8]) {
+        const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+        expect(Math.abs(got - Math.tanh(xVal) ** power)).toBeLessThan(1e-5);
+      }
+    }
+  });
+
+  it("Phase 17: integrates tanh^2(2x+1) with the chain-rule factor", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const arg = app(ADD, [app(MUL, [int(2), x]), int(1)]);
+    const integrand = app(POW, [app(TANH, [arg]), int(2)]);
+    const antideriv = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Integrate")).toBe(false);
+    expect(containsHeadName(antideriv as unknown as ReturnType<typeof sym>, "Tanh")).toBe(true);
+    for (const xVal of [-0.4, 0.1, 0.5]) {
+      const got = numericalDerivative28(antideriv as unknown as ReturnType<typeof sym>, xVal);
+      expect(Math.abs(got - Math.tanh(2 * xVal + 1) ** 2)).toBeLessThan(1e-5);
+    }
+  });
+
+  it("Phase 17: leaves tanh^2(x^2) deferred", () => {
+    const vm = new VM(new SymbolicBackend());
+    const x = sym("x");
+    const integrand = app(POW, [app(TANH, [app(POW, [x, int(2)])]), int(2)]);
+    const result = vm.eval(app(INTEGRATE, [integrand, x]));
+    expect(containsHeadName(result as unknown as ReturnType<typeof sym>, "Integrate")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add TypeScript Phase 17 integration for `tanh^n(ax+b)` with nonnegative integer powers and linear arguments.
- Add Rust parity for the same identity reduction recurrence: `I_n = I_{n-2} - tanh^(n-1)/((n-1)a)`.
- Add derivative-based coverage for base/linear power cases and non-linear argument fallthrough guards.

## Local verification
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\typescript\bin\tsc --noEmit`
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe .\node_modules\vitest\vitest.mjs run`
- `C:\Users\adhit\.cargo\bin\cargo.exe test --manifest-path code\packages\rust\symbolic-vm\Cargo.toml`
- `C:\Users\adhit\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest --no-cov code\packages\python\symbolic-vm\tests\test_phase17.py`
- `git diff --check`