### PR TITLE
Add MACSYMA cas-matrix eigenvectors parity

### DIFF
--- a/code/packages/rust/cas-matrix/src/eigenvalues.rs
+++ b/code/packages/rust/cas-matrix/src/eigenvalues.rs
@@ -2,10 +2,11 @@
 
 use cas_solve::frac::Frac as SolveFrac;
 use cas_solve::{solve_linear, solve_quadratic, SolveResult};
-use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, POW};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, LIST, MUL, NEG, POW};
 
-use crate::matrix::{num_cols, num_rows, MatrixError, MatrixResult};
+use crate::matrix::{matrix, num_cols, num_rows, MatrixError, MatrixResult};
 use crate::rowreduce::{matrix_to_fracs, Frac};
+use crate::subspaces::nullspace;
 
 /// Return coefficients for `det(lambda I - A)` in ascending power order.
 pub fn char_poly_coeffs(m: &IRNode) -> MatrixResult<Vec<IRNode>> {
@@ -87,6 +88,76 @@ pub fn eigenvalues(m: &IRNode) -> MatrixResult<IRNode> {
     ))
 }
 
+/// Return `List(List(lambda, multiplicity, List(vector, ...)), ...)`.
+///
+/// Exact eigenvector bases are returned for rational eigenvalues.  Irrational
+/// or complex roots keep the eigenvalue/multiplicity pair but receive an empty
+/// vector list, matching the Python reference fallback.
+pub fn eigenvectors(m: &IRNode) -> MatrixResult<IRNode> {
+    let rows = matrix_to_fracs(m)?;
+    let eigs = eigenvalues(m)?;
+    let IRNode::Apply(eigs_apply) = eigs else {
+        return Ok(apply(sym("Eigenvectors"), vec![m.clone()]));
+    };
+    if eigs_apply.head != sym(LIST) {
+        return Ok(apply(sym("Eigenvectors"), vec![m.clone()]));
+    }
+
+    let mut triples = Vec::new();
+    for pair in eigs_apply.args {
+        let IRNode::Apply(pair_apply) = pair else {
+            triples.push(apply(
+                sym(LIST),
+                vec![pair, int(1), apply(sym(LIST), vec![])],
+            ));
+            continue;
+        };
+        let pair_args = pair_apply.args;
+        if pair_args.len() < 2 {
+            triples.push(apply(
+                sym(LIST),
+                vec![
+                    apply(sym(LIST), pair_args),
+                    int(1),
+                    apply(sym(LIST), vec![]),
+                ],
+            ));
+            continue;
+        }
+        let lambda = pair_args[0].clone();
+        let multiplicity = pair_args[1].clone();
+        let Some(lambda_frac) = ir_to_frac(&lambda) else {
+            triples.push(apply(
+                sym(LIST),
+                vec![lambda, multiplicity, apply(sym(LIST), vec![])],
+            ));
+            continue;
+        };
+
+        let shifted = rows
+            .iter()
+            .enumerate()
+            .map(|(row_index, row)| {
+                row.iter()
+                    .enumerate()
+                    .map(|(col_index, entry)| {
+                        let adjustment = if row_index == col_index {
+                            lambda_frac
+                        } else {
+                            Frac::zero()
+                        };
+                        Ok((*entry - adjustment).to_irnode()?)
+                    })
+                    .collect::<MatrixResult<Vec<IRNode>>>()
+            })
+            .collect::<MatrixResult<Vec<Vec<IRNode>>>>()?;
+        let vectors = nullspace(&matrix(shifted)?)?;
+        triples.push(apply(sym(LIST), vec![lambda, multiplicity, vectors]));
+    }
+
+    Ok(apply(sym(LIST), triples))
+}
+
 pub(crate) fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
     let n = num_rows(m)?;
     let ncols = num_cols(m)?;
@@ -115,6 +186,17 @@ pub(crate) fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
         .collect();
 
     Ok(det_poly(&poly_rows))
+}
+
+fn ir_to_frac(node: &IRNode) -> Option<Frac> {
+    match node {
+        IRNode::Integer(value) => Some(Frac::from_i64(*value)),
+        IRNode::Rational(numer, denom) => Some(Frac::new(*numer as i128, *denom as i128)),
+        IRNode::Apply(apply) if apply.head == sym(NEG) && apply.args.len() == 1 => {
+            ir_to_frac(&apply.args[0]).map(|value| -value)
+        }
+        _ => None,
+    }
 }
 
 fn to_solve_frac(value: Frac) -> MatrixResult<SolveFrac> {

--- a/code/packages/rust/cas-matrix/src/lib.rs
+++ b/code/packages/rust/cas-matrix/src/lib.rs
@@ -61,7 +61,7 @@ pub use arithmetic::{
     zero_matrix,
 };
 pub use determinant::{determinant, inverse};
-pub use eigenvalues::{char_poly_coeffs, charpoly, eigenvalues};
+pub use eigenvalues::{char_poly_coeffs, charpoly, eigenvalues, eigenvectors};
 pub use lu::lu_decompose;
 pub use matrix::{
     dimensions, get_entry, is_matrix, matrix, num_cols, num_rows, rows_of, MatrixError,

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -5,9 +5,9 @@
 
 use cas_matrix::{
     add_matrices, char_poly_coeffs, charpoly, columnspace, determinant, dimensions, dot,
-    eigenvalues, frobenius_norm, get_entry, identity_matrix, inverse, is_matrix, lu_decompose,
-    matrix, norm, nullspace, num_cols, num_rows, rank, row_reduce, rowspace, scalar_multiply,
-    sub_matrices, trace, transpose, zero_matrix, MatrixError, MATRIX,
+    eigenvalues, eigenvectors, frobenius_norm, get_entry, identity_matrix, inverse, is_matrix,
+    lu_decompose, matrix, norm, nullspace, num_cols, num_rows, rank, row_reduce, rowspace,
+    scalar_multiply, sub_matrices, trace, transpose, zero_matrix, MatrixError, MATRIX,
 };
 use symbolic_ir::{apply, flt, int, rat, sym, ADD, LIST, MUL, POW, SQRT, SUB};
 
@@ -530,6 +530,128 @@ fn eigenvalues_rejects_unsupported_shapes_and_symbolic_entries() {
 
     let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
     assert!(eigenvalues(&symbolic).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Eigenvectors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eigenvectors_1x1_and_2x2_distinct() {
+    let scalar = matrix(vec![irow(&[7])]).unwrap();
+    assert_eq!(
+        eigenvectors(&scalar).unwrap(),
+        apply(
+            sym(LIST),
+            vec![apply(
+                sym(LIST),
+                vec![
+                    int(7),
+                    int(1),
+                    apply(sym(LIST), vec![matrix(vec![irow(&[1])]).unwrap()])
+                ],
+            )],
+        )
+    );
+
+    let m = matrix(vec![irow(&[1, 2]), irow(&[2, 1])]).unwrap();
+    assert_eq!(
+        eigenvectors(&m).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(-1),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[-1]), irow(&[1])]).unwrap()]
+                        ),
+                    ],
+                ),
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(3),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[1]), irow(&[1])]).unwrap()]
+                        ),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn eigenvectors_repeated_and_rational() {
+    let rational = matrix(vec![vec![rat(1, 2), int(0)], vec![int(0), int(3)]]).unwrap();
+    assert_eq!(
+        eigenvectors(&rational).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(
+                    sym(LIST),
+                    vec![
+                        rat(1, 2),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[1]), irow(&[0])]).unwrap()]
+                        ),
+                    ],
+                ),
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(3),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[0]), irow(&[1])]).unwrap()]
+                        ),
+                    ],
+                ),
+            ],
+        )
+    );
+
+    let repeated = matrix(vec![irow(&[2, 0]), irow(&[0, 2])]).unwrap();
+    assert_eq!(
+        eigenvectors(&repeated).unwrap(),
+        apply(
+            sym(LIST),
+            vec![apply(
+                sym(LIST),
+                vec![
+                    int(2),
+                    int(2),
+                    apply(
+                        sym(LIST),
+                        vec![
+                            matrix(vec![irow(&[1]), irow(&[0])]).unwrap(),
+                            matrix(vec![irow(&[0]), irow(&[1])]).unwrap(),
+                        ],
+                    ),
+                ],
+            )],
+        )
+    );
+}
+
+#[test]
+fn eigenvectors_rejects_unsupported_shapes_and_symbolic_entries() {
+    let non_square = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
+    assert!(eigenvectors(&non_square).is_err());
+    assert!(eigenvectors(&identity_matrix(3).unwrap()).is_err());
+
+    let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
+    assert!(eigenvectors(&symbolic).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -219,6 +219,29 @@ export function eigenvalues(node: IRNode): IRNode {
   return app(LIST, result.roots.map((root) => app(LIST, [root, int(multiplicity)])));
 }
 
+export function eigenvectors(node: IRNode): IRNode {
+  const rows = matrixToRationals(node);
+  const eigs = eigenvalues(node);
+  if (eigs.kind !== "apply" || headName(eigs.head) !== LIST.name) {
+    return app(sym("Eigenvectors"), [node]);
+  }
+
+  return app(LIST, eigs.args.map((pair) => {
+    if (pair.kind !== "apply" || pair.args.length < 2) {
+      return app(LIST, [pair, int(1), app(LIST, [])]);
+    }
+    const [lambda, multiplicity] = pair.args;
+    const lambdaValue = irToRationalValue(lambda);
+    if (lambdaValue === undefined) {
+      return app(LIST, [lambda, multiplicity, app(LIST, [])]);
+    }
+
+    const shifted = rows.map((row, rowIndex) =>
+      row.map((entry, colIndex) => entry.sub(rowIndex === colIndex ? lambdaValue : RationalValue.zero())));
+    return app(LIST, [lambda, multiplicity, nullspace(rationalsToMatrix(shifted))]);
+  }));
+}
+
 export function inverse(node: IRNode): IRNode {
   const rows = rowsOf(node);
   const n = rows.length;
@@ -598,6 +621,15 @@ function rationalToIr(value: RationalValue): IRNode {
 
 function toSolveFrac(value: RationalValue): SolveFrac {
   return new SolveFrac(value.numer, value.denom);
+}
+
+function irToRationalValue(node: IRNode): RationalValue | undefined {
+  if (node.kind === "integer") return new RationalValue(node.value, 1n);
+  if (node.kind === "rational") return new RationalValue(node.numer, node.denom);
+  if (node.kind === "apply" && headName(node.head) === NEG.name && node.args.length === 1) {
+    return irToRationalValue(node.args[0])?.neg();
+  }
+  return undefined;
 }
 
 function rationalsToMatrix(rows: readonly (readonly RationalValue[])[]): IRNode {

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -9,6 +9,7 @@ import {
   determinant,
   dimensions,
   dot,
+  eigenvectors,
   eigenvalues,
   frobeniusNorm,
   getEntry,
@@ -296,6 +297,52 @@ describe("eigenvalues", () => {
     expect(() => eigenvalues(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
     expect(() => eigenvalues(identityMatrix(3))).toThrow(MatrixError);
     expect(() => eigenvalues(matrix([[sym("a")]]))).toThrow(MatrixError);
+  });
+});
+
+describe("eigenvectors", () => {
+  it("returns MACSYMA-style eigenvalue/multiplicity/vector triples", () => {
+    expect(eigenvectors(matrix([irow([7])]))).toEqual(app(LIST, [
+      app(LIST, [int(7), int(1), app(LIST, [matrix([irow([1])])])]),
+    ]));
+
+    expect(eigenvectors(matrix([irow([1, 2]), irow([2, 1])]))).toEqual(app(LIST, [
+      app(LIST, [int(-1), int(1), app(LIST, [matrix([irow([-1]), irow([1])])])]),
+      app(LIST, [int(3), int(1), app(LIST, [matrix([irow([1]), irow([1])])])]),
+    ]));
+  });
+
+  it("preserves rational and repeated eigenvalue vector bases", () => {
+    expect(eigenvectors(matrix([[rational(1, 2), int(0)], [int(0), int(3)]]))).toEqual(app(LIST, [
+      app(LIST, [rational(1, 2), int(1), app(LIST, [matrix([irow([1]), irow([0])])])]),
+      app(LIST, [int(3), int(1), app(LIST, [matrix([irow([0]), irow([1])])])]),
+    ]));
+
+    expect(eigenvectors(matrix([irow([2, 0]), irow([0, 2])]))).toEqual(app(LIST, [
+      app(LIST, [int(2), int(2), app(LIST, [
+        matrix([irow([1]), irow([0])]),
+        matrix([irow([0]), irow([1])]),
+      ])]),
+    ]));
+  });
+
+  it("returns an empty vector list for non-rational eigenvalues", () => {
+    const triples = eigenvectors(matrix([irow([0, 1]), irow([-1, 0])]));
+    expect(triples.kind).toBe("apply");
+    if (triples.kind !== "apply") return;
+    expect(triples.args.length).toBe(2);
+    triples.args.forEach((triple) => {
+      expect(triple.kind).toBe("apply");
+      if (triple.kind !== "apply") return;
+      expect(triple.args[1]).toEqual(int(1));
+      expect(triple.args[2]).toEqual(app(LIST, []));
+    });
+  });
+
+  it("rejects unsupported shapes and symbolic entries", () => {
+    expect(() => eigenvectors(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
+    expect(() => eigenvectors(identityMatrix(3))).toThrow(MatrixError);
+    expect(() => eigenvectors(matrix([[sym("a")]]))).toThrow(MatrixError);
   });
 });
 


### PR DESCRIPTION
## Summary
- add TypeScript `eigenvectors` for exact-rational 1x1/2x2 matrices using existing `eigenvalues` and `nullspace`
- add Rust `eigenvectors` with the same MACSYMA-style triple output and export it from `cas-matrix`
- cover distinct, rational, repeated, unsupported-shape, and symbolic-entry cases

## Testing
- `node ..\macsyma-runtime\node_modules\vitest\vitest.mjs run tests/cas-matrix.test.ts`
- `node ..\macsyma-runtime\node_modules\typescript\bin\tsc --noEmit`
- `cargo test --manifest-path code\packages\rust\Cargo.toml -p cas-matrix`
- `git diff --check`