### PR TITLE
Add browser event handler descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -9,6 +9,9 @@ documented in this file.
 - Browser-readiness resource-endpoint descriptors now expose refresh redirects
   plus resolved document resources as a flat endpoint inventory for
   fetch/navigation planning.
+- Browser-readiness event-handler descriptors now expose document, body, and
+  element inline handler metadata as a categorized flat inventory for browser
+  readiness planning without evaluating script text.
 - Browser-readiness navigation-target descriptors now expose policy-rich anchor
   and image-map area targets with resolved URLs, target selection, rel policy,
   ping/attribution endpoints, language/type hints, referrer policy, download,

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -827,6 +827,7 @@ pub struct BrowserDocument {
     pub body_dir: Option<String>,
     pub document_event_handlers: Vec<String>,
     pub body_event_handlers: Vec<String>,
+    pub event_handler_descriptors: Vec<BrowserEventHandlerDescriptor>,
     pub body_text: String,
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
@@ -1316,6 +1317,25 @@ pub struct BrowserGlobalStateDescriptor {
     pub draggable_state: Option<String>,
     pub spellcheck: Option<String>,
     pub translate: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserEventHandlerDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub role: Option<String>,
+    pub source: String,
+    pub event_handlers: Vec<String>,
+    pub handler_count: usize,
+    pub activation_handlers: Vec<String>,
+    pub keyboard_handlers: Vec<String>,
+    pub pointer_handlers: Vec<String>,
+    pub form_handlers: Vec<String>,
+    pub media_handlers: Vec<String>,
+    pub lifecycle_handlers: Vec<String>,
+    pub error_handlers: Vec<String>,
     pub text: String,
 }
 
@@ -2736,7 +2756,13 @@ impl BrowserDocument {
         if let Some(descriptor) = browser_document_policy_descriptor(&summary.metadata) {
             summary.document_policy_descriptors.push(descriptor);
         }
-        for element in [html, body].into_iter().flatten() {
+        for (source, element) in [("document", html), ("body", body)] {
+            let Some(element) = element else {
+                continue;
+            };
+            if let Some(descriptor) = browser_event_handler_descriptor(element, source) {
+                summary.event_handler_descriptors.push(descriptor);
+            }
             if let Some(descriptor) = browser_global_state_descriptor(element) {
                 summary.global_state_descriptors.push(descriptor);
             }
@@ -9930,6 +9956,9 @@ fn collect_browser_facts(
         if let Some(interactive) = browser_interactive_element(element, labels, id_texts) {
             summary.interactive_elements.push(interactive);
         }
+        if let Some(descriptor) = browser_event_handler_descriptor(element, "element") {
+            summary.event_handler_descriptors.push(descriptor);
+        }
         if let Some(disclosure) = browser_disclosure_element(element, id_texts) {
             summary.disclosures.push(disclosure);
         }
@@ -12980,6 +13009,43 @@ fn browser_global_state_descriptor(element: &Element) -> Option<BrowserGlobalSta
     })
 }
 
+fn browser_event_handler_descriptor(
+    element: &Element,
+    source: &str,
+) -> Option<BrowserEventHandlerDescriptor> {
+    let event_handlers = browser_event_handlers(element);
+    if event_handlers.is_empty() {
+        return None;
+    }
+
+    Some(BrowserEventHandlerDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        role: browser_content_role(&element.name).map(ToOwned::to_owned),
+        source: source.to_string(),
+        handler_count: event_handlers.len(),
+        activation_handlers: browser_event_handlers_by_kind(
+            &event_handlers,
+            browser_activation_event,
+        ),
+        keyboard_handlers: browser_event_handlers_by_kind(&event_handlers, browser_keyboard_event),
+        pointer_handlers: browser_event_handlers_by_kind(&event_handlers, browser_pointer_event),
+        form_handlers: browser_event_handlers_by_kind(&event_handlers, browser_form_event),
+        media_handlers: browser_event_handlers_by_kind(&event_handlers, browser_media_event),
+        lifecycle_handlers: browser_event_handlers_by_kind(
+            &event_handlers,
+            browser_lifecycle_event,
+        ),
+        error_handlers: browser_event_handlers_by_kind(&event_handlers, browser_error_event),
+        event_handlers,
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+    })
+}
+
 fn browser_aria_relation_descriptor(
     element: &Element,
     id_texts: &[(String, String)],
@@ -14069,6 +14135,111 @@ fn browser_event_handlers(element: &Element) -> Vec<String> {
             (name.len() > 2 && name.starts_with("on")).then(|| name.to_string())
         })
         .collect()
+}
+
+fn browser_event_handlers_by_kind(
+    event_handlers: &[String],
+    predicate: fn(&str) -> bool,
+) -> Vec<String> {
+    event_handlers
+        .iter()
+        .filter(|handler| predicate(handler.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn browser_activation_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onclick" | "ondblclick" | "onsubmit" | "onreset" | "oncommand" | "ontoggle"
+    )
+}
+
+fn browser_keyboard_event(handler: &str) -> bool {
+    matches!(handler, "onkeydown" | "onkeypress" | "onkeyup")
+}
+
+fn browser_pointer_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onpointerdown"
+            | "onpointermove"
+            | "onpointerup"
+            | "onpointercancel"
+            | "onpointerenter"
+            | "onpointerleave"
+            | "onpointerover"
+            | "onpointerout"
+            | "onmousedown"
+            | "onmousemove"
+            | "onmouseup"
+            | "onmouseenter"
+            | "onmouseleave"
+            | "onmouseover"
+            | "onmouseout"
+            | "ontouchstart"
+            | "ontouchmove"
+            | "ontouchend"
+            | "ontouchcancel"
+            | "ondrag"
+            | "ondragstart"
+            | "ondragend"
+            | "ondragenter"
+            | "ondragleave"
+            | "ondragover"
+            | "ondrop"
+            | "onwheel"
+    )
+}
+
+fn browser_form_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "oninput" | "onchange" | "oninvalid" | "onselect" | "onsubmit" | "onreset"
+    )
+}
+
+fn browser_media_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onplay"
+            | "onplaying"
+            | "onpause"
+            | "onended"
+            | "onvolumechange"
+            | "ontimeupdate"
+            | "onratechange"
+            | "onwaiting"
+            | "onstalled"
+            | "onsuspend"
+            | "onloadeddata"
+            | "onloadedmetadata"
+            | "onloadstart"
+            | "oncanplay"
+            | "oncanplaythrough"
+            | "ondurationchange"
+            | "onemptied"
+            | "onprogress"
+            | "onseeking"
+            | "onseeked"
+    )
+}
+
+fn browser_lifecycle_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onload"
+            | "onunload"
+            | "onbeforeunload"
+            | "onpageshow"
+            | "onpagehide"
+            | "onreadystatechange"
+            | "ondomcontentloaded"
+    )
+}
+
+fn browser_error_event(handler: &str) -> bool {
+    matches!(handler, "onerror" | "onabort" | "oncancel")
 }
 
 fn browser_popover_target(element: &Element) -> Option<String> {
@@ -19447,6 +19618,56 @@ mod tests {
             render_tree.children[0].children[1].event_handlers,
             vec!["onplay".to_string(), "onpause".to_string()]
         );
+    }
+
+    #[test]
+    fn browser_event_handler_descriptors_track_document_body_and_inline_handlers() {
+        let html = "<html onreadystatechange=ready><body onload=boot onunload=teardown>\
+             <main id=app onclick=delegate><button onclick=save onkeydown=shortcut>Save</button>\
+             <video controls onplay=play onpause=pause></video><img src=hero.jpg alt=Hero onerror=fallback>\
+             <input value=Draft oninput=edit onchange=commit></main></body></html>";
+        let summary = parse_browser_document(html).expect("browser document should parse");
+
+        assert_eq!(summary.event_handler_descriptors.len(), 7);
+
+        let document = &summary.event_handler_descriptors[0];
+        assert_eq!(document.element, "html");
+        assert_eq!(document.source, "document");
+        assert_eq!(document.event_handlers, vec!["onreadystatechange"]);
+        assert_eq!(document.lifecycle_handlers, vec!["onreadystatechange"]);
+        assert_eq!(document.handler_count, 1);
+
+        let body = &summary.event_handler_descriptors[1];
+        assert_eq!(body.element, "body");
+        assert_eq!(body.source, "body");
+        assert_eq!(body.event_handlers, vec!["onload", "onunload"]);
+        assert_eq!(body.lifecycle_handlers, vec!["onload", "onunload"]);
+        assert_eq!(body.handler_count, 2);
+
+        let main = &summary.event_handler_descriptors[2];
+        assert_eq!(main.element, "main");
+        assert_eq!(main.id.as_deref(), Some("app"));
+        assert_eq!(main.role.as_deref(), Some("main"));
+        assert_eq!(main.activation_handlers, vec!["onclick"]);
+        assert_eq!(main.text, "Save");
+
+        let button = &summary.event_handler_descriptors[3];
+        assert_eq!(button.element, "button");
+        assert_eq!(button.role.as_deref(), Some("control"));
+        assert_eq!(button.activation_handlers, vec!["onclick"]);
+        assert_eq!(button.keyboard_handlers, vec!["onkeydown"]);
+
+        let video = &summary.event_handler_descriptors[4];
+        assert_eq!(video.role.as_deref(), Some("media"));
+        assert_eq!(video.media_handlers, vec!["onplay", "onpause"]);
+
+        let image = &summary.event_handler_descriptors[5];
+        assert_eq!(image.role.as_deref(), Some("image"));
+        assert_eq!(image.error_handlers, vec!["onerror"]);
+
+        let input = &summary.event_handler_descriptors[6];
+        assert_eq!(input.role.as_deref(), Some("control"));
+        assert_eq!(input.form_handlers, vec!["oninput", "onchange"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -4,19 +4,19 @@ use coding_adventures_html_parser::{
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
     BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor,
-    BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
-    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
-    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
-    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
-    BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
-    BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton,
+    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
+    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
+    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
+    BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
+    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
     BrowserScriptExecutionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
     BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
@@ -63,6 +63,8 @@ struct ExpectedBrowserDocument {
     document_event_handlers: Vec<String>,
     #[serde(default)]
     body_event_handlers: Vec<String>,
+    #[serde(default)]
+    event_handler_descriptors: Vec<ExpectedEventHandlerDescriptor>,
     body_text: String,
     metas: Vec<ExpectedMeta>,
     resources: Vec<ExpectedResource>,
@@ -567,6 +569,38 @@ struct ExpectedFetchPolicyDescriptor {
     allowfullscreen: bool,
     #[serde(default)]
     credentialless: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedEventHandlerDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    role: Option<String>,
+    source: String,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    handler_count: usize,
+    #[serde(default)]
+    activation_handlers: Vec<String>,
+    #[serde(default)]
+    keyboard_handlers: Vec<String>,
+    #[serde(default)]
+    pointer_handlers: Vec<String>,
+    #[serde(default)]
+    form_handlers: Vec<String>,
+    #[serde(default)]
+    media_handlers: Vec<String>,
+    #[serde(default)]
+    lifecycle_handlers: Vec<String>,
+    #[serde(default)]
+    error_handlers: Vec<String>,
+    #[serde(default)]
+    text: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4009,6 +4043,28 @@ fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_element
     );
 }
 
+#[test]
+fn browser_event_handler_descriptors_track_document_and_element_wiring() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "event-handler-page")
+        .expect("event handler fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("event handler fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.event_handler_descriptors,
+        case.expected
+            .into_browser_document()
+            .event_handler_descriptors,
+        "event handler descriptors should preserve document/body handlers and categorize inline element handlers without evaluating script text",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         let metadata = self.metadata.into_browser_document_metadata();
@@ -4116,6 +4172,11 @@ impl ExpectedBrowserDocument {
             body_dir: self.body_dir,
             document_event_handlers: self.document_event_handlers,
             body_event_handlers: self.body_event_handlers,
+            event_handler_descriptors: self
+                .event_handler_descriptors
+                .into_iter()
+                .map(ExpectedEventHandlerDescriptor::into_browser_event_handler_descriptor)
+                .collect(),
             body_text: self.body_text,
             metas: self
                 .metas
@@ -4511,6 +4572,28 @@ impl ExpectedGlobalStateDescriptor {
             draggable_state: self.draggable_state,
             spellcheck: self.spellcheck,
             translate: self.translate,
+            text: self.text,
+        }
+    }
+}
+
+impl ExpectedEventHandlerDescriptor {
+    fn into_browser_event_handler_descriptor(self) -> BrowserEventHandlerDescriptor {
+        BrowserEventHandlerDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            role: self.role,
+            source: self.source,
+            event_handlers: self.event_handlers,
+            handler_count: self.handler_count,
+            activation_handlers: self.activation_handlers,
+            keyboard_handlers: self.keyboard_handlers,
+            pointer_handlers: self.pointer_handlers,
+            form_handlers: self.form_handlers,
+            media_handlers: self.media_handlers,
+            lifecycle_handlers: self.lifecycle_handlers,
+            error_handlers: self.error_handlers,
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -41,6 +41,9 @@ policy tokens, validation bypass state, and submitter overrides.
 Navigation-target descriptor cases pin policy-rich anchor and image-map area
 targets with target selection, rel policy, ping/attribution endpoints,
 language/type hints, download/referrer policy, and area geometry.
+Event-handler descriptor cases pin document, body, and element inline handler
+metadata as a flat inventory categorized by activation, keyboard, form, media,
+lifecycle, and error/event-recovery concerns without evaluating script text.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1278,6 +1278,15 @@
         "base_target": null,
         "document_event_handlers": ["onreadystatechange"],
         "body_event_handlers": ["onload", "onunload"],
+        "event_handler_descriptors": [
+          { "element": "html", "role": "block", "source": "document", "event_handlers": ["onreadystatechange"], "handler_count": 1, "lifecycle_handlers": ["onreadystatechange"], "text": "Save" },
+          { "element": "body", "role": "block", "source": "body", "event_handlers": ["onload", "onunload"], "handler_count": 2, "lifecycle_handlers": ["onload", "onunload"], "text": "Save" },
+          { "element": "main", "id": "app", "role": "main", "source": "element", "event_handlers": ["onclick"], "handler_count": 1, "activation_handlers": ["onclick"], "text": "Save" },
+          { "element": "button", "role": "control", "source": "element", "event_handlers": ["onclick", "onkeydown"], "handler_count": 2, "activation_handlers": ["onclick"], "keyboard_handlers": ["onkeydown"], "text": "Save" },
+          { "element": "video", "role": "media", "source": "element", "event_handlers": ["onplay", "onpause"], "handler_count": 2, "media_handlers": ["onplay", "onpause"] },
+          { "element": "img", "role": "image", "source": "element", "event_handlers": ["onerror"], "handler_count": 1, "error_handlers": ["onerror"] },
+          { "element": "input", "role": "control", "source": "element", "event_handlers": ["oninput", "onchange"], "handler_count": 2, "form_handlers": ["oninput", "onchange"] }
+        ],
         "body_text": "Save",
         "metas": [],
         "resources": [
@@ -1319,6 +1328,10 @@
         "body_text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative",
         "metas": [],
         "resources": [],
+        "event_handler_descriptors": [
+          { "element": "button", "id": "menu", "role": "control", "source": "element", "event_handlers": ["onclick"], "handler_count": 1, "activation_handlers": ["onclick"], "text": "Menu" },
+          { "element": "div", "id": "action", "role": "block", "source": "element", "event_handlers": ["onkeydown"], "handler_count": 1, "keyboard_handlers": ["onkeydown"], "text": "Inline action" }
+        ],
         "anchors": [
           { "id": "app", "name": null, "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative" },
           { "id": "menu", "name": null, "text": "Menu" },


### PR DESCRIPTION
## Summary
- add BrowserEventHandlerDescriptor as a flat browser-readiness inventory for html/body/element inline event handlers
- categorize handlers into activation, keyboard, pointer, form, media, lifecycle, and error buckets without evaluating script text
- pin event-handler descriptor expectations in browser readiness fixtures and docs

## Verification
- cargo test -p coding-adventures-html-parser browser_event_handler_descriptors_track_document_body_and_inline_handlers
- cargo test -p coding-adventures-html-parser browser_event_handler_descriptors_track_document_and_element_wiring
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- cargo test -p coding-adventures-html-parser browser_
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser