### PR TITLE
Add browser disclosure state descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness disclosure-state descriptors now expose details/dialog open
+  state, grouped details names, summary text, modal/closedby behavior, and
+  accessible naming metadata as a flat browser-planning inventory.
 - Browser-readiness resource-endpoint descriptors now expose refresh redirects
   plus resolved document resources as a flat endpoint inventory for
   fetch/navigation planning.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -862,6 +862,7 @@ pub struct BrowserDocument {
     pub embedded_policy_descriptors: Vec<BrowserEmbeddedPolicyDescriptor>,
     pub interactive_elements: Vec<BrowserInteractiveElement>,
     pub disclosures: Vec<BrowserDisclosure>,
+    pub disclosure_state_descriptors: Vec<BrowserDisclosureStateDescriptor>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
     pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
     pub global_state_descriptors: Vec<BrowserGlobalStateDescriptor>,
@@ -2260,6 +2261,29 @@ pub struct BrowserDisclosure {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserDisclosureStateDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub disclosure_kind: String,
+    pub open: bool,
+    pub grouped: bool,
+    pub group_name: Option<String>,
+    pub has_summary: bool,
+    pub summary_text: Option<String>,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub aria_describedby: Vec<String>,
+    pub aria_modal: Option<String>,
+    pub modal: bool,
+    pub closedby: Option<String>,
+    pub text: String,
+    pub text_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserForm {
     pub id: Option<String>,
     pub action: Option<String>,
@@ -2785,6 +2809,8 @@ impl BrowserDocument {
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.embedded_policy_descriptors =
             browser_embedded_policy_descriptors(&summary.embedded_contexts);
+        summary.disclosure_state_descriptors =
+            browser_disclosure_state_descriptors(&summary.disclosures);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -11365,6 +11391,51 @@ fn browser_disclosure_element(
     })
 }
 
+fn browser_disclosure_state_descriptors(
+    disclosures: &[BrowserDisclosure],
+) -> Vec<BrowserDisclosureStateDescriptor> {
+    disclosures
+        .iter()
+        .map(browser_disclosure_state_descriptor)
+        .collect()
+}
+
+fn browser_disclosure_state_descriptor(
+    disclosure: &BrowserDisclosure,
+) -> BrowserDisclosureStateDescriptor {
+    let disclosure_kind = if disclosure.element == "dialog" {
+        "dialog"
+    } else {
+        "details"
+    };
+    let grouped = disclosure.element == "details" && disclosure.name.is_some();
+
+    BrowserDisclosureStateDescriptor {
+        element: disclosure.element.clone(),
+        id: disclosure.id.clone(),
+        name: disclosure.name.clone(),
+        disclosure_kind: disclosure_kind.to_string(),
+        open: disclosure.open,
+        grouped,
+        group_name: grouped.then(|| disclosure.name.clone()).flatten(),
+        has_summary: disclosure.summary_text.is_some(),
+        summary_text: disclosure.summary_text.clone(),
+        accessible_name: disclosure.accessible_name.clone(),
+        accessible_description: disclosure.accessible_description.clone(),
+        aria_label: disclosure.aria_label.clone(),
+        aria_labelledby: disclosure.aria_labelledby.clone(),
+        aria_describedby: disclosure.aria_describedby.clone(),
+        aria_modal: disclosure.aria_modal.clone(),
+        modal: disclosure
+            .aria_modal
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("true")),
+        closedby: disclosure.closedby.clone(),
+        text: disclosure.text.clone(),
+        text_length: disclosure.text.chars().count(),
+    }
+}
+
 fn browser_details_summary_text(element: &Element) -> Option<String> {
     if element.name != "details" {
         return None;
@@ -18463,6 +18534,61 @@ mod tests {
             Some("Review totals")
         );
         assert_eq!(dialog.aria_modal.as_deref(), Some("true"));
+        assert_eq!(dialog.closedby.as_deref(), Some("any"));
+        assert_eq!(dialog.text, "Confirm copy");
+    }
+
+    #[test]
+    fn browser_disclosure_state_descriptors_track_details_dialog_and_modal_state() {
+        let document = parse_html(
+            "<body>\
+             <details id=shipping name=checkout open aria-describedby=ship-help>\
+               <summary>Shipping options</summary><p id=ship-help>Choose speed</p>\
+             </details>\
+             <details id=billing name=checkout><summary>Billing</summary><p>Cards</p></details>\
+             <h2 id=dialog-title>Confirm order</h2>\
+             <p id=dialog-help>Review totals</p>\
+             <dialog id=confirm open aria-labelledby=dialog-title aria-describedby=dialog-help aria-modal=true closedby=any>\
+               <p>Confirm copy</p>\
+             </dialog>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.disclosure_state_descriptors.len(), 3);
+
+        let shipping = &summary.disclosure_state_descriptors[0];
+        assert_eq!(shipping.element, "details");
+        assert_eq!(shipping.id.as_deref(), Some("shipping"));
+        assert_eq!(shipping.disclosure_kind, "details");
+        assert!(shipping.open);
+        assert!(shipping.grouped);
+        assert_eq!(shipping.group_name.as_deref(), Some("checkout"));
+        assert!(shipping.has_summary);
+        assert_eq!(shipping.summary_text.as_deref(), Some("Shipping options"));
+        assert_eq!(
+            shipping.accessible_description.as_deref(),
+            Some("Choose speed")
+        );
+
+        let billing = &summary.disclosure_state_descriptors[1];
+        assert_eq!(billing.id.as_deref(), Some("billing"));
+        assert!(!billing.open);
+        assert!(billing.grouped);
+        assert_eq!(billing.summary_text.as_deref(), Some("Billing"));
+        assert_eq!(billing.text_length, "Billing Cards".chars().count());
+
+        let dialog = &summary.disclosure_state_descriptors[2];
+        assert_eq!(dialog.element, "dialog");
+        assert_eq!(dialog.disclosure_kind, "dialog");
+        assert!(dialog.open);
+        assert!(!dialog.grouped);
+        assert!(!dialog.has_summary);
+        assert_eq!(dialog.accessible_name.as_deref(), Some("Confirm order"));
+        assert_eq!(dialog.aria_labelledby, vec!["dialog-title"]);
+        assert_eq!(dialog.aria_describedby, vec!["dialog-help"]);
+        assert_eq!(dialog.aria_modal.as_deref(), Some("true"));
+        assert!(dialog.modal);
         assert_eq!(dialog.closedby.as_deref(), Some("any"));
         assert_eq!(dialog.text, "Confirm copy");
     }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,21 +2,22 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserAnchor, BrowserAriaCollection, BrowserAriaCollectionItem,
     BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
     BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
-    BrowserDatalistOption, BrowserDisclosure, BrowserDocument, BrowserDocumentMetadata,
-    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor,
-    BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton,
-    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
-    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
-    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
-    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
-    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
-    BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
-    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
+    BrowserDocumentMetadata, BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext,
+    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
+    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
+    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
+    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
+    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
+    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
+    BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
     BrowserScriptExecutionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
     BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
@@ -126,6 +127,8 @@ struct ExpectedBrowserDocument {
     interactive_elements: Vec<ExpectedInteractiveElement>,
     #[serde(default)]
     disclosures: Vec<ExpectedDisclosure>,
+    #[serde(default)]
+    disclosure_state_descriptors: Option<Vec<ExpectedDisclosureStateDescriptor>>,
     #[serde(default)]
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
     #[serde(default)]
@@ -1853,6 +1856,46 @@ struct ExpectedDisclosure {
     aria_modal: Option<String>,
     #[serde(default)]
     closedby: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDisclosureStateDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    disclosure_kind: String,
+    #[serde(default)]
+    open: bool,
+    #[serde(default)]
+    grouped: bool,
+    #[serde(default)]
+    group_name: Option<String>,
+    #[serde(default)]
+    has_summary: bool,
+    #[serde(default)]
+    summary_text: Option<String>,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    aria_modal: Option<String>,
+    #[serde(default)]
+    modal: bool,
+    #[serde(default)]
+    closedby: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    text_length: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3966,6 +4009,26 @@ fn browser_disclosure_descriptor_metadata_tracks_details_and_dialogs() {
 }
 
 #[test]
+fn browser_disclosure_state_descriptor_metadata_tracks_details_and_dialogs() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive disclosure-state fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive disclosure-state fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.disclosure_state_descriptors,
+        case.expected.into_browser_document().disclosure_state_descriptors,
+        "disclosure-state descriptors should preserve details/dialog open, summary, modal, naming, and grouping metadata",
+    );
+}
+
+#[test]
 fn browser_navigation_attribution_metadata_tracks_links_areas_and_form_targets() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -4158,6 +4221,22 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_image_candidate_descriptors(&images));
+        let disclosures: Vec<_> = self
+            .disclosures
+            .into_iter()
+            .map(ExpectedDisclosure::into_browser_disclosure)
+            .collect();
+        let disclosure_state_descriptors = self
+            .disclosure_state_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedDisclosureStateDescriptor::into_browser_disclosure_state_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_disclosure_state_descriptors(&disclosures));
 
         BrowserDocument {
             title: self.title,
@@ -4290,11 +4369,8 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedInteractiveElement::into_browser_interactive_element)
                 .collect(),
-            disclosures: self
-                .disclosures
-                .into_iter()
-                .map(ExpectedDisclosure::into_browser_disclosure)
-                .collect(),
+            disclosures,
+            disclosure_state_descriptors,
             component_hydration_targets: self
                 .component_hydration_targets
                 .into_iter()
@@ -4914,6 +4990,51 @@ fn expected_embedded_resource_kind(element: &str) -> &'static str {
         "object" => "object",
         "embed" => "embed",
         _ => "embedded",
+    }
+}
+
+fn expected_disclosure_state_descriptors(
+    disclosures: &[BrowserDisclosure],
+) -> Vec<BrowserDisclosureStateDescriptor> {
+    disclosures
+        .iter()
+        .map(expected_disclosure_state_descriptor)
+        .collect()
+}
+
+fn expected_disclosure_state_descriptor(
+    disclosure: &BrowserDisclosure,
+) -> BrowserDisclosureStateDescriptor {
+    let disclosure_kind = if disclosure.element == "dialog" {
+        "dialog"
+    } else {
+        "details"
+    };
+    let grouped = disclosure.element == "details" && disclosure.name.is_some();
+
+    BrowserDisclosureStateDescriptor {
+        element: disclosure.element.clone(),
+        id: disclosure.id.clone(),
+        name: disclosure.name.clone(),
+        disclosure_kind: disclosure_kind.to_string(),
+        open: disclosure.open,
+        grouped,
+        group_name: grouped.then(|| disclosure.name.clone()).flatten(),
+        has_summary: disclosure.summary_text.is_some(),
+        summary_text: disclosure.summary_text.clone(),
+        accessible_name: disclosure.accessible_name.clone(),
+        accessible_description: disclosure.accessible_description.clone(),
+        aria_label: disclosure.aria_label.clone(),
+        aria_labelledby: disclosure.aria_labelledby.clone(),
+        aria_describedby: disclosure.aria_describedby.clone(),
+        aria_modal: disclosure.aria_modal.clone(),
+        modal: disclosure
+            .aria_modal
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("true")),
+        closedby: disclosure.closedby.clone(),
+        text: disclosure.text.clone(),
+        text_length: disclosure.text.chars().count(),
     }
 }
 
@@ -6007,6 +6128,32 @@ impl ExpectedDisclosure {
             aria_describedby: self.aria_describedby,
             aria_modal: self.aria_modal,
             closedby: self.closedby,
+        }
+    }
+}
+
+impl ExpectedDisclosureStateDescriptor {
+    fn into_browser_disclosure_state_descriptor(self) -> BrowserDisclosureStateDescriptor {
+        BrowserDisclosureStateDescriptor {
+            element: self.element,
+            id: self.id,
+            name: self.name,
+            disclosure_kind: self.disclosure_kind,
+            open: self.open,
+            grouped: self.grouped,
+            group_name: self.group_name,
+            has_summary: self.has_summary,
+            summary_text: self.summary_text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            aria_describedby: self.aria_describedby,
+            aria_modal: self.aria_modal,
+            modal: self.modal,
+            closedby: self.closedby,
+            text: self.text,
+            text_length: self.text_length,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -44,6 +44,9 @@ language/type hints, download/referrer policy, and area geometry.
 Event-handler descriptor cases pin document, body, and element inline handler
 metadata as a flat inventory categorized by activation, keyboard, form, media,
 lifecycle, and error/event-recovery concerns without evaluating script text.
+Disclosure-state descriptor cases pin details/dialog open state, grouped details
+names, summary text, dialog modal/closedby behavior, and accessible naming
+metadata as a flat browser-planning inventory.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1381,6 +1381,10 @@
           { "element": "dialog", "id": "dialog", "text": "Dialog copy", "open": true, "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true" },
           { "element": "details", "id": "more", "text": "More Extra", "summary_text": "More", "open": true, "accessible_name": "More" }
         ],
+        "disclosure_state_descriptors": [
+          { "element": "dialog", "id": "dialog", "disclosure_kind": "dialog", "text": "Dialog copy", "text_length": 11, "open": true, "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true", "modal": true },
+          { "element": "details", "id": "more", "disclosure_kind": "details", "text": "More Extra", "text_length": 10, "summary_text": "More", "has_summary": true, "open": true, "accessible_name": "More" }
+        ],
         "global_state_descriptors": [
           { "element": "section", "id": "panel", "inert": true, "text": "Settings Choose options Inline action Editable copy" },
           { "element": "div", "id": "action", "tabindex": "-1", "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "text": "Inline action" },


### PR DESCRIPTION
## Summary
- add disclosure-state descriptors for details/dialog planning metadata
- derive open/grouping/summary/modal/closedby and accessible-name fields from existing disclosures
- pin fixture expectations and browser-readiness coverage for the interactive state page

## Tests
- cargo fmt -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_disclosure_state_descriptors_track_details_dialog_and_modal_state
- cargo test -p coding-adventures-html-parser browser_disclosure_state_descriptor_metadata_tracks_details_and_dialogs
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser