### PR TITLE
Add MACSYMA charpoly parity to TS and Rust

### DIFF
--- a/code/packages/rust/cas-matrix/src/eigenvalues.rs
+++ b/code/packages/rust/cas-matrix/src/eigenvalues.rs
@@ -1,0 +1,146 @@
+//! Characteristic polynomial helpers for exact-rational matrices.
+
+use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, POW};
+
+use crate::matrix::{num_cols, num_rows, MatrixError, MatrixResult};
+use crate::rowreduce::{matrix_to_fracs, Frac};
+
+/// Return coefficients for `det(lambda I - A)` in ascending power order.
+pub fn char_poly_coeffs(m: &IRNode) -> MatrixResult<Vec<IRNode>> {
+    char_poly_coeff_fracs(m)?
+        .into_iter()
+        .map(Frac::to_irnode)
+        .collect()
+}
+
+/// Return `det(lambda I - A)` as an un-simplified IR polynomial.
+pub fn charpoly(m: &IRNode, variable: &IRNode) -> MatrixResult<IRNode> {
+    let terms = char_poly_coeff_fracs(m)?.into_iter().enumerate().try_fold(
+        Vec::new(),
+        |mut terms, (power, coeff)| -> MatrixResult<Vec<IRNode>> {
+            if coeff.is_zero() {
+                return Ok(terms);
+            }
+            let coeff_node = coeff.to_irnode()?;
+            if power == 0 {
+                terms.push(coeff_node);
+                return Ok(terms);
+            }
+            let variable_power = if power == 1 {
+                variable.clone()
+            } else {
+                apply(sym(POW), vec![variable.clone(), int(power as i64)])
+            };
+            if coeff == Frac::one() {
+                terms.push(variable_power);
+            } else {
+                terms.push(apply(sym(MUL), vec![coeff_node, variable_power]));
+            }
+            Ok(terms)
+        },
+    )?;
+
+    Ok(match terms.len() {
+        0 => int(0),
+        1 => terms.into_iter().next().unwrap(),
+        _ => apply(sym(ADD), terms),
+    })
+}
+
+fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
+    let n = num_rows(m)?;
+    let ncols = num_cols(m)?;
+    if n != ncols {
+        return Err(MatrixError(format!(
+            "char_poly_coeffs: matrix must be square, got {n}x{ncols}"
+        )));
+    }
+
+    let rows = matrix_to_fracs(m)?;
+    let poly_rows: Vec<Vec<Vec<Frac>>> = rows
+        .iter()
+        .enumerate()
+        .map(|(row_index, row)| {
+            row.iter()
+                .enumerate()
+                .map(|(col_index, entry)| {
+                    if row_index == col_index {
+                        vec![-*entry, Frac::one()]
+                    } else {
+                        vec![-*entry]
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    Ok(det_poly(&poly_rows))
+}
+
+fn det_poly(rows: &[Vec<Vec<Frac>>]) -> Vec<Frac> {
+    let n = rows.len();
+    match n {
+        0 => vec![Frac::one()],
+        1 => rows[0][0].clone(),
+        2 => {
+            let a = &rows[0][0];
+            let b = &rows[0][1];
+            let c = &rows[1][0];
+            let d = &rows[1][1];
+            poly_sub(&poly_mul(a, d), &poly_mul(b, c))
+        }
+        _ => rows[0]
+            .iter()
+            .enumerate()
+            .fold(vec![Frac::zero()], |acc, (col, entry)| {
+                let product = poly_mul(entry, &det_poly(&minor_poly(rows, 0, col)));
+                if col % 2 == 0 {
+                    poly_add(&acc, &product)
+                } else {
+                    poly_sub(&acc, &product)
+                }
+            }),
+    }
+}
+
+fn minor_poly(rows: &[Vec<Vec<Frac>>], skip_row: usize, skip_col: usize) -> Vec<Vec<Vec<Frac>>> {
+    rows.iter()
+        .enumerate()
+        .filter(|(row_index, _)| *row_index != skip_row)
+        .map(|(_, row)| {
+            row.iter()
+                .enumerate()
+                .filter(|(col_index, _)| *col_index != skip_col)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        })
+        .collect()
+}
+
+fn poly_add(left: &[Frac], right: &[Frac]) -> Vec<Frac> {
+    let length = left.len().max(right.len());
+    (0..length)
+        .map(|i| {
+            left.get(i).copied().unwrap_or_else(Frac::zero)
+                + right.get(i).copied().unwrap_or_else(Frac::zero)
+        })
+        .collect()
+}
+
+fn poly_sub(left: &[Frac], right: &[Frac]) -> Vec<Frac> {
+    let neg_right: Vec<Frac> = right.iter().map(|entry| -*entry).collect();
+    poly_add(left, &neg_right)
+}
+
+fn poly_mul(left: &[Frac], right: &[Frac]) -> Vec<Frac> {
+    if left.is_empty() || right.is_empty() {
+        return vec![Frac::zero()];
+    }
+    let mut result = vec![Frac::zero(); left.len() + right.len() - 1];
+    for (i, a) in left.iter().enumerate() {
+        for (j, b) in right.iter().enumerate() {
+            result[i + j] = result[i + j] + (*a * *b);
+        }
+    }
+    result
+}

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -49,6 +49,7 @@
 pub mod arithmetic;
 mod backend;
 pub mod determinant;
+pub mod eigenvalues;
 pub mod lu;
 pub mod matrix;
 pub mod norms;
@@ -60,6 +61,7 @@ pub use arithmetic::{
     zero_matrix,
 };
 pub use determinant::{determinant, inverse};
+pub use eigenvalues::{char_poly_coeffs, charpoly};
 pub use lu::lu_decompose;
 pub use matrix::{
     dimensions, get_entry, is_matrix, matrix, num_cols, num_rows, rows_of, MatrixError,

--- a/code/packages/rust/cas-matrix/src/rowreduce.rs
+++ b/code/packages/rust/cas-matrix/src/rowreduce.rs
@@ -131,6 +131,10 @@ impl Frac {
         Self { numer: 0, denom: 1 }
     }
 
+    pub(crate) fn one() -> Self {
+        Self { numer: 1, denom: 1 }
+    }
+
     pub(crate) fn new(numer: i128, denom: i128) -> Self {
         assert!(denom != 0, "Frac denominator must not be zero");
         if numer == 0 {

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -4,12 +4,12 @@
 // code/packages/python/cas-matrix/tests/.
 
 use cas_matrix::{
-    add_matrices, columnspace, determinant, dimensions, dot, frobenius_norm, get_entry,
-    identity_matrix, inverse, is_matrix, lu_decompose, matrix, norm, nullspace, num_cols, num_rows,
-    rank, row_reduce, rowspace, scalar_multiply, sub_matrices, trace, transpose, zero_matrix,
-    MatrixError, MATRIX,
+    add_matrices, char_poly_coeffs, charpoly, columnspace, determinant, dimensions, dot,
+    frobenius_norm, get_entry, identity_matrix, inverse, is_matrix, lu_decompose, matrix, norm,
+    nullspace, num_cols, num_rows, rank, row_reduce, rowspace, scalar_multiply, sub_matrices,
+    trace, transpose, zero_matrix, MatrixError, MATRIX,
 };
-use symbolic_ir::{apply, flt, int, rat, sym, ADD, LIST, MUL, SQRT, SUB};
+use symbolic_ir::{apply, flt, int, rat, sym, ADD, LIST, MUL, POW, SQRT, SUB};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -426,6 +426,54 @@ fn inverse_1x1_shape() {
 fn inverse_non_square_raises() {
     let m = matrix(vec![irow(&[1, 2, 3])]).unwrap();
     assert!(inverse(&m).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Characteristic polynomial
+// ---------------------------------------------------------------------------
+
+#[test]
+fn char_poly_coeffs_2x2_integer() {
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 1])]).unwrap();
+    assert_eq!(
+        char_poly_coeffs(&m).unwrap(),
+        vec![int(-3), int(-2), int(1)]
+    );
+}
+
+#[test]
+fn char_poly_coeffs_2x2_rational() {
+    let m = matrix(vec![vec![rat(1, 2), int(1)], vec![int(0), int(2)]]).unwrap();
+    assert_eq!(
+        char_poly_coeffs(&m).unwrap(),
+        vec![int(1), rat(-5, 2), int(1)]
+    );
+}
+
+#[test]
+fn charpoly_builds_ir_polynomial() {
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 1])]).unwrap();
+    let lambda = sym("lambda");
+    assert_eq!(
+        charpoly(&m, &lambda).unwrap(),
+        apply(
+            sym(ADD),
+            vec![
+                int(-3),
+                apply(sym(MUL), vec![int(-2), lambda.clone()]),
+                apply(sym(POW), vec![lambda, int(2)]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn charpoly_rejects_non_square_and_symbolic_entries() {
+    let non_square = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
+    assert!(char_poly_coeffs(&non_square).is_err());
+
+    let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
+    assert!(charpoly(&symbolic, &sym("lambda")).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -4,6 +4,7 @@ import {
   LIST,
   MUL,
   NEG,
+  POW,
   SQRT,
   SUB,
   app,
@@ -177,6 +178,23 @@ export function determinant(node: IRNode): IRNode {
     throw new MatrixError(`determinant: matrix must be square, got ${n}x${ncols}`);
   }
   return det(rows);
+}
+
+export function charPolyCoeffs(node: IRNode): IRNode[] {
+  return charPolyCoeffValues(node).map(rationalToIr);
+}
+
+export function charPoly(node: IRNode, variable: IRNode): IRNode {
+  const terms = charPolyCoeffValues(node).flatMap((coeff, power) => {
+    if (coeff.isZero()) return [];
+    const coeffNode = rationalToIr(coeff);
+    if (power === 0) return [coeffNode];
+    const variablePower = power === 1 ? variable : app(POW, [variable, int(power)]);
+    return coeff.equals(RationalValue.one()) ? [variablePower] : [app(MUL, [coeffNode, variablePower])];
+  });
+  if (terms.length === 0) return int(0);
+  if (terms.length === 1) return terms[0];
+  return app(ADD, terms);
 }
 
 export function inverse(node: IRNode): IRNode {
@@ -489,6 +507,59 @@ function minor(rows: MatrixRows, skipRow: number, skipCol: number): MatrixRows {
     .map((row) => row.filter((_, colIndex) => colIndex !== skipCol));
 }
 
+function charPolyCoeffValues(node: IRNode): RationalValue[] {
+  const rows = matrixToRationals(node);
+  const n = rows.length;
+  const ncols = rows[0]?.length ?? 0;
+  if (n !== ncols) {
+    throw new MatrixError(`charPolyCoeffs: matrix must be square, got ${n}x${ncols}`);
+  }
+  const polyRows = rows.map((row, i) =>
+    row.map((entry, j) => (i === j ? [entry.neg(), RationalValue.one()] : [entry.neg()])));
+  return detPoly(polyRows);
+}
+
+function detPoly(rows: RationalValue[][][]): RationalValue[] {
+  const n = rows.length;
+  if (n === 0) return [RationalValue.one()];
+  if (n === 1) return [...rows[0][0]];
+  if (n === 2) {
+    const [[a, b], [c, d]] = rows;
+    return polySub(polyMul(a, d), polyMul(b, c));
+  }
+  return rows[0].reduce((acc, entry, col) => {
+    const product = polyMul(entry, detPoly(minorPoly(rows, 0, col)));
+    return col % 2 === 0 ? polyAdd(acc, product) : polySub(acc, product);
+  }, [RationalValue.zero()]);
+}
+
+function minorPoly(rows: RationalValue[][][], skipRow: number, skipCol: number): RationalValue[][][] {
+  return rows
+    .filter((_, rowIndex) => rowIndex !== skipRow)
+    .map((row) => row.filter((_, colIndex) => colIndex !== skipCol));
+}
+
+function polyAdd(left: RationalValue[], right: RationalValue[]): RationalValue[] {
+  const length = Math.max(left.length, right.length);
+  return Array.from({ length }, (_, i) =>
+    (left[i] ?? RationalValue.zero()).add(right[i] ?? RationalValue.zero()));
+}
+
+function polySub(left: RationalValue[], right: RationalValue[]): RationalValue[] {
+  return polyAdd(left, right.map((entry) => entry.neg()));
+}
+
+function polyMul(left: RationalValue[], right: RationalValue[]): RationalValue[] {
+  if (left.length === 0 || right.length === 0) return [RationalValue.zero()];
+  const result = Array.from({ length: left.length + right.length - 1 }, () => RationalValue.zero());
+  left.forEach((a, i) => {
+    right.forEach((b, j) => {
+      result[i + j] = result[i + j].add(a.mul(b));
+    });
+  });
+  return result;
+}
+
 function matrixToRationals(node: IRNode): RationalValue[][] {
   return rowsOf(node).map((row) => row.map(entryToRational));
 }
@@ -617,6 +688,10 @@ class RationalValue {
 
   isZero(): boolean {
     return this.numer === 0n;
+  }
+
+  equals(other: RationalValue): boolean {
+    return this.numer === other.numer && this.denom === other.denom;
   }
 
   add(other: RationalValue): RationalValue {

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -3,6 +3,8 @@ import {
   MATRIX,
   MatrixError,
   addMatrices,
+  charPoly,
+  charPolyCoeffs,
   columnspace,
   determinant,
   dimensions,
@@ -28,7 +30,7 @@ import {
   transpose,
   zeroMatrix,
 } from "../src/index";
-import { ADD, LIST, MUL, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
+import { ADD, LIST, MUL, POW, SQRT, SUB, app, equals, int, numberNode, rational, sym, type IRNode } from "@coding-adventures/symbolic-ir";
 import { Matrix, getMatrixBackend, resetMatrixBackend, setMatrixBackend, type MatrixBackend } from "matrix";
 
 function irow(values: readonly number[]): IRNode[] {
@@ -236,6 +238,35 @@ describe("determinant and inverse", () => {
     expect(numRows(inv1)).toBe(1);
     expect(numCols(inv1)).toBe(1);
     expect(() => inverse(matrix([irow([1, 2, 3])]))).toThrow(MatrixError);
+  });
+});
+
+describe("characteristic polynomial", () => {
+  it("returns coefficients for det(lambda I - A)", () => {
+    expect(charPolyCoeffs(matrix([irow([1, 2]), irow([2, 1])]))).toEqual([
+      int(-3),
+      int(-2),
+      int(1),
+    ]);
+    expect(charPolyCoeffs(matrix([[rational(1, 2), int(1)], [int(0), int(2)]]))).toEqual([
+      int(1),
+      rational(-5, 2),
+      int(1),
+    ]);
+  });
+
+  it("builds an IR polynomial in the requested variable", () => {
+    const lambda = sym("lambda");
+    expect(charPoly(matrix([irow([1, 2]), irow([2, 1])]), lambda)).toEqual(app(ADD, [
+      int(-3),
+      app(MUL, [int(-2), lambda]),
+      app(POW, [lambda, int(2)]),
+    ]));
+  });
+
+  it("rejects non-square and symbolic-entry matrices", () => {
+    expect(() => charPolyCoeffs(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
+    expect(() => charPoly(matrix([[sym("a")]]), sym("lambda"))).toThrow(MatrixError);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add exact-rational characteristic polynomial coefficient computation to TypeScript cas-matrix.
- Add Rust cas-matrix `char_poly_coeffs`/`charpoly` parity using the existing exact `Frac` helper.
- Cover integer/rational 2x2 matrices, IR polynomial output, and rejection of non-square/symbolic-entry matrices.

## Verification
- `node ..\macsyma-runtime\node_modules\vitest\vitest.mjs run tests/cas-matrix.test.ts` from `code/packages/typescript/cas-matrix`
- `node ..\macsyma-runtime\node_modules\typescript\bin\tsc --noEmit` from `code/packages/typescript/cas-matrix`
- `cargo test --manifest-path code\packages\rust\Cargo.toml -p cas-matrix`
- `git diff --check`