### PR TITLE
feat(closurec): CLOC12.40 — close gap-033 (try/catch trailing `;`)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.46.0] - 2026-06-08
+
+### Changed
+- **CLOSES gap-033**: try/catch trailing `;` after `}`. The
+  CLI WHITESPACE_ONLY token re-stitcher now emits a synthetic
+  `;` after the last clause of a try/catch/finally chain,
+  mirroring upstream Closure v20240317's behaviour and same
+  family as gap-030's function-decl trailing `;`.
+- `brace_stack` was refactored from `Vec<bool>` to
+  `Vec<BlockKind>` with three variants: `Function`,
+  `TryChain`, `Other`. The new `BlockKind::TryChain` is pushed
+  whenever a `{` immediately follows a `try` / `catch` /
+  `finally` keyword (tracked via a new
+  `next_block_is_try_chain` flag).
+- When a `}` pops a `BlockKind::TryChain`, the emitter peeks
+  the very next non-trivia token. If it's `catch` or `finally`
+  the chain continues, no `;` is emitted. Otherwise the chain
+  has ended and a synthetic `;` is appended (and tracked by
+  `last_emit_was_synthetic_semi` so rule-C dedup applies).
+- `minify_try_catch` flipped from IGNORED → PASS. The
+  `diff_minify` harness now reports `15 matched, 0 failed,
+  2 skipped (of 17 total)` (gap-031 and gap-032 remain).
+
+### Added
+- 6 new inline tests in `whitespace_only::tests::gap033_*`:
+  - `gap033_try_catch_gets_trailing_semi` — the target fixture
+    shape.
+  - `gap033_try_finally_gets_trailing_semi` — try/finally
+    (no catch).
+  - `gap033_try_catch_finally_only_final_semi` — only the
+    LAST `}` in a 3-clause chain gets `;`.
+  - `gap033_nested_try_catch_each_gets_semi` — depth
+    regression; brace_stack must track all open chains.
+  - `gap033_function_decl_inside_try_block_still_gets_semi` —
+    `BlockKind::Function` and `BlockKind::TryChain` don't
+    interfere; nested `function f(){}` inside a try-body still
+    gets its gap-030 trailing `;`.
+  - `gap033_optional_catch_binding` — ES2019 `catch{...}`
+    without `(e)` binding.
+
 ## [0.45.0] - 2026-06-08
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -94,6 +94,29 @@ impl std::error::Error for MinifyError {}
 // Public entry point
 // ---------------------------------------------------------------------------
 
+/// What kind of block does an open `{` start? Pushed onto
+/// `brace_stack` and consulted on the matching `}` to decide
+/// whether to emit a synthetic `;` after the closing brace.
+///
+/// | Kind        | Trigger to push                          | `}` action |
+/// |-------------|------------------------------------------|-------------|
+/// | `Function`  | `function` keyword at stmt boundary      | always emit `;` (gap-030 rule B) |
+/// | `TryChain`  | `try`/`catch`/`finally` keyword          | emit `;` IFF next non-trivia is NOT `catch`/`finally` (gap-033) |
+/// | `Other`     | any other block (if/while/for/plain block)| no synthetic `;` |
+///
+/// The `TryChain` variant captures both the try-body block and
+/// each catch/finally clause body in the chain. The chain ends
+/// when a `}` closing a `TryChain` block is NOT followed by
+/// another `catch` or `finally` keyword — at that point the
+/// trailing `;` is emitted, mirroring upstream Closure
+/// v20240317's normalisation of try-statement output shape.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BlockKind {
+    Function,
+    TryChain,
+    Other,
+}
+
 /// Apply WHITESPACE_ONLY to a single source string.
 ///
 /// Returns the comment-stripped, whitespace-collapsed equivalent.
@@ -151,15 +174,27 @@ pub fn whitespace_only_minify(
     let mut out = String::with_capacity(source.len());
 
     // State machine:
-    let mut brace_stack: Vec<bool> = Vec::new();
-    // ^ for each open `{`, true iff this `{` opened a
-    //   function-declaration body. Popped on matching `}`.
+    let mut brace_stack: Vec<BlockKind> = Vec::new();
+    // ^ for each open `{`, the kind of block it opens.
+    //   `BlockKind::Function` triggers gap-030 rule-B (emit
+    //   `;` after closing `}`); `BlockKind::TryChain` triggers
+    //   gap-033 rule (emit `;` after closing `}` iff next
+    //   non-trivia token is NOT `catch` or `finally` — i.e.
+    //   the chain has ended).
     let mut paren_stack: Vec<bool> = Vec::new();
     // ^ for each open `(`, true iff this `(` was the head of
     //   an `if` / `while` / `for` (control-flow construct
     //   whose body slot follows the close-paren). Popped on
     //   matching `)`.
     let mut saw_function_kw_at_boundary = false;
+    let mut next_block_is_try_chain = false;
+    // ^ gap-033: armed by `try` / `catch` / `finally`
+    //   keywords; consumed by the next `{` and stored on the
+    //   brace stack as `BlockKind::TryChain`. `try` arms it
+    //   at a statement boundary. `catch` and `finally` arm
+    //   it whenever they appear (they only legally appear
+    //   after a preceding `}` that closed a try-chain block,
+    //   so the boundary context is already correct).
     let mut next_paren_is_control_flow_head = false;
     let mut body_position_next = false;
     let mut at_stmt_boundary = true;
@@ -198,6 +233,12 @@ pub fn whitespace_only_minify(
             }
         }
 
+        // Snapshot prev BEFORE the emit overwrites it, so
+        // the state-update branches below can inspect the
+        // token that came *before* the current one. Needed
+        // for gap-033's `catch`/`finally` guard.
+        let prev_before_this_emit = prev_emitted_tok;
+
         // Emit the token (with separator if needed).
         if let Some(prev) = prev_emitted_tok {
             if needs_separator(prev, tok) {
@@ -213,23 +254,51 @@ pub fn whitespace_only_minify(
         }
         prev_emitted_tok = Some(tok);
 
-        // Rule B: a `}` that closes a function-declaration
-        // body gets a synthetic `;` appended.
+        // Rule B / gap-033: a `}` that closes a
+        // function-declaration body, or the LAST clause of a
+        // try-chain, gets a synthetic `;` appended.
         if val == "}" {
-            let was_function_decl = brace_stack.pop().unwrap_or(false);
-            if was_function_decl {
+            let kind = brace_stack.pop().unwrap_or(BlockKind::Other);
+            let needs_synthetic_semi = match kind {
+                BlockKind::Function => true,
+                BlockKind::TryChain => {
+                    // gap-033: the chain continues iff the
+                    // very next non-trivia token is `catch`
+                    // or `finally`. If so, suppress the `;`
+                    // because the next clause will own the
+                    // terminator. Otherwise the chain has
+                    // ended — emit `;`.
+                    let next_val = kept.get(idx + 1).map(|t| t.value.as_str());
+                    !matches!(next_val, Some("catch") | Some("finally"))
+                }
+                BlockKind::Other => false,
+            };
+            if needs_synthetic_semi {
                 out.push(';');
                 last_emit_was_synthetic_semi = true;
             }
             at_stmt_boundary = true;
             body_position_next = false;
         } else if val == "{" {
-            brace_stack.push(saw_function_kw_at_boundary);
+            // Priority: TryChain > Function > Other. A `{`
+            // immediately after `try`/`catch`/`finally` is a
+            // try-chain body; one preceded by `function` at a
+            // statement boundary is a function-decl body;
+            // everything else is Other.
+            let kind = if next_block_is_try_chain {
+                BlockKind::TryChain
+            } else if saw_function_kw_at_boundary {
+                BlockKind::Function
+            } else {
+                BlockKind::Other
+            };
+            brace_stack.push(kind);
+            next_block_is_try_chain = false;
             saw_function_kw_at_boundary = false;
             // A `{` either opens a Block-as-body (consumes
-            // body_position_next) or opens a function-decl
-            // body (independent of body_position). Either
-            // way the body slot is filled by this brace.
+            // body_position_next) or opens a function-decl /
+            // try-chain body (independent of body_position).
+            // Either way the body slot is filled by this brace.
             body_position_next = false;
             at_stmt_boundary = true;
         } else if val == "(" {
@@ -255,6 +324,49 @@ pub fn whitespace_only_minify(
             // mid-expression and don't qualify.
             if at_stmt_boundary {
                 saw_function_kw_at_boundary = true;
+            }
+            at_stmt_boundary = false;
+        } else if val == "try" {
+            // gap-033: `try` opens a try-chain ONLY when it
+            // is acting as a statement-starting keyword. Two
+            // guards needed:
+            //
+            //   1. `at_stmt_boundary` — filters out e.g.
+            //      `return try` (which is illegal anyway,
+            //      defense in depth).
+            //   2. Next non-trivia token must be `{` — this
+            //      filters out `try` appearing as a PROPERTY
+            //      NAME in an object literal (`{try: 1}`)
+            //      where `at_stmt_boundary` would be true
+            //      after the object-opening `{` but `try` is
+            //      semantically a key, not a statement.
+            //      Without this guard, the flag would leak
+            //      forward and contaminate the next
+            //      unrelated `{`, turning e.g.
+            //      `var t={try:1};do{y}while(x);` into
+            //      `var t={try:1};do{y};while(x);` — a
+            //      do/while SyntaxError. Caught by pre-push
+            //      security review.
+            let next_is_brace =
+                kept.get(idx + 1).map(|t| t.value.as_str()) == Some("{");
+            if at_stmt_boundary && next_is_brace {
+                next_block_is_try_chain = true;
+            }
+            at_stmt_boundary = false;
+        } else if matches!(val, "catch" | "finally") {
+            // `catch` / `finally` open a try-chain clause
+            // ONLY when they follow a try-chain block's
+            // closing `}` — which is the only legal position
+            // per ECMAScript §14.15. The previous emitted
+            // token tells us this. Without the guard, member
+            // access like `obj.catch(...)` (where the lexer
+            // still tags `catch` as KEYWORD) would arm the
+            // flag and contaminate the next unrelated `{`.
+            // Same family of defect as the `try` filter above.
+            let prev_is_brace =
+                prev_before_this_emit.map(|t| t.value.as_str()) == Some("}");
+            if prev_is_brace {
+                next_block_is_try_chain = true;
             }
             at_stmt_boundary = false;
         } else if matches!(val, "if" | "while" | "for") {
@@ -639,5 +751,137 @@ mod tests {
     #[test]
     fn gap030_top_level_var_unchanged() {
         assert_eq!(minify("var x=1;"), "var x=1;");
+    }
+
+    // ---- gap-033: try/catch/finally trailing `;` ----------
+
+    /// The target fixture for gap-033. A try/catch chain
+    /// gets a trailing `;` after the LAST clause's `}`.
+    /// Inner `;`s are correctly dropped by rule A from
+    /// gap-030 (already working before this change).
+    #[test]
+    fn gap033_try_catch_gets_trailing_semi() {
+        assert_eq!(
+            minify("try{a();}catch(e){b();}"),
+            "try{a()}catch(e){b()};"
+        );
+    }
+
+    /// try-only (no catch, but a finally) gets `;` after
+    /// `finally`'s `}`.
+    #[test]
+    fn gap033_try_finally_gets_trailing_semi() {
+        assert_eq!(
+            minify("try{a();}finally{c();}"),
+            "try{a()}finally{c()};"
+        );
+    }
+
+    /// try/catch/finally chain — only the FINAL `}` gets `;`.
+    /// The brace stack pops TryChain three times; the first
+    /// two pops suppress `;` because next non-trivia is
+    /// `catch` or `finally`.
+    #[test]
+    fn gap033_try_catch_finally_only_final_semi() {
+        assert_eq!(
+            minify("try{a();}catch(e){b();}finally{c();}"),
+            "try{a()}catch(e){b()}finally{c()};"
+        );
+    }
+
+    /// Nested try/catch — each chain independently gets its
+    /// own trailing `;`. Important regression: brace_stack
+    /// must track depth, not a single boolean.
+    #[test]
+    fn gap033_nested_try_catch_each_gets_semi() {
+        // try{ try{a;}catch(e){b;} }catch(f){c;}
+        // After inner-catch `}`: peek is `}` (outer-try's),
+        // not catch/finally — inner chain ends, emit `;`.
+        // After outer-try-body `}`: peek is `catch`, chain
+        // continues, no `;`.
+        // After outer-catch `}`: peek is EOF, chain ends,
+        // emit `;`.
+        assert_eq!(
+            minify("try{try{a;}catch(e){b;}}catch(f){c;}"),
+            "try{try{a}catch(e){b};}catch(f){c};"
+        );
+    }
+
+    /// Critical regression test: gap-030's function-decl
+    /// trailing `;` is preserved when function-decl appears
+    /// inside a try-block. brace_stack handles Function and
+    /// TryChain as separate cases — they don't interfere.
+    #[test]
+    fn gap033_function_decl_inside_try_block_still_gets_semi() {
+        // try{ function f(){} } catches no semi inside (rule A
+        // wouldn't fire on the function-decl `}` because
+        // brace_stack pop is Function not TryChain). The
+        // function-decl gets its own `;`. The try-body's `}`
+        // then pops TryChain.
+        assert_eq!(
+            minify("try{function f(){}}catch(e){b;}"),
+            "try{function f(){};}catch(e){b};"
+        );
+    }
+
+    /// catch-with-no-binding (ES2019 optional catch binding):
+    /// `try{a;}catch{b;}` — no `(e)`. Should still work.
+    #[test]
+    fn gap033_optional_catch_binding() {
+        assert_eq!(
+            minify("try{a;}catch{b;}"),
+            "try{a}catch{b};"
+        );
+    }
+
+    /// Critical regression from pre-push security review:
+    /// `try` as an OBJECT-LITERAL PROPERTY NAME must NOT arm
+    /// the try-chain flag. Without this guard, the flag would
+    /// leak forward and contaminate the next unrelated `{` —
+    /// specifically breaking `do{...}while(...)` because the
+    /// spurious `;` after the do-body's `}` would terminate
+    /// the do-statement and turn `while(x)` into an
+    /// independent while-loop, a grammar error.
+    #[test]
+    fn gap033_try_as_object_property_does_not_arm() {
+        // The original failing input the security review
+        // identified.
+        assert_eq!(
+            minify("var t={try:1};do{y}while(x);"),
+            "var t={try:1};do{y}while(x);"
+        );
+    }
+
+    /// Same family as the above: `try` as a property name
+    /// followed by other constructs that have their own `{}`.
+    #[test]
+    fn gap033_try_as_property_then_function_decl_unchanged() {
+        assert_eq!(
+            minify("var t={try:1};function g(){};var z=1;"),
+            "var t={try:1};function g(){};var z=1;"
+        );
+    }
+
+    /// `obj.catch(...)` — `catch` as method name on an
+    /// object. The lexer tags `catch` as KEYWORD even here,
+    /// so the state machine must use the prev-emitted-token
+    /// guard (must be `}`) to filter out this case.
+    #[test]
+    fn gap033_catch_as_method_does_not_arm() {
+        assert_eq!(
+            minify("obj.catch(err);"),
+            "obj.catch(err);"
+        );
+    }
+
+    /// Promise-style chain: `p.then().catch(f)`. Both `catch`
+    /// occurrences are method calls, not statement clauses.
+    /// Neither should arm the try-chain.
+    #[test]
+    fn gap033_promise_catch_chain_unchanged() {
+        assert_eq!(
+            minify("p.then(g).catch(f);"),
+            "p.then(g).catch(f);"
+        );
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.45.0
+Version: 0.46.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -95,10 +95,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // gap-010 (DCE block flattening, already resolved).
     // Discovered by CLOC14.3.
     ("if_else", "gap-032: single-stmt if/else block flattening"),
-    // gap-033: try/catch trailing `;` after `}`. Same family
-    // as gap-030 (function-decl trailing `;`) but for
-    // try/catch statements. Discovered by CLOC14.3.
-    ("try_catch", "gap-033: try/catch trailing `;` after `}`"),
+    // gap-033 was RESOLVED in CLOC12.40 — the brace_stack
+    // state machine now tracks try/catch/finally chains via
+    // BlockKind::TryChain. `minify_try_catch` flipped from
+    // IGNORED to PASS.
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -258,10 +258,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-033 — try/catch trailing `;` after `}`
 
-- **Status:** OPEN — newly discovered by CLOC14.3. **Same family as gap-030** (function-decl trailing `;`).
-- **Upstream byte-identity test:** `minify_try_catch` seed fixture.
-- **Why it fails:** Upstream emits a `;` after the last `}` of a try/catch statement, mirroring its function-decl normalisation:
-  - Input: `try{a();}catch(e){b();}`
-  - Upstream: `try{a()}catch(e){b()};`  (note inner `;`s dropped per gap-030's rule-A and trailing `;` added)
-  - closurec: `try{a()}catch(e){b()}`  (inner `;`s correctly dropped; trailing missing)
-- **What it needs:** Extend the CLI token state machine (CLOC12.39's brace_stack) to track try/catch blocks the same way as function declarations. When a `}` closes the LAST catch/finally clause of a `try`, emit `;`. The `try` keyword is the marker; track it like `function` is tracked.
+- **Status:** **RESOLVED** in CLOC12.40 (PR pending). `minify_try_catch` flipped IGNORED → PASS.
+- **Upstream byte-identity test:** `minify_try_catch` seed fixture. PASS.
+- **Why it failed:** Upstream emits a `;` after the last `}` of a try/catch statement, mirroring its function-decl normalisation. closurec correctly dropped inner `;`s per gap-030 rule A but never emitted the trailing `;`.
+- **Resolution:** Extended the CLI token state machine. `brace_stack` was refactored from `Vec<bool>` to `Vec<BlockKind>` with three variants: `Function`, `TryChain`, `Other`. A new flag `next_block_is_try_chain` is armed by the `try`/`catch`/`finally` keywords; the next `{` consumes it and pushes `BlockKind::TryChain` onto the stack. When a `}` pops a `TryChain` kind, the emitter peeks the next non-trivia token: if it's `catch` or `finally`, the chain continues and no `;` is emitted; otherwise the chain has ended and a synthetic `;` is appended. 6 inline tests pin the behavior including nested try/catch, try/catch/finally chains, function-decl inside try-block (no interference between Function and TryChain), and ES2019 optional catch binding (`try{a;}catch{b;}`).


### PR DESCRIPTION
## Summary

**Closes gap-033.** \`minify_try_catch\` flipped IGNORED → PASS. Harness now 15/17 matched.

\`\`\`
before: 14 matched, 0 failed, 3 skipped (of 17 total)
after:  15 matched, 0 failed, 2 skipped (of 17 total)
\`\`\`

## Implementation

\`brace_stack\` refactored \`Vec<bool>\` → \`Vec<BlockKind>\` (Function / TryChain / Other). \`try\`/\`catch\`/\`finally\` keywords arm \`next_block_is_try_chain\`; the next \`{\` consumes it. When \`}\` pops a \`TryChain\`, peek next: if \`catch\`/\`finally\` the chain continues (no \`;\`), otherwise the chain has ended (emit \`;\`).

## Pre-push security review caught a real bug

Failing input: \`var t={try:1};do{y}while(x);\`

The original cut armed \`next_block_is_try_chain\` on ANY \`try\` token (including reserved-word property names like \`{try:1}\` per §13.2.5). The flag leaked forward, contaminated the next unrelated \`{\` (here, do-body), and emitted a spurious \`;\` after \`}\` — breaking do-while grammar.

**Fix (two guards):**
- \`try\` only arms when (a) \`at_stmt_boundary\` is true AND (b) the next non-trivia token is \`{\`. Filters property names + member access.
- \`catch\`/\`finally\` only arm when the previously emitted token was \`}\`. Filters \`obj.catch(...)\` Promise chains.

A secondary bug surfaced: \`prev_emitted_tok\` was overwritten before the state-update branches inspected it, so the catch guard compared catch-against-catch. Snapshot fix added.

## Tests

10 inline tests in \`whitespace_only::tests::gap033_*\`. Includes 4 regression tests for the security-review-caught bug:
- \`gap033_try_as_object_property_does_not_arm\` (verbatim failing input)
- \`gap033_try_as_property_then_function_decl_unchanged\`
- \`gap033_catch_as_method_does_not_arm\` (\`obj.catch(err);\`)
- \`gap033_promise_catch_chain_unchanged\` (\`p.then(g).catch(f);\`)

Full closurec suite: **283 passed, 0 failed**.

## Version

0.45.0 → 0.46.0 (Cargo.toml + cli.spec.json + help-markdown fixture bumped together — same lesson as CLOC12.39).

## Test plan

- [x] \`cargo test\` → 283 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 15 matched, 0 failed, 2 skipped
- [x] Pre-push security review (2 rounds, bug-fix between) → PASS
- [ ] CI green

## Closes

- **gap-033** (try/catch trailing \`;\` after \`}\`). gap-031 and gap-032 remain open (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)