### PR TITLE
Enable ALGOL mod on shared IIR backends

### DIFF
--- a/code/packages/rust/algol-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/algol-iir-compiler/CHANGELOG.md
@@ -3,5 +3,5 @@
 ## 0.1.0
 
 - Add an ALGOL 60 scalar frontend for the LANG VM Rust chain.
-- Lower integer and boolean declarations, scalar assignments, integer arithmetic, comparisons, if/else, compound statements, goto labels, and simple `for step until` loops to `interpreter_ir::IIRModule`.
+- Lower integer and boolean declarations, scalar assignments, integer arithmetic including `div`/`mod`, comparisons, if/else, compound statements, goto labels, and simple `for step until` loops to `interpreter_ir::IIRModule`.
 - Prove the emitted IIR runs through `vm-core`, `jit-core`, `aot-core`, WebAssembly, JVM, CLR, BEAM, and LLVM backend paths.

--- a/code/packages/rust/algol-iir-compiler/README.md
+++ b/code/packages/rust/algol-iir-compiler/README.md
@@ -12,8 +12,9 @@ ALGOL source -> algol-lexer/parser -> algol-iir-compiler -> IIRModule
 ```
 
 The first slice supports scalar `integer` and `boolean` programs with
-assignments, integer arithmetic, comparisons, `if`/`else`, compound statements,
-labels, `goto`, and `for i := a step k until b do ...` where `k` is a constant
-integer. Unsupported ALGOL 60 features, including arrays, procedures, strings,
-reals, switches, nested declaration scopes, and by-name calls, return explicit
+assignments, integer arithmetic (`+`, `-`, `*`, `div`, `mod`), comparisons,
+`if`/`else`, compound statements, labels, `goto`, and
+`for i := a step k until b do ...` where `k` is a constant integer.
+Unsupported ALGOL 60 features, including arrays, procedures, strings, reals,
+switches, nested declaration scopes, and by-name calls, return explicit
 compiler errors.

--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -814,7 +814,7 @@ impl Compiler {
         rhs: ExprValue,
     ) -> Result<ExprValue, CompileError> {
         match op {
-            "+" | "-" | "*" | "div" => {
+            "+" | "-" | "*" | "div" | "mod" => {
                 if lhs.ty != ScalarType::Integer || rhs.ty != ScalarType::Integer {
                     return Err(CompileError::Type(format!(
                         "operator {op:?} requires integer operands"
@@ -825,6 +825,7 @@ impl Compiler {
                     "-" => "sub",
                     "*" => "mul",
                     "div" => "div",
+                    "mod" => "mod",
                     _ => unreachable!(),
                 };
                 let dest = self.fresh_temp();
@@ -841,9 +842,6 @@ impl Compiler {
             }
             "/" => Err(CompileError::Unsupported(
                 "real division '/' in the integer-only backend slice; use div".into(),
-            )),
-            "mod" => Err(CompileError::Unsupported(
-                "mod until the WASM backend accepts the shared IIR 'mod' opcode".into(),
             )),
             "=" | "!=" | "<>" | "<" | "<=" | ">" | ">=" => {
                 if lhs.ty != rhs.ty {
@@ -1198,6 +1196,12 @@ mod tests {
     fn compiles_and_runs_integer_assignment() {
         let src = "begin integer result; result := 40 + 2 end";
         assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn compiles_and_runs_mod_expression() {
+        let src = "begin integer result; result := 17 mod 5 end";
+        assert_eq!(run_i64(src), 2);
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -5,32 +5,38 @@ use algol_iir_compiler::compile_source;
 const ALGOL_SUM: &str =
     "begin integer i, result; result := 0; for i := 1 step 1 until 6 do result := result + i end";
 
-fn compile_sum() -> interpreter_ir::IIRModule {
-    compile_source(ALGOL_SUM, "algol_backend_compat").expect("ALGOL sum should compile")
+const ALGOL_MOD: &str = "begin integer result; result := 17 mod 5 end";
+
+fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
+    compile_source(source, module_name).expect("ALGOL source should compile")
 }
 
 #[test]
 fn algol_iir_validates_for_every_direct_backend() {
-    let module = compile_sum();
-    let checks = [
-        ("wasm", iir_to_wasm::validate_for_wasm(&module)),
-        ("jvm", iir_to_jvm_class_file::validate_for_jvm(&module)),
-        ("clr", iir_to_cil_bytecode::validate_iir_for_clr(&module)),
-        ("beam", iir_to_beam::validate_for_beam(&module)),
-        ("llvm", iir_to_llvm::validate_for_llvm(&module)),
-    ];
-    for (name, errors) in checks {
-        assert!(
-            errors.is_empty(),
-            "{name} rejected ALGOL scalar IIR with {} errors: {errors:?}",
-            errors.len()
-        );
+    for (case, module) in [
+        ("sum", compile_case(ALGOL_SUM, "algol_backend_compat")),
+        ("mod", compile_case(ALGOL_MOD, "algol_mod_backend_compat")),
+    ] {
+        let checks = [
+            ("wasm", iir_to_wasm::validate_for_wasm(&module)),
+            ("jvm", iir_to_jvm_class_file::validate_for_jvm(&module)),
+            ("clr", iir_to_cil_bytecode::validate_iir_for_clr(&module)),
+            ("beam", iir_to_beam::validate_for_beam(&module)),
+            ("llvm", iir_to_llvm::validate_for_llvm(&module)),
+        ];
+        for (name, errors) in checks {
+            assert!(
+                errors.is_empty(),
+                "{name} rejected ALGOL {case} IIR with {} errors: {errors:?}",
+                errors.len()
+            );
+        }
     }
 }
 
 #[test]
 fn algol_iir_lowers_to_wasm_jvm_clr_beam_and_llvm() {
-    let module = compile_sum();
+    let module = compile_case(ALGOL_SUM, "algol_backend_compat");
 
     let wasm =
         iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolSum"))
@@ -63,4 +69,20 @@ fn algol_iir_lowers_to_wasm_jvm_clr_beam_and_llvm() {
             .expect("ALGOL IIR should lower to LLVM");
     assert!(llvm.contains("define i64 @main()"));
     assert!(llvm.contains("target triple"));
+}
+
+#[test]
+fn algol_mod_lowers_to_wasm_and_llvm_remainder_ops() {
+    let module = compile_case(ALGOL_MOD, "algol_mod_backend_compat");
+
+    let wasm =
+        iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolMod"))
+            .expect("ALGOL mod IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let llvm =
+        iir_to_llvm::lower_iir_to_llvm(&module, &iir_to_llvm::IIRLlvmConfig::new("algol_mod"))
+            .expect("ALGOL mod IIR should lower to LLVM");
+    assert!(llvm.contains("srem i64"), "LLVM should lower ALGOL mod as signed remainder");
 }

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -212,7 +212,7 @@ fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlv
 /// [`lower_instr`] — the validator and the lowerer must stay in lockstep.
 ///
 /// LLVM02 added: `const`, `mov`, `ret`, `ret_void`.
-/// LLVM03 added: arithmetic (`add`/`sub`/`mul`/`div`/`rem`), comparison
+/// LLVM03 added: arithmetic (`add`/`sub`/`mul`/`div`/`mod`/`rem`), comparison
 /// (`eq`/`ne`/`lt`/`le`/`gt`/`ge` plus their `cmp_`-prefixed aliases per
 /// gap G1 in the multi-language backend plan), and control flow
 /// (`label`/`jmp`/`jmp_if_true`/`jmp_if_false`).
@@ -220,7 +220,7 @@ const SUPPORTED_OPS: &[&str] = &[
     // LLVM02
     "const", "mov", "ret", "ret_void",
     // LLVM03 — arithmetic
-    "add", "sub", "mul", "div", "rem",
+    "add", "sub", "mul", "div", "mod", "rem",
     // LLVM03 — comparison (both naked and cmp_-prefixed; see G1)
     "eq", "ne", "lt", "le", "gt", "ge",
     "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
@@ -528,9 +528,9 @@ fn lower_instr(
         //
         // Two-operand integer or float operation.  Signedness comes from
         // the type_hint prefix (`i*` = signed, `u*` = unsigned), which only
-        // matters for `div` and `rem` (LLVM splits these into `sdiv`/`udiv`
+        // matters for `div` and `mod`/`rem` (LLVM splits these into `sdiv`/`udiv`
         // and `srem`/`urem`; `add`/`sub`/`mul` are signedness-agnostic).
-        "add" | "sub" | "mul" | "div" | "rem" => {
+        "add" | "sub" | "mul" | "div" | "mod" | "rem" => {
             lower_arith(instr.op.as_str(), instr, state, out)
         }
 
@@ -641,7 +641,7 @@ fn is_unsigned_type(s: &str) -> bool {
 
 /// Pick the LLVM opcode for a binary arithmetic instruction.
 ///
-/// The result is signedness-aware for `div` and `rem` (split into
+/// The result is signedness-aware for `div` and `mod`/`rem` (split into
 /// `sdiv`/`udiv` and `srem`/`urem`), and operand-type-aware for floats
 /// (use `f*` variants).  `add`/`sub`/`mul` share opcodes between signed
 /// and unsigned because in two's-complement they produce the same bits.
@@ -655,7 +655,7 @@ fn llvm_arith_op(iir_op: &str, type_hint: &str) -> &'static str {
         "div" => {
             if f { "fdiv" } else if u { "udiv" } else { "sdiv" }
         }
-        "rem" => {
+        "mod" | "rem" => {
             if f { "frem" } else if u { "urem" } else { "srem" }
         }
         _ => unreachable!("llvm_arith_op called with non-arith op {iir_op}"),

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -789,7 +789,7 @@ fn emit_instr(
         // ── Binary arithmetic ────────────────────────────────────────────────
         //
         // Pattern: local.get r1; local.get r2; <opcode>; local.set rd
-        "add" | "sub" | "mul" | "div" | "rem" => {
+        "add" | "sub" | "mul" | "div" | "mod" | "rem" => {
             let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
                 function: fn_name.to_string(),
                 detail: format!("{} must have a dest", instr.op),
@@ -820,10 +820,10 @@ fn emit_instr(
                 ("div", t) if is_float_hint(t) => F64_DIV,
                 ("div", t) if is_unsigned_hint(t) => I32_DIV_U,
                 ("div", _) => I32_DIV_S,
-                ("rem", t) if is_i64_hint(t) && is_unsigned_hint(t) => I64_REM_U,
-                ("rem", t) if is_i64_hint(t) => I64_REM_S,
-                ("rem", t) if is_unsigned_hint(t) => I32_REM_U,
-                ("rem", _) => I32_REM_S,
+                ("mod" | "rem", t) if is_i64_hint(t) && is_unsigned_hint(t) => I64_REM_U,
+                ("mod" | "rem", t) if is_i64_hint(t) => I64_REM_S,
+                ("mod" | "rem", t) if is_unsigned_hint(t) => I32_REM_U,
+                ("mod" | "rem", _) => I32_REM_S,
                 _ => unreachable!("matched outer pattern"),
             };
             code.push(opcode);

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -66,6 +66,20 @@ fn algol_scalar_emits_and_runs_on_wasm() {
 }
 
 #[test]
+fn algol_mod_emits_and_runs_on_wasm() {
+    let source = "begin integer result; result := 17 mod 5 end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_mod")
+        .expect("ALGOL mod should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL 17 mod 5)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL mod wasm must run");
+    assert_eq!(result, vec![2], "ALGOL mod should return 2");
+}
+
+#[test]
 fn algol_for_loop_emits_and_runs_on_wasm() {
     let source =
         "begin integer i, result; result := 0; for i := 1 step 1 until 6 do result := result + i end";


### PR DESCRIPTION
## Summary
- lower ALGOL `mod` through the Rust LANG VM IIR compiler instead of rejecting it
- accept shared IIR `mod` as a remainder alias in the WASM and LLVM backend lowerers
- add ALGOL compiler, direct backend compatibility, and AOT WASM runtime coverage for `17 mod 5`

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol`
- `cargo test -p iir-to-wasm`
- `cargo test -p iir-to-llvm`
- `git diff --check`

## Security review
- scanned touched files for `unsafe`, process spawning, filesystem reads/writes, panic/todo/unimplemented, and broad unwrap/expect usage
- no new production unsafe/process/filesystem paths; new `expect` usage is confined to tests
- `cargo audit` and `cargo deny` are not installed in this environment
