### PR TITLE
Add browser media playback descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -255,7 +255,8 @@ documented in this file.
   and authored dimensions for fetch and layout planning.
 - Browser-facing document, content-tree, and render-tree projections now carry
   media playback metadata for `audio` and `video`, including playback flags,
-  and preload/poster fields.
+  preload/poster fields, and flattened playback descriptors with source/track
+  counts.
 - Browser-facing document summaries now carry script and stylesheet loading
   metadata, including script kind, async/defer/nomodule flags, inline
   script/style text, integrity/crossorigin/referrer-policy hints, fetch

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -853,6 +853,7 @@ pub struct BrowserDocument {
     pub images: Vec<BrowserImage>,
     pub image_maps: Vec<BrowserImageMap>,
     pub media: Vec<BrowserMedia>,
+    pub media_playback_descriptors: Vec<BrowserMediaPlaybackDescriptor>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
     pub interactive_elements: Vec<BrowserInteractiveElement>,
     pub disclosures: Vec<BrowserDisclosure>,
@@ -1988,6 +1989,33 @@ pub struct BrowserMediaTrack {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserMediaPlaybackDescriptor {
+    pub kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub poster: Option<String>,
+    pub resolved_poster: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub controls: bool,
+    pub autoplay: bool,
+    pub loop_media: bool,
+    pub muted: bool,
+    pub playsinline: bool,
+    pub preload: Option<String>,
+    pub crossorigin: Option<String>,
+    pub controlslist: Option<String>,
+    pub controlslist_tokens: Vec<String>,
+    pub disableremoteplayback: bool,
+    pub disablepictureinpicture: bool,
+    pub source_count: usize,
+    pub sources: Vec<BrowserMediaSource>,
+    pub track_count: usize,
+    pub default_track_count: usize,
+    pub tracks: Vec<BrowserMediaTrack>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserEmbeddedContext {
     pub element: String,
     pub url: Option<String>,
@@ -2617,6 +2645,7 @@ impl BrowserDocument {
             &[],
             body_children,
         );
+        summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -10186,6 +10215,47 @@ fn browser_resource_endpoint_descriptors(
             .map(browser_resource_endpoint_descriptor),
     );
     descriptors
+}
+
+fn browser_media_playback_descriptors(
+    media: &[BrowserMedia],
+) -> Vec<BrowserMediaPlaybackDescriptor> {
+    media
+        .iter()
+        .map(browser_media_playback_descriptor)
+        .collect()
+}
+
+fn browser_media_playback_descriptor(media: &BrowserMedia) -> BrowserMediaPlaybackDescriptor {
+    BrowserMediaPlaybackDescriptor {
+        kind: media.kind.clone(),
+        src: media.src.clone(),
+        resolved_src: media.resolved_src.clone(),
+        poster: media.poster.clone(),
+        resolved_poster: media.resolved_poster.clone(),
+        width: media.width.clone(),
+        height: media.height.clone(),
+        controls: media.controls,
+        autoplay: media.autoplay,
+        loop_media: media.loop_media,
+        muted: media.muted,
+        playsinline: media.playsinline,
+        preload: media.preload.clone(),
+        crossorigin: media.crossorigin.clone(),
+        controlslist: media.controlslist.clone(),
+        controlslist_tokens: media.controlslist_tokens.clone(),
+        disableremoteplayback: media.disableremoteplayback,
+        disablepictureinpicture: media.disablepictureinpicture,
+        source_count: media.sources.len(),
+        sources: media.sources.clone(),
+        track_count: media.tracks.len(),
+        default_track_count: media
+            .tracks
+            .iter()
+            .filter(|track| track.default_track)
+            .count(),
+        tracks: media.tracks.clone(),
+    }
 }
 
 fn browser_resource_endpoint_descriptor(
@@ -19594,6 +19664,65 @@ mod tests {
         assert_eq!(audio.sources[0].src.as_deref(), Some("theme.ogg"));
         assert_eq!(audio.sources[0].type_hint.as_deref(), Some("audio/ogg"));
         assert!(audio.tracks.is_empty());
+    }
+
+    #[test]
+    fn browser_media_playback_descriptors_track_controls_sources_and_tracks() {
+        let document = parse_html(
+            "<base href=\"https://example.test/watch/index.html\"><body>\
+             <video src=movie.mp4 poster=poster.jpg controls autoplay loop muted playsinline \
+                 preload=metadata crossorigin=anonymous controlslist=\"nodownload noremoteplayback\" \
+                 disableremoteplayback disablepictureinpicture width=640 height=360>\
+               <source src=movie.webm type=video/webm media=\"(min-width: 700px)\">\
+               <track kind=captions src=captions.vtt srclang=en label=English default>\
+               <track src=descriptions.vtt label=Descriptions>\
+             </video>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.media_playback_descriptors.len(), 1);
+
+        let descriptor = &summary.media_playback_descriptors[0];
+        assert_eq!(descriptor.kind, "video");
+        assert_eq!(descriptor.src.as_deref(), Some("movie.mp4"));
+        assert_eq!(
+            descriptor.resolved_src.as_deref(),
+            Some("https://example.test/watch/movie.mp4")
+        );
+        assert_eq!(
+            descriptor.resolved_poster.as_deref(),
+            Some("https://example.test/watch/poster.jpg")
+        );
+        assert_eq!(descriptor.width.as_deref(), Some("640"));
+        assert!(descriptor.controls);
+        assert!(descriptor.autoplay);
+        assert!(descriptor.loop_media);
+        assert!(descriptor.muted);
+        assert!(descriptor.playsinline);
+        assert_eq!(descriptor.preload.as_deref(), Some("metadata"));
+        assert_eq!(descriptor.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(
+            descriptor.controlslist_tokens,
+            vec!["nodownload", "noremoteplayback"]
+        );
+        assert!(descriptor.disableremoteplayback);
+        assert!(descriptor.disablepictureinpicture);
+        assert_eq!(descriptor.source_count, 1);
+        assert_eq!(descriptor.sources[0].src.as_deref(), Some("movie.webm"));
+        assert_eq!(
+            descriptor.sources[0].media.as_deref(),
+            Some("(min-width: 700px)")
+        );
+        assert_eq!(descriptor.track_count, 2);
+        assert_eq!(descriptor.default_track_count, 1);
+        assert_eq!(descriptor.tracks[0].kind, "captions");
+        assert_eq!(
+            descriptor.tracks[0].resolved_src.as_deref(),
+            Some("https://example.test/watch/captions.vtt")
+        );
+        assert!(descriptor.tracks[0].default_track);
+        assert_eq!(descriptor.tracks[1].kind, "subtitles");
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -12,13 +12,13 @@ use coding_adventures_html_parser::{
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
-    BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaSource, BrowserMediaTrack,
-    BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic,
-    BrowserThemeColor,
+    BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor,
+    BrowserMediaSource, BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective,
+    BrowserNavigationGroup, BrowserNavigationTargetDescriptor, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
+    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -106,6 +106,8 @@ struct ExpectedBrowserDocument {
     image_maps: Vec<ExpectedImageMap>,
     #[serde(default)]
     media: Vec<ExpectedMedia>,
+    #[serde(default)]
+    media_playback_descriptors: Option<Vec<ExpectedMediaPlaybackDescriptor>>,
     #[serde(default)]
     embedded_contexts: Vec<ExpectedEmbeddedContext>,
     #[serde(default)]
@@ -1415,6 +1417,55 @@ struct ExpectedMediaTrack {
     label: Option<String>,
     #[serde(default)]
     default_track: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMediaPlaybackDescriptor {
+    kind: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    poster: Option<String>,
+    #[serde(default)]
+    resolved_poster: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    controls: bool,
+    #[serde(default)]
+    autoplay: bool,
+    #[serde(default)]
+    loop_media: bool,
+    #[serde(default)]
+    muted: bool,
+    #[serde(default)]
+    playsinline: bool,
+    #[serde(default)]
+    preload: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    controlslist: Option<String>,
+    #[serde(default)]
+    controlslist_tokens: Vec<String>,
+    #[serde(default)]
+    disableremoteplayback: bool,
+    #[serde(default)]
+    disablepictureinpicture: bool,
+    #[serde(default)]
+    source_count: usize,
+    #[serde(default)]
+    sources: Vec<ExpectedMediaSource>,
+    #[serde(default)]
+    track_count: usize,
+    #[serde(default)]
+    default_track_count: usize,
+    #[serde(default)]
+    tracks: Vec<ExpectedMediaTrack>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3772,6 +3823,11 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedResource::into_browser_resource)
             .collect();
+        let media: Vec<_> = self
+            .media
+            .into_iter()
+            .map(ExpectedMedia::into_browser_media)
+            .collect();
         let resource_endpoint_descriptors = self
             .resource_endpoint_descriptors
             .map(|descriptors| {
@@ -3783,6 +3839,15 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_resource_endpoint_descriptors(&metadata, &resources));
+        let media_playback_descriptors = self
+            .media_playback_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedMediaPlaybackDescriptor::into_browser_media_playback_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_media_playback_descriptors(&media));
 
         BrowserDocument {
             title: self.title,
@@ -3910,11 +3975,8 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedImageMap::into_browser_image_map)
                 .collect(),
-            media: self
-                .media
-                .into_iter()
-                .map(ExpectedMedia::into_browser_media)
-                .collect(),
+            media,
+            media_playback_descriptors,
             embedded_contexts: self
                 .embedded_contexts
                 .into_iter()
@@ -4371,6 +4433,47 @@ fn expected_resource_endpoint_element(kind: &str) -> &str {
         "frame" => "iframe",
         "image" => "img",
         other => other,
+    }
+}
+
+fn expected_media_playback_descriptors(
+    media: &[BrowserMedia],
+) -> Vec<BrowserMediaPlaybackDescriptor> {
+    media
+        .iter()
+        .map(expected_media_playback_descriptor)
+        .collect()
+}
+
+fn expected_media_playback_descriptor(media: &BrowserMedia) -> BrowserMediaPlaybackDescriptor {
+    BrowserMediaPlaybackDescriptor {
+        kind: media.kind.clone(),
+        src: media.src.clone(),
+        resolved_src: media.resolved_src.clone(),
+        poster: media.poster.clone(),
+        resolved_poster: media.resolved_poster.clone(),
+        width: media.width.clone(),
+        height: media.height.clone(),
+        controls: media.controls,
+        autoplay: media.autoplay,
+        loop_media: media.loop_media,
+        muted: media.muted,
+        playsinline: media.playsinline,
+        preload: media.preload.clone(),
+        crossorigin: media.crossorigin.clone(),
+        controlslist: media.controlslist.clone(),
+        controlslist_tokens: media.controlslist_tokens.clone(),
+        disableremoteplayback: media.disableremoteplayback,
+        disablepictureinpicture: media.disablepictureinpicture,
+        source_count: media.sources.len(),
+        sources: media.sources.clone(),
+        track_count: media.tracks.len(),
+        default_track_count: media
+            .tracks
+            .iter()
+            .filter(|track| track.default_track)
+            .count(),
+        tracks: media.tracks.clone(),
     }
 }
 
@@ -5108,6 +5211,44 @@ impl ExpectedMediaTrack {
             srclang: self.srclang,
             label: self.label,
             default_track: self.default_track,
+        }
+    }
+}
+
+impl ExpectedMediaPlaybackDescriptor {
+    fn into_browser_media_playback_descriptor(self) -> BrowserMediaPlaybackDescriptor {
+        BrowserMediaPlaybackDescriptor {
+            kind: self.kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            poster: self.poster,
+            resolved_poster: self.resolved_poster,
+            width: self.width,
+            height: self.height,
+            controls: self.controls,
+            autoplay: self.autoplay,
+            loop_media: self.loop_media,
+            muted: self.muted,
+            playsinline: self.playsinline,
+            preload: self.preload,
+            crossorigin: self.crossorigin,
+            controlslist: self.controlslist,
+            controlslist_tokens: self.controlslist_tokens,
+            disableremoteplayback: self.disableremoteplayback,
+            disablepictureinpicture: self.disablepictureinpicture,
+            source_count: self.source_count,
+            sources: self
+                .sources
+                .into_iter()
+                .map(ExpectedMediaSource::into_browser_media_source)
+                .collect(),
+            track_count: self.track_count,
+            default_track_count: self.default_track_count,
+            tracks: self
+                .tracks
+                .into_iter()
+                .map(ExpectedMediaTrack::into_browser_media_track)
+                .collect(),
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -42,7 +42,8 @@ targets with target selection, rel policy, ping/attribution endpoints,
 language/type hints, download/referrer policy, and area geometry.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
-Media cases pin audio/video playback flags and preload/poster metadata.
+Media cases pin audio/video playback flags, preload/poster metadata, and
+flattened playback descriptors with source/track counts.
 Script/style cases pin module/classic script kind, async/defer/nomodule flags,
 inline script/style text, and loading-policy hints such as integrity,
 crossorigin, referrer policy, fetch priority, blocking, disabled state, and

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -745,6 +745,49 @@
             "disableremoteplayback": true
           }
         ],
+        "media_playback_descriptors": [
+          {
+            "kind": "video",
+            "src": "movie.mp4",
+            "resolved_src": "https://example.test/watch/movie.mp4",
+            "poster": "poster.jpg",
+            "resolved_poster": "https://example.test/watch/poster.jpg",
+            "width": "640",
+            "height": "360",
+            "controls": true,
+            "autoplay": true,
+            "loop_media": true,
+            "muted": true,
+            "playsinline": true,
+            "preload": "metadata",
+            "crossorigin": "anonymous",
+            "controlslist": "nodownload noplaybackrate",
+            "controlslist_tokens": ["nodownload", "noplaybackrate"],
+            "disableremoteplayback": true,
+            "disablepictureinpicture": true,
+            "source_count": 0,
+            "sources": [],
+            "track_count": 0,
+            "default_track_count": 0,
+            "tracks": []
+          },
+          {
+            "kind": "audio",
+            "src": "theme.ogg",
+            "resolved_src": "https://example.test/watch/theme.ogg",
+            "controls": true,
+            "preload": "none",
+            "crossorigin": "use-credentials",
+            "controlslist": "nodownload",
+            "controlslist_tokens": ["nodownload"],
+            "disableremoteplayback": true,
+            "source_count": 0,
+            "sources": [],
+            "track_count": 0,
+            "default_track_count": 0,
+            "tracks": []
+          }
+        ],
         "forms": [],
         "tables": []
       }
@@ -791,6 +834,36 @@
             "sources": [
               { "src": "theme.ogg", "resolved_src": "https://example.test/watch/theme.ogg", "type_hint": "audio/ogg" }
             ],
+            "tracks": []
+          }
+        ],
+        "media_playback_descriptors": [
+          {
+            "kind": "video",
+            "src": null,
+            "controls": true,
+            "source_count": 2,
+            "sources": [
+              { "src": "movie.webm", "resolved_src": "https://example.test/watch/movie.webm", "type_hint": "video/webm", "media": "(min-width: 700px)" },
+              { "src": "movie.mp4", "resolved_src": "https://example.test/watch/movie.mp4", "type_hint": "video/mp4" }
+            ],
+            "track_count": 2,
+            "default_track_count": 1,
+            "tracks": [
+              { "kind": "captions", "src": "captions.vtt", "resolved_src": "https://example.test/watch/captions.vtt", "srclang": "en", "label": "English", "default_track": true },
+              { "kind": "subtitles", "src": "descriptions.vtt", "resolved_src": "https://example.test/watch/descriptions.vtt", "label": "Descriptions" }
+            ]
+          },
+          {
+            "kind": "audio",
+            "src": null,
+            "controls": true,
+            "source_count": 1,
+            "sources": [
+              { "src": "theme.ogg", "resolved_src": "https://example.test/watch/theme.ogg", "type_hint": "audio/ogg" }
+            ],
+            "track_count": 0,
+            "default_track_count": 0,
             "tracks": []
           }
         ],


### PR DESCRIPTION
## Summary
- add flattened browser media playback descriptors for audio/video playback policy, sources, and tracks
- pin descriptor expectations in browser-readiness media fixtures
- update fixture inventory and changelog wording

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_media_playback_descriptors_track_controls_sources_and_tracks
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser