### PR TITLE
Add browser embedded policy descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -252,7 +252,8 @@ documented in this file.
 - Browser-facing document, content-tree, and render-tree projections now carry
   embedded resource metadata for frames, objects, embeds, media, and images,
   including resolved source URLs, resource kind, type hints, media attributes,
-  and authored dimensions for fetch and layout planning.
+  authored dimensions, and flattened embedded policy descriptors for fetch,
+  sandboxing, permissions, and fallback planning.
 - Browser-facing document, content-tree, and render-tree projections now carry
   media playback metadata for `audio` and `video`, including playback flags,
   preload/poster fields, and flattened playback descriptors with source/track

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -855,6 +855,7 @@ pub struct BrowserDocument {
     pub media: Vec<BrowserMedia>,
     pub media_playback_descriptors: Vec<BrowserMediaPlaybackDescriptor>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
+    pub embedded_policy_descriptors: Vec<BrowserEmbeddedPolicyDescriptor>,
     pub interactive_elements: Vec<BrowserInteractiveElement>,
     pub disclosures: Vec<BrowserDisclosure>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
@@ -2038,6 +2039,31 @@ pub struct BrowserEmbeddedContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserEmbeddedPolicyDescriptor {
+    pub element: String,
+    pub resource_kind: String,
+    pub url: Option<String>,
+    pub resolved_url: Option<String>,
+    pub browsing_context_name: Option<String>,
+    pub title: Option<String>,
+    pub type_hint: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub loading: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub csp: Option<String>,
+    pub sandbox: Vec<String>,
+    pub sandbox_token_count: usize,
+    pub allow: Option<String>,
+    pub allowfullscreen: bool,
+    pub referrerpolicy: Option<String>,
+    pub srcdoc: Option<String>,
+    pub has_srcdoc: bool,
+    pub credentialless: bool,
+    pub fallback_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserInteractiveElement {
     pub element: String,
     pub id: Option<String>,
@@ -2646,6 +2672,8 @@ impl BrowserDocument {
             body_children,
         );
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
+        summary.embedded_policy_descriptors =
+            browser_embedded_policy_descriptors(&summary.embedded_contexts);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -10258,6 +10286,52 @@ fn browser_media_playback_descriptor(media: &BrowserMedia) -> BrowserMediaPlayba
     }
 }
 
+fn browser_embedded_policy_descriptors(
+    contexts: &[BrowserEmbeddedContext],
+) -> Vec<BrowserEmbeddedPolicyDescriptor> {
+    contexts
+        .iter()
+        .map(browser_embedded_policy_descriptor)
+        .collect()
+}
+
+fn browser_embedded_policy_descriptor(
+    context: &BrowserEmbeddedContext,
+) -> BrowserEmbeddedPolicyDescriptor {
+    BrowserEmbeddedPolicyDescriptor {
+        element: context.element.clone(),
+        resource_kind: browser_embedded_resource_kind(&context.element).to_string(),
+        url: context.url.clone(),
+        resolved_url: context.resolved_url.clone(),
+        browsing_context_name: context.browsing_context_name.clone(),
+        title: context.title.clone(),
+        type_hint: context.type_hint.clone(),
+        width: context.width.clone(),
+        height: context.height.clone(),
+        loading: context.loading.clone(),
+        fetchpriority: context.fetchpriority.clone(),
+        csp: context.csp.clone(),
+        sandbox: context.sandbox.clone(),
+        sandbox_token_count: context.sandbox.len(),
+        allow: context.allow.clone(),
+        allowfullscreen: context.allowfullscreen,
+        referrerpolicy: context.referrerpolicy.clone(),
+        srcdoc: context.srcdoc.clone(),
+        has_srcdoc: context.srcdoc.is_some(),
+        credentialless: context.credentialless,
+        fallback_text: context.fallback_text.clone(),
+    }
+}
+
+fn browser_embedded_resource_kind(element: &str) -> &'static str {
+    match element {
+        "iframe" | "frame" => "document",
+        "object" => "object",
+        "embed" => "embed",
+        _ => "embedded",
+    }
+}
+
 fn browser_resource_endpoint_descriptor(
     resource: &BrowserResource,
 ) -> BrowserResourceEndpointDescriptor {
@@ -17152,6 +17226,62 @@ mod tests {
         );
         assert!(render_tree.children[0].allowfullscreen);
         assert_eq!(render_tree.children[1].display, "inline-replaced");
+    }
+
+    #[test]
+    fn browser_embedded_policy_descriptors_track_context_policy_and_fallbacks() {
+        let document = parse_html(
+            "<base href=\"https://example.test/media/index.html\">\
+             <iframe src=frame.html name=preview loading=lazy fetchpriority=high \
+                 csp=\"script-src 'self'\" sandbox=\"allow-scripts allow-same-origin\" \
+                 allow=\"fullscreen; geolocation\" allowfullscreen \
+                 referrerpolicy=no-referrer srcdoc=\"<p>Fallback</p>\" \
+                 credentialless width=320 height=200 title=Frame></iframe>\
+             <object data=movie.swf type=\"application/x-shockwave-flash\" width=400 height=300>\
+                 Fallback player\
+             </object>\
+             <embed src=legacy.mov type=\"video/quicktime\" width=160 height=120>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.embedded_policy_descriptors.len(), 3);
+
+        let frame = &summary.embedded_policy_descriptors[0];
+        assert_eq!(frame.element, "iframe");
+        assert_eq!(frame.resource_kind, "document");
+        assert_eq!(frame.url.as_deref(), Some("frame.html"));
+        assert_eq!(
+            frame.resolved_url.as_deref(),
+            Some("https://example.test/media/frame.html")
+        );
+        assert_eq!(frame.browsing_context_name.as_deref(), Some("preview"));
+        assert_eq!(frame.title.as_deref(), Some("Frame"));
+        assert_eq!(frame.width.as_deref(), Some("320"));
+        assert_eq!(frame.loading.as_deref(), Some("lazy"));
+        assert_eq!(frame.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(frame.csp.as_deref(), Some("script-src 'self'"));
+        assert_eq!(frame.sandbox, vec!["allow-scripts", "allow-same-origin"]);
+        assert_eq!(frame.sandbox_token_count, 2);
+        assert_eq!(frame.allow.as_deref(), Some("fullscreen; geolocation"));
+        assert!(frame.allowfullscreen);
+        assert_eq!(frame.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(frame.srcdoc.as_deref(), Some("<p>Fallback</p>"));
+        assert!(frame.has_srcdoc);
+        assert!(frame.credentialless);
+
+        let object = &summary.embedded_policy_descriptors[1];
+        assert_eq!(object.resource_kind, "object");
+        assert_eq!(
+            object.type_hint.as_deref(),
+            Some("application/x-shockwave-flash")
+        );
+        assert_eq!(object.fallback_text, "Fallback player");
+
+        let embed = &summary.embedded_policy_descriptors[2];
+        assert_eq!(embed.resource_kind, "embed");
+        assert_eq!(embed.type_hint.as_deref(), Some("video/quicktime"));
+        assert!(!embed.has_srcdoc);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,11 +3,11 @@ use coding_adventures_html_parser::{
     BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
-    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserFetchPolicyDescriptor,
-    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
-    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
+    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor,
+    BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
+    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
+    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
+    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
     BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
@@ -110,6 +110,8 @@ struct ExpectedBrowserDocument {
     media_playback_descriptors: Option<Vec<ExpectedMediaPlaybackDescriptor>>,
     #[serde(default)]
     embedded_contexts: Vec<ExpectedEmbeddedContext>,
+    #[serde(default)]
+    embedded_policy_descriptors: Option<Vec<ExpectedEmbeddedPolicyDescriptor>>,
     #[serde(default)]
     interactive_elements: Vec<ExpectedInteractiveElement>,
     #[serde(default)]
@@ -1501,6 +1503,51 @@ struct ExpectedEmbeddedContext {
     referrerpolicy: Option<String>,
     #[serde(default)]
     srcdoc: Option<String>,
+    #[serde(default)]
+    credentialless: bool,
+    #[serde(default)]
+    fallback_text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedEmbeddedPolicyDescriptor {
+    element: String,
+    #[serde(default)]
+    resource_kind: String,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    browsing_context_name: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    csp: Option<String>,
+    #[serde(default)]
+    sandbox: Vec<String>,
+    #[serde(default)]
+    sandbox_token_count: usize,
+    #[serde(default)]
+    allow: Option<String>,
+    #[serde(default)]
+    allowfullscreen: bool,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    srcdoc: Option<String>,
+    #[serde(default)]
+    has_srcdoc: bool,
     #[serde(default)]
     credentialless: bool,
     #[serde(default)]
@@ -3828,6 +3875,11 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedMedia::into_browser_media)
             .collect();
+        let embedded_contexts: Vec<_> = self
+            .embedded_contexts
+            .into_iter()
+            .map(ExpectedEmbeddedContext::into_browser_embedded_context)
+            .collect();
         let resource_endpoint_descriptors = self
             .resource_endpoint_descriptors
             .map(|descriptors| {
@@ -3848,6 +3900,15 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_media_playback_descriptors(&media));
+        let embedded_policy_descriptors = self
+            .embedded_policy_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedEmbeddedPolicyDescriptor::into_browser_embedded_policy_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_embedded_policy_descriptors(&embedded_contexts));
 
         BrowserDocument {
             title: self.title,
@@ -3977,11 +4038,8 @@ impl ExpectedBrowserDocument {
                 .collect(),
             media,
             media_playback_descriptors,
-            embedded_contexts: self
-                .embedded_contexts
-                .into_iter()
-                .map(ExpectedEmbeddedContext::into_browser_embedded_context)
-                .collect(),
+            embedded_contexts,
+            embedded_policy_descriptors,
             interactive_elements: self
                 .interactive_elements
                 .into_iter()
@@ -4474,6 +4532,52 @@ fn expected_media_playback_descriptor(media: &BrowserMedia) -> BrowserMediaPlayb
             .filter(|track| track.default_track)
             .count(),
         tracks: media.tracks.clone(),
+    }
+}
+
+fn expected_embedded_policy_descriptors(
+    contexts: &[BrowserEmbeddedContext],
+) -> Vec<BrowserEmbeddedPolicyDescriptor> {
+    contexts
+        .iter()
+        .map(expected_embedded_policy_descriptor)
+        .collect()
+}
+
+fn expected_embedded_policy_descriptor(
+    context: &BrowserEmbeddedContext,
+) -> BrowserEmbeddedPolicyDescriptor {
+    BrowserEmbeddedPolicyDescriptor {
+        element: context.element.clone(),
+        resource_kind: expected_embedded_resource_kind(&context.element).to_string(),
+        url: context.url.clone(),
+        resolved_url: context.resolved_url.clone(),
+        browsing_context_name: context.browsing_context_name.clone(),
+        title: context.title.clone(),
+        type_hint: context.type_hint.clone(),
+        width: context.width.clone(),
+        height: context.height.clone(),
+        loading: context.loading.clone(),
+        fetchpriority: context.fetchpriority.clone(),
+        csp: context.csp.clone(),
+        sandbox: context.sandbox.clone(),
+        sandbox_token_count: context.sandbox.len(),
+        allow: context.allow.clone(),
+        allowfullscreen: context.allowfullscreen,
+        referrerpolicy: context.referrerpolicy.clone(),
+        srcdoc: context.srcdoc.clone(),
+        has_srcdoc: context.srcdoc.is_some(),
+        credentialless: context.credentialless,
+        fallback_text: context.fallback_text.clone(),
+    }
+}
+
+fn expected_embedded_resource_kind(element: &str) -> &'static str {
+    match element {
+        "iframe" | "frame" => "document",
+        "object" => "object",
+        "embed" => "embed",
+        _ => "embedded",
     }
 }
 
@@ -5272,6 +5376,34 @@ impl ExpectedEmbeddedContext {
             allowfullscreen: self.allowfullscreen,
             referrerpolicy: self.referrerpolicy,
             srcdoc: self.srcdoc,
+            credentialless: self.credentialless,
+            fallback_text: self.fallback_text,
+        }
+    }
+}
+
+impl ExpectedEmbeddedPolicyDescriptor {
+    fn into_browser_embedded_policy_descriptor(self) -> BrowserEmbeddedPolicyDescriptor {
+        BrowserEmbeddedPolicyDescriptor {
+            element: self.element,
+            resource_kind: self.resource_kind,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            browsing_context_name: self.browsing_context_name,
+            title: self.title,
+            type_hint: self.type_hint,
+            width: self.width,
+            height: self.height,
+            loading: self.loading,
+            fetchpriority: self.fetchpriority,
+            csp: self.csp,
+            sandbox: self.sandbox,
+            sandbox_token_count: self.sandbox_token_count,
+            allow: self.allow,
+            allowfullscreen: self.allowfullscreen,
+            referrerpolicy: self.referrerpolicy,
+            srcdoc: self.srcdoc,
+            has_srcdoc: self.has_srcdoc,
             credentialless: self.credentialless,
             fallback_text: self.fallback_text,
         }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -32,7 +32,8 @@ error-message, and flow relationship target text.
 Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
 decoding, fetch priority, blocking, and media preload metadata.
 Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
-iframe CSP/sandbox/permissions, fullscreen, and credentialless metadata.
+iframe CSP/sandbox/permissions, fullscreen, credentialless metadata, and
+flattened embedded-policy descriptors.
 Resource-endpoint descriptor cases pin refresh redirects plus resolved document
 resources as a flat endpoint inventory for fetch/navigation planning.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -680,6 +680,12 @@
           { "element": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "type_hint": "video/quicktime", "width": "160", "height": "120", "fallback_text": "" },
           { "element": "iframe", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "allow": "payment", "srcdoc": "<h1>Inline</h1>", "fallback_text": "" }
         ],
+        "embedded_policy_descriptors": [
+          { "element": "iframe", "resource_kind": "document", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "fetchpriority": "high", "csp": "script-src 'self'", "sandbox": ["allow-scripts", "allow-same-origin"], "sandbox_token_count": 2, "allow": "fullscreen; geolocation", "allowfullscreen": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "has_srcdoc": true, "credentialless": true, "fallback_text": "" },
+          { "element": "object", "resource_kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "" },
+          { "element": "embed", "resource_kind": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "type_hint": "video/quicktime", "width": "160", "height": "120", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "" },
+          { "element": "iframe", "resource_kind": "document", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "sandbox_token_count": 0, "allow": "payment", "srcdoc": "<h1>Inline</h1>", "has_srcdoc": true, "fallback_text": "" }
+        ],
         "forms": [],
         "tables": []
       }
@@ -1743,6 +1749,11 @@
           { "element": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "fallback_text": "Fallback player" },
           { "element": "object", "url": "/external.bin", "resolved_url": "https://example.test/external.bin", "type_hint": "application/octet-stream", "fallback_text": "External fallback" },
           { "element": "object", "url": "outside.bin", "resolved_url": "https://example.test/media/outside.bin", "fallback_text": "Outside fallback" }
+        ],
+        "embedded_policy_descriptors": [
+          { "element": "object", "resource_kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "Fallback player" },
+          { "element": "object", "resource_kind": "object", "url": "/external.bin", "resolved_url": "https://example.test/external.bin", "type_hint": "application/octet-stream", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "External fallback" },
+          { "element": "object", "resource_kind": "object", "url": "outside.bin", "resolved_url": "https://example.test/media/outside.bin", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "Outside fallback" }
         ],
         "form_policy_descriptors": [
           { "id": "player", "method": "get" }


### PR DESCRIPTION
## Summary
- add flattened browser embedded-policy descriptors for iframe/frame/object/embed policy and endpoint planning
- derive descriptor fields from embedded-context summaries, including resource kind, sandbox counts, srcdoc state, and fallbacks
- pin embedded descriptor expectations in browser-readiness fixtures and update fixture docs/changelog

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_embedded_policy_descriptors_track_context_policy_and_fallbacks
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser