### PR TITLE
Track browser form policy descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness form-policy descriptors now expose form submission targets,
+  accept/autocomplete/rel policy tokens, validation bypass state, and submitter
+  overrides as a flat browser-planning inventory.
 - Browser-readiness fetch-policy descriptors now expose subresource integrity,
   CORS, nonce, referrer policy, iframe CSP/sandbox/permissions, fullscreen, and
   credentialless metadata as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -834,6 +834,7 @@ pub struct BrowserDocument {
     pub stylesheets: Vec<BrowserStylesheet>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
+    pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
@@ -1053,6 +1054,46 @@ pub struct BrowserFetchPolicyDescriptor {
     pub allow: Option<String>,
     pub allowfullscreen: bool,
     pub credentialless: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormPolicyDescriptor {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub action: Option<String>,
+    pub resolved_action: Option<String>,
+    pub method: String,
+    pub enctype: Option<String>,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub accept_charset: Option<String>,
+    pub accept_charset_tokens: Vec<String>,
+    pub autocomplete: Option<String>,
+    pub autocomplete_tokens: Vec<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub rel_external: bool,
+    pub rel_nofollow: bool,
+    pub rel_noopener: bool,
+    pub rel_noreferrer: bool,
+    pub novalidate: bool,
+    pub submitters: Vec<BrowserFormPolicySubmitterDescriptor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormPolicySubmitterDescriptor {
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub accessible_name: Option<String>,
+    pub action: Option<String>,
+    pub resolved_action: Option<String>,
+    pub method: String,
+    pub enctype: Option<String>,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub novalidate: bool,
+    pub value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9747,14 +9788,20 @@ fn collect_browser_facts(
             "style" => summary
                 .stylesheets
                 .push(browser_style_element(element, summary.base_href.as_deref())),
-            "form" => summary.forms.push(browser_form(
-                body_root,
-                element,
-                labels,
-                id_texts,
-                summary.base_href.as_deref(),
-                summary.base_target.as_deref(),
-            )),
+            "form" => {
+                let form = browser_form(
+                    body_root,
+                    element,
+                    labels,
+                    id_texts,
+                    summary.base_href.as_deref(),
+                    summary.base_target.as_deref(),
+                );
+                summary
+                    .form_policy_descriptors
+                    .push(browser_form_policy_descriptor(&form));
+                summary.forms.push(form);
+            }
             "table" => {
                 let table_index = summary.tables.len() + 1;
                 summary.tables.push(BrowserTable {
@@ -14787,6 +14834,54 @@ fn browser_form(
     }
 }
 
+fn browser_form_policy_descriptor(form: &BrowserForm) -> BrowserFormPolicyDescriptor {
+    BrowserFormPolicyDescriptor {
+        id: form.id.clone(),
+        name: form.name.clone(),
+        action: form.action.clone(),
+        resolved_action: form.resolved_action.clone(),
+        method: form.method.clone(),
+        enctype: form.enctype.clone(),
+        target: form.target.clone(),
+        effective_target: form.effective_target.clone(),
+        accept_charset: form.accept_charset.clone(),
+        accept_charset_tokens: form.accept_charset_tokens.clone(),
+        autocomplete: form.autocomplete.clone(),
+        autocomplete_tokens: form.autocomplete_tokens.clone(),
+        rel: form.rel.clone(),
+        rel_tokens: form.rel_tokens.clone(),
+        rel_external: form.rel_external,
+        rel_nofollow: form.rel_nofollow,
+        rel_noopener: form.rel_noopener,
+        rel_noreferrer: form.rel_noreferrer,
+        novalidate: form.novalidate,
+        submitters: form
+            .submitters
+            .iter()
+            .map(browser_form_policy_submitter_descriptor)
+            .collect(),
+    }
+}
+
+fn browser_form_policy_submitter_descriptor(
+    submitter: &BrowserFormSubmitter,
+) -> BrowserFormPolicySubmitterDescriptor {
+    BrowserFormPolicySubmitterDescriptor {
+        id: submitter.id.clone(),
+        control_type: submitter.control_type.clone(),
+        name: submitter.name.clone(),
+        accessible_name: submitter.accessible_name.clone(),
+        action: submitter.action.clone(),
+        resolved_action: submitter.resolved_action.clone(),
+        method: submitter.method.clone(),
+        enctype: submitter.enctype.clone(),
+        target: submitter.target.clone(),
+        effective_target: submitter.effective_target.clone(),
+        novalidate: submitter.novalidate,
+        value: submitter.value.clone(),
+    }
+}
+
 fn collect_form_labels_for_form(
     body_root: &[Node],
     target_form: &Element,
@@ -17766,6 +17861,89 @@ mod tests {
                 .as_deref(),
             Some("Query")
         );
+    }
+
+    #[test]
+    fn browser_form_policy_descriptors_track_form_and_submitter_navigation() {
+        let document = parse_html(
+            "<base href=\"https://example.test/search/index.html\" target=_base>\
+             <form id=search name=searchForm action=find.html method=post \
+             enctype=\"multipart/form-data\" target=results \
+             accept-charset=\"utf-8 windows-1252\" autocomplete=off \
+             rel=\"external noreferrer\" novalidate>\
+             <input name=q value=rust>\
+             <button id=go type=submit name=go value=run formaction=run.html \
+             formenctype=\"application/x-www-form-urlencoded\" formmethod=dialog \
+             formtarget=dialog formnovalidate>Run</button>\
+             <input id=imageGo type=image name=image-go src=buttons/search.png \
+             alt=\"Search image\"></form>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.form_policy_descriptors.len(), 1);
+
+        let descriptor = &summary.form_policy_descriptors[0];
+        assert_eq!(descriptor.id.as_deref(), Some("search"));
+        assert_eq!(descriptor.name.as_deref(), Some("searchForm"));
+        assert_eq!(descriptor.action.as_deref(), Some("find.html"));
+        assert_eq!(
+            descriptor.resolved_action.as_deref(),
+            Some("https://example.test/search/find.html")
+        );
+        assert_eq!(descriptor.method, "post");
+        assert_eq!(descriptor.enctype.as_deref(), Some("multipart/form-data"));
+        assert_eq!(descriptor.target.as_deref(), Some("results"));
+        assert_eq!(descriptor.effective_target.as_deref(), Some("results"));
+        assert_eq!(
+            descriptor.accept_charset.as_deref(),
+            Some("utf-8 windows-1252")
+        );
+        assert_eq!(
+            descriptor.accept_charset_tokens,
+            vec!["utf-8", "windows-1252"]
+        );
+        assert_eq!(descriptor.autocomplete.as_deref(), Some("off"));
+        assert_eq!(descriptor.autocomplete_tokens, vec!["off"]);
+        assert_eq!(descriptor.rel.as_deref(), Some("external noreferrer"));
+        assert_eq!(descriptor.rel_tokens, vec!["external", "noreferrer"]);
+        assert!(descriptor.rel_external);
+        assert!(!descriptor.rel_nofollow);
+        assert!(!descriptor.rel_noopener);
+        assert!(descriptor.rel_noreferrer);
+        assert!(descriptor.novalidate);
+        assert_eq!(descriptor.submitters.len(), 2);
+
+        let button = &descriptor.submitters[0];
+        assert_eq!(button.id.as_deref(), Some("go"));
+        assert_eq!(button.control_type, "submit");
+        assert_eq!(button.name.as_deref(), Some("go"));
+        assert_eq!(button.accessible_name.as_deref(), Some("Run"));
+        assert_eq!(button.action.as_deref(), Some("run.html"));
+        assert_eq!(
+            button.resolved_action.as_deref(),
+            Some("https://example.test/search/run.html")
+        );
+        assert_eq!(button.method, "dialog");
+        assert_eq!(
+            button.enctype.as_deref(),
+            Some("application/x-www-form-urlencoded")
+        );
+        assert_eq!(button.target.as_deref(), Some("dialog"));
+        assert_eq!(button.effective_target.as_deref(), Some("dialog"));
+        assert!(button.novalidate);
+        assert_eq!(button.value.as_deref(), Some("run"));
+
+        let image = &descriptor.submitters[1];
+        assert_eq!(image.id.as_deref(), Some("imageGo"));
+        assert_eq!(image.control_type, "image");
+        assert_eq!(image.name.as_deref(), Some("image-go"));
+        assert_eq!(image.accessible_name.as_deref(), Some("Search image"));
+        assert_eq!(image.action.as_deref(), Some("find.html"));
+        assert_eq!(image.method, "post");
+        assert_eq!(image.target.as_deref(), Some("results"));
+        assert_eq!(image.effective_target.as_deref(), Some("results"));
+        assert!(image.novalidate);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -7,7 +7,8 @@ use coding_adventures_html_parser::{
     BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
     BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
     BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
-    BrowserFormSelect, BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
     BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
     BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
     BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
@@ -69,6 +70,8 @@ struct ExpectedBrowserDocument {
     loading_hint_descriptors: Vec<ExpectedLoadingHintDescriptor>,
     #[serde(default)]
     fetch_policy_descriptors: Vec<ExpectedFetchPolicyDescriptor>,
+    #[serde(default)]
+    form_policy_descriptors: Vec<ExpectedFormPolicyDescriptor>,
     anchors: Vec<ExpectedAnchor>,
     headings: Vec<ExpectedHeading>,
     #[serde(default)]
@@ -449,6 +452,75 @@ struct ExpectedFetchPolicyDescriptor {
     allowfullscreen: bool,
     #[serde(default)]
     credentialless: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormPolicyDescriptor {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    resolved_action: Option<String>,
+    method: String,
+    #[serde(default)]
+    enctype: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    accept_charset: Option<String>,
+    #[serde(default)]
+    accept_charset_tokens: Vec<String>,
+    #[serde(default)]
+    autocomplete: Option<String>,
+    #[serde(default)]
+    autocomplete_tokens: Vec<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_external: bool,
+    #[serde(default)]
+    rel_nofollow: bool,
+    #[serde(default)]
+    rel_noopener: bool,
+    #[serde(default)]
+    rel_noreferrer: bool,
+    #[serde(default)]
+    novalidate: bool,
+    #[serde(default)]
+    submitters: Vec<ExpectedFormPolicySubmitterDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormPolicySubmitterDescriptor {
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    resolved_action: Option<String>,
+    method: String,
+    #[serde(default)]
+    enctype: Option<String>,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    novalidate: bool,
+    #[serde(default)]
+    value: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3554,6 +3626,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedFetchPolicyDescriptor::into_browser_fetch_policy_descriptor)
                 .collect(),
+            form_policy_descriptors: self
+                .form_policy_descriptors
+                .into_iter()
+                .map(ExpectedFormPolicyDescriptor::into_browser_form_policy_descriptor)
+                .collect(),
             anchors: self
                 .anchors
                 .into_iter()
@@ -4063,6 +4140,58 @@ impl ExpectedFetchPolicyDescriptor {
             allow: self.allow,
             allowfullscreen: self.allowfullscreen,
             credentialless: self.credentialless,
+        }
+    }
+}
+
+impl ExpectedFormPolicyDescriptor {
+    fn into_browser_form_policy_descriptor(self) -> BrowserFormPolicyDescriptor {
+        BrowserFormPolicyDescriptor {
+            id: self.id,
+            name: self.name,
+            action: self.action,
+            resolved_action: self.resolved_action,
+            method: self.method,
+            enctype: self.enctype,
+            target: self.target,
+            effective_target: self.effective_target,
+            accept_charset: self.accept_charset,
+            accept_charset_tokens: self.accept_charset_tokens,
+            autocomplete: self.autocomplete,
+            autocomplete_tokens: self.autocomplete_tokens,
+            rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            rel_external: self.rel_external,
+            rel_nofollow: self.rel_nofollow,
+            rel_noopener: self.rel_noopener,
+            rel_noreferrer: self.rel_noreferrer,
+            novalidate: self.novalidate,
+            submitters: self
+                .submitters
+                .into_iter()
+                .map(
+                    ExpectedFormPolicySubmitterDescriptor::into_browser_form_policy_submitter_descriptor,
+                )
+                .collect(),
+        }
+    }
+}
+
+impl ExpectedFormPolicySubmitterDescriptor {
+    fn into_browser_form_policy_submitter_descriptor(self) -> BrowserFormPolicySubmitterDescriptor {
+        BrowserFormPolicySubmitterDescriptor {
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            accessible_name: self.accessible_name,
+            action: self.action,
+            resolved_action: self.resolved_action,
+            method: self.method,
+            enctype: self.enctype,
+            target: self.target,
+            effective_target: self.effective_target,
+            novalidate: self.novalidate,
+            value: self.value,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -30,6 +30,8 @@ Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
 decoding, fetch priority, blocking, and media preload metadata.
 Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
 iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata.
+Form-policy descriptor cases pin submission targets, accept/autocomplete/rel
+policy tokens, validation bypass state, and submitter overrides.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -71,6 +71,18 @@
         ],
         "links": [],
         "images": [],
+        "form_policy_descriptors": [
+          {
+            "action": "/search",
+            "method": "post",
+            "enctype": "multipart/form-data",
+            "target": "results",
+            "effective_target": "results",
+            "submitters": [
+              { "control_type": "submit", "name": "go", "accessible_name": "Search", "action": "/search", "method": "post", "enctype": "multipart/form-data", "target": "results", "effective_target": "results" }
+            ]
+          }
+        ],
         "forms": [
           {
             "id": null,
@@ -246,6 +258,29 @@
         "interactive_elements": [
           { "element": "input", "id": "q", "role": "control", "text": "", "accessible_name": "Query", "accessible_description": "Query", "aria_describedby": ["q-help"], "spellcheck": "false" },
           { "element": "textarea", "id": "notes", "role": "control", "text": "Keep me", "accessible_name": "Details", "spellcheck": "true" }
+        ],
+        "form_policy_descriptors": [
+          {
+            "id": "search",
+            "name": "searchForm",
+            "action": "find.html",
+            "resolved_action": "https://example.test/search/find.html",
+            "method": "post",
+            "effective_target": "_search",
+            "accept_charset": "utf-8 windows-1252",
+            "accept_charset_tokens": ["utf-8", "windows-1252"],
+            "autocomplete": "on",
+            "autocomplete_tokens": ["on"],
+            "rel": "noreferrer external",
+            "rel_tokens": ["noreferrer", "external"],
+            "rel_external": true,
+            "rel_noreferrer": true,
+            "novalidate": true,
+            "submitters": [
+              { "id": "go", "control_type": "submit", "accessible_name": "Run search", "action": "run.html", "resolved_action": "https://example.test/search/run.html", "method": "post", "enctype": "application/x-www-form-urlencoded", "target": "results", "effective_target": "results", "novalidate": true },
+              { "id": "imageGo", "control_type": "image", "name": "image-go", "accessible_name": "Search image", "action": "find.html", "resolved_action": "https://example.test/search/find.html", "method": "post", "effective_target": "_search", "novalidate": true }
+            ]
+          }
         ],
         "forms": [
           {
@@ -1473,6 +1508,9 @@
         "headings": [],
         "links": [],
         "images": [],
+        "form_policy_descriptors": [
+          { "id": "telemetry", "method": "get" }
+        ],
         "forms": [
           {
             "id": "telemetry",
@@ -1538,6 +1576,9 @@
           { "element": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "fallback_text": "Fallback player" },
           { "element": "object", "url": "/external.bin", "resolved_url": "https://example.test/external.bin", "type_hint": "application/octet-stream", "fallback_text": "External fallback" },
           { "element": "object", "url": "outside.bin", "resolved_url": "https://example.test/media/outside.bin", "fallback_text": "Outside fallback" }
+        ],
+        "form_policy_descriptors": [
+          { "id": "player", "method": "get" }
         ],
         "forms": [
           {


### PR DESCRIPTION
## Summary
- add flat `form_policy_descriptors` to `BrowserDocument` for form submission policy and navigation planning
- derive descriptors from existing `BrowserForm` / submitter metadata, including action resolution, method/enctype/target, validation bypass, accept-charset/autocomplete/rel tokens, and submitter overrides
- update browser-readiness fixtures, harness expectations, fixture docs, and changelog

## Tests
- `for test_name in browser_form_policy_descriptors_track_form_and_submitter_navigation browser_fetch_policy_descriptors_track_security_and_policy_hints browser_loading_hint_descriptors_track_head_and_body_scheduling_hints browser_aria_relation_metadata_tracks_details_errors_and_flow browser_shell_global_state_metadata_tracks_document_and_body_attributes browser_readiness_cases_extract_browser_document_facts browser_text_semantic_descriptor_metadata_tracks_inline_annotations; do cargo test -p coding-adventures-html-parser "$test_name" || exit 1; done`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`