### PR TITLE
Expose Chief smart-home topology tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_capability_grant_summary` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect grant governance without owning
   smart-home authorization policy.
+- Added `smart_home.list_rooms` and `smart_home.get_topology_summary` handlers
+  over the D23 runtime read facade so Chief of Staff jobs can inspect room,
+  state, and scene coverage without owning registry topology logic.
 - Added `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`,
   and `smart_home.list_pairing_sessions` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect automation backlog, reconciliation

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -26,6 +26,7 @@ Chief of Staff job/session/agent
   -> D18D smart_home.discover / smart_home.command tool calls
   -> smart-home runtime authorization
   -> discovery records and unpaired bridge candidates
+  -> room topology and aggregate topology summary reads
   -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
   -> event-log and subscription-backlog reads
@@ -49,6 +50,7 @@ Chief of Staff job/session/agent
 - `smart_home.discover`
 - `smart_home.list_bridges`
 - `smart_home.list_devices`
+- `smart_home.list_rooms`
 - `smart_home.list_scenes`
 - `smart_home.describe_scene`
 - `smart_home.get_state`
@@ -65,6 +67,7 @@ Chief of Staff job/session/agent
 - `smart_home.list_capability_grants`
 - `smart_home.get_capability_grant_summary`
 - `smart_home.get_runtime_snapshot`
+- `smart_home.get_topology_summary`
 - `smart_home.list_desired_states`
 - `smart_home.list_pairing_sessions`
 - `smart_home.list_workers`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,6 +36,7 @@ use smart_home_integration_catalog::{
     IntegrationReadinessReport, PrimitiveBacklogCoverageItem, PrimitiveBacklogItem,
     PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
+use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
 use smart_home_runtime::{
     DesiredEntityState, DesiredStateAction, DesiredStateInventorySummary, DesiredStateQuery,
@@ -49,15 +50,15 @@ use smart_home_runtime::{
     RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
     RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
     RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
-    RuntimeReadToolRequest, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
-    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
-    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
-    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
-    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
-    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
-    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
-    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
-    WorkerRestartReason, WorkerStatus,
+    RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary,
+    RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus,
+    RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery,
+    RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort, RuntimeSupervisionPlan,
+    RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest,
+    RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest,
+    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime, SupervisedBridgeWorker,
+    SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport, WorkerHeartbeatDeadline,
+    WorkerHeartbeatSchedule, WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -65,6 +66,7 @@ use std::rc::Rc;
 pub const SMART_HOME_LIST_BRIDGES_TOOL_ID: &str = "smart_home.list_bridges";
 pub const SMART_HOME_DISCOVER_TOOL_ID: &str = "smart_home.discover";
 pub const SMART_HOME_LIST_DEVICES_TOOL_ID: &str = "smart_home.list_devices";
+pub const SMART_HOME_LIST_ROOMS_TOOL_ID: &str = "smart_home.list_rooms";
 pub const SMART_HOME_LIST_SCENES_TOOL_ID: &str = "smart_home.list_scenes";
 pub const SMART_HOME_DESCRIBE_SCENE_TOOL_ID: &str = "smart_home.describe_scene";
 pub const SMART_HOME_GET_STATE_TOOL_ID: &str = "smart_home.get_state";
@@ -82,6 +84,7 @@ pub const SMART_HOME_LIST_CAPABILITY_GRANTS_TOOL_ID: &str = "smart_home.list_cap
 pub const SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_capability_grant_summary";
 pub const SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID: &str = "smart_home.get_runtime_snapshot";
+pub const SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID: &str = "smart_home.get_topology_summary";
 pub const SMART_HOME_LIST_DESIRED_STATES_TOOL_ID: &str = "smart_home.list_desired_states";
 pub const SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID: &str = "smart_home.list_pairing_sessions";
 pub const SMART_HOME_LIST_WORKERS_TOOL_ID: &str = "smart_home.list_workers";
@@ -185,6 +188,17 @@ impl SmartHomeToolBridge {
                         .execute_read_tool(principal_id, request, now_ms)
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "list_devices"))
+                }
+                SMART_HOME_LIST_ROOMS_TOOL_ID => {
+                    let query = room_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::ListRooms { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "list_rooms"))
                 }
                 SMART_HOME_LIST_SCENES_TOOL_ID => {
                     let request = list_scenes_request(&arguments)?;
@@ -357,6 +371,17 @@ impl SmartHomeToolBridge {
                         )
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "get_runtime_snapshot"))
+                }
+                SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID => {
+                    let _ = expect_object(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::GetTopologySummary,
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "get_topology_summary"))
                 }
                 SMART_HOME_LIST_DESIRED_STATES_TOOL_ID => {
                     let request = list_desired_states_request(&arguments)?;
@@ -669,6 +694,36 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             collection_output_schema("devices"),
         ),
         read_definition(
+            SMART_HOME_LIST_ROOMS_TOOL_ID,
+            "List smart-home rooms",
+            "List runtime-derived D23 room topology summaries, including device health, state coverage, and scene action coverage.",
+            object_schema(
+                vec![
+                    SchemaProperty::new("room_id", JsonSchema::String),
+                    SchemaProperty::new("attention_only", JsonSchema::Boolean),
+                    SchemaProperty::new("state_gaps_only", JsonSchema::Boolean),
+                    SchemaProperty::new("sort", JsonSchema::String),
+                    SchemaProperty::new("limit", JsonSchema::Integer),
+                ],
+                vec![],
+                false,
+            ),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "rooms",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("topology", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec!["rooms", "topology", "count"],
+                false,
+            ),
+        ),
+        read_definition(
             SMART_HOME_LIST_SCENES_TOOL_ID,
             "List smart-home scenes",
             "List normalized D23 smart-home scenes, optionally filtered by scope, target entity, or target capability.",
@@ -766,6 +821,7 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         list_capability_grants_definition(),
         get_capability_grant_summary_definition(),
         get_runtime_snapshot_definition(),
+        get_topology_summary_definition(),
         list_desired_states_definition(),
         list_pairing_sessions_definition(),
         list_workers_definition(),
@@ -1206,6 +1262,20 @@ fn get_runtime_snapshot_definition() -> ToolDefinition {
                 "pending_work",
                 "has_pending_work",
             ],
+            false,
+        ),
+    )
+}
+
+fn get_topology_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID,
+        "Get smart-home topology summary",
+        "Read aggregate D23 registry topology coverage across bridges, devices, rooms, entities, cached states, and scenes.",
+        empty_object_schema(),
+        object_schema(
+            vec![SchemaProperty::new("summary", JsonSchema::Any)],
+            vec!["summary"],
             false,
         ),
     )
@@ -1660,6 +1730,27 @@ fn list_devices_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest,
             .transpose()?,
         capability_id: optional_string(arguments, "capability_id")?.map(CapabilityId::trusted),
     })
+}
+
+fn room_query(arguments: &JsonValue) -> Result<RuntimeRoomQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut query = RuntimeRoomQuery::new();
+    if let Some(room_id) = optional_string(arguments, "room_id")? {
+        query = query.for_room(room_id);
+    }
+    if let Some(attention_only) = optional_bool(arguments, "attention_only")? {
+        query = query.attention_only(attention_only);
+    }
+    if let Some(state_gaps_only) = optional_bool(arguments, "state_gaps_only")? {
+        query = query.state_gaps_only(state_gaps_only);
+    }
+    if let Some(sort) = optional_string(arguments, "sort")? {
+        query = query.sorted_by(parse_room_sort(&sort)?);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        query = query.with_limit(limit as usize);
+    }
+    Ok(query)
 }
 
 fn list_scenes_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest, ToolCallError> {
@@ -2240,6 +2331,14 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
             ),
             ("count", integer(devices.len() as i64)),
         ]),
+        RuntimeReadToolOutput::Rooms { rooms, topology } => object([
+            (
+                "rooms",
+                JsonValue::Array(rooms.iter().map(room_summary_json).collect()),
+            ),
+            ("topology", topology_summary_json(&topology)),
+            ("count", integer(rooms.len() as i64)),
+        ]),
         RuntimeReadToolOutput::Scenes(scenes) => object([
             (
                 "scenes",
@@ -2351,6 +2450,9 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
         ]),
         RuntimeReadToolOutput::CapabilityGrantSummary { summary } => {
             object([("summary", capability_grant_inventory_summary_json(&summary))])
+        }
+        RuntimeReadToolOutput::TopologySummary { summary } => {
+            object([("summary", topology_summary_json(&summary))])
         }
         RuntimeReadToolOutput::DesiredStates {
             desired_states,
@@ -2692,6 +2794,164 @@ fn runtime_read_snapshot_json(snapshot: &RuntimeReadSnapshot) -> JsonValue {
         (
             "has_pending_work",
             JsonValue::Bool(snapshot.has_pending_work()),
+        ),
+    ])
+}
+
+fn room_summary_json(room: &RuntimeRoomSummary) -> JsonValue {
+    object([
+        ("room_id", string(&room.room_id)),
+        ("device_count", integer(room.device_count as i64)),
+        ("online_devices", integer(room.online_devices as i64)),
+        (
+            "pairing_candidate_devices",
+            integer(room.pairing_candidate_devices as i64),
+        ),
+        ("attention_devices", integer(room.attention_devices as i64)),
+        ("entity_count", integer(room.entity_count as i64)),
+        (
+            "commandable_entities",
+            integer(room.commandable_entities as i64),
+        ),
+        (
+            "entities_with_state",
+            integer(room.entities_with_state as i64),
+        ),
+        (
+            "entities_without_state",
+            integer(room.entities_without_state as i64),
+        ),
+        ("stale_entities", integer(room.stale_entities as i64)),
+        ("state_gap_count", integer(room.state_gap_count() as i64)),
+        ("scene_count", integer(room.scene_count as i64)),
+        (
+            "scene_action_count",
+            integer(room.scene_action_count as i64),
+        ),
+        (
+            "has_attention_items",
+            JsonValue::Bool(room.has_attention_items()),
+        ),
+        ("has_state_gaps", JsonValue::Bool(room.has_state_gaps())),
+        (
+            "has_scene_actions",
+            JsonValue::Bool(room.has_scene_actions()),
+        ),
+    ])
+}
+
+fn topology_summary_json(summary: &RegistryTopologySummary) -> JsonValue {
+    object([
+        ("bridges", integer(summary.bridges as i64)),
+        ("devices", integer(summary.devices as i64)),
+        ("entities", integer(summary.entities as i64)),
+        ("scenes", integer(summary.scenes as i64)),
+        ("lan_http_bridges", integer(summary.lan_http_bridges as i64)),
+        ("mdns_bridges", integer(summary.mdns_bridges as i64)),
+        ("serial_bridges", integer(summary.serial_bridges as i64)),
+        ("ble_bridges", integer(summary.ble_bridges as i64)),
+        ("cloud_bridges", integer(summary.cloud_bridges as i64)),
+        (
+            "local_process_bridges",
+            integer(summary.local_process_bridges as i64),
+        ),
+        ("online_bridges", integer(summary.online_bridges as i64)),
+        (
+            "pairing_candidate_bridges",
+            integer(summary.pairing_candidate_bridges as i64),
+        ),
+        (
+            "attention_bridges",
+            integer(summary.attention_bridges as i64),
+        ),
+        ("online_devices", integer(summary.online_devices as i64)),
+        (
+            "pairing_candidate_devices",
+            integer(summary.pairing_candidate_devices as i64),
+        ),
+        (
+            "attention_devices",
+            integer(summary.attention_devices as i64),
+        ),
+        (
+            "devices_with_entities",
+            integer(summary.devices_with_entities as i64),
+        ),
+        (
+            "devices_without_entities",
+            integer(summary.devices_without_entities as i64),
+        ),
+        (
+            "devices_with_room",
+            integer(summary.devices_with_room as i64),
+        ),
+        (
+            "devices_without_room",
+            integer(summary.devices_without_room as i64),
+        ),
+        ("unique_rooms", integer(summary.unique_rooms as i64)),
+        ("light_entities", integer(summary.light_entities as i64)),
+        (
+            "light_group_entities",
+            integer(summary.light_group_entities as i64),
+        ),
+        ("switch_entities", integer(summary.switch_entities as i64)),
+        ("sensor_entities", integer(summary.sensor_entities as i64)),
+        ("lock_entities", integer(summary.lock_entities as i64)),
+        (
+            "thermostat_entities",
+            integer(summary.thermostat_entities as i64),
+        ),
+        ("scene_entities", integer(summary.scene_entities as i64)),
+        ("input_entities", integer(summary.input_entities as i64)),
+        (
+            "bridge_health_entities",
+            integer(summary.bridge_health_entities as i64),
+        ),
+        (
+            "network_diagnostic_entities",
+            integer(summary.network_diagnostic_entities as i64),
+        ),
+        ("unknown_entities", integer(summary.unknown_entities as i64)),
+        (
+            "entities_with_state",
+            integer(summary.entities_with_state as i64),
+        ),
+        (
+            "entities_without_state",
+            integer(summary.entities_without_state as i64),
+        ),
+        (
+            "total_capabilities",
+            integer(summary.total_capabilities as i64),
+        ),
+        ("room_scenes", integer(summary.room_scenes as i64)),
+        ("zone_scenes", integer(summary.zone_scenes as i64)),
+        ("home_scenes", integer(summary.home_scenes as i64)),
+        ("bridge_scenes", integer(summary.bridge_scenes as i64)),
+        ("custom_scenes", integer(summary.custom_scenes as i64)),
+        ("scene_actions", integer(summary.scene_actions as i64)),
+        ("has_topology", JsonValue::Bool(summary.has_topology())),
+        (
+            "has_pairing_candidates",
+            JsonValue::Bool(summary.has_pairing_candidates()),
+        ),
+        (
+            "has_attention_items",
+            JsonValue::Bool(summary.has_attention_items()),
+        ),
+        (
+            "has_devices_without_entities",
+            JsonValue::Bool(summary.has_devices_without_entities()),
+        ),
+        ("has_state_gaps", JsonValue::Bool(summary.has_state_gaps())),
+        (
+            "has_scene_actions",
+            JsonValue::Bool(summary.has_scene_actions()),
+        ),
+        (
+            "has_multi_transport_bridges",
+            JsonValue::Bool(summary.has_multi_transport_bridges()),
         ),
     ])
 }
@@ -4915,6 +5175,16 @@ fn parse_event_sort(label: &str) -> Result<RuntimeEventSort, ToolCallError> {
     }
 }
 
+fn parse_room_sort(label: &str) -> Result<RuntimeRoomSort, ToolCallError> {
+    match label {
+        "room_id" | "id" => Ok(RuntimeRoomSort::RoomId),
+        "attention_desc" | "attention" => Ok(RuntimeRoomSort::AttentionDesc),
+        "entity_count_desc" | "entities_desc" => Ok(RuntimeRoomSort::EntityCountDesc),
+        "scene_count_desc" | "scenes_desc" => Ok(RuntimeRoomSort::SceneCountDesc),
+        _ => Err(validation_error(format!("unknown room sort `{label}`"))),
+    }
+}
+
 fn parse_authorization_decision_sort(
     label: &str,
 ) -> Result<RuntimeAuthorizationDecisionSort, ToolCallError> {
@@ -5949,7 +6219,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 32);
+        assert_eq!(definitions.len(), 34);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -5964,6 +6234,7 @@ mod tests {
             .tool_ids()
             .contains(&SMART_HOME_DESCRIBE_PRIMITIVE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
+        assert!(export.tool_ids().contains(&SMART_HOME_LIST_ROOMS_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_LIST_SCENES_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -5996,6 +6267,9 @@ mod tests {
             .contains(&SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_LIST_DESIRED_STATES_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -6019,7 +6293,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            28
+            30
         );
         assert_eq!(
             export
@@ -6032,8 +6306,10 @@ mod tests {
             1
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_SCENES_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_DESCRIBE_SCENE_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID).is_some());
         assert!(smart_home_tool_definition("smart_home.unknown").is_none());
     }
 
@@ -6209,6 +6485,33 @@ mod tests {
         assert_eq!(list_trace.summary().terminal_event_count, 1);
         assert_eq!(
             field(list_trace.result.output.as_ref().unwrap(), "count"),
+            Some(&integer(1))
+        );
+
+        let list_rooms_request = request(
+            "call-list-rooms",
+            SMART_HOME_LIST_ROOMS_TOOL_ID,
+            object([
+                ("room_id", string("kitchen")),
+                ("sort", string("scenes_desc")),
+            ]),
+            1_001,
+        );
+        let list_rooms_trace = tool_runtime.invoke_with_events(&list_rooms_request);
+        assert!(list_rooms_trace.result.ok);
+        let list_rooms_output = list_rooms_trace.result.output.as_ref().unwrap();
+        assert_eq!(field(list_rooms_output, "count"), Some(&integer(1)));
+        let room_summary = array_item(field(list_rooms_output, "rooms").unwrap(), 0).unwrap();
+        assert_eq!(field(room_summary, "room_id"), Some(&string("kitchen")));
+        assert_eq!(field(room_summary, "device_count"), Some(&integer(1)));
+        assert_eq!(field(room_summary, "entity_count"), Some(&integer(2)));
+        assert_eq!(field(room_summary, "scene_count"), Some(&integer(1)));
+        assert_eq!(field(room_summary, "scene_action_count"), Some(&integer(1)));
+        assert_eq!(
+            field(
+                field(list_rooms_output, "topology").unwrap(),
+                "unique_rooms"
+            ),
             Some(&integer(1))
         );
 
@@ -6507,6 +6810,27 @@ mod tests {
                 "event_backlog_count"
             ),
             Some(&integer(1))
+        );
+
+        let topology_summary_request = request(
+            "call-topology-summary",
+            SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID,
+            object([]),
+            1_100,
+        );
+        let topology_summary_trace = tool_runtime.invoke_with_events(&topology_summary_request);
+        assert!(topology_summary_trace.result.ok);
+        let topology_summary_output = topology_summary_trace.result.output.as_ref().unwrap();
+        let topology_summary = field(topology_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(topology_summary, "devices_with_room"),
+            Some(&integer(1))
+        );
+        assert_eq!(field(topology_summary, "unique_rooms"), Some(&integer(1)));
+        assert_eq!(field(topology_summary, "room_scenes"), Some(&integer(1)));
+        assert_eq!(
+            field(topology_summary, "has_scene_actions"),
+            Some(&JsonValue::Bool(true))
         );
 
         let supervision_plan_request = request(
@@ -6951,6 +7275,7 @@ mod tests {
         journal.record_trace(list_primitives_request, list_primitives_trace);
         journal.record_trace(describe_primitive_request, describe_primitive_trace);
         journal.record_trace(list_request, list_trace);
+        journal.record_trace(list_rooms_request, list_rooms_trace);
         journal.record_trace(list_scenes_request, list_scenes_trace);
         journal.record_trace(describe_scene_request, describe_scene_trace);
         journal.record_trace(discover_request, discover_trace);
@@ -6963,6 +7288,7 @@ mod tests {
         journal.record_trace(pair_request, pair_trace);
         journal.record_trace(command_request, command_trace);
         journal.record_trace(runtime_snapshot_request, runtime_snapshot_trace);
+        journal.record_trace(topology_summary_request, topology_summary_trace);
         journal.record_trace(supervision_plan_request, supervision_plan_trace);
         journal.record_trace(desired_states_request, desired_states_trace);
         journal.record_trace(pairing_sessions_request, pairing_sessions_trace);
@@ -6982,9 +7308,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 31);
-        assert_eq!(journal_summary.completed_count, 31);
-        assert_eq!(journal.audit_records().len(), 31);
+        assert_eq!(journal_summary.invocation_count, 33);
+        assert_eq!(journal_summary.completed_count, 33);
+        assert_eq!(journal.audit_records().len(), 33);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -6997,7 +7323,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            28,
+            30,
             "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_capability_grants` and
   `smart_home.get_capability_grant_summary` tool descriptors plus
   `CapabilityGrantInventorySummary` for read-only grant-governance inspection.
+- `smart_home.list_rooms` and `smart_home.get_topology_summary` tool
+  descriptors for read-only room and topology coverage inspection.
 - `smart_home.get_runtime_snapshot`, `smart_home.list_desired_states`, and
   `smart_home.list_pairing_sessions` tool descriptors for read-only runtime
   automation inventory inspection.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -55,6 +55,8 @@ Current scope:
   allow/deny summaries
 - D18D capability-grant tool descriptors for listing grant rows and compact
   grant inventory summaries
+- D18D topology tool descriptors for room summaries and aggregate bridge,
+  device, entity, state, and scene coverage
 - D18D runtime automation inventory tool descriptors for read-only snapshots,
   desired-state targets, and pairing-session status
 - D18D bridge-worker inventory descriptors for read-only supervisor and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1449,6 +1449,7 @@ pub enum SmartHomeTool {
     PairBridge,
     ListBridges,
     ListDevices,
+    ListRooms,
     ListScenes,
     DescribeScene,
     GetState,
@@ -1463,6 +1464,7 @@ pub enum SmartHomeTool {
     ListCapabilityGrants,
     GetCapabilityGrantSummary,
     GetRuntimeSnapshot,
+    GetTopologySummary,
     ListDesiredStates,
     ListPairingSessions,
     ListWorkers,
@@ -1492,6 +1494,7 @@ impl SmartHomeTool {
             },
             Self::ListBridges => read_tool("smart_home.list_bridges"),
             Self::ListDevices => read_tool("smart_home.list_devices"),
+            Self::ListRooms => read_tool("smart_home.list_rooms"),
             Self::ListScenes => read_tool("smart_home.list_scenes"),
             Self::DescribeScene => read_tool("smart_home.describe_scene"),
             Self::GetState => read_tool("smart_home.get_state"),
@@ -1513,6 +1516,7 @@ impl SmartHomeTool {
             Self::ListCapabilityGrants => read_tool("smart_home.list_capability_grants"),
             Self::GetCapabilityGrantSummary => read_tool("smart_home.get_capability_grant_summary"),
             Self::GetRuntimeSnapshot => read_tool("smart_home.get_runtime_snapshot"),
+            Self::GetTopologySummary => read_tool("smart_home.get_topology_summary"),
             Self::ListDesiredStates => read_tool("smart_home.list_desired_states"),
             Self::ListPairingSessions => read_tool("smart_home.list_pairing_sessions"),
             Self::ListWorkers => read_tool("smart_home.list_workers"),
@@ -2056,6 +2060,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::PairBridge,
         SmartHomeTool::ListBridges,
         SmartHomeTool::ListDevices,
+        SmartHomeTool::ListRooms,
         SmartHomeTool::ListScenes,
         SmartHomeTool::DescribeScene,
         SmartHomeTool::GetState,
@@ -2070,6 +2075,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::ListCapabilityGrants,
         SmartHomeTool::GetCapabilityGrantSummary,
         SmartHomeTool::GetRuntimeSnapshot,
+        SmartHomeTool::GetTopologySummary,
         SmartHomeTool::ListDesiredStates,
         SmartHomeTool::ListPairingSessions,
         SmartHomeTool::ListWorkers,
@@ -2875,7 +2881,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 28);
+        assert_eq!(catalog.len(), 30);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2901,6 +2907,11 @@ mod tests {
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_scenes"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_rooms"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -2953,6 +2964,11 @@ mod tests {
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
             .iter()
+            .any(|tool| tool.tool_id == "smart_home.get_topology_summary"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
             .any(|tool| tool.tool_id == "smart_home.list_desired_states"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -2982,15 +2998,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 28);
-        assert_eq!(summary.read_tools, 24);
+        assert_eq!(summary.total_tools, 30);
+        assert_eq!(summary.read_tools, 26);
         assert_eq!(summary.write_tools, 0);
         assert_eq!(summary.external_tools, 4);
-        assert_eq!(summary.read_only_tier_tools, 24);
+        assert_eq!(summary.read_only_tier_tools, 26);
         assert_eq!(summary.low_risk_tier_tools, 3);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 28);
+        assert_eq!(summary.total_required_capabilities, 30);
         assert_eq!(summary.risky_tool_count(), 4);
         assert_eq!(summary.approval_gated_tool_count(), 1);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -66,6 +66,10 @@ All notable changes to this package will be documented in this file.
 - `RuntimeReadToolRequest::ListCapabilityGrants` and
   `RuntimeReadToolRequest::GetCapabilityGrantSummary` for authorized D18D
   reads over registry-backed smart-home capability grant governance.
+- `RuntimeRoomQuery`, `RuntimeRoomSummary`,
+  `RuntimeReadToolRequest::ListRooms`, and
+  `RuntimeReadToolRequest::GetTopologySummary` for authorized D18D reads over
+  registry-derived room and topology coverage.
 - `RuntimeReadToolRequest::GetRuntimeSnapshot`,
   `RuntimeReadToolRequest::ListDesiredStates`, and
   `RuntimeReadToolRequest::ListPairingSessions` for authorized D18D reads over

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -65,14 +65,17 @@ Included surfaces:
 - read-side authorization-decision queries and summaries for Chief audit tools
 - read-side capability-grant queries and summaries for Chief grant governance
   tools
+- read-side room summaries and topology coverage derived from registry-owned
+  devices, entities, cached states, and scenes
 - D18D-facing read tool facade for listing bridges/devices/scenes, describing
-  scenes, reading entity state, describing capabilities, inspecting bridge
-  health, listing event subscriptions, inspecting event-log entries, reading
+  scenes, reading room topology summaries, reading aggregate topology coverage,
+  reading entity state, describing capabilities, inspecting bridge health,
+  listing event subscriptions, inspecting event-log entries, reading
   authorization decisions and summaries, reading capability grants and
   summaries, reading compact runtime snapshots, listing desired-state targets,
-  listing pairing sessions, listing supervised bridge workers, reading worker heartbeat
-  schedules, previewing supervision plans, and observing supervision status
-  without invoking integrations
+  listing pairing sessions, listing supervised bridge workers, reading worker
+  heartbeat schedules, previewing supervision plans, and observing supervision
+  status without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and
   registers filtered replay subscriptions with checkpoints
 - D18D-facing poll and unsubscribe tool facades that authorize event-stream

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -26,7 +26,7 @@ use smart_home_discovery::{
 };
 use smart_home_registry::{
     AuthorizationDecisionSelector, DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts,
-    RegistryError, StateRefreshPlan, StateRefreshReason,
+    RegistryError, RegistryTopologySummary, StateRefreshPlan, StateRefreshReason,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::{fmt, time::Duration};
@@ -3365,6 +3365,148 @@ impl RuntimeCapabilityGrantQuery {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeRoomSort {
+    RoomId,
+    AttentionDesc,
+    EntityCountDesc,
+    SceneCountDesc,
+}
+
+impl Default for RuntimeRoomSort {
+    fn default() -> Self {
+        Self::RoomId
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuntimeRoomQuery {
+    pub room_id: Option<String>,
+    pub attention_only: bool,
+    pub state_gaps_only: bool,
+    pub sort: RuntimeRoomSort,
+    pub limit: Option<usize>,
+}
+
+impl RuntimeRoomQuery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_room(mut self, room_id: impl Into<String>) -> Self {
+        self.room_id = Some(room_id.into());
+        self
+    }
+
+    pub fn attention_only(mut self, attention_only: bool) -> Self {
+        self.attention_only = attention_only;
+        self
+    }
+
+    pub fn state_gaps_only(mut self, state_gaps_only: bool) -> Self {
+        self.state_gaps_only = state_gaps_only;
+        self
+    }
+
+    pub fn sorted_by(mut self, sort: RuntimeRoomSort) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeRoomSummary {
+    pub room_id: String,
+    pub device_count: usize,
+    pub online_devices: usize,
+    pub pairing_candidate_devices: usize,
+    pub attention_devices: usize,
+    pub entity_count: usize,
+    pub commandable_entities: usize,
+    pub entities_with_state: usize,
+    pub entities_without_state: usize,
+    pub stale_entities: usize,
+    pub scene_count: usize,
+    pub scene_action_count: usize,
+}
+
+impl RuntimeRoomSummary {
+    pub fn new(room_id: impl Into<String>) -> Self {
+        Self {
+            room_id: room_id.into(),
+            device_count: 0,
+            online_devices: 0,
+            pairing_candidate_devices: 0,
+            attention_devices: 0,
+            entity_count: 0,
+            commandable_entities: 0,
+            entities_with_state: 0,
+            entities_without_state: 0,
+            stale_entities: 0,
+            scene_count: 0,
+            scene_action_count: 0,
+        }
+    }
+
+    fn record_device(&mut self, device: &Device) {
+        self.device_count += 1;
+        if device.health.is_online() {
+            self.online_devices += 1;
+        }
+        if device.health.is_pairing_candidate() {
+            self.pairing_candidate_devices += 1;
+        }
+        if device.health.needs_attention() {
+            self.attention_devices += 1;
+        }
+    }
+
+    fn record_entity(&mut self, entity: &Entity, state: Option<&StateSnapshot>, now_ms: u64) {
+        self.entity_count += 1;
+        if entity.capability_summary().has_command_surface() {
+            self.commandable_entities += 1;
+        }
+        match state {
+            Some(snapshot) => {
+                self.entities_with_state += 1;
+                if snapshot.is_stale_at(now_ms) {
+                    self.stale_entities += 1;
+                }
+            }
+            None => self.entities_without_state += 1,
+        }
+    }
+
+    fn record_scene_actions(&mut self, action_count: usize) {
+        if action_count == 0 {
+            return;
+        }
+        self.scene_count += 1;
+        self.scene_action_count += action_count;
+    }
+
+    pub fn has_attention_items(&self) -> bool {
+        self.attention_devices > 0
+    }
+
+    pub fn has_state_gaps(&self) -> bool {
+        self.entities_without_state > 0 || self.stale_entities > 0
+    }
+
+    pub fn state_gap_count(&self) -> usize {
+        self.entities_without_state + self.stale_entities
+    }
+
+    pub fn has_scene_actions(&self) -> bool {
+        self.scene_action_count > 0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeReadToolRequest {
     GetRuntimeSnapshot,
@@ -3373,6 +3515,9 @@ pub enum RuntimeReadToolRequest {
         bridge_id: Option<BridgeId>,
         health: Option<Health>,
         capability_id: Option<CapabilityId>,
+    },
+    ListRooms {
+        query: RuntimeRoomQuery,
     },
     ListScenes {
         scope: Option<SceneScope>,
@@ -3409,6 +3554,7 @@ pub enum RuntimeReadToolRequest {
     GetCapabilityGrantSummary {
         query: RuntimeCapabilityGrantQuery,
     },
+    GetTopologySummary,
     ListDesiredStates {
         query: DesiredStateQuery,
     },
@@ -3433,6 +3579,7 @@ impl RuntimeReadToolRequest {
             Self::GetRuntimeSnapshot => SmartHomeTool::GetRuntimeSnapshot,
             Self::ListBridges => SmartHomeTool::ListBridges,
             Self::ListDevices { .. } => SmartHomeTool::ListDevices,
+            Self::ListRooms { .. } => SmartHomeTool::ListRooms,
             Self::ListScenes { .. } => SmartHomeTool::ListScenes,
             Self::DescribeScene { .. } => SmartHomeTool::DescribeScene,
             Self::GetState { .. } => SmartHomeTool::GetState,
@@ -3444,6 +3591,7 @@ impl RuntimeReadToolRequest {
             Self::GetAuthorizationSummary { .. } => SmartHomeTool::GetAuthorizationSummary,
             Self::ListCapabilityGrants { .. } => SmartHomeTool::ListCapabilityGrants,
             Self::GetCapabilityGrantSummary { .. } => SmartHomeTool::GetCapabilityGrantSummary,
+            Self::GetTopologySummary => SmartHomeTool::GetTopologySummary,
             Self::ListDesiredStates { .. } => SmartHomeTool::ListDesiredStates,
             Self::ListPairingSessions { .. } => SmartHomeTool::ListPairingSessions,
             Self::ListWorkers { .. } => SmartHomeTool::ListWorkers,
@@ -3667,6 +3815,10 @@ pub enum RuntimeReadToolOutput {
     RuntimeSnapshot(RuntimeReadSnapshot),
     Bridges(Vec<Bridge>),
     Devices(Vec<Device>),
+    Rooms {
+        rooms: Vec<RuntimeRoomSummary>,
+        topology: RegistryTopologySummary,
+    },
     Scenes(Vec<Scene>),
     Scene {
         scene_id: SceneId,
@@ -3702,6 +3854,9 @@ pub enum RuntimeReadToolOutput {
     },
     CapabilityGrantSummary {
         summary: CapabilityGrantInventorySummary,
+    },
+    TopologySummary {
+        summary: RegistryTopologySummary,
     },
     DesiredStates {
         desired_states: Vec<DesiredEntityState>,
@@ -3873,6 +4028,90 @@ impl SmartHomeRuntime {
                 .sum(),
             state_refresh_target_count: self.registry.state_refresh_plan_at(now_ms).len(),
         }
+    }
+
+    pub fn topology_summary(&self) -> RegistryTopologySummary {
+        self.registry.topology_summary()
+    }
+
+    pub fn room_summaries_at(&self, now_ms: u64) -> Vec<RuntimeRoomSummary> {
+        let mut rooms = BTreeMap::new();
+        let mut entity_rooms = BTreeMap::new();
+
+        for device in self.registry.devices() {
+            let Some(room_id) = device.room_id.as_ref() else {
+                continue;
+            };
+            let room = rooms
+                .entry(room_id.clone())
+                .or_insert_with(|| RuntimeRoomSummary::new(room_id.clone()));
+            room.record_device(device);
+
+            for entity in self.registry.entities_for_device(&device.device_id) {
+                room.record_entity(entity, self.registry.state(&entity.entity_id), now_ms);
+                entity_rooms.insert(entity.entity_id.clone(), room_id.clone());
+            }
+        }
+
+        for scene in self.registry.scenes() {
+            let mut room_action_counts: BTreeMap<String, usize> = BTreeMap::new();
+            for action in &scene.actions {
+                if let Some(room_id) = entity_rooms.get(&action.entity_id) {
+                    *room_action_counts.entry(room_id.clone()).or_default() += 1;
+                }
+            }
+
+            for (room_id, action_count) in room_action_counts {
+                rooms
+                    .entry(room_id.clone())
+                    .or_insert_with(|| RuntimeRoomSummary::new(room_id))
+                    .record_scene_actions(action_count);
+            }
+        }
+
+        rooms.into_values().collect()
+    }
+
+    pub fn query_room_summaries_at(
+        &self,
+        query: &RuntimeRoomQuery,
+        now_ms: u64,
+    ) -> Vec<RuntimeRoomSummary> {
+        if query.limit == Some(0) {
+            return Vec::new();
+        }
+
+        let mut rooms = self
+            .room_summaries_at(now_ms)
+            .into_iter()
+            .filter(|room| room_summary_matches_query(room, query))
+            .collect::<Vec<_>>();
+        match query.sort {
+            RuntimeRoomSort::RoomId => {
+                rooms.sort_by(|left, right| left.room_id.cmp(&right.room_id))
+            }
+            RuntimeRoomSort::AttentionDesc => rooms.sort_by(|left, right| {
+                right
+                    .attention_devices
+                    .cmp(&left.attention_devices)
+                    .then_with(|| right.state_gap_count().cmp(&left.state_gap_count()))
+                    .then_with(|| left.room_id.cmp(&right.room_id))
+            }),
+            RuntimeRoomSort::EntityCountDesc => rooms.sort_by(|left, right| {
+                right
+                    .entity_count
+                    .cmp(&left.entity_count)
+                    .then_with(|| left.room_id.cmp(&right.room_id))
+            }),
+            RuntimeRoomSort::SceneCountDesc => rooms.sort_by(|left, right| {
+                right
+                    .scene_count
+                    .cmp(&left.scene_count)
+                    .then_with(|| left.room_id.cmp(&right.room_id))
+            }),
+        }
+        apply_limit(&mut rooms, query.limit);
+        rooms
     }
 
     pub fn event_bus_health_summary(&self) -> RuntimeEventBusHealthSummary {
@@ -4628,6 +4867,10 @@ impl SmartHomeRuntime {
                         .collect(),
                 ))
             }
+            RuntimeReadToolRequest::ListRooms { query } => Ok(RuntimeReadToolOutput::Rooms {
+                rooms: self.query_room_summaries_at(&query, now_ms),
+                topology: self.topology_summary(),
+            }),
             RuntimeReadToolRequest::ListScenes {
                 scope,
                 entity_id,
@@ -4736,6 +4979,11 @@ impl SmartHomeRuntime {
             RuntimeReadToolRequest::GetCapabilityGrantSummary { query } => {
                 Ok(RuntimeReadToolOutput::CapabilityGrantSummary {
                     summary: self.capability_grant_summary_at(&query, now_ms),
+                })
+            }
+            RuntimeReadToolRequest::GetTopologySummary => {
+                Ok(RuntimeReadToolOutput::TopologySummary {
+                    summary: self.topology_summary(),
                 })
             }
             RuntimeReadToolRequest::ListDesiredStates { query } => {
@@ -5610,6 +5858,15 @@ fn supervised_worker_matches_query(
         && query
             .min_restart_count
             .is_none_or(|minimum| worker.restart_count >= minimum)
+}
+
+fn room_summary_matches_query(room: &RuntimeRoomSummary, query: &RuntimeRoomQuery) -> bool {
+    query
+        .room_id
+        .as_ref()
+        .is_none_or(|room_id| &room.room_id == room_id)
+        && (!query.attention_only || room.has_attention_items())
+        && (!query.state_gaps_only || room.has_state_gaps())
 }
 
 fn desired_state_matches_query(
@@ -8412,6 +8669,13 @@ mod tests {
             Capability::light_brightness(),
         ]);
         let principal = AgentId::trusted("agent:observer");
+        let mut kitchen_device = runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .unwrap()
+            .clone();
+        kitchen_device.room_id = Some("kitchen".to_string());
+        runtime.upsert_device(kitchen_device).unwrap();
         runtime.registry_mut().upsert_capability_grant(
             CapabilityGrant::for_capability(
                 CapabilityGrantId::trusted("grant-read"),
@@ -8698,6 +8962,24 @@ mod tests {
                 1_519,
             )
             .unwrap();
+        let rooms = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::ListRooms {
+                    query: RuntimeRoomQuery::new()
+                        .for_room("kitchen")
+                        .sorted_by(RuntimeRoomSort::SceneCountDesc),
+                },
+                1_520,
+            )
+            .unwrap();
+        let topology_summary = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::GetTopologySummary,
+                1_521,
+            )
+            .unwrap();
 
         assert!(matches!(
             bridges,
@@ -8878,7 +9160,33 @@ mod tests {
                     && summary.unique_principals == 1
                     && !summary.needs_review()
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 20);
+        assert!(matches!(
+            rooms,
+            RuntimeReadToolOutput::Rooms { rooms, topology }
+                if rooms.len() == 1
+                    && rooms[0].room_id == "kitchen"
+                    && rooms[0].device_count == 1
+                    && rooms[0].entity_count == 1
+                    && rooms[0].commandable_entities == 1
+                    && rooms[0].entities_with_state == 1
+                    && rooms[0].scene_count == 1
+                    && rooms[0].scene_action_count == 1
+                    && topology.devices_with_room == 1
+                    && topology.unique_rooms == 1
+                    && topology.room_scenes == 1
+        ));
+        assert!(matches!(
+            topology_summary,
+            RuntimeReadToolOutput::TopologySummary { summary }
+                if summary.bridges == 1
+                    && summary.devices == 1
+                    && summary.entities == 1
+                    && summary.scenes == 1
+                    && summary.devices_with_room == 1
+                    && summary.unique_rooms == 1
+                    && summary.scene_actions == 1
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 22);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add read-only smart-home room and topology descriptors to the shared core tool catalog
- derive runtime room summaries and registry topology snapshots without moving D23 ownership into the Chief adapter
- wire D18D Chief smart-home handlers and JSON outputs for smart_home.list_rooms and smart_home.get_topology_summary

## Validation
- cargo fmt -p smart-home-core -p smart-home-runtime -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools