### PR TITLE
Add browser script execution descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -261,7 +261,8 @@ documented in this file.
 - Browser-facing document summaries now carry script and stylesheet loading
   metadata, including script kind, async/defer/nomodule flags, inline
   script/style text, integrity/crossorigin/referrer-policy hints, fetch
-  priority, blocking, alternate stylesheets, and disabled stylesheet state.
+  priority, blocking, flattened script execution descriptors, alternate
+  stylesheets, and disabled stylesheet state.
 - Browser-facing image summaries now carry responsive image selection metadata,
   including `srcset`/`sizes`, resolved candidate URLs, `picture/source`
   media/type hints, lazy loading, decoding, fetch priority, CORS/referrer

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -831,6 +831,7 @@ pub struct BrowserDocument {
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
     pub scripts: Vec<BrowserScript>,
+    pub script_execution_descriptors: Vec<BrowserScriptExecutionDescriptor>,
     pub stylesheets: Vec<BrowserStylesheet>,
     pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
@@ -1048,6 +1049,29 @@ pub struct BrowserScript {
     pub blocking: Option<String>,
     pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserScriptExecutionDescriptor {
+    pub script_kind: String,
+    pub execution_kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub type_hint: Option<String>,
+    pub async_script: bool,
+    pub defer_script: bool,
+    pub nomodule: bool,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub nonce: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
+    pub blocking_token_count: usize,
+    pub render_blocking: bool,
+    pub has_text: bool,
+    pub text_length: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2671,6 +2695,8 @@ impl BrowserDocument {
             &[],
             body_children,
         );
+        summary.script_execution_descriptors =
+            browser_script_execution_descriptors(&summary.scripts);
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.embedded_policy_descriptors =
             browser_embedded_policy_descriptors(&summary.embedded_contexts);
@@ -10329,6 +10355,51 @@ fn browser_embedded_resource_kind(element: &str) -> &'static str {
         "object" => "object",
         "embed" => "embed",
         _ => "embedded",
+    }
+}
+
+fn browser_script_execution_descriptors(
+    scripts: &[BrowserScript],
+) -> Vec<BrowserScriptExecutionDescriptor> {
+    scripts
+        .iter()
+        .map(browser_script_execution_descriptor)
+        .collect()
+}
+
+fn browser_script_execution_descriptor(script: &BrowserScript) -> BrowserScriptExecutionDescriptor {
+    let text_length = script
+        .text
+        .as_ref()
+        .map(|text| text.chars().count())
+        .unwrap_or_default();
+    BrowserScriptExecutionDescriptor {
+        script_kind: script.script_kind.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        async_script: script.async_script,
+        defer_script: script.defer_script,
+        nomodule: script.nomodule,
+        integrity: script.integrity.clone(),
+        crossorigin: script.crossorigin.clone(),
+        nonce: script.nonce.clone(),
+        referrerpolicy: script.referrerpolicy.clone(),
+        fetchpriority: script.fetchpriority.clone(),
+        blocking: script.blocking.clone(),
+        blocking_tokens: script.blocking_tokens.clone(),
+        blocking_token_count: script.blocking_tokens.len(),
+        render_blocking: script
+            .blocking_tokens
+            .iter()
+            .any(|token| token.eq_ignore_ascii_case("render")),
+        has_text: script.text.is_some(),
+        text_length,
     }
 }
 
@@ -19266,6 +19337,62 @@ mod tests {
         );
         assert_eq!(stylesheet_preload.fetchpriority.as_deref(), Some("high"));
         assert_eq!(stylesheet_preload.blocking.as_deref(), Some("render"));
+    }
+
+    #[test]
+    fn browser_script_execution_descriptors_track_execution_and_policy_hints() {
+        let document = parse_html(
+            "<base href=\"https://example.test/app/index.html\">\
+             <script type=module src=app.js async integrity=sha384-js crossorigin=use-credentials \
+                 nonce=moduleNonce referrerpolicy=origin fetchpriority=low blocking=render></script>\
+             <script type=\"text/javascript; charset=utf-8\">classicMime();</script>\
+             <script nomodule defer nonce=legacyNonce>legacy();</script>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.script_execution_descriptors.len(), 3);
+
+        let module = &summary.script_execution_descriptors[0];
+        assert_eq!(module.script_kind, "module");
+        assert_eq!(module.execution_kind, "external");
+        assert_eq!(module.src.as_deref(), Some("app.js"));
+        assert_eq!(
+            module.resolved_src.as_deref(),
+            Some("https://example.test/app/app.js")
+        );
+        assert!(module.async_script);
+        assert!(!module.defer_script);
+        assert_eq!(module.integrity.as_deref(), Some("sha384-js"));
+        assert_eq!(module.crossorigin.as_deref(), Some("use-credentials"));
+        assert_eq!(module.nonce.as_deref(), Some("moduleNonce"));
+        assert_eq!(module.referrerpolicy.as_deref(), Some("origin"));
+        assert_eq!(module.fetchpriority.as_deref(), Some("low"));
+        assert_eq!(module.blocking.as_deref(), Some("render"));
+        assert_eq!(module.blocking_tokens, vec!["render"]);
+        assert_eq!(module.blocking_token_count, 1);
+        assert!(module.render_blocking);
+        assert!(!module.has_text);
+        assert_eq!(module.text_length, 0);
+
+        let classic = &summary.script_execution_descriptors[1];
+        assert_eq!(classic.script_kind, "classic");
+        assert_eq!(classic.execution_kind, "inline");
+        assert_eq!(
+            classic.type_hint.as_deref(),
+            Some("text/javascript; charset=utf-8")
+        );
+        assert!(classic.has_text);
+        assert_eq!(classic.text_length, "classicMime();".chars().count());
+        assert!(!classic.render_blocking);
+
+        let legacy = &summary.script_execution_descriptors[2];
+        assert_eq!(legacy.script_kind, "classic");
+        assert_eq!(legacy.execution_kind, "inline");
+        assert!(legacy.nomodule);
+        assert!(legacy.defer_script);
+        assert_eq!(legacy.nonce.as_deref(), Some("legacyNonce"));
+        assert_eq!(legacy.text_length, "legacy();".chars().count());
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -16,9 +16,9 @@ use coding_adventures_html_parser::{
     BrowserMediaSource, BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective,
     BrowserNavigationGroup, BrowserNavigationTargetDescriptor, BrowserPopover,
     BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -66,6 +66,8 @@ struct ExpectedBrowserDocument {
     resources: Vec<ExpectedResource>,
     #[serde(default)]
     scripts: Vec<ExpectedScript>,
+    #[serde(default)]
+    script_execution_descriptors: Option<Vec<ExpectedScriptExecutionDescriptor>>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
     #[serde(default)]
@@ -811,6 +813,47 @@ struct ExpectedScript {
     blocking_tokens: Vec<String>,
     #[serde(default)]
     text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedScriptExecutionDescriptor {
+    script_kind: String,
+    #[serde(default)]
+    execution_kind: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    async_script: bool,
+    #[serde(default)]
+    defer_script: bool,
+    #[serde(default)]
+    nomodule: bool,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
+    blocking_token_count: usize,
+    #[serde(default)]
+    render_blocking: bool,
+    #[serde(default)]
+    has_text: bool,
+    #[serde(default)]
+    text_length: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3870,6 +3913,11 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedResource::into_browser_resource)
             .collect();
+        let scripts: Vec<_> = self
+            .scripts
+            .into_iter()
+            .map(ExpectedScript::into_browser_script)
+            .collect();
         let media: Vec<_> = self
             .media
             .into_iter()
@@ -3909,6 +3957,17 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_embedded_policy_descriptors(&embedded_contexts));
+        let script_execution_descriptors = self
+            .script_execution_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedScriptExecutionDescriptor::into_browser_script_execution_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_script_execution_descriptors(&scripts));
 
         BrowserDocument {
             title: self.title,
@@ -3930,11 +3989,8 @@ impl ExpectedBrowserDocument {
                 .map(ExpectedMeta::into_browser_meta)
                 .collect(),
             resources,
-            scripts: self
-                .scripts
-                .into_iter()
-                .map(ExpectedScript::into_browser_script)
-                .collect(),
+            scripts,
+            script_execution_descriptors,
             stylesheets: self
                 .stylesheets
                 .into_iter()
@@ -4581,6 +4637,53 @@ fn expected_embedded_resource_kind(element: &str) -> &'static str {
     }
 }
 
+fn expected_script_execution_descriptors(
+    scripts: &[BrowserScript],
+) -> Vec<BrowserScriptExecutionDescriptor> {
+    scripts
+        .iter()
+        .map(expected_script_execution_descriptor)
+        .collect()
+}
+
+fn expected_script_execution_descriptor(
+    script: &BrowserScript,
+) -> BrowserScriptExecutionDescriptor {
+    let text_length = script
+        .text
+        .as_ref()
+        .map(|text| text.chars().count())
+        .unwrap_or_default();
+    BrowserScriptExecutionDescriptor {
+        script_kind: script.script_kind.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        async_script: script.async_script,
+        defer_script: script.defer_script,
+        nomodule: script.nomodule,
+        integrity: script.integrity.clone(),
+        crossorigin: script.crossorigin.clone(),
+        nonce: script.nonce.clone(),
+        referrerpolicy: script.referrerpolicy.clone(),
+        fetchpriority: script.fetchpriority.clone(),
+        blocking: script.blocking.clone(),
+        blocking_tokens: script.blocking_tokens.clone(),
+        blocking_token_count: script.blocking_tokens.len(),
+        render_blocking: script
+            .blocking_tokens
+            .iter()
+            .any(|token| token.eq_ignore_ascii_case("render")),
+        has_text: script.text.is_some(),
+        text_length,
+    }
+}
+
 impl ExpectedResourceEndpointDescriptor {
     fn into_browser_resource_endpoint_descriptor(self) -> BrowserResourceEndpointDescriptor {
         let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
@@ -4651,6 +4754,34 @@ impl ExpectedScript {
             blocking: self.blocking,
             blocking_tokens,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedScriptExecutionDescriptor {
+    fn into_browser_script_execution_descriptor(self) -> BrowserScriptExecutionDescriptor {
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
+        BrowserScriptExecutionDescriptor {
+            script_kind: self.script_kind,
+            execution_kind: self.execution_kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            type_hint: self.type_hint,
+            async_script: self.async_script,
+            defer_script: self.defer_script,
+            nomodule: self.nomodule,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            nonce: self.nonce,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            blocking_tokens,
+            blocking_token_count: self.blocking_token_count,
+            render_blocking: self.render_blocking,
+            has_text: self.has_text,
+            text_length: self.text_length,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -46,9 +46,10 @@ annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and
 flattened playback descriptors with source/track counts.
 Script/style cases pin module/classic script kind, async/defer/nomodule flags,
-inline script/style text, and loading-policy hints such as integrity,
-crossorigin, referrer policy, fetch priority, blocking, disabled state, and
-alternate stylesheets. Responsive image cases pin `srcset`/`sizes`, resolved
+inline script/style text, flattened script execution descriptors, and
+loading-policy hints such as integrity, crossorigin, referrer policy, fetch
+priority, blocking, disabled state, and alternate stylesheets. Responsive image
+cases pin `srcset`/`sizes`, resolved
 candidate URLs, `picture/source` media/type hints, lazy loading, decoding, fetch
 priority, CORS/referrer policy, usemap, and server-side image-map state. Link
 resource cases pin relation-derived resource kinds, `as` hints,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -903,6 +903,11 @@
           { "script_kind": "classic", "src": null, "resolved_src": null, "type_hint": null, "defer_script": true, "nomodule": true, "nonce": "legacyNonce", "text": "legacy();" },
           { "script_kind": "classic", "src": "late.js", "resolved_src": "https://example.test/app/late.js", "type_hint": null, "nonce": "lateNonce", "defer_script": true }
         ],
+        "script_execution_descriptors": [
+          { "script_kind": "module", "execution_kind": "external", "src": "app.js", "resolved_src": "https://example.test/app/app.js", "type_hint": "module", "async_script": true, "integrity": "sha384-js", "crossorigin": "use-credentials", "nonce": "moduleNonce", "referrerpolicy": "origin", "fetchpriority": "low", "blocking": "render", "blocking_tokens": ["render"], "blocking_token_count": 1, "render_blocking": true, "has_text": false, "text_length": 0 },
+          { "script_kind": "classic", "execution_kind": "inline", "src": null, "resolved_src": null, "type_hint": null, "defer_script": true, "nomodule": true, "nonce": "legacyNonce", "blocking_token_count": 0, "render_blocking": false, "has_text": true, "text_length": 9 },
+          { "script_kind": "classic", "execution_kind": "external", "src": "late.js", "resolved_src": "https://example.test/app/late.js", "type_hint": null, "nonce": "lateNonce", "defer_script": true, "blocking_token_count": 0, "render_blocking": false, "has_text": false, "text_length": 0 }
+        ],
         "stylesheets": [
           { "source": "link", "href": "app.css", "resolved_href": "https://example.test/app/app.css", "rel": "stylesheet preload", "rel_tokens": ["stylesheet", "preload"], "media": "screen", "title": "main", "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"] },
           { "source": "link", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "rel_tokens": ["alternate", "stylesheet"], "title": "print", "disabled": true, "alternate": true },


### PR DESCRIPTION
## Summary
- add flattened browser script execution descriptors for external/inline scripts
- track module/classic/nomodule, async/defer, blocking, policy hints, and inline text metadata
- pin descriptor expectations in browser-readiness fixtures and update fixture docs/changelog

## Tests
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_script_execution_descriptors_track_execution_and_policy_hints
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser