### PR TITLE
Add browser image candidate descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -264,7 +264,8 @@ documented in this file.
   priority, blocking, flattened script execution descriptors, alternate
   stylesheets, and disabled stylesheet state.
 - Browser-facing image summaries now carry responsive image selection metadata,
-  including `srcset`/`sizes`, resolved candidate URLs, `picture/source`
+  including `srcset`/`sizes`, resolved candidate URLs, flattened image
+  candidate descriptors with source/candidate counts, `picture/source`
   media/type hints, lazy loading, decoding, fetch priority, CORS/referrer
   policy, usemap, and server-side image-map state.
 - Browser-facing table summaries and tree projections now carry table layout and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -852,6 +852,7 @@ pub struct BrowserDocument {
     pub aria_relation_descriptors: Vec<BrowserAriaRelationDescriptor>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
+    pub image_candidate_descriptors: Vec<BrowserImageCandidateDescriptor>,
     pub image_maps: Vec<BrowserImageMap>,
     pub media: Vec<BrowserMedia>,
     pub media_playback_descriptors: Vec<BrowserMediaPlaybackDescriptor>,
@@ -1940,6 +1941,32 @@ pub struct BrowserImageSource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImageCandidateDescriptor {
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub srcset: Option<String>,
+    pub resolved_srcset: Option<String>,
+    pub sizes: Option<String>,
+    pub alt: Option<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub loading: Option<String>,
+    pub decoding: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub crossorigin: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub usemap: Option<String>,
+    pub ismap: bool,
+    pub has_alt: bool,
+    pub source_count: usize,
+    pub source_srcset_count: usize,
+    pub candidate_count: usize,
+    pub source_type_hints: Vec<String>,
+    pub source_media: Vec<String>,
+    pub sources: Vec<BrowserImageSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserImageMap {
     pub id: Option<String>,
     pub name: Option<String>,
@@ -2697,6 +2724,7 @@ impl BrowserDocument {
         );
         summary.script_execution_descriptors =
             browser_script_execution_descriptors(&summary.scripts);
+        summary.image_candidate_descriptors = browser_image_candidate_descriptors(&summary.images);
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.embedded_policy_descriptors =
             browser_embedded_policy_descriptors(&summary.embedded_contexts);
@@ -10271,6 +10299,75 @@ fn browser_resource_endpoint_descriptors(
     descriptors
 }
 
+fn browser_image_candidate_descriptors(
+    images: &[BrowserImage],
+) -> Vec<BrowserImageCandidateDescriptor> {
+    images
+        .iter()
+        .map(browser_image_candidate_descriptor)
+        .collect()
+}
+
+fn browser_image_candidate_descriptor(image: &BrowserImage) -> BrowserImageCandidateDescriptor {
+    let image_srcset_count = image
+        .srcset
+        .as_deref()
+        .map(browser_srcset_candidate_count)
+        .unwrap_or_default();
+    let source_srcset_count = image
+        .sources
+        .iter()
+        .filter(|source| source.srcset.is_some())
+        .count();
+    let source_candidate_count = image
+        .sources
+        .iter()
+        .filter_map(|source| source.srcset.as_deref())
+        .map(browser_srcset_candidate_count)
+        .sum::<usize>();
+
+    BrowserImageCandidateDescriptor {
+        src: image.src.clone(),
+        resolved_src: image.resolved_src.clone(),
+        srcset: image.srcset.clone(),
+        resolved_srcset: image.resolved_srcset.clone(),
+        sizes: image.sizes.clone(),
+        alt: image.alt.clone(),
+        width: image.width.clone(),
+        height: image.height.clone(),
+        loading: image.loading.clone(),
+        decoding: image.decoding.clone(),
+        fetchpriority: image.fetchpriority.clone(),
+        crossorigin: image.crossorigin.clone(),
+        referrerpolicy: image.referrerpolicy.clone(),
+        usemap: image.usemap.clone(),
+        ismap: image.ismap,
+        has_alt: image.alt.is_some(),
+        source_count: image.sources.len(),
+        source_srcset_count,
+        candidate_count: image_srcset_count + source_candidate_count,
+        source_type_hints: image
+            .sources
+            .iter()
+            .filter_map(|source| source.type_hint.clone())
+            .collect(),
+        source_media: image
+            .sources
+            .iter()
+            .filter_map(|source| source.media.clone())
+            .collect(),
+        sources: image.sources.clone(),
+    }
+}
+
+fn browser_srcset_candidate_count(srcset: &str) -> usize {
+    srcset
+        .split(',')
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .count()
+}
+
 fn browser_media_playback_descriptors(
     media: &[BrowserMedia],
 ) -> Vec<BrowserMediaPlaybackDescriptor> {
@@ -17401,6 +17498,40 @@ mod tests {
             Some("https://example.test/gallery/hero-wide.avif 1x, https://example.test/gallery/hero-wide@2x.avif 2x")
         );
         assert_eq!(image.sources[1].sizes.as_deref(), Some("100vw"));
+
+        assert_eq!(summary.image_candidate_descriptors.len(), 1);
+        let descriptor = &summary.image_candidate_descriptors[0];
+        assert_eq!(descriptor.src.as_deref(), Some("hero.jpg"));
+        assert_eq!(
+            descriptor.resolved_src.as_deref(),
+            Some("https://example.test/gallery/hero.jpg")
+        );
+        assert_eq!(descriptor.alt.as_deref(), Some("Hero"));
+        assert!(descriptor.has_alt);
+        assert_eq!(descriptor.width.as_deref(), Some("640"));
+        assert_eq!(descriptor.height.as_deref(), Some("360"));
+        assert_eq!(descriptor.loading.as_deref(), Some("lazy"));
+        assert_eq!(descriptor.decoding.as_deref(), Some("async"));
+        assert_eq!(descriptor.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(descriptor.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(descriptor.referrerpolicy.as_deref(), Some("no-referrer"));
+        assert_eq!(descriptor.usemap.as_deref(), Some("#hero-map"));
+        assert!(descriptor.ismap);
+        assert_eq!(descriptor.source_count, 2);
+        assert_eq!(descriptor.source_srcset_count, 2);
+        assert_eq!(descriptor.candidate_count, 6);
+        assert_eq!(
+            descriptor.source_type_hints,
+            vec!["image/avif".to_string(), "image/webp".to_string()]
+        );
+        assert_eq!(
+            descriptor.source_media,
+            vec![
+                "(min-width: 800px)".to_string(),
+                "(min-width: 400px)".to_string()
+            ]
+        );
+        assert_eq!(descriptor.sources.len(), 2);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -11,14 +11,15 @@ use coding_adventures_html_parser::{
     BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageMap, BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement,
-    BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor,
-    BrowserMediaSource, BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective,
-    BrowserNavigationGroup, BrowserNavigationTargetDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
+    BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
+    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -104,6 +105,8 @@ struct ExpectedBrowserDocument {
     aria_relation_descriptors: Vec<ExpectedAriaRelationDescriptor>,
     links: Vec<ExpectedLink>,
     images: Vec<ExpectedImage>,
+    #[serde(default)]
+    image_candidate_descriptors: Option<Vec<ExpectedImageCandidateDescriptor>>,
     #[serde(default)]
     image_maps: Vec<ExpectedImageMap>,
     #[serde(default)]
@@ -1336,6 +1339,54 @@ struct ExpectedImageSource {
     media: Option<String>,
     #[serde(default)]
     type_hint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedImageCandidateDescriptor {
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    srcset: Option<String>,
+    #[serde(default)]
+    resolved_srcset: Option<String>,
+    #[serde(default)]
+    sizes: Option<String>,
+    #[serde(default)]
+    alt: Option<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    loading: Option<String>,
+    #[serde(default)]
+    decoding: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    usemap: Option<String>,
+    #[serde(default)]
+    ismap: bool,
+    #[serde(default)]
+    has_alt: bool,
+    #[serde(default)]
+    source_count: usize,
+    #[serde(default)]
+    source_srcset_count: usize,
+    #[serde(default)]
+    candidate_count: usize,
+    #[serde(default)]
+    source_type_hints: Vec<String>,
+    #[serde(default)]
+    source_media: Vec<String>,
+    #[serde(default)]
+    sources: Vec<ExpectedImageSource>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3918,6 +3969,11 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedScript::into_browser_script)
             .collect();
+        let images: Vec<_> = self
+            .images
+            .into_iter()
+            .map(ExpectedImage::into_browser_image)
+            .collect();
         let media: Vec<_> = self
             .media
             .into_iter()
@@ -3968,6 +4024,15 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_script_execution_descriptors(&scripts));
+        let image_candidate_descriptors = self
+            .image_candidate_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedImageCandidateDescriptor::into_browser_image_candidate_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_image_candidate_descriptors(&images));
 
         BrowserDocument {
             title: self.title,
@@ -4082,11 +4147,8 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedLink::into_browser_link)
                 .collect(),
-            images: self
-                .images
-                .into_iter()
-                .map(ExpectedImage::into_browser_image)
-                .collect(),
+            images,
+            image_candidate_descriptors,
             image_maps: self
                 .image_maps
                 .into_iter()
@@ -4589,6 +4651,75 @@ fn expected_media_playback_descriptor(media: &BrowserMedia) -> BrowserMediaPlayb
             .count(),
         tracks: media.tracks.clone(),
     }
+}
+
+fn expected_image_candidate_descriptors(
+    images: &[BrowserImage],
+) -> Vec<BrowserImageCandidateDescriptor> {
+    images
+        .iter()
+        .map(expected_image_candidate_descriptor)
+        .collect()
+}
+
+fn expected_image_candidate_descriptor(image: &BrowserImage) -> BrowserImageCandidateDescriptor {
+    let image_srcset_count = image
+        .srcset
+        .as_deref()
+        .map(expected_srcset_candidate_count)
+        .unwrap_or_default();
+    let source_srcset_count = image
+        .sources
+        .iter()
+        .filter(|source| source.srcset.is_some())
+        .count();
+    let source_candidate_count = image
+        .sources
+        .iter()
+        .filter_map(|source| source.srcset.as_deref())
+        .map(expected_srcset_candidate_count)
+        .sum::<usize>();
+
+    BrowserImageCandidateDescriptor {
+        src: image.src.clone(),
+        resolved_src: image.resolved_src.clone(),
+        srcset: image.srcset.clone(),
+        resolved_srcset: image.resolved_srcset.clone(),
+        sizes: image.sizes.clone(),
+        alt: image.alt.clone(),
+        width: image.width.clone(),
+        height: image.height.clone(),
+        loading: image.loading.clone(),
+        decoding: image.decoding.clone(),
+        fetchpriority: image.fetchpriority.clone(),
+        crossorigin: image.crossorigin.clone(),
+        referrerpolicy: image.referrerpolicy.clone(),
+        usemap: image.usemap.clone(),
+        ismap: image.ismap,
+        has_alt: image.alt.is_some(),
+        source_count: image.sources.len(),
+        source_srcset_count,
+        candidate_count: image_srcset_count + source_candidate_count,
+        source_type_hints: image
+            .sources
+            .iter()
+            .filter_map(|source| source.type_hint.clone())
+            .collect(),
+        source_media: image
+            .sources
+            .iter()
+            .filter_map(|source| source.media.clone())
+            .collect(),
+        sources: image.sources.clone(),
+    }
+}
+
+fn expected_srcset_candidate_count(srcset: &str) -> usize {
+    srcset
+        .split(',')
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .count()
 }
 
 fn expected_embedded_policy_descriptors(
@@ -5345,6 +5476,39 @@ impl ExpectedImageSource {
             sizes: self.sizes,
             media: self.media,
             type_hint: self.type_hint,
+        }
+    }
+}
+
+impl ExpectedImageCandidateDescriptor {
+    fn into_browser_image_candidate_descriptor(self) -> BrowserImageCandidateDescriptor {
+        BrowserImageCandidateDescriptor {
+            src: self.src,
+            resolved_src: self.resolved_src,
+            srcset: self.srcset,
+            resolved_srcset: self.resolved_srcset,
+            sizes: self.sizes,
+            alt: self.alt,
+            width: self.width,
+            height: self.height,
+            loading: self.loading,
+            decoding: self.decoding,
+            fetchpriority: self.fetchpriority,
+            crossorigin: self.crossorigin,
+            referrerpolicy: self.referrerpolicy,
+            usemap: self.usemap,
+            ismap: self.ismap,
+            has_alt: self.has_alt,
+            source_count: self.source_count,
+            source_srcset_count: self.source_srcset_count,
+            candidate_count: self.candidate_count,
+            source_type_hints: self.source_type_hints,
+            source_media: self.source_media,
+            sources: self
+                .sources
+                .into_iter()
+                .map(ExpectedImageSource::into_browser_image_source)
+                .collect(),
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -49,8 +49,8 @@ Script/style cases pin module/classic script kind, async/defer/nomodule flags,
 inline script/style text, flattened script execution descriptors, and
 loading-policy hints such as integrity, crossorigin, referrer policy, fetch
 priority, blocking, disabled state, and alternate stylesheets. Responsive image
-cases pin `srcset`/`sizes`, resolved
-candidate URLs, `picture/source` media/type hints, lazy loading, decoding, fetch
+cases pin `srcset`/`sizes`, resolved candidate URLs, flattened image candidate
+descriptors, `picture/source` media/type hints, lazy loading, decoding, fetch
 priority, CORS/referrer policy, usemap, and server-side image-map state. Link
 resource cases pin relation-derived resource kinds, `as` hints,
 integrity/CORS/referrer policy, fetch priority, blocking, and responsive image

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -246,6 +246,35 @@
             ]
           }
         ],
+        "image_candidate_descriptors": [
+          {
+            "src": "hero.jpg",
+            "resolved_src": "https://example.test/gallery/hero.jpg",
+            "srcset": "hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w",
+            "resolved_srcset": "https://example.test/gallery/hero-small.jpg 480w, https://cdn.example.test/hero.jpg 960w",
+            "sizes": "(max-width: 600px) 100vw, 50vw",
+            "alt": "Hero",
+            "width": "640",
+            "height": "360",
+            "loading": "lazy",
+            "decoding": "async",
+            "fetchpriority": "high",
+            "crossorigin": "anonymous",
+            "referrerpolicy": "no-referrer",
+            "usemap": "#hero-map",
+            "ismap": true,
+            "has_alt": true,
+            "source_count": 2,
+            "source_srcset_count": 2,
+            "candidate_count": 6,
+            "source_type_hints": ["image/avif", "image/webp"],
+            "source_media": ["(min-width: 800px)", "(min-width: 400px)"],
+            "sources": [
+              { "srcset": "hero-wide.avif 1x, hero-wide@2x.avif 2x", "resolved_srcset": "https://example.test/gallery/hero-wide.avif 1x, https://example.test/gallery/hero-wide@2x.avif 2x", "sizes": "80vw", "media": "(min-width: 800px)", "type_hint": "image/avif" },
+              { "srcset": "hero.webp 640w, hero-large.webp 1280w", "resolved_srcset": "https://example.test/gallery/hero.webp 640w, https://example.test/gallery/hero-large.webp 1280w", "sizes": "100vw", "media": "(min-width: 400px)", "type_hint": "image/webp" }
+            ]
+          }
+        ],
         "image_maps": [
           {
             "name": "hero-map",


### PR DESCRIPTION
## Summary
- add flattened browser image candidate descriptors for img and picture/source metadata
- track src/srcset/sizes, source media/type hints, candidate counts, loading/decoding/fetch policy, and image-map flags
- pin descriptor expectations in browser-readiness fixtures and update fixture docs/changelog

## Tests
- python3 -m json.tool html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_responsive_image_metadata_tracks_sources_and_loading_hints
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser