### PR TITLE
feat(closurec): CLOC12.45 — close gap-038 (hex/oct/bin → decimal) — HARNESS NOW 33/33

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.51.0] - 2026-06-08
+
+### Changed
+- **CLOSES gap-038** — hex/oct/bin numeric literal
+  shortest-form normalisation. **The byte-identity harness
+  now reports `33 matched, 0 failed, 0 skipped (of 33
+  total)`** — third 100% milestone today (after 17/17 and
+  25/25 earlier).
+- Added `normalize_number_value()`: detects hex/oct/bin
+  prefixes, parses to `u128`, formats as decimal, emits
+  whichever is shorter (tie-break to decimal). Tie-break
+  rule verified directly against
+  `closure-compiler-v20240317.jar`: `0xffffffff` (10 chars)
+  → `4294967295` (10 chars, ties → decimal),
+  `0xfffffffff` (11 chars) → `68719476735` (11 chars, ties
+  → decimal).
+- Added `is_number_literal()` helper for grammar-name
+  detection (mirrors `is_string_literal`).
+- Wired the normaliser into both emit sites: the main loop
+  emit and the gap-032 single-statement pre-emit pathway.
+
+### Added
+- 9 new `gap038_*` inline tests covering: hex short, hex
+  tie picks decimal, hex kept when shorter (14-char hex vs
+  15-char decimal), octal, binary, uppercase prefix (`0X`),
+  decimal unchanged, BigInt verbatim, overflow safety.
+
+### Limitations carried forward (each becomes its own gap if a fixture surfaces it)
+- **BigInt literals** (`0xfn`) need bigint arithmetic.
+  Left verbatim; upstream emits `15n`.
+- **Decimal floating-point shortest-form** (`0.5` → `.5`,
+  `10.0` → `10`).
+- **Scientific notation uppercasing** (`1e3` → `1E3`).
+- **u128 overflow**: hex literals exceeding `u128::MAX` stay
+  verbatim rather than panicking.
+
 ## [0.50.0] - 2026-06-08
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -359,6 +359,8 @@ pub fn whitespace_only_minify(
                                 &mut out, &t.value,
                             );
                             out.push('"');
+                        } else if is_number_literal(t) {
+                            out.push_str(&normalize_number_value(&t.value));
                         } else {
                             out.push_str(&t.value);
                         }
@@ -455,6 +457,10 @@ pub fn whitespace_only_minify(
             out.push('"');
             push_quoted_string_content(&mut out, &tok.value);
             out.push('"');
+        } else if is_number_literal(tok) {
+            // gap-038: rewrite hex/oct/bin literals to
+            // decimal when decimal is no longer than source.
+            out.push_str(&normalize_number_value(&tok.value));
         } else {
             out.push_str(&tok.value);
         }
@@ -714,6 +720,92 @@ fn is_keyword_function(tok: &lexer::token::Token) -> bool {
             || upper.starts_with("KEYWORD");
     }
     true
+}
+
+/// True iff this token is a numeric literal (NUMBER token).
+/// Mirrors `is_string_literal`'s grammar-name detection but
+/// for the numeric-rule family. Used by gap-038's shortest-
+/// form normalisation.
+fn is_number_literal(tok: &lexer::token::Token) -> bool {
+    if let Some(name) = &tok.type_name {
+        let upper = name.to_ascii_uppercase();
+        if upper == "NUMBER" || upper == "NUMERIC_LITERAL" || upper == "NUMBER_LITERAL" {
+            return true;
+        }
+    }
+    matches!(tok.type_, lexer::token::TokenType::Number)
+}
+
+/// gap-038: rewrite hex / octal / binary integer literals to
+/// their decimal form when decimal is no longer than source.
+///
+/// Upstream Closure under WHITESPACE_ONLY normalises numeric
+/// literals to a shortest-form representation. For non-BigInt
+/// hex/oct/bin literals, the decimal form is chosen iff its
+/// string length is **less than or equal to** the source-form
+/// length — i.e. tie-breaks go to decimal.
+///
+/// **Worked examples** (verified against
+/// `closure-compiler-v20240317.jar`):
+///   `0xff`         (4 chars) → `255`             (3 chars) → DECIMAL wins
+///   `0xfff`        (5 chars) → `4095`            (4 chars) → DECIMAL wins
+///   `0xffffffff`  (10 chars) → `4294967295`     (10 chars) → DECIMAL wins (tie)
+///   `0xfffffffff` (11 chars) → `68719476735`    (11 chars) → DECIMAL wins (tie)
+///   `0xffffffffffff` (14 chars) → `281474976710655` (15 chars) → HEX wins
+///   `0o777`        (5 chars) → `511`             (3 chars) → DECIMAL wins
+///   `0b1010`       (6 chars) → `10`              (2 chars) → DECIMAL wins
+///
+/// **Not handled (left for follow-up gaps):**
+///   - BigInt literals (anything ending in `n`) need
+///     arbitrary-precision arithmetic. `0xfn` stays as
+///     `0xfn` rather than becoming `15n`.
+///   - Decimal floating-point normalisation: `0.5` → `.5`,
+///     `1e3` → `1E3`, `10.0` → `10`. These are different
+///     rules in different parts of the upstream code path.
+///   - Numbers that exceed `u128::MAX` parse as `None` and
+///     stay verbatim.
+fn normalize_number_value(value: &str) -> String {
+    // BigInt — defer to a future gap.
+    if value.ends_with('n') {
+        return value.to_string();
+    }
+    // Try each radix prefix in turn. The prefixes are
+    // case-insensitive per §12.8.3.
+    let parsed: Option<u128> = if let Some(rest) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u128::from_str_radix(rest, 16).ok()
+    } else if let Some(rest) = value
+        .strip_prefix("0o")
+        .or_else(|| value.strip_prefix("0O"))
+    {
+        u128::from_str_radix(rest, 8).ok()
+    } else if let Some(rest) = value
+        .strip_prefix("0b")
+        .or_else(|| value.strip_prefix("0B"))
+    {
+        u128::from_str_radix(rest, 2).ok()
+    } else {
+        // Decimal or no radix prefix — leave alone. Decimal
+        // floating-point shortest-form is a separate concern
+        // (see function doc).
+        return value.to_string();
+    };
+
+    let Some(n) = parsed else {
+        // Doesn't fit in u128 — leave verbatim.
+        return value.to_string();
+    };
+    let decimal = n.to_string();
+    // `<= value.len()` because upstream tie-breaks to decimal
+    // (verified via JAR probe: `0xffffffff` (10) → `4294967295` (10)
+    // → DECIMAL wins).
+    if decimal.len() <= value.len() {
+        decimal
+    } else {
+        value.to_string()
+    }
 }
 
 /// True iff this token came from a string-literal rule. The
@@ -1642,5 +1734,81 @@ mod tests {
             minify("var f=async function(){};"),
             "var f=async function(){};"
         );
+    }
+
+    // ---- gap-038: number literal shortest-form normalisation
+
+    /// Target fixture: hex literal `0xff` shortens to `255`.
+    #[test]
+    fn gap038_hex_short() {
+        assert_eq!(minify("var x=0xff;"), "var x=255;");
+    }
+
+    /// Hex tie-break: `0xffffffff` (10 chars) → `4294967295`
+    /// (10 chars). Upstream tie-breaks to DECIMAL.
+    #[test]
+    fn gap038_hex_tie_picks_decimal() {
+        assert_eq!(
+            minify("var x=0xffffffff;"),
+            "var x=4294967295;"
+        );
+    }
+
+    /// Hex too long for decimal: 14-char hex →
+    /// 15-char decimal. Keep hex.
+    #[test]
+    fn gap038_hex_kept_when_shorter() {
+        assert_eq!(
+            minify("var x=0xffffffffffff;"),
+            "var x=0xffffffffffff;"
+        );
+    }
+
+    /// Octal literal: `0o777` → `511` (5 chars → 3).
+    #[test]
+    fn gap038_octal_short() {
+        assert_eq!(minify("var x=0o777;"), "var x=511;");
+    }
+
+    /// Binary literal: `0b1010` → `10` (6 chars → 2).
+    #[test]
+    fn gap038_binary_short() {
+        assert_eq!(minify("var x=0b1010;"), "var x=10;");
+    }
+
+    /// Uppercase prefix `0X` is equivalent to `0x` per
+    /// §12.8.3 — same normalisation rule applies.
+    #[test]
+    fn gap038_uppercase_hex_prefix() {
+        assert_eq!(minify("var x=0XFF;"), "var x=255;");
+    }
+
+    /// **Non-regression**: decimal literals are NOT touched.
+    /// Decimal-floating-point shortest-form (e.g. `0.5` → `.5`)
+    /// is a different rule and out of scope for this gap.
+    #[test]
+    fn gap038_decimal_unchanged() {
+        assert_eq!(minify("var x=42;"), "var x=42;");
+    }
+
+    /// **Non-regression**: BigInt literals are NOT touched.
+    /// `0xfn` would canonicalise to `15n` upstream, but
+    /// that requires bigint arithmetic — left for a
+    /// follow-up gap. Leaving verbatim is safer than
+    /// truncating.
+    #[test]
+    fn gap038_bigint_left_verbatim() {
+        assert_eq!(minify("var x=0xfn;"), "var x=0xfn;");
+    }
+
+    /// **Non-regression**: number that overflows u128 stays
+    /// verbatim rather than panicking. Hex digits >>32 are
+    /// rare in practice but we must not crash on input that
+    /// happens to be very large.
+    #[test]
+    fn gap038_overflow_left_verbatim() {
+        let big = "0x".to_string() + &"f".repeat(40); // u160 worth
+        let src = format!("var x={};", big);
+        assert_eq!(minify(&src), src);
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.50.0
+Version: 0.51.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,13 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // following `function` keyword via the
     // `saw_async_kw_at_boundary` flag. `minify_async` flipped
     // IGNORED → PASS.
-    // gap-038: hex numeric literal normalized to decimal.
-    // Upstream emits `var x=255;` for `var x=0xff;` even
-    // under WHITESPACE_ONLY. closurec preserves the source
-    // literal verbatim. Discovered by CLOC14.5.
-    ("hex_number", "gap-038: hex literal → decimal"),
+    // gap-038 was RESOLVED in CLOC12.45 — hex/oct/bin
+    // integer literals now normalise to decimal when
+    // decimal length is <= source length (tie-break to
+    // decimal), matching upstream's shortest-form rule.
+    // `minify_hex_number` flipped IGNORED → PASS.
+    // **The byte-identity harness now reports 33 matched,
+    // 0 failed, 0 skipped (of 33 total).**
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -282,7 +282,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-038 — hex numeric literal normalised to decimal
 
-- **Status:** OPEN — newly discovered by CLOC14.5.
-- **Upstream byte-identity test:** `minify_hex_number` seed fixture.
-- **Why it fails:** Upstream emits `var x=255;` for `var x=0xff;` even under WHITESPACE_ONLY. closurec preserves `0xff` verbatim. Note: this is a SHORTEST-FORM normalisation — if the decimal form were longer than the hex form (e.g. `0xffffffff` vs `4294967295`), upstream would presumably keep the hex. The rule is "emit the shorter representation, tie-break to decimal."
-- **What it needs:** Detect NUMBER tokens with hex (`0x` prefix), octal (`0o`), or binary (`0b`) prefixes, parse to a numeric value, format as both decimal and the source form, emit the shorter (tie-break decimal). closure-emitter already has shortest-form number formatting infrastructure (CLOC12.12) — could reuse the same logic at the token-stream layer.
+- **Status:** **RESOLVED** in CLOC12.45 (PR pending). `minify_hex_number` flipped IGNORED → PASS. **Harness reports 33/33 PASS — full byte-identity across the entire seed set.**
+- **Resolution:** Added `normalize_number_value()` helper to the WHITESPACE_ONLY token emit path. Detects hex/oct/bin integer literals via prefix (`0x`, `0X`, `0o`, `0O`, `0b`, `0B`), parses to `u128`, formats as decimal, emits whichever is shorter (tie-break to decimal). Verified against `closure-compiler-v20240317.jar` for ties — upstream's behaviour is "decimal when ≤ source length". `is_number_literal()` helper mirrors `is_string_literal()` for grammar-name detection.
+- **Limitations carried forward** (each will become its own gap if a fixture surfaces it):
+  - **BigInt literals** (`0xfn`) need arbitrary-precision arithmetic — left verbatim for now. Upstream would emit `15n`.
+  - **Decimal floating-point shortest-form** (`0.5` → `.5`, `10.0` → `10`) is a different normalisation family handled elsewhere in upstream's code path.
+  - **Scientific notation uppercasing** (`1e3` → `1E3`) is a separate rule — pure case change, not numeric normalisation.
+  - **u128 overflow**: literals exceeding `u128::MAX` parse as `None` and stay verbatim rather than panicking.


### PR DESCRIPTION
## Summary

🎯 **THIRD 100% MILESTONE today.** Harness goes 32/33 → **33/33 PASS** — full byte-identity across the entire 33-fixture seed set.

Today's progression:
- **17/17** at CLOC12.42 (gap-032)
- **25/25** at CLOC12.43 (gap-034/035/036)
- **33/33** at CLOC12.45 (gap-038) ← this PR

## What's normalised

Hex/oct/bin integer literals → decimal when decimal length ≤ source length (tie-break to decimal, verified against upstream JAR):

| Input | Output |
|-------|--------|
| \`0xff\` | \`255\` |
| \`0xffffffff\` | \`4294967295\` (tie → decimal) |
| \`0xffffffffffff\` | \`0xffffffffffff\` (hex shorter) |
| \`0o777\` | \`511\` |
| \`0b1010\` | \`10\` |
| \`0xfn\` | \`0xfn\` (BigInt verbatim — follow-up) |

## Implementation

Two helpers (~80 lines + docstrings):
- \`is_number_literal(tok)\` mirrors \`is_string_literal\`
- \`normalize_number_value(value)\` parses hex/oct/bin → u128 → decimal, picks shorter (tie → decimal)

Wired into both emit sites.

## Pre-push security review

Verdict PASS on round 1. Traced 9 concerns: empty digits, negative numbers, invalid chars, tie-break direction, underscore separators (safe miss), bare \`0\`, legacy octal, both emit sites wired, target fixture arithmetic.

## Tests

9 new \`gap038_*\` inline tests including overflow safety + BigInt non-regression. Full suite: **331 passed**.

## Version

0.50.0 → 0.51.0.

## Test plan

- [x] \`cargo test\` → 331 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → **33 matched, 0 failed, 0 skipped (of 33)**
- [x] Security review → PASS
- [ ] CI green

## Marathon

This brings the marathon to a notable resting point: every WHITESPACE_ONLY shape in the seed set now matches upstream byte-for-byte. The flywheel keeps spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)