### PR TITLE
Track browser fetch policy descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness fetch-policy descriptors now expose subresource integrity,
+  CORS, nonce, referrer policy, iframe CSP/sandbox/permissions, fullscreen, and
+  credentialless metadata as a flat browser-planning inventory.
 - Browser-readiness loading-hint descriptors now expose lazy/eager loading,
   decoding, fetch priority, blocking, and media preload scheduling metadata.
 - Browser-readiness ARIA relation descriptors now expose details, error-message,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -833,6 +833,7 @@ pub struct BrowserDocument {
     pub scripts: Vec<BrowserScript>,
     pub stylesheets: Vec<BrowserStylesheet>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
+    pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
@@ -1035,6 +1036,23 @@ pub struct BrowserLoadingHintDescriptor {
     pub preload: Option<String>,
     pub as_hint: Option<String>,
     pub media: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFetchPolicyDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub url: Option<String>,
+    pub resolved_url: Option<String>,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub nonce: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub csp: Option<String>,
+    pub sandbox: Vec<String>,
+    pub allow: Option<String>,
+    pub allowfullscreen: bool,
+    pub credentialless: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9615,6 +9633,11 @@ fn collect_browser_facts(
         {
             summary.loading_hint_descriptors.push(descriptor);
         }
+        if let Some(descriptor) =
+            browser_fetch_policy_descriptor(element, summary.base_href.as_deref())
+        {
+            summary.fetch_policy_descriptors.push(descriptor);
+        }
         if let Some(context) = browser_embedded_context(element, summary.base_href.as_deref()) {
             summary.embedded_contexts.push(context);
         }
@@ -9778,6 +9801,11 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             browser_loading_hint_descriptor(element, summary.base_href.as_deref())
         {
             summary.loading_hint_descriptors.push(descriptor);
+        }
+        if let Some(descriptor) =
+            browser_fetch_policy_descriptor(element, summary.base_href.as_deref())
+        {
+            summary.fetch_policy_descriptors.push(descriptor);
         }
 
         match element.name.as_str() {
@@ -12346,6 +12374,80 @@ fn browser_loading_hint_descriptor(
 fn browser_loading_hint_url(element: &Element) -> Option<String> {
     match element.name.as_str() {
         "link" => element.attribute("href"),
+        "audio" | "frame" | "iframe" | "img" | "script" | "video" => element.attribute("src"),
+        _ => None,
+    }
+    .map(ToOwned::to_owned)
+}
+
+fn browser_fetch_policy_descriptor(
+    element: &Element,
+    base_href: Option<&str>,
+) -> Option<BrowserFetchPolicyDescriptor> {
+    let integrity = match element.name.as_str() {
+        "link" | "script" => element.attribute("integrity").map(ToOwned::to_owned),
+        _ => None,
+    };
+    let crossorigin = match element.name.as_str() {
+        "audio" | "img" | "link" | "script" | "video" => {
+            element.attribute("crossorigin").map(ToOwned::to_owned)
+        }
+        _ => None,
+    };
+    let nonce = match element.name.as_str() {
+        "link" | "script" | "style" => element.attribute("nonce").map(ToOwned::to_owned),
+        _ => None,
+    };
+    let referrerpolicy = match element.name.as_str() {
+        "a" | "area" | "iframe" | "img" | "link" | "script" => {
+            element.attribute("referrerpolicy").map(ToOwned::to_owned)
+        }
+        _ => None,
+    };
+    let csp = browser_browsing_context_csp(element);
+    let sandbox = browser_browsing_context_sandbox(element);
+    let allow = browser_browsing_context_allow(element);
+    let allowfullscreen = browser_browsing_context_allowfullscreen(element);
+    let credentialless = browser_browsing_context_credentialless(element);
+
+    if integrity.is_none()
+        && crossorigin.is_none()
+        && nonce.is_none()
+        && referrerpolicy.is_none()
+        && csp.is_none()
+        && sandbox.is_empty()
+        && allow.is_none()
+        && !allowfullscreen
+        && !credentialless
+    {
+        return None;
+    }
+
+    let url = browser_policy_url(element);
+    let resolved_url = url
+        .as_deref()
+        .and_then(|url| resolve_browser_url(url, base_href));
+
+    Some(BrowserFetchPolicyDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        url,
+        resolved_url,
+        integrity,
+        crossorigin,
+        nonce,
+        referrerpolicy,
+        csp,
+        sandbox,
+        allow,
+        allowfullscreen,
+        credentialless,
+    })
+}
+
+fn browser_policy_url(element: &Element) -> Option<String> {
+    match element.name.as_str() {
+        "a" | "area" | "link" => element.attribute("href"),
         "audio" | "frame" | "iframe" | "img" | "script" | "video" => element.attribute("src"),
         _ => None,
     }
@@ -18394,6 +18496,73 @@ mod tests {
         let video = &summary.loading_hint_descriptors[5];
         assert_eq!(video.element, "video");
         assert_eq!(video.preload.as_deref(), Some("metadata"));
+    }
+
+    #[test]
+    fn browser_fetch_policy_descriptors_track_security_and_policy_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/\">\
+             <link id=font rel=preload href=fonts/site.woff2 as=font integrity=sha384-font crossorigin=anonymous referrerpolicy=no-referrer nonce=fontNonce>\
+             <style id=critical nonce=styleNonce>body{color:black}</style>\
+             <script id=boot src=scripts/app.js integrity=sha384-js crossorigin=use-credentials referrerpolicy=origin nonce=scriptNonce></script>\
+             <body>\
+               <img id=hero src=hero.jpg crossorigin=anonymous referrerpolicy=no-referrer>\
+               <iframe id=frame src=frame.html csp=\"script-src 'self'\" sandbox=\"allow-scripts allow-same-origin\" allow=\"fullscreen; geolocation\" allowfullscreen referrerpolicy=no-referrer credentialless></iframe>\
+               <video id=movie src=movie.mp4 crossorigin=anonymous></video>\
+             </body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.fetch_policy_descriptors.len(), 6);
+
+        let link = &summary.fetch_policy_descriptors[0];
+        assert_eq!(link.element, "link");
+        assert_eq!(link.id.as_deref(), Some("font"));
+        assert_eq!(
+            link.resolved_url.as_deref(),
+            Some("https://example.test/app/fonts/site.woff2")
+        );
+        assert_eq!(link.integrity.as_deref(), Some("sha384-font"));
+        assert_eq!(link.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(link.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(link.nonce.as_deref(), Some("fontNonce"));
+
+        let style = &summary.fetch_policy_descriptors[1];
+        assert_eq!(style.element, "style");
+        assert_eq!(style.id.as_deref(), Some("critical"));
+        assert_eq!(style.nonce.as_deref(), Some("styleNonce"));
+
+        let script = &summary.fetch_policy_descriptors[2];
+        assert_eq!(script.element, "script");
+        assert_eq!(
+            script.resolved_url.as_deref(),
+            Some("https://example.test/app/scripts/app.js")
+        );
+        assert_eq!(script.integrity.as_deref(), Some("sha384-js"));
+        assert_eq!(script.crossorigin.as_deref(), Some("use-credentials"));
+        assert_eq!(script.referrerpolicy.as_deref(), Some("origin"));
+        assert_eq!(script.nonce.as_deref(), Some("scriptNonce"));
+
+        let image = &summary.fetch_policy_descriptors[3];
+        assert_eq!(image.element, "img");
+        assert_eq!(image.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(image.referrerpolicy.as_deref(), Some("no-referrer"));
+
+        let frame = &summary.fetch_policy_descriptors[4];
+        assert_eq!(frame.element, "iframe");
+        assert_eq!(frame.csp.as_deref(), Some("script-src 'self'"));
+        assert_eq!(
+            frame.sandbox,
+            vec!["allow-scripts".to_string(), "allow-same-origin".to_string()]
+        );
+        assert_eq!(frame.allow.as_deref(), Some("fullscreen; geolocation"));
+        assert!(frame.allowfullscreen);
+        assert!(frame.credentialless);
+
+        let video = &summary.fetch_policy_descriptors[5];
+        assert_eq!(video.element, "video");
+        assert_eq!(video.crossorigin.as_deref(), Some("anonymous"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,11 +3,11 @@ use coding_adventures_html_parser::{
     BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
-    BrowserEmbeddedContext, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
-    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
-    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
-    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormSelect,
-    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserEmbeddedContext, BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton,
+    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
+    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
+    BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
     BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
     BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
     BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
@@ -67,6 +67,8 @@ struct ExpectedBrowserDocument {
     stylesheets: Vec<ExpectedStylesheet>,
     #[serde(default)]
     loading_hint_descriptors: Vec<ExpectedLoadingHintDescriptor>,
+    #[serde(default)]
+    fetch_policy_descriptors: Vec<ExpectedFetchPolicyDescriptor>,
     anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
     #[serde(default)]
@@ -418,6 +420,35 @@ struct ExpectedLoadingHintDescriptor {
     as_hint: Option<String>,
     #[serde(default)]
     media: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFetchPolicyDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    csp: Option<String>,
+    #[serde(default)]
+    sandbox: Vec<String>,
+    #[serde(default)]
+    allow: Option<String>,
+    #[serde(default)]
+    allowfullscreen: bool,
+    #[serde(default)]
+    credentialless: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3518,6 +3549,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedLoadingHintDescriptor::into_browser_loading_hint_descriptor)
                 .collect(),
+            fetch_policy_descriptors: self
+                .fetch_policy_descriptors
+                .into_iter()
+                .map(ExpectedFetchPolicyDescriptor::into_browser_fetch_policy_descriptor)
+                .collect(),
             anchors: self
                 .anchors
                 .into_iter()
@@ -4007,6 +4043,26 @@ impl ExpectedLoadingHintDescriptor {
             preload: self.preload,
             as_hint: self.as_hint,
             media: self.media,
+        }
+    }
+}
+
+impl ExpectedFetchPolicyDescriptor {
+    fn into_browser_fetch_policy_descriptor(self) -> BrowserFetchPolicyDescriptor {
+        BrowserFetchPolicyDescriptor {
+            element: self.element,
+            id: self.id,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            nonce: self.nonce,
+            referrerpolicy: self.referrerpolicy,
+            csp: self.csp,
+            sandbox: self.sandbox,
+            allow: self.allow,
+            allowfullscreen: self.allowfullscreen,
+            credentialless: self.credentialless,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -28,6 +28,8 @@ ARIA descriptor cases pin collection/range/live-region semantics plus details,
 error-message, and flow relationship target text.
 Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
 decoding, fetch priority, blocking, and media preload metadata.
+Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
+iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -32,6 +32,9 @@
         "navigation_groups": [
           { "element": "ul", "role": "list", "text": "One Two", "list_kind": "unordered", "item_count": 2 }
         ],
+        "fetch_policy_descriptors": [
+          { "element": "a", "url": "intro.html", "resolved_url": "https://example.test/docs/intro.html", "referrerpolicy": "no-referrer" }
+        ],
         "links": [
           { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "attributionsrc": ["attr/register", "https://ad.example/register"], "resolved_attributionsrc": ["https://example.test/docs/attr/register", "https://ad.example/register"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
         ],
@@ -152,6 +155,9 @@
         "headings": [],
         "loading_hint_descriptors": [
           { "element": "img", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "loading": "lazy", "decoding": "async", "fetchpriority": "high" }
+        ],
+        "fetch_policy_descriptors": [
+          { "element": "img", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "crossorigin": "anonymous", "referrerpolicy": "no-referrer" }
         ],
         "links": [
           { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "attributionsrc": ["area-attr.html"], "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"], "hreflang": "en", "text": "Details" }
@@ -450,6 +456,12 @@
           { "element": "link", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "blocking": "render", "blocking_tokens": ["render"] },
           { "element": "link", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "fetchpriority": "high", "as_hint": "image" }
         ],
+        "fetch_policy_descriptors": [
+          { "element": "link", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "crossorigin": "" },
+          { "element": "link", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "integrity": "sha384-font", "crossorigin": "anonymous" },
+          { "element": "link", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "integrity": "sha384-module", "referrerpolicy": "no-referrer" },
+          { "element": "link", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "crossorigin": "use-credentials" }
+        ],
         "links": [],
         "images": [],
         "forms": [],
@@ -517,6 +529,10 @@
         "loading_hint_descriptors": [
           { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "loading": "lazy", "fetchpriority": "high" }
         ],
+        "fetch_policy_descriptors": [
+          { "element": "iframe", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "referrerpolicy": "no-referrer", "csp": "script-src 'self'", "sandbox": ["allow-scripts", "allow-same-origin"], "allow": "fullscreen; geolocation", "allowfullscreen": true, "credentialless": true },
+          { "element": "iframe", "url": null, "resolved_url": null, "sandbox": [], "allow": "payment" }
+        ],
         "links": [],
         "images": [],
         "media": [
@@ -560,6 +576,10 @@
         "loading_hint_descriptors": [
           { "element": "video", "id": "hero", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "preload": "metadata" },
           { "element": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "preload": "none" }
+        ],
+        "fetch_policy_descriptors": [
+          { "element": "video", "id": "hero", "url": "movie.mp4", "resolved_url": "https://example.test/watch/movie.mp4", "crossorigin": "anonymous" },
+          { "element": "audio", "url": "theme.ogg", "resolved_url": "https://example.test/watch/theme.ogg", "crossorigin": "use-credentials" }
         ],
         "links": [],
         "images": [],
@@ -685,6 +705,13 @@
         "loading_hint_descriptors": [
           { "element": "link", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"], "as_hint": null, "media": "screen" },
           { "element": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "fetchpriority": "low", "blocking": "render", "blocking_tokens": ["render"] }
+        ],
+        "fetch_policy_descriptors": [
+          { "element": "link", "url": "app.css", "resolved_url": "https://example.test/app/app.css", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer" },
+          { "element": "style", "nonce": "inlineStyleNonce" },
+          { "element": "script", "url": "app.js", "resolved_url": "https://example.test/app/app.js", "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin" },
+          { "element": "script", "url": null, "resolved_url": null, "nonce": "legacyNonce" },
+          { "element": "script", "url": "late.js", "resolved_url": "https://example.test/app/late.js", "nonce": "lateNonce" }
         ],
         "links": [],
         "images": [],


### PR DESCRIPTION
## Summary
- add flat browser fetch-policy descriptors for SRI, CORS, nonce, referrer policy, iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata
- wire the descriptor into browser-readiness fixture expectations
- document the new fixture coverage and changelog entry

## Verification
- cargo test -p coding-adventures-html-parser browser_fetch_policy_descriptors_track_security_and_policy_hints
- for test_name in browser_loading_hint_descriptors_track_head_and_body_scheduling_hints browser_aria_relation_metadata_tracks_details_errors_and_flow browser_shell_global_state_metadata_tracks_document_and_body_attributes browser_readiness_cases_extract_browser_document_facts browser_text_semantic_descriptor_metadata_tracks_inline_annotations; do cargo test -p coding-adventures-html-parser "$test_name" || exit 1; done
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser