### PR TITLE
feat(closure-emitter): CLOC12.38 — gap-030 AST emitter side (drop inner `;` + add trailing `;` after function-decl `}`)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.12.0] - 2026-06-08
+
+### Changed
+- **gap-030 part 1 (AST emitter side):** Function-declaration
+  ASI policy now matches upstream Closure v20240317 in compact
+  (non-pretty) mode.
+  - `emit_block_statement` drops a single trailing `;` before
+    `}` via a new `pop_trailing_semi_if_compact()` helper —
+    BUT only when the block's last child is a leaf
+    statement-terminator type (gated by
+    `last_stmt_uses_terminator_semi`). Per ECMAScript §11.9
+    (Automatic Semicolon Insertion), the `}` terminates the
+    in-progress statement, so a true terminator `;` is
+    redundant noise that upstream Closure doesn't emit.
+  - **Critical correctness gate:** when the block's last child
+    is a compound statement (If/While/For/Labeled) whose body
+    is an `EmptyStatement`, the trailing `;` is structurally
+    part of the body grammar — NOT a terminator. Popping it
+    would produce SyntaxError-emitting output like
+    `function f(){if(x)}` or `function f(){for(;;)}`. The
+    `last_stmt_uses_terminator_semi` helper enumerates the
+    safe-to-pop set (ExpressionStatement / ReturnStatement /
+    BreakStatement / ContinueStatement / ThrowStatement); all
+    other types fall through to the conservative "preserve
+    `;`" path. Caught by pre-push security review.
+  - `emit_function_declaration` emits a `;` after the body's
+    closing `}` in compact mode. Even at EOF this is a no-op
+    `EmptyStatement`, but in concatenation contexts it keeps
+    the function-declaration's output shape predictable.
+- **Pretty mode is unchanged.** Visual delimiter clarity
+  outranks byte minimization in the human-facing pretty mode;
+  both gap-030 changes are compact-only.
+- The pre-existing `function_declaration_minified` test
+  assertion was updated from `function f(x){return x;}` to
+  `function f(x){return x};` to track the new compact-mode
+  shape.
+
+### Added
+- Five new inline tests:
+  - `gap030_block_multi_stmts_drops_only_last_semi`: multi-
+    statement blocks drop only the final `;` (intermediate
+    `;`s between statements are preserved).
+  - `gap030_pretty_mode_unchanged`: pretty mode still emits
+    inner `;` and no trailing `;` after `}`.
+  - `gap030_empty_function_body_compact`: empty body stays
+    `{}` with trailing `;` (`function noop(){};`).
+  - `gap030_does_not_pop_empty_body_of_if`: regression for the
+    security-review-caught bug — `function f(){if(x);}` must
+    not collapse to `function f(){if(x)}` (SyntaxError).
+  - `gap030_does_not_pop_empty_body_of_while`: same defense
+    applied to `while(x);` body shape.
+
+### Known limitation
+- **closurec's CLI WHITESPACE_ONLY path uses a separate
+  token-level re-stitcher** (`whitespace_only.rs`), not this
+  emitter. So gap-030's `minify_function_decl` byte-identity
+  fixture stays IGNORED for now; flipping it to PASS requires
+  porting the same two rules to the token re-stitcher in a
+  follow-up PR (gap-030 spec entry tracks both parts).
+
 ## [0.11.0] - 2026-06-04
 
 ### Added — CLOC12.33: `SwitchStatement` emitter rule (gap-014)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -351,8 +351,44 @@ impl<'a> Emitter<'a> {
                 }
                 self.emit_statement(s);
             }
+            // gap-030 part A: drop the trailing `;` of the
+            // block's last statement in compact mode IFF that
+            // `;` came from a real statement-terminator (not a
+            // body slot). The `}` we're about to write
+            // terminates the statement per ECMAScript §11.9
+            // (Automatic Semicolon Insertion), so a true
+            // terminator `;` is redundant noise that upstream
+            // Closure doesn't emit either. But we MUST NOT pop
+            // when the trailing `;` is structurally a body
+            // (`if(x);`, `for(;;);`, `while(x);`, `lbl:;`)
+            // because the grammar requires a Statement there
+            // and `}` is not a valid Statement start. The
+            // last-child type tells us which case we're in.
+            if let Some(last) = b.body.last() {
+                if last_stmt_uses_terminator_semi(last) {
+                    self.pop_trailing_semi_if_compact();
+                }
+            }
         }
         self.write_str("}");
+    }
+
+    /// Pop a single trailing `;` from the emitter's output
+    /// buffer in compact mode. Used by gap-030's
+    /// drop-redundant-semi-before-`}` rule under the
+    /// `last_stmt_uses_terminator_semi` gate. Pretty mode is
+    /// intentionally untouched — visual clarity outranks byte
+    /// minimization there.
+    fn pop_trailing_semi_if_compact(&mut self) {
+        if self.opts.pretty {
+            return;
+        }
+        if self.out.ends_with(';') {
+            self.out.pop();
+            // Decrement column so any subsequent maybe_map call
+            // stays accurate. ASCII `;` is one UTF-16 unit.
+            self.col = self.col.saturating_sub(1);
+        }
     }
 
     fn emit_if(&mut self, i: &IfStatement) {
@@ -622,6 +658,18 @@ impl<'a> Emitter<'a> {
         self.write_str(")");
         self.pretty_ws();
         self.emit_block_statement(&f.body);
+        // gap-030 part B: emit a trailing `;` after the
+        // function-declaration's closing `}` in compact mode.
+        // Upstream Closure does this to normalise the
+        // function-declaration output shape — even at EOF it's
+        // a no-op `EmptyStatement`, but in concatenation
+        // contexts (multiple top-level declarations) it keeps
+        // the next statement unambiguously separated. Pretty
+        // mode preserves the unparenthesised shape for
+        // readability.
+        if !self.opts.pretty {
+            self.write_str(";");
+        }
     }
 
     // ---- Expressions ---------------------------------------------
@@ -1167,6 +1215,60 @@ fn unary_op_str(op: UnaryOperator) -> &'static str {
     }
 }
 
+/// Decide whether a block's last child statement ends in a `;`
+/// that is a TRUE statement terminator (safe for gap-030's
+/// drop-before-`}` rule to strip) versus a `;` that is
+/// structurally a body slot (must NOT be stripped because the
+/// grammar requires a Statement there, and `}` doesn't satisfy
+/// that).
+///
+/// Truth table for the leaf statement types:
+///
+/// | Last child                  | Trailing `;` is... | Safe to pop? |
+/// |-----------------------------|--------------------|--------------|
+/// | ExpressionStatement         | terminator         | YES          |
+/// | ReturnStatement             | terminator         | YES          |
+/// | BreakStatement              | terminator         | YES          |
+/// | ContinueStatement           | terminator         | YES          |
+/// | ThrowStatement              | terminator         | YES          |
+/// | EmptyStatement              | the statement      | NO (rare; preserve so empty bodies survive) |
+/// | Declaration::*              | terminator-ish     | NO (FunctionDeclaration adds a part-B `;` we want to keep) |
+/// | IfStatement                 | body's `;` maybe   | NO  |
+/// | WhileStatement              | body's `;` maybe   | NO  |
+/// | ForStatement                | body's `;` maybe   | NO  |
+/// | LabeledStatement            | body's `;` maybe   | NO  |
+/// | BlockStatement              | ends in `}`        | (no `;` to pop anyway) |
+/// | SwitchStatement             | ends in `}`        | (no `;` to pop anyway) |
+///
+/// The pessimistic default for "compound" statements
+/// (If/While/For/Labeled) reflects ECMAScript §13.7-§13.13:
+/// each of those grammars takes a Statement in the body
+/// position, and `;` (EmptyStatement) is a legal Statement,
+/// while `}` is not. Stripping the `;` from
+/// `function f(){for(;;);}` would produce
+/// `function f(){for(;;)}` — a SyntaxError. Hence: only pop
+/// after the listed leaf terminator types.
+fn last_stmt_uses_terminator_semi(s: &Statement) -> bool {
+    match s {
+        Statement::Tagged(t) => matches!(
+            t,
+            TaggedStatement::ExpressionStatement(_)
+                | TaggedStatement::ReturnStatement(_)
+                | TaggedStatement::BreakStatement(_)
+                | TaggedStatement::ContinueStatement(_)
+                | TaggedStatement::ThrowStatement(_)
+        ),
+        // Declarations are conservatively excluded. Both
+        // VariableDeclaration and FunctionDeclaration end in
+        // `;` in compact mode, but for the former the saving
+        // is a single byte and for the latter the `;` is
+        // gap-030's part-B addition that we explicitly want to
+        // keep at top-level (popping it here would undo part
+        // B's contribution).
+        Statement::Declaration(_) => false,
+    }
+}
+
 fn assignment_op_str(op: AssignmentOperator) -> &'static str {
     use AssignmentOperator::*;
     match op {
@@ -1565,8 +1667,12 @@ mod tests {
         let out = emit_default(prog);
         // No spaces inside `{` `}` or around params in minified
         // mode, but `function` and `return` keywords are followed
-        // by required whitespace.
-        assert_eq!(out.code, "function f(x){return x;}");
+        // by required whitespace. After gap-030 the inner `;`
+        // before `}` is dropped (ASI lets the brace terminate
+        // the return statement) and a trailing `;` is added
+        // after the function-declaration's closing `}` to
+        // match upstream Closure v20240317.
+        assert_eq!(out.code, "function f(x){return x};");
     }
 
     #[test]
@@ -1603,6 +1709,192 @@ mod tests {
             },
         );
         assert_eq!(out.code, "function f(x) {\n  return x;\n}");
+    }
+
+    // ---- gap-030: function-decl + block ASI policy ----------
+
+    /// Block with multiple statements drops only the LAST `;`.
+    /// `{a;b;}` → `{a;b}` in compact mode. The internal `;`
+    /// between statements is preserved because there's no `}`
+    /// adjacent to terminate the first statement via ASI.
+    #[test]
+    fn gap030_block_multi_stmts_drops_only_last_semi() {
+        let mk = |name: &str| {
+            Statement::expression_statement(ExpressionStatement {
+                cv: None,
+                expression: ident(name),
+            })
+        };
+        let block = BlockStatement {
+            cv: None,
+            body: vec![mk("a"), mk("b")],
+        };
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "g".to_string(),
+            },
+            params: vec![],
+            body: block,
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_default(prog);
+        // Both intermediate `;` and the trailing function-decl
+        // `;` after `}` follow gap-030's rules.
+        assert_eq!(out.code, "function g(){a;b};");
+    }
+
+    /// Pretty mode preserves all `;`s for visual clarity. The
+    /// gap-030 changes are compact-only.
+    #[test]
+    fn gap030_pretty_mode_unchanged() {
+        let body = BlockStatement {
+            cv: None,
+            body: vec![Statement::return_statement(ReturnStatement {
+                cv: None,
+                argument: Some(num(1.0)),
+            })],
+        };
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "h".to_string(),
+            },
+            params: vec![],
+            body,
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_with(
+            prog,
+            EmitOptions {
+                pretty: true,
+                ..Default::default()
+            },
+        );
+        // Inner `;` AND no trailing `;` after `}` — pretty mode
+        // is untouched by gap-030. The visual delimiter
+        // benefits of pretty-printing outrank byte-minimization.
+        assert_eq!(out.code, "function h() {\n  return 1;\n}");
+    }
+
+    /// Regression test for the security-review-caught bug:
+    /// when the block's last child is an `IfStatement` with an
+    /// `EmptyStatement` body, the trailing `;` belongs to the
+    /// EmptyStatement (which IS a body slot for the if), not
+    /// to a statement terminator. Popping it would produce
+    /// `function f(){if(x)};` which `}` cannot satisfy as a
+    /// Statement at the body position — SyntaxError.
+    ///
+    /// The fix: gate the pop on
+    /// `last_stmt_uses_terminator_semi()`, which returns
+    /// `false` for IfStatement so the trailing `;` survives.
+    #[test]
+    fn gap030_does_not_pop_empty_body_of_if() {
+        // Build: function f(){if(x);}
+        let empty = Statement::Tagged(TaggedStatement::EmptyStatement(EmptyStatement {
+            cv: None,
+        }));
+        let if_stmt = TaggedStatement::IfStatement(IfStatement {
+            cv: None,
+            test: ident("x"),
+            consequent: Box::new(empty),
+            alternate: None,
+        });
+        let body = BlockStatement {
+            cv: None,
+            body: vec![Statement::Tagged(if_stmt)],
+        };
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "f".to_string(),
+            },
+            params: vec![],
+            body,
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_default(prog);
+        // The `;` inside `if(x);` MUST be preserved — it's the
+        // IfStatement's body. Trailing `;` after `}` is the
+        // gap-030 part-B addition for the function-declaration.
+        assert_eq!(out.code, "function f(){if(x);};");
+    }
+
+    /// Same defense applied to `WhileStatement` with an
+    /// `EmptyStatement` body — `while(x);` must not collapse to
+    /// `while(x)`. Mirrors `gap030_does_not_pop_empty_body_of_if`.
+    #[test]
+    fn gap030_does_not_pop_empty_body_of_while() {
+        let empty = Statement::Tagged(TaggedStatement::EmptyStatement(EmptyStatement {
+            cv: None,
+        }));
+        let while_stmt = TaggedStatement::WhileStatement(WhileStatement {
+            cv: None,
+            test: ident("x"),
+            body: Box::new(empty),
+        });
+        let body = BlockStatement {
+            cv: None,
+            body: vec![Statement::Tagged(while_stmt)],
+        };
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "g".to_string(),
+            },
+            params: vec![],
+            body,
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_default(prog);
+        assert_eq!(out.code, "function g(){while(x);};");
+    }
+
+    /// Empty function body stays `{}` — no `;` to drop, no
+    /// regression introduced by the pop-trailing-semi helper.
+    /// Trailing `;` after `{}` still applies per gap-030 part B.
+    #[test]
+    fn gap030_empty_function_body_compact() {
+        let body = BlockStatement {
+            cv: None,
+            body: vec![],
+        };
+        let f = FunctionDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "noop".to_string(),
+            },
+            params: vec![],
+            body,
+            generator: false,
+            is_async: false,
+        };
+        let prog = program().with_body(vec![ProgramItem::Declaration(
+            Declaration::FunctionDeclaration(f),
+        )]);
+        let out = emit_default(prog);
+        assert_eq!(out.code, "function noop(){};");
     }
 
     // ---- arrays + objects -----------------------------------

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -218,9 +218,21 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-030 — function-declaration semicolon ASI policy
 
-- **Status:** OPEN — newly discovered by CLOC14.2.
-- **Upstream byte-identity test:** `minify_function_decl` seed fixture (in CLOC14 harness).
-- **Why it fails:** Upstream Closure v20240317 normalises function-declaration emit in two ways our emitter doesn't yet do:
-  1. **Drops the redundant inner `;`** before `}` in single-statement blocks (`function f(){return 1;}` → `function f(){return 1}`). ASI lets the closing `}` terminate the inner statement, so the `;` is noise.
-  2. **Adds a trailing `;`** after the function-declaration's closing `}` at top-level statement-list position (`}` → `};`). Even at end-of-file this is a no-op, but it keeps the function-declaration output shape predictable for concatenation cases.
-- **What it needs:** Two pure emitter changes (no AST work). Conservative trigger for (1): emit `;` only when the next sibling is not the closing brace. (2) lands as a post-emit step for `FunctionDeclaration` at top-level. The `minify_function_decl` fixture flips from IGNORED to PASS the moment both land.
+- **Status:** PARTIALLY RESOLVED in CLOC12.38 (PR pending). **Two-half gap.**
+- **Upstream byte-identity test:** `minify_function_decl` seed fixture (in CLOC14 harness). Still IGNORED — the CLI WHITESPACE_ONLY path is the half that flips the fixture, and CLOC12.38 only addressed the AST emitter half.
+- **The two halves:**
+
+  **A. AST emitter side (closure-emitter)** — **RESOLVED in CLOC12.38.**
+  - `emit_block_statement` now drops a trailing `;` before `}` via `pop_trailing_semi_if_compact()` (compact mode only). Per ECMAScript §11.9 (Automatic Semicolon Insertion), `}` terminates any in-progress statement, so the inner `;` is redundant.
+  - `emit_function_declaration` now emits `;` after the body's closing `}` in compact mode.
+  - Pretty mode is intentionally untouched — visual delimiter clarity outranks byte minimization there.
+  - Three new inline tests pin: multi-stmt blocks drop only last `;`, pretty mode unchanged, empty body still gets trailing `;`.
+  - **Why this matters:** When the full pass pipeline eventually drives the CLI's output for SIMPLE_OPTIMIZATIONS / ADVANCED_OPTIMIZATIONS levels (currently the CLI only wires WHITESPACE_ONLY via a token re-stitcher), this emitter half is what produces parity. The work isn't observable in the current diff_minify harness, but it's the right foundation.
+
+  **B. CLI WHITESPACE_ONLY token re-stitcher side (`closurec/src/whitespace_only.rs`)** — **OPEN.**
+  - The closurec CLI does NOT call closure-emitter for WHITESPACE_ONLY. It uses a token-level re-stitcher that walks the lexer's token stream, drops trivia (comments/whitespace), and concatenates with a separator inserted between adjacent word-like tokens.
+  - To flip `minify_function_decl` to PASS, two more rules are needed at this layer:
+    1. **Drop `;` token if next non-trivia token is `}`.** Mechanical — no AST awareness needed.
+    2. **Emit `;` after `}` that closes a function-DECLARATION body.** Requires a small state machine: track "saw `function` keyword at statement boundary" + push/pop a per-brace flag. Statement boundary = at start-of-input, or after a previously-emitted `;` or `}`. Distinguishes function declarations (get trailing `;`) from function expressions (don't — they're nested in another expression that owns its own punctuation).
+  - **Why split:** The token-level state machine has real edge cases (function expressions, double-`;` after `;function`, share-body fall-through patterns). Splitting CLOC12.38 (AST half) from a follow-up CLOC12.39 (CLI token half) keeps each PR small and reviewable.
+- **The `minify_function_decl` fixture flips to PASS** when CLOC12.39 lands the token re-stitcher half.


### PR DESCRIPTION
## Summary

**Closes gap-030 part 1 of 2.** Brings the closure-emitter crate to byte-parity with upstream Closure v20240317's function-declaration ASI policy in compact mode. The corresponding byte-identity fixture \`minify_function_decl\` stays IGNORED pending part 2 (the CLI WHITESPACE_ONLY token re-stitcher).

## Two compact-mode emitter changes

1. **Drop redundant trailing \`;\`** in \`emit_block_statement\` when the block's last statement is a true terminator (ExpressionStatement / Return / Break / Continue / Throw). Per ECMAScript §11.9 (ASI), the closing \`}\` terminates the in-progress statement, so the inner \`;\` is noise.
2. **Emit trailing \`;\`** after a \`FunctionDeclaration\`'s closing \`}\`. Even at EOF this is a no-op \`EmptyStatement\`, but in concatenation contexts it keeps the function-decl output shape predictable.

Pretty mode is intentionally untouched — visual clarity outranks byte minimization there.

## Critical correctness gate (security review caught)

First cut of \`pop_trailing_semi_if_compact()\` was byte-naive. Pre-push security review caught: when the block's last child is a compound statement (If / While / For / Labeled) whose body is an \`EmptyStatement\`, the trailing \`;\` is grammar-required body, NOT a terminator. Stripping it would emit SyntaxError output like \`function f(){if(x)};\`.

Fix: \`last_stmt_uses_terminator_semi(s: &Statement)\` enumerates the safe-to-pop set. Compound statements return \`false\` so their body-slot \`;\` survives. Declarations also return \`false\` — critical so part-B \`;\` is preserved on nested function decls.

## Tests (50 inline, was 45)

5 new tests including two regression tests for the bug the security review caught.

## Scope note: \`minify_function_decl\` fixture stays IGNORED

closurec's CLI uses a separate token re-stitcher (\`whitespace_only.rs\`) — NOT this emitter. Flipping the fixture to PASS requires gap-030 part 2: porting the same rules to the token re-stitcher. Separate PR because token-level state machine has edge cases (function expressions, double-\`;\` after \`;function\`) that deserve focused review.

## Test plan

- [x] \`cargo test --lib\` in closure-emitter → 50 passed, 0 failed
- [x] \`cargo test\` in closurec → all 263+ tests pass
- [x] Pre-push security review (2 rounds) → PASS
- [ ] CI green

## Closes

- **gap-030 part 1 of 2** (AST emitter half).
- Files gap-030 part 2 in spec as the path to flipping the \`minify_function_decl\` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)