### PR TITLE
Add MACSYMA eigenvalues parity for small matrices

### DIFF
--- a/code/packages/rust/cas-matrix/BUILD
+++ b/code/packages/rust/cas-matrix/BUILD
@@ -4,6 +4,6 @@ _targets = [
     rust_library(
         name = "cas-matrix",
         srcs = ["src/**/*.rs", "tests/**/*.rs"],
-        deps = ["symbolic-ir"],
+        deps = ["cas-solve", "symbolic-ir"],
     ),
 ]

--- a/code/packages/rust/cas-matrix/Cargo.toml
+++ b/code/packages/rust/cas-matrix/Cargo.toml
@@ -6,6 +6,7 @@ description = "Matrix operations over symbolic IR (construction, arithmetic, det
 license = "MIT"
 
 [dependencies]
+cas-solve = { path = "../cas-solve" }
 compute-ir = { path = "../compute-ir" }
 executor-protocol = { path = "../executor-protocol" }
 matrix-cpu = { path = "../matrix-cpu" }

--- a/code/packages/rust/cas-matrix/src/eigenvalues.rs
+++ b/code/packages/rust/cas-matrix/src/eigenvalues.rs
@@ -1,5 +1,7 @@
 //! Characteristic polynomial helpers for exact-rational matrices.
 
+use cas_solve::frac::Frac as SolveFrac;
+use cas_solve::{solve_linear, solve_quadratic, SolveResult};
 use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, POW};
 
 use crate::matrix::{num_cols, num_rows, MatrixError, MatrixResult};
@@ -47,7 +49,45 @@ pub fn charpoly(m: &IRNode, variable: &IRNode) -> MatrixResult<IRNode> {
     })
 }
 
-fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
+/// Return `List(List(lambda, multiplicity), ...)` for 1x1/2x2 exact matrices.
+pub fn eigenvalues(m: &IRNode) -> MatrixResult<IRNode> {
+    let n = num_rows(m)?;
+    let ncols = num_cols(m)?;
+    if n != ncols {
+        return Err(MatrixError(format!(
+            "eigenvalues: matrix must be square, got {n}x{ncols}"
+        )));
+    }
+    if n > 2 {
+        return Err(MatrixError(
+            "eigenvalues: only 1x1 and 2x2 matrices are supported in this Rust port".into(),
+        ));
+    }
+
+    let coeffs: Vec<SolveFrac> = char_poly_coeff_fracs(m)?
+        .into_iter()
+        .map(to_solve_frac)
+        .collect::<MatrixResult<Vec<SolveFrac>>>()?;
+    let result = if n == 1 {
+        solve_linear(coeffs[1], coeffs[0])
+    } else {
+        solve_quadratic(coeffs[2], coeffs[1], coeffs[0])
+    };
+
+    let SolveResult::Solutions(roots) = result else {
+        return Ok(apply(sym("Eigenvalues"), vec![m.clone()]));
+    };
+    let multiplicity = if n == 2 && roots.len() == 1 { 2 } else { 1 };
+    Ok(apply(
+        sym("List"),
+        roots
+            .into_iter()
+            .map(|root| apply(sym("List"), vec![root, int(multiplicity)]))
+            .collect(),
+    ))
+}
+
+pub(crate) fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
     let n = num_rows(m)?;
     let ncols = num_cols(m)?;
     if n != ncols {
@@ -75,6 +115,17 @@ fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
         .collect();
 
     Ok(det_poly(&poly_rows))
+}
+
+fn to_solve_frac(value: Frac) -> MatrixResult<SolveFrac> {
+    let node = value.to_irnode()?;
+    match node {
+        IRNode::Integer(n) => Ok(SolveFrac::from_int(n)),
+        IRNode::Rational(n, d) => Ok(SolveFrac::new(n, d)),
+        other => Err(MatrixError(format!(
+            "eigenvalues: expected rational coefficient, got {other:?}"
+        ))),
+    }
 }
 
 fn det_poly(rows: &[Vec<Vec<Frac>>]) -> Vec<Frac> {

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -61,7 +61,7 @@ pub use arithmetic::{
     zero_matrix,
 };
 pub use determinant::{determinant, inverse};
-pub use eigenvalues::{char_poly_coeffs, charpoly};
+pub use eigenvalues::{char_poly_coeffs, charpoly, eigenvalues};
 pub use lu::lu_decompose;
 pub use matrix::{
     dimensions, get_entry, is_matrix, matrix, num_cols, num_rows, rows_of, MatrixError,

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -5,9 +5,9 @@
 
 use cas_matrix::{
     add_matrices, char_poly_coeffs, charpoly, columnspace, determinant, dimensions, dot,
-    frobenius_norm, get_entry, identity_matrix, inverse, is_matrix, lu_decompose, matrix, norm,
-    nullspace, num_cols, num_rows, rank, row_reduce, rowspace, scalar_multiply, sub_matrices,
-    trace, transpose, zero_matrix, MatrixError, MATRIX,
+    eigenvalues, frobenius_norm, get_entry, identity_matrix, inverse, is_matrix, lu_decompose,
+    matrix, norm, nullspace, num_cols, num_rows, rank, row_reduce, rowspace, scalar_multiply,
+    sub_matrices, trace, transpose, zero_matrix, MatrixError, MATRIX,
 };
 use symbolic_ir::{apply, flt, int, rat, sym, ADD, LIST, MUL, POW, SQRT, SUB};
 
@@ -474,6 +474,62 @@ fn charpoly_rejects_non_square_and_symbolic_entries() {
 
     let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
     assert!(charpoly(&symbolic, &sym("lambda")).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Eigenvalues
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eigenvalues_1x1_and_2x2_distinct() {
+    let scalar = matrix(vec![irow(&[7])]).unwrap();
+    assert_eq!(
+        eigenvalues(&scalar).unwrap(),
+        apply(sym(LIST), vec![apply(sym(LIST), vec![int(7), int(1)])])
+    );
+
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 1])]).unwrap();
+    assert_eq!(
+        eigenvalues(&m).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(LIST), vec![int(-1), int(1)]),
+                apply(sym(LIST), vec![int(3), int(1)]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn eigenvalues_repeated_and_rational() {
+    let repeated = matrix(vec![irow(&[2, 0]), irow(&[0, 2])]).unwrap();
+    assert_eq!(
+        eigenvalues(&repeated).unwrap(),
+        apply(sym(LIST), vec![apply(sym(LIST), vec![int(2), int(2)])])
+    );
+
+    let rational = matrix(vec![vec![rat(1, 2), int(0)], vec![int(0), int(3)]]).unwrap();
+    assert_eq!(
+        eigenvalues(&rational).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(LIST), vec![rat(1, 2), int(1)]),
+                apply(sym(LIST), vec![int(3), int(1)]),
+            ],
+        )
+    );
+}
+
+#[test]
+fn eigenvalues_rejects_unsupported_shapes_and_symbolic_entries() {
+    let non_square = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
+    assert!(eigenvalues(&non_square).is_err());
+    assert!(eigenvalues(&identity_matrix(3).unwrap()).is_err());
+
+    let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
+    assert!(eigenvalues(&symbolic).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-matrix/BUILD
+++ b/code/packages/typescript/cas-matrix/BUILD
@@ -1,4 +1,5 @@
 while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
+cd ../cas-solve && npm ci --quiet
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-matrix/package-lock.json
+++ b/code/packages/typescript/cas-matrix/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@coding-adventures/cas-solve": "file:../cas-solve",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
         "matrix": "file:../matrix"
       },
@@ -30,6 +31,20 @@
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
+      }
+    },
+    "../cas-solve": {
+      "name": "@coding-adventures/cas-solve",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
       }
     },
     "../symbolic-ir": {
@@ -97,6 +112,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@coding-adventures/cas-solve": {
+      "resolved": "../cas-solve",
+      "link": true
     },
     "node_modules/@coding-adventures/symbolic-ir": {
       "resolved": "../symbolic-ir",

--- a/code/packages/typescript/cas-matrix/package.json
+++ b/code/packages/typescript/cas-matrix/package.json
@@ -13,6 +13,7 @@
   "author": "Adhithya Rajasekaran",
   "license": "MIT",
   "dependencies": {
+    "@coding-adventures/cas-solve": "file:../cas-solve",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
     "matrix": "file:../matrix"
   },

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -16,6 +16,7 @@ import {
   type IRInteger,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
+import { Frac as SolveFrac, solveLinear, solveQuadratic } from "@coding-adventures/cas-solve";
 import { Matrix, getMatrixBackend } from "matrix";
 
 export const MATRIX = "Matrix";
@@ -195,6 +196,27 @@ export function charPoly(node: IRNode, variable: IRNode): IRNode {
   if (terms.length === 0) return int(0);
   if (terms.length === 1) return terms[0];
   return app(ADD, terms);
+}
+
+export function eigenvalues(node: IRNode): IRNode {
+  const rows = matrixToRationals(node);
+  const n = rows.length;
+  const ncols = rows[0]?.length ?? 0;
+  if (n !== ncols) {
+    throw new MatrixError(`eigenvalues: matrix must be square, got ${n}x${ncols}`);
+  }
+  if (n > 2) {
+    throw new MatrixError("eigenvalues: only 1x1 and 2x2 matrices are supported in this TypeScript port");
+  }
+
+  const coeffs = charPolyCoeffValues(node).map(toSolveFrac);
+  const result = n === 1
+    ? solveLinear(coeffs[1], coeffs[0])
+    : solveQuadratic(coeffs[2], coeffs[1], coeffs[0]);
+  if (result.kind === "all") return app(sym("Eigenvalues"), [node]);
+
+  const multiplicity = n === 2 && result.roots.length === 1 ? 2 : 1;
+  return app(LIST, result.roots.map((root) => app(LIST, [root, int(multiplicity)])));
 }
 
 export function inverse(node: IRNode): IRNode {
@@ -572,6 +594,10 @@ function entryToRational(node: IRNode): RationalValue {
 
 function rationalToIr(value: RationalValue): IRNode {
   return value.denom === 1n ? int(value.numer) : rational(value.numer, value.denom);
+}
+
+function toSolveFrac(value: RationalValue): SolveFrac {
+  return new SolveFrac(value.numer, value.denom);
 }
 
 function rationalsToMatrix(rows: readonly (readonly RationalValue[])[]): IRNode {

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -9,6 +9,7 @@ import {
   determinant,
   dimensions,
   dot,
+  eigenvalues,
   frobeniusNorm,
   getEntry,
   identityMatrix,
@@ -267,6 +268,34 @@ describe("characteristic polynomial", () => {
   it("rejects non-square and symbolic-entry matrices", () => {
     expect(() => charPolyCoeffs(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
     expect(() => charPoly(matrix([[sym("a")]]), sym("lambda"))).toThrow(MatrixError);
+  });
+});
+
+describe("eigenvalues", () => {
+  it("returns MACSYMA-style eigenvalue/multiplicity pairs for 1x1 and 2x2 matrices", () => {
+    expect(eigenvalues(matrix([irow([7])]))).toEqual(app(LIST, [
+      app(LIST, [int(7), int(1)]),
+    ]));
+    expect(eigenvalues(matrix([irow([1, 2]), irow([2, 1])]))).toEqual(app(LIST, [
+      app(LIST, [int(-1), int(1)]),
+      app(LIST, [int(3), int(1)]),
+    ]));
+  });
+
+  it("preserves repeated and rational eigenvalue multiplicity", () => {
+    expect(eigenvalues(matrix([irow([2, 0]), irow([0, 2])]))).toEqual(app(LIST, [
+      app(LIST, [int(2), int(2)]),
+    ]));
+    expect(eigenvalues(matrix([[rational(1, 2), int(0)], [int(0), int(3)]]))).toEqual(app(LIST, [
+      app(LIST, [rational(1, 2), int(1)]),
+      app(LIST, [int(3), int(1)]),
+    ]));
+  });
+
+  it("rejects unsupported shapes and symbolic entries", () => {
+    expect(() => eigenvalues(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
+    expect(() => eigenvalues(identityMatrix(3))).toThrow(MatrixError);
+    expect(() => eigenvalues(matrix([[sym("a")]]))).toThrow(MatrixError);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `eigenvalues` to TypeScript cas-matrix for exact-rational 1x1/2x2 matrices.
- Add matching Rust cas-matrix `eigenvalues` support, delegating roots to `cas-solve`.
- Preserve MACSYMA-style `List(List(lambda, multiplicity), ...)` output including repeated 2x2 roots.

## Verification
- `node ..\macsyma-runtime\node_modules\vitest\vitest.mjs run tests/cas-matrix.test.ts` from `code/packages/typescript/cas-matrix`
- `node ..\macsyma-runtime\node_modules\typescript\bin\tsc --noEmit` from `code/packages/typescript/cas-matrix`
- `cargo test --manifest-path code\packages\rust\Cargo.toml -p cas-matrix`
- `git diff --check`