### PR TITLE
Track browser document policy descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness document-policy descriptors now expose charset, viewport,
+  referrer/robots/color-scheme policy, CSP/Permissions/Origin-Trial/Accept-CH
+  hints, theme colors, refresh, canonical, and manifest metadata as a flat
+  browser-planning inventory.
 - Browser-readiness form-policy descriptors now expose form submission targets,
   accept/autocomplete/rel policy tokens, validation bypass state, and submitter
   overrides as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -832,6 +832,7 @@ pub struct BrowserDocument {
     pub resources: Vec<BrowserResource>,
     pub scripts: Vec<BrowserScript>,
     pub stylesheets: Vec<BrowserStylesheet>,
+    pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
     pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
@@ -1021,6 +1022,31 @@ pub struct BrowserStylesheet {
     pub blocking: Option<String>,
     pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserDocumentPolicyDescriptor {
+    pub charset: Option<String>,
+    pub viewport: Option<String>,
+    pub viewport_directives: Vec<BrowserMetadataDirective>,
+    pub description: Option<String>,
+    pub application_name: Option<String>,
+    pub referrer_policy: Option<String>,
+    pub robots: Option<String>,
+    pub robots_directives: Vec<String>,
+    pub color_scheme: Option<String>,
+    pub content_security_policy: Option<String>,
+    pub permissions_policy: Option<String>,
+    pub origin_trials: Vec<String>,
+    pub accept_ch: Option<String>,
+    pub accept_ch_tokens: Vec<String>,
+    pub dns_prefetch_control: Option<String>,
+    pub theme_colors: Vec<BrowserThemeColor>,
+    pub refresh: Option<BrowserRefresh>,
+    pub canonical_url: Option<String>,
+    pub resolved_canonical_url: Option<String>,
+    pub manifest_url: Option<String>,
+    pub resolved_manifest_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2499,6 +2525,9 @@ impl BrowserDocument {
 
         if let Some(head) = head {
             collect_head_browser_facts(&head.children, &mut summary);
+        }
+        if let Some(descriptor) = browser_document_policy_descriptor(&summary.metadata) {
+            summary.document_policy_descriptors.push(descriptor);
         }
         for element in [html, body].into_iter().flatten() {
             if let Some(descriptor) = browser_global_state_descriptor(element) {
@@ -10016,6 +10045,85 @@ fn collect_link_document_metadata(element: &Element, summary: &mut BrowserDocume
             summary.metadata.resource_hints.push(resource_hint);
         }
     }
+}
+
+fn browser_document_policy_descriptor(
+    metadata: &BrowserDocumentMetadata,
+) -> Option<BrowserDocumentPolicyDescriptor> {
+    let content_security_policy =
+        browser_http_equiv_hint_content(metadata, "content-security-policy");
+    let permissions_policy = browser_http_equiv_hint_content(metadata, "permissions-policy");
+    let origin_trials = browser_http_equiv_hint_contents(metadata, "origin-trial");
+    let accept_ch = browser_http_equiv_hint_content(metadata, "accept-ch");
+    let accept_ch_tokens = accept_ch
+        .as_deref()
+        .map(browser_metadata_list)
+        .unwrap_or_default();
+    let dns_prefetch_control = browser_http_equiv_hint_content(metadata, "x-dns-prefetch-control");
+
+    let has_policy_metadata = metadata.charset.is_some()
+        || metadata.viewport.is_some()
+        || metadata.description.is_some()
+        || metadata.application_name.is_some()
+        || metadata.referrer_policy.is_some()
+        || metadata.robots.is_some()
+        || metadata.color_scheme.is_some()
+        || content_security_policy.is_some()
+        || permissions_policy.is_some()
+        || !origin_trials.is_empty()
+        || accept_ch.is_some()
+        || dns_prefetch_control.is_some()
+        || !metadata.theme_colors.is_empty()
+        || metadata.refresh.is_some()
+        || metadata.canonical_url.is_some()
+        || metadata.manifest_url.is_some();
+
+    has_policy_metadata.then(|| BrowserDocumentPolicyDescriptor {
+        charset: metadata.charset.clone(),
+        viewport: metadata.viewport.clone(),
+        viewport_directives: metadata.viewport_directives.clone(),
+        description: metadata.description.clone(),
+        application_name: metadata.application_name.clone(),
+        referrer_policy: metadata.referrer_policy.clone(),
+        robots: metadata.robots.clone(),
+        robots_directives: metadata.robots_directives.clone(),
+        color_scheme: metadata.color_scheme.clone(),
+        content_security_policy,
+        permissions_policy,
+        origin_trials,
+        accept_ch,
+        accept_ch_tokens,
+        dns_prefetch_control,
+        theme_colors: metadata.theme_colors.clone(),
+        refresh: metadata.refresh.clone(),
+        canonical_url: metadata.canonical_url.clone(),
+        resolved_canonical_url: metadata.resolved_canonical_url.clone(),
+        manifest_url: metadata.manifest_url.clone(),
+        resolved_manifest_url: metadata.resolved_manifest_url.clone(),
+    })
+}
+
+fn browser_http_equiv_hint_content(
+    metadata: &BrowserDocumentMetadata,
+    expected: &str,
+) -> Option<String> {
+    metadata
+        .http_equiv_hints
+        .iter()
+        .find(|hint| hint.name == expected)
+        .map(|hint| hint.content.clone())
+}
+
+fn browser_http_equiv_hint_contents(
+    metadata: &BrowserDocumentMetadata,
+    expected: &str,
+) -> Vec<String> {
+    metadata
+        .http_equiv_hints
+        .iter()
+        .filter(|hint| hint.name == expected)
+        .map(|hint| hint.content.clone())
+        .collect()
 }
 
 fn browser_meta_name_is(element: &Element, expected: &str) -> bool {
@@ -18617,6 +18725,102 @@ mod tests {
         );
         assert_eq!(stylesheet_preload.fetchpriority.as_deref(), Some("high"));
         assert_eq!(stylesheet_preload.blocking.as_deref(), Some("render"));
+    }
+
+    #[test]
+    fn browser_document_policy_descriptors_track_head_policy_and_app_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/page.html\">\
+             <meta http-equiv=content-type content=\"text/html; charset=windows-1252\">\
+             <meta name=viewport content=\"width=device-width, initial-scale=1, viewport-fit=cover\">\
+             <meta name=description content=\"HTML parser workbench\">\
+             <meta name=application-name content=Venture>\
+             <meta name=referrer content=no-referrer>\
+             <meta name=robots content=\"index, follow, max-image-preview:large\">\
+             <meta name=color-scheme content=\"light dark\">\
+             <meta http-equiv=Content-Security-Policy content=\"default-src 'self'; img-src https:\">\
+             <meta http-equiv=Permissions-Policy content=\"geolocation=(), camera=()\">\
+             <meta http-equiv=Origin-Trial content=trial-token>\
+             <meta http-equiv=Accept-CH content=\"Sec-CH-UA-Platform, DPR\">\
+             <meta http-equiv=x-dns-prefetch-control content=off>\
+             <meta name=theme-color content=\"#ffffff\" media=\"(prefers-color-scheme: light)\">\
+             <meta http-equiv=refresh content=\"5; url=next.html\">\
+             <link rel=canonical href=\"https://example.test/app/\">\
+             <link rel=manifest href=\"site.webmanifest\">",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.document_policy_descriptors.len(), 1);
+
+        let descriptor = &summary.document_policy_descriptors[0];
+        assert_eq!(descriptor.charset.as_deref(), Some("windows-1252"));
+        assert_eq!(
+            descriptor.viewport.as_deref(),
+            Some("width=device-width, initial-scale=1, viewport-fit=cover")
+        );
+        assert_eq!(
+            descriptor
+                .viewport_directives
+                .iter()
+                .map(|directive| (directive.name.as_str(), directive.value.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("width", Some("device-width")),
+                ("initial-scale", Some("1")),
+                ("viewport-fit", Some("cover")),
+            ]
+        );
+        assert_eq!(
+            descriptor.description.as_deref(),
+            Some("HTML parser workbench")
+        );
+        assert_eq!(descriptor.application_name.as_deref(), Some("Venture"));
+        assert_eq!(descriptor.referrer_policy.as_deref(), Some("no-referrer"));
+        assert_eq!(
+            descriptor.robots_directives,
+            vec!["index", "follow", "max-image-preview:large"]
+        );
+        assert_eq!(descriptor.color_scheme.as_deref(), Some("light dark"));
+        assert_eq!(
+            descriptor.content_security_policy.as_deref(),
+            Some("default-src 'self'; img-src https:")
+        );
+        assert_eq!(
+            descriptor.permissions_policy.as_deref(),
+            Some("geolocation=(), camera=()")
+        );
+        assert_eq!(descriptor.origin_trials, vec!["trial-token"]);
+        assert_eq!(
+            descriptor.accept_ch_tokens,
+            vec!["Sec-CH-UA-Platform", "DPR"]
+        );
+        assert_eq!(descriptor.dns_prefetch_control.as_deref(), Some("off"));
+        assert_eq!(descriptor.theme_colors.len(), 1);
+        assert_eq!(descriptor.theme_colors[0].color, "#ffffff");
+        assert_eq!(
+            descriptor.theme_colors[0].media.as_deref(),
+            Some("(prefers-color-scheme: light)")
+        );
+        let refresh = descriptor
+            .refresh
+            .as_ref()
+            .expect("refresh metadata should be preserved");
+        assert_eq!(refresh.delay.as_deref(), Some("5"));
+        assert_eq!(refresh.url.as_deref(), Some("next.html"));
+        assert_eq!(
+            refresh.resolved_url.as_deref(),
+            Some("https://example.test/app/next.html")
+        );
+        assert_eq!(
+            descriptor.resolved_canonical_url.as_deref(),
+            Some("https://example.test/app/")
+        );
+        assert_eq!(descriptor.manifest_url.as_deref(), Some("site.webmanifest"));
+        assert_eq!(
+            descriptor.resolved_manifest_url.as_deref(),
+            Some("https://example.test/app/site.webmanifest")
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,20 +3,21 @@ use coding_adventures_html_parser::{
     BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
-    BrowserEmbeddedContext, BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton,
-    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
-    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
-    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
-    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
-    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaSource, BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective,
-    BrowserNavigationGroup, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
-    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserFetchPolicyDescriptor,
+    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
+    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
+    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
+    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
+    BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
+    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
+    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
+    BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -66,6 +67,8 @@ struct ExpectedBrowserDocument {
     scripts: Vec<ExpectedScript>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
+    #[serde(default)]
+    document_policy_descriptors: Vec<ExpectedDocumentPolicyDescriptor>,
     #[serde(default)]
     loading_hint_descriptors: Vec<ExpectedLoadingHintDescriptor>,
     #[serde(default)]
@@ -396,6 +399,52 @@ struct ExpectedAriaRelationDescriptor {
     aria_flowto: Vec<String>,
     #[serde(default)]
     flowto_text: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDocumentPolicyDescriptor {
+    #[serde(default)]
+    charset: Option<String>,
+    #[serde(default)]
+    viewport: Option<String>,
+    #[serde(default)]
+    viewport_directives: Vec<ExpectedMetadataDirective>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    application_name: Option<String>,
+    #[serde(default)]
+    referrer_policy: Option<String>,
+    #[serde(default)]
+    robots: Option<String>,
+    #[serde(default)]
+    robots_directives: Vec<String>,
+    #[serde(default)]
+    color_scheme: Option<String>,
+    #[serde(default)]
+    content_security_policy: Option<String>,
+    #[serde(default)]
+    permissions_policy: Option<String>,
+    #[serde(default)]
+    origin_trials: Vec<String>,
+    #[serde(default)]
+    accept_ch: Option<String>,
+    #[serde(default)]
+    accept_ch_tokens: Vec<String>,
+    #[serde(default)]
+    dns_prefetch_control: Option<String>,
+    #[serde(default)]
+    theme_colors: Vec<ExpectedThemeColor>,
+    #[serde(default)]
+    refresh: Option<ExpectedRefresh>,
+    #[serde(default)]
+    canonical_url: Option<String>,
+    #[serde(default)]
+    resolved_canonical_url: Option<String>,
+    #[serde(default)]
+    manifest_url: Option<String>,
+    #[serde(default)]
+    resolved_manifest_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3616,6 +3665,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedStylesheet::into_browser_stylesheet)
                 .collect(),
+            document_policy_descriptors: self
+                .document_policy_descriptors
+                .into_iter()
+                .map(ExpectedDocumentPolicyDescriptor::into_browser_document_policy_descriptor)
+                .collect(),
             loading_hint_descriptors: self
                 .loading_hint_descriptors
                 .into_iter()
@@ -4140,6 +4194,42 @@ impl ExpectedFetchPolicyDescriptor {
             allow: self.allow,
             allowfullscreen: self.allowfullscreen,
             credentialless: self.credentialless,
+        }
+    }
+}
+
+impl ExpectedDocumentPolicyDescriptor {
+    fn into_browser_document_policy_descriptor(self) -> BrowserDocumentPolicyDescriptor {
+        BrowserDocumentPolicyDescriptor {
+            charset: self.charset,
+            viewport: self.viewport,
+            viewport_directives: self
+                .viewport_directives
+                .into_iter()
+                .map(ExpectedMetadataDirective::into_browser_metadata_directive)
+                .collect(),
+            description: self.description,
+            application_name: self.application_name,
+            referrer_policy: self.referrer_policy,
+            robots: self.robots,
+            robots_directives: self.robots_directives,
+            color_scheme: self.color_scheme,
+            content_security_policy: self.content_security_policy,
+            permissions_policy: self.permissions_policy,
+            origin_trials: self.origin_trials,
+            accept_ch: self.accept_ch,
+            accept_ch_tokens: self.accept_ch_tokens,
+            dns_prefetch_control: self.dns_prefetch_control,
+            theme_colors: self
+                .theme_colors
+                .into_iter()
+                .map(ExpectedThemeColor::into_browser_theme_color)
+                .collect(),
+            refresh: self.refresh.map(ExpectedRefresh::into_browser_refresh),
+            canonical_url: self.canonical_url,
+            resolved_canonical_url: self.resolved_canonical_url,
+            manifest_url: self.manifest_url,
+            resolved_manifest_url: self.resolved_manifest_url,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -24,6 +24,9 @@ placeholder/autocomplete hints, and required/readonly/multiple control state.
 Global-state descriptor cases pin document/body shell state plus non-form
 inert/hidden, editing, drag, spellcheck, translate, accesskey, autofocus, and
 related focus metadata.
+Document-policy descriptor cases pin charset, viewport, referrer/robots/color
+scheme, CSP/Permissions/Origin-Trial/Accept-CH hints, theme colors, refresh,
+canonical, and manifest metadata.
 ARIA descriptor cases pin collection/range/live-region semantics plus details,
 error-message, and flow relationship target text.
 Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -12,6 +12,9 @@
         "base_href": "https://example.test/docs/",
         "base_target": "_top",
         "metadata": { "charset": "utf-8" },
+        "document_policy_descriptors": [
+          { "charset": "utf-8" }
+        ],
         "body_text": "Example Directory Welcome to Venture HTML. One Two",
         "metas": [
           { "name": null, "http_equiv": null, "property": null, "charset": "utf-8", "content": null }
@@ -54,6 +57,9 @@
         "base_href": null,
         "base_target": null,
         "metadata": { "refresh": { "delay": "30", "url": "/next", "resolved_url": null } },
+        "document_policy_descriptors": [
+          { "refresh": { "delay": "30", "url": "/next", "resolved_url": null } }
+        ],
         "document_lang": "en",
         "document_dir": "ltr",
         "body_id": "catalog",
@@ -441,6 +447,38 @@
           { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "async_script": false, "defer_script": false },
           { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "async_script": false, "defer_script": false }
         ],
+        "document_policy_descriptors": [
+          {
+            "charset": "windows-1252",
+            "viewport": "width=device-width, initial-scale=1, viewport-fit=cover",
+            "viewport_directives": [
+              { "name": "width", "value": "device-width" },
+              { "name": "initial-scale", "value": "1" },
+              { "name": "viewport-fit", "value": "cover" }
+            ],
+            "description": "HTML parser workbench",
+            "application_name": "Venture",
+            "referrer_policy": "no-referrer",
+            "robots": "index, follow, max-image-preview:large",
+            "robots_directives": ["index", "follow", "max-image-preview:large"],
+            "color_scheme": "light dark",
+            "content_security_policy": "default-src 'self'; img-src https:",
+            "permissions_policy": "geolocation=(), camera=()",
+            "origin_trials": ["trial-token"],
+            "accept_ch": "Sec-CH-UA-Platform, DPR",
+            "accept_ch_tokens": ["Sec-CH-UA-Platform", "DPR"],
+            "dns_prefetch_control": "off",
+            "theme_colors": [
+              { "color": "#ffffff", "media": "(prefers-color-scheme: light)" },
+              { "color": "#111111", "media": "(prefers-color-scheme: dark)" }
+            ],
+            "refresh": { "delay": "5", "url": "next.html", "resolved_url": "https://example.test/app/next.html" },
+            "canonical_url": "https://example.test/app/",
+            "resolved_canonical_url": "https://example.test/app/",
+            "manifest_url": "site.webmanifest",
+            "resolved_manifest_url": "https://example.test/app/site.webmanifest"
+          }
+        ],
         "anchors": [],
         "headings": [],
         "links": [],
@@ -483,6 +521,14 @@
           { "kind": "icon", "url": "favicon.ico", "resolved_url": "https://example.test/app/favicon.ico", "rel": "shortcut icon", "rel_tokens": ["shortcut", "icon"], "type_hint": "image/x-icon", "sizes": "any", "async_script": false, "defer_script": false },
           { "kind": "icon", "url": "mask.svg", "resolved_url": "https://example.test/app/mask.svg", "rel": "mask-icon", "rel_tokens": ["mask-icon"], "color": "#0055ff", "async_script": false, "defer_script": false },
           { "kind": "alternate", "url": "feed.xml", "resolved_url": "https://example.test/app/feed.xml", "rel": "alternate", "rel_tokens": ["alternate"], "type_hint": "application/rss+xml", "title": "Feed", "hreflang": "en", "async_script": false, "defer_script": false }
+        ],
+        "document_policy_descriptors": [
+          {
+            "canonical_url": "https://example.test/app/",
+            "resolved_canonical_url": "https://example.test/app/",
+            "manifest_url": "site.webmanifest",
+            "resolved_manifest_url": "https://example.test/app/site.webmanifest"
+          }
         ],
         "anchors": [],
         "headings": [],


### PR DESCRIPTION
## Summary
- add flat `document_policy_descriptors` to `BrowserDocument` for document-level head policy and app metadata
- derive normalized descriptor fields from existing head metadata, including charset, viewport directives, referrer/robots/color-scheme, CSP, Permissions-Policy, Origin-Trial, Accept-CH, DNS prefetch control, theme colors, refresh, canonical, and manifest URLs
- update the browser-readiness fixture harness, affected fixture cases, fixture README, and changelog

## Tests
- `for test_name in browser_document_policy_descriptors_track_head_policy_and_app_hints browser_form_policy_descriptors_track_form_and_submitter_navigation browser_fetch_policy_descriptors_track_security_and_policy_hints browser_loading_hint_descriptors_track_head_and_body_scheduling_hints browser_aria_relation_metadata_tracks_details_errors_and_flow browser_shell_global_state_metadata_tracks_document_and_body_attributes browser_readiness_cases_extract_browser_document_facts browser_text_semantic_descriptor_metadata_tracks_inline_annotations; do cargo test -p coding-adventures-html-parser "$test_name" || exit 1; done`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`