### PR TITLE
feat(closurec): CLOC12.39 — gap-030 part 2 CLOSES gap-030 (CLI WHITESPACE_ONLY)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.45.0] - 2026-06-08
+
+### Changed
+- **gap-030 part 2 (CLI WHITESPACE_ONLY side): CLOSES gap-030.**
+  Ports the same ASI-policy rules CLOC12.38 added to the AST
+  emitter to closurec's CLI token re-stitcher
+  (`src/whitespace_only.rs`). The previously-IGNORED
+  `minify_function_decl` byte-identity fixture now PASSes
+  against upstream Closure v20240317.
+- The simple for-loop re-stitcher is replaced with a
+  state-machine while-loop tracking:
+  - `brace_stack: Vec<bool>` — for each open `{`, true iff it
+    opens a function-declaration body.
+  - `paren_stack: Vec<bool>` — for each open `(`, true iff it
+    is the head of an `if`/`while`/`for`.
+  - `body_position_next` — set on `)` popping a control-flow
+    head; suppresses the rule-A `;`-drop so we never strip an
+    `EmptyStatement` body (`if(x);`, `while(x);`, `for(;;);`).
+  - `saw_function_kw_at_boundary` — captured on `function` at
+    a statement boundary; consumed by the next `{`. Only
+    DECLARATIONS get the rule-B trailing `;` (function
+    expressions like `var f=function(){};` don't).
+  - `last_emit_was_synthetic_semi` — rule-C dedup so
+    `function f(){};var g=1;` stays as `};var` instead of
+    `};;var`.
+
+### Added
+- 10 new inline tests in `whitespace_only::tests::gap030_*`.
+
+### Fixed
+- `tests/diff/whitespace-only/expected.stdout` updated. The
+  pre-existing golden was hand-traced from closurec's old
+  shape (`function add(a,b){return a+b;}`); upstream Closure
+  v20240317 actually emits `function add(a,b){return a+b};`.
+  Re-captured from the upstream JAR.
+
 ## [0.44.0] - 2026-06-02
 
 ### Added — CLOC14: end-to-end byte-identity test harness

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -121,10 +121,85 @@ pub fn whitespace_only_minify(
     // literals get re-quoted because the lexer's `value` field
     // is the *unescaped* content (per the `lexer::token::Token`
     // docstring); emitting it raw would corrupt the program.
+    //
+    // gap-030 rules layered on top of the simple re-stitch:
+    //
+    // **Rule A — drop `;` immediately before `}`:** Per
+    // ECMAScript §11.9 (Automatic Semicolon Insertion), `}`
+    // terminates any in-progress statement, so a `;` right
+    // before `}` is redundant noise. EXCEPT when that `;` is
+    // structurally a body slot (the EmptyStatement body of
+    // `if(x);` / `while(x);` / `for(;;);`). The
+    // `body_position_next` flag tracks whether we're emitting
+    // into a statement-body position (set by the closing `)`
+    // of an if/while/for head) and suppresses the drop.
+    //
+    // **Rule B — emit `;` after a function-DECLARATION's
+    // closing `}`:** Upstream Closure normalises this so the
+    // function-decl output shape stays predictable for
+    // concatenation. We distinguish declarations from
+    // expressions by tracking whether the `function` keyword
+    // was seen at a statement boundary (start-of-input, or
+    // after a previously-emitted `;`/`}`/`{`); declarations
+    // are at-boundary, expressions live mid-expression.
+    //
+    // **Rule C — dedup `;` after synthetic `;`:** When Rule B
+    // emits a `;` and the very next source token is also `;`,
+    // skip the source `;` to avoid `};;` in output. The
+    // semantic content is identical (the source's `;` would
+    // have been an `EmptyStatement` that contributes nothing).
     let mut out = String::with_capacity(source.len());
-    for (i, tok) in kept.iter().enumerate() {
-        if i > 0 {
-            let prev = kept[i - 1];
+
+    // State machine:
+    let mut brace_stack: Vec<bool> = Vec::new();
+    // ^ for each open `{`, true iff this `{` opened a
+    //   function-declaration body. Popped on matching `}`.
+    let mut paren_stack: Vec<bool> = Vec::new();
+    // ^ for each open `(`, true iff this `(` was the head of
+    //   an `if` / `while` / `for` (control-flow construct
+    //   whose body slot follows the close-paren). Popped on
+    //   matching `)`.
+    let mut saw_function_kw_at_boundary = false;
+    let mut next_paren_is_control_flow_head = false;
+    let mut body_position_next = false;
+    let mut at_stmt_boundary = true;
+    let mut last_emit_was_synthetic_semi = false;
+    let mut prev_emitted_tok: Option<&lexer::token::Token> = None;
+
+    let mut idx = 0usize;
+    while idx < kept.len() {
+        let tok = kept[idx];
+        let val = tok.value.as_str();
+
+        // Rule C: dedup source `;` directly after our
+        // synthetic `;` from rule B.
+        if val == ";" && last_emit_was_synthetic_semi {
+            last_emit_was_synthetic_semi = false;
+            idx += 1;
+            continue;
+        }
+        // The synthetic-semi window only spans one token; any
+        // other token after the synthetic `;` clears the flag.
+        last_emit_was_synthetic_semi = false;
+
+        // Rule A: drop `;` directly before `}`, UNLESS the
+        // `;` is a body slot (body_position_next).
+        if val == ";" && !body_position_next {
+            if let Some(next) = kept.get(idx + 1) {
+                if next.value == "}" {
+                    // Skip this `;`. We are still at a stmt
+                    // boundary after dropping it (the
+                    // upcoming `}` terminates the enclosing
+                    // statement just as a `;` would).
+                    at_stmt_boundary = true;
+                    idx += 1;
+                    continue;
+                }
+            }
+        }
+
+        // Emit the token (with separator if needed).
+        if let Some(prev) = prev_emitted_tok {
             if needs_separator(prev, tok) {
                 out.push(' ');
             }
@@ -136,8 +211,91 @@ pub fn whitespace_only_minify(
         } else {
             out.push_str(&tok.value);
         }
+        prev_emitted_tok = Some(tok);
+
+        // Rule B: a `}` that closes a function-declaration
+        // body gets a synthetic `;` appended.
+        if val == "}" {
+            let was_function_decl = brace_stack.pop().unwrap_or(false);
+            if was_function_decl {
+                out.push(';');
+                last_emit_was_synthetic_semi = true;
+            }
+            at_stmt_boundary = true;
+            body_position_next = false;
+        } else if val == "{" {
+            brace_stack.push(saw_function_kw_at_boundary);
+            saw_function_kw_at_boundary = false;
+            // A `{` either opens a Block-as-body (consumes
+            // body_position_next) or opens a function-decl
+            // body (independent of body_position). Either
+            // way the body slot is filled by this brace.
+            body_position_next = false;
+            at_stmt_boundary = true;
+        } else if val == "(" {
+            paren_stack.push(next_paren_is_control_flow_head);
+            next_paren_is_control_flow_head = false;
+            at_stmt_boundary = false;
+        } else if val == ")" {
+            let was_cf = paren_stack.pop().unwrap_or(false);
+            // The body slot of an if/while/for opens after
+            // the closing `)`. The next emitted statement
+            // (or `;` / `{`) fills that slot.
+            body_position_next = was_cf;
+            at_stmt_boundary = false;
+        } else if val == ";" {
+            // We emitted a real `;` (either a terminator or
+            // a body slot per body_position_next). Either
+            // way, body_position_next is consumed.
+            body_position_next = false;
+            at_stmt_boundary = true;
+        } else if is_keyword_function(tok) {
+            // Only treat as a function-DECLARATION when at a
+            // statement boundary. Expressions live
+            // mid-expression and don't qualify.
+            if at_stmt_boundary {
+                saw_function_kw_at_boundary = true;
+            }
+            at_stmt_boundary = false;
+        } else if matches!(val, "if" | "while" | "for") {
+            // The next `(` is a control-flow head.
+            next_paren_is_control_flow_head = true;
+            at_stmt_boundary = false;
+        } else {
+            // Any other token consumes the body slot (the
+            // body of `if(x)y();` is `y()`, so once we emit
+            // `y` the slot is filled).
+            body_position_next = false;
+            at_stmt_boundary = false;
+        }
+
+        idx += 1;
     }
     Ok(out)
+}
+
+/// True iff this token is the `function` keyword. Used by
+/// gap-030 part 2 to decide whether a `{` opens a
+/// function-DECLARATION body. We check by literal value plus
+/// the grammar's KEYWORD type tag, so we don't accidentally
+/// pick up a method/property named `function` (those would
+/// arrive as `NAME` or `STRING`).
+fn is_keyword_function(tok: &lexer::token::Token) -> bool {
+    if tok.value != "function" {
+        return false;
+    }
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        // Accept any of the common keyword-rule names a JS
+        // grammar might use. If the grammar doesn't tag it,
+        // fall back to value-only matching — bare value
+        // `function` is reserved per §11.6.2.1 so the
+        // identifier-collision case can't legally arise.
+        return upper == "KEYWORD"
+            || upper == "FUNCTION"
+            || upper.starts_with("KEYWORD");
+    }
+    true
 }
 
 /// True iff this token came from a string-literal rule. The
@@ -376,5 +534,110 @@ mod tests {
         let e = MinifyError::LexError("bad input".into());
         assert!(e.to_string().contains("tokenizer failed"));
         let _: &dyn std::error::Error = &e;
+    }
+
+    // ---- gap-030 part 2: token-level ASI policy ------------
+
+    /// The target fixture for gap-030. closurec must produce
+    /// exactly upstream Closure v20240317's output:
+    /// `function f(){return 1};`.
+    #[test]
+    fn gap030_function_decl_drops_inner_and_adds_trailing_semi() {
+        assert_eq!(
+            minify("function f(){return 1;}"),
+            "function f(){return 1};"
+        );
+    }
+
+    /// Empty function declaration still gets the trailing `;`
+    /// (rule B). No `;` to drop inside since the body is empty.
+    #[test]
+    fn gap030_empty_function_decl_gets_trailing_semi() {
+        assert_eq!(minify("function f(){}"), "function f(){};");
+    }
+
+    /// Function EXPRESSION (mid-expression, e.g.
+    /// `var f=function(){};`) must NOT receive a synthetic
+    /// trailing `;` after its `}` — the source's `;` outside
+    /// the expression is the only terminator.
+    #[test]
+    fn gap030_function_expression_does_not_get_trailing_semi() {
+        assert_eq!(
+            minify("var f=function(){};"),
+            "var f=function(){};"
+        );
+    }
+
+    /// A block that is NOT a function-decl body (e.g. an
+    /// if-block) must NOT receive a trailing `;` after its
+    /// `}`. The inner `;` before `}` IS droppable because the
+    /// last child is a terminator (`y()` expression).
+    #[test]
+    fn gap030_if_block_drops_inner_semi_no_trailing() {
+        assert_eq!(minify("if(x){y();}"), "if(x){y()}");
+    }
+
+    /// Critical correctness gate (same shape as the
+    /// security-review-caught bug in CLOC12.38, mirrored at
+    /// the token level): the `;` in `if(x);` is structurally
+    /// the body of the if-statement, NOT a terminator.
+    /// Dropping it would produce `if(x)}` — SyntaxError.
+    /// `body_position_next` flag suppresses the drop.
+    #[test]
+    fn gap030_does_not_drop_empty_body_of_if() {
+        assert_eq!(
+            minify("function f(){if(x);}"),
+            "function f(){if(x);};"
+        );
+    }
+
+    /// Same defense for `while(x);` body shape.
+    #[test]
+    fn gap030_does_not_drop_empty_body_of_while() {
+        assert_eq!(
+            minify("function f(){while(x);}"),
+            "function f(){while(x);};"
+        );
+    }
+
+    /// `for(;;);` — the `;` tokens inside `for(...)` are
+    /// grammar parts of the for-head and are emitted as-is.
+    /// The `;` after `)` is the for-loop's EmptyStatement
+    /// body, which `body_position_next` protects from drop.
+    #[test]
+    fn gap030_for_loop_empty_body_preserved() {
+        assert_eq!(
+            minify("function f(){for(;;);}"),
+            "function f(){for(;;);};"
+        );
+    }
+
+    /// Source `;` immediately following a synthetic trailing
+    /// `;` is deduped (rule C). Otherwise
+    /// `function f(){};var g=1;` would emit `};;var g=1;`.
+    #[test]
+    fn gap030_dedup_source_semi_after_synthetic() {
+        assert_eq!(
+            minify("function f(){};var g=1;"),
+            "function f(){};var g=1;"
+        );
+    }
+
+    /// Multi-statement function body: only the FINAL `;`
+    /// before `}` is dropped; intermediate `;`s between
+    /// sibling statements are preserved.
+    #[test]
+    fn gap030_multi_stmt_body_drops_only_last_semi() {
+        assert_eq!(
+            minify("function f(){a;b;}"),
+            "function f(){a;b};"
+        );
+    }
+
+    /// Top-level `var x=1;` is untouched — no function-decl
+    /// context, no `;`-before-`}` situation.
+    #[test]
+    fn gap030_top_level_var_unchanged() {
+        assert_eq!(minify("var x=1;"), "var x=1;");
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.44.0
+Version: 0.45.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/whitespace-only/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/whitespace-only/expected.stdout
@@ -1,1 +1,1 @@
-var x=1;var y=2;function add(a,b){return a+b;}
+var x=1;var y=2;function add(a,b){return a+b};

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,15 +85,12 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-030: emitter divergence around function-declaration
-    // semicolons. Upstream Closure v20240317 drops the inner `;`
-    // before `}` (ASI lets the brace terminate) AND emits a
-    // trailing `;` after the function-declaration's closing
-    // brace. closurec preserves the inner `;` and emits no
-    // trailing `;`. See
-    // tests/diff/minify_function_decl/README.md for the byte
-    // breakdown and what an emitter fix would need to do.
-    ("function_decl", "gap-030: function-decl semicolon ASI policy"),
+    // Empty. gap-030 (function-decl ASI policy) was resolved
+    // in CLOC12.38 (AST emitter side) + CLOC12.39 (CLI
+    // WHITESPACE_ONLY token re-stitcher side). The
+    // `minify_function_decl` fixture flipped from IGNORED to
+    // PASS in CLOC12.39 — closurec now matches upstream
+    // Closure v20240317 byte-for-byte.
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -218,21 +218,19 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-030 — function-declaration semicolon ASI policy
 
-- **Status:** PARTIALLY RESOLVED in CLOC12.38 (PR pending). **Two-half gap.**
-- **Upstream byte-identity test:** `minify_function_decl` seed fixture (in CLOC14 harness). Still IGNORED — the CLI WHITESPACE_ONLY path is the half that flips the fixture, and CLOC12.38 only addressed the AST emitter half.
+- **Status:** **FULLY RESOLVED** by CLOC12.38 (AST emitter half — merged PR #5140) and CLOC12.39 (CLI WHITESPACE_ONLY token re-stitcher half, PR pending). The `minify_function_decl` seed fixture flipped from IGNORED to **PASS** in CLOC12.39: closurec now emits `function f(){return 1};\n` byte-for-byte identical to upstream Closure v20240317.
+- **Upstream byte-identity test:** `minify_function_decl` seed fixture (in CLOC14 harness). PASS.
 - **The two halves:**
 
-  **A. AST emitter side (closure-emitter)** — **RESOLVED in CLOC12.38.**
-  - `emit_block_statement` now drops a trailing `;` before `}` via `pop_trailing_semi_if_compact()` (compact mode only). Per ECMAScript §11.9 (Automatic Semicolon Insertion), `}` terminates any in-progress statement, so the inner `;` is redundant.
-  - `emit_function_declaration` now emits `;` after the body's closing `}` in compact mode.
-  - Pretty mode is intentionally untouched — visual delimiter clarity outranks byte minimization there.
-  - Three new inline tests pin: multi-stmt blocks drop only last `;`, pretty mode unchanged, empty body still gets trailing `;`.
-  - **Why this matters:** When the full pass pipeline eventually drives the CLI's output for SIMPLE_OPTIMIZATIONS / ADVANCED_OPTIMIZATIONS levels (currently the CLI only wires WHITESPACE_ONLY via a token re-stitcher), this emitter half is what produces parity. The work isn't observable in the current diff_minify harness, but it's the right foundation.
+  **A. AST emitter side (closure-emitter)** — **RESOLVED in CLOC12.38** (merged PR #5140).
+  - `emit_block_statement` drops a trailing `;` before `}` via `pop_trailing_semi_if_compact()` (compact mode only), gated by `last_stmt_uses_terminator_semi` so EmptyStatement-body cases like `if(x);` survive.
+  - `emit_function_declaration` emits `;` after the body's closing `}` in compact mode.
+  - Pretty mode is intentionally untouched.
 
-  **B. CLI WHITESPACE_ONLY token re-stitcher side (`closurec/src/whitespace_only.rs`)** — **OPEN.**
-  - The closurec CLI does NOT call closure-emitter for WHITESPACE_ONLY. It uses a token-level re-stitcher that walks the lexer's token stream, drops trivia (comments/whitespace), and concatenates with a separator inserted between adjacent word-like tokens.
-  - To flip `minify_function_decl` to PASS, two more rules are needed at this layer:
-    1. **Drop `;` token if next non-trivia token is `}`.** Mechanical — no AST awareness needed.
-    2. **Emit `;` after `}` that closes a function-DECLARATION body.** Requires a small state machine: track "saw `function` keyword at statement boundary" + push/pop a per-brace flag. Statement boundary = at start-of-input, or after a previously-emitted `;` or `}`. Distinguishes function declarations (get trailing `;`) from function expressions (don't — they're nested in another expression that owns its own punctuation).
-  - **Why split:** The token-level state machine has real edge cases (function expressions, double-`;` after `;function`, share-body fall-through patterns). Splitting CLOC12.38 (AST half) from a follow-up CLOC12.39 (CLI token half) keeps each PR small and reviewable.
-- **The `minify_function_decl` fixture flips to PASS** when CLOC12.39 lands the token re-stitcher half.
+  **B. CLI WHITESPACE_ONLY token re-stitcher side (`closurec/src/whitespace_only.rs`)** — **RESOLVED in CLOC12.39.**
+  - The closurec CLI uses a token-level re-stitcher (NOT closure-emitter) for WHITESPACE_ONLY. CLOC12.39 ports the same two rules to this layer:
+    1. **Rule A — drop `;` token before `}`**: with a `body_position_next` guard that protects EmptyStatement body slots (`if(x);` / `while(x);` / `for(;;);`).
+    2. **Rule B — emit `;` after `}` of a function DECLARATION body**: state machine tracks "saw `function` keyword at statement boundary" + a per-`{` brace stack flag.
+    3. **Rule C — dedup**: source `;` immediately after a synthetic `;` (rule B) is dropped to avoid `};;` in output for shapes like `function f(){};var g=1;`.
+  - 10 inline tests pin every rule + edge case (function-expression doesn't get trailing `;`, if/while/for body slots preserved, dedup works, multi-stmt drops only last `;`, top-level `var` unchanged).
+  - The pre-existing `tests/diff/whitespace-only/expected.stdout` was updated — its hand-written golden predicted `function add(a,b){return a+b;}` (closurec's old shape), but upstream Closure actually emits `function add(a,b){return a+b};`. Re-captured from upstream JAR to match the now-correct output.


### PR DESCRIPTION
## Summary

**Closes gap-030 fully.** Ports the same ASI-policy rules CLOC12.38 added to the AST emitter to closurec's CLI token re-stitcher. The previously-IGNORED \`minify_function_decl\` byte-identity fixture flips to PASS — closurec now emits \`function f(){return 1};\\n\` byte-for-byte identical to upstream Closure v20240317.

## Harness state

\`\`\`
before:  diff_minify: 8 matched, 0 failed, 1 skipped (of 9 total)
after:   diff_minify: 9 matched, 0 failed, 0 skipped (of 9 total)
\`\`\`

## Three rules

- **Rule A** — drop \`;\` before \`}\`, with \`body_position_next\` guard so \`if(x);\` / \`while(x);\` / \`for(;;);\` / \`do{}while(x);\` body \`;\`s survive.
- **Rule B** — emit \`;\` after function-DECLARATION \`}\`. Function EXPRESSIONS (\`var f=function(){};\`, \`[function(){}]\`, \`{p:function(){}}\`) don't qualify because \`(\`, \`[\`, \`:\` leave \`at_stmt_boundary=false\`.
- **Rule C** — dedup: source \`;\` directly after a synthetic \`;\` is dropped.

## State variables

\`brace_stack\` (function-decl-body flag per \`{\`), \`paren_stack\` (control-flow-head flag per \`(\`), \`body_position_next\`, \`at_stmt_boundary\`, \`saw_function_kw_at_boundary\`, \`next_paren_is_control_flow_head\`, \`last_emit_was_synthetic_semi\`.

## Tests

10 new inline tests + 1 existing fixture re-captured from upstream JAR (the hand-traced golden had assumed closurec's old pre-gap-030 shape).

## Pre-push security review

PASS. Verified: rule A doesn't drop load-bearing \`;\` in \`for(...)\`, \`do{}while\`, \`try/catch\`, \`class\`, \`switch\`, labeled. Rule B doesn't misfire on function expressions. Rule C only dedups immediately-following \`;\`.

## Test plan

- [x] \`cargo test\` in closurec → 273+ tests pass (263 unit + 10 new + integration)
- [x] \`cargo test --test diff_minify\` → 9 matched, 0 failed, 0 skipped
- [x] Manual upstream parity check (\`xxd\` byte-for-byte match)
- [x] Pre-push security review → PASS
- [ ] CI green

## Closes

- **gap-030** (function-declaration semicolon ASI policy) — closes the gap entirely. Both halves now resolved: CLOC12.38 (AST emitter side) and CLOC12.39 (CLI WHITESPACE_ONLY token side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)