### PR TITLE
Expose Chief smart-home authorization audit tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -33,6 +33,10 @@ All notable changes to this package will be documented in this file.
   handlers over the D23 runtime read facade so Chief of Staff jobs can inspect
   event-stream backlog pressure and checkpointed event history without draining
   subscriptions.
+- Added `smart_home.list_authorization_decisions` and
+  `smart_home.get_authorization_summary` handlers over the D23 runtime read
+  facade so Chief of Staff jobs can inspect allow/deny audit history without
+  owning smart-home authorization logic.
 - Added `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`,
   and `smart_home.list_pairing_sessions` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect automation backlog, reconciliation

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -29,6 +29,7 @@ Chief of Staff job/session/agent
   -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
   -> event-log and subscription-backlog reads
+  -> authorization decision audit reads and summaries
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> non-mutating supervision plan previews
   -> authorized desired-state reconciliation and supervision ticks
@@ -58,6 +59,8 @@ Chief of Staff job/session/agent
 - `smart_home.unsubscribe`
 - `smart_home.list_subscriptions`
 - `smart_home.inspect_event_log`
+- `smart_home.list_authorization_decisions`
+- `smart_home.get_authorization_summary`
 - `smart_home.get_runtime_snapshot`
 - `smart_home.list_desired_states`
 - `smart_home.list_pairing_sessions`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -15,8 +15,9 @@ use chief_of_staff_tool_api::{
 };
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use smart_home_core::{
-    AgentId, Bridge, BridgeId, Capability, CapabilityId, CommandResult, CommandStatus, CommandType,
-    Device, DeviceCommand, DeviceEvent, DeviceEventType, EntityId, EntityKind, Health,
+    AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary, AuthorizationOutcome,
+    AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityId, CommandResult, CommandStatus,
+    CommandType, Device, DeviceCommand, DeviceEvent, DeviceEventType, EntityId, EntityKind, Health,
     IntegrationId, Metadata, PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene,
     SceneAction, SceneId, SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource,
     Value,
@@ -38,22 +39,22 @@ use smart_home_registry::StateRefreshReason;
 use smart_home_runtime::{
     DesiredEntityState, DesiredStateAction, DesiredStateInventorySummary, DesiredStateQuery,
     DesiredStateSort, DiscoveryWorkerRunInstruction, PairingSessionStatus, ReconciliationReason,
-    RuntimeCommandToolRequest, RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError,
-    RuntimeEvent, RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter,
-    RuntimeEventLogRecord, RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort,
-    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingSession,
-    RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
-    RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
-    RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
-    RuntimeReadToolRequest, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
-    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
-    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
-    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
-    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
-    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
-    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
-    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
-    WorkerRestartReason, WorkerStatus,
+    RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort, RuntimeCommandToolRequest,
+    RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError, RuntimeEvent,
+    RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter, RuntimeEventLogRecord,
+    RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort, RuntimePairBridgeToolOutput,
+    RuntimePairBridgeToolRequest, RuntimePairingSession, RuntimePairingSessionId,
+    RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery, RuntimePairingSessionSort,
+    RuntimePendingWorkSummary, RuntimePollEventsToolOutput, RuntimePollEventsToolRequest,
+    RuntimeReadSnapshot, RuntimeReadToolOutput, RuntimeReadToolRequest, RuntimeSubscribeToolOutput,
+    RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId,
+    RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot,
+    RuntimeSubscriptionSort, RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary,
+    RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot,
+    RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot,
+    SmartHomeRuntime, SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort,
+    SupervisionTickReport, WorkerHeartbeatDeadline, WorkerHeartbeatSchedule,
+    WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -70,6 +71,10 @@ pub const SMART_HOME_POLL_EVENTS_TOOL_ID: &str = "smart_home.poll_events";
 pub const SMART_HOME_UNSUBSCRIBE_TOOL_ID: &str = "smart_home.unsubscribe";
 pub const SMART_HOME_LIST_SUBSCRIPTIONS_TOOL_ID: &str = "smart_home.list_subscriptions";
 pub const SMART_HOME_INSPECT_EVENT_LOG_TOOL_ID: &str = "smart_home.inspect_event_log";
+pub const SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID: &str =
+    "smart_home.list_authorization_decisions";
+pub const SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_authorization_summary";
 pub const SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID: &str = "smart_home.get_runtime_snapshot";
 pub const SMART_HOME_LIST_DESIRED_STATES_TOOL_ID: &str = "smart_home.list_desired_states";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
@@ -282,6 +287,34 @@ impl SmartHomeToolBridge {
                         .execute_read_tool(principal_id, request, now_ms)
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "inspect_event_log"))
+                }
+                SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID => {
+                    let query = authorization_decision_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::ListAuthorizationDecisions { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(
+                        output,
+                        "list_authorization_decisions",
+                    ))
+                }
+                SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID => {
+                    let query = authorization_decision_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::GetAuthorizationSummary { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(
+                        output,
+                        "get_authorization_summary",
+                    ))
                 }
                 SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID => {
                     let _ = expect_object(&arguments)?;
@@ -697,6 +730,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         unsubscribe_definition(),
         list_subscriptions_definition(),
         inspect_event_log_definition(),
+        list_authorization_decisions_definition(),
+        get_authorization_summary_definition(),
         get_runtime_snapshot_definition(),
         list_desired_states_definition(),
         list_pairing_sessions_definition(),
@@ -991,6 +1026,56 @@ fn inspect_event_log_definition() -> ToolDefinition {
             vec!["events", "summary", "count"],
             false,
         ),
+    )
+}
+
+fn list_authorization_decisions_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID,
+        "List smart-home authorization decisions",
+        "List D23 smart-home tool and command authorization decisions, optionally filtered by Chief principal or outcome.",
+        authorization_decision_query_schema(),
+        object_schema(
+            vec![
+                SchemaProperty::new(
+                    "decisions",
+                    JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    },
+                ),
+                SchemaProperty::new("summary", JsonSchema::Any),
+                SchemaProperty::new("count", JsonSchema::Integer),
+            ],
+            vec!["decisions", "summary", "count"],
+            false,
+        ),
+    )
+}
+
+fn get_authorization_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID,
+        "Get smart-home authorization summary",
+        "Summarize D23 smart-home authorization decisions without returning individual audit rows.",
+        authorization_decision_query_schema(),
+        object_schema(
+            vec![SchemaProperty::new("summary", JsonSchema::Any)],
+            vec!["summary"],
+            false,
+        ),
+    )
+}
+
+fn authorization_decision_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("principal_id", JsonSchema::String),
+            SchemaProperty::new("outcome", JsonSchema::String),
+            SchemaProperty::new("sort", JsonSchema::String),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
     )
 }
 
@@ -1599,6 +1684,26 @@ fn inspect_event_log_request(
     Ok(RuntimeReadToolRequest::InspectEventLog { query })
 }
 
+fn authorization_decision_query(
+    arguments: &JsonValue,
+) -> Result<RuntimeAuthorizationDecisionQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut query = RuntimeAuthorizationDecisionQuery::new();
+    if let Some(principal_id) = optional_string(arguments, "principal_id")? {
+        query = query.for_principal(AgentId::trusted(principal_id));
+    }
+    if let Some(outcome) = optional_string(arguments, "outcome")? {
+        query = query.with_outcome(parse_authorization_outcome(&outcome)?);
+    }
+    if let Some(sort) = optional_string(arguments, "sort")? {
+        query = query.sorted_by(parse_authorization_decision_sort(&sort)?);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        query = query.with_limit(limit as usize);
+    }
+    Ok(query)
+}
+
 fn list_desired_states_request(
     arguments: &JsonValue,
 ) -> Result<RuntimeReadToolRequest, ToolCallError> {
@@ -2105,6 +2210,17 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
             ("summary", event_log_summary_json(&summary)),
             ("count", integer(entries.len() as i64)),
         ]),
+        RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary } => object([
+            (
+                "decisions",
+                JsonValue::Array(decisions.iter().map(authorization_decision_json).collect()),
+            ),
+            ("summary", authorization_decision_log_summary_json(&summary)),
+            ("count", integer(decisions.len() as i64)),
+        ]),
+        RuntimeReadToolOutput::AuthorizationSummary { summary } => {
+            object([("summary", authorization_decision_log_summary_json(&summary))])
+        }
         RuntimeReadToolOutput::DesiredStates {
             desired_states,
             summary,
@@ -4150,6 +4266,134 @@ fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     ])
 }
 
+fn authorization_decision_json(decision: &AuthorizationDecision) -> JsonValue {
+    object([
+        ("principal_id", string(decision.principal_id.as_str())),
+        (
+            "subject_kind",
+            string(authorization_subject_label(&decision.subject)),
+        ),
+        ("subject", authorization_subject_json(&decision.subject)),
+        (
+            "outcome",
+            string(authorization_outcome_label(decision.outcome)),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(decision.required_tier)),
+        ),
+        (
+            "required_capabilities",
+            JsonValue::Array(
+                decision
+                    .required_capabilities
+                    .iter()
+                    .map(|capability_id| string(capability_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "matched_grants",
+            JsonValue::Array(
+                decision
+                    .matched_grants
+                    .iter()
+                    .map(|grant_id| string(grant_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "missing_capabilities",
+            JsonValue::Array(
+                decision
+                    .missing_capabilities
+                    .iter()
+                    .map(|capability_id| string(capability_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        ("decided_at_ms", integer(decision.decided_at_ms as i64)),
+        ("allowed", JsonValue::Bool(decision.is_allowed())),
+    ])
+}
+
+fn authorization_subject_json(subject: &AuthorizationSubject) -> JsonValue {
+    match subject {
+        AuthorizationSubject::Tool(tool) => object([
+            ("subject_kind", string("tool")),
+            ("tool_id", string(tool.descriptor().tool_id)),
+        ]),
+        AuthorizationSubject::Command {
+            command_id,
+            entity_id,
+            command_type,
+        } => object([
+            ("subject_kind", string("command")),
+            ("command_id", string(command_id.as_str())),
+            ("entity_id", string(entity_id.as_str())),
+            ("command_type", string(command_type_label(*command_type))),
+        ]),
+    }
+}
+
+fn authorization_decision_log_summary_json(summary: &AuthorizationDecisionLogSummary) -> JsonValue {
+    object([
+        ("total_decisions", integer(summary.total_decisions as i64)),
+        (
+            "allowed_decisions",
+            integer(summary.allowed_decisions as i64),
+        ),
+        ("denied_decisions", integer(summary.denied_decisions as i64)),
+        ("tool_decisions", integer(summary.tool_decisions as i64)),
+        (
+            "command_decisions",
+            integer(summary.command_decisions as i64),
+        ),
+        (
+            "read_only_tier_decisions",
+            integer(summary.read_only_tier_decisions as i64),
+        ),
+        (
+            "low_risk_tier_decisions",
+            integer(summary.low_risk_tier_decisions as i64),
+        ),
+        (
+            "human_approval_tier_decisions",
+            integer(summary.human_approval_tier_decisions as i64),
+        ),
+        (
+            "high_risk_tier_decisions",
+            integer(summary.high_risk_tier_decisions as i64),
+        ),
+        (
+            "decisions_with_missing_capabilities",
+            integer(summary.decisions_with_missing_capabilities as i64),
+        ),
+        (
+            "total_required_capabilities",
+            integer(summary.total_required_capabilities as i64),
+        ),
+        (
+            "total_matched_grants",
+            integer(summary.total_matched_grants as i64),
+        ),
+        (
+            "total_missing_capabilities",
+            integer(summary.total_missing_capabilities as i64),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_denials", JsonValue::Bool(summary.has_denials())),
+        (
+            "has_missing_capabilities",
+            JsonValue::Bool(summary.has_missing_capabilities()),
+        ),
+        (
+            "approval_gated_decisions",
+            integer(summary.approval_gated_decisions() as i64),
+        ),
+    ])
+}
+
 fn event_filter_json(filter: &RuntimeEventFilter) -> JsonValue {
     match filter {
         RuntimeEventFilter::All => object([("filter_type", string("all"))]),
@@ -4428,6 +4672,28 @@ fn parse_event_sort(label: &str) -> Result<RuntimeEventSort, ToolCallError> {
         "sequence_asc" | "oldest_first" => Ok(RuntimeEventSort::SequenceAsc),
         "sequence_desc" | "newest_first" => Ok(RuntimeEventSort::SequenceDesc),
         _ => Err(validation_error(format!("unknown event sort `{label}`"))),
+    }
+}
+
+fn parse_authorization_decision_sort(
+    label: &str,
+) -> Result<RuntimeAuthorizationDecisionSort, ToolCallError> {
+    match label {
+        "decided_at_asc" | "oldest_first" => Ok(RuntimeAuthorizationDecisionSort::DecidedAtAsc),
+        "decided_at_desc" | "newest_first" => Ok(RuntimeAuthorizationDecisionSort::DecidedAtDesc),
+        _ => Err(validation_error(format!(
+            "unknown authorization decision sort `{label}`"
+        ))),
+    }
+}
+
+fn parse_authorization_outcome(label: &str) -> Result<AuthorizationOutcome, ToolCallError> {
+    match label {
+        "allowed" | "allow" => Ok(AuthorizationOutcome::Allowed),
+        "denied" | "deny" => Ok(AuthorizationOutcome::Denied),
+        _ => Err(validation_error(format!(
+            "unknown authorization outcome `{label}`"
+        ))),
     }
 }
 
@@ -4868,6 +5134,20 @@ fn privilege_tier_label(tier: PrivilegeTier) -> &'static str {
         PrivilegeTier::LowRisk => "low_risk",
         PrivilegeTier::HumanApproval => "human_approval",
         PrivilegeTier::HighRisk => "high_risk",
+    }
+}
+
+fn authorization_outcome_label(outcome: AuthorizationOutcome) -> &'static str {
+    match outcome {
+        AuthorizationOutcome::Allowed => "allowed",
+        AuthorizationOutcome::Denied => "denied",
+    }
+}
+
+fn authorization_subject_label(subject: &AuthorizationSubject) -> &'static str {
+    match subject {
+        AuthorizationSubject::Tool(_) => "tool",
+        AuthorizationSubject::Command { .. } => "command",
     }
 }
 
@@ -5371,7 +5651,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 28);
+        assert_eq!(definitions.len(), 30);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -5403,6 +5683,12 @@ mod tests {
             .contains(&SMART_HOME_INSPECT_EVENT_LOG_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -5429,7 +5715,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            24
+            26
         );
         assert_eq!(
             export
@@ -6099,6 +6385,63 @@ mod tests {
             Some(&integer(1))
         );
 
+        let list_authorization_request = request(
+            "call-list-authorization-decisions",
+            SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID,
+            object([
+                ("principal_id", string(AGENT_ID)),
+                ("outcome", string("allowed")),
+                ("sort", string("newest_first")),
+                ("limit", integer(1)),
+            ]),
+            1_103,
+        );
+        let list_authorization_trace = tool_runtime.invoke_with_events(&list_authorization_request);
+        assert!(list_authorization_trace.result.ok);
+        let list_authorization_output = list_authorization_trace.result.output.as_ref().unwrap();
+        assert_eq!(field(list_authorization_output, "count"), Some(&integer(1)));
+        let latest_decision =
+            array_item(field(list_authorization_output, "decisions").unwrap(), 0).unwrap();
+        assert_eq!(
+            field(latest_decision, "subject_kind"),
+            Some(&string("tool"))
+        );
+        assert_eq!(
+            field(field(latest_decision, "subject").unwrap(), "tool_id"),
+            Some(&string(SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID))
+        );
+        assert_eq!(
+            field(
+                field(list_authorization_output, "summary").unwrap(),
+                "allowed_decisions"
+            ),
+            Some(&integer(1))
+        );
+
+        let authorization_summary_request = request(
+            "call-authorization-summary",
+            SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID,
+            object([
+                ("principal_id", string(AGENT_ID)),
+                ("outcome", string("denied")),
+            ]),
+            1_104,
+        );
+        let authorization_summary_trace =
+            tool_runtime.invoke_with_events(&authorization_summary_request);
+        assert!(authorization_summary_trace.result.ok);
+        let authorization_summary_output =
+            authorization_summary_trace.result.output.as_ref().unwrap();
+        let authorization_summary = field(authorization_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(authorization_summary, "total_decisions"),
+            Some(&integer(0))
+        );
+        assert_eq!(
+            field(authorization_summary, "has_denials"),
+            Some(&JsonValue::Bool(false))
+        );
+
         let poll_request = request(
             "call-poll-events",
             SMART_HOME_POLL_EVENTS_TOOL_ID,
@@ -6258,6 +6601,8 @@ mod tests {
         journal.record_trace(pairing_sessions_request, pairing_sessions_trace);
         journal.record_trace(list_subscriptions_request, list_subscriptions_trace);
         journal.record_trace(inspect_event_log_request, inspect_event_log_trace);
+        journal.record_trace(list_authorization_request, list_authorization_trace);
+        journal.record_trace(authorization_summary_request, authorization_summary_trace);
         journal.record_trace(poll_request, poll_trace);
         journal.record_trace(state_request, state_trace);
         journal.record_trace(unsubscribe_request, unsubscribe_trace);
@@ -6265,9 +6610,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 27);
-        assert_eq!(journal_summary.completed_count, 27);
-        assert_eq!(journal.audit_records().len(), 27);
+        assert_eq!(journal_summary.invocation_count, 29);
+        assert_eq!(journal_summary.completed_count, 29);
+        assert_eq!(journal.audit_records().len(), 29);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -6280,7 +6625,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            24,
+            26,
             "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this package will be documented in this file.
   model-facing event subscription lifecycle control.
 - `smart_home.list_subscriptions` and `smart_home.inspect_event_log` tool
   descriptors for read-only event-stream backlog and replay-log inspection.
+- `smart_home.list_authorization_decisions` and
+  `smart_home.get_authorization_summary` tool descriptors for read-only
+  authorization-audit inspection.
 - `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`, and
   `smart_home.list_pairing_sessions` tool descriptors for read-only runtime
   automation inventory inspection.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -51,6 +51,8 @@ Current scope:
   unsubscribing from runtime event streams
 - D18D event observability tool descriptors for listing active subscriptions and
   inspecting checkpointed runtime event-log entries
+- D18D authorization-audit tool descriptors for listing decisions and compact
+  allow/deny summaries
 - D18D runtime automation inventory tool descriptors for read-only snapshots,
   desired-state targets, and pairing-session status
 - D18D bridge-worker inventory descriptors for read-only supervisor and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1458,6 +1458,8 @@ pub enum SmartHomeTool {
     Unsubscribe,
     ListSubscriptions,
     InspectEventLog,
+    ListAuthorizationDecisions,
+    GetAuthorizationSummary,
     GetRuntimeSnapshot,
     ListDesiredStates,
     ListPairingSessions,
@@ -1502,6 +1504,10 @@ impl SmartHomeTool {
             Self::Unsubscribe => read_tool("smart_home.unsubscribe"),
             Self::ListSubscriptions => read_tool("smart_home.list_subscriptions"),
             Self::InspectEventLog => read_tool("smart_home.inspect_event_log"),
+            Self::ListAuthorizationDecisions => {
+                read_tool("smart_home.list_authorization_decisions")
+            }
+            Self::GetAuthorizationSummary => read_tool("smart_home.get_authorization_summary"),
             Self::GetRuntimeSnapshot => read_tool("smart_home.get_runtime_snapshot"),
             Self::ListDesiredStates => read_tool("smart_home.list_desired_states"),
             Self::ListPairingSessions => read_tool("smart_home.list_pairing_sessions"),
@@ -1975,6 +1981,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::Unsubscribe,
         SmartHomeTool::ListSubscriptions,
         SmartHomeTool::InspectEventLog,
+        SmartHomeTool::ListAuthorizationDecisions,
+        SmartHomeTool::GetAuthorizationSummary,
         SmartHomeTool::GetRuntimeSnapshot,
         SmartHomeTool::ListDesiredStates,
         SmartHomeTool::ListPairingSessions,
@@ -2781,7 +2789,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 24);
+        assert_eq!(catalog.len(), 26);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2834,6 +2842,15 @@ mod tests {
             .any(|tool| tool.tool_id == "smart_home.inspect_event_log"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_authorization_decisions"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(
+            |tool| tool.tool_id == "smart_home.get_authorization_summary"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]
+        ));
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.get_runtime_snapshot"
@@ -2870,15 +2887,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 24);
-        assert_eq!(summary.read_tools, 20);
+        assert_eq!(summary.total_tools, 26);
+        assert_eq!(summary.read_tools, 22);
         assert_eq!(summary.write_tools, 0);
         assert_eq!(summary.external_tools, 4);
-        assert_eq!(summary.read_only_tier_tools, 20);
+        assert_eq!(summary.read_only_tier_tools, 22);
         assert_eq!(summary.low_risk_tier_tools, 3);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 24);
+        assert_eq!(summary.total_required_capabilities, 26);
         assert_eq!(summary.risky_tool_count(), 4);
         assert_eq!(summary.approval_gated_tool_count(), 1);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -60,6 +60,9 @@ All notable changes to this package will be documented in this file.
 - `RuntimeReadToolRequest::ListSubscriptions` and
   `RuntimeReadToolRequest::InspectEventLog` for authorized D18D reads over
   event-stream backlog pressure and checkpointed runtime event history.
+- `RuntimeReadToolRequest::ListAuthorizationDecisions` and
+  `RuntimeReadToolRequest::GetAuthorizationSummary` for authorized D18D reads
+  over registry-backed smart-home authorization audit decisions.
 - `RuntimeReadToolRequest::GetRuntimeSnapshot`,
   `RuntimeReadToolRequest::ListDesiredStates`, and
   `RuntimeReadToolRequest::ListPairingSessions` for authorized D18D reads over

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -62,11 +62,13 @@ Included surfaces:
 - registry-backed authorization decision auditing for accepted and rejected
   authorized commands
 - registry-backed tool authorization decisions for Chief of Staff tool calls
+- read-side authorization-decision queries and summaries for Chief audit tools
 - D18D-facing read tool facade for listing bridges/devices/scenes, describing
   scenes, reading entity state, describing capabilities, inspecting bridge
   health, listing event subscriptions, inspecting event-log entries, reading
-  compact runtime snapshots, listing desired-state targets, listing pairing
-  sessions, listing supervised bridge workers, reading worker heartbeat
+  authorization decisions and summaries, reading compact runtime snapshots,
+  listing desired-state targets, listing pairing sessions, listing supervised
+  bridge workers, reading worker heartbeat
   schedules, previewing supervision plans, and observing supervision status
   without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -8,12 +8,13 @@
 #![forbid(unsafe_code)]
 
 use smart_home_core::{
-    tier_for_command, AgentId, AuthorizationDecision, Bridge, BridgeId, Capability,
-    CapabilityGrant, CapabilityGrantScope, CapabilityId, CapabilityMode, CommandId, CommandResult,
-    CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType,
-    DeviceId, Entity, EntityId, EventId, Health, IntegrationId, Metadata, PrivilegeTier, Scene,
-    SceneId, SceneScope, SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot,
-    StateSource, Value, VaultRef,
+    tier_for_command, AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary,
+    AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant, CapabilityGrantScope,
+    CapabilityId, CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType,
+    CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId,
+    EventId, Health, IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope,
+    SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
+    VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError, DiscoveryRecord,
@@ -24,8 +25,8 @@ use smart_home_discovery::{
     MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
 };
 use smart_home_registry::{
-    DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts, RegistryError, StateRefreshPlan,
-    StateRefreshReason,
+    AuthorizationDecisionSelector, DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts,
+    RegistryError, StateRefreshPlan, StateRefreshReason,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::{fmt, time::Duration};
@@ -3231,6 +3232,63 @@ impl RuntimeDiscoverToolOutput {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeAuthorizationDecisionSort {
+    DecidedAtAsc,
+    DecidedAtDesc,
+}
+
+impl Default for RuntimeAuthorizationDecisionSort {
+    fn default() -> Self {
+        Self::DecidedAtDesc
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeAuthorizationDecisionQuery {
+    pub principal_id: Option<AgentId>,
+    pub outcome: Option<AuthorizationOutcome>,
+    pub sort: RuntimeAuthorizationDecisionSort,
+    pub limit: Option<usize>,
+}
+
+impl RuntimeAuthorizationDecisionQuery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_principal(mut self, principal_id: AgentId) -> Self {
+        self.principal_id = Some(principal_id);
+        self
+    }
+
+    pub fn with_outcome(mut self, outcome: AuthorizationOutcome) -> Self {
+        self.outcome = Some(outcome);
+        self
+    }
+
+    pub fn sorted_by(mut self, sort: RuntimeAuthorizationDecisionSort) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    fn selector(&self) -> AuthorizationDecisionSelector {
+        let mut selector = AuthorizationDecisionSelector::new();
+        if let Some(principal_id) = self.principal_id.clone() {
+            selector = selector.for_principal(principal_id);
+        }
+        if let Some(outcome) = self.outcome {
+            selector = selector.with_outcome(outcome);
+        }
+        selector
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeReadToolRequest {
     GetRuntimeSnapshot,
@@ -3263,6 +3321,12 @@ pub enum RuntimeReadToolRequest {
     InspectEventLog {
         query: RuntimeEventQuery,
     },
+    ListAuthorizationDecisions {
+        query: RuntimeAuthorizationDecisionQuery,
+    },
+    GetAuthorizationSummary {
+        query: RuntimeAuthorizationDecisionQuery,
+    },
     ListDesiredStates {
         query: DesiredStateQuery,
     },
@@ -3294,6 +3358,8 @@ impl RuntimeReadToolRequest {
             Self::GetHealth { .. } => SmartHomeTool::GetHealth,
             Self::ListSubscriptions { .. } => SmartHomeTool::ListSubscriptions,
             Self::InspectEventLog { .. } => SmartHomeTool::InspectEventLog,
+            Self::ListAuthorizationDecisions { .. } => SmartHomeTool::ListAuthorizationDecisions,
+            Self::GetAuthorizationSummary { .. } => SmartHomeTool::GetAuthorizationSummary,
             Self::ListDesiredStates { .. } => SmartHomeTool::ListDesiredStates,
             Self::ListPairingSessions { .. } => SmartHomeTool::ListPairingSessions,
             Self::ListWorkers { .. } => SmartHomeTool::ListWorkers,
@@ -3539,6 +3605,13 @@ pub enum RuntimeReadToolOutput {
         entries: Vec<RuntimeEventLogRecord>,
         summary: RuntimeEventLogSummary,
     },
+    AuthorizationDecisions {
+        decisions: Vec<AuthorizationDecision>,
+        summary: AuthorizationDecisionLogSummary,
+    },
+    AuthorizationSummary {
+        summary: AuthorizationDecisionLogSummary,
+    },
     DesiredStates {
         desired_states: Vec<DesiredEntityState>,
         summary: DesiredStateInventorySummary,
@@ -3771,6 +3844,35 @@ impl SmartHomeRuntime {
             self.query_pairing_sessions(query),
             now_ms,
         )
+    }
+
+    pub fn query_authorization_decisions(
+        &self,
+        query: &RuntimeAuthorizationDecisionQuery,
+    ) -> Vec<&AuthorizationDecision> {
+        if query.limit == Some(0) {
+            return Vec::new();
+        }
+
+        let selector = query.selector();
+        let mut decisions = self.registry.query_authorization_decisions(&selector);
+        match query.sort {
+            RuntimeAuthorizationDecisionSort::DecidedAtAsc => {
+                decisions.sort_by(|left, right| left.decided_at_ms.cmp(&right.decided_at_ms));
+            }
+            RuntimeAuthorizationDecisionSort::DecidedAtDesc => {
+                decisions.sort_by(|left, right| right.decided_at_ms.cmp(&left.decided_at_ms));
+            }
+        }
+        apply_limit(&mut decisions, query.limit);
+        decisions
+    }
+
+    pub fn authorization_decision_summary(
+        &self,
+        query: &RuntimeAuthorizationDecisionQuery,
+    ) -> AuthorizationDecisionLogSummary {
+        AuthorizationDecisionLogSummary::from_decisions(self.query_authorization_decisions(query))
     }
 
     pub fn desired_state(&self, entity_id: &EntityId) -> Option<&DesiredEntityState> {
@@ -4445,6 +4547,18 @@ impl SmartHomeRuntime {
                     .collect::<Vec<_>>();
                 let summary = self.event_bus.event_log_summary(&query);
                 Ok(RuntimeReadToolOutput::EventLog { entries, summary })
+            }
+            RuntimeReadToolRequest::ListAuthorizationDecisions { query } => {
+                let decision_refs = self.query_authorization_decisions(&query);
+                let summary =
+                    AuthorizationDecisionLogSummary::from_decisions(decision_refs.iter().copied());
+                let decisions = decision_refs.into_iter().cloned().collect();
+                Ok(RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary })
+            }
+            RuntimeReadToolRequest::GetAuthorizationSummary { query } => {
+                Ok(RuntimeReadToolOutput::AuthorizationSummary {
+                    summary: self.authorization_decision_summary(&query),
+                })
             }
             RuntimeReadToolRequest::ListDesiredStates { query } => {
                 let desired_state_refs = self.query_desired_states(&query);
@@ -5411,8 +5525,9 @@ fn event_entity_id(event: &RuntimeEvent) -> Option<&EntityId> {
 mod tests {
     use super::*;
     use smart_home_core::{
-        AuthorizationOutcome, BridgeTransport, Capability, CapabilityGrantId, CommandId,
-        CorrelationId, EntityKind, IntegrationId, ProtocolFamily, ProtocolIdentifier, StateDelta,
+        AuthorizationOutcome, AuthorizationSubject, BridgeTransport, Capability, CapabilityGrantId,
+        CommandId, CorrelationId, EntityKind, IntegrationId, ProtocolFamily, ProtocolIdentifier,
+        StateDelta,
     };
     use smart_home_discovery::{
         DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert,
@@ -6373,6 +6488,69 @@ mod tests {
             expired.missing_capabilities,
             vec![CapabilityId::trusted("smart_home.read")]
         );
+    }
+
+    #[test]
+    fn authorization_read_tools_filter_denied_decisions() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:lighting-planner");
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            )
+            .with_expiry(2_000),
+        );
+        let denied =
+            runtime.authorize_tool_for_principal(principal.clone(), SmartHomeTool::Command, 1_250);
+
+        let decisions = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::ListAuthorizationDecisions {
+                    query: RuntimeAuthorizationDecisionQuery::new()
+                        .for_principal(principal.clone())
+                        .with_outcome(AuthorizationOutcome::Denied),
+                },
+                1_500,
+            )
+            .unwrap();
+        let summary = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::GetAuthorizationSummary {
+                    query: RuntimeAuthorizationDecisionQuery::new()
+                        .for_principal(principal)
+                        .with_outcome(AuthorizationOutcome::Denied),
+                },
+                1_501,
+            )
+            .unwrap();
+
+        assert_eq!(denied.outcome, AuthorizationOutcome::Denied);
+        assert!(matches!(
+            decisions,
+            RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary }
+                if decisions.len() == 1
+                    && decisions[0].subject == AuthorizationSubject::Tool(SmartHomeTool::Command)
+                    && decisions[0].missing_capabilities
+                        == vec![CapabilityId::trusted("smart_home.command.light")]
+                    && summary.total_decisions == 1
+                    && summary.denied_decisions == 1
+                    && summary.allowed_decisions == 0
+        ));
+        assert!(matches!(
+            summary,
+            RuntimeReadToolOutput::AuthorizationSummary { summary }
+                if summary.total_decisions == 1
+                    && summary.denied_decisions == 1
+                    && summary.decisions_with_missing_capabilities == 1
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 3);
     }
 
     #[test]
@@ -8150,6 +8328,30 @@ mod tests {
                 1_515,
             )
             .unwrap();
+        let authorization_decisions = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::ListAuthorizationDecisions {
+                    query: RuntimeAuthorizationDecisionQuery::new()
+                        .for_principal(AgentId::trusted("agent:observer"))
+                        .with_outcome(AuthorizationOutcome::Allowed)
+                        .sorted_by(RuntimeAuthorizationDecisionSort::DecidedAtDesc)
+                        .with_limit(2),
+                },
+                1_516,
+            )
+            .unwrap();
+        let authorization_summary = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::GetAuthorizationSummary {
+                    query: RuntimeAuthorizationDecisionQuery::new()
+                        .for_principal(AgentId::trusted("agent:observer"))
+                        .with_outcome(AuthorizationOutcome::Allowed),
+                },
+                1_517,
+            )
+            .unwrap();
 
         assert!(matches!(
             bridges,
@@ -8292,7 +8494,27 @@ mod tests {
                     && schedule.deadlines[0].bridge_id == BridgeId::trusted("bridge-1")
                     && schedule.deadlines[0].is_due_at(1_515)
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 16);
+        assert!(matches!(
+            authorization_decisions,
+            RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary }
+                if decisions.len() == 2
+                    && decisions[0].decided_at_ms == 1_516
+                    && decisions[0].subject == AuthorizationSubject::Tool(
+                        SmartHomeTool::ListAuthorizationDecisions
+                    )
+                    && summary.total_decisions == 2
+                    && summary.allowed_decisions == 2
+                    && summary.denied_decisions == 0
+        ));
+        assert!(matches!(
+            authorization_summary,
+            RuntimeReadToolOutput::AuthorizationSummary { summary }
+                if summary.total_decisions == 18
+                    && summary.allowed_decisions == 18
+                    && summary.denied_decisions == 0
+                    && summary.tool_decisions == 18
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 18);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add read-only D18D smart-home tool descriptors for listing authorization decisions and summarizing authorization history
- expose runtime authorization decision query/sort/summary support over the existing registry-backed audit log
- wire Chief-of-Staff smart-home handlers and JSON serialization for authorization decision audit reads

## Validation
- cargo fmt --check -p smart-home-core -p smart-home-runtime -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools