### PR TITLE
Extend cas-matrix eigen parity to 4x4

### DIFF
--- a/code/packages/rust/cas-matrix/src/eigenvalues.rs
+++ b/code/packages/rust/cas-matrix/src/eigenvalues.rs
@@ -1,7 +1,9 @@
 //! Characteristic polynomial helpers for exact-rational matrices.
 
+use std::cmp::Ordering;
+
 use cas_solve::frac::Frac as SolveFrac;
-use cas_solve::{solve_linear, solve_quadratic, SolveResult};
+use cas_solve::{solve_cubic, solve_linear, solve_quadratic, solve_quartic, SolveResult};
 use symbolic_ir::{apply, int, sym, IRNode, ADD, LIST, MUL, NEG, POW};
 
 use crate::matrix::{matrix, num_cols, num_rows, MatrixError, MatrixResult};
@@ -50,7 +52,7 @@ pub fn charpoly(m: &IRNode, variable: &IRNode) -> MatrixResult<IRNode> {
     })
 }
 
-/// Return `List(List(lambda, multiplicity), ...)` for 1x1/2x2 exact matrices.
+/// Return `List(List(lambda, multiplicity), ...)` for exact matrices up to 4x4.
 pub fn eigenvalues(m: &IRNode) -> MatrixResult<IRNode> {
     let n = num_rows(m)?;
     let ncols = num_cols(m)?;
@@ -59,31 +61,34 @@ pub fn eigenvalues(m: &IRNode) -> MatrixResult<IRNode> {
             "eigenvalues: matrix must be square, got {n}x{ncols}"
         )));
     }
-    if n > 2 {
+    if n > 4 {
         return Err(MatrixError(
-            "eigenvalues: only 1x1 and 2x2 matrices are supported in this Rust port".into(),
+            "eigenvalues: only matrices up to 4x4 are supported in this Rust port".into(),
         ));
     }
 
-    let coeffs: Vec<SolveFrac> = char_poly_coeff_fracs(m)?
+    let coeff_fracs = char_poly_coeff_fracs(m)?;
+    let coeffs: Vec<SolveFrac> = coeff_fracs
+        .iter()
+        .copied()
         .into_iter()
         .map(to_solve_frac)
         .collect::<MatrixResult<Vec<SolveFrac>>>()?;
-    let result = if n == 1 {
-        solve_linear(coeffs[1], coeffs[0])
-    } else {
-        solve_quadratic(coeffs[2], coeffs[1], coeffs[0])
-    };
+    let result = solve_characteristic(&coeffs)?;
 
-    let SolveResult::Solutions(roots) = result else {
+    let SolveResult::Solutions(mut roots) = result else {
         return Ok(apply(sym("Eigenvalues"), vec![m.clone()]));
     };
-    let multiplicity = if n == 2 && roots.len() == 1 { 2 } else { 1 };
+    roots.sort_by(compare_eigen_root);
+    let root_count = roots.len();
     Ok(apply(
         sym("List"),
         roots
             .into_iter()
-            .map(|root| apply(sym("List"), vec![root, int(multiplicity)]))
+            .map(|root| {
+                let multiplicity = root_multiplicity(&root, &coeff_fracs, n, root_count) as i64;
+                apply(sym("List"), vec![root, int(multiplicity)])
+            })
             .collect(),
     ))
 }
@@ -186,6 +191,69 @@ pub(crate) fn char_poly_coeff_fracs(m: &IRNode) -> MatrixResult<Vec<Frac>> {
         .collect();
 
     Ok(det_poly(&poly_rows))
+}
+
+fn solve_characteristic(coeffs: &[SolveFrac]) -> MatrixResult<SolveResult> {
+    let degree = coeffs.len().saturating_sub(1);
+    match degree {
+        1 => Ok(solve_linear(coeffs[1], coeffs[0])),
+        2 => Ok(solve_quadratic(coeffs[2], coeffs[1], coeffs[0])),
+        3 => Ok(solve_cubic(coeffs[3], coeffs[2], coeffs[1], coeffs[0])),
+        4 => Ok(solve_quartic(
+            coeffs[4], coeffs[3], coeffs[2], coeffs[1], coeffs[0],
+        )),
+        _ => Err(MatrixError(format!(
+            "eigenvalues: unsupported characteristic polynomial degree {degree}"
+        ))),
+    }
+}
+
+fn compare_eigen_root(left: &IRNode, right: &IRNode) -> Ordering {
+    match (ir_to_frac(left), ir_to_frac(right)) {
+        (Some(left), Some(right)) => (left.numer * right.denom).cmp(&(right.numer * left.denom)),
+        _ => Ordering::Equal,
+    }
+}
+
+fn root_multiplicity(
+    root: &IRNode,
+    coeffs: &[Frac],
+    matrix_size: usize,
+    root_count: usize,
+) -> usize {
+    let Some(rational_root) = ir_to_frac(root) else {
+        return if root_count == 1 { matrix_size } else { 1 };
+    };
+
+    let mut remaining = coeffs.to_vec();
+    let mut multiplicity = 0;
+    while remaining.len() > 1 {
+        let (quotient, remainder) = divide_by_linear_factor(&remaining, rational_root);
+        if !remainder.is_zero() {
+            break;
+        }
+        multiplicity += 1;
+        remaining = quotient;
+    }
+    multiplicity.max(1)
+}
+
+fn divide_by_linear_factor(coeffs: &[Frac], root: Frac) -> (Vec<Frac>, Frac) {
+    let degree = coeffs.len().saturating_sub(1);
+    if degree == 0 {
+        return (
+            Vec::new(),
+            coeffs.first().copied().unwrap_or_else(Frac::zero),
+        );
+    }
+
+    let mut quotient = vec![Frac::zero(); degree];
+    quotient[degree - 1] = coeffs[degree];
+    for i in (0..degree.saturating_sub(1)).rev() {
+        quotient[i] = coeffs[i + 1] + root * quotient[i + 1];
+    }
+    let remainder = coeffs[0] + root * quotient[0];
+    (quotient, remainder)
 }
 
 fn ir_to_frac(node: &IRNode) -> Option<Frac> {

--- a/code/packages/rust/cas-matrix/tests/tests.rs
+++ b/code/packages/rust/cas-matrix/tests/tests.rs
@@ -509,6 +509,11 @@ fn eigenvalues_repeated_and_rational() {
         apply(sym(LIST), vec![apply(sym(LIST), vec![int(2), int(2)])])
     );
 
+    assert_eq!(
+        eigenvalues(&identity_matrix(3).unwrap()).unwrap(),
+        apply(sym(LIST), vec![apply(sym(LIST), vec![int(1), int(3)])])
+    );
+
     let rational = matrix(vec![vec![rat(1, 2), int(0)], vec![int(0), int(3)]]).unwrap();
     assert_eq!(
         eigenvalues(&rational).unwrap(),
@@ -523,10 +528,46 @@ fn eigenvalues_repeated_and_rational() {
 }
 
 #[test]
+fn eigenvalues_3x3_and_4x4_exact_roots() {
+    let cubic = matrix(vec![irow(&[1, 0, 0]), irow(&[0, 2, 0]), irow(&[0, 0, 3])]).unwrap();
+    assert_eq!(
+        eigenvalues(&cubic).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(LIST), vec![int(1), int(1)]),
+                apply(sym(LIST), vec![int(2), int(1)]),
+                apply(sym(LIST), vec![int(3), int(1)]),
+            ],
+        )
+    );
+
+    let quartic = matrix(vec![
+        irow(&[-2, 0, 0, 0]),
+        irow(&[0, -1, 0, 0]),
+        irow(&[0, 0, 1, 0]),
+        irow(&[0, 0, 0, 2]),
+    ])
+    .unwrap();
+    assert_eq!(
+        eigenvalues(&quartic).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(sym(LIST), vec![int(-2), int(1)]),
+                apply(sym(LIST), vec![int(-1), int(1)]),
+                apply(sym(LIST), vec![int(1), int(1)]),
+                apply(sym(LIST), vec![int(2), int(1)]),
+            ],
+        )
+    );
+}
+
+#[test]
 fn eigenvalues_rejects_unsupported_shapes_and_symbolic_entries() {
     let non_square = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
     assert!(eigenvalues(&non_square).is_err());
-    assert!(eigenvalues(&identity_matrix(3).unwrap()).is_err());
+    assert!(eigenvalues(&identity_matrix(5).unwrap()).is_err());
 
     let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
     assert!(eigenvalues(&symbolic).is_err());
@@ -645,10 +686,56 @@ fn eigenvectors_repeated_and_rational() {
 }
 
 #[test]
+fn eigenvectors_3x3_exact_rational_bases() {
+    let m = matrix(vec![irow(&[1, 0, 0]), irow(&[0, 2, 0]), irow(&[0, 0, 3])]).unwrap();
+    assert_eq!(
+        eigenvectors(&m).unwrap(),
+        apply(
+            sym(LIST),
+            vec![
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(1),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[1]), irow(&[0]), irow(&[0])]).unwrap()]
+                        ),
+                    ],
+                ),
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(2),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[0]), irow(&[1]), irow(&[0])]).unwrap()]
+                        ),
+                    ],
+                ),
+                apply(
+                    sym(LIST),
+                    vec![
+                        int(3),
+                        int(1),
+                        apply(
+                            sym(LIST),
+                            vec![matrix(vec![irow(&[0]), irow(&[0]), irow(&[1])]).unwrap()]
+                        ),
+                    ],
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
 fn eigenvectors_rejects_unsupported_shapes_and_symbolic_entries() {
     let non_square = matrix(vec![irow(&[1, 2, 3]), irow(&[4, 5, 6])]).unwrap();
     assert!(eigenvectors(&non_square).is_err());
-    assert!(eigenvectors(&identity_matrix(3).unwrap()).is_err());
+    assert!(eigenvectors(&identity_matrix(5).unwrap()).is_err());
 
     let symbolic = matrix(vec![vec![sym("a")]]).unwrap();
     assert!(eigenvectors(&symbolic).is_err());

--- a/code/packages/typescript/cas-matrix/src/index.ts
+++ b/code/packages/typescript/cas-matrix/src/index.ts
@@ -16,7 +16,7 @@ import {
   type IRInteger,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
-import { Frac as SolveFrac, solveLinear, solveQuadratic } from "@coding-adventures/cas-solve";
+import { Frac as SolveFrac, solveCubic, solveLinear, solveQuadratic, solveQuartic } from "@coding-adventures/cas-solve";
 import { Matrix, getMatrixBackend } from "matrix";
 
 export const MATRIX = "Matrix";
@@ -205,18 +205,20 @@ export function eigenvalues(node: IRNode): IRNode {
   if (n !== ncols) {
     throw new MatrixError(`eigenvalues: matrix must be square, got ${n}x${ncols}`);
   }
-  if (n > 2) {
-    throw new MatrixError("eigenvalues: only 1x1 and 2x2 matrices are supported in this TypeScript port");
+  if (n > 4) {
+    throw new MatrixError("eigenvalues: only matrices up to 4x4 are supported in this TypeScript port");
   }
 
-  const coeffs = charPolyCoeffValues(node).map(toSolveFrac);
-  const result = n === 1
-    ? solveLinear(coeffs[1], coeffs[0])
-    : solveQuadratic(coeffs[2], coeffs[1], coeffs[0]);
+  const coeffValues = charPolyCoeffValues(node);
+  const coeffs = coeffValues.map(toSolveFrac);
+  const result = solveCharacteristic(coeffs);
   if (result.kind === "all") return app(sym("Eigenvalues"), [node]);
 
-  const multiplicity = n === 2 && result.roots.length === 1 ? 2 : 1;
-  return app(LIST, result.roots.map((root) => app(LIST, [root, int(multiplicity)])));
+  const roots = [...result.roots].sort(compareEigenRoot);
+  return app(LIST, roots.map((root) => app(LIST, [
+    root,
+    int(rootMultiplicity(root, coeffValues, n, roots.length)),
+  ])));
 }
 
 export function eigenvectors(node: IRNode): IRNode {
@@ -564,6 +566,64 @@ function charPolyCoeffValues(node: IRNode): RationalValue[] {
   return detPoly(polyRows);
 }
 
+function solveCharacteristic(coeffs: readonly SolveFrac[]) {
+  const degree = coeffs.length - 1;
+  if (degree === 1) return solveLinear(coeffs[1], coeffs[0]);
+  if (degree === 2) return solveQuadratic(coeffs[2], coeffs[1], coeffs[0]);
+  if (degree === 3) return solveCubic(coeffs[3], coeffs[2], coeffs[1], coeffs[0]);
+  if (degree === 4) return solveQuartic(coeffs[4], coeffs[3], coeffs[2], coeffs[1], coeffs[0]);
+  throw new MatrixError(`eigenvalues: unsupported characteristic polynomial degree ${degree}`);
+}
+
+function compareEigenRoot(left: IRNode, right: IRNode): number {
+  const leftRational = irToRationalValue(left);
+  const rightRational = irToRationalValue(right);
+  if (leftRational !== undefined && rightRational !== undefined) {
+    return compareRationalValues(leftRational, rightRational);
+  }
+  return 0;
+}
+
+function rootMultiplicity(
+  root: IRNode,
+  coeffs: readonly RationalValue[],
+  matrixSize: number,
+  rootCount: number,
+): number {
+  const rationalRoot = irToRationalValue(root);
+  if (rationalRoot === undefined) {
+    return rootCount === 1 ? matrixSize : 1;
+  }
+
+  let remaining = [...coeffs];
+  let multiplicity = 0;
+  while (remaining.length > 1) {
+    const division = divideByLinearFactor(remaining, rationalRoot);
+    if (!division.remainder.isZero()) break;
+    multiplicity += 1;
+    remaining = division.quotient;
+  }
+  return multiplicity === 0 ? 1 : multiplicity;
+}
+
+function divideByLinearFactor(
+  coeffs: readonly RationalValue[],
+  root: RationalValue,
+): { quotient: RationalValue[]; remainder: RationalValue } {
+  const degree = coeffs.length - 1;
+  if (degree <= 0) return { quotient: [], remainder: coeffs[0] ?? RationalValue.zero() };
+
+  const quotient = Array.from({ length: degree }, () => RationalValue.zero());
+  quotient[degree - 1] = coeffs[degree] ?? RationalValue.zero();
+  for (let i = degree - 2; i >= 0; i -= 1) {
+    quotient[i] = (coeffs[i + 1] ?? RationalValue.zero()).add(root.mul(quotient[i + 1]));
+  }
+  return {
+    quotient,
+    remainder: (coeffs[0] ?? RationalValue.zero()).add(root.mul(quotient[0])),
+  };
+}
+
 function detPoly(rows: RationalValue[][][]): RationalValue[] {
   const n = rows.length;
   if (n === 0) return [RationalValue.one()];
@@ -715,6 +775,13 @@ function integerSqrt(value: bigint): bigint {
 function compareAbsRational(a: RationalValue, b: RationalValue): number {
   const left = abs(a.numer) * b.denom;
   const right = abs(b.numer) * a.denom;
+  if (left === right) return 0;
+  return left > right ? 1 : -1;
+}
+
+function compareRationalValues(a: RationalValue, b: RationalValue): number {
+  const left = a.numer * b.denom;
+  const right = b.numer * a.denom;
   if (left === right) return 0;
   return left > right ? 1 : -1;
 }

--- a/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
+++ b/code/packages/typescript/cas-matrix/tests/cas-matrix.test.ts
@@ -287,15 +287,37 @@ describe("eigenvalues", () => {
     expect(eigenvalues(matrix([irow([2, 0]), irow([0, 2])]))).toEqual(app(LIST, [
       app(LIST, [int(2), int(2)]),
     ]));
+    expect(eigenvalues(identityMatrix(3))).toEqual(app(LIST, [
+      app(LIST, [int(1), int(3)]),
+    ]));
     expect(eigenvalues(matrix([[rational(1, 2), int(0)], [int(0), int(3)]]))).toEqual(app(LIST, [
       app(LIST, [rational(1, 2), int(1)]),
       app(LIST, [int(3), int(1)]),
     ]));
   });
 
+  it("solves cubic and quartic characteristic polynomials for 3x3 and 4x4 matrices", () => {
+    expect(eigenvalues(matrix([irow([1, 0, 0]), irow([0, 2, 0]), irow([0, 0, 3])]))).toEqual(app(LIST, [
+      app(LIST, [int(1), int(1)]),
+      app(LIST, [int(2), int(1)]),
+      app(LIST, [int(3), int(1)]),
+    ]));
+    expect(eigenvalues(matrix([
+      irow([-2, 0, 0, 0]),
+      irow([0, -1, 0, 0]),
+      irow([0, 0, 1, 0]),
+      irow([0, 0, 0, 2]),
+    ]))).toEqual(app(LIST, [
+      app(LIST, [int(-2), int(1)]),
+      app(LIST, [int(-1), int(1)]),
+      app(LIST, [int(1), int(1)]),
+      app(LIST, [int(2), int(1)]),
+    ]));
+  });
+
   it("rejects unsupported shapes and symbolic entries", () => {
     expect(() => eigenvalues(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
-    expect(() => eigenvalues(identityMatrix(3))).toThrow(MatrixError);
+    expect(() => eigenvalues(identityMatrix(5))).toThrow(MatrixError);
     expect(() => eigenvalues(matrix([[sym("a")]]))).toThrow(MatrixError);
   });
 });
@@ -326,6 +348,14 @@ describe("eigenvectors", () => {
     ]));
   });
 
+  it("returns 3x3 exact rational eigenvector bases", () => {
+    expect(eigenvectors(matrix([irow([1, 0, 0]), irow([0, 2, 0]), irow([0, 0, 3])]))).toEqual(app(LIST, [
+      app(LIST, [int(1), int(1), app(LIST, [matrix([irow([1]), irow([0]), irow([0])])])]),
+      app(LIST, [int(2), int(1), app(LIST, [matrix([irow([0]), irow([1]), irow([0])])])]),
+      app(LIST, [int(3), int(1), app(LIST, [matrix([irow([0]), irow([0]), irow([1])])])]),
+    ]));
+  });
+
   it("returns an empty vector list for non-rational eigenvalues", () => {
     const triples = eigenvectors(matrix([irow([0, 1]), irow([-1, 0])]));
     expect(triples.kind).toBe("apply");
@@ -341,7 +371,7 @@ describe("eigenvectors", () => {
 
   it("rejects unsupported shapes and symbolic entries", () => {
     expect(() => eigenvectors(matrix([irow([1, 2, 3]), irow([4, 5, 6])]))).toThrow(MatrixError);
-    expect(() => eigenvectors(identityMatrix(3))).toThrow(MatrixError);
+    expect(() => eigenvectors(identityMatrix(5))).toThrow(MatrixError);
     expect(() => eigenvectors(matrix([[sym("a")]]))).toThrow(MatrixError);
   });
 });


### PR DESCRIPTION
## Summary
- extend TypeScript and Rust cas-matrix eigenvalue dispatch from 1x1/2x2 to exact rational matrices up to 4x4
- reuse cubic/quartic cas-solve paths and sort exact rational roots for stable MACSYMA-style output
- compute multiplicities from the characteristic polynomial so deduplicated cubic/quartic roots still report repeated eigenvalues correctly
- add 3x3/4x4 eigenvalue coverage and 3x3 eigenvector parity tests

## Tests
- `node ..\macsyma-runtime\node_modules\typescript\bin\tsc --noEmit`
- `node ..\macsyma-runtime\node_modules\vitest\vitest.mjs run tests/cas-matrix.test.ts`
- `cargo test --manifest-path code\packages\rust\Cargo.toml -p cas-matrix`