### PR TITLE
Expose Chief smart-home capability grant tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_authorization_summary` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect allow/deny audit history without
   owning smart-home authorization logic.
+- Added `smart_home.list_capability_grants` and
+  `smart_home.get_capability_grant_summary` handlers over the D23 runtime read
+  facade so Chief of Staff jobs can inspect grant governance without owning
+  smart-home authorization policy.
 - Added `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`,
   and `smart_home.list_pairing_sessions` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect automation backlog, reconciliation

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -30,6 +30,7 @@ Chief of Staff job/session/agent
   -> discovery worker health and retry state in smart_home.observe_supervision
   -> event-log and subscription-backlog reads
   -> authorization decision audit reads and summaries
+  -> capability grant ledger reads and summaries
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> non-mutating supervision plan previews
   -> authorized desired-state reconciliation and supervision ticks
@@ -61,6 +62,8 @@ Chief of Staff job/session/agent
 - `smart_home.inspect_event_log`
 - `smart_home.list_authorization_decisions`
 - `smart_home.get_authorization_summary`
+- `smart_home.list_capability_grants`
+- `smart_home.get_capability_grant_summary`
 - `smart_home.get_runtime_snapshot`
 - `smart_home.list_desired_states`
 - `smart_home.list_pairing_sessions`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -16,11 +16,12 @@ use chief_of_staff_tool_api::{
 use coding_adventures_json_value::{JsonNumber, JsonValue};
 use smart_home_core::{
     AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary, AuthorizationOutcome,
-    AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityId, CommandResult, CommandStatus,
-    CommandType, Device, DeviceCommand, DeviceEvent, DeviceEventType, EntityId, EntityKind, Health,
-    IntegrationId, Metadata, PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene,
-    SceneAction, SceneId, SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource,
-    Value,
+    AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityGrant,
+    CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
+    CommandResult, CommandStatus, CommandType, Device, DeviceCommand, DeviceEvent, DeviceEventType,
+    EntityId, EntityKind, Health, IntegrationId, Metadata, PrivilegeTier, ProtocolFamily,
+    ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope, StateConfidence,
+    StateDelta, StateSnapshot, StateSource, Value,
 };
 use smart_home_discovery::{DiscoveryRecord, DiscoverySource};
 use smart_home_integration_catalog::{
@@ -39,22 +40,24 @@ use smart_home_registry::StateRefreshReason;
 use smart_home_runtime::{
     DesiredEntityState, DesiredStateAction, DesiredStateInventorySummary, DesiredStateQuery,
     DesiredStateSort, DiscoveryWorkerRunInstruction, PairingSessionStatus, ReconciliationReason,
-    RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort, RuntimeCommandToolRequest,
-    RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError, RuntimeEvent,
-    RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter, RuntimeEventLogRecord,
-    RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort, RuntimePairBridgeToolOutput,
-    RuntimePairBridgeToolRequest, RuntimePairingSession, RuntimePairingSessionId,
-    RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery, RuntimePairingSessionSort,
-    RuntimePendingWorkSummary, RuntimePollEventsToolOutput, RuntimePollEventsToolRequest,
-    RuntimeReadSnapshot, RuntimeReadToolOutput, RuntimeReadToolRequest, RuntimeSubscribeToolOutput,
-    RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId,
-    RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot,
-    RuntimeSubscriptionSort, RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary,
-    RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot,
-    RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot,
-    SmartHomeRuntime, SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort,
-    SupervisionTickReport, WorkerHeartbeatDeadline, WorkerHeartbeatSchedule,
-    WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
+    RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort,
+    RuntimeCapabilityGrantQuery, RuntimeCapabilityGrantScopeKind, RuntimeCapabilityGrantSort,
+    RuntimeCommandToolRequest, RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError,
+    RuntimeEvent, RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter,
+    RuntimeEventLogRecord, RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort,
+    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingSession,
+    RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
+    RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
+    RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
+    RuntimeReadToolRequest, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
+    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
+    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
+    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
+    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
+    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
+    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
+    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
+    WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -75,6 +78,9 @@ pub const SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID: &str =
     "smart_home.list_authorization_decisions";
 pub const SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_authorization_summary";
+pub const SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID: &str = "smart_home.list_capability_grants";
+pub const SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_capability_grant_summary";
 pub const SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID: &str = "smart_home.get_runtime_snapshot";
 pub const SMART_HOME_LIST_DESIRED_STATES_TOOL_ID: &str = "smart_home.list_desired_states";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
@@ -314,6 +320,31 @@ impl SmartHomeToolBridge {
                     Ok(read_output_handler_output(
                         output,
                         "get_authorization_summary",
+                    ))
+                }
+                SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID => {
+                    let query = capability_grant_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::ListCapabilityGrants { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "list_capability_grants"))
+                }
+                SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID => {
+                    let query = capability_grant_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::GetCapabilityGrantSummary { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(
+                        output,
+                        "get_capability_grant_summary",
                     ))
                 }
                 SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID => {
@@ -732,6 +763,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         inspect_event_log_definition(),
         list_authorization_decisions_definition(),
         get_authorization_summary_definition(),
+        list_capability_grants_definition(),
+        get_capability_grant_summary_definition(),
         get_runtime_snapshot_definition(),
         list_desired_states_definition(),
         list_pairing_sessions_definition(),
@@ -1066,11 +1099,64 @@ fn get_authorization_summary_definition() -> ToolDefinition {
     )
 }
 
+fn list_capability_grants_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID,
+        "List smart-home capability grants",
+        "List D23 smart-home capability grants, optionally filtered by Chief principal, effective status, scope, capability, or entity.",
+        capability_grant_query_schema(),
+        object_schema(
+            vec![
+                SchemaProperty::new(
+                    "grants",
+                    JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    },
+                ),
+                SchemaProperty::new("summary", JsonSchema::Any),
+                SchemaProperty::new("count", JsonSchema::Integer),
+            ],
+            vec!["grants", "summary", "count"],
+            false,
+        ),
+    )
+}
+
+fn get_capability_grant_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID,
+        "Get smart-home capability grant summary",
+        "Summarize D23 smart-home capability grants without returning individual grant rows.",
+        capability_grant_query_schema(),
+        object_schema(
+            vec![SchemaProperty::new("summary", JsonSchema::Any)],
+            vec!["summary"],
+            false,
+        ),
+    )
+}
+
 fn authorization_decision_query_schema() -> JsonSchema {
     object_schema(
         vec![
             SchemaProperty::new("principal_id", JsonSchema::String),
             SchemaProperty::new("outcome", JsonSchema::String),
+            SchemaProperty::new("sort", JsonSchema::String),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
+    )
+}
+
+fn capability_grant_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("principal_id", JsonSchema::String),
+            SchemaProperty::new("status", JsonSchema::String),
+            SchemaProperty::new("scope_kind", JsonSchema::String),
+            SchemaProperty::new("capability_id", JsonSchema::String),
+            SchemaProperty::new("entity_id", JsonSchema::String),
             SchemaProperty::new("sort", JsonSchema::String),
             SchemaProperty::new("limit", JsonSchema::Integer),
         ],
@@ -1704,6 +1790,35 @@ fn authorization_decision_query(
     Ok(query)
 }
 
+fn capability_grant_query(
+    arguments: &JsonValue,
+) -> Result<RuntimeCapabilityGrantQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut query = RuntimeCapabilityGrantQuery::new();
+    if let Some(principal_id) = optional_string(arguments, "principal_id")? {
+        query = query.for_principal(AgentId::trusted(principal_id));
+    }
+    if let Some(status) = optional_string(arguments, "status")? {
+        query = query.with_status(parse_capability_grant_status(&status)?);
+    }
+    if let Some(scope_kind) = optional_string(arguments, "scope_kind")? {
+        query = query.with_scope_kind(parse_capability_grant_scope_kind(&scope_kind)?);
+    }
+    if let Some(capability_id) = optional_string(arguments, "capability_id")? {
+        query = query.with_capability(CapabilityId::trusted(capability_id));
+    }
+    if let Some(entity_id) = optional_string(arguments, "entity_id")? {
+        query = query.for_entity(EntityId::trusted(entity_id));
+    }
+    if let Some(sort) = optional_string(arguments, "sort")? {
+        query = query.sorted_by(parse_capability_grant_sort(&sort)?);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        query = query.with_limit(limit as usize);
+    }
+    Ok(query)
+}
+
 fn list_desired_states_request(
     arguments: &JsonValue,
 ) -> Result<RuntimeReadToolRequest, ToolCallError> {
@@ -2220,6 +2335,22 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
         ]),
         RuntimeReadToolOutput::AuthorizationSummary { summary } => {
             object([("summary", authorization_decision_log_summary_json(&summary))])
+        }
+        RuntimeReadToolOutput::CapabilityGrants { grants, summary } => object([
+            (
+                "grants",
+                JsonValue::Array(
+                    grants
+                        .iter()
+                        .map(|grant| capability_grant_json(grant, summary.generated_at_ms))
+                        .collect(),
+                ),
+            ),
+            ("summary", capability_grant_inventory_summary_json(&summary)),
+            ("count", integer(grants.len() as i64)),
+        ]),
+        RuntimeReadToolOutput::CapabilityGrantSummary { summary } => {
+            object([("summary", capability_grant_inventory_summary_json(&summary))])
         }
         RuntimeReadToolOutput::DesiredStates {
             desired_states,
@@ -4266,6 +4397,115 @@ fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     ])
 }
 
+fn capability_grant_json(grant: &CapabilityGrant, now_ms: u64) -> JsonValue {
+    object([
+        ("grant_id", string(grant.grant_id.as_str())),
+        ("principal_id", string(grant.principal_id.as_str())),
+        (
+            "scope_kind",
+            string(capability_grant_scope_label(&grant.scope)),
+        ),
+        ("scope", capability_grant_scope_json(&grant.scope)),
+        ("max_tier", string(privilege_tier_label(grant.max_tier))),
+        ("granted_by", string(&grant.granted_by)),
+        ("granted_at_ms", integer(grant.granted_at_ms as i64)),
+        (
+            "expires_at_ms",
+            grant
+                .expires_at_ms
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "status",
+            string(capability_grant_status_label(grant.status)),
+        ),
+        (
+            "effective_status",
+            string(capability_grant_status_label(grant.status_at(now_ms))),
+        ),
+        ("effective_status_at_ms", integer(now_ms as i64)),
+        ("is_active", JsonValue::Bool(grant.is_active_at(now_ms))),
+        (
+            "metadata",
+            JsonValue::Array(grant.metadata.iter().map(metadata_json).collect()),
+        ),
+    ])
+}
+
+fn capability_grant_scope_json(scope: &CapabilityGrantScope) -> JsonValue {
+    match scope {
+        CapabilityGrantScope::Tool(tool) => object([
+            ("scope_kind", string("tool")),
+            ("tool_id", string(tool.descriptor().tool_id)),
+        ]),
+        CapabilityGrantScope::Capability(capability_id) => object([
+            ("scope_kind", string("capability")),
+            ("capability_id", string(capability_id.as_str())),
+        ]),
+        CapabilityGrantScope::EntityCapability {
+            entity_id,
+            capability_id,
+        } => object([
+            ("scope_kind", string("entity_capability")),
+            ("entity_id", string(entity_id.as_str())),
+            ("capability_id", string(capability_id.as_str())),
+        ]),
+        CapabilityGrantScope::AllSmartHome => object([("scope_kind", string("all_smart_home"))]),
+    }
+}
+
+fn capability_grant_inventory_summary_json(summary: &CapabilityGrantInventorySummary) -> JsonValue {
+    object([
+        ("generated_at_ms", integer(summary.generated_at_ms as i64)),
+        ("total_grants", integer(summary.total_grants as i64)),
+        ("active_grants", integer(summary.active_grants as i64)),
+        ("pending_grants", integer(summary.pending_grants as i64)),
+        ("revoked_grants", integer(summary.revoked_grants as i64)),
+        ("expired_grants", integer(summary.expired_grants as i64)),
+        ("tool_grants", integer(summary.tool_grants as i64)),
+        (
+            "capability_grants",
+            integer(summary.capability_grants as i64),
+        ),
+        (
+            "entity_capability_grants",
+            integer(summary.entity_capability_grants as i64),
+        ),
+        (
+            "all_smart_home_grants",
+            integer(summary.all_smart_home_grants as i64),
+        ),
+        (
+            "read_only_tier_grants",
+            integer(summary.read_only_tier_grants as i64),
+        ),
+        (
+            "low_risk_tier_grants",
+            integer(summary.low_risk_tier_grants as i64),
+        ),
+        (
+            "human_approval_tier_grants",
+            integer(summary.human_approval_tier_grants as i64),
+        ),
+        (
+            "high_risk_tier_grants",
+            integer(summary.high_risk_tier_grants as i64),
+        ),
+        ("expiring_grants", integer(summary.expiring_grants as i64)),
+        (
+            "unique_principals",
+            integer(summary.unique_principals as i64),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_active_grants",
+            JsonValue::Bool(summary.has_active_grants()),
+        ),
+        ("needs_review", JsonValue::Bool(summary.needs_review())),
+    ])
+}
+
 fn authorization_decision_json(decision: &AuthorizationDecision) -> JsonValue {
     object([
         ("principal_id", string(decision.principal_id.as_str())),
@@ -4693,6 +4933,46 @@ fn parse_authorization_outcome(label: &str) -> Result<AuthorizationOutcome, Tool
         "denied" | "deny" => Ok(AuthorizationOutcome::Denied),
         _ => Err(validation_error(format!(
             "unknown authorization outcome `{label}`"
+        ))),
+    }
+}
+
+fn parse_capability_grant_status(label: &str) -> Result<CapabilityGrantStatus, ToolCallError> {
+    match label {
+        "pending" => Ok(CapabilityGrantStatus::Pending),
+        "active" => Ok(CapabilityGrantStatus::Active),
+        "revoked" => Ok(CapabilityGrantStatus::Revoked),
+        "expired" => Ok(CapabilityGrantStatus::Expired),
+        _ => Err(validation_error(format!(
+            "unknown capability grant status `{label}`"
+        ))),
+    }
+}
+
+fn parse_capability_grant_scope_kind(
+    label: &str,
+) -> Result<RuntimeCapabilityGrantScopeKind, ToolCallError> {
+    match label {
+        "tool" => Ok(RuntimeCapabilityGrantScopeKind::Tool),
+        "capability" => Ok(RuntimeCapabilityGrantScopeKind::Capability),
+        "entity_capability" | "entity" => Ok(RuntimeCapabilityGrantScopeKind::EntityCapability),
+        "all_smart_home" | "all" => Ok(RuntimeCapabilityGrantScopeKind::AllSmartHome),
+        _ => Err(validation_error(format!(
+            "unknown capability grant scope kind `{label}`"
+        ))),
+    }
+}
+
+fn parse_capability_grant_sort(label: &str) -> Result<RuntimeCapabilityGrantSort, ToolCallError> {
+    match label {
+        "grant_id" | "id" => Ok(RuntimeCapabilityGrantSort::GrantId),
+        "principal_id" | "principal" => Ok(RuntimeCapabilityGrantSort::PrincipalId),
+        "granted_at_asc" | "oldest_first" => Ok(RuntimeCapabilityGrantSort::GrantedAtAsc),
+        "granted_at_desc" | "newest_first" => Ok(RuntimeCapabilityGrantSort::GrantedAtDesc),
+        "expires_at_asc" | "expires_first" => Ok(RuntimeCapabilityGrantSort::ExpiresAtAsc),
+        "expires_at_desc" | "expires_last" => Ok(RuntimeCapabilityGrantSort::ExpiresAtDesc),
+        _ => Err(validation_error(format!(
+            "unknown capability grant sort `{label}`"
         ))),
     }
 }
@@ -5134,6 +5414,24 @@ fn privilege_tier_label(tier: PrivilegeTier) -> &'static str {
         PrivilegeTier::LowRisk => "low_risk",
         PrivilegeTier::HumanApproval => "human_approval",
         PrivilegeTier::HighRisk => "high_risk",
+    }
+}
+
+fn capability_grant_status_label(status: CapabilityGrantStatus) -> &'static str {
+    match status {
+        CapabilityGrantStatus::Pending => "pending",
+        CapabilityGrantStatus::Active => "active",
+        CapabilityGrantStatus::Revoked => "revoked",
+        CapabilityGrantStatus::Expired => "expired",
+    }
+}
+
+fn capability_grant_scope_label(scope: &CapabilityGrantScope) -> &'static str {
+    match scope {
+        CapabilityGrantScope::Tool(_) => "tool",
+        CapabilityGrantScope::Capability(_) => "capability",
+        CapabilityGrantScope::EntityCapability { .. } => "entity_capability",
+        CapabilityGrantScope::AllSmartHome => "all_smart_home",
     }
 }
 
@@ -5651,7 +5949,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 30);
+        assert_eq!(definitions.len(), 32);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -5689,6 +5987,12 @@ mod tests {
             .contains(&SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -5715,7 +6019,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            26
+            28
         );
         assert_eq!(
             export
@@ -6442,6 +6746,69 @@ mod tests {
             Some(&JsonValue::Bool(false))
         );
 
+        let list_capability_grants_request = request(
+            "call-list-capability-grants",
+            SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID,
+            object([
+                ("principal_id", string(AGENT_ID)),
+                ("status", string("active")),
+                ("scope_kind", string("all_smart_home")),
+                ("sort", string("newest_first")),
+                ("limit", integer(1)),
+            ]),
+            1_105,
+        );
+        let list_capability_grants_trace =
+            tool_runtime.invoke_with_events(&list_capability_grants_request);
+        assert!(list_capability_grants_trace.result.ok);
+        let list_capability_grants_output =
+            list_capability_grants_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(list_capability_grants_output, "count"),
+            Some(&integer(1))
+        );
+        let grant = array_item(field(list_capability_grants_output, "grants").unwrap(), 0).unwrap();
+        assert_eq!(field(grant, "grant_id"), Some(&string("grant-smart-home")));
+        assert_eq!(field(grant, "effective_status"), Some(&string("active")));
+        assert_eq!(
+            field(field(grant, "scope").unwrap(), "scope_kind"),
+            Some(&string("all_smart_home"))
+        );
+        assert_eq!(
+            field(
+                field(list_capability_grants_output, "summary").unwrap(),
+                "human_approval_tier_grants"
+            ),
+            Some(&integer(1))
+        );
+
+        let capability_grant_summary_request = request(
+            "call-capability-grant-summary",
+            SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID,
+            object([
+                ("principal_id", string(AGENT_ID)),
+                ("status", string("active")),
+            ]),
+            1_106,
+        );
+        let capability_grant_summary_trace =
+            tool_runtime.invoke_with_events(&capability_grant_summary_request);
+        assert!(capability_grant_summary_trace.result.ok);
+        let capability_grant_summary_output = capability_grant_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let capability_grant_summary = field(capability_grant_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(capability_grant_summary, "total_grants"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(capability_grant_summary, "has_active_grants"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let poll_request = request(
             "call-poll-events",
             SMART_HOME_POLL_EVENTS_TOOL_ID,
@@ -6603,6 +6970,11 @@ mod tests {
         journal.record_trace(inspect_event_log_request, inspect_event_log_trace);
         journal.record_trace(list_authorization_request, list_authorization_trace);
         journal.record_trace(authorization_summary_request, authorization_summary_trace);
+        journal.record_trace(list_capability_grants_request, list_capability_grants_trace);
+        journal.record_trace(
+            capability_grant_summary_request,
+            capability_grant_summary_trace,
+        );
         journal.record_trace(poll_request, poll_trace);
         journal.record_trace(state_request, state_trace);
         journal.record_trace(unsubscribe_request, unsubscribe_trace);
@@ -6610,9 +6982,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 29);
-        assert_eq!(journal_summary.completed_count, 29);
-        assert_eq!(journal.audit_records().len(), 29);
+        assert_eq!(journal_summary.invocation_count, 31);
+        assert_eq!(journal_summary.completed_count, 31);
+        assert_eq!(journal.audit_records().len(), 31);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -6625,7 +6997,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            26,
+            28,
             "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_authorization_decisions` and
   `smart_home.get_authorization_summary` tool descriptors for read-only
   authorization-audit inspection.
+- `smart_home.list_capability_grants` and
+  `smart_home.get_capability_grant_summary` tool descriptors plus
+  `CapabilityGrantInventorySummary` for read-only grant-governance inspection.
 - `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`, and
   `smart_home.list_pairing_sessions` tool descriptors for read-only runtime
   automation inventory inspection.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -53,6 +53,8 @@ Current scope:
   inspecting checkpointed runtime event-log entries
 - D18D authorization-audit tool descriptors for listing decisions and compact
   allow/deny summaries
+- D18D capability-grant tool descriptors for listing grant rows and compact
+  grant inventory summaries
 - D18D runtime automation inventory tool descriptors for read-only snapshots,
   desired-state targets, and pairing-session status
 - D18D bridge-worker inventory descriptors for read-only supervisor and
@@ -67,6 +69,8 @@ Current scope:
 - authorization decisions that can be logged by runtimes and agents
 - authorization-decision summaries for allow/deny, grant, and
   missing-capability inspection
+- capability-grant inventory summaries for grant status, scope, tier, expiry,
+  and principal review counts
 - MQTT topic names, topic filters, QoS levels, topic roles, and topic bindings
   for MQTT-backed integrations
 

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1460,6 +1460,8 @@ pub enum SmartHomeTool {
     InspectEventLog,
     ListAuthorizationDecisions,
     GetAuthorizationSummary,
+    ListCapabilityGrants,
+    GetCapabilityGrantSummary,
     GetRuntimeSnapshot,
     ListDesiredStates,
     ListPairingSessions,
@@ -1508,6 +1510,8 @@ impl SmartHomeTool {
                 read_tool("smart_home.list_authorization_decisions")
             }
             Self::GetAuthorizationSummary => read_tool("smart_home.get_authorization_summary"),
+            Self::ListCapabilityGrants => read_tool("smart_home.list_capability_grants"),
+            Self::GetCapabilityGrantSummary => read_tool("smart_home.get_capability_grant_summary"),
             Self::GetRuntimeSnapshot => read_tool("smart_home.get_runtime_snapshot"),
             Self::ListDesiredStates => read_tool("smart_home.list_desired_states"),
             Self::ListPairingSessions => read_tool("smart_home.list_pairing_sessions"),
@@ -1731,6 +1735,86 @@ impl ToolDescriptor {
 
     pub fn requires_human_approval(&self) -> bool {
         self.required_tier == PrivilegeTier::HumanApproval
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CapabilityGrantInventorySummary {
+    pub generated_at_ms: u64,
+    pub total_grants: usize,
+    pub active_grants: usize,
+    pub pending_grants: usize,
+    pub revoked_grants: usize,
+    pub expired_grants: usize,
+    pub tool_grants: usize,
+    pub capability_grants: usize,
+    pub entity_capability_grants: usize,
+    pub all_smart_home_grants: usize,
+    pub read_only_tier_grants: usize,
+    pub low_risk_tier_grants: usize,
+    pub human_approval_tier_grants: usize,
+    pub high_risk_tier_grants: usize,
+    pub expiring_grants: usize,
+    pub unique_principals: usize,
+}
+
+impl CapabilityGrantInventorySummary {
+    pub fn empty(generated_at_ms: u64) -> Self {
+        Self {
+            generated_at_ms,
+            ..Self::default()
+        }
+    }
+
+    pub fn from_grants_at<'a, I>(grants: I, now_ms: u64) -> Self
+    where
+        I: IntoIterator<Item = &'a CapabilityGrant>,
+    {
+        let mut summary = Self::empty(now_ms);
+        let mut principals = BTreeSet::new();
+        for grant in grants {
+            summary.record_grant_at(grant, now_ms);
+            principals.insert(grant.principal_id.clone());
+        }
+        summary.unique_principals = principals.len();
+        summary
+    }
+
+    pub fn record_grant_at(&mut self, grant: &CapabilityGrant, now_ms: u64) {
+        self.total_grants += 1;
+        match grant.status_at(now_ms) {
+            CapabilityGrantStatus::Active => self.active_grants += 1,
+            CapabilityGrantStatus::Pending => self.pending_grants += 1,
+            CapabilityGrantStatus::Revoked => self.revoked_grants += 1,
+            CapabilityGrantStatus::Expired => self.expired_grants += 1,
+        }
+        match &grant.scope {
+            CapabilityGrantScope::Tool(_) => self.tool_grants += 1,
+            CapabilityGrantScope::Capability(_) => self.capability_grants += 1,
+            CapabilityGrantScope::EntityCapability { .. } => self.entity_capability_grants += 1,
+            CapabilityGrantScope::AllSmartHome => self.all_smart_home_grants += 1,
+        }
+        match grant.max_tier {
+            PrivilegeTier::ReadOnly => self.read_only_tier_grants += 1,
+            PrivilegeTier::LowRisk => self.low_risk_tier_grants += 1,
+            PrivilegeTier::HumanApproval => self.human_approval_tier_grants += 1,
+            PrivilegeTier::HighRisk => self.high_risk_tier_grants += 1,
+        }
+        if grant.expires_at_ms.is_some() {
+            self.expiring_grants += 1;
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_grants == 0
+    }
+
+    pub fn has_active_grants(&self) -> bool {
+        self.active_grants > 0
+    }
+
+    pub fn needs_review(&self) -> bool {
+        self.pending_grants > 0 || self.revoked_grants > 0 || self.expired_grants > 0
     }
 }
 
@@ -1983,6 +2067,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::InspectEventLog,
         SmartHomeTool::ListAuthorizationDecisions,
         SmartHomeTool::GetAuthorizationSummary,
+        SmartHomeTool::ListCapabilityGrants,
+        SmartHomeTool::GetCapabilityGrantSummary,
         SmartHomeTool::GetRuntimeSnapshot,
         SmartHomeTool::ListDesiredStates,
         SmartHomeTool::ListPairingSessions,
@@ -2789,7 +2875,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 26);
+        assert_eq!(catalog.len(), 28);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2853,6 +2939,15 @@ mod tests {
         ));
         assert!(catalog
             .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_capability_grants"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_capability_grant_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
             .any(|tool| tool.tool_id == "smart_home.get_runtime_snapshot"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -2887,15 +2982,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 26);
-        assert_eq!(summary.read_tools, 22);
+        assert_eq!(summary.total_tools, 28);
+        assert_eq!(summary.read_tools, 24);
         assert_eq!(summary.write_tools, 0);
         assert_eq!(summary.external_tools, 4);
-        assert_eq!(summary.read_only_tier_tools, 22);
+        assert_eq!(summary.read_only_tier_tools, 24);
         assert_eq!(summary.low_risk_tier_tools, 3);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 26);
+        assert_eq!(summary.total_required_capabilities, 28);
         assert_eq!(summary.risky_tool_count(), 4);
         assert_eq!(summary.approval_gated_tool_count(), 1);
         assert!(pair_bridge.requires_human_approval());
@@ -2933,6 +3028,70 @@ mod tests {
         assert!(!command.is_satisfied_by(&principal, &grants, 2_000));
         assert!(!command.is_satisfied_by(&other_principal, &grants, 1_500));
         assert_eq!(grants[1].status_at(2_000), CapabilityGrantStatus::Expired);
+    }
+
+    #[test]
+    fn capability_grant_inventory_summary_counts_status_scope_and_tier() {
+        let lighting_principal = AgentId::trusted("agent:lighting-planner");
+        let installer_principal = AgentId::trusted("agent:installer");
+        let grants = vec![
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                lighting_principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            ),
+            CapabilityGrant::for_tool(
+                CapabilityGrantId::trusted("grant-command"),
+                lighting_principal.clone(),
+                SmartHomeTool::Command,
+                "chief-of-staff",
+                1_010,
+            )
+            .with_expiry(2_000),
+            CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant-entity-command"),
+                lighting_principal,
+                EntityId::trusted("entity-light-1"),
+                CapabilityId::trusted("light.on_off"),
+                PrivilegeTier::LowRisk,
+                "chief-of-staff",
+                1_020,
+            )
+            .with_status(CapabilityGrantStatus::Revoked),
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-installer"),
+                installer_principal,
+                PrivilegeTier::HumanApproval,
+                "chief-of-staff",
+                1_030,
+            )
+            .with_status(CapabilityGrantStatus::Pending),
+        ];
+
+        let summary = CapabilityGrantInventorySummary::from_grants_at(&grants, 2_000);
+
+        assert_eq!(summary.generated_at_ms, 2_000);
+        assert_eq!(summary.total_grants, 4);
+        assert_eq!(summary.active_grants, 1);
+        assert_eq!(summary.pending_grants, 1);
+        assert_eq!(summary.revoked_grants, 1);
+        assert_eq!(summary.expired_grants, 1);
+        assert_eq!(summary.tool_grants, 1);
+        assert_eq!(summary.capability_grants, 1);
+        assert_eq!(summary.entity_capability_grants, 1);
+        assert_eq!(summary.all_smart_home_grants, 1);
+        assert_eq!(summary.read_only_tier_grants, 1);
+        assert_eq!(summary.low_risk_tier_grants, 2);
+        assert_eq!(summary.human_approval_tier_grants, 1);
+        assert_eq!(summary.high_risk_tier_grants, 0);
+        assert_eq!(summary.expiring_grants, 1);
+        assert_eq!(summary.unique_principals, 2);
+        assert!(summary.has_active_grants());
+        assert!(summary.needs_review());
+        assert!(CapabilityGrantInventorySummary::empty(3_000).is_empty());
     }
 
     #[test]

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -63,6 +63,9 @@ All notable changes to this package will be documented in this file.
 - `RuntimeReadToolRequest::ListAuthorizationDecisions` and
   `RuntimeReadToolRequest::GetAuthorizationSummary` for authorized D18D reads
   over registry-backed smart-home authorization audit decisions.
+- `RuntimeReadToolRequest::ListCapabilityGrants` and
+  `RuntimeReadToolRequest::GetCapabilityGrantSummary` for authorized D18D
+  reads over registry-backed smart-home capability grant governance.
 - `RuntimeReadToolRequest::GetRuntimeSnapshot`,
   `RuntimeReadToolRequest::ListDesiredStates`, and
   `RuntimeReadToolRequest::ListPairingSessions` for authorized D18D reads over

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -63,12 +63,14 @@ Included surfaces:
   authorized commands
 - registry-backed tool authorization decisions for Chief of Staff tool calls
 - read-side authorization-decision queries and summaries for Chief audit tools
+- read-side capability-grant queries and summaries for Chief grant governance
+  tools
 - D18D-facing read tool facade for listing bridges/devices/scenes, describing
   scenes, reading entity state, describing capabilities, inspecting bridge
   health, listing event subscriptions, inspecting event-log entries, reading
-  authorization decisions and summaries, reading compact runtime snapshots,
-  listing desired-state targets, listing pairing sessions, listing supervised
-  bridge workers, reading worker heartbeat
+  authorization decisions and summaries, reading capability grants and
+  summaries, reading compact runtime snapshots, listing desired-state targets,
+  listing pairing sessions, listing supervised bridge workers, reading worker heartbeat
   schedules, previewing supervision plans, and observing supervision status
   without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -9,12 +9,12 @@
 
 use smart_home_core::{
     tier_for_command, AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary,
-    AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant, CapabilityGrantScope,
-    CapabilityId, CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType,
-    CorrelationId, Device, DeviceCommand, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId,
-    EventId, Health, IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope,
-    SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
-    VaultRef,
+    AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant,
+    CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
+    CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
+    DeviceCommand, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId, EventId, Health,
+    IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope, SmartHomeError,
+    SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError, DiscoveryRecord,
@@ -3289,6 +3289,82 @@ impl RuntimeAuthorizationDecisionQuery {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCapabilityGrantScopeKind {
+    Tool,
+    Capability,
+    EntityCapability,
+    AllSmartHome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCapabilityGrantSort {
+    GrantId,
+    PrincipalId,
+    GrantedAtAsc,
+    GrantedAtDesc,
+    ExpiresAtAsc,
+    ExpiresAtDesc,
+}
+
+impl Default for RuntimeCapabilityGrantSort {
+    fn default() -> Self {
+        Self::GrantId
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeCapabilityGrantQuery {
+    pub principal_id: Option<AgentId>,
+    pub status: Option<CapabilityGrantStatus>,
+    pub scope_kind: Option<RuntimeCapabilityGrantScopeKind>,
+    pub capability_id: Option<CapabilityId>,
+    pub entity_id: Option<EntityId>,
+    pub sort: RuntimeCapabilityGrantSort,
+    pub limit: Option<usize>,
+}
+
+impl RuntimeCapabilityGrantQuery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_principal(mut self, principal_id: AgentId) -> Self {
+        self.principal_id = Some(principal_id);
+        self
+    }
+
+    pub fn with_status(mut self, status: CapabilityGrantStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn with_scope_kind(mut self, scope_kind: RuntimeCapabilityGrantScopeKind) -> Self {
+        self.scope_kind = Some(scope_kind);
+        self
+    }
+
+    pub fn with_capability(mut self, capability_id: CapabilityId) -> Self {
+        self.capability_id = Some(capability_id);
+        self
+    }
+
+    pub fn for_entity(mut self, entity_id: EntityId) -> Self {
+        self.entity_id = Some(entity_id);
+        self
+    }
+
+    pub fn sorted_by(mut self, sort: RuntimeCapabilityGrantSort) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeReadToolRequest {
     GetRuntimeSnapshot,
@@ -3327,6 +3403,12 @@ pub enum RuntimeReadToolRequest {
     GetAuthorizationSummary {
         query: RuntimeAuthorizationDecisionQuery,
     },
+    ListCapabilityGrants {
+        query: RuntimeCapabilityGrantQuery,
+    },
+    GetCapabilityGrantSummary {
+        query: RuntimeCapabilityGrantQuery,
+    },
     ListDesiredStates {
         query: DesiredStateQuery,
     },
@@ -3360,6 +3442,8 @@ impl RuntimeReadToolRequest {
             Self::InspectEventLog { .. } => SmartHomeTool::InspectEventLog,
             Self::ListAuthorizationDecisions { .. } => SmartHomeTool::ListAuthorizationDecisions,
             Self::GetAuthorizationSummary { .. } => SmartHomeTool::GetAuthorizationSummary,
+            Self::ListCapabilityGrants { .. } => SmartHomeTool::ListCapabilityGrants,
+            Self::GetCapabilityGrantSummary { .. } => SmartHomeTool::GetCapabilityGrantSummary,
             Self::ListDesiredStates { .. } => SmartHomeTool::ListDesiredStates,
             Self::ListPairingSessions { .. } => SmartHomeTool::ListPairingSessions,
             Self::ListWorkers { .. } => SmartHomeTool::ListWorkers,
@@ -3611,6 +3695,13 @@ pub enum RuntimeReadToolOutput {
     },
     AuthorizationSummary {
         summary: AuthorizationDecisionLogSummary,
+    },
+    CapabilityGrants {
+        grants: Vec<CapabilityGrant>,
+        summary: CapabilityGrantInventorySummary,
+    },
+    CapabilityGrantSummary {
+        summary: CapabilityGrantInventorySummary,
     },
     DesiredStates {
         desired_states: Vec<DesiredEntityState>,
@@ -3873,6 +3964,79 @@ impl SmartHomeRuntime {
         query: &RuntimeAuthorizationDecisionQuery,
     ) -> AuthorizationDecisionLogSummary {
         AuthorizationDecisionLogSummary::from_decisions(self.query_authorization_decisions(query))
+    }
+
+    pub fn query_capability_grants_at(
+        &self,
+        query: &RuntimeCapabilityGrantQuery,
+        now_ms: u64,
+    ) -> Vec<&CapabilityGrant> {
+        if query.limit == Some(0) {
+            return Vec::new();
+        }
+
+        let mut grants = match &query.principal_id {
+            Some(principal_id) => self.registry.capability_grants_for_principal(principal_id),
+            None => self.registry.capability_grants().collect::<Vec<_>>(),
+        }
+        .into_iter()
+        .filter(|grant| capability_grant_matches_query(grant, query, now_ms))
+        .collect::<Vec<_>>();
+        match query.sort {
+            RuntimeCapabilityGrantSort::GrantId => {
+                grants.sort_by(|left, right| left.grant_id.cmp(&right.grant_id));
+            }
+            RuntimeCapabilityGrantSort::PrincipalId => {
+                grants.sort_by(|left, right| {
+                    left.principal_id
+                        .cmp(&right.principal_id)
+                        .then_with(|| left.grant_id.cmp(&right.grant_id))
+                });
+            }
+            RuntimeCapabilityGrantSort::GrantedAtAsc => {
+                grants.sort_by(|left, right| {
+                    left.granted_at_ms
+                        .cmp(&right.granted_at_ms)
+                        .then_with(|| left.grant_id.cmp(&right.grant_id))
+                });
+            }
+            RuntimeCapabilityGrantSort::GrantedAtDesc => {
+                grants.sort_by(|left, right| {
+                    right
+                        .granted_at_ms
+                        .cmp(&left.granted_at_ms)
+                        .then_with(|| left.grant_id.cmp(&right.grant_id))
+                });
+            }
+            RuntimeCapabilityGrantSort::ExpiresAtAsc => {
+                grants.sort_by(|left, right| {
+                    left.expires_at_ms
+                        .cmp(&right.expires_at_ms)
+                        .then_with(|| left.grant_id.cmp(&right.grant_id))
+                });
+            }
+            RuntimeCapabilityGrantSort::ExpiresAtDesc => {
+                grants.sort_by(|left, right| {
+                    right
+                        .expires_at_ms
+                        .cmp(&left.expires_at_ms)
+                        .then_with(|| left.grant_id.cmp(&right.grant_id))
+                });
+            }
+        }
+        apply_limit(&mut grants, query.limit);
+        grants
+    }
+
+    pub fn capability_grant_summary_at(
+        &self,
+        query: &RuntimeCapabilityGrantQuery,
+        now_ms: u64,
+    ) -> CapabilityGrantInventorySummary {
+        CapabilityGrantInventorySummary::from_grants_at(
+            self.query_capability_grants_at(query, now_ms),
+            now_ms,
+        )
     }
 
     pub fn desired_state(&self, entity_id: &EntityId) -> Option<&DesiredEntityState> {
@@ -4558,6 +4722,20 @@ impl SmartHomeRuntime {
             RuntimeReadToolRequest::GetAuthorizationSummary { query } => {
                 Ok(RuntimeReadToolOutput::AuthorizationSummary {
                     summary: self.authorization_decision_summary(&query),
+                })
+            }
+            RuntimeReadToolRequest::ListCapabilityGrants { query } => {
+                let grant_refs = self.query_capability_grants_at(&query, now_ms);
+                let summary = CapabilityGrantInventorySummary::from_grants_at(
+                    grant_refs.iter().copied(),
+                    now_ms,
+                );
+                let grants = grant_refs.into_iter().cloned().collect();
+                Ok(RuntimeReadToolOutput::CapabilityGrants { grants, summary })
+            }
+            RuntimeReadToolRequest::GetCapabilityGrantSummary { query } => {
+                Ok(RuntimeReadToolOutput::CapabilityGrantSummary {
+                    summary: self.capability_grant_summary_at(&query, now_ms),
                 })
             }
             RuntimeReadToolRequest::ListDesiredStates { query } => {
@@ -5458,6 +5636,63 @@ fn desired_state_matches_query(
         && query
             .max_command_timeout_ms
             .is_none_or(|maximum| desired_state.command_timeout_ms <= maximum)
+}
+
+fn capability_grant_matches_query(
+    grant: &CapabilityGrant,
+    query: &RuntimeCapabilityGrantQuery,
+    now_ms: u64,
+) -> bool {
+    query
+        .status
+        .is_none_or(|status| grant.status_at(now_ms) == status)
+        && query
+            .scope_kind
+            .is_none_or(|scope_kind| capability_grant_scope_matches_kind(&grant.scope, scope_kind))
+        && query
+            .capability_id
+            .as_ref()
+            .is_none_or(|capability_id| match &grant.scope {
+                CapabilityGrantScope::Capability(granted)
+                | CapabilityGrantScope::EntityCapability {
+                    capability_id: granted,
+                    ..
+                } => granted == capability_id,
+                CapabilityGrantScope::Tool(_) | CapabilityGrantScope::AllSmartHome => false,
+            })
+        && query
+            .entity_id
+            .as_ref()
+            .is_none_or(|entity_id| match &grant.scope {
+                CapabilityGrantScope::EntityCapability {
+                    entity_id: granted, ..
+                } => granted == entity_id,
+                CapabilityGrantScope::Tool(_)
+                | CapabilityGrantScope::Capability(_)
+                | CapabilityGrantScope::AllSmartHome => false,
+            })
+}
+
+fn capability_grant_scope_matches_kind(
+    scope: &CapabilityGrantScope,
+    kind: RuntimeCapabilityGrantScopeKind,
+) -> bool {
+    matches!(
+        (scope, kind),
+        (
+            CapabilityGrantScope::Tool(_),
+            RuntimeCapabilityGrantScopeKind::Tool
+        ) | (
+            CapabilityGrantScope::Capability(_),
+            RuntimeCapabilityGrantScopeKind::Capability
+        ) | (
+            CapabilityGrantScope::EntityCapability { .. },
+            RuntimeCapabilityGrantScopeKind::EntityCapability
+        ) | (
+            CapabilityGrantScope::AllSmartHome,
+            RuntimeCapabilityGrantScopeKind::AllSmartHome
+        )
+    )
 }
 
 fn pairing_session_matches_query(
@@ -6551,6 +6786,93 @@ mod tests {
                     && summary.decisions_with_missing_capabilities == 1
         ));
         assert_eq!(runtime.registry().counts().authorization_decisions, 3);
+    }
+
+    #[test]
+    fn capability_grant_read_tools_filter_effective_status_and_scope() {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:lighting-planner");
+        let installer = AgentId::trusted("agent:installer");
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-read"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.read"),
+                PrivilegeTier::ReadOnly,
+                "chief-of-staff",
+                1_000,
+            ));
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant-light-command"),
+                principal.clone(),
+                EntityId::trusted("entity-light-1"),
+                CapabilityId::trusted("light.on_off"),
+                PrivilegeTier::LowRisk,
+                "chief-of-staff",
+                1_100,
+            )
+            .with_expiry(2_000),
+        );
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-installer"),
+                installer,
+                PrivilegeTier::HumanApproval,
+                "chief-of-staff",
+                1_200,
+            )
+            .with_status(CapabilityGrantStatus::Pending),
+        );
+
+        let grants = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::ListCapabilityGrants {
+                    query: RuntimeCapabilityGrantQuery::new()
+                        .for_principal(principal.clone())
+                        .with_status(CapabilityGrantStatus::Expired)
+                        .with_scope_kind(RuntimeCapabilityGrantScopeKind::EntityCapability)
+                        .with_capability(CapabilityId::trusted("light.on_off"))
+                        .for_entity(EntityId::trusted("entity-light-1"))
+                        .sorted_by(RuntimeCapabilityGrantSort::GrantedAtDesc),
+                },
+                2_500,
+            )
+            .unwrap();
+        let summary = runtime
+            .execute_read_tool(
+                principal,
+                RuntimeReadToolRequest::GetCapabilityGrantSummary {
+                    query: RuntimeCapabilityGrantQuery::new()
+                        .with_status(CapabilityGrantStatus::Pending)
+                        .with_scope_kind(RuntimeCapabilityGrantScopeKind::AllSmartHome),
+                },
+                2_501,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            grants,
+            RuntimeReadToolOutput::CapabilityGrants { grants, summary }
+                if grants.len() == 1
+                    && grants[0].grant_id == CapabilityGrantId::trusted("grant-light-command")
+                    && summary.total_grants == 1
+                    && summary.expired_grants == 1
+                    && summary.entity_capability_grants == 1
+                    && summary.unique_principals == 1
+        ));
+        assert!(matches!(
+            summary,
+            RuntimeReadToolOutput::CapabilityGrantSummary { summary }
+                if summary.total_grants == 1
+                    && summary.pending_grants == 1
+                    && summary.all_smart_home_grants == 1
+                    && summary.human_approval_tier_grants == 1
+                    && summary.needs_review()
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 2);
     }
 
     #[test]
@@ -8352,6 +8674,30 @@ mod tests {
                 1_517,
             )
             .unwrap();
+        let capability_grants = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::ListCapabilityGrants {
+                    query: RuntimeCapabilityGrantQuery::new()
+                        .for_principal(AgentId::trusted("agent:observer"))
+                        .with_status(CapabilityGrantStatus::Active)
+                        .with_scope_kind(RuntimeCapabilityGrantScopeKind::Capability)
+                        .with_capability(CapabilityId::trusted("smart_home.read")),
+                },
+                1_518,
+            )
+            .unwrap();
+        let capability_grant_summary = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::GetCapabilityGrantSummary {
+                    query: RuntimeCapabilityGrantQuery::new()
+                        .with_status(CapabilityGrantStatus::Active)
+                        .with_scope_kind(RuntimeCapabilityGrantScopeKind::Capability),
+                },
+                1_519,
+            )
+            .unwrap();
 
         assert!(matches!(
             bridges,
@@ -8514,7 +8860,25 @@ mod tests {
                     && summary.denied_decisions == 0
                     && summary.tool_decisions == 18
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 18);
+        assert!(matches!(
+            capability_grants,
+            RuntimeReadToolOutput::CapabilityGrants { grants, summary }
+                if grants.len() == 1
+                    && grants[0].grant_id == CapabilityGrantId::trusted("grant-read")
+                    && summary.total_grants == 1
+                    && summary.active_grants == 1
+                    && summary.capability_grants == 1
+                    && summary.read_only_tier_grants == 1
+        ));
+        assert!(matches!(
+            capability_grant_summary,
+            RuntimeReadToolOutput::CapabilityGrantSummary { summary }
+                if summary.total_grants == 1
+                    && summary.active_grants == 1
+                    && summary.unique_principals == 1
+                    && !summary.needs_review()
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 20);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add read-only smart-home capability grant inventory and summary tool descriptors
- expose runtime grant query/summarization APIs with effective status filtering and deterministic sorting
- wire Chief-of-Staff smart-home tools to list and summarize grants through JSON/D18D adapters

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools

Generated code/packages/rust/Cargo.lock was removed before commit.