### PR TITLE
feat(closurec): CLOC12.41 — close gap-031 (empty `{}` body collapses to `;`)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.47.0] - 2026-06-08
+
+### Changed
+- **CLOSES gap-031**: empty `{}` body collapses to `;`
+  (EmptyStatement substitution per ECMAScript §13.2). When
+  the CLI WHITESPACE_ONLY re-stitcher encounters `{` with
+  `body_position_next` true (i.e. it's the body slot of a
+  `for`/`while`/`if`/`labeled` after the closing `)`) AND the
+  next non-trivia token is `}`, the emitter writes a single
+  `;` in place of the `{}` pair and skips both braces.
+- `minify_for_loop` flipped IGNORED → PASS. Harness now
+  reports `16 matched, 0 failed, 1 skipped (of 17 total)`;
+  only gap-032 (single-statement if/else block flattening)
+  remains open.
+
+### Added
+- 8 new inline tests in `whitespace_only::tests::gap031_*`:
+  - **Positive (rule fires):**
+    - `gap031_empty_for_body_collapses` — the target fixture.
+    - `gap031_empty_while_body_collapses` — `while(x){}` → `while(x);`.
+    - `gap031_empty_if_body_collapses` — `if(x){}` → `if(x);`.
+  - **Non-regression (rule does NOT fire):**
+    - `gap031_function_empty_body_unaffected` — function-decl
+      body stays `{}` (no control-flow paren).
+    - `gap031_nonempty_for_body_unaffected` — `{...}` with
+      content stays as is.
+    - `gap031_top_level_empty_block_unaffected` — `{}` at
+      statement position (not body position) stays as is.
+    - `gap031_empty_object_literal_unaffected` — `{}` in
+      expression position stays as is.
+    - `gap031_try_empty_body_unaffected` — `try{}` body stays
+      `{}` (try doesn't have a `(...)` head); composes
+      correctly with gap-033 try-chain processing.
+
 ## [0.46.0] - 2026-06-08
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -233,6 +233,53 @@ pub fn whitespace_only_minify(
             }
         }
 
+        // gap-031: empty `{}` in body position collapses to
+        // `;`. Upstream Closure substitutes an EmptyStatement
+        // (`;`) for an empty Block when the block is in the
+        // body slot of a control-flow construct
+        // (`for(...){...}` / `while(x){}` / `if(x){}` etc.).
+        // The trigger is `{}` (a `{` immediately followed by
+        // `}`) WHERE `body_position_next` is true. We emit a
+        // single `;` and skip both braces. Function-decl
+        // bodies are unaffected because `body_position_next`
+        // is false in that context (no paren-stack push of
+        // control-flow head). Plain block-as-statement at
+        // top level is also unaffected (also no control-flow
+        // head). The substitution is semantically identical
+        // — ECMAScript §13.2 lets either Block or
+        // EmptyStatement satisfy the Statement nonterminal
+        // in the body slot.
+        if val == "{" && body_position_next {
+            if let Some(next) = kept.get(idx + 1) {
+                if next.value == "}" {
+                    // Emit `;` in place of `{}`.
+                    out.push(';');
+                    // The body slot is now filled by the
+                    // EmptyStatement we just emitted.
+                    body_position_next = false;
+                    at_stmt_boundary = true;
+                    // Arm rule-C dedup so an immediately-
+                    // following source `;` (e.g.
+                    // `for(...){};var x=1;`) gets folded into
+                    // the synthetic one — output stays
+                    // `for(...);var x=1;` instead of
+                    // becoming `for(...);;var x=1;`. Same
+                    // mechanism rule B uses for function-decl
+                    // trailing `;`. Pre-push security review
+                    // flagged this as an optimality regression.
+                    last_emit_was_synthetic_semi = true;
+                    // prev_emitted_tok is left untouched —
+                    // the next real token will compute its
+                    // separator against whatever came before
+                    // our substituted `;` (typically `)`),
+                    // which is not word-like so no separator
+                    // is needed.
+                    idx += 2; // Skip `{` and `}`.
+                    continue;
+                }
+            }
+        }
+
         // Snapshot prev BEFORE the emit overwrites it, so
         // the state-update branches below can inspect the
         // token that came *before* the current one. Needed
@@ -882,6 +929,101 @@ mod tests {
         assert_eq!(
             minify("p.then(g).catch(f);"),
             "p.then(g).catch(f);"
+        );
+    }
+
+    // ---- gap-031: empty `{}` body collapses to `;` --------
+
+    /// Target fixture: empty for-body collapses to `;`.
+    #[test]
+    fn gap031_empty_for_body_collapses() {
+        assert_eq!(
+            minify("for(var i=0;i<10;i++){}"),
+            "for(var i=0;i<10;i++);"
+        );
+    }
+
+    /// Empty while-body collapses.
+    #[test]
+    fn gap031_empty_while_body_collapses() {
+        assert_eq!(minify("while(x){}"), "while(x);");
+    }
+
+    /// Empty if-body collapses (with no else).
+    #[test]
+    fn gap031_empty_if_body_collapses() {
+        assert_eq!(minify("if(x){}"), "if(x);");
+    }
+
+    /// Empty function-decl body is NOT in body-position
+    /// (the `(...)` head of `function` is not a control-flow
+    /// head). So `function f(){}` stays as is + gets the
+    /// gap-030 trailing `;`. Important non-regression for
+    /// gap-031's interaction with gap-030.
+    #[test]
+    fn gap031_function_empty_body_unaffected() {
+        assert_eq!(minify("function f(){}"), "function f(){};");
+    }
+
+    /// A NON-empty for-body must NOT collapse — only `{}`
+    /// (empty) triggers the rule. The `{` arm checks that
+    /// the very next token is `}`.
+    #[test]
+    fn gap031_nonempty_for_body_unaffected() {
+        assert_eq!(
+            minify("for(var i=0;i<10;i++){a;}"),
+            "for(var i=0;i<10;i++){a}"
+        );
+    }
+
+    /// Top-level `{}` is a Block statement, NOT in body
+    /// position. body_position_next is false there, so the
+    /// rule does not fire. (Plain `{}` stays as `{}`.)
+    #[test]
+    fn gap031_top_level_empty_block_unaffected() {
+        // Top-level `{}` followed by a statement. The rule's
+        // body_position_next guard means we don't substitute.
+        assert_eq!(minify("{}var x=1;"), "{}var x=1;");
+    }
+
+    /// Object literal `{}` is in expression position, NOT in
+    /// body position. body_position_next would be false
+    /// (it's set by control-flow `)` only). Non-regression
+    /// for empty object literals.
+    #[test]
+    fn gap031_empty_object_literal_unaffected() {
+        assert_eq!(minify("var x={};"), "var x={};");
+    }
+
+    /// Critical interaction with gap-033: a try-body that is
+    /// empty `{}`. The try-body's `{` is opening a TryChain
+    /// block — but it is NOT in body position (try doesn't
+    /// have a `(...)` head). So gap-031 does NOT fire and
+    /// gap-033 correctly processes the try-chain.
+    #[test]
+    fn gap031_try_empty_body_unaffected() {
+        // `try{}catch(e){a;}` — try-body stays `{}` because
+        // it's not in body position; catch-body works as in
+        // gap-033.
+        assert_eq!(
+            minify("try{}catch(e){a;}"),
+            "try{}catch(e){a};"
+        );
+    }
+
+    /// Optimality regression test (caught by pre-push
+    /// security review). A source `;` immediately after the
+    /// `{}` collapse-target gets folded into the synthetic
+    /// `;` via rule C dedup. Without the
+    /// `last_emit_was_synthetic_semi = true` line in the
+    /// gap-031 branch, this would emit `for(...);;var x=1;`
+    /// — syntactically valid (the extra `;` is an
+    /// EmptyStatement) but ugly and non-minimal.
+    #[test]
+    fn gap031_for_loop_with_trailing_semi_deduped() {
+        assert_eq!(
+            minify("for(var i=0;i<10;i++){};var x=1;"),
+            "for(var i=0;i<10;i++);var x=1;"
         );
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.46.0
+Version: 0.47.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,10 +85,10 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-031: empty for-body `{}` collapses to `;`
-    // (EmptyStatement) in upstream Closure. Discovered by
-    // CLOC14.3. See tests/diff/minify_for_loop/README.md.
-    ("for_loop", "gap-031: empty `{}` body collapses to `;`"),
+    // gap-031 was RESOLVED in CLOC12.41 — empty `{}` body
+    // collapses to `;` per §13.2 EmptyStatement substitution
+    // in body position. `minify_for_loop` flipped from
+    // IGNORED to PASS.
     // gap-032: single-statement if/else block flattening.
     // Upstream emits `if(x)a();else b();` not
     // `if(x){a()}else{b()}`. CLI counterpart to AST-level

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -237,9 +237,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-031 — empty `{}` body collapses to `;`
 
-- **Status:** OPEN — newly discovered by CLOC14.3.
-- **Upstream byte-identity test:** `minify_for_loop` seed fixture.
-- **Why it fails:** Upstream Closure emits `for(...){}` as `for(...);` — the empty block body is replaced by an `EmptyStatement` (`;`). closurec preserves the `{}`.
+- **Status:** **RESOLVED** in CLOC12.41 (PR pending). `minify_for_loop` flipped IGNORED → PASS.
+- **Upstream byte-identity test:** `minify_for_loop` seed fixture. PASS.
+- **Resolution:** Added a third gap-rule in `whitespace_only.rs` between rule A (drop `;` before `}`) and the token emit. When the current token is `{` AND `body_position_next` is true AND the next non-trivia token is `}`, emit a single `;` and skip both braces. The substitution is ECMAScript §13.2 — either Block or EmptyStatement satisfies the body-position Statement nonterminal. The `body_position_next` guard is critical: it scopes the rule to true body-positions (for/while/if/labeled) and leaves untouched (a) function-decl bodies (no control-flow paren-stack push, so guard is false), (b) plain Block-as-statement at top level (no guard), (c) object literals in expression position (no guard), and (d) try/catch bodies (try doesn't have a `(...)` head, so guard is false). 8 inline tests pin the behaviour including 5 non-regression tests for the cases the guard must NOT fire on.
+- **Original divergence (now historical):**
   - Input: `for(var i=0;i<10;i++){}`
   - Upstream: `for(var i=0;i<10;i++);`
   - closurec: `for(var i=0;i<10;i++){}`


### PR DESCRIPTION
## Summary

**Closes gap-031.** \`minify_for_loop\` flipped IGNORED → PASS. Harness now **16/17**.

\`\`\`
before: 15 matched, 0 failed, 2 skipped (of 17 total)
after:  16 matched, 0 failed, 1 skipped (of 17 total)  ← only gap-032 remains
\`\`\`

## Rule

When CLI WHITESPACE_ONLY sees \`{\` AND \`body_position_next\` is true AND next non-trivia is \`}\`, emit \`;\` in place of \`{}\` and skip both braces. Per ECMAScript §13.2, either Block or EmptyStatement satisfies the body-position Statement nonterminal.

## body_position_next is the critical guard

Correctly leaves these untouched:
- Function-decl body (\`function f(){}\`) — \`function\`'s \`(...)\` isn't a control-flow head.
- Top-level \`{}\` (plain block, not body position).
- Object literal \`{}\` (expression position).
- Try-body \`try{}catch(e){}\` (try has no \`(...)\` head).

## Pre-push security review

Verdict PASS on correctness for all traced cases (\`do/while\`, \`for-in\`, \`for-of\`, \`labeled:\`, function-decl, try-chain). Reviewer flagged an **optimality** regression: \`for(...){};var x=1;\` produced \`for(...);;var x=1;\` (double \`;\`). One-line fix: set \`last_emit_was_synthetic_semi = true\` in the new branch so rule C dedup folds the source \`;\` immediately after the synthetic one.

## Tests

9 new inline tests: 3 positive, 5 non-regression, 1 optimality. Full closurec suite: **291 passed, 0 failed**.

## Version

0.46.0 → 0.47.0 (Cargo.toml + cli.spec.json + help-markdown fixture bumped together).

## Test plan

- [x] \`cargo test\` → 291 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 16 matched, 0 failed, 1 skipped
- [x] Pre-push security review → PASS on correctness; optimality fix applied
- [ ] CI green

## Closes

- **gap-031** (empty \`{}\` body → \`;\`). Only gap-032 (single-statement if/else block flattening) remains in the gap-031/032/033 cluster from CLOC14.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)