### PR TITLE
Enable ALGOL boolean ops across IIR backends

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -625,17 +625,11 @@ impl Compiler {
     }
 
     fn emit_bool_wrapper(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
-        let found_op = pieces(node).into_iter().find_map(|p| {
-            if let Piece::Op(op) = p {
-                matches!(op.as_str(), "and" | "or" | "impl" | "eqv").then_some(op)
-            } else {
-                None
-            }
-        });
-        if let Some(op) = found_op {
-            return Err(CompileError::Unsupported(format!(
-                "boolean operator {op:?}"
-            )));
+        if pieces(node)
+            .iter()
+            .any(|p| matches!(p, Piece::Op(op) if matches!(op.as_str(), "and" | "or" | "impl" | "eqv")))
+        {
+            return self.emit_binary_or_child(node, BinaryFamily::Boolean);
         }
         self.emit_single_child_expr(node)
     }
@@ -647,21 +641,7 @@ impl Compiler {
                 .copied()
                 .ok_or_else(|| CompileError::Malformed("not expression missing operand".into()))?;
             let value = self.emit_expr(child)?;
-            if value.ty != ScalarType::Boolean {
-                return Err(CompileError::Type("not operand must be boolean".into()));
-            }
-            let false_slot = self.emit_const(ScalarType::Boolean, Operand::Bool(false));
-            let dest = self.fresh_temp();
-            self.emit(IIRInstr::new(
-                "cmp_eq",
-                Some(dest.clone()),
-                vec![Operand::Var(value.slot), Operand::Var(false_slot)],
-                "bool",
-            ));
-            Ok(ExprValue {
-                slot: dest,
-                ty: ScalarType::Boolean,
-            })
+            self.emit_not_value(value)
         } else {
             self.emit_single_child_expr(node)
         }
@@ -878,13 +858,75 @@ impl Compiler {
                 })
             }
             "^" | "**" => Err(CompileError::Unsupported("exponentiation".into())),
-            "and" | "or" | "impl" | "eqv" => Err(CompileError::Unsupported(format!(
-                "boolean operator {op:?}"
-            ))),
+            "and" | "or" => {
+                self.ensure_boolean_operands(op, &lhs, &rhs)?;
+                let dest = self.fresh_temp();
+                self.emit(IIRInstr::new(
+                    op,
+                    Some(dest.clone()),
+                    vec![Operand::Var(lhs.slot), Operand::Var(rhs.slot)],
+                    "bool",
+                ));
+                Ok(ExprValue {
+                    slot: dest,
+                    ty: ScalarType::Boolean,
+                })
+            }
+            "impl" => {
+                self.ensure_boolean_operands(op, &lhs, &rhs)?;
+                let not_lhs = self.emit_not_value(lhs)?;
+                self.emit_binary("or", not_lhs, rhs)
+            }
+            "eqv" => {
+                self.ensure_boolean_operands(op, &lhs, &rhs)?;
+                let dest = self.fresh_temp();
+                self.emit(IIRInstr::new(
+                    "cmp_eq",
+                    Some(dest.clone()),
+                    vec![Operand::Var(lhs.slot), Operand::Var(rhs.slot)],
+                    "bool",
+                ));
+                Ok(ExprValue {
+                    slot: dest,
+                    ty: ScalarType::Boolean,
+                })
+            }
             other => Err(CompileError::Malformed(format!(
                 "unknown operator {other:?}"
             ))),
         }
+    }
+
+    fn ensure_boolean_operands(
+        &self,
+        op: &str,
+        lhs: &ExprValue,
+        rhs: &ExprValue,
+    ) -> Result<(), CompileError> {
+        if lhs.ty != ScalarType::Boolean || rhs.ty != ScalarType::Boolean {
+            return Err(CompileError::Type(format!(
+                "operator {op:?} requires boolean operands"
+            )));
+        }
+        Ok(())
+    }
+
+    fn emit_not_value(&mut self, value: ExprValue) -> Result<ExprValue, CompileError> {
+        if value.ty != ScalarType::Boolean {
+            return Err(CompileError::Type("not operand must be boolean".into()));
+        }
+        let false_slot = self.emit_const(ScalarType::Boolean, Operand::Bool(false));
+        let dest = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_eq",
+            Some(dest.clone()),
+            vec![Operand::Var(value.slot), Operand::Var(false_slot)],
+            "bool",
+        ));
+        Ok(ExprValue {
+            slot: dest,
+            ty: ScalarType::Boolean,
+        })
     }
 
     fn emit_unary_minus(&mut self, value: ExprValue) -> Result<ExprValue, CompileError> {
@@ -1027,6 +1069,7 @@ enum BinaryFamily {
     Additive,
     Multiplicative,
     Comparison,
+    Boolean,
 }
 
 fn node_loc(node: &GrammarASTNode) -> SourceLoc {
@@ -1225,6 +1268,12 @@ mod tests {
     #[test]
     fn boolean_not_assignment_runs() {
         let src = "begin boolean flag; integer result; flag := true; if not flag then result := 1 else result := 42 end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn boolean_operators_run() {
+        let src = "begin boolean a, b; integer result; a := true; b := false; if (a and not b) and ((b impl a) eqv (a or b)) then result := 42 else result := 1 end";
         assert_eq!(run_i64(src), 42);
     }
 

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -7,6 +7,8 @@ const ALGOL_SUM: &str =
 
 const ALGOL_MOD: &str = "begin integer result; result := 17 mod 5 end";
 
+const ALGOL_BOOL_OPS: &str = "begin boolean a, b; integer result; a := true; b := false; if (a and not b) and ((b impl a) eqv (a or b)) then result := 42 else result := 1 end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -16,6 +18,10 @@ fn algol_iir_validates_for_every_direct_backend() {
     for (case, module) in [
         ("sum", compile_case(ALGOL_SUM, "algol_backend_compat")),
         ("mod", compile_case(ALGOL_MOD, "algol_mod_backend_compat")),
+        (
+            "bool_ops",
+            compile_case(ALGOL_BOOL_OPS, "algol_bool_ops_backend_compat"),
+        ),
     ] {
         let checks = [
             ("wasm", iir_to_wasm::validate_for_wasm(&module)),
@@ -85,4 +91,41 @@ fn algol_mod_lowers_to_wasm_and_llvm_remainder_ops() {
         iir_to_llvm::lower_iir_to_llvm(&module, &iir_to_llvm::IIRLlvmConfig::new("algol_mod"))
             .expect("ALGOL mod IIR should lower to LLVM");
     assert!(llvm.contains("srem i64"), "LLVM should lower ALGOL mod as signed remainder");
+}
+
+#[test]
+fn algol_boolean_ops_lower_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_BOOL_OPS, "algol_bool_ops_backend_compat");
+
+    let wasm =
+        iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolBoolOps"))
+            .expect("ALGOL boolean IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolBoolOps"),
+    )
+    .expect("ALGOL boolean IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL boolean IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam =
+        iir_to_beam::lower_iir_to_beam(&module, &iir_to_beam::IIRBeamConfig::new("algol_bool_ops"))
+            .expect("ALGOL boolean IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm =
+        iir_to_llvm::lower_iir_to_llvm(&module, &iir_to_llvm::IIRLlvmConfig::new("algol_bool_ops"))
+            .expect("ALGOL boolean IIR should lower to LLVM");
+    assert!(llvm.contains("and i1"), "LLVM should lower ALGOL and as i1 and");
+    assert!(llvm.contains("or i1"), "LLVM should lower ALGOL or as i1 or");
 }

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -181,8 +181,7 @@ impl std::error::Error for IIRLlvmError {}
 //
 // Float and double map to LLVM's `float` and `double` respectively.
 //
-// Anything else (refs, str, bool, polymorphic) is rejected; v0.2.0 deals
-// only in numeric scalars.
+// Anything else (refs, str, polymorphic) is rejected in this scalar layer.
 fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlvmError> {
     match type_hint {
         "void" => Ok("void"),
@@ -219,8 +218,9 @@ fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlv
 const SUPPORTED_OPS: &[&str] = &[
     // LLVM02
     "const", "mov", "ret", "ret_void",
-    // LLVM03 — arithmetic
+    // LLVM03 — arithmetic and bitwise/logical scalar ops
     "add", "sub", "mul", "div", "mod", "rem",
+    "and", "or", "xor",
     // LLVM03 — comparison (both naked and cmp_-prefixed; see G1)
     "eq", "ne", "lt", "le", "gt", "ge",
     "cmp_eq", "cmp_ne", "cmp_lt", "cmp_le", "cmp_gt", "cmp_ge",
@@ -534,6 +534,13 @@ fn lower_instr(
             lower_arith(instr.op.as_str(), instr, state, out)
         }
 
+        // ── bitwise / logical ───────────────────────────────────────────
+        //
+        // On `bool`/`i1` this is logical `and`/`or`/`xor`; on integer widths
+        // it is the usual bitwise operation.  The same IIR opcodes are used
+        // by WASM/JVM/CLR/BEAM, so LLVM accepts them too.
+        "and" | "or" | "xor" => lower_bitwise(instr.op.as_str(), instr, state, out),
+
         // ── comparison ──────────────────────────────────────────────────
         //
         // LLVM `icmp` and `fcmp` always return i1.  IIR's type_hint on a
@@ -718,18 +725,42 @@ fn lower_cmp(
     ));
     state.env_i1.insert(dest.clone(), i1_name.clone());
 
-    // If the IIR type_hint is i1 (width 1), use the i1 form directly.
-    // Otherwise zext to the wider type so subsequent arithmetic stays
-    // typed-correctly.  We approximate "is i1" as type_hint == "i1" since
-    // IIR doesn't currently emit a literal "i1" — most callers use the
-    // operand type as the result type (wasm convention).
-    if instr.type_hint == "i1" {
-        state.env.insert(dest, i1_name);
+    // If the operand type maps to i1 (`i1` or `bool`), use the i1 form
+    // directly. Otherwise zext to the wider type so subsequent arithmetic
+    // stays typed-correctly.
+    if operand_ty == "i1" {
+        state.env.insert(dest.clone(), i1_name.clone());
     } else {
         out.push_str(&format!(
             "  %{dest} = zext i1 {i1_name} to {operand_ty}\n"
         ));
         state.env.insert(dest.clone(), format!("%{dest}"));
+    }
+    Ok(())
+}
+
+fn lower_bitwise(
+    iir_op: &str,
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    if is_float_type(&instr.type_hint) {
+        return Err(IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: format!("{iir_op} does not support floating-point operands"),
+        });
+    }
+    let dest = require_dest(instr, iir_op, state.fn_name)?.to_string();
+    let ty = llvm_type_for(&instr.type_hint, state.fn_name)?;
+    let a = resolve_operand(instr.srcs.first(), &state.env, &instr.type_hint, state.fn_name)?;
+    let b = resolve_operand(instr.srcs.get(1), &state.env, &instr.type_hint, state.fn_name)?;
+
+    out.push_str(&format!("  %{dest} = {iir_op} {ty} {a}, {b}\n"));
+    let value = format!("%{dest}");
+    state.env.insert(dest.clone(), value.clone());
+    if ty == "i1" {
+        state.env_i1.insert(dest, value);
     }
     Ok(())
 }
@@ -768,12 +799,17 @@ fn lower_jmp_if(
                 name: cond_name.clone(),
             }
         })?;
-        // Truncate to i1.  Need to know the cond's current type for the
-        // trunc — use the instr's type_hint as the operand type.
+        // Truncate to i1 unless the condition is already a boolean/i1 value.
+        // Need to know the cond's current type for the trunc — use the
+        // instr's type_hint as the operand type.
         let cond_ty = llvm_type_for(&instr.type_hint, state.fn_name)?;
-        let i1 = state.fresh("trunc");
-        out.push_str(&format!("  {i1} = trunc {cond_ty} {cond_op} to i1\n"));
-        i1
+        if cond_ty == "i1" {
+            cond_op
+        } else {
+            let i1 = state.fresh("trunc");
+            out.push_str(&format!("  {i1} = trunc {cond_ty} {cond_op} to i1\n"));
+            i1
+        }
     };
 
     let fallthrough = format!("__fall{}", {

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -441,6 +441,30 @@ fn arith_inlines_const_operand() {
         "const operand should inline literally; got:\n{ll}");
 }
 
+#[test]
+fn bitwise_bool_ops_lower_as_i1_logic() {
+    let f = IIRFunction::new(
+        "f",
+        vec![("a".into(), "bool".into()), ("b".into(), "bool".into())],
+        "bool",
+        vec![
+            IIRInstr::new("and", Some("both".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "bool"),
+            IIRInstr::new("or", Some("either".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())], "bool"),
+            IIRInstr::new("xor", Some("v".into()),
+                vec![Operand::Var("both".into()), Operand::Var("either".into())], "bool"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "bool"),
+        ]);
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("%both = and i1 %a, %b"),
+        "expected i1 and; got:\n{ll}");
+    assert!(ll.contains("%either = or i1 %a, %b"),
+        "expected i1 or; got:\n{ll}");
+    assert!(ll.contains("%v = xor i1 %both, %either"),
+        "expected i1 xor; got:\n{ll}");
+}
+
 // ===========================================================================
 // 9. LLVM03 — comparison
 // ===========================================================================

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -80,6 +80,20 @@ fn algol_mod_emits_and_runs_on_wasm() {
 }
 
 #[test]
+fn algol_boolean_ops_emit_and_run_on_wasm() {
+    let source = "begin boolean a, b; integer result; a := true; b := false; if (a and not b) and ((b impl a) eqv (a or b)) then result := 42 else result := 1 end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_bool_ops")
+        .expect("ALGOL boolean operators should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL boolean operators)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL boolean-operator wasm must run");
+    assert_eq!(result, vec![42], "ALGOL boolean operators should return 42");
+}
+
+#[test]
 fn algol_for_loop_emits_and_runs_on_wasm() {
     let source =
         "begin integer i, result; result := 0; for i := 1 step 1 until 6 do result := result + i end";


### PR DESCRIPTION
## Summary
- lower ALGOL `and`, `or`, `impl`, and `eqv` to shared Rust IIR boolean operations
- teach the LLVM backend to accept/lower `and`/`or`/`xor` for bool/i1 and avoid redundant i1 trunc/zext cases
- add VM, direct-backend, LLVM, and AOT/WASM regression coverage for ALGOL boolean operators

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p iir-to-llvm`
- `cargo test -p lang-aot algol_boolean_ops_emit_and_run_on_wasm`
- `git diff --check`

## Security review
- scanned touched files for `unsafe`, shell/file APIs, panics, and placeholders; only test/doc `expect`/`panic` usage found
- `cargo audit` and `cargo deny` are not installed in this workspace
