### PR TITLE
feat(closurec): CLOC12.44 — close gap-037 (async function trailing `;`)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.50.0] - 2026-06-08
+
+### Changed
+- **CLOSES gap-037** — async function declaration trailing `;`.
+  The byte-identity harness now reports
+  `32 matched, 0 failed, 1 skipped (of 33 total)` — only
+  gap-038 (hex literal → decimal normalisation) remains.
+- Added `saw_async_kw_at_boundary` flag. `async` keyword at
+  a statement boundary arms it ONLY when the very next
+  non-trivia token is `function` (gate). The next
+  `function` keyword consumes the flag and arms
+  `saw_function_kw_at_boundary` as if `function` itself had
+  been at the boundary. The matching `}` then emits the
+  gap-030 trailing `;`.
+- The `function` keyword arm is now `at_stmt_boundary
+  || saw_async_kw_at_boundary` (was just `at_stmt_boundary`),
+  and the async flag is cleared whether or not the function
+  branch fires.
+
+### Added
+- 5 new inline `gap037_*` tests:
+  - `gap037_async_function_trailing_semi` — target fixture
+  - `gap037_empty_async_function_trailing_semi`
+  - `gap037_async_method_shorthand_does_not_arm` —
+    non-regression: `{async f(){}}` doesn't arm.
+  - `gap037_async_arrow_does_not_arm` — non-regression:
+    `async()=>x` doesn't arm.
+  - `gap037_async_function_expression_no_trailing_semi` —
+    non-regression: `var f=async function(){};` doesn't get
+    extra `;`.
+
+### Design — keyword-arming guard family
+
+This continues the keyword-as-property defense pattern
+established by gap-033 (`try`), gap-034 (`class`), and
+gap-036 (`switch`): never arm a keyword flag without
+checking the next non-trivia token. The `async` keyword is
+particularly important to guard because it's NOT a reserved
+word in ES (it's a contextual keyword), so users can name
+methods `async` legally. The guard requires next-is-`function`
+which is grammatically necessary for the async-function-decl
+shape (per §15.8) and surgically excludes async arrow
+functions, async methods, and async-named properties.
+
 ## [0.49.0] - 2026-06-08
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -218,6 +218,13 @@ pub fn whitespace_only_minify(
     //   boundary. The next `{` (after the optional class name
     //   and optional `extends` clause) consumes the flag and
     //   pushes `BlockKind::Class`.
+    let mut saw_async_kw_at_boundary = false;
+    // ^ gap-037: armed by `async` keyword at a statement
+    //   boundary when the very next token is `function`. The
+    //   next `function` token consumes the flag and treats
+    //   the upcoming function-decl shape as if `function`
+    //   itself were at a statement boundary, so the matching
+    //   `}` emits the gap-030 trailing `;`.
     let mut next_paren_is_control_flow_head = false;
     let mut next_paren_is_switch_head = false;
     // ^ gap-036: armed by the `switch` keyword. When the `(`
@@ -539,10 +546,30 @@ pub fn whitespace_only_minify(
             at_stmt_boundary = true;
         } else if is_keyword_function(tok) {
             // Only treat as a function-DECLARATION when at a
-            // statement boundary. Expressions live
-            // mid-expression and don't qualify.
-            if at_stmt_boundary {
+            // statement boundary OR when we just saw `async`
+            // at a statement boundary (gap-037). Expressions
+            // live mid-expression and don't qualify.
+            if at_stmt_boundary || saw_async_kw_at_boundary {
                 saw_function_kw_at_boundary = true;
+            }
+            saw_async_kw_at_boundary = false;
+            at_stmt_boundary = false;
+        } else if val == "async" {
+            // gap-037: `async` keyword before `function` makes
+            // `async function f(){}` a function-DECLARATION
+            // shape. Track that we just saw `async` at a
+            // statement boundary, and propagate that boundary
+            // forward through the next `function` keyword
+            // arming. Filter out method-shorthand `async
+            // m(){}` (next token would be IDENT followed by
+            // `(`) and async-arrow `async()=>{}` (next is
+            // `(`) by requiring the next non-trivia to be
+            // `function`. Without this guard the flag would
+            // leak forward and contaminate an unrelated `{`.
+            let next_is_function =
+                kept.get(idx + 1).map(|t| t.value.as_str()) == Some("function");
+            if at_stmt_boundary && next_is_function {
+                saw_async_kw_at_boundary = true;
             }
             at_stmt_boundary = false;
         } else if val == "try" {
@@ -1555,6 +1582,65 @@ mod tests {
         assert_eq!(
             minify("var o={switch:1};while(x){a;b;}"),
             "var o={switch:1};while(x){a;b}"
+        );
+    }
+
+    // ---- gap-037: async function trailing `;` ------------
+
+    /// Target fixture: async function declaration gets a
+    /// trailing `;` mirroring gap-030's plain-function rule.
+    #[test]
+    fn gap037_async_function_trailing_semi() {
+        assert_eq!(
+            minify("async function f(){await x;}"),
+            "async function f(){await x};"
+        );
+    }
+
+    /// Empty-body async function also gets the trailing `;`.
+    #[test]
+    fn gap037_empty_async_function_trailing_semi() {
+        assert_eq!(
+            minify("async function f(){}"),
+            "async function f(){};"
+        );
+    }
+
+    /// **Non-regression**: `async` as method-shorthand name
+    /// in an object literal (`{async(){...}}`) must NOT arm
+    /// the flag. The next token after `async` is the IDENT
+    /// for the method name (or `(` for the bare shorthand),
+    /// not `function`, so the guard correctly filters this.
+    #[test]
+    fn gap037_async_method_shorthand_does_not_arm() {
+        // `{async f(){}}` — `async` shorthand prefix on a
+        // method. Output: object literal preserved; no
+        // trailing `;` injected.
+        assert_eq!(
+            minify("var o={async f(){}};"),
+            "var o={async f(){}};"
+        );
+    }
+
+    /// **Non-regression**: `async()=>x` (async arrow
+    /// function) must NOT arm. Next token is `(`, not
+    /// `function`.
+    #[test]
+    fn gap037_async_arrow_does_not_arm() {
+        assert_eq!(
+            minify("var f=async()=>1;"),
+            "var f=async()=>1;"
+        );
+    }
+
+    /// **Non-regression**: async function EXPRESSION (mid-
+    /// expression position) doesn't get the trailing `;`.
+    /// at_stmt_boundary is false in this position.
+    #[test]
+    fn gap037_async_function_expression_no_trailing_semi() {
+        assert_eq!(
+            minify("var f=async function(){};"),
+            "var f=async function(){};"
         );
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.49.0
+Version: 0.50.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,13 +85,11 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-037: async function declaration trailing `;` —
-    // sibling of gap-030. closurec's state machine arms
-    // `saw_function_kw_at_boundary` on `function` keyword at
-    // stmt boundary, but `async` consumes the boundary first,
-    // so the subsequent `function` doesn't see at_boundary=true.
-    // Discovered by CLOC14.5. See README in fixture dir.
-    ("async", "gap-037: async function trailing `;`"),
+    // gap-037 was RESOLVED in CLOC12.44 — `async` keyword at
+    // stmt boundary now propagates the boundary to the
+    // following `function` keyword via the
+    // `saw_async_kw_at_boundary` flag. `minify_async` flipped
+    // IGNORED → PASS.
     // gap-038: hex numeric literal normalized to decimal.
     // Upstream emits `var x=255;` for `var x=0xff;` even
     // under WHITESPACE_ONLY. closurec preserves the source

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -277,10 +277,8 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-037 — async function declaration trailing `;`
 
-- **Status:** OPEN — newly discovered by CLOC14.5. **Sibling of gap-030.**
-- **Upstream byte-identity test:** `minify_async` seed fixture.
-- **Why it fails:** Upstream emits `async function f(){await x};` for `async function f(){await x;}`. closurec emits `async function f(){await x}` (missing trailing `;`). The state machine's `saw_function_kw_at_boundary` arming requires `function` to be at a statement boundary, but the `async` keyword consumes the boundary (sets `at_stmt_boundary=false`) before `function` is seen.
-- **What it needs:** Add an `async`-tracking flag. When `async` is seen at a statement boundary, set both `at_stmt_boundary=false` (current behavior) AND a sticky `next_keyword_inherits_boundary` flag. The next `function` keyword checks both `at_stmt_boundary` and that flag. Alternative: just track "saw `async` immediately before this `function`" — simpler scope.
+- **Status:** **RESOLVED** in CLOC12.44 (PR pending). `minify_async` flipped IGNORED → PASS.
+- **Resolution:** Added `saw_async_kw_at_boundary` flag. `async` keyword at stmt boundary arms it ONLY when the very next non-trivia token is `function` (filters out async-arrow `async()=>x`, async method shorthand `{async m(){}}`, etc.). The next `function` keyword checks both `at_stmt_boundary` and `saw_async_kw_at_boundary` to decide whether to arm `saw_function_kw_at_boundary`. Same guard family as gap-033's `try` and gap-034's `class` — never arm a keyword flag without next-token confirmation.
 
 ### gap-038 — hex numeric literal normalised to decimal
 


### PR DESCRIPTION
## Summary

**Closes gap-037.** \`minify_async\` flipped IGNORED → PASS. Harness now **32/33** — only gap-038 (hex → decimal) remains in the seed.

## The fix

Added \`saw_async_kw_at_boundary\` flag with a contextual-keyword guard:

- Arm only when \`at_stmt_boundary\` AND next non-trivia token is \`function\`.
- The \`function\` arm now checks \`at_stmt_boundary || saw_async_kw_at_boundary\`.
- Flag always cleared in the function branch.

The next-is-\`function\` gate is critical because \`async\` is a CONTEXTUAL keyword (not reserved) — surgically excludes async arrows, async methods, async-named properties. Same guard family as gap-033 (\`try\`), gap-034 (\`class\`), gap-036 (\`switch\`).

## Tests

5 new \`gap037_*\` tests including 3 explicit non-regression cases (method shorthand, arrow, expression). Full suite **323 passed**.

## Pre-push security review

Verdict PASS on round 1. Traced 5 concerns: property-name leak, class-body async method, async function as property value, trivia race, sequential \`async async function\`.

## Version

0.49.0 → 0.50.0.

## Test plan

- [x] \`cargo test\` → 323 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 32 matched, 0 failed, 1 skipped (of 33)
- [x] Security review → PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)