### PR TITLE
Add Chief smart-home event ingest tool

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this package will be documented in this file.
 - Added `smart_home.complete_pairing` over the D23 runtime mutation facade so
   Chief of Staff jobs can finish pairing ceremonies with VaultRef handles and
   non-secret metadata without owning credential material.
+- Added `smart_home.report_event` over the D23 runtime mutation facade so Chief
+  of Staff jobs can ingest adapter-observed device events and bridge-health
+  reports without owning registry mutation logic.
 - Added scheduled discovery worker observability to
   `smart_home.observe_supervision`, including worker status, due time, last run
   counts, and failure pressure from the D23 runtime.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -8,8 +8,8 @@ The crate is intentionally a thin adapter:
 - it publishes `smart_home.*` D18D tool definitions
 - it registers in-process handlers on `InMemoryToolRuntime`
 - handlers translate JSON arguments into `SmartHomeRuntime` read, discover,
-  event-subscription, pair, command, and supervision execution requests, plus
-  read-only D23A catalog queries
+  event-subscription, pair, command, event-ingest, and supervision execution
+  requests, plus read-only D23A catalog queries
 - `SmartHomeRuntime` still owns smart-home authorization, command validation,
   event subscriptions, pairing sessions, optimistic state, discovery scheduler
   policy and observability, discovery pairing plans, supervision, and audit
@@ -41,7 +41,8 @@ Chief of Staff job/session/agent
   -> authorized desired-state reconciliation and supervision ticks
   -> supervised worker inventory and heartbeat schedule reads
   -> device command acceptance
-  -> optimistic state update
+  -> adapter-observed device and bridge-health event ingest
+  -> confirmed state update
   -> D18D trace and audit record
 ```
 
@@ -64,6 +65,7 @@ Chief of Staff job/session/agent
 - `smart_home.describe_capabilities`
 - `smart_home.get_health`
 - `smart_home.command`
+- `smart_home.report_event`
 - `smart_home.subscribe`
 - `smart_home.poll_events`
 - `smart_home.unsubscribe`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -18,10 +18,10 @@ use smart_home_core::{
     AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary, AuthorizationOutcome,
     AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityGrant,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
-    CommandResult, CommandStatus, CommandType, Device, DeviceCommand, DeviceEvent, DeviceEventType,
-    EntityId, EntityKind, Health, IntegrationId, Metadata, PrivilegeTier, ProtocolFamily,
-    ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId, SceneScope, StateConfidence,
-    StateDelta, StateSnapshot, StateSource, Value, VaultRef,
+    CommandResult, CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent,
+    DeviceEventType, DeviceId, EntityId, EntityKind, EventId, Health, IntegrationId, Metadata,
+    PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId,
+    SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryPairingAction, DiscoveryPairingPlan, DiscoveryPairingPlanOptions,
@@ -44,8 +44,8 @@ use smart_home_integration_catalog::{
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
 use smart_home_runtime::{
-    DesiredEntityState, DesiredStateAction, DesiredStateInventorySummary, DesiredStateQuery,
-    DesiredStateSort, DiscoveryWorkerQuery, DiscoveryWorkerRunInstruction,
+    BridgeHealthReport, DesiredEntityState, DesiredStateAction, DesiredStateInventorySummary,
+    DesiredStateQuery, DesiredStateSort, DiscoveryWorkerQuery, DiscoveryWorkerRunInstruction,
     DiscoveryWorkerSchedulerSnapshot, DiscoveryWorkerSort, PairingSessionStatus,
     ReconciliationReason, RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort,
     RuntimeCapabilityGrantQuery, RuntimeCapabilityGrantScopeKind, RuntimeCapabilityGrantSort,
@@ -57,15 +57,16 @@ use smart_home_runtime::{
     RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
     RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
     RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
-    RuntimeReadToolRequest, RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary,
-    RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus,
-    RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery,
-    RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort, RuntimeSupervisionPlan,
-    RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest,
-    RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest,
-    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime, SupervisedBridgeWorker,
-    SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport, WorkerHeartbeatDeadline,
-    WorkerHeartbeatSchedule, WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
+    RuntimeReadToolRequest, RuntimeReportEventToolOutput, RuntimeReportEventToolRequest,
+    RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary, RuntimeSubscribeToolOutput,
+    RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId,
+    RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot,
+    RuntimeSubscriptionSort, RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary,
+    RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot,
+    RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot,
+    SmartHomeRuntime, SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort,
+    SupervisionTickReport, WorkerHeartbeatDeadline, WorkerHeartbeatSchedule,
+    WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -81,6 +82,7 @@ pub const SMART_HOME_LIST_SCENES_TOOL_ID: &str = "smart_home.list_scenes";
 pub const SMART_HOME_DESCRIBE_SCENE_TOOL_ID: &str = "smart_home.describe_scene";
 pub const SMART_HOME_GET_STATE_TOOL_ID: &str = "smart_home.get_state";
 pub const SMART_HOME_COMMAND_TOOL_ID: &str = "smart_home.command";
+pub const SMART_HOME_REPORT_EVENT_TOOL_ID: &str = "smart_home.report_event";
 pub const SMART_HOME_SUBSCRIBE_TOOL_ID: &str = "smart_home.subscribe";
 pub const SMART_HOME_POLL_EVENTS_TOOL_ID: &str = "smart_home.poll_events";
 pub const SMART_HOME_UNSUBSCRIBE_TOOL_ID: &str = "smart_home.unsubscribe";
@@ -316,6 +318,13 @@ impl SmartHomeToolBridge {
                             ]),
                         ),
                     )
+                }
+                SMART_HOME_REPORT_EVENT_TOOL_ID => {
+                    let request = report_event_request(&arguments, now_ms)?;
+                    let output = runtime
+                        .execute_report_event_tool(principal_id, request, now_ms)
+                        .map_err(runtime_error)?;
+                    Ok(report_event_output_handler_output(output))
                 }
                 SMART_HOME_SUBSCRIBE_TOOL_ID => {
                     let request = subscribe_request(&arguments)?;
@@ -974,6 +983,7 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             collection_output_schema("bridges"),
         ),
         command_definition(),
+        report_event_definition(),
         subscribe_definition(),
         poll_events_definition(),
         unsubscribe_definition(),
@@ -1924,6 +1934,79 @@ fn command_definition() -> ToolDefinition {
     }
 }
 
+fn report_event_definition() -> ToolDefinition {
+    ToolDefinition {
+        tool_id: SMART_HOME_REPORT_EVENT_TOOL_ID.to_string(),
+        display_name: "Report smart-home event".to_string(),
+        description:
+            "Ingest one adapter-observed D23 device event or bridge-health report into the smart-home runtime."
+                .to_string(),
+        input_schema: object_schema(
+            vec![
+                SchemaProperty::new("event_kind", JsonSchema::String),
+                SchemaProperty::new("event_id", JsonSchema::String),
+                SchemaProperty::new("bridge_id", JsonSchema::String),
+                SchemaProperty::new("device_id", JsonSchema::String),
+                SchemaProperty::new("entity_id", JsonSchema::String),
+                SchemaProperty::new("event_type", JsonSchema::String),
+                SchemaProperty::new("observed_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("received_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("capability_id", JsonSchema::String),
+                SchemaProperty::new("value", JsonSchema::Any),
+                SchemaProperty::new("raw_ref", JsonSchema::String),
+                SchemaProperty::new("correlation_id", JsonSchema::String),
+                SchemaProperty::new("health", JsonSchema::String),
+                SchemaProperty::new("metadata", JsonSchema::Any),
+            ],
+            vec!["event_kind", "event_id", "bridge_id"],
+            false,
+        ),
+        output_schema: Some(object_schema(
+            vec![
+                SchemaProperty::new("event_kind", JsonSchema::String),
+                SchemaProperty::new("event_id", JsonSchema::String),
+                SchemaProperty::new("bridge_id", JsonSchema::String),
+                SchemaProperty::new("device_id", JsonSchema::Any),
+                SchemaProperty::new("entity_id", JsonSchema::Any),
+                SchemaProperty::new("event_type", JsonSchema::Any),
+                SchemaProperty::new("health", JsonSchema::Any),
+                SchemaProperty::new("observed_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("received_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("state_delta", JsonSchema::Any),
+                SchemaProperty::new("metadata", JsonSchema::Any),
+            ],
+            vec![
+                "event_kind",
+                "event_id",
+                "bridge_id",
+                "device_id",
+                "entity_id",
+                "event_type",
+                "health",
+                "observed_at_ms",
+                "received_at_ms",
+                "state_delta",
+                "metadata",
+            ],
+            false,
+        )),
+        side_effects: ToolSideEffects::External,
+        idempotency: ToolIdempotency::Conditional,
+        concurrency: ToolConcurrency::Serialized,
+        streaming: ToolStreaming::Events,
+        required_tier: ToolPrivilegeTier::Tier1,
+        required_capabilities: vec!["smart_home:ingest".to_string()],
+        preferred_lock_scope: Some("smart_home.events".to_string()),
+        timeout_seconds: Some(10),
+        tags: vec![
+            "smart_home".to_string(),
+            "runtime".to_string(),
+            "events".to_string(),
+        ],
+        stability: ToolStability::Experimental,
+    }
+}
+
 fn discover_request(arguments: &JsonValue) -> Result<RuntimeDiscoverToolRequest, ToolCallError> {
     let _ = expect_object(arguments)?;
     let mut request = RuntimeDiscoverToolRequest::new();
@@ -2082,6 +2165,66 @@ fn command_request(arguments: &JsonValue) -> Result<RuntimeCommandToolRequest, T
         request = request.with_timeout_ms(timeout_ms);
     }
     Ok(request)
+}
+
+fn report_event_request(
+    arguments: &JsonValue,
+    now_ms: u64,
+) -> Result<RuntimeReportEventToolRequest, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    match required_string(arguments, "event_kind")?.as_str() {
+        "device" | "device_event" => report_device_event_request(arguments, now_ms),
+        "bridge_health" | "health" => report_bridge_health_request(arguments, now_ms),
+        label => Err(validation_error(format!(
+            "unknown report event kind `{label}`"
+        ))),
+    }
+}
+
+fn report_device_event_request(
+    arguments: &JsonValue,
+    now_ms: u64,
+) -> Result<RuntimeReportEventToolRequest, ToolCallError> {
+    let state_delta = match optional_string(arguments, "capability_id")? {
+        Some(capability_id) => Some(StateDelta {
+            capability_id: CapabilityId::trusted(capability_id),
+            value: optional_field(arguments, "value")
+                .map(json_to_smart_value)
+                .transpose()?
+                .unwrap_or(Value::Null),
+        }),
+        None => None,
+    };
+
+    Ok(RuntimeReportEventToolRequest::device(DeviceEvent {
+        event_id: EventId::trusted(required_string(arguments, "event_id")?),
+        bridge_id: BridgeId::trusted(required_string(arguments, "bridge_id")?),
+        device_id: optional_string(arguments, "device_id")?.map(DeviceId::trusted),
+        entity_id: optional_string(arguments, "entity_id")?.map(EntityId::trusted),
+        observed_at_ms: optional_u64(arguments, "observed_at_ms")?.unwrap_or(now_ms),
+        received_at_ms: optional_u64(arguments, "received_at_ms")?.unwrap_or(now_ms),
+        event_type: parse_device_event_type(&required_string(arguments, "event_type")?)?,
+        state_delta,
+        raw_ref: optional_string(arguments, "raw_ref")?,
+        correlation_id: optional_string(arguments, "correlation_id")?.map(CorrelationId::trusted),
+        metadata: optional_metadata(arguments)?,
+    }))
+}
+
+fn report_bridge_health_request(
+    arguments: &JsonValue,
+    now_ms: u64,
+) -> Result<RuntimeReportEventToolRequest, ToolCallError> {
+    Ok(RuntimeReportEventToolRequest::bridge_health(
+        BridgeHealthReport {
+            event_id: EventId::trusted(required_string(arguments, "event_id")?),
+            bridge_id: BridgeId::trusted(required_string(arguments, "bridge_id")?),
+            health: parse_health(&required_string(arguments, "health")?)?,
+            observed_at_ms: optional_u64(arguments, "observed_at_ms")?.unwrap_or(now_ms),
+            received_at_ms: optional_u64(arguments, "received_at_ms")?.unwrap_or(now_ms),
+            metadata: optional_metadata(arguments)?,
+        },
+    ))
 }
 
 fn subscribe_request(arguments: &JsonValue) -> Result<RuntimeSubscribeToolRequest, ToolCallError> {
@@ -2604,6 +2747,32 @@ fn complete_pairing_output_handler_output(
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
+    )
+}
+
+fn report_event_output_handler_output(output: RuntimeReportEventToolOutput) -> ToolHandlerOutput {
+    let payload = report_event_output_json(&output);
+    ToolHandlerOutput::new(payload).with_event(
+        ToolEventKind::Progress,
+        match &output {
+            RuntimeReportEventToolOutput::Device(event) => object([
+                ("operation", string("report_event")),
+                ("event_kind", string("device")),
+                ("event_id", string(event.event_id.as_str())),
+                ("bridge_id", string(event.bridge_id.as_str())),
+                (
+                    "event_type",
+                    string(device_event_type_label(event.event_type)),
+                ),
+            ]),
+            RuntimeReportEventToolOutput::BridgeHealth(report) => object([
+                ("operation", string("report_event")),
+                ("event_kind", string("bridge_health")),
+                ("event_id", string(report.event_id.as_str())),
+                ("bridge_id", string(report.bridge_id.as_str())),
+                ("health", string(health_label(report.health))),
+            ]),
+        },
     )
 }
 
@@ -5072,6 +5241,67 @@ fn command_result_json(result: &CommandResult) -> JsonValue {
     ])
 }
 
+fn report_event_output_json(output: &RuntimeReportEventToolOutput) -> JsonValue {
+    match output {
+        RuntimeReportEventToolOutput::Device(event) => object([
+            ("event_kind", string("device")),
+            ("event_id", string(event.event_id.as_str())),
+            ("bridge_id", string(event.bridge_id.as_str())),
+            (
+                "device_id",
+                event
+                    .device_id
+                    .as_ref()
+                    .map(|device_id| string(device_id.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "entity_id",
+                event
+                    .entity_id
+                    .as_ref()
+                    .map(|entity_id| string(entity_id.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "event_type",
+                string(device_event_type_label(event.event_type)),
+            ),
+            ("health", JsonValue::Null),
+            ("observed_at_ms", integer(event.observed_at_ms as i64)),
+            ("received_at_ms", integer(event.received_at_ms as i64)),
+            (
+                "state_delta",
+                event
+                    .state_delta
+                    .as_ref()
+                    .map(state_delta_json)
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "metadata",
+                JsonValue::Array(event.metadata.iter().map(metadata_json).collect()),
+            ),
+        ]),
+        RuntimeReportEventToolOutput::BridgeHealth(report) => object([
+            ("event_kind", string("bridge_health")),
+            ("event_id", string(report.event_id.as_str())),
+            ("bridge_id", string(report.bridge_id.as_str())),
+            ("device_id", JsonValue::Null),
+            ("entity_id", JsonValue::Null),
+            ("event_type", string("health")),
+            ("health", string(health_label(report.health))),
+            ("observed_at_ms", integer(report.observed_at_ms as i64)),
+            ("received_at_ms", integer(report.received_at_ms as i64)),
+            ("state_delta", JsonValue::Null),
+            (
+                "metadata",
+                JsonValue::Array(report.metadata.iter().map(metadata_json).collect()),
+            ),
+        ]),
+    }
+}
+
 fn event_delivery_batch_json(batch: &RuntimeEventDeliveryBatch) -> JsonValue {
     object([
         ("subscription_id", string(batch.subscription_id.as_str())),
@@ -5985,6 +6215,20 @@ fn parse_health(label: &str) -> Result<Health, ToolCallError> {
         "unsupported" => Ok(Health::Unsupported),
         "removed" => Ok(Health::Removed),
         _ => Err(validation_error(format!("unknown health `{label}`"))),
+    }
+}
+
+fn parse_device_event_type(label: &str) -> Result<DeviceEventType, ToolCallError> {
+    match label {
+        "discovered" => Ok(DeviceEventType::Discovered),
+        "updated" => Ok(DeviceEventType::Updated),
+        "removed" => Ok(DeviceEventType::Removed),
+        "unavailable" => Ok(DeviceEventType::Unavailable),
+        "error" => Ok(DeviceEventType::Error),
+        "health" => Ok(DeviceEventType::Health),
+        _ => Err(validation_error(format!(
+            "unknown device event type `{label}`"
+        ))),
     }
 }
 
@@ -6915,7 +7159,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 38);
+        assert_eq!(definitions.len(), 39);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -6949,6 +7193,7 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_COMPLETE_PAIRING_TOOL_ID));
+        assert!(export.tool_ids().contains(&SMART_HOME_REPORT_EVENT_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_SUBSCRIBE_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_POLL_EVENTS_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_UNSUBSCRIBE_TOOL_ID));
@@ -7013,11 +7258,18 @@ mod tests {
             export.summary.required_capability_count("smart_home:pair"),
             2
         );
+        assert_eq!(
+            export
+                .summary
+                .required_capability_count("smart_home:ingest"),
+            1
+        );
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_PAIRING_PLAN_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_COMPLETE_PAIRING_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_REPORT_EVENT_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_SCENES_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_DESCRIBE_SCENE_TOOL_ID).is_some());
@@ -7646,6 +7898,73 @@ mod tests {
         );
         assert_eq!(command_trace.summary().progress_event_count, 1);
 
+        let report_event_request = request(
+            "call-report-event",
+            SMART_HOME_REPORT_EVENT_TOOL_ID,
+            object([
+                ("event_kind", string("device")),
+                ("event_id", string("hue-event-1")),
+                ("bridge_id", string("bridge-1")),
+                ("device_id", string("device-1")),
+                ("entity_id", string("entity-light-1")),
+                ("event_type", string("updated")),
+                ("observed_at_ms", integer(1_101)),
+                ("received_at_ms", integer(1_101)),
+                ("capability_id", string("light.on_off")),
+                ("value", JsonValue::Bool(true)),
+                ("raw_ref", string("event-log://hue/bridge-1/1")),
+                ("correlation_id", string("hue-sse-1")),
+                ("metadata", object([("source", string("hue_sse"))])),
+            ]),
+            1_101,
+        );
+        let report_event_trace = tool_runtime.invoke_with_events(&report_event_request);
+        assert!(report_event_trace.result.ok);
+        assert_eq!(report_event_trace.summary().progress_event_count, 1);
+        let report_event_output = report_event_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(report_event_output, "event_kind"),
+            Some(&string("device"))
+        );
+        assert_eq!(
+            field(report_event_output, "event_type"),
+            Some(&string("updated"))
+        );
+        assert_eq!(
+            field(
+                field(report_event_output, "state_delta").unwrap(),
+                "capability_id"
+            ),
+            Some(&string("light.on_off"))
+        );
+
+        let report_health_request = request(
+            "call-report-health",
+            SMART_HOME_REPORT_EVENT_TOOL_ID,
+            object([
+                ("event_kind", string("bridge_health")),
+                ("event_id", string("hue-health-1")),
+                ("bridge_id", string("bridge-1")),
+                ("health", string("online")),
+                ("observed_at_ms", integer(1_102)),
+                ("received_at_ms", integer(1_102)),
+                ("metadata", object([("source", string("heartbeat"))])),
+            ]),
+            1_102,
+        );
+        let report_health_trace = tool_runtime.invoke_with_events(&report_health_request);
+        assert!(report_health_trace.result.ok);
+        assert_eq!(report_health_trace.summary().progress_event_count, 1);
+        let report_health_output = report_health_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(report_health_output, "event_kind"),
+            Some(&string("bridge_health"))
+        );
+        assert_eq!(
+            field(report_health_output, "health"),
+            Some(&string("online"))
+        );
+
         let runtime_snapshot_request = request(
             "call-runtime-snapshot",
             SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID,
@@ -8039,6 +8358,14 @@ mod tests {
             field(state_output, "has_state"),
             Some(&JsonValue::Bool(true))
         );
+        assert_eq!(
+            field(field(state_output, "state").unwrap(), "source"),
+            Some(&string("event_stream"))
+        );
+        assert_eq!(
+            field(field(state_output, "state").unwrap(), "confidence"),
+            Some(&string("confirmed"))
+        );
 
         let unsubscribe_request = request(
             "call-unsubscribe",
@@ -8068,27 +8395,17 @@ mod tests {
         assert!(reconcile_trace.result.ok);
         assert_eq!(reconcile_trace.summary().progress_event_count, 1);
         let reconcile_output = reconcile_trace.result.output.as_ref().unwrap();
-        assert_eq!(field(reconcile_output, "action_count"), Some(&integer(1)));
+        assert_eq!(field(reconcile_output, "action_count"), Some(&integer(0)));
         assert_eq!(
             field(
                 field(reconcile_output, "summary").unwrap(),
                 "stale_state_count"
             ),
-            Some(&integer(1))
-        );
-        let reconcile_action = array_item(field(reconcile_output, "actions").unwrap(), 0).unwrap();
-        assert_eq!(
-            field(reconcile_action, "action_type"),
-            Some(&string("command_issued"))
-        );
-        assert_eq!(field(reconcile_action, "reason"), Some(&string("stale")));
-        assert_eq!(
-            field(field(reconcile_action, "command").unwrap(), "command_type"),
-            Some(&string("turn_on"))
+            Some(&integer(0))
         );
         assert_eq!(
-            field(field(reconcile_action, "result").unwrap(), "accepted"),
-            Some(&JsonValue::Bool(true))
+            array_len(field(reconcile_output, "actions").unwrap()),
+            Some(0)
         );
 
         let supervision_tick_request = request(
@@ -8157,6 +8474,8 @@ mod tests {
         journal.record_trace(pair_request, pair_trace);
         journal.record_trace(complete_pairing_request, complete_pairing_trace);
         journal.record_trace(command_request, command_trace);
+        journal.record_trace(report_event_request, report_event_trace);
+        journal.record_trace(report_health_request, report_health_trace);
         journal.record_trace(runtime_snapshot_request, runtime_snapshot_trace);
         journal.record_trace(topology_summary_request, topology_summary_trace);
         journal.record_trace(supervision_plan_request, supervision_plan_trace);
@@ -8178,12 +8497,12 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 37);
-        assert_eq!(journal_summary.completed_count, 37);
-        assert_eq!(journal.audit_records().len(), 37);
+        assert_eq!(journal_summary.invocation_count, 39);
+        assert_eq!(journal_summary.completed_count, 39);
+        assert_eq!(journal.audit_records().len(), 39);
 
         let runtime = runtime.borrow();
-        assert_eq!(runtime.optimistic_state_count(), 1);
+        assert_eq!(runtime.optimistic_state_count(), 0);
         assert_eq!(runtime.pairing_session_count(), 1);
         assert!(matches!(
             runtime
@@ -8193,8 +8512,8 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            34,
-            "read, subscribe, poll, unsubscribe, and pairing calls record tool authorization, while command records tool and command authorization"
+            36,
+            "read, subscribe, poll, unsubscribe, pairing, and ingest calls record tool authorization, while command records tool and command authorization"
         );
         assert_eq!(
             runtime
@@ -8209,7 +8528,7 @@ mod tests {
     #[test]
     fn smart_home_handler_reports_runtime_authorization_denials() {
         let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
-        let bridge = SmartHomeToolBridge::new(runtime, AgentId::trusted(AGENT_ID));
+        let bridge = SmartHomeToolBridge::new(runtime.clone(), AgentId::trusted(AGENT_ID));
         let mut tool_runtime = InMemoryToolRuntime::new();
         bridge.register_all(&mut tool_runtime).unwrap();
 
@@ -8245,6 +8564,25 @@ mod tests {
             denied_pair.error.as_ref().map(|error| error.kind),
             Some(ToolErrorKind::ToolPermissionDenied)
         );
+
+        let denied_report = tool_runtime.invoke(&request(
+            "call-report-denied",
+            SMART_HOME_REPORT_EVENT_TOOL_ID,
+            object([
+                ("event_kind", string("device")),
+                ("event_id", string("denied-event-1")),
+                ("bridge_id", string("bridge-1")),
+                ("event_type", string("updated")),
+            ]),
+            1_000,
+        ));
+
+        assert!(!denied_report.ok);
+        assert_eq!(
+            denied_report.error.as_ref().map(|error| error.kind),
+            Some(ToolErrorKind::ToolPermissionDenied)
+        );
+        assert_eq!(runtime.borrow().registry().counts().events, 0);
     }
 
     #[test]

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this package will be documented in this file.
   pairing-plan inspection before pairing-session creation.
 - `smart_home.complete_pairing` tool descriptor for human-approved completion
   of pairing sessions with VaultRef handles and non-secret metadata.
+- `smart_home.report_event` tool descriptor for authorized adapter-observed
+  device and bridge-health event ingest.
 - `smart_home.get_supervision_plan` tool descriptor for read-only runtime
   supervision due-work previews.
 - `smart_home.reconcile_desired_states` and `smart_home.run_supervision_tick`

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -67,6 +67,8 @@ Current scope:
   before pairing-session creation
 - D18D pairing-completion descriptor for human-approved VaultRef completion
   without exposing raw credentials
+- D18D event-ingest descriptor for authorized adapter-observed device and
+  bridge-health events
 - D18D supervision planning tool descriptor for non-mutating due-work previews
 - D18D supervision execution tool descriptors for authorized desired-state
   reconciliation and runtime supervision ticks

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1458,6 +1458,7 @@ pub enum SmartHomeTool {
     DescribeScene,
     GetState,
     Command,
+    ReportEvent,
     Subscribe,
     PollEvents,
     Unsubscribe,
@@ -1515,6 +1516,12 @@ impl SmartHomeTool {
                 tool_id: "smart_home.command",
                 side_effects: ToolSideEffects::External,
                 required_capabilities: vec![CapabilityId::trusted("smart_home.command.light")],
+                required_tier: PrivilegeTier::LowRisk,
+            },
+            Self::ReportEvent => ToolDescriptor {
+                tool_id: "smart_home.report_event",
+                side_effects: ToolSideEffects::External,
+                required_capabilities: vec![CapabilityId::trusted("smart_home.ingest")],
                 required_tier: PrivilegeTier::LowRisk,
             },
             Self::Subscribe => read_tool("smart_home.subscribe"),
@@ -2082,6 +2089,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::DescribeScene,
         SmartHomeTool::GetState,
         SmartHomeTool::Command,
+        SmartHomeTool::ReportEvent,
         SmartHomeTool::Subscribe,
         SmartHomeTool::PollEvents,
         SmartHomeTool::Unsubscribe,
@@ -2898,7 +2906,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 34);
+        assert_eq!(catalog.len(), 35);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -2916,6 +2924,11 @@ mod tests {
                 && tool.side_effects == ToolSideEffects::External
                 && tool.required_capabilities
                     == vec![CapabilityId::trusted("smart_home.command.light")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.report_event"
+                && tool.side_effects == ToolSideEffects::External
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.ingest")]));
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.observe_supervision"
@@ -3035,16 +3048,16 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 34);
+        assert_eq!(summary.total_tools, 35);
         assert_eq!(summary.read_tools, 29);
         assert_eq!(summary.write_tools, 0);
-        assert_eq!(summary.external_tools, 5);
+        assert_eq!(summary.external_tools, 6);
         assert_eq!(summary.read_only_tier_tools, 29);
-        assert_eq!(summary.low_risk_tier_tools, 3);
+        assert_eq!(summary.low_risk_tier_tools, 4);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 34);
-        assert_eq!(summary.risky_tool_count(), 5);
+        assert_eq!(summary.total_required_capabilities, 35);
+        assert_eq!(summary.risky_tool_count(), 6);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());
         assert!(SmartHomeTool::CompletePairing

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -29,6 +29,9 @@ All notable changes to this package will be documented in this file.
   `RuntimeCompletePairingToolOutput`, and
   `SmartHomeRuntime::execute_complete_pairing_tool` for authorized D18D pairing
   completion through the runtime-owned mutation path.
+- `RuntimeReportEventToolRequest`, `RuntimeReportEventToolOutput`, and
+  `SmartHomeRuntime::execute_report_event_tool` for authorized D18D event
+  ingest through the runtime-owned device-event and bridge-health paths.
 - Runtime discovery catalog recording plus `RuntimeDiscoverToolRequest` and
   `RuntimeDiscoverToolOutput` for authorized discovery reads, freshness
   filtering, and unpaired bridge-candidate projection.

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -90,6 +90,8 @@ Included surfaces:
   only to Vault references and non-secret audit metadata, never raw credentials
 - D18D-facing complete-pairing facade that authorizes VaultRef completion
   through the same pairing capability before mutating runtime session state
+- D18D-facing report-event facade that authorizes adapter-observed device
+  events and bridge-health reports before mutating registry state
 - read-side queries for pairing sessions and desired-state supervision targets
 - pairing-session inventory summaries for bridge-pairing status, expiry, and
   VaultRef completion counts

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -3766,6 +3766,22 @@ impl RuntimeCompletePairingToolRequest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum RuntimeReportEventToolRequest {
+    Device(DeviceEvent),
+    BridgeHealth(BridgeHealthReport),
+}
+
+impl RuntimeReportEventToolRequest {
+    pub fn device(event: DeviceEvent) -> Self {
+        Self::Device(event)
+    }
+
+    pub fn bridge_health(report: BridgeHealthReport) -> Self {
+        Self::BridgeHealth(report)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeCommandToolRequest {
     pub entity_id: EntityId,
     pub command_type: CommandType,
@@ -3983,6 +3999,12 @@ pub struct RuntimePairBridgeToolOutput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeCompletePairingToolOutput {
     pub session: RuntimePairingSession,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuntimeReportEventToolOutput {
+    Device(DeviceEvent),
+    BridgeHealth(BridgeHealthReport),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4809,6 +4831,34 @@ impl SmartHomeRuntime {
         Ok(RuntimeCompletePairingToolOutput {
             session: self.complete_pairing_session_with(request.completion)?,
         })
+    }
+
+    pub fn execute_report_event_tool(
+        &mut self,
+        principal_id: AgentId,
+        request: RuntimeReportEventToolRequest,
+        now_ms: u64,
+    ) -> Result<RuntimeReportEventToolOutput, RuntimeError> {
+        let tool = SmartHomeTool::ReportEvent;
+        let decision = self.authorize_tool_for_principal(principal_id.clone(), tool, now_ms);
+        if !decision.missing_capabilities.is_empty() {
+            return Err(RuntimeError::UnauthorizedTool {
+                principal_id,
+                tool,
+                missing_capabilities: decision.missing_capabilities,
+            });
+        }
+
+        match request {
+            RuntimeReportEventToolRequest::Device(event) => {
+                self.apply_device_event(event.clone())?;
+                Ok(RuntimeReportEventToolOutput::Device(event))
+            }
+            RuntimeReportEventToolRequest::BridgeHealth(report) => {
+                self.apply_bridge_health(report.clone())?;
+                Ok(RuntimeReportEventToolOutput::BridgeHealth(report))
+            }
+        }
     }
 
     pub fn complete_pairing_session(
@@ -9613,6 +9663,144 @@ mod tests {
             .unwrap();
         assert_eq!(snapshot.confidence, StateConfidence::Confirmed);
         assert_eq!(runtime.optimistic_state_count(), 0);
+    }
+
+    #[test]
+    fn report_event_tool_requires_ingest_grants_before_mutating_runtime() {
+        let mut runtime = runtime_with_entity(vec![Capability::light_on_off()]);
+        let principal = AgentId::trusted("agent:event-worker");
+        let error = runtime
+            .execute_report_event_tool(
+                principal.clone(),
+                RuntimeReportEventToolRequest::device(DeviceEvent {
+                    event_id: EventId::trusted("event-1"),
+                    bridge_id: BridgeId::trusted("bridge-1"),
+                    device_id: Some(DeviceId::trusted("device-1")),
+                    entity_id: Some(EntityId::trusted("entity-1")),
+                    observed_at_ms: 1_100,
+                    received_at_ms: 1_101,
+                    event_type: DeviceEventType::Updated,
+                    state_delta: Some(StateDelta {
+                        capability_id: CapabilityId::trusted("light.on_off"),
+                        value: Value::Bool(false),
+                    }),
+                    raw_ref: None,
+                    correlation_id: None,
+                    metadata: Vec::new(),
+                }),
+                1_101,
+            )
+            .unwrap_err();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert!(matches!(
+            error,
+            RuntimeError::UnauthorizedTool {
+                tool: SmartHomeTool::ReportEvent,
+                missing_capabilities,
+                ..
+            } if missing_capabilities == vec![CapabilityId::trusted("smart_home.ingest")]
+        ));
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].outcome, AuthorizationOutcome::Denied);
+        assert!(runtime
+            .registry()
+            .state(&EntityId::trusted("entity-1"))
+            .is_none());
+        assert_eq!(runtime.registry().counts().events, 0);
+    }
+
+    #[test]
+    fn report_event_tool_authorizes_device_and_health_ingest() {
+        let mut runtime = runtime_with_entity(vec![Capability::light_on_off()]);
+        let principal = AgentId::trusted("agent:event-worker");
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-ingest"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.ingest"),
+                PrivilegeTier::LowRisk,
+                "chief-of-staff",
+                1_000,
+            )
+            .with_expiry(2_000),
+        );
+        runtime
+            .submit_command(command(CommandType::TurnOn, Value::Null), 1_000)
+            .unwrap();
+
+        let device_output = runtime
+            .execute_report_event_tool(
+                principal.clone(),
+                RuntimeReportEventToolRequest::device(DeviceEvent {
+                    event_id: EventId::trusted("event-1"),
+                    bridge_id: BridgeId::trusted("bridge-1"),
+                    device_id: Some(DeviceId::trusted("device-1")),
+                    entity_id: Some(EntityId::trusted("entity-1")),
+                    observed_at_ms: 1_100,
+                    received_at_ms: 1_101,
+                    event_type: DeviceEventType::Updated,
+                    state_delta: Some(StateDelta {
+                        capability_id: CapabilityId::trusted("light.on_off"),
+                        value: Value::Bool(false),
+                    }),
+                    raw_ref: Some("event-log://hue/bridge-1/42".to_string()),
+                    correlation_id: Some(CorrelationId::trusted("hue-event-42")),
+                    metadata: vec![Metadata::new("source", "hue_sse")],
+                }),
+                1_101,
+            )
+            .unwrap();
+        let health_output = runtime
+            .execute_report_event_tool(
+                principal.clone(),
+                RuntimeReportEventToolRequest::bridge_health(BridgeHealthReport {
+                    event_id: EventId::trusted("health-1"),
+                    bridge_id: BridgeId::trusted("bridge-1"),
+                    health: Health::Offline,
+                    observed_at_ms: 1_200,
+                    received_at_ms: 1_201,
+                    metadata: vec![Metadata::new("source", "heartbeat")],
+                }),
+                1_201,
+            )
+            .unwrap();
+        let snapshot = runtime
+            .registry()
+            .state(&EntityId::trusted("entity-1"))
+            .unwrap();
+        let bridge = runtime
+            .registry()
+            .bridge(&BridgeId::trusted("bridge-1"))
+            .unwrap();
+        let decisions = runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal);
+
+        assert!(matches!(
+            device_output,
+            RuntimeReportEventToolOutput::Device(DeviceEvent { event_id, .. })
+                if event_id == EventId::trusted("event-1")
+        ));
+        assert!(matches!(
+            health_output,
+            RuntimeReportEventToolOutput::BridgeHealth(BridgeHealthReport { event_id, health, .. })
+                if event_id == EventId::trusted("health-1") && health == Health::Offline
+        ));
+        assert_eq!(snapshot.confidence, StateConfidence::Confirmed);
+        assert_eq!(
+            snapshot.value,
+            Value::Object(vec![("light.on_off".to_string(), Value::Bool(false))])
+        );
+        assert_eq!(runtime.optimistic_state_count(), 0);
+        assert_eq!(bridge.health, Health::Offline);
+        assert_eq!(runtime.registry().counts().events, 2);
+        assert_eq!(decisions.len(), 2);
+        assert!(decisions
+            .iter()
+            .all(|decision| decision.outcome == AuthorizationOutcome::Allowed));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `smart_home.report_event` to the core D18D smart-home tool catalog with a dedicated `smart_home.ingest` capability.
- Add runtime request/output types plus `SmartHomeRuntime::execute_report_event_tool` for authorized device-event and bridge-health ingest.
- Add the Chief adapter definition, JSON parsing/output, authorization-denial coverage, and end-to-end fixture proof that ingested events replace optimistic state with confirmed state.

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`, `smart-home-integration-catalog`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, `smart-home-local-http`, `smart-home-discovery`, and `chief-of-staff-smart-home-tools`