### PR TITLE
Add browser resource endpoint descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness resource-endpoint descriptors now expose refresh redirects
+  plus resolved document resources as a flat endpoint inventory for
+  fetch/navigation planning.
 - Browser-readiness navigation-target descriptors now expose policy-rich anchor
   and image-map area targets with resolved URLs, target selection, rel policy,
   ping/attribution endpoints, language/type hints, referrer policy, download,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -835,6 +835,7 @@ pub struct BrowserDocument {
     pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
+    pub resource_endpoint_descriptors: Vec<BrowserResourceEndpointDescriptor>,
     pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
@@ -945,6 +946,50 @@ pub struct BrowserMeta {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserResource {
     pub kind: String,
+    pub url: String,
+    pub resolved_url: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub as_hint: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub title: Option<String>,
+    pub sizes: Option<String>,
+    pub hreflang: Option<String>,
+    pub color: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub nonce: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub csp: Option<String>,
+    pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
+    pub browsing_context_name: Option<String>,
+    pub loading: Option<String>,
+    pub sandbox: Vec<String>,
+    pub allow: Option<String>,
+    pub allowfullscreen: bool,
+    pub srcdoc: Option<String>,
+    pub credentialless: bool,
+    pub imagesrcset: Option<String>,
+    pub resolved_imagesrcset: Option<String>,
+    pub imagesizes: Option<String>,
+    pub track_kind: Option<String>,
+    pub srclang: Option<String>,
+    pub track_label: Option<String>,
+    pub default_track: bool,
+    pub async_script: bool,
+    pub defer_script: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserResourceEndpointDescriptor {
+    pub endpoint_kind: String,
+    pub element: String,
+    pub resource_kind: Option<String>,
     pub url: String,
     pub resolved_url: Option<String>,
     pub rel: Option<String>,
@@ -2572,6 +2617,7 @@ impl BrowserDocument {
             &[],
             body_children,
         );
+        summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
 }
@@ -10079,6 +10125,125 @@ fn collect_link_document_metadata(element: &Element, summary: &mut BrowserDocume
         {
             summary.metadata.resource_hints.push(resource_hint);
         }
+    }
+}
+
+fn browser_resource_endpoint_descriptors(
+    summary: &BrowserDocument,
+) -> Vec<BrowserResourceEndpointDescriptor> {
+    let mut descriptors = Vec::new();
+    if let Some(refresh) = &summary.metadata.refresh {
+        if let Some(url) = &refresh.url {
+            descriptors.push(BrowserResourceEndpointDescriptor {
+                endpoint_kind: "metadata-refresh".to_string(),
+                element: "meta".to_string(),
+                resource_kind: Some("refresh".to_string()),
+                url: url.clone(),
+                resolved_url: refresh.resolved_url.clone(),
+                rel: None,
+                rel_tokens: Vec::new(),
+                as_hint: None,
+                type_hint: None,
+                media: None,
+                title: None,
+                sizes: None,
+                hreflang: None,
+                color: None,
+                width: None,
+                height: None,
+                integrity: None,
+                crossorigin: None,
+                nonce: None,
+                referrerpolicy: None,
+                fetchpriority: None,
+                csp: None,
+                blocking: None,
+                blocking_tokens: Vec::new(),
+                browsing_context_name: None,
+                loading: None,
+                sandbox: Vec::new(),
+                allow: None,
+                allowfullscreen: false,
+                srcdoc: None,
+                credentialless: false,
+                imagesrcset: None,
+                resolved_imagesrcset: None,
+                imagesizes: None,
+                track_kind: None,
+                srclang: None,
+                track_label: None,
+                default_track: false,
+                async_script: false,
+                defer_script: false,
+            });
+        }
+    }
+
+    descriptors.extend(
+        summary
+            .resources
+            .iter()
+            .map(browser_resource_endpoint_descriptor),
+    );
+    descriptors
+}
+
+fn browser_resource_endpoint_descriptor(
+    resource: &BrowserResource,
+) -> BrowserResourceEndpointDescriptor {
+    BrowserResourceEndpointDescriptor {
+        endpoint_kind: "resource".to_string(),
+        element: browser_resource_endpoint_element(&resource.kind).to_string(),
+        resource_kind: Some(resource.kind.clone()),
+        url: resource.url.clone(),
+        resolved_url: resource.resolved_url.clone(),
+        rel: resource.rel.clone(),
+        rel_tokens: resource.rel_tokens.clone(),
+        as_hint: resource.as_hint.clone(),
+        type_hint: resource.type_hint.clone(),
+        media: resource.media.clone(),
+        title: resource.title.clone(),
+        sizes: resource.sizes.clone(),
+        hreflang: resource.hreflang.clone(),
+        color: resource.color.clone(),
+        width: resource.width.clone(),
+        height: resource.height.clone(),
+        integrity: resource.integrity.clone(),
+        crossorigin: resource.crossorigin.clone(),
+        nonce: resource.nonce.clone(),
+        referrerpolicy: resource.referrerpolicy.clone(),
+        fetchpriority: resource.fetchpriority.clone(),
+        csp: resource.csp.clone(),
+        blocking: resource.blocking.clone(),
+        blocking_tokens: resource.blocking_tokens.clone(),
+        browsing_context_name: resource.browsing_context_name.clone(),
+        loading: resource.loading.clone(),
+        sandbox: resource.sandbox.clone(),
+        allow: resource.allow.clone(),
+        allowfullscreen: resource.allowfullscreen,
+        srcdoc: resource.srcdoc.clone(),
+        credentialless: resource.credentialless,
+        imagesrcset: resource.imagesrcset.clone(),
+        resolved_imagesrcset: resource.resolved_imagesrcset.clone(),
+        imagesizes: resource.imagesizes.clone(),
+        track_kind: resource.track_kind.clone(),
+        srclang: resource.srclang.clone(),
+        track_label: resource.track_label.clone(),
+        default_track: resource.default_track,
+        async_script: resource.async_script,
+        defer_script: resource.defer_script,
+    }
+}
+
+fn browser_resource_endpoint_element(kind: &str) -> &str {
+    match kind {
+        "alternate" | "canonical" | "dns-prefetch" | "icon" | "link" | "manifest"
+        | "modulepreload" | "preconnect" | "prefetch" | "preload" | "prerender" | "stylesheet" => {
+            "link"
+        }
+        "frame" => "iframe",
+        "image" => "img",
+        other => other,
     }
 }
 
@@ -19121,6 +19286,101 @@ mod tests {
         let video = &summary.fetch_policy_descriptors[5];
         assert_eq!(video.element, "video");
         assert_eq!(video.crossorigin.as_deref(), Some("anonymous"));
+    }
+
+    #[test]
+    fn browser_resource_endpoint_descriptors_track_document_and_fetch_endpoints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/page.html\">\
+             <meta http-equiv=refresh content=\"5; url=next.html\">\
+             <link rel=canonical href=\"https://example.test/app/\">\
+             <link rel=manifest href=\"site.webmanifest\">\
+             <link rel=preload href=\"app.css\" as=style type=text/css integrity=sha384-css crossorigin=anonymous fetchpriority=high blocking=render>\
+             <script src=app.js async defer nonce=n1></script>\
+             <body><img src=hero.jpg width=640 height=360 loading=lazy>\
+             <iframe src=frame.html name=preview sandbox=\"allow-scripts\" allow=fullscreen credentialless></iframe>\
+             <video src=movie.mp4><track kind=captions src=captions.vtt srclang=en label=English default></video></body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.resource_endpoint_descriptors.len(), 9);
+
+        let refresh = &summary.resource_endpoint_descriptors[0];
+        assert_eq!(refresh.endpoint_kind, "metadata-refresh");
+        assert_eq!(refresh.element, "meta");
+        assert_eq!(refresh.resource_kind.as_deref(), Some("refresh"));
+        assert_eq!(refresh.url, "next.html");
+        assert_eq!(
+            refresh.resolved_url.as_deref(),
+            Some("https://example.test/app/next.html")
+        );
+
+        let canonical = &summary.resource_endpoint_descriptors[1];
+        assert_eq!(canonical.endpoint_kind, "resource");
+        assert_eq!(canonical.element, "link");
+        assert_eq!(canonical.resource_kind.as_deref(), Some("canonical"));
+        assert_eq!(canonical.rel_tokens, vec!["canonical"]);
+        assert_eq!(
+            canonical.resolved_url.as_deref(),
+            Some("https://example.test/app/")
+        );
+
+        let manifest = &summary.resource_endpoint_descriptors[2];
+        assert_eq!(manifest.resource_kind.as_deref(), Some("manifest"));
+        assert_eq!(
+            manifest.resolved_url.as_deref(),
+            Some("https://example.test/app/site.webmanifest")
+        );
+
+        let preload = &summary.resource_endpoint_descriptors[3];
+        assert_eq!(preload.resource_kind.as_deref(), Some("preload"));
+        assert_eq!(preload.as_hint.as_deref(), Some("style"));
+        assert_eq!(preload.type_hint.as_deref(), Some("text/css"));
+        assert_eq!(preload.integrity.as_deref(), Some("sha384-css"));
+        assert_eq!(preload.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(preload.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(preload.blocking_tokens, vec!["render"]);
+
+        let script = &summary.resource_endpoint_descriptors[4];
+        assert_eq!(script.element, "script");
+        assert_eq!(
+            script.resolved_url.as_deref(),
+            Some("https://example.test/app/app.js")
+        );
+        assert_eq!(script.nonce.as_deref(), Some("n1"));
+        assert!(script.async_script);
+        assert!(script.defer_script);
+
+        let image = &summary.resource_endpoint_descriptors[5];
+        assert_eq!(image.element, "img");
+        assert_eq!(image.resource_kind.as_deref(), Some("image"));
+        assert_eq!(image.width.as_deref(), Some("640"));
+        assert_eq!(image.height.as_deref(), Some("360"));
+
+        let frame = &summary.resource_endpoint_descriptors[6];
+        assert_eq!(frame.element, "iframe");
+        assert_eq!(frame.resource_kind.as_deref(), Some("frame"));
+        assert_eq!(frame.browsing_context_name.as_deref(), Some("preview"));
+        assert_eq!(frame.sandbox, vec!["allow-scripts"]);
+        assert_eq!(frame.allow.as_deref(), Some("fullscreen"));
+        assert!(frame.credentialless);
+
+        let video = &summary.resource_endpoint_descriptors[7];
+        assert_eq!(video.element, "video");
+        assert_eq!(video.resource_kind.as_deref(), Some("video"));
+        assert_eq!(
+            video.resolved_url.as_deref(),
+            Some("https://example.test/app/movie.mp4")
+        );
+
+        let track = &summary.resource_endpoint_descriptors[8];
+        assert_eq!(track.element, "track");
+        assert_eq!(track.resource_kind.as_deref(), Some("track"));
+        assert_eq!(track.track_kind.as_deref(), Some("captions"));
+        assert_eq!(track.srclang.as_deref(), Some("en"));
+        assert_eq!(track.track_label.as_deref(), Some("English"));
+        assert!(track.default_track);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -15,9 +15,10 @@ use coding_adventures_html_parser::{
     BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
     BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
     BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceHint, BrowserScript, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
+    BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -73,6 +74,8 @@ struct ExpectedBrowserDocument {
     loading_hint_descriptors: Vec<ExpectedLoadingHintDescriptor>,
     #[serde(default)]
     fetch_policy_descriptors: Vec<ExpectedFetchPolicyDescriptor>,
+    #[serde(default)]
+    resource_endpoint_descriptors: Option<Vec<ExpectedResourceEndpointDescriptor>>,
     #[serde(default)]
     form_policy_descriptors: Vec<ExpectedFormPolicyDescriptor>,
     anchors: Vec<ExpectedAnchor>,
@@ -691,6 +694,87 @@ struct ExpectedResource {
     #[serde(default)]
     default_track: bool,
     async_script: bool,
+    defer_script: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedResourceEndpointDescriptor {
+    endpoint_kind: String,
+    element: String,
+    #[serde(default)]
+    resource_kind: Option<String>,
+    url: String,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    as_hint: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    sizes: Option<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
+    #[serde(default)]
+    color: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    csp: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
+    browsing_context_name: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    sandbox: Vec<String>,
+    #[serde(default)]
+    allow: Option<String>,
+    #[serde(default)]
+    allowfullscreen: bool,
+    #[serde(default)]
+    srcdoc: Option<String>,
+    #[serde(default)]
+    credentialless: bool,
+    #[serde(default)]
+    imagesrcset: Option<String>,
+    #[serde(default)]
+    resolved_imagesrcset: Option<String>,
+    #[serde(default)]
+    imagesizes: Option<String>,
+    #[serde(default)]
+    track_kind: Option<String>,
+    #[serde(default)]
+    srclang: Option<String>,
+    #[serde(default)]
+    track_label: Option<String>,
+    #[serde(default)]
+    default_track: bool,
+    #[serde(default)]
+    async_script: bool,
+    #[serde(default)]
     defer_script: bool,
 }
 
@@ -3682,11 +3766,29 @@ fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_element
 
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
+        let metadata = self.metadata.into_browser_document_metadata();
+        let resources: Vec<_> = self
+            .resources
+            .into_iter()
+            .map(ExpectedResource::into_browser_resource)
+            .collect();
+        let resource_endpoint_descriptors = self
+            .resource_endpoint_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedResourceEndpointDescriptor::into_browser_resource_endpoint_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_resource_endpoint_descriptors(&metadata, &resources));
+
         BrowserDocument {
             title: self.title,
             base_href: self.base_href,
             base_target: self.base_target,
-            metadata: self.metadata.into_browser_document_metadata(),
+            metadata,
             document_lang: self.document_lang,
             document_dir: self.document_dir,
             body_id: self.body_id,
@@ -3701,11 +3803,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedMeta::into_browser_meta)
                 .collect(),
-            resources: self
-                .resources
-                .into_iter()
-                .map(ExpectedResource::into_browser_resource)
-                .collect(),
+            resources,
             scripts: self
                 .scripts
                 .into_iter()
@@ -3731,6 +3829,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedFetchPolicyDescriptor::into_browser_fetch_policy_descriptor)
                 .collect(),
+            resource_endpoint_descriptors,
             form_policy_descriptors: self
                 .form_policy_descriptors
                 .into_iter()
@@ -4120,6 +4219,170 @@ impl ExpectedResource {
             expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
         BrowserResource {
             kind: self.kind,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            rel: self.rel,
+            rel_tokens,
+            as_hint: self.as_hint,
+            type_hint: self.type_hint,
+            media: self.media,
+            title: self.title,
+            sizes: self.sizes,
+            hreflang: self.hreflang,
+            color: self.color,
+            width: self.width,
+            height: self.height,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            nonce: self.nonce,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            csp: self.csp,
+            blocking: self.blocking,
+            blocking_tokens,
+            browsing_context_name: self.browsing_context_name,
+            loading: self.loading,
+            sandbox: self.sandbox,
+            allow: self.allow,
+            allowfullscreen: self.allowfullscreen,
+            srcdoc: self.srcdoc,
+            credentialless: self.credentialless,
+            imagesrcset: self.imagesrcset,
+            resolved_imagesrcset: self.resolved_imagesrcset,
+            imagesizes: self.imagesizes,
+            track_kind: self.track_kind,
+            srclang: self.srclang,
+            track_label: self.track_label,
+            default_track: self.default_track,
+            async_script: self.async_script,
+            defer_script: self.defer_script,
+        }
+    }
+}
+
+fn expected_resource_endpoint_descriptors(
+    metadata: &BrowserDocumentMetadata,
+    resources: &[BrowserResource],
+) -> Vec<BrowserResourceEndpointDescriptor> {
+    let mut descriptors = Vec::new();
+    if let Some(refresh) = &metadata.refresh {
+        if let Some(url) = &refresh.url {
+            descriptors.push(BrowserResourceEndpointDescriptor {
+                endpoint_kind: "metadata-refresh".to_string(),
+                element: "meta".to_string(),
+                resource_kind: Some("refresh".to_string()),
+                url: url.clone(),
+                resolved_url: refresh.resolved_url.clone(),
+                rel: None,
+                rel_tokens: Vec::new(),
+                as_hint: None,
+                type_hint: None,
+                media: None,
+                title: None,
+                sizes: None,
+                hreflang: None,
+                color: None,
+                width: None,
+                height: None,
+                integrity: None,
+                crossorigin: None,
+                nonce: None,
+                referrerpolicy: None,
+                fetchpriority: None,
+                csp: None,
+                blocking: None,
+                blocking_tokens: Vec::new(),
+                browsing_context_name: None,
+                loading: None,
+                sandbox: Vec::new(),
+                allow: None,
+                allowfullscreen: false,
+                srcdoc: None,
+                credentialless: false,
+                imagesrcset: None,
+                resolved_imagesrcset: None,
+                imagesizes: None,
+                track_kind: None,
+                srclang: None,
+                track_label: None,
+                default_track: false,
+                async_script: false,
+                defer_script: false,
+            });
+        }
+    }
+    descriptors.extend(resources.iter().map(expected_resource_endpoint_descriptor));
+    descriptors
+}
+
+fn expected_resource_endpoint_descriptor(
+    resource: &BrowserResource,
+) -> BrowserResourceEndpointDescriptor {
+    BrowserResourceEndpointDescriptor {
+        endpoint_kind: "resource".to_string(),
+        element: expected_resource_endpoint_element(&resource.kind).to_string(),
+        resource_kind: Some(resource.kind.clone()),
+        url: resource.url.clone(),
+        resolved_url: resource.resolved_url.clone(),
+        rel: resource.rel.clone(),
+        rel_tokens: resource.rel_tokens.clone(),
+        as_hint: resource.as_hint.clone(),
+        type_hint: resource.type_hint.clone(),
+        media: resource.media.clone(),
+        title: resource.title.clone(),
+        sizes: resource.sizes.clone(),
+        hreflang: resource.hreflang.clone(),
+        color: resource.color.clone(),
+        width: resource.width.clone(),
+        height: resource.height.clone(),
+        integrity: resource.integrity.clone(),
+        crossorigin: resource.crossorigin.clone(),
+        nonce: resource.nonce.clone(),
+        referrerpolicy: resource.referrerpolicy.clone(),
+        fetchpriority: resource.fetchpriority.clone(),
+        csp: resource.csp.clone(),
+        blocking: resource.blocking.clone(),
+        blocking_tokens: resource.blocking_tokens.clone(),
+        browsing_context_name: resource.browsing_context_name.clone(),
+        loading: resource.loading.clone(),
+        sandbox: resource.sandbox.clone(),
+        allow: resource.allow.clone(),
+        allowfullscreen: resource.allowfullscreen,
+        srcdoc: resource.srcdoc.clone(),
+        credentialless: resource.credentialless,
+        imagesrcset: resource.imagesrcset.clone(),
+        resolved_imagesrcset: resource.resolved_imagesrcset.clone(),
+        imagesizes: resource.imagesizes.clone(),
+        track_kind: resource.track_kind.clone(),
+        srclang: resource.srclang.clone(),
+        track_label: resource.track_label.clone(),
+        default_track: resource.default_track,
+        async_script: resource.async_script,
+        defer_script: resource.defer_script,
+    }
+}
+
+fn expected_resource_endpoint_element(kind: &str) -> &str {
+    match kind {
+        "alternate" | "canonical" | "dns-prefetch" | "icon" | "link" | "manifest"
+        | "modulepreload" | "preconnect" | "prefetch" | "preload" | "prerender" | "stylesheet" => {
+            "link"
+        }
+        "frame" => "iframe",
+        "image" => "img",
+        other => other,
+    }
+}
+
+impl ExpectedResourceEndpointDescriptor {
+    fn into_browser_resource_endpoint_descriptor(self) -> BrowserResourceEndpointDescriptor {
+        let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
+        BrowserResourceEndpointDescriptor {
+            endpoint_kind: self.endpoint_kind,
+            element: self.element,
+            resource_kind: self.resource_kind,
             url: self.url,
             resolved_url: self.resolved_url,
             rel: self.rel,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -33,6 +33,8 @@ Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
 decoding, fetch priority, blocking, and media preload metadata.
 Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
 iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata.
+Resource-endpoint descriptor cases pin refresh redirects plus resolved document
+resources as a flat endpoint inventory for fetch/navigation planning.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel
 policy tokens, validation bypass state, and submitter overrides.
 Navigation-target descriptor cases pin policy-rich anchor and image-map area

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -490,6 +490,11 @@
           { "kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical", "async_script": false, "defer_script": false },
           { "kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest", "async_script": false, "defer_script": false }
         ],
+        "resource_endpoint_descriptors": [
+          { "endpoint_kind": "metadata-refresh", "element": "meta", "resource_kind": "refresh", "url": "next.html", "resolved_url": "https://example.test/app/next.html" },
+          { "endpoint_kind": "resource", "element": "link", "resource_kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel": "canonical" },
+          { "endpoint_kind": "resource", "element": "link", "resource_kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel": "manifest" }
+        ],
         "document_policy_descriptors": [
           {
             "charset": "windows-1252",


### PR DESCRIPTION
## Summary
- add BrowserResourceEndpointDescriptor to BrowserDocument as a flat endpoint inventory
- derive refresh redirect endpoints plus all collected document/body resources in document order
- extend browser-readiness fixture expectations, inventory docs, changelog, and focused unit coverage

## Tests
- cargo test -p coding-adventures-html-parser browser_resource_endpoint_descriptors_track_document_and_fetch_endpoints
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser