### PR TITLE
Add browser stylesheet planning descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -261,8 +261,8 @@ documented in this file.
 - Browser-facing document summaries now carry script and stylesheet loading
   metadata, including script kind, async/defer/nomodule flags, inline
   script/style text, integrity/crossorigin/referrer-policy hints, fetch
-  priority, blocking, flattened script execution descriptors, alternate
-  stylesheets, and disabled stylesheet state.
+  priority, blocking, flattened script execution and stylesheet planning
+  descriptors, alternate stylesheets, and disabled stylesheet state.
 - Browser-facing image summaries now carry responsive image selection metadata,
   including `srcset`/`sizes`, resolved candidate URLs, flattened image
   candidate descriptors with source/candidate counts, `picture/source`

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -833,6 +833,7 @@ pub struct BrowserDocument {
     pub scripts: Vec<BrowserScript>,
     pub script_execution_descriptors: Vec<BrowserScriptExecutionDescriptor>,
     pub stylesheets: Vec<BrowserStylesheet>,
+    pub stylesheet_planning_descriptors: Vec<BrowserStylesheetPlanningDescriptor>,
     pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
@@ -1095,6 +1096,34 @@ pub struct BrowserStylesheet {
     pub blocking: Option<String>,
     pub blocking_tokens: Vec<String>,
     pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserStylesheetPlanningDescriptor {
+    pub source: String,
+    pub stylesheet_kind: String,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub rel: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub rel_token_count: usize,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub title: Option<String>,
+    pub disabled: bool,
+    pub alternate: bool,
+    pub applies_by_default: bool,
+    pub integrity: Option<String>,
+    pub crossorigin: Option<String>,
+    pub nonce: Option<String>,
+    pub referrerpolicy: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking: Option<String>,
+    pub blocking_tokens: Vec<String>,
+    pub blocking_token_count: usize,
+    pub render_blocking: bool,
+    pub has_text: bool,
+    pub text_length: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2724,6 +2753,8 @@ impl BrowserDocument {
         );
         summary.script_execution_descriptors =
             browser_script_execution_descriptors(&summary.scripts);
+        summary.stylesheet_planning_descriptors =
+            browser_stylesheet_planning_descriptors(&summary.stylesheets);
         summary.image_candidate_descriptors = browser_image_candidate_descriptors(&summary.images);
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.embedded_policy_descriptors =
@@ -10496,6 +10527,58 @@ fn browser_script_execution_descriptor(script: &BrowserScript) -> BrowserScriptE
             .iter()
             .any(|token| token.eq_ignore_ascii_case("render")),
         has_text: script.text.is_some(),
+        text_length,
+    }
+}
+
+fn browser_stylesheet_planning_descriptors(
+    stylesheets: &[BrowserStylesheet],
+) -> Vec<BrowserStylesheetPlanningDescriptor> {
+    stylesheets
+        .iter()
+        .map(browser_stylesheet_planning_descriptor)
+        .collect()
+}
+
+fn browser_stylesheet_planning_descriptor(
+    stylesheet: &BrowserStylesheet,
+) -> BrowserStylesheetPlanningDescriptor {
+    let text_length = stylesheet
+        .text
+        .as_ref()
+        .map(|text| text.chars().count())
+        .unwrap_or_default();
+    BrowserStylesheetPlanningDescriptor {
+        source: stylesheet.source.clone(),
+        stylesheet_kind: if stylesheet.href.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        href: stylesheet.href.clone(),
+        resolved_href: stylesheet.resolved_href.clone(),
+        rel: stylesheet.rel.clone(),
+        rel_tokens: stylesheet.rel_tokens.clone(),
+        rel_token_count: stylesheet.rel_tokens.len(),
+        type_hint: stylesheet.type_hint.clone(),
+        media: stylesheet.media.clone(),
+        title: stylesheet.title.clone(),
+        disabled: stylesheet.disabled,
+        alternate: stylesheet.alternate,
+        applies_by_default: !stylesheet.disabled && !stylesheet.alternate,
+        integrity: stylesheet.integrity.clone(),
+        crossorigin: stylesheet.crossorigin.clone(),
+        nonce: stylesheet.nonce.clone(),
+        referrerpolicy: stylesheet.referrerpolicy.clone(),
+        fetchpriority: stylesheet.fetchpriority.clone(),
+        blocking: stylesheet.blocking.clone(),
+        blocking_tokens: stylesheet.blocking_tokens.clone(),
+        blocking_token_count: stylesheet.blocking_tokens.len(),
+        render_blocking: stylesheet
+            .blocking_tokens
+            .iter()
+            .any(|token| token.eq_ignore_ascii_case("render")),
+        has_text: stylesheet.text.is_some(),
         text_length,
     }
 }
@@ -19409,6 +19492,61 @@ mod tests {
         assert_eq!(inline_style.source, "style");
         assert_eq!(inline_style.media.as_deref(), Some("print"));
         assert_eq!(inline_style.text.as_deref(), Some("body { color: black; }"));
+
+        assert_eq!(summary.stylesheet_planning_descriptors.len(), 3);
+        let main_descriptor = &summary.stylesheet_planning_descriptors[0];
+        assert_eq!(main_descriptor.source, "link");
+        assert_eq!(main_descriptor.stylesheet_kind, "external");
+        assert_eq!(main_descriptor.href.as_deref(), Some("app.css"));
+        assert_eq!(
+            main_descriptor.resolved_href.as_deref(),
+            Some("https://example.test/app/app.css")
+        );
+        assert_eq!(
+            main_descriptor.rel_tokens,
+            vec!["stylesheet".to_string(), "preload".to_string()]
+        );
+        assert_eq!(main_descriptor.rel_token_count, 2);
+        assert_eq!(main_descriptor.media.as_deref(), Some("screen"));
+        assert_eq!(main_descriptor.title.as_deref(), Some("main"));
+        assert!(main_descriptor.applies_by_default);
+        assert!(!main_descriptor.alternate);
+        assert!(!main_descriptor.disabled);
+        assert_eq!(main_descriptor.integrity.as_deref(), Some("sha256-css"));
+        assert_eq!(main_descriptor.crossorigin.as_deref(), Some("anonymous"));
+        assert_eq!(main_descriptor.nonce, None);
+        assert_eq!(
+            main_descriptor.referrerpolicy.as_deref(),
+            Some("no-referrer")
+        );
+        assert_eq!(main_descriptor.fetchpriority.as_deref(), Some("high"));
+        assert_eq!(main_descriptor.blocking.as_deref(), Some("render"));
+        assert_eq!(main_descriptor.blocking_tokens, vec!["render"]);
+        assert_eq!(main_descriptor.blocking_token_count, 1);
+        assert!(main_descriptor.render_blocking);
+        assert!(!main_descriptor.has_text);
+        assert_eq!(main_descriptor.text_length, 0);
+
+        let alternate_descriptor = &summary.stylesheet_planning_descriptors[1];
+        assert_eq!(alternate_descriptor.stylesheet_kind, "external");
+        assert!(alternate_descriptor.alternate);
+        assert!(alternate_descriptor.disabled);
+        assert!(!alternate_descriptor.applies_by_default);
+        assert_eq!(alternate_descriptor.rel_token_count, 2);
+        assert!(!alternate_descriptor.render_blocking);
+
+        let inline_descriptor = &summary.stylesheet_planning_descriptors[2];
+        assert_eq!(inline_descriptor.source, "style");
+        assert_eq!(inline_descriptor.stylesheet_kind, "inline");
+        assert_eq!(inline_descriptor.media.as_deref(), Some("print"));
+        assert_eq!(inline_descriptor.title.as_deref(), Some("print"));
+        assert_eq!(inline_descriptor.nonce, None);
+        assert!(inline_descriptor.applies_by_default);
+        assert!(inline_descriptor.has_text);
+        assert_eq!(
+            inline_descriptor.text_length,
+            "body { color: black; }".chars().count()
+        );
 
         assert_eq!(summary.scripts.len(), 4);
         let module_script = &summary.scripts[0];

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -18,8 +18,9 @@ use coding_adventures_html_parser::{
     BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
     BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
     BrowserScriptExecutionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet, BrowserTable,
-    BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
+    BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -71,6 +72,8 @@ struct ExpectedBrowserDocument {
     script_execution_descriptors: Option<Vec<ExpectedScriptExecutionDescriptor>>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
+    #[serde(default)]
+    stylesheet_planning_descriptors: Option<Vec<ExpectedStylesheetPlanningDescriptor>>,
     #[serde(default)]
     document_policy_descriptors: Vec<ExpectedDocumentPolicyDescriptor>,
     #[serde(default)]
@@ -896,6 +899,56 @@ struct ExpectedStylesheet {
     blocking_tokens: Vec<String>,
     #[serde(default)]
     text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedStylesheetPlanningDescriptor {
+    source: String,
+    stylesheet_kind: String,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    rel: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    rel_token_count: usize,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    alternate: bool,
+    #[serde(default)]
+    applies_by_default: bool,
+    #[serde(default)]
+    integrity: Option<String>,
+    #[serde(default)]
+    crossorigin: Option<String>,
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    referrerpolicy: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
+    blocking_token_count: usize,
+    #[serde(default)]
+    render_blocking: bool,
+    #[serde(default)]
+    has_text: bool,
+    #[serde(default)]
+    text_length: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3974,6 +4027,11 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedImage::into_browser_image)
             .collect();
+        let stylesheets: Vec<_> = self
+            .stylesheets
+            .into_iter()
+            .map(ExpectedStylesheet::into_browser_stylesheet)
+            .collect();
         let media: Vec<_> = self
             .media
             .into_iter()
@@ -4024,6 +4082,17 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_script_execution_descriptors(&scripts));
+        let stylesheet_planning_descriptors = self
+            .stylesheet_planning_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedStylesheetPlanningDescriptor::into_browser_stylesheet_planning_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_stylesheet_planning_descriptors(&stylesheets));
         let image_candidate_descriptors = self
             .image_candidate_descriptors
             .map(|descriptors| {
@@ -4056,11 +4125,8 @@ impl ExpectedBrowserDocument {
             resources,
             scripts,
             script_execution_descriptors,
-            stylesheets: self
-                .stylesheets
-                .into_iter()
-                .map(ExpectedStylesheet::into_browser_stylesheet)
-                .collect(),
+            stylesheets,
+            stylesheet_planning_descriptors,
             document_policy_descriptors: self
                 .document_policy_descriptors
                 .into_iter()
@@ -4815,6 +4881,58 @@ fn expected_script_execution_descriptor(
     }
 }
 
+fn expected_stylesheet_planning_descriptors(
+    stylesheets: &[BrowserStylesheet],
+) -> Vec<BrowserStylesheetPlanningDescriptor> {
+    stylesheets
+        .iter()
+        .map(expected_stylesheet_planning_descriptor)
+        .collect()
+}
+
+fn expected_stylesheet_planning_descriptor(
+    stylesheet: &BrowserStylesheet,
+) -> BrowserStylesheetPlanningDescriptor {
+    let text_length = stylesheet
+        .text
+        .as_ref()
+        .map(|text| text.chars().count())
+        .unwrap_or_default();
+    BrowserStylesheetPlanningDescriptor {
+        source: stylesheet.source.clone(),
+        stylesheet_kind: if stylesheet.href.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        href: stylesheet.href.clone(),
+        resolved_href: stylesheet.resolved_href.clone(),
+        rel: stylesheet.rel.clone(),
+        rel_tokens: stylesheet.rel_tokens.clone(),
+        rel_token_count: stylesheet.rel_tokens.len(),
+        type_hint: stylesheet.type_hint.clone(),
+        media: stylesheet.media.clone(),
+        title: stylesheet.title.clone(),
+        disabled: stylesheet.disabled,
+        alternate: stylesheet.alternate,
+        applies_by_default: !stylesheet.disabled && !stylesheet.alternate,
+        integrity: stylesheet.integrity.clone(),
+        crossorigin: stylesheet.crossorigin.clone(),
+        nonce: stylesheet.nonce.clone(),
+        referrerpolicy: stylesheet.referrerpolicy.clone(),
+        fetchpriority: stylesheet.fetchpriority.clone(),
+        blocking: stylesheet.blocking.clone(),
+        blocking_tokens: stylesheet.blocking_tokens.clone(),
+        blocking_token_count: stylesheet.blocking_tokens.len(),
+        render_blocking: stylesheet
+            .blocking_tokens
+            .iter()
+            .any(|token| token.eq_ignore_ascii_case("render")),
+        has_text: stylesheet.text.is_some(),
+        text_length,
+    }
+}
+
 impl ExpectedResourceEndpointDescriptor {
     fn into_browser_resource_endpoint_descriptor(self) -> BrowserResourceEndpointDescriptor {
         let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
@@ -4941,6 +5059,40 @@ impl ExpectedStylesheet {
             blocking: self.blocking,
             blocking_tokens,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedStylesheetPlanningDescriptor {
+    fn into_browser_stylesheet_planning_descriptor(self) -> BrowserStylesheetPlanningDescriptor {
+        let rel_tokens = expected_tokens_from_raw(self.rel_tokens, self.rel.as_deref());
+        let blocking_tokens =
+            expected_tokens_from_raw(self.blocking_tokens, self.blocking.as_deref());
+        BrowserStylesheetPlanningDescriptor {
+            source: self.source,
+            stylesheet_kind: self.stylesheet_kind,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            rel: self.rel,
+            rel_tokens,
+            rel_token_count: self.rel_token_count,
+            type_hint: self.type_hint,
+            media: self.media,
+            title: self.title,
+            disabled: self.disabled,
+            alternate: self.alternate,
+            applies_by_default: self.applies_by_default,
+            integrity: self.integrity,
+            crossorigin: self.crossorigin,
+            nonce: self.nonce,
+            referrerpolicy: self.referrerpolicy,
+            fetchpriority: self.fetchpriority,
+            blocking: self.blocking,
+            blocking_tokens,
+            blocking_token_count: self.blocking_token_count,
+            render_blocking: self.render_blocking,
+            has_text: self.has_text,
+            text_length: self.text_length,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -46,10 +46,10 @@ annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and
 flattened playback descriptors with source/track counts.
 Script/style cases pin module/classic script kind, async/defer/nomodule flags,
-inline script/style text, flattened script execution descriptors, and
-loading-policy hints such as integrity, crossorigin, referrer policy, fetch
-priority, blocking, disabled state, and alternate stylesheets. Responsive image
-cases pin `srcset`/`sizes`, resolved candidate URLs, flattened image candidate
+inline script/style text, flattened script execution and stylesheet planning
+descriptors, and loading-policy hints such as integrity, crossorigin, referrer
+policy, fetch priority, blocking, disabled state, and alternate stylesheets.
+Responsive image cases pin `srcset`/`sizes`, resolved candidate URLs, flattened image candidate
 descriptors, `picture/source` media/type hints, lazy loading, decoding, fetch
 priority, CORS/referrer policy, usemap, and server-side image-map state. Link
 resource cases pin relation-derived resource kinds, `as` hints,

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -942,6 +942,11 @@
           { "source": "link", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "rel_tokens": ["alternate", "stylesheet"], "title": "print", "disabled": true, "alternate": true },
           { "source": "style", "media": "print", "title": "print", "nonce": "inlineStyleNonce", "text": "body { color: black; }" }
         ],
+        "stylesheet_planning_descriptors": [
+          { "source": "link", "stylesheet_kind": "external", "href": "app.css", "resolved_href": "https://example.test/app/app.css", "rel": "stylesheet preload", "rel_tokens": ["stylesheet", "preload"], "rel_token_count": 2, "media": "screen", "title": "main", "applies_by_default": true, "integrity": "sha256-css", "crossorigin": "anonymous", "nonce": "styleNonce", "referrerpolicy": "no-referrer", "fetchpriority": "high", "blocking": "render", "blocking_tokens": ["render"], "blocking_token_count": 1, "render_blocking": true, "has_text": false, "text_length": 0 },
+          { "source": "link", "stylesheet_kind": "external", "href": "print.css", "resolved_href": "https://example.test/app/print.css", "rel": "alternate stylesheet", "rel_tokens": ["alternate", "stylesheet"], "rel_token_count": 2, "title": "print", "disabled": true, "alternate": true, "applies_by_default": false, "blocking_token_count": 0, "render_blocking": false, "has_text": false, "text_length": 0 },
+          { "source": "style", "stylesheet_kind": "inline", "media": "print", "title": "print", "nonce": "inlineStyleNonce", "rel_token_count": 0, "applies_by_default": true, "blocking_token_count": 0, "render_blocking": false, "has_text": true, "text_length": 22 }
+        ],
         "anchors": [],
         "headings": [],
         "loading_hint_descriptors": [


### PR DESCRIPTION
## Summary
- add flattened browser stylesheet planning descriptors for link and inline style records
- track external/inline kind, rel and blocking counts, default/alternate/disabled planning state, policy hints, and inline text length
- pin descriptor expectations in browser-readiness fixtures and update fixture docs/changelog

## Tests
- python3 -m json.tool html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_script_style_metadata_tracks_loading_and_inline_text
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser