### PR TITLE
Expose Chief smart-home pairing completion tool

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this package will be documented in this file.
 - Added `smart_home.get_pairing_plan` over the D23 runtime read facade so Chief
   of Staff jobs can inspect actionable discovery pairing plans before starting
   a pairing session.
+- Added `smart_home.complete_pairing` over the D23 runtime mutation facade so
+  Chief of Staff jobs can finish pairing ceremonies with VaultRef handles and
+  non-secret metadata without owning credential material.
 - Added scheduled discovery worker observability to
   `smart_home.observe_supervision`, including worker status, due time, last run
   counts, and failure pressure from the D23 runtime.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -29,6 +29,7 @@ Chief of Staff job/session/agent
   -> discovery records and unpaired bridge candidates
   -> discovery worker inventory and discovery freshness summaries
   -> discovery pairing-plan previews for required host actions
+  -> human-approved pairing completion with VaultRef handles
   -> room topology and aggregate topology summary reads
   -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
@@ -82,6 +83,7 @@ Chief of Staff job/session/agent
 - `smart_home.reconcile_desired_states`
 - `smart_home.run_supervision_tick`
 - `smart_home.pair_bridge`
+- `smart_home.complete_pairing`
 - `smart_home.observe_supervision`
 
 ## Development

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -21,7 +21,7 @@ use smart_home_core::{
     CommandResult, CommandStatus, CommandType, Device, DeviceCommand, DeviceEvent, DeviceEventType,
     EntityId, EntityKind, Health, IntegrationId, Metadata, PrivilegeTier, ProtocolFamily,
     ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope, StateConfidence,
-    StateDelta, StateSnapshot, StateSource, Value,
+    StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryPairingAction, DiscoveryPairingPlan, DiscoveryPairingPlanOptions,
@@ -49,23 +49,23 @@ use smart_home_runtime::{
     DiscoveryWorkerSchedulerSnapshot, DiscoveryWorkerSort, PairingSessionStatus,
     ReconciliationReason, RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort,
     RuntimeCapabilityGrantQuery, RuntimeCapabilityGrantScopeKind, RuntimeCapabilityGrantSort,
-    RuntimeCommandToolRequest, RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError,
-    RuntimeEvent, RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter,
-    RuntimeEventLogRecord, RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort,
-    RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest, RuntimePairingPlanToolRequest,
-    RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionInventorySummary,
-    RuntimePairingSessionQuery, RuntimePairingSessionSort, RuntimePendingWorkSummary,
-    RuntimePollEventsToolOutput, RuntimePollEventsToolRequest, RuntimeReadSnapshot,
-    RuntimeReadToolOutput, RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort,
-    RuntimeRoomSummary, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
-    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
-    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
-    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
-    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
-    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
-    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
-    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
-    WorkerRestartReason, WorkerStatus,
+    RuntimeCommandToolRequest, RuntimeCompletePairingToolOutput, RuntimeCompletePairingToolRequest,
+    RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError, RuntimeEvent,
+    RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter, RuntimeEventLogRecord,
+    RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort, RuntimePairBridgeToolOutput,
+    RuntimePairBridgeToolRequest, RuntimePairingPlanToolRequest, RuntimePairingSession,
+    RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
+    RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
+    RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
+    RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary,
+    RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus,
+    RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery,
+    RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort, RuntimeSupervisionPlan,
+    RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest,
+    RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest,
+    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime, SupervisedBridgeWorker,
+    SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport, WorkerHeartbeatDeadline,
+    WorkerHeartbeatSchedule, WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -106,6 +106,7 @@ pub const SMART_HOME_RUN_SUPERVISION_TICK_TOOL_ID: &str = "smart_home.run_superv
 pub const SMART_HOME_DESCRIBE_CAPABILITIES_TOOL_ID: &str = "smart_home.describe_capabilities";
 pub const SMART_HOME_GET_HEALTH_TOOL_ID: &str = "smart_home.get_health";
 pub const SMART_HOME_PAIR_BRIDGE_TOOL_ID: &str = "smart_home.pair_bridge";
+pub const SMART_HOME_COMPLETE_PAIRING_TOOL_ID: &str = "smart_home.complete_pairing";
 pub const SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID: &str = "smart_home.observe_supervision";
 pub const SMART_HOME_LIST_INTEGRATIONS_TOOL_ID: &str = "smart_home.list_integrations";
 pub const SMART_HOME_DESCRIBE_INTEGRATION_TOOL_ID: &str = "smart_home.describe_integration";
@@ -502,6 +503,13 @@ impl SmartHomeToolBridge {
                         .execute_pair_bridge_tool(principal_id, request, now_ms)
                         .map_err(runtime_error)?;
                     Ok(pair_bridge_output_handler_output(output))
+                }
+                SMART_HOME_COMPLETE_PAIRING_TOOL_ID => {
+                    let request = complete_pairing_request(&arguments, now_ms)?;
+                    let output = runtime
+                        .execute_complete_pairing_tool(principal_id, request, now_ms)
+                        .map_err(runtime_error)?;
+                    Ok(complete_pairing_output_handler_output(output))
                 }
                 SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID => {
                     let _ = expect_object(&arguments)?;
@@ -985,6 +993,7 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         reconcile_desired_states_definition(),
         run_supervision_tick_definition(),
         pair_bridge_definition(),
+        complete_pairing_definition(),
         read_definition(
             SMART_HOME_OBSERVE_SUPERVISION_TOOL_ID,
             "Observe smart-home supervision",
@@ -1803,6 +1812,65 @@ fn pair_bridge_definition() -> ToolDefinition {
     }
 }
 
+fn complete_pairing_definition() -> ToolDefinition {
+    ToolDefinition {
+        tool_id: SMART_HOME_COMPLETE_PAIRING_TOOL_ID.to_string(),
+        display_name: "Complete smart-home pairing".to_string(),
+        description:
+            "Complete a D23 bridge-pairing session using a VaultRef and non-secret metadata only."
+                .to_string(),
+        input_schema: object_schema(
+            vec![
+                SchemaProperty::new("session_id", JsonSchema::String),
+                SchemaProperty::new("vault_ref", JsonSchema::String),
+                SchemaProperty::new("completed_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("metadata", JsonSchema::Any),
+            ],
+            vec!["session_id", "vault_ref"],
+            false,
+        ),
+        output_schema: Some(object_schema(
+            vec![
+                SchemaProperty::new("session_id", JsonSchema::String),
+                SchemaProperty::new("bridge_id", JsonSchema::String),
+                SchemaProperty::new("integration_id", JsonSchema::String),
+                SchemaProperty::new("requested_by", JsonSchema::String),
+                SchemaProperty::new("started_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("expires_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("status", JsonSchema::String),
+                SchemaProperty::new("vault_ref", JsonSchema::Any),
+                SchemaProperty::new("metadata", JsonSchema::Any),
+            ],
+            vec![
+                "session_id",
+                "bridge_id",
+                "integration_id",
+                "requested_by",
+                "started_at_ms",
+                "expires_at_ms",
+                "status",
+                "vault_ref",
+                "metadata",
+            ],
+            false,
+        )),
+        side_effects: ToolSideEffects::External,
+        idempotency: ToolIdempotency::Conditional,
+        concurrency: ToolConcurrency::Serialized,
+        streaming: ToolStreaming::Events,
+        required_tier: ToolPrivilegeTier::Tier2,
+        required_capabilities: vec!["smart_home:pair".to_string()],
+        preferred_lock_scope: Some("smart_home.pairing".to_string()),
+        timeout_seconds: Some(30),
+        tags: vec![
+            "smart_home".to_string(),
+            "runtime".to_string(),
+            "pairing".to_string(),
+        ],
+        stability: ToolStability::Experimental,
+    }
+}
+
 fn command_definition() -> ToolDefinition {
     ToolDefinition {
         tool_id: SMART_HOME_COMMAND_TOOL_ID.to_string(),
@@ -2268,6 +2336,22 @@ fn pair_bridge_request(
     Ok(request)
 }
 
+fn complete_pairing_request(
+    arguments: &JsonValue,
+    now_ms: u64,
+) -> Result<RuntimeCompletePairingToolRequest, ToolCallError> {
+    let mut request = RuntimeCompletePairingToolRequest::new(
+        RuntimePairingSessionId::trusted(required_string(arguments, "session_id")?),
+        VaultRef::trusted(required_string(arguments, "vault_ref")?),
+        optional_u64(arguments, "completed_at_ms")?.unwrap_or(now_ms),
+    );
+    let metadata = optional_metadata(arguments)?;
+    if !metadata.is_empty() {
+        request = request.with_metadata(metadata);
+    }
+    Ok(request)
+}
+
 fn integration_catalog_query(
     arguments: &JsonValue,
 ) -> Result<IntegrationCatalogQuery, ToolCallError> {
@@ -2493,6 +2577,31 @@ fn pair_bridge_output_handler_output(output: RuntimePairBridgeToolOutput) -> Too
             (
                 "status",
                 string(pairing_status_label(output.session.status)),
+            ),
+        ]),
+    )
+}
+
+fn complete_pairing_output_handler_output(
+    output: RuntimeCompletePairingToolOutput,
+) -> ToolHandlerOutput {
+    ToolHandlerOutput::new(complete_pairing_output_json(&output)).with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("complete_pairing")),
+            ("session_id", string(output.session.session_id.as_str())),
+            (
+                "status",
+                string(pairing_status_label(output.session.status)),
+            ),
+            (
+                "vault_ref",
+                output
+                    .session
+                    .vault_ref
+                    .as_ref()
+                    .map(|vault_ref| string(vault_ref.as_str()))
+                    .unwrap_or(JsonValue::Null),
             ),
         ]),
     )
@@ -2863,6 +2972,10 @@ fn unsubscribe_output_json(output: &RuntimeUnsubscribeToolOutput) -> JsonValue {
 }
 
 fn pair_bridge_output_json(output: &RuntimePairBridgeToolOutput) -> JsonValue {
+    pairing_session_json(&output.session)
+}
+
+fn complete_pairing_output_json(output: &RuntimeCompletePairingToolOutput) -> JsonValue {
     pairing_session_json(&output.session)
 }
 
@@ -6802,7 +6915,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 37);
+        assert_eq!(definitions.len(), 38);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -6833,6 +6946,9 @@ mod tests {
             .contains(&SMART_HOME_DESCRIBE_SCENE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_COMMAND_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_PAIR_BRIDGE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_COMPLETE_PAIRING_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_SUBSCRIBE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_POLL_EVENTS_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_UNSUBSCRIBE_TOOL_ID));
@@ -6895,12 +7011,13 @@ mod tests {
         );
         assert_eq!(
             export.summary.required_capability_count("smart_home:pair"),
-            1
+            2
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_PAIRING_PLAN_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_COMPLETE_PAIRING_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_SCENES_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_DESCRIBE_SCENE_TOOL_ID).is_some());
@@ -7481,6 +7598,35 @@ mod tests {
             Some(&string("pending_user_presence"))
         );
 
+        let complete_pairing_request = request(
+            "call-complete-pairing",
+            SMART_HOME_COMPLETE_PAIRING_TOOL_ID,
+            object([
+                ("session_id", string("pairing-session-1")),
+                (
+                    "vault_ref",
+                    string("vault://smart-home/hue/bridge-1/app-key"),
+                ),
+                ("completed_at_ms", integer(1_050)),
+                (
+                    "metadata",
+                    object([("credential_kind", string("application_key"))]),
+                ),
+            ]),
+            1_050,
+        );
+        let complete_pairing_trace = tool_runtime.invoke_with_events(&complete_pairing_request);
+        assert!(complete_pairing_trace.result.ok);
+        let complete_pairing_output = complete_pairing_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(complete_pairing_output, "status"),
+            Some(&string("completed"))
+        );
+        assert_eq!(
+            field(complete_pairing_output, "vault_ref"),
+            Some(&string("vault://smart-home/hue/bridge-1/app-key"))
+        );
+
         let command_request = request(
             "call-turn-on",
             SMART_HOME_COMMAND_TOOL_ID,
@@ -7629,7 +7775,7 @@ mod tests {
             SMART_HOME_LIST_PAIRING_SESSIONS_TOOL_ID,
             object([
                 ("bridge_id", string("bridge-1")),
-                ("status", string("pending_user_presence")),
+                ("status", string("completed")),
                 ("sort", string("expires_at")),
             ]),
             1_100,
@@ -7648,7 +7794,14 @@ mod tests {
         assert_eq!(
             field(
                 field(pairing_sessions_output, "summary").unwrap(),
-                "pending_user_presence_sessions"
+                "completed_sessions"
+            ),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(
+                field(pairing_sessions_output, "summary").unwrap(),
+                "sessions_with_vault_ref"
             ),
             Some(&integer(1))
         );
@@ -7949,11 +8102,11 @@ mod tests {
         let supervision_tick_output = supervision_tick_trace.result.output.as_ref().unwrap();
         assert_eq!(
             field(supervision_tick_output, "action_count"),
-            Some(&integer(2))
+            Some(&integer(1))
         );
         assert_eq!(
             array_len(field(supervision_tick_output, "expired_pairing_sessions").unwrap()),
-            Some(1)
+            Some(0)
         );
         assert_eq!(
             array_len(field(supervision_tick_output, "expired_entities").unwrap()),
@@ -7972,7 +8125,7 @@ mod tests {
                 field(supervision_tick_output, "summary").unwrap(),
                 "expired_pairing_session_count"
             ),
-            Some(&integer(1))
+            Some(&integer(0))
         );
         assert_eq!(
             field(
@@ -8002,6 +8155,7 @@ mod tests {
         journal.record_trace(supervision_request, supervision_trace);
         journal.record_trace(subscribe_request, subscribe_trace);
         journal.record_trace(pair_request, pair_trace);
+        journal.record_trace(complete_pairing_request, complete_pairing_trace);
         journal.record_trace(command_request, command_trace);
         journal.record_trace(runtime_snapshot_request, runtime_snapshot_trace);
         journal.record_trace(topology_summary_request, topology_summary_trace);
@@ -8024,9 +8178,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 36);
-        assert_eq!(journal_summary.completed_count, 36);
-        assert_eq!(journal.audit_records().len(), 36);
+        assert_eq!(journal_summary.invocation_count, 37);
+        assert_eq!(journal_summary.completed_count, 37);
+        assert_eq!(journal.audit_records().len(), 37);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 1);
@@ -8039,8 +8193,16 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            33,
-            "read, subscribe, poll, unsubscribe, and pair calls record tool authorization, while command records tool and command authorization"
+            34,
+            "read, subscribe, poll, unsubscribe, and pairing calls record tool authorization, while command records tool and command authorization"
+        );
+        assert_eq!(
+            runtime
+                .registry()
+                .bridge(&BridgeId::trusted("bridge-1"))
+                .unwrap()
+                .auth_ref,
+            Some(VaultRef::trusted("vault://smart-home/hue/bridge-1/app-key"))
         );
     }
 

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this package will be documented in this file.
   discovery governance and freshness inspection.
 - `smart_home.get_pairing_plan` tool descriptor for read-only discovery
   pairing-plan inspection before pairing-session creation.
+- `smart_home.complete_pairing` tool descriptor for human-approved completion
+  of pairing sessions with VaultRef handles and non-secret metadata.
 - `smart_home.get_supervision_plan` tool descriptor for read-only runtime
   supervision due-work previews.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -65,6 +65,8 @@ Current scope:
   worker inventory and compact discovery freshness summaries
 - D18D discovery pairing-plan descriptor for read-only host-action previews
   before pairing-session creation
+- D18D pairing-completion descriptor for human-approved VaultRef completion
+  without exposing raw credentials
 - D18D supervision planning tool descriptor for non-mutating due-work previews
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1447,6 +1447,7 @@ impl SmartHomeToolCatalogSummary {
 pub enum SmartHomeTool {
     Discover,
     PairBridge,
+    CompletePairing,
     ListDiscoveryWorkers,
     GetDiscoverySummary,
     GetPairingPlan,
@@ -1491,6 +1492,12 @@ impl SmartHomeTool {
             },
             Self::PairBridge => ToolDescriptor {
                 tool_id: "smart_home.pair_bridge",
+                side_effects: ToolSideEffects::External,
+                required_capabilities: vec![CapabilityId::trusted("smart_home.pair")],
+                required_tier: PrivilegeTier::HumanApproval,
+            },
+            Self::CompletePairing => ToolDescriptor {
+                tool_id: "smart_home.complete_pairing",
                 side_effects: ToolSideEffects::External,
                 required_capabilities: vec![CapabilityId::trusted("smart_home.pair")],
                 required_tier: PrivilegeTier::HumanApproval,
@@ -2064,6 +2071,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
     [
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
+        SmartHomeTool::CompletePairing,
         SmartHomeTool::ListDiscoveryWorkers,
         SmartHomeTool::GetDiscoverySummary,
         SmartHomeTool::GetPairingPlan,
@@ -2890,7 +2898,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 33);
+        assert_eq!(catalog.len(), 34);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2923,6 +2931,11 @@ mod tests {
             .any(|tool| tool.tool_id == "smart_home.get_discovery_summary"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.complete_pairing"
+                && tool.side_effects == ToolSideEffects::External
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.pair")]));
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.get_pairing_plan"
@@ -3022,18 +3035,21 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 33);
+        assert_eq!(summary.total_tools, 34);
         assert_eq!(summary.read_tools, 29);
         assert_eq!(summary.write_tools, 0);
-        assert_eq!(summary.external_tools, 4);
+        assert_eq!(summary.external_tools, 5);
         assert_eq!(summary.read_only_tier_tools, 29);
         assert_eq!(summary.low_risk_tier_tools, 3);
         assert_eq!(summary.high_risk_tier_tools, 0);
-        assert_eq!(summary.human_approval_tier_tools, 1);
-        assert_eq!(summary.total_required_capabilities, 33);
-        assert_eq!(summary.risky_tool_count(), 4);
-        assert_eq!(summary.approval_gated_tool_count(), 1);
+        assert_eq!(summary.human_approval_tier_tools, 2);
+        assert_eq!(summary.total_required_capabilities, 34);
+        assert_eq!(summary.risky_tool_count(), 5);
+        assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());
+        assert!(SmartHomeTool::CompletePairing
+            .descriptor()
+            .requires_human_approval());
         assert!(!SmartHomeTool::Command
             .descriptor()
             .requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this package will be documented in this file.
 - `RuntimePairingCompletion` for completing pending pairing sessions with a
   VaultRef plus non-secret completion metadata that is copied into the session
   and bridge-health audit event.
+- `RuntimeCompletePairingToolRequest`,
+  `RuntimeCompletePairingToolOutput`, and
+  `SmartHomeRuntime::execute_complete_pairing_tool` for authorized D18D pairing
+  completion through the runtime-owned mutation path.
 - Runtime discovery catalog recording plus `RuntimeDiscoverToolRequest` and
   `RuntimeDiscoverToolOutput` for authorized discovery reads, freshness
   filtering, and unpaired bridge-candidate projection.

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -88,6 +88,8 @@ Included surfaces:
   events when subscriptions are retired
 - D18D-facing pair-bridge facade with short-lived pairing sessions that complete
   only to Vault references and non-secret audit metadata, never raw credentials
+- D18D-facing complete-pairing facade that authorizes VaultRef completion
+  through the same pairing capability before mutating runtime session state
 - read-side queries for pairing sessions and desired-state supervision targets
 - pairing-session inventory summaries for bridge-pairing status, expiry, and
   VaultRef completion counts

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -3743,6 +3743,28 @@ impl RuntimePairBridgeToolRequest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCompletePairingToolRequest {
+    pub completion: RuntimePairingCompletion,
+}
+
+impl RuntimeCompletePairingToolRequest {
+    pub fn new(
+        session_id: RuntimePairingSessionId,
+        vault_ref: VaultRef,
+        completed_at_ms: u64,
+    ) -> Self {
+        Self {
+            completion: RuntimePairingCompletion::new(session_id, vault_ref, completed_at_ms),
+        }
+    }
+
+    pub fn with_metadata(mut self, metadata: Vec<Metadata>) -> Self {
+        self.completion = self.completion.with_metadata(metadata);
+        self
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeCommandToolRequest {
     pub entity_id: EntityId,
@@ -3955,6 +3977,11 @@ pub struct RuntimeUnsubscribeToolOutput {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimePairBridgeToolOutput {
+    pub session: RuntimePairingSession,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCompletePairingToolOutput {
     pub session: RuntimePairingSession,
 }
 
@@ -4760,6 +4787,27 @@ impl SmartHomeRuntime {
         );
         Ok(RuntimePairBridgeToolOutput {
             session: self.start_pairing_session(session)?,
+        })
+    }
+
+    pub fn execute_complete_pairing_tool(
+        &mut self,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        now_ms: u64,
+    ) -> Result<RuntimeCompletePairingToolOutput, RuntimeError> {
+        let tool = SmartHomeTool::CompletePairing;
+        let decision = self.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+        if !decision.missing_capabilities.is_empty() {
+            return Err(RuntimeError::UnauthorizedTool {
+                principal_id,
+                tool,
+                missing_capabilities: decision.missing_capabilities,
+            });
+        }
+
+        Ok(RuntimeCompletePairingToolOutput {
+            session: self.complete_pairing_session_with(request.completion)?,
         })
     }
 
@@ -8229,7 +8277,7 @@ mod tests {
     }
 
     #[test]
-    fn pair_bridge_tool_requires_pair_grants_before_starting_session() {
+    fn pairing_tools_require_pair_grants_before_mutating_sessions() {
         let mut runtime = SmartHomeRuntime::new();
         runtime.upsert_bridge(bridge("bridge-1")).unwrap();
         let principal = AgentId::trusted("agent:installer");
@@ -8261,6 +8309,46 @@ mod tests {
         assert_eq!(decisions.len(), 1);
         assert_eq!(decisions[0].outcome, AuthorizationOutcome::Denied);
         assert!(runtime.pairing_session(&session).is_none());
+
+        runtime
+            .start_pairing_session(RuntimePairingSession::pending(
+                session.clone(),
+                runtime
+                    .registry()
+                    .bridge(&BridgeId::trusted("bridge-1"))
+                    .unwrap(),
+                principal.clone(),
+                1_000,
+                1_500,
+                Vec::new(),
+            ))
+            .unwrap();
+        let complete_error = runtime
+            .execute_complete_pairing_tool(
+                principal.clone(),
+                RuntimeCompletePairingToolRequest::new(
+                    session.clone(),
+                    VaultRef::trusted("vault://smart-home/hue/bridge-1/app-key"),
+                    1_200,
+                ),
+                1_200,
+            )
+            .unwrap_err();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert!(matches!(
+            complete_error,
+            RuntimeError::UnauthorizedTool {
+                tool: SmartHomeTool::CompletePairing,
+                missing_capabilities,
+                ..
+            } if missing_capabilities == vec![CapabilityId::trusted("smart_home.pair")]
+        ));
+        assert_eq!(decisions.len(), 2);
+        assert_eq!(decisions[1].outcome, AuthorizationOutcome::Denied);
+        assert_eq!(runtime.pairing_session(&session).unwrap().vault_ref, None);
     }
 
     #[test]
@@ -8314,12 +8402,18 @@ mod tests {
         );
 
         let completed = runtime
-            .complete_pairing_session(
-                &session_id,
-                VaultRef::trusted("vault://smart-home/hue/bridge-1/app-key"),
+            .execute_complete_pairing_tool(
+                principal.clone(),
+                RuntimeCompletePairingToolRequest::new(
+                    session_id.clone(),
+                    VaultRef::trusted("vault://smart-home/hue/bridge-1/app-key"),
+                    1_200,
+                )
+                .with_metadata(vec![Metadata::new("pairing_kind", "hue_link_button")]),
                 1_200,
             )
-            .unwrap();
+            .unwrap()
+            .session;
         let bridge = runtime
             .registry()
             .bridge(&BridgeId::trusted("bridge-1"))
@@ -8343,6 +8437,10 @@ mod tests {
                     && event.metadata.iter().any(|metadata| {
                         metadata.key == "smart_home.pairing_session"
                             && metadata.value == "pairing-1"
+                    })
+                    && event.metadata.iter().any(|metadata| {
+                        metadata.key == "pairing_kind"
+                            && metadata.value == "hue_link_button"
                     })
                     && event.metadata.iter().all(|metadata| {
                         !metadata.value.contains("app-key")
@@ -8369,6 +8467,13 @@ mod tests {
         assert_eq!(
             runtime.pairing_session(&session_id).unwrap().vault_ref,
             Some(VaultRef::trusted("vault://smart-home/hue/bridge-1/app-key"))
+        );
+        assert_eq!(
+            runtime
+                .registry()
+                .authorization_decisions_for_principal(&principal)
+                .len(),
+            2
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `smart_home.complete_pairing` to the core tool catalog as a human-approval pairing tool gated by `smart_home.pair`.
- Add the runtime `execute_complete_pairing_tool` facade so pairing completion goes through tool authorization before mutating sessions with VaultRef handles.
- Add the Chief adapter definition, JSON parser, handler output, and Hue-style end-to-end coverage for completing a pairing ceremony without raw credentials.

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
- `git diff --check`