### PR TITLE
Track browser navigation target descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness navigation-target descriptors now expose policy-rich anchor
+  and image-map area targets with resolved URLs, target selection, rel policy,
+  ping/attribution endpoints, language/type hints, referrer policy, download,
+  and area geometry metadata as a flat browser-planning inventory.
 - Browser-readiness document-policy descriptors now expose charset, viewport,
   referrer/robots/color-scheme policy, CSP/Permissions/Origin-Trial/Accept-CH
   hints, theme colors, refresh, canonical, and manifest metadata as a flat

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -839,6 +839,7 @@ pub struct BrowserDocument {
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
     pub text_semantics: Vec<BrowserTextSemantic>,
+    pub navigation_target_descriptors: Vec<BrowserNavigationTargetDescriptor>,
     pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub command_elements: Vec<BrowserCommandElement>,
@@ -1626,6 +1627,33 @@ pub struct BrowserTextSemantic {
     pub ruby_kind: Option<String>,
     pub bidi_kind: Option<String>,
     pub phrase_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserNavigationTargetDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub text: String,
+    pub target: Option<String>,
+    pub effective_target: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub rel_external: bool,
+    pub rel_nofollow: bool,
+    pub rel_noopener: bool,
+    pub rel_noreferrer: bool,
+    pub download: Option<String>,
+    pub ping: Vec<String>,
+    pub resolved_ping: Vec<String>,
+    pub attributionsrc: Vec<String>,
+    pub resolved_attributionsrc: Vec<String>,
+    pub hreflang: Option<String>,
+    pub type_hint: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub area_shape: Option<String>,
+    pub area_coords: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9773,6 +9801,13 @@ fn collect_browser_facts(
         }
 
         if is_browser_document_link(element) {
+            if let Some(descriptor) = browser_navigation_target_descriptor(
+                element,
+                summary.base_href.as_deref(),
+                summary.base_target.as_deref(),
+            ) {
+                summary.navigation_target_descriptors.push(descriptor);
+            }
             summary.links.push(browser_link(
                 element,
                 summary.base_href.as_deref(),
@@ -10313,6 +10348,77 @@ fn browser_link(
         referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
         text: browser_link_text(element),
     }
+}
+
+fn browser_navigation_target_descriptor(
+    element: &Element,
+    base_href: Option<&str>,
+    base_target: Option<&str>,
+) -> Option<BrowserNavigationTargetDescriptor> {
+    if element.attribute("href").is_none() {
+        return None;
+    }
+
+    let rel_tokens = browser_rel_tokens(element);
+    let ping = browser_anchor_ping(element);
+    let attributionsrc = browser_anchor_attributionsrc(element);
+    let has_navigation_policy = element.attribute("target").is_some()
+        || element.attribute("rel").is_some()
+        || element.attribute("download").is_some()
+        || !ping.is_empty()
+        || !attributionsrc.is_empty()
+        || element.attribute("hreflang").is_some()
+        || element.attribute("type").is_some()
+        || element.attribute("referrerpolicy").is_some()
+        || element.name == "area";
+
+    if !has_navigation_policy {
+        return None;
+    }
+
+    let href = element.attribute("href").map(ToOwned::to_owned);
+    let target = element.attribute("target").map(ToOwned::to_owned);
+    let area_shape = (element.name == "area")
+        .then(|| browser_image_map_shape(element).unwrap_or_else(|| "rect".to_string()));
+    let area_coords = (element.name == "area")
+        .then(|| browser_image_map_coords(element))
+        .flatten();
+
+    Some(BrowserNavigationTargetDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        resolved_href: href
+            .as_deref()
+            .and_then(|href| resolve_browser_url(href, base_href)),
+        href,
+        text: browser_link_text(element),
+        effective_target: target
+            .clone()
+            .or_else(|| base_target.map(ToOwned::to_owned)),
+        target,
+        rel: element.attribute("rel").map(ToOwned::to_owned),
+        rel_external: browser_rel_tokens_contain(&rel_tokens, "external"),
+        rel_nofollow: browser_rel_tokens_contain(&rel_tokens, "nofollow"),
+        rel_noopener: browser_rel_tokens_contain(&rel_tokens, "noopener"),
+        rel_noreferrer: browser_rel_tokens_contain(&rel_tokens, "noreferrer"),
+        rel_tokens,
+        download: browser_anchor_download(element),
+        resolved_ping: ping
+            .iter()
+            .filter_map(|ping| resolve_browser_url(ping, base_href))
+            .collect(),
+        ping,
+        resolved_attributionsrc: attributionsrc
+            .iter()
+            .filter_map(|attributionsrc| resolve_browser_url(attributionsrc, base_href))
+            .collect(),
+        attributionsrc,
+        hreflang: element.attribute("hreflang").map(ToOwned::to_owned),
+        type_hint: element.attribute("type").map(ToOwned::to_owned),
+        referrerpolicy: element.attribute("referrerpolicy").map(ToOwned::to_owned),
+        area_shape,
+        area_coords,
+    })
 }
 
 fn is_browser_document_link(element: &Element) -> bool {
@@ -17124,6 +17230,76 @@ mod tests {
         assert_eq!(render_tree.children[1].display, "block");
         assert_eq!(render_tree.children[1].children[0].display, "list-item");
         assert_eq!(render_tree.children[2].children[0].display, "list-item");
+    }
+
+    #[test]
+    fn browser_navigation_target_descriptors_track_links_and_image_map_areas() {
+        let document = parse_html(
+            "<base href=\"https://example.test/docs/\" target=_top>\
+             <body><a id=plain href=plain.html>Plain</a>\
+             <a id=intro href=intro.html target=main rel=\"next external noreferrer\" download=intro.html ping=\"track.html https://metrics.example/p\" attributionsrc=\"attr/register https://ad.example/register\" hreflang=en type=text/html referrerpolicy=no-referrer>Intro</a>\
+             <map name=hero><area id=detail shape=circle coords=\"20,20,10\" href=detail.html alt=Details target=preview rel=\"nofollow external\" ping=area-track.html attributionsrc=area-attr.html hreflang=en></map></body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.navigation_target_descriptors.len(), 2);
+
+        let anchor = &summary.navigation_target_descriptors[0];
+        assert_eq!(anchor.element, "a");
+        assert_eq!(anchor.id.as_deref(), Some("intro"));
+        assert_eq!(anchor.href.as_deref(), Some("intro.html"));
+        assert_eq!(
+            anchor.resolved_href.as_deref(),
+            Some("https://example.test/docs/intro.html")
+        );
+        assert_eq!(anchor.text, "Intro");
+        assert_eq!(anchor.target.as_deref(), Some("main"));
+        assert_eq!(anchor.effective_target.as_deref(), Some("main"));
+        assert_eq!(anchor.rel_tokens, vec!["next", "external", "noreferrer"]);
+        assert!(anchor.rel_external);
+        assert!(anchor.rel_noreferrer);
+        assert_eq!(anchor.download.as_deref(), Some("intro.html"));
+        assert_eq!(anchor.ping, vec!["track.html", "https://metrics.example/p"]);
+        assert_eq!(
+            anchor.resolved_ping,
+            vec![
+                "https://example.test/docs/track.html",
+                "https://metrics.example/p"
+            ]
+        );
+        assert_eq!(
+            anchor.attributionsrc,
+            vec!["attr/register", "https://ad.example/register"]
+        );
+        assert_eq!(
+            anchor.resolved_attributionsrc,
+            vec![
+                "https://example.test/docs/attr/register",
+                "https://ad.example/register"
+            ]
+        );
+        assert_eq!(anchor.hreflang.as_deref(), Some("en"));
+        assert_eq!(anchor.type_hint.as_deref(), Some("text/html"));
+        assert_eq!(anchor.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(anchor.area_shape, None);
+
+        let area = &summary.navigation_target_descriptors[1];
+        assert_eq!(area.element, "area");
+        assert_eq!(area.id.as_deref(), Some("detail"));
+        assert_eq!(area.text, "Details");
+        assert_eq!(area.area_shape.as_deref(), Some("circle"));
+        assert_eq!(area.area_coords.as_deref(), Some("20,20,10"));
+        assert_eq!(area.target.as_deref(), Some("preview"));
+        assert_eq!(area.effective_target.as_deref(), Some("preview"));
+        assert_eq!(area.rel_tokens, vec!["nofollow", "external"]);
+        assert!(area.rel_external);
+        assert!(area.rel_nofollow);
+        assert_eq!(area.hreflang.as_deref(), Some("en"));
+        assert_eq!(
+            area.resolved_attributionsrc,
+            vec!["https://example.test/docs/area-attr.html"]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -13,11 +13,11 @@ use coding_adventures_html_parser::{
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
     BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
-    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceHint, BrowserScript,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
-    BrowserThemeColor,
+    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -79,6 +79,8 @@ struct ExpectedBrowserDocument {
     headings: Vec<ExpectedHeading>,
     #[serde(default)]
     text_semantics: Vec<ExpectedTextSemantic>,
+    #[serde(default)]
+    navigation_target_descriptors: Vec<ExpectedNavigationTargetDescriptor>,
     #[serde(default)]
     navigation_groups: Vec<ExpectedNavigationGroup>,
     #[serde(default)]
@@ -445,6 +447,55 @@ struct ExpectedDocumentPolicyDescriptor {
     manifest_url: Option<String>,
     #[serde(default)]
     resolved_manifest_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedNavigationTargetDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_external: bool,
+    #[serde(default)]
+    rel_nofollow: bool,
+    #[serde(default)]
+    rel_noopener: bool,
+    #[serde(default)]
+    rel_noreferrer: bool,
+    #[serde(default)]
+    download: Option<String>,
+    #[serde(default)]
+    ping: Vec<String>,
+    #[serde(default)]
+    resolved_ping: Vec<String>,
+    #[serde(default)]
+    attributionsrc: Vec<String>,
+    #[serde(default)]
+    resolved_attributionsrc: Vec<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    area_shape: Option<String>,
+    #[serde(default)]
+    area_coords: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3700,6 +3751,11 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedTextSemantic::into_browser_text_semantic)
                 .collect(),
+            navigation_target_descriptors: self
+                .navigation_target_descriptors
+                .into_iter()
+                .map(ExpectedNavigationTargetDescriptor::into_browser_navigation_target_descriptor)
+                .collect(),
             navigation_groups: self
                 .navigation_groups
                 .into_iter()
@@ -4230,6 +4286,36 @@ impl ExpectedDocumentPolicyDescriptor {
             resolved_canonical_url: self.resolved_canonical_url,
             manifest_url: self.manifest_url,
             resolved_manifest_url: self.resolved_manifest_url,
+        }
+    }
+}
+
+impl ExpectedNavigationTargetDescriptor {
+    fn into_browser_navigation_target_descriptor(self) -> BrowserNavigationTargetDescriptor {
+        BrowserNavigationTargetDescriptor {
+            element: self.element,
+            id: self.id,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            text: self.text,
+            target: self.target,
+            effective_target: self.effective_target,
+            rel: self.rel,
+            rel_tokens: self.rel_tokens,
+            rel_external: self.rel_external,
+            rel_nofollow: self.rel_nofollow,
+            rel_noopener: self.rel_noopener,
+            rel_noreferrer: self.rel_noreferrer,
+            download: self.download,
+            ping: self.ping,
+            resolved_ping: self.resolved_ping,
+            attributionsrc: self.attributionsrc,
+            resolved_attributionsrc: self.resolved_attributionsrc,
+            hreflang: self.hreflang,
+            type_hint: self.type_hint,
+            referrerpolicy: self.referrerpolicy,
+            area_shape: self.area_shape,
+            area_coords: self.area_coords,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -35,6 +35,9 @@ Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
 iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel
 policy tokens, validation bypass state, and submitter overrides.
+Navigation-target descriptor cases pin policy-rich anchor and image-map area
+targets with target selection, rel policy, ping/attribution endpoints,
+language/type hints, download/referrer policy, and area geometry.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags and preload/poster metadata.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -38,6 +38,28 @@
         "fetch_policy_descriptors": [
           { "element": "a", "url": "intro.html", "resolved_url": "https://example.test/docs/intro.html", "referrerpolicy": "no-referrer" }
         ],
+        "navigation_target_descriptors": [
+          {
+            "element": "a",
+            "href": "intro.html",
+            "resolved_href": "https://example.test/docs/intro.html",
+            "text": "Venture HTML",
+            "target": "main",
+            "effective_target": "main",
+            "rel": "next external noreferrer",
+            "rel_tokens": ["next", "external", "noreferrer"],
+            "rel_external": true,
+            "rel_noreferrer": true,
+            "download": "intro.html",
+            "ping": ["track.html", "https://metrics.example/p"],
+            "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"],
+            "attributionsrc": ["attr/register", "https://ad.example/register"],
+            "resolved_attributionsrc": ["https://example.test/docs/attr/register", "https://ad.example/register"],
+            "hreflang": "en",
+            "type_hint": "text/html",
+            "referrerpolicy": "no-referrer"
+          }
+        ],
         "links": [
           { "href": "intro.html", "resolved_href": "https://example.test/docs/intro.html", "name": null, "target": "main", "effective_target": "main", "rel": "next external noreferrer", "rel_tokens": ["next", "external", "noreferrer"], "rel_external": true, "rel_noreferrer": true, "title": "Intro", "download": "intro.html", "ping": ["track.html", "https://metrics.example/p"], "resolved_ping": ["https://example.test/docs/track.html", "https://metrics.example/p"], "attributionsrc": ["attr/register", "https://ad.example/register"], "resolved_attributionsrc": ["https://example.test/docs/attr/register", "https://ad.example/register"], "hreflang": "en", "type_hint": "text/html", "referrerpolicy": "no-referrer", "text": "Venture HTML" }
         ],
@@ -176,6 +198,27 @@
         ],
         "fetch_policy_descriptors": [
           { "element": "img", "url": "hero.jpg", "resolved_url": "https://example.test/gallery/hero.jpg", "crossorigin": "anonymous", "referrerpolicy": "no-referrer" }
+        ],
+        "navigation_target_descriptors": [
+          {
+            "element": "area",
+            "href": "details.html",
+            "resolved_href": "https://example.test/gallery/details.html",
+            "text": "Details",
+            "target": "preview",
+            "effective_target": "preview",
+            "rel": "nofollow external",
+            "rel_tokens": ["nofollow", "external"],
+            "rel_external": true,
+            "rel_nofollow": true,
+            "ping": ["track.html"],
+            "resolved_ping": ["https://example.test/gallery/track.html"],
+            "attributionsrc": ["area-attr.html"],
+            "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"],
+            "hreflang": "en",
+            "area_shape": "rect",
+            "area_coords": "0,0,120,60"
+          }
         ],
         "links": [
           { "element": "area", "href": "details.html", "resolved_href": "https://example.test/gallery/details.html", "name": null, "target": "preview", "effective_target": "preview", "rel": "nofollow external", "rel_tokens": ["nofollow", "external"], "rel_external": true, "rel_nofollow": true, "title": null, "ping": ["track.html"], "resolved_ping": ["https://example.test/gallery/track.html"], "attributionsrc": ["area-attr.html"], "resolved_attributionsrc": ["https://example.test/gallery/area-attr.html"], "hreflang": "en", "text": "Details" }


### PR DESCRIPTION
## Summary
- Add flat `navigation_target_descriptors` to `BrowserDocument` for policy-rich anchors and image-map areas.
- Capture resolved hrefs, effective targets, rel policy booleans/tokens, download, ping and attribution endpoints, language/type/referrer hints, and area geometry.
- Update browser-readiness fixtures, harness expectations, README inventory, and changelog notes.

## Tests
- `for test_name in browser_navigation_target_descriptors_track_links_and_image_map_areas browser_document_policy_descriptors_track_head_policy_and_app_hints browser_form_policy_descriptors_track_form_and_submitter_navigation browser_fetch_policy_descriptors_track_security_and_policy_hints browser_loading_hint_descriptors_track_head_and_body_scheduling_hints browser_aria_relation_metadata_tracks_details_errors_and_flow browser_shell_global_state_metadata_tracks_document_and_body_attributes browser_readiness_cases_extract_browser_document_facts browser_text_semantic_descriptor_metadata_tracks_inline_annotations; do cargo test -p coding-adventures-html-parser "$test_name" || exit 1; done`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
