### PR TITLE
papers: Phase 0 — positioning memo + Paper 1/2 skeletons

### DIFF
--- a/code/specs/papers/PAPER1-skeleton.md
+++ b/code/specs/papers/PAPER1-skeleton.md
@@ -1,0 +1,38 @@
+# Paper 1 skeleton — Byte-Recursive Provenance for Auditable, Correctable LLM Adjudication
+
+**Target:** TMLR (primary), workshop for early feedback. **Status:** skeleton.
+
+## One-sentence claim
+A recursive byte-accounting contract — every byte of every artifact, at every pipeline stage, is accounted-for or discarded-with-a-justification; every extracted fact is anchored to source bytes; every rule is verified to be entailed by its cited bytes — turns LLM adjudication into work that is **auditable** (every link traces to bytes) and **correctable** (errors localize to a clause), and its central mechanism is that **forced justification of discards attacks omission-class hallucination.**
+
+## Framing arc (intro → discussion)
+- **Motivation:** resident vs. attending. The fix for a wrong resident is not a smarter resident; it's showing work so the attending can find the omitted fact / bad inference and correct *that*, cheaply. Current LLMs emit untraceable prose — un-correctable. Shift the goal from **correctness** to **correctability**.
+- **History:** MYCIN worked but died on build/maintain/trust, not accuracy. LLMs dissolve the knowledge-acquisition and natural-language bottlenecks — but introduce a new one, unreliable knowledge. Byte-recursive provenance is how you pay that new cost.
+- **Scope:** adjudicative knowledge work (apply criteria to evidence for a defensible judgment). Inclusion test stated; out-of-scope named.
+
+## Contributions (C1–C4)
+- **C1.** The recursive byte-accounting **stage contract** (formal): input→IR, rulebook→IR, decision, each gated; no silent drops; discards justified; facts byte-anchored; rules entailment-checked. *(vs. output-only citation — §2 of memo.)*
+- **C2.** **Provenance for the negative space:** forced justification of discards, and the finding that the ignored span is where omission-hallucination hides. *(novel vs. attribution literature.)*
+- **C3.** **Hallucination-as-omission** mechanism + the isolating ablation (bare / coverage-only / justified-discards × present-but-skimmed / absent). *(the science.)*
+- **C4.** **Byte-stability boundary result** (demoted): sampling-consistency over verbatim source bytes detects *invention* but not *relevance/stable-error*; a second entailment layer is required. *(honest extension of SelfCheckGPT/semantic-entropy.)*
+
+## Experiments
+| # | experiment | status | task |
+|---|---|---|---|
+| E1 | Mechanistic ablation (justified-discards is the lever), open-weights Ollama, stratified items | TO BUILD | #47 |
+| E2 | Correction-loop study (localize + fix + persist; framework vs prose) — *correctability headline* | TO BUILD | #48 |
+| E3 | Cross-domain matrix (same machinery, N domains, only rulebook changes) | CONSOLIDATE (ADJ49/56/59/70/71 + clinical) | #49 |
+| E4 | HLE/defensibility screening harness (blind controls; correctness + defensibility + error bars; cross-model byte-stability) | TO BUILD (extend ADJ72 50-sample) | #50 |
+| (E0) | Two worked HLE runs (Palmyrene stable-error; hummingbird unstable-gap) | DONE (ADJ72) | — |
+
+## Related work (positions per memo)
+SelfCheckGPT / semantic entropy (C4 demotion); ALCE / VeriCite / attribution survey (C1–C2 contrast); knowledge-conflict / lost-in-the-middle / parametric-vs-contextual (C3 home); process supervision / PRMs + faithful-CoT (the discipline; byte-grounding as answer to CoT-unfaithfulness); Attention-is-not-Explanation (frame C3 as information-flow, not attention weights).
+
+## Threats to validity
+Contamination (public benchmarks in training data → use less-contaminated/held-out items, state it); single model family (add cross-model arm); the stable-error-with-no-flagged-neighbor hole; n / error bars; correctness scoring protocol.
+
+## Reproducibility
+Clean repo + fixed prompts + one-command harness; every quantitative claim traces to a repo artifact (byte-provenance applied to the paper itself). Public data only — no real PHI; no IRB needed.
+
+## Headline candidate
+**E2 (correctability)** is likely the most persuasive — it measures the thing nobody else measures (cost-to-correct), and it can't be scooped by accuracy or hallucination-detection work.

--- a/code/specs/papers/PAPER2-skeleton.md
+++ b/code/specs/papers/PAPER2-skeleton.md
@@ -27,10 +27,13 @@ Byte-grounded rulebooks compile **once** into content-addressed (CAS) executable
 ## Related work (positions per memo)
 Knowledge compilation (Darwiche & Marquis); model editing ROME/MEMIT/AlphaEdit + **the editing-collapse result** (foil); IKE / parameter-preserving editing; belief revision / truth-maintenance (corrections + conflict); **FrugalGPT (TMLR 2024) + cascades/routing** — the critical foil for the cost headline.
 
-## The headline — reframed (see memo §6)
-**"Small model = big model at a fraction of cost" is FrugalGPT's, already published.** Our defensible headline:
-> A small **local** model with the framework matches frontier accuracy on auditable adjudication **at a fraction of cost, with a full audit trail neither bare model produces, because the knowledge lives in a verified external library rather than the model — enabling PHI-local deployment.**
-Measure **accuracy parity + cost ratio + defensibility** together; the headline is the conjunction. Reframe vs. cascades: they *gamble* on the cheap model; we *verify* it, and the small model does *extraction*, not *reasoning*.
+## The headline — DEFENSIBILITY-parity, not capability-parity (see memo §6)
+**Do NOT claim "Haiku matches Opus on accuracy" — that's FrugalGPT's axis (TMLR 2024), and it isn't even true.** The claim is on a different, uncontested axis:
+> **Defensibility is a property of the verification discipline, not of model scale.** Under the framework, a small **local** model (Haiku) produces work whose audit trail is **as defensible and auditable as a frontier model's (Opus)** — abstaining/kicking-back where it cannot ground rather than fabricating — enabling PHI-local deployment.
+
+**Honest boundary:** the accuracy/coverage gap persists (Haiku abstains where Opus completes); the **defensibility** gap closes to ~0; neither produces un-auditable work.
+
+**The 2×2 experiment:** {Haiku, Opus} × {bare, +framework}, same items, blind adversarial auditor scoring **defensibility-fraction** + accuracy + abstention/kickback rate. Prediction: the framework collapses the Haiku↔Opus *defensibility* gap to ~0 while the *accuracy/coverage* gap persists and is absorbed by honest abstention. Reframe vs. cascades: they measure correctness-parity and *gamble* on the cheap model; we measure *defensibility*-parity and *verify* it.
 
 ## Threats to validity
 Rule-interaction consistency at scale (belief-revision is hard; conflict-detection + regression-gate is partial); local-extraction fidelity on real inputs; library coverage gaps (must kick back, never silently proceed); liability/governance (deployment barrier the audit trail mitigates but doesn't remove).

--- a/code/specs/papers/PAPER2-skeleton.md
+++ b/code/specs/papers/PAPER2-skeleton.md
@@ -1,0 +1,39 @@
+# Paper 2 skeleton — Knowledge Compilation for Auditable Adjudication: CAS-Cached, Human-Correctable, Privacy-Local Rulebooks
+
+**Target:** TMLR (primary) or a systems venue. **Depends on:** Paper 1 preprint being out. **Status:** skeleton.
+
+## One-sentence claim
+Byte-grounded rulebooks compile **once** into content-addressed (CAS) executable libraries that future cases query on **CPU with zero answer-time model calls**; because every compiled rule cites verified source bytes, the cache is trustworthy, **human-correctable** (edit a rule → new CAS version, regression-gated), and **model-decoupled**; and the derive-offline / execute-local split makes the system **privacy-compliant (PHI-local) by construction.**
+
+## Framing arc
+- **The cache is institutional memory of corrections, not a speed hack.** When the attending corrects the resident, the resident doesn't make that mistake again. The CAS does the same: a corrected, byte-grounded rule is versioned and reused; the system carries forward every correction, auditably.
+- **Provenance is the precondition for trust-free reuse.** You can only run a cached rule on CPU without re-invoking the model because the rule traces to verified bytes.
+- **The privacy boundary aligns with the architecture's natural split.**
+
+## Contributions (C1–C4)
+- **C1.** **Knowledge compilation for LLM reasoning:** compile a byte-grounded rulebook into a CAS executable library; input IR → deterministic program that imports the library; reasoning is CPU-bound. *(Darwiche/Marquis knowledge compilation, modernized.)*
+- **C2.** **External, editable, versioned corrections vs. weight editing:** human override = a provenance-tagged assertion (`human_override(editor, ts, justification, authority, scope)`); committed only if conflict-checked + **regression-gated** (CI for the knowledge base). Contrast with ROME/MEMIT (opaque, collapse-prone, model-bound). *(belief revision / TMS for the conflict logic.)*
+- **C3.** **Model-decoupling:** corrections persist across a model swap (knowledge in the artifact, not the weights). The experiment cascades/model-editing can't run cleanly.
+- **C4.** **Privacy-local deployment:** frontier model derives+compiles offline on *public* sources (never sees PHI); small local model ingests the case → byte-accounted IR; deterministic compiler emits the program; CPU executes locally; coverage-gaps kick back to a human. The decision **replays locally and deterministically** from local artifacts.
+
+## Experiments
+| # | experiment | status | task |
+|---|---|---|---|
+| E1 | CAS knowledge-compilation benchmark: cold-vs-warm cost, accuracy parity (compiled-CPU vs LLM-answer-time), cache hit-rate / generalization, ≥2 domains | EXTEND ADJ71 (one slice done) | #52 |
+| E2 | Correction-persistence + **model-swap durability** (edit persists; swap model → corrections survive) | TO BUILD | #52 |
+| E3 | **Privacy-local deployment**: frontier-offline-derive + local-Gemma-ingest + deterministic-emit + CPU-exec; extraction fidelity, parity vs frontier, coverage-gap kickback | TO BUILD | #53 |
+| (E0) | Narrow CAS program-cache slice (8 U.S.C. 1427 naturalization) | DONE (ADJ71) | — |
+
+## Related work (positions per memo)
+Knowledge compilation (Darwiche & Marquis); model editing ROME/MEMIT/AlphaEdit + **the editing-collapse result** (foil); IKE / parameter-preserving editing; belief revision / truth-maintenance (corrections + conflict); **FrugalGPT (TMLR 2024) + cascades/routing** — the critical foil for the cost headline.
+
+## The headline — reframed (see memo §6)
+**"Small model = big model at a fraction of cost" is FrugalGPT's, already published.** Our defensible headline:
+> A small **local** model with the framework matches frontier accuracy on auditable adjudication **at a fraction of cost, with a full audit trail neither bare model produces, because the knowledge lives in a verified external library rather than the model — enabling PHI-local deployment.**
+Measure **accuracy parity + cost ratio + defensibility** together; the headline is the conjunction. Reframe vs. cascades: they *gamble* on the cheap model; we *verify* it, and the small model does *extraction*, not *reasoning*.
+
+## Threats to validity
+Rule-interaction consistency at scale (belief-revision is hard; conflict-detection + regression-gate is partial); local-extraction fidelity on real inputs; library coverage gaps (must kick back, never silently proceed); liability/governance (deployment barrier the audit trail mitigates but doesn't remove).
+
+## Reproducibility / ethics
+Public sources only (statutes, literature, court opinions) — **no real PHI**; the HIPAA discussion concerns the deployment *architecture*, not the experiments. CAS hashes + generated libraries + programs committed as artifacts.

--- a/code/specs/papers/POSITIONING-MEMO.md
+++ b/code/specs/papers/POSITIONING-MEMO.md
@@ -58,10 +58,13 @@ contribution: the close prior art, the genuine gap, and the defensible framing.
 
 **Verdict: "small model matches big model at a fraction of cost" is NOT a novel headline. FrugalGPT owns it.** A bare "Haiku reaches Opus cheaply" claim will be desk-rejected as derivative.
 
-**What's open / how to position — the headline must shift to what cascades DON'T do:**
-- Cascades route on **answer confidence / ensemble agreement**; they never make the cheap model's output **auditable** or **safe-by-verification**. They gamble that the cheap model is right; we **verify** it byte-by-byte.
-- In our split the small model does **extraction**, not **reasoning** — the reasoning lives in the compiled external library. Cascades still ask each model to *reason*.
-- **The defensible headline:** *"A small **local** model matches a frontier model's accuracy on auditable adjudication **at a fraction of cost AND with a full audit trail neither bare model produces — because the knowledge lives in a verified external library, not the model** — enabling privacy-compliant (PHI-local) deployment."* The novelty is **auditability + privacy-local + knowledge-in-external-library**, not the cost/accuracy parity (which is FrugalGPT's).
+**What's open / how to position — a DIFFERENT AXIS from cascades entirely:**
+- Cascades / FrugalGPT measure **answer-correctness parity** at lower cost. We do **not** claim Haiku matches Opus on capability/accuracy — it doesn't, and we don't need it to.
+- **The claim is defensibility-parity, not capability-parity:** *defensibility is a property of the verification discipline, not of model scale.* Under the framework, Haiku produces work whose **audit trail is as defensible/verifiable as Opus's** — the intelligence that makes work defensible lives in the discipline, so a small model inherits it.
+- **Honest boundary (this is what makes it bulletproof):** Haiku and Opus differ on **coverage**, not on **defensibility-of-completed-work**. Where Haiku hits a capability ceiling it **abstains / kicks back** rather than fabricating; Opus reaches further. So the *accuracy/coverage* gap persists (honest); the *defensibility* gap closes to ~0; neither produces un-auditable work.
+- **Why this isn't FrugalGPT's territory:** nobody measures **defensibility-parity across model scale** (the ADJ68 axis). FrugalGPT owns correctness-parity; this lane is uncontested.
+- **The headline:** *"Defensibility is model-independent under the discipline: a small **local** model produces work as defensible and auditable as a frontier model — abstaining where it cannot ground rather than fabricating — enabling privacy-compliant (PHI-local) deployment."*
+- **The experiment (2×2):** {Haiku, Opus} × {bare, +framework}, same items, blind adversarial auditor scoring **defensibility-fraction** + accuracy + abstention/kickback rate. Prediction: the framework collapses the Haiku↔Opus **defensibility** gap to ~0 while the **accuracy/coverage** gap persists and is absorbed by honest abstention.
 
 ---
 

--- a/code/specs/papers/POSITIONING-MEMO.md
+++ b/code/specs/papers/POSITIONING-MEMO.md
@@ -1,0 +1,73 @@
+# Positioning memo — what's taken, what's open, how to position
+
+Phase 0 deliverable (task #46). Based on a related-work scan, 2026-06-08. For each
+contribution: the close prior art, the genuine gap, and the defensible framing.
+
+---
+
+## 1. Byte-stability (sampling self-consistency over verbatim source bytes)
+
+**TAKEN — and heavily.** This is essentially **SelfCheckGPT** (Manakul et al., arXiv 2303.08896): "if an LLM has knowledge of a concept, sampled responses are consistent." Plus **semantic entropy** (Farquhar et al., *Nature* 2024) and **LLM-Check**. The core idea — resample, measure consistency, low consistency ⇒ hallucination — is established and crowded.
+
+**Verdict: DEMOTE. Do not present byte-stability as a novel detector.** It will read as "SelfCheckGPT on verbatim passages."
+
+**What's still open / how to position:**
+- It's a **component**, not the contribution. Lead with the recursive stage-contract; byte-stability is *one gate* inside it.
+- The genuine novelty is the **negative result**: byte-stability detects *invention* but NOT *relevance* or *stable-error* (the Watson–Crick "closing sentence"; the Palmyrene stable misparse). The consistency-detection literature frames consistency as a hallucination signal; we show its precise *failure boundary* and that you need a second (entailment) layer above it. That boundary result is publishable and is NOT in SelfCheckGPT.
+- Requiring the model to emit **source bytes** (not just resample answers) is a stricter, verifiable variant — worth one sentence, not a section.
+
+## 2. Provenance / citation / attribution
+
+**TAKEN at the output level.** **ALCE** (Gao et al., arXiv 2305.14627) is the citation benchmark (recall/precision of citations). **VeriCite**, blueprint models (Fierro 2024), VTG (Sun 2024), and a 2025 survey ("Attribution, Citation, and Quotation") cover answer→source citation + verification. Documented citation-hallucination rates 11–57%.
+
+**What's open / how to position:**
+- Existing work cites at the **output level** (the answer cites sources). Nobody enforces **byte-accounting at *every stage*** with **no silent drops** and **justified discards**.
+- **The novel move is provenance for the *negative space*:** existing work checks whether citations *support* what was *said* (inclusion). We additionally force justification of what was *ignored* (exclusion) — and argue (with the omission framing) that the ignored span is where the load-bearing error hides.
+- Input-side + rulebook-side provenance, recursively, not just output-side.
+- **Frame:** "Prior attribution work grounds what the model *says*; we grounds what it *ignores*, and enforce it recursively at every pipeline stage."
+
+## 3. Hallucination-as-omission (the science / the mechanism)
+
+**SUPPORTING, not scooping.** **Knowledge conflict** (EMNLP 2024 survey), **lost-in-the-middle**, parametric-vs-contextual interplay (ECIR 2025 keynote) all establish that models under-use context in favor of parametric priors. This literature is your **home** — it sets up the problem your contract attacks.
+
+**What's open / how to position:**
+- Nobody frames a **forced-justification-of-discards contract** as the *intervention* against context-under-utilization.
+- **The isolating ablation is the novel empirical contribution**: bare / coverage-only / justified-discards × stratified (present-but-skimmed vs absent). Predict justified-discards ≫ coverage-only ≈ bare on the omission subclass. This is the experiment that converts the story into science.
+- Caveat to respect (interpretability reviewers): frame as **information flow / context utilization**, not raw attention-as-importance ("Attention is not Explanation," Jain & Wallace 2019). The contract is an *output-level constraint that induces* context-faithful processing — not a weight intervention.
+
+## 4. Process supervision / faithful CoT (the discipline)
+
+**TAKEN.** "Let's Verify Step by Step" (Lightman et al., ICLR) + PRMs = supervise/score intermediate steps. Faithful-CoT work (Lanham; FaithCoT-Bench; "CoT Monitorability," 2025) shows free-text rationales often don't reflect the true computation.
+
+**What's open / how to position:**
+- Process supervision **scores** steps with a reward model; we make the process **byte-grounded and human-editable** — the attending edits a specific clause, not a scalar reward.
+- **Faithful-CoT is your ammunition, not your competitor:** because free-text rationales are unreliable, *byte-grounded* provenance (cite the actual input bytes, checkable) is strictly stronger than "explain your reasoning." This is the one-line answer to "why not just prompt for an explanation."
+
+## 5. Knowledge compilation / model editing (Paper 2)
+
+**TAKEN (the foil).** **ROME** (NeurIPS'22), **MEMIT** (ICLR'23), **AlphaEdit** (ICLR'25) edit facts *in weights*. Critically: **"Understanding the Collapse of LLMs in Model Editing" (2406.11263)** documents that weight editing is brittle and collapse-prone. **IKE** and parameter-preserving editing store knowledge externally.
+
+**What's open / how to position:**
+- Model editing edits **weights** — opaque, collapse-prone, entangled, model-bound, hard to revert. **We edit an external, versioned, content-addressed, executable rulebook** — transparent, diffable, revertible, regression-gated, **model-decoupled**.
+- **"Knowledge compilation"** (Darwiche & Marquis) is the precise established term: preprocess a KB into a form that makes queries tractable. We modernize it: compile a *byte-grounded* rulebook into a *CAS executable program*; the query is the input IR; reasoning runs on CPU.
+- **Frame:** "We don't edit the model; we edit and compile the knowledge base the model reasons over — and cite the model-editing-collapse result as evidence that weights are the wrong place to put correctable knowledge."
+
+## 6. LLM cascades / routing (the "small beats big" headline) — READ THIS
+
+**TAKEN, and this is the most important finding for the headline.** **FrugalGPT** (Chen et al., **TMLR 2024**) already published: *"match the performance of the best individual LLM (GPT-4) with up to 98% cost reduction."* Plus AutoMix, C3PO, **Agreement-Based Cascading** (escalate on ensemble agreement — close to your byte-stability gate!), MixLLM, and a 2026 routing/cascading survey.
+
+**Verdict: "small model matches big model at a fraction of cost" is NOT a novel headline. FrugalGPT owns it.** A bare "Haiku reaches Opus cheaply" claim will be desk-rejected as derivative.
+
+**What's open / how to position — the headline must shift to what cascades DON'T do:**
+- Cascades route on **answer confidence / ensemble agreement**; they never make the cheap model's output **auditable** or **safe-by-verification**. They gamble that the cheap model is right; we **verify** it byte-by-byte.
+- In our split the small model does **extraction**, not **reasoning** — the reasoning lives in the compiled external library. Cascades still ask each model to *reason*.
+- **The defensible headline:** *"A small **local** model matches a frontier model's accuracy on auditable adjudication **at a fraction of cost AND with a full audit trail neither bare model produces — because the knowledge lives in a verified external library, not the model** — enabling privacy-compliant (PHI-local) deployment."* The novelty is **auditability + privacy-local + knowledge-in-external-library**, not the cost/accuracy parity (which is FrugalGPT's).
+
+---
+
+## Net effect on strategy
+
+1. **Lead Paper 1 with the recursive stage-contract + justified-discards (provenance for the negative space) + the omission ablation.** Byte-stability is a demoted component with a publishable *boundary* result.
+2. **Lead Paper 2 with knowledge compilation to an editable, model-decoupled CAS library**, model-editing as the foil, and the **privacy-local deployment** as the deployment contribution.
+3. **The "Haiku = Opus" number must be reframed**: not "cheap parity" (FrugalGPT) but **"cheap parity + auditable + PHI-local + knowledge-external."** Measure accuracy parity, cost, AND defensibility together; the headline is the conjunction, not the accuracy alone.
+4. **Strong venue signal:** FrugalGPT is a **TMLR** paper. TMLR is the right primary target for both.


### PR DESCRIPTION
## Summary

Phase 0 of the publication plan (tasks #46): a related-work scan and positioning for two papers, plus one-page skeletons for each.

- `code/specs/papers/POSITIONING-MEMO.md` — what's taken / what's open / how to position, across 6 prior-art areas.
- `code/specs/papers/PAPER1-skeleton.md` — byte-recursive provenance for auditable/correctable adjudication.
- `code/specs/papers/PAPER2-skeleton.md` — knowledge compilation to CAS-cached, human-correctable, privacy-local rulebooks.

## Two findings that change strategy

1. **Byte-stability overlaps SelfCheckGPT / semantic entropy** — demote it from "novel detector" to a component; the publishable part is the *failure boundary* (detects invention, not relevance/stable-error), which the consistency-detection literature doesn't frame.
2. **FrugalGPT (TMLR 2024) already owns "small model = big model at a fraction of cost"** — the cheap-parity headline is taken. Reframe to **cheap-parity + auditable + PHI-local + knowledge-in-external-library** (the part cascades/routing don't do).

Docs-only planning artifacts; public data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)