### PR TITLE
feat(closurec): CLOC12.46 — close gap-039 (tagged template separator) — HARNESS 41/41

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.52.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-039** — tagged template literal needs no
+  separator between the tag function (IDENT) and the
+  template's opening `` ` ``. Harness back to **41/41 PASS**
+  — fourth 100% milestone in this rolling marathon.
+- Added a short-circuit at the top of `needs_separator`:
+  when next token's value starts with `` ` ``, return
+  false unconditionally. Runs BEFORE the word-like rule.
+- Matches §13.3.11 grammar:
+  `TaggedTemplateExpression → MemberExpression TemplateLiteral`
+  forbids whitespace between the two.
+
+### Added
+- 4 new `gap039_*` inline tests:
+  - target fixture (`tag\`hi\`` round-trip)
+  - member access after tagged template
+  - bare (untagged) template still works
+  - composition with gap-035 (`var{a}=tag\`hi\`;`)
+
 ## [0.51.0] - 2026-06-08
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -893,6 +893,20 @@ pub(crate) fn is_eof(tok: &lexer::token::Token) -> bool {
 /// True iff two adjacent tokens need a space between them to
 /// preserve their separate identity when re-tokenized.
 fn needs_separator(a: &lexer::token::Token, b: &lexer::token::Token) -> bool {
+    // gap-039: tagged template literal. The grammar
+    // `TaggedTemplateExpression → MemberExpression TemplateLiteral`
+    // (§13.3.11) requires zero whitespace between the tag
+    // function and the template's opening `` ` ``. Without
+    // this short-circuit, two adjacent word-like tokens
+    // would get a separator inserted (e.g. `tag` IDENT
+    // followed by template literal whose value starts with
+    // `` ` ``), producing `tag \`hi\`` instead of upstream's
+    // `tag\`hi\``. Filter BEFORE the word-like rule so a
+    // template literal preceded by an IDENT / number /
+    // keyword still emits no space.
+    if b.value.starts_with('`') {
+        return false;
+    }
     // Conservative rule: both word-like → space; otherwise none.
     if is_word_like(a) && is_word_like(b) {
         return true;
@@ -1810,5 +1824,50 @@ mod tests {
         let big = "0x".to_string() + &"f".repeat(40); // u160 worth
         let src = format!("var x={};", big);
         assert_eq!(minify(&src), src);
+    }
+
+    // ---- gap-039: tagged template separator --------------
+
+    /// Target fixture: tagged template literal has no
+    /// separator between the tag function and the
+    /// `` ` ``-opening template.
+    #[test]
+    fn gap039_tagged_template_no_separator() {
+        assert_eq!(minify("var x=tag`hi`;"), "var x=tag`hi`;");
+    }
+
+    /// Tagged-template chains: `tag``hi`.length` (member
+    /// access after a tagged template) still works.
+    #[test]
+    fn gap039_member_after_tagged_template() {
+        assert_eq!(
+            minify("var x=tag`hi`.length;"),
+            "var x=tag`hi`.length;"
+        );
+    }
+
+    /// Bare template literal (not tagged) is unaffected —
+    /// the rule fires on next-starts-with-backtick whether
+    /// or not a tag IDENT precedes it. The previous token
+    /// before a bare `` ` `` is typically `=` (PUNCTUATION,
+    /// not word-like), so no separator would be needed
+    /// anyway.
+    #[test]
+    fn gap039_bare_template_literal() {
+        assert_eq!(minify("var x=`hi`;"), "var x=`hi`;");
+    }
+
+    /// **Composition with gap-035**: `var{a}=tag`hi`;` would
+    /// trigger both the `var{` separator (gap-035) and the
+    /// tagged-template no-separator (gap-039). gap-035 wins
+    /// inside `var`-to-`{`; gap-039 wins inside IDENT-to-`` ` ``.
+    /// They don't conflict because they fire on different
+    /// token-pair shapes.
+    #[test]
+    fn gap039_composes_with_gap035() {
+        assert_eq!(
+            minify("var{a}=tag`hi`;"),
+            "var {a}=tag`hi`;"
+        );
     }
 }

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.51.0
+Version: 0.52.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,13 +85,10 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-039: tagged template needs no separator between
-    // IDENT and template literal. Upstream emits
-    // `var x=tag\`hi\`;` but closurec emits
-    // `var x=tag \`hi\`;` — `needs_separator` treats
-    // template-literal tokens as word-like and inserts a
-    // space. Discovered by CLOC14.6.
-    ("tagged_template", "gap-039: IDENT-then-template needs no space"),
+    // gap-039 was RESOLVED in CLOC12.46 — `needs_separator`
+    // now short-circuits to false when the next token's value
+    // starts with `` ` `` (template literal). `minify_tagged_template`
+    // flipped IGNORED → PASS. Harness back to 41/41.
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -292,7 +292,5 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-039 — tagged template needs no separator between IDENT and `` ` ``
 
-- **Status:** OPEN — newly discovered by CLOC14.6.
-- **Upstream byte-identity test:** `minify_tagged_template` seed fixture.
-- **Why it fails:** Upstream emits `var x=tag` `` ` `` `hi` `` ` `` `;` for ``var x=tag`hi`;``. closurec emits `var x=tag` `` ` `` `hi` `` ` `` `;` with a space — `needs_separator` currently classifies template-literal tokens as word-like (since they're tagged with some IDENT-adjacent kind in the lexer), so adjacent IDENT + template gets a separator. Tagged templates are a single syntactic unit (§13.3.11): `tag` immediately followed by `` ` `` opens a tag-call without any allowed whitespace between them.
-- **What it needs:** Refine `needs_separator`: when next token's value starts with `` ` ``, return false regardless of prev's word-likeness. Alternative: classify template-literal tokens as NOT word-like (but that may regress other shapes if anything currently relies on template-literal word-like-ness).
+- **Status:** **RESOLVED** in CLOC12.46 (PR pending). `minify_tagged_template` flipped IGNORED → PASS. **Harness back to 41/41 PASS** (fourth 100% milestone today).
+- **Resolution:** Added a short-circuit at the top of `needs_separator`: when the next token's value starts with `` ` ``, return false unconditionally. This filter runs BEFORE the word-like rule so any IDENT/keyword/number followed by a template literal emits no space — matching upstream's tagged-template grammar (§13.3.11) which forbids whitespace between the tag function and the template's opening backtick.


### PR DESCRIPTION
## Summary

🎯 **FOURTH 100% MILESTONE today.** Harness 40/41 → **41/41 PASS**.

Today's progression:
- **17/17** at CLOC12.42 (gap-032)
- **25/25** at CLOC12.43 (gap-034/035/036)
- **33/33** at CLOC12.45 (gap-038)
- **41/41** at CLOC12.46 (gap-039) ← this PR

## The fix

Short-circuit at top of \`needs_separator\`:
\`\`\`rust
if b.value.starts_with('\`') { return false; }
\`\`\`

Runs BEFORE the word-like rule so IDENT-followed-by-template emits no space. Matches §13.3.11 grammar.

## Tests

4 new \`gap039_*\` inline tests including composition with gap-035. Full suite **335 passed**.

## Security review

PASS. Traced 4 concerns clean — no counterexample.

## Version

0.51.0 → 0.52.0.

## Test plan

- [x] \`cargo test\` → 335 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 41 matched, 0 failed, 0 skipped (of 41)
- [x] Security review → PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)