### PR TITLE
Expose Chief smart-home pairing plan tool

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_discovery_summary` handlers over the D23 runtime read facade
   so Chief of Staff jobs can inspect scheduled discovery work and candidate
   freshness without owning discovery scheduler logic.
+- Added `smart_home.get_pairing_plan` over the D23 runtime read facade so Chief
+  of Staff jobs can inspect actionable discovery pairing plans before starting
+  a pairing session.
 - Added scheduled discovery worker observability to
   `smart_home.observe_supervision`, including worker status, due time, last run
   counts, and failure pressure from the D23 runtime.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -12,7 +12,8 @@ The crate is intentionally a thin adapter:
   read-only D23A catalog queries
 - `SmartHomeRuntime` still owns smart-home authorization, command validation,
   event subscriptions, pairing sessions, optimistic state, discovery scheduler
-  policy and observability, supervision, and audit decisions
+  policy and observability, discovery pairing plans, supervision, and audit
+  decisions
 - `smart-home-integration-catalog` still owns D23A integration and primitive
   catalog semantics
 - D18D still owns tool validation, policy decisions, event streams, terminal
@@ -27,6 +28,7 @@ Chief of Staff job/session/agent
   -> smart-home runtime authorization
   -> discovery records and unpaired bridge candidates
   -> discovery worker inventory and discovery freshness summaries
+  -> discovery pairing-plan previews for required host actions
   -> room topology and aggregate topology summary reads
   -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
@@ -51,6 +53,7 @@ Chief of Staff job/session/agent
 - `smart_home.discover`
 - `smart_home.list_discovery_workers`
 - `smart_home.get_discovery_summary`
+- `smart_home.get_pairing_plan`
 - `smart_home.list_bridges`
 - `smart_home.list_devices`
 - `smart_home.list_rooms`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -24,8 +24,10 @@ use smart_home_core::{
     StateDelta, StateSnapshot, StateSource, Value,
 };
 use smart_home_discovery::{
-    DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary, DiscoverySource,
-    DiscoveryWorkerId, DiscoveryWorkerKind,
+    DiscoveryPairingAction, DiscoveryPairingPlan, DiscoveryPairingPlanOptions,
+    DiscoveryPairingPlanSort, DiscoveryPairingPlanSummary, DiscoveryPairingTarget, DiscoveryRecord,
+    DiscoveryRecordSummary, DiscoverySignalStatus, DiscoverySignalSummary, DiscoverySource,
+    DiscoveryWorkerId, DiscoveryWorkerKind, PairingRequirement,
 };
 use smart_home_integration_catalog::{
     activation_plan_for_entry, describe_primitive_family, ecosystem_platforms_requiring_primitive,
@@ -50,19 +52,20 @@ use smart_home_runtime::{
     RuntimeCommandToolRequest, RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError,
     RuntimeEvent, RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter,
     RuntimeEventLogRecord, RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort,
-    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingSession,
-    RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
-    RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
-    RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
-    RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary,
-    RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus,
-    RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery,
-    RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort, RuntimeSupervisionPlan,
-    RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest,
-    RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest,
-    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime, SupervisedBridgeWorker,
-    SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport, WorkerHeartbeatDeadline,
-    WorkerHeartbeatSchedule, WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
+    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingPlanToolRequest,
+    RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionInventorySummary,
+    RuntimePairingSessionQuery, RuntimePairingSessionSort, RuntimePendingWorkSummary,
+    RuntimePollEventsToolOutput, RuntimePollEventsToolRequest, RuntimeReadSnapshot,
+    RuntimeReadToolOutput, RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort,
+    RuntimeRoomSummary, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
+    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
+    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
+    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
+    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
+    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
+    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
+    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
+    WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -71,6 +74,7 @@ pub const SMART_HOME_LIST_BRIDGES_TOOL_ID: &str = "smart_home.list_bridges";
 pub const SMART_HOME_DISCOVER_TOOL_ID: &str = "smart_home.discover";
 pub const SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID: &str = "smart_home.list_discovery_workers";
 pub const SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID: &str = "smart_home.get_discovery_summary";
+pub const SMART_HOME_GET_PAIRING_PLAN_TOOL_ID: &str = "smart_home.get_pairing_plan";
 pub const SMART_HOME_LIST_DEVICES_TOOL_ID: &str = "smart_home.list_devices";
 pub const SMART_HOME_LIST_ROOMS_TOOL_ID: &str = "smart_home.list_rooms";
 pub const SMART_HOME_LIST_SCENES_TOOL_ID: &str = "smart_home.list_scenes";
@@ -198,6 +202,17 @@ impl SmartHomeToolBridge {
                         )
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "get_discovery_summary"))
+                }
+                SMART_HOME_GET_PAIRING_PLAN_TOOL_ID => {
+                    let request = pairing_plan_request(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::GetPairingPlan { request },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "get_pairing_plan"))
                 }
                 SMART_HOME_LIST_BRIDGES_TOOL_ID => {
                     let _ = expect_object(&arguments)?;
@@ -765,6 +780,49 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
                     "record_summary",
                     "signal_summary",
                 ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_PAIRING_PLAN_TOOL_ID,
+            "Get smart-home pairing plan",
+            "Read the D23 discovery pairing plan and host action queue without starting a pairing session.",
+            object_schema(
+                vec![
+                    SchemaProperty::new("integration_id", JsonSchema::String),
+                    SchemaProperty::new("integration_ids", string_array_schema()),
+                    SchemaProperty::new("source", JsonSchema::String),
+                    SchemaProperty::new("sources", string_array_schema()),
+                    SchemaProperty::new("signal_status", JsonSchema::String),
+                    SchemaProperty::new("signal_statuses", string_array_schema()),
+                    SchemaProperty::new("pairing_requirement", JsonSchema::String),
+                    SchemaProperty::new("pairing_requirements", string_array_schema()),
+                    SchemaProperty::new("action", JsonSchema::String),
+                    SchemaProperty::new("actions", string_array_schema()),
+                    SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
+                    SchemaProperty::new("requires_human_action", JsonSchema::Boolean),
+                    SchemaProperty::new("actionable_only", JsonSchema::Boolean),
+                    SchemaProperty::new("sort", JsonSchema::String),
+                    SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+                    SchemaProperty::new("limit", JsonSchema::Integer),
+                ],
+                vec![],
+                false,
+            ),
+            object_schema(
+                vec![
+                    SchemaProperty::new("generated_at_ms", JsonSchema::Integer),
+                    SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+                    SchemaProperty::new(
+                        "targets",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                ],
+                vec!["generated_at_ms", "ttl_ms", "targets", "summary", "count"],
                 false,
             ),
         ),
@@ -1855,6 +1913,51 @@ fn discovery_worker_query(arguments: &JsonValue) -> Result<DiscoveryWorkerQuery,
     Ok(query)
 }
 
+fn pairing_plan_request(
+    arguments: &JsonValue,
+) -> Result<RuntimePairingPlanToolRequest, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut options = DiscoveryPairingPlanOptions::new();
+    for integration_id in optional_string_list(arguments, "integration_id", "integration_ids")? {
+        options = options.with_integration(IntegrationId::trusted(integration_id));
+    }
+    for source in optional_string_list(arguments, "source", "sources")? {
+        options = options.with_source(parse_discovery_source(&source)?);
+    }
+    for status in optional_string_list(arguments, "signal_status", "signal_statuses")? {
+        options = options.with_signal_status(parse_discovery_signal_status(&status)?);
+    }
+    for requirement in
+        optional_string_list(arguments, "pairing_requirement", "pairing_requirements")?
+    {
+        options = options.with_pairing_requirement(parse_pairing_requirement(&requirement)?);
+    }
+    for action in optional_string_list(arguments, "action", "actions")? {
+        options = options.with_action(parse_discovery_pairing_action(&action)?);
+    }
+    if let Some(priority) = optional_u8(arguments, "priority_at_or_before")? {
+        options = options.at_or_before_priority(priority);
+    }
+    if let Some(requires_human_action) = optional_bool(arguments, "requires_human_action")? {
+        options = options.requiring_human_action(requires_human_action);
+    }
+    if let Some(actionable_only) = optional_bool(arguments, "actionable_only")? {
+        options = options.actionable_only(actionable_only);
+    }
+    if let Some(sort) = optional_string(arguments, "sort")? {
+        options = options.sorted_by(parse_discovery_pairing_plan_sort(&sort)?);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        options = options.limited_to(limit as usize);
+    }
+
+    let mut request = RuntimePairingPlanToolRequest::new().with_options(options);
+    if let Some(ttl_ms) = optional_u64(arguments, "ttl_ms")? {
+        request = request.with_ttl_ms(ttl_ms);
+    }
+    Ok(request)
+}
+
 fn list_devices_request(arguments: &JsonValue) -> Result<RuntimeReadToolRequest, ToolCallError> {
     Ok(RuntimeReadToolRequest::ListDevices {
         bridge_id: optional_string(arguments, "bridge_id")?.map(BridgeId::trusted),
@@ -2475,6 +2578,11 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
                 discovery_signal_summary_json(&signal_summary),
             ),
         ]),
+        RuntimeReadToolOutput::PairingPlan {
+            ttl_ms,
+            plan,
+            summary,
+        } => pairing_plan_output_json(ttl_ms, &plan, &summary),
         RuntimeReadToolOutput::Bridges(bridges) => object([
             (
                 "bridges",
@@ -2863,6 +2971,122 @@ fn discovery_signal_summary_json(summary: &DiscoverySignalSummary) -> JsonValue 
         (
             "has_stale_or_expired_signals",
             JsonValue::Bool(summary.stale > 0 || summary.expired > 0),
+        ),
+    ])
+}
+
+fn pairing_plan_output_json(
+    ttl_ms: u64,
+    plan: &DiscoveryPairingPlan,
+    summary: &DiscoveryPairingPlanSummary,
+) -> JsonValue {
+    object([
+        ("generated_at_ms", integer(plan.generated_at_ms as i64)),
+        ("ttl_ms", integer(ttl_ms as i64)),
+        (
+            "targets",
+            JsonValue::Array(plan.targets.iter().map(pairing_target_json).collect()),
+        ),
+        ("summary", pairing_plan_summary_json(summary)),
+        ("count", integer(plan.targets.len() as i64)),
+    ])
+}
+
+fn pairing_target_json(target: &DiscoveryPairingTarget) -> JsonValue {
+    object([
+        ("fingerprint", string(target.fingerprint.as_str())),
+        ("bridge_id", string(target.bridge_id.as_str())),
+        ("integration_id", string(target.integration_id.as_str())),
+        ("native_bridge_id", string(&target.native_bridge_id)),
+        ("display_name", optional_string_json(&target.display_name)),
+        ("priority", integer(target.priority as i64)),
+        ("source", string(target.source.as_str())),
+        ("confidence", string(target.confidence.as_str())),
+        ("signal_status", string(target.signal_status.as_str())),
+        (
+            "pairing_requirement",
+            string(target.pairing_requirement.as_str()),
+        ),
+        ("action", string(target.action.as_str())),
+        (
+            "requires_human_action",
+            JsonValue::Bool(target.requires_human_action()),
+        ),
+        ("is_actionable", JsonValue::Bool(target.is_actionable())),
+        ("address", optional_string_json(&target.address)),
+        ("discovered_at_ms", integer(target.discovered_at_ms as i64)),
+    ])
+}
+
+fn pairing_plan_summary_json(summary: &DiscoveryPairingPlanSummary) -> JsonValue {
+    object([
+        ("generated_at_ms", integer(summary.generated_at_ms as i64)),
+        ("total", integer(summary.total as i64)),
+        ("actionable", integer(summary.actionable as i64)),
+        ("ready", integer(summary.ready as i64)),
+        (
+            "requires_human_action",
+            integer(summary.requires_human_action as i64),
+        ),
+        (
+            "blocked_unknown_requirement",
+            integer(summary.blocked_unknown_requirement as i64),
+        ),
+        ("fresh", integer(summary.fresh as i64)),
+        ("stale", integer(summary.stale as i64)),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "by_source",
+            JsonValue::Array(
+                summary
+                    .by_source
+                    .iter()
+                    .map(|(source, count)| {
+                        object([
+                            ("source", string(source.as_str())),
+                            ("count", integer(*count as i64)),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+        (
+            "by_pairing_requirement",
+            JsonValue::Array(
+                summary
+                    .by_pairing_requirement
+                    .iter()
+                    .map(|(requirement, count)| {
+                        object([
+                            ("pairing_requirement", string(requirement.as_str())),
+                            ("count", integer(*count as i64)),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+        (
+            "by_action",
+            JsonValue::Array(
+                summary
+                    .by_action
+                    .iter()
+                    .map(|(action, count)| {
+                        object([
+                            ("action", string(action.as_str())),
+                            ("count", integer(*count as i64)),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ),
+        (
+            "next_actionable_target",
+            summary
+                .next_actionable_target
+                .as_ref()
+                .map(pairing_target_json)
+                .unwrap_or(JsonValue::Null),
         ),
     ])
 }
@@ -5680,6 +5904,75 @@ fn parse_discovery_source(label: &str) -> Result<DiscoverySource, ToolCallError>
     }
 }
 
+fn parse_discovery_signal_status(label: &str) -> Result<DiscoverySignalStatus, ToolCallError> {
+    match label {
+        "fresh" => Ok(DiscoverySignalStatus::Fresh),
+        "stale" => Ok(DiscoverySignalStatus::Stale),
+        "expired" => Ok(DiscoverySignalStatus::Expired),
+        _ => Err(validation_error(format!(
+            "unknown discovery signal status `{label}`"
+        ))),
+    }
+}
+
+fn parse_pairing_requirement(label: &str) -> Result<PairingRequirement, ToolCallError> {
+    match label {
+        "unknown" => Ok(PairingRequirement::Unknown),
+        "none" | "ready" => Ok(PairingRequirement::None),
+        "physical_presence" | "button" | "link_button" => Ok(PairingRequirement::PhysicalPresence),
+        "local_code" | "code" => Ok(PairingRequirement::LocalCode),
+        "credentials" => Ok(PairingRequirement::Credentials),
+        "oauth2" | "oauth" => Ok(PairingRequirement::OAuth2),
+        "certificate" | "cert" => Ok(PairingRequirement::Certificate),
+        "radio_inclusion" | "inclusion" => Ok(PairingRequirement::RadioInclusion),
+        "mqtt_credentials" | "mqtt" => Ok(PairingRequirement::MqttCredentials),
+        _ => Err(validation_error(format!(
+            "unknown pairing requirement `{label}`"
+        ))),
+    }
+}
+
+fn parse_discovery_pairing_action(label: &str) -> Result<DiscoveryPairingAction, ToolCallError> {
+    match label {
+        "ready" => Ok(DiscoveryPairingAction::Ready),
+        "press_physical_button" | "press_button" | "link_button" => {
+            Ok(DiscoveryPairingAction::PressPhysicalButton)
+        }
+        "enter_local_code" | "local_code" => Ok(DiscoveryPairingAction::EnterLocalCode),
+        "provide_credentials" | "credentials" => Ok(DiscoveryPairingAction::ProvideCredentials),
+        "complete_oauth2" | "oauth2" | "oauth" => Ok(DiscoveryPairingAction::CompleteOAuth2),
+        "install_certificate" | "certificate" => Ok(DiscoveryPairingAction::InstallCertificate),
+        "start_radio_inclusion" | "radio_inclusion" => {
+            Ok(DiscoveryPairingAction::StartRadioInclusion)
+        }
+        "configure_mqtt_credentials" | "mqtt_credentials" | "mqtt" => {
+            Ok(DiscoveryPairingAction::ConfigureMqttCredentials)
+        }
+        "investigate_unknown_requirement" | "unknown" => {
+            Ok(DiscoveryPairingAction::InvestigateUnknownRequirement)
+        }
+        _ => Err(validation_error(format!(
+            "unknown discovery pairing action `{label}`"
+        ))),
+    }
+}
+
+fn parse_discovery_pairing_plan_sort(
+    label: &str,
+) -> Result<DiscoveryPairingPlanSort, ToolCallError> {
+    match label {
+        "plan_rank" | "rank" => Ok(DiscoveryPairingPlanSort::PlanRank),
+        "newest_first" | "newest" => Ok(DiscoveryPairingPlanSort::NewestFirst),
+        "integration_then_bridge" | "integration" => {
+            Ok(DiscoveryPairingPlanSort::IntegrationThenBridge)
+        }
+        "source_preference" | "source" => Ok(DiscoveryPairingPlanSort::SourcePreference),
+        _ => Err(validation_error(format!(
+            "unknown discovery pairing plan sort `{label}`"
+        ))),
+    }
+}
+
 fn parse_integration_category(label: &str) -> Result<IntegrationCategory, ToolCallError> {
     match label {
         "protocol_standard" => Ok(IntegrationCategory::ProtocolStandard),
@@ -6509,7 +6802,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 36);
+        assert_eq!(definitions.len(), 37);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -6530,6 +6823,9 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_PAIRING_PLAN_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_LIST_ROOMS_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_LIST_SCENES_TOOL_ID));
         assert!(export
@@ -6589,7 +6885,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            32
+            33
         );
         assert_eq!(
             export
@@ -6604,6 +6900,7 @@ mod tests {
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_GET_PAIRING_PLAN_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_SCENES_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_DESCRIBE_SCENE_TOOL_ID).is_some());
@@ -6963,6 +7260,48 @@ mod tests {
             field(
                 field(discovery_summary_output, "signal_summary").unwrap(),
                 "fresh"
+            ),
+            Some(&integer(1))
+        );
+
+        let pairing_plan_request = request(
+            "call-get-pairing-plan",
+            SMART_HOME_GET_PAIRING_PLAN_TOOL_ID,
+            object([
+                ("integration_id", string("hue")),
+                ("source", string("mdns")),
+                ("pairing_requirement", string("physical_presence")),
+                ("actionable_only", JsonValue::Bool(true)),
+                ("ttl_ms", integer(1_000)),
+                ("limit", integer(1)),
+            ]),
+            1_057,
+        );
+        let pairing_plan_trace = tool_runtime.invoke_with_events(&pairing_plan_request);
+        assert!(pairing_plan_trace.result.ok);
+        let pairing_plan_output = pairing_plan_trace.result.output.as_ref().unwrap();
+        assert_eq!(field(pairing_plan_output, "count"), Some(&integer(1)));
+        let pairing_target = array_item(field(pairing_plan_output, "targets").unwrap(), 0).unwrap();
+        assert_eq!(
+            field(pairing_target, "bridge_id"),
+            Some(&string("hue.bridge.001788fffediscovered"))
+        );
+        assert_eq!(
+            field(pairing_target, "action"),
+            Some(&string("press_physical_button"))
+        );
+        assert_eq!(
+            field(pairing_target, "requires_human_action"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(field(pairing_plan_output, "summary").unwrap(), "actionable"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(
+                field(pairing_plan_output, "summary").unwrap(),
+                "requires_human_action"
             ),
             Some(&integer(1))
         );
@@ -7655,6 +7994,7 @@ mod tests {
         journal.record_trace(discover_request, discover_trace);
         journal.record_trace(list_discovery_workers_request, list_discovery_workers_trace);
         journal.record_trace(discovery_summary_request, discovery_summary_trace);
+        journal.record_trace(pairing_plan_request, pairing_plan_trace);
         journal.record_trace(capabilities_request, capabilities_trace);
         journal.record_trace(health_request, health_trace);
         journal.record_trace(list_workers_request, list_workers_trace);
@@ -7684,9 +8024,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 35);
-        assert_eq!(journal_summary.completed_count, 35);
-        assert_eq!(journal.audit_records().len(), 35);
+        assert_eq!(journal_summary.invocation_count, 36);
+        assert_eq!(journal_summary.completed_count, 36);
+        assert_eq!(journal.audit_records().len(), 36);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -7699,7 +8039,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            32,
+            33,
             "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
         );
     }

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_discovery_workers` and
   `smart_home.get_discovery_summary` tool descriptors for read-only scheduled
   discovery governance and freshness inspection.
+- `smart_home.get_pairing_plan` tool descriptor for read-only discovery
+  pairing-plan inspection before pairing-session creation.
 - `smart_home.get_supervision_plan` tool descriptor for read-only runtime
   supervision due-work previews.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -63,6 +63,8 @@ Current scope:
   heartbeat deadline inspection
 - D18D discovery-governance descriptors for read-only scheduled discovery
   worker inventory and compact discovery freshness summaries
+- D18D discovery pairing-plan descriptor for read-only host-action previews
+  before pairing-session creation
 - D18D supervision planning tool descriptor for non-mutating due-work previews
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1449,6 +1449,7 @@ pub enum SmartHomeTool {
     PairBridge,
     ListDiscoveryWorkers,
     GetDiscoverySummary,
+    GetPairingPlan,
     ListBridges,
     ListDevices,
     ListRooms,
@@ -1496,6 +1497,7 @@ impl SmartHomeTool {
             },
             Self::ListDiscoveryWorkers => read_tool("smart_home.list_discovery_workers"),
             Self::GetDiscoverySummary => read_tool("smart_home.get_discovery_summary"),
+            Self::GetPairingPlan => read_tool("smart_home.get_pairing_plan"),
             Self::ListBridges => read_tool("smart_home.list_bridges"),
             Self::ListDevices => read_tool("smart_home.list_devices"),
             Self::ListRooms => read_tool("smart_home.list_rooms"),
@@ -2064,6 +2066,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::PairBridge,
         SmartHomeTool::ListDiscoveryWorkers,
         SmartHomeTool::GetDiscoverySummary,
+        SmartHomeTool::GetPairingPlan,
         SmartHomeTool::ListBridges,
         SmartHomeTool::ListDevices,
         SmartHomeTool::ListRooms,
@@ -2887,7 +2890,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 32);
+        assert_eq!(catalog.len(), 33);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2918,6 +2921,11 @@ mod tests {
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.get_discovery_summary"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.get_pairing_plan"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog
@@ -3014,15 +3022,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 32);
-        assert_eq!(summary.read_tools, 28);
+        assert_eq!(summary.total_tools, 33);
+        assert_eq!(summary.read_tools, 29);
         assert_eq!(summary.write_tools, 0);
         assert_eq!(summary.external_tools, 4);
-        assert_eq!(summary.read_only_tier_tools, 28);
+        assert_eq!(summary.read_only_tier_tools, 29);
         assert_eq!(summary.low_risk_tier_tools, 3);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 32);
+        assert_eq!(summary.total_required_capabilities, 33);
         assert_eq!(summary.risky_tool_count(), 4);
         assert_eq!(summary.approval_gated_tool_count(), 1);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -80,6 +80,10 @@ All notable changes to this package will be documented in this file.
 - `RuntimeReadToolRequest::ListDiscoveryWorkers` and
   `RuntimeReadToolRequest::GetDiscoverySummary` for authorized D18D reads over
   scheduled discovery worker pressure and discovery freshness summaries.
+- `RuntimePairingPlanToolRequest` and
+  `RuntimeReadToolRequest::GetPairingPlan` for authorized D18D reads over
+  discovery pairing plans derived from recorded discovery signals and the
+  first-party integration catalog.
 - `RuntimeReadToolRequest::GetSupervisionPlan` for authorized D18D previews of
   non-mutating supervision due work.
 - `RuntimeSupervisionToolRequest` / `RuntimeSupervisionToolOutput` and

--- a/code/packages/rust/smart-home-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT"
 [dependencies]
 smart-home-core = { path = "../smart-home-core" }
 smart-home-discovery = { path = "../smart-home-discovery" }
+smart-home-integration-catalog = { path = "../smart-home-integration-catalog" }
 smart-home-registry = { path = "../smart-home-registry" }

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -56,6 +56,8 @@ Included surfaces:
   filters, summaries, and bridge-candidate output
 - D18D-facing read tool facade entries for listing scheduled discovery workers
   and reading compact discovery record/signal summaries without invoking scans
+- read-side discovery pairing plans that combine recorded discovery signals with
+  first-party integration pairing semantics before any pairing session starts
 - composed event-bus health summaries for replay history, stream coverage, and
   current queue pressure checks
 - command validation against entity capabilities and command modes
@@ -77,8 +79,8 @@ Included surfaces:
   summaries, reading compact runtime snapshots, listing desired-state targets,
   listing pairing sessions, listing supervised bridge workers, reading worker
   heartbeat schedules, listing scheduled discovery workers, reading discovery
-  summaries, previewing supervision plans, and observing supervision status
-  without invoking integrations
+  summaries, reading discovery pairing plans, previewing supervision plans, and
+  observing supervision status without invoking integrations
 - D18D-facing subscribe tool facade that authorizes event-stream access and
   registers filtered replay subscriptions with checkpoints
 - D18D-facing poll and unsubscribe tool facades that authorize event-stream
@@ -125,6 +127,7 @@ Included surfaces:
 
 - smart-home-core
 - smart-home-discovery
+- smart-home-integration-catalog
 - smart-home-registry
 
 ## Development

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -17,13 +17,15 @@ use smart_home_core::{
     SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
-    run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError, DiscoveryRecord,
-    DiscoveryRecordSummary, DiscoverySignalSummary, DiscoverySource, DiscoveryUpsert,
-    DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-    DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary, MdnsScanNetwork, MdnsWorkerScanExecutor,
-    MdnsWorkerScanPlan, MdnsWorkerScanReport, MdnsWorkerScanRequest, UdpMdnsWorkerScanExecutor,
-    MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
+    run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError,
+    DiscoveryPairingPlan, DiscoveryPairingPlanOptions, DiscoveryPairingPlanSummary,
+    DiscoveryRecord, DiscoveryRecordSummary, DiscoverySignalSummary, DiscoverySource,
+    DiscoveryUpsert, DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind,
+    DiscoveryWorkerRun, DiscoveryWorkerRunStatus, DiscoveryWorkerRunSummary, MdnsScanNetwork,
+    MdnsWorkerScanExecutor, MdnsWorkerScanPlan, MdnsWorkerScanReport, MdnsWorkerScanRequest,
+    UdpMdnsWorkerScanExecutor, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
 };
+use smart_home_integration_catalog::first_party_catalog;
 use smart_home_registry::{
     AuthorizationDecisionSelector, DeviceSelector, InMemorySmartHomeRegistry, RegistryCounts,
     RegistryError, RegistryTopologySummary, StateRefreshPlan, StateRefreshReason,
@@ -3213,6 +3215,37 @@ impl Default for RuntimeDiscoverToolRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePairingPlanToolRequest {
+    pub options: DiscoveryPairingPlanOptions,
+    pub ttl_ms: u64,
+}
+
+impl RuntimePairingPlanToolRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_options(mut self, options: DiscoveryPairingPlanOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub fn with_ttl_ms(mut self, ttl_ms: u64) -> Self {
+        self.ttl_ms = ttl_ms;
+        self
+    }
+}
+
+impl Default for RuntimePairingPlanToolRequest {
+    fn default() -> Self {
+        Self {
+            options: DiscoveryPairingPlanOptions::new(),
+            ttl_ms: 60_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeDiscoverToolOutput {
     pub generated_at_ms: u64,
     pub ttl_ms: u64,
@@ -3516,6 +3549,9 @@ pub enum RuntimeReadToolRequest {
     GetDiscoverySummary {
         request: RuntimeDiscoverToolRequest,
     },
+    GetPairingPlan {
+        request: RuntimePairingPlanToolRequest,
+    },
     ListBridges,
     ListDevices {
         bridge_id: Option<BridgeId>,
@@ -3585,6 +3621,7 @@ impl RuntimeReadToolRequest {
             Self::GetRuntimeSnapshot => SmartHomeTool::GetRuntimeSnapshot,
             Self::ListDiscoveryWorkers { .. } => SmartHomeTool::ListDiscoveryWorkers,
             Self::GetDiscoverySummary { .. } => SmartHomeTool::GetDiscoverySummary,
+            Self::GetPairingPlan { .. } => SmartHomeTool::GetPairingPlan,
             Self::ListBridges => SmartHomeTool::ListBridges,
             Self::ListDevices { .. } => SmartHomeTool::ListDevices,
             Self::ListRooms { .. } => SmartHomeTool::ListRooms,
@@ -3830,6 +3867,11 @@ pub enum RuntimeReadToolOutput {
         ttl_ms: u64,
         record_summary: DiscoveryRecordSummary,
         signal_summary: DiscoverySignalSummary,
+    },
+    PairingPlan {
+        ttl_ms: u64,
+        plan: DiscoveryPairingPlan,
+        summary: DiscoveryPairingPlanSummary,
     },
     Bridges(Vec<Bridge>),
     Devices(Vec<Device>),
@@ -4078,6 +4120,20 @@ impl SmartHomeRuntime {
             .collect::<Vec<_>>();
         let signal_summary = DiscoverySignalSummary::from_signals(&signals, now_ms);
         (record_summary, signal_summary)
+    }
+
+    pub fn discovery_pairing_plan_at(
+        &self,
+        request: &RuntimePairingPlanToolRequest,
+        now_ms: u64,
+    ) -> DiscoveryPairingPlan {
+        let catalog = first_party_catalog();
+        self.discovery.pairing_plan_with_options_at(
+            &catalog,
+            now_ms,
+            request.ttl_ms,
+            &request.options,
+        )
     }
 
     pub fn topology_summary(&self) -> RegistryTopologySummary {
@@ -4904,6 +4960,15 @@ impl SmartHomeRuntime {
                     ttl_ms: request.ttl_ms,
                     record_summary,
                     signal_summary,
+                })
+            }
+            RuntimeReadToolRequest::GetPairingPlan { request } => {
+                let plan = self.discovery_pairing_plan_at(&request, now_ms);
+                let summary = plan.summary();
+                Ok(RuntimeReadToolOutput::PairingPlan {
+                    ttl_ms: request.ttl_ms,
+                    plan,
+                    summary,
                 })
             }
             RuntimeReadToolRequest::ListBridges => Ok(RuntimeReadToolOutput::Bridges(
@@ -6087,10 +6152,10 @@ mod tests {
         StateDelta,
     };
     use smart_home_discovery::{
-        DiscoveryConfidence, DiscoveryRecord, DiscoverySource, DiscoveryUpsert,
-        DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind, DiscoveryWorkerRun,
-        DiscoveryWorkerRunStatus, MdnsResponsePacket, MdnsScanResult, MdnsWorkerScanRequest,
-        PairingRequirement,
+        DiscoveryConfidence, DiscoveryPairingAction, DiscoveryRecord, DiscoverySource,
+        DiscoveryUpsert, DiscoveryWorkerFailure, DiscoveryWorkerId, DiscoveryWorkerKind,
+        DiscoveryWorkerRun, DiscoveryWorkerRunStatus, MdnsResponsePacket, MdnsScanResult,
+        MdnsWorkerScanRequest, PairingRequirement,
     };
     use smart_home_registry::StateRefreshReason;
 
@@ -9078,6 +9143,24 @@ mod tests {
                 1_523,
             )
             .unwrap();
+        let pairing_plan = runtime
+            .execute_read_tool(
+                AgentId::trusted("agent:observer"),
+                RuntimeReadToolRequest::GetPairingPlan {
+                    request: RuntimePairingPlanToolRequest::new()
+                        .with_ttl_ms(1_000)
+                        .with_options(
+                            DiscoveryPairingPlanOptions::new()
+                                .with_integration(IntegrationId::trusted("hue"))
+                                .with_source(DiscoverySource::Mdns)
+                                .with_pairing_requirement(PairingRequirement::PhysicalPresence)
+                                .actionable_only(true)
+                                .limited_to(1),
+                        ),
+                },
+                1_524,
+            )
+            .unwrap();
 
         assert!(matches!(
             bridges,
@@ -9308,7 +9391,23 @@ mod tests {
                 && record_summary.fresh == 1
                 && signal_summary.fresh == 1
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 24);
+        assert!(matches!(
+            pairing_plan,
+            RuntimeReadToolOutput::PairingPlan {
+                ttl_ms,
+                plan,
+                summary,
+            } if ttl_ms == 1_000
+                && plan.generated_at_ms == 1_524
+                && plan.targets.len() == 1
+                && plan.targets[0].bridge_id
+                    == BridgeId::trusted("hue.bridge.001788fffediscovered")
+                && plan.targets[0].action == DiscoveryPairingAction::PressPhysicalButton
+                && summary.total == 1
+                && summary.actionable == 1
+                && summary.requires_human_action == 1
+        ));
+        assert_eq!(runtime.registry().counts().authorization_decisions, 25);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add the read-only smart_home.get_pairing_plan descriptor to the shared smart-home tool catalog
- expose a runtime read facade that builds discovery pairing plans from recorded discovery signals and the first-party integration catalog
- add the Chief thin-adapter handler, JSON schemas, output projection, docs, and end-to-end Hue fixture coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools