### PR TITLE
Add browser activation descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness activation descriptors now expose command, popover,
+  disclosure, ARIA, focus, and inline handler routing metadata as a flat
+  activation-planning inventory.
 - Browser-readiness disclosure-state descriptors now expose details/dialog open
   state, grouped details names, summary text, modal/closedby behavior, and
   accessible naming metadata as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -847,6 +847,7 @@ pub struct BrowserDocument {
     pub navigation_groups: Vec<BrowserNavigationGroup>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
     pub command_elements: Vec<BrowserCommandElement>,
+    pub activation_descriptors: Vec<BrowserActivationDescriptor>,
     pub popovers: Vec<BrowserPopover>,
     pub aria_collections: Vec<BrowserAriaCollection>,
     pub aria_ranges: Vec<BrowserAriaRange>,
@@ -1850,6 +1851,47 @@ pub struct BrowserCommandElement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserActivationDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub authored_role: Option<String>,
+    pub command_kind: String,
+    pub activation_kind: String,
+    pub target_id: Option<String>,
+    pub target_kind: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub disabled: bool,
+    pub focusable: bool,
+    pub tabindex: Option<String>,
+    pub accesskey: Vec<String>,
+    pub event_handlers: Vec<String>,
+    pub handler_count: usize,
+    pub command: Option<String>,
+    pub command_for: Option<String>,
+    pub popover_target: Option<String>,
+    pub popover_target_action: Option<String>,
+    pub aria_controls: Vec<String>,
+    pub aria_expanded: Option<String>,
+    pub aria_haspopup: Option<String>,
+    pub aria_pressed: Option<String>,
+    pub aria_current: Option<String>,
+    pub aria_disabled: Option<String>,
+    pub control_type: Option<String>,
+    pub href: Option<String>,
+    pub resolved_href: Option<String>,
+    pub effective_target: Option<String>,
+    pub form_owner: Option<String>,
+    pub form_action: Option<String>,
+    pub resolved_form_action: Option<String>,
+    pub form_method: Option<String>,
+    pub form_target: Option<String>,
+    pub form_novalidate: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserAriaCollection {
     pub element: String,
     pub id: Option<String>,
@@ -2811,6 +2853,11 @@ impl BrowserDocument {
             browser_embedded_policy_descriptors(&summary.embedded_contexts);
         summary.disclosure_state_descriptors =
             browser_disclosure_state_descriptors(&summary.disclosures);
+        summary.activation_descriptors = browser_activation_descriptors(
+            &summary.command_elements,
+            &summary.popovers,
+            &summary.disclosures,
+        );
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -12428,6 +12475,150 @@ fn browser_command_element(
     })
 }
 
+fn browser_activation_descriptors(
+    commands: &[BrowserCommandElement],
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> Vec<BrowserActivationDescriptor> {
+    commands
+        .iter()
+        .map(|command| browser_activation_descriptor(command, popovers, disclosures))
+        .collect()
+}
+
+fn browser_activation_descriptor(
+    command: &BrowserCommandElement,
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> BrowserActivationDescriptor {
+    BrowserActivationDescriptor {
+        element: command.element.clone(),
+        id: command.id.clone(),
+        role: command.role.clone(),
+        authored_role: command.authored_role.clone(),
+        command_kind: command.command_kind.clone(),
+        activation_kind: browser_activation_kind(command),
+        target_id: browser_activation_target_id(command),
+        target_kind: browser_activation_target_kind(command, popovers, disclosures),
+        text: command.text.clone(),
+        accessible_name: command.accessible_name.clone(),
+        accessible_description: command.accessible_description.clone(),
+        disabled: command.disabled,
+        focusable: command.focusable,
+        tabindex: command.tabindex.clone(),
+        accesskey: command.accesskey.clone(),
+        event_handlers: command.event_handlers.clone(),
+        handler_count: command.event_handlers.len(),
+        command: command.command.clone(),
+        command_for: command.command_for.clone(),
+        popover_target: command.popover_target.clone(),
+        popover_target_action: command.popover_target_action.clone(),
+        aria_controls: command.aria_controls.clone(),
+        aria_expanded: command.aria_expanded.clone(),
+        aria_haspopup: command.aria_haspopup.clone(),
+        aria_pressed: command.aria_pressed.clone(),
+        aria_current: command.aria_current.clone(),
+        aria_disabled: command.aria_disabled.clone(),
+        control_type: command.control_type.clone(),
+        href: command.href.clone(),
+        resolved_href: command.resolved_href.clone(),
+        effective_target: command.effective_target.clone(),
+        form_owner: command.form_owner.clone(),
+        form_action: command.form_action.clone(),
+        resolved_form_action: command.resolved_form_action.clone(),
+        form_method: command.form_method.clone(),
+        form_target: command.form_target.clone(),
+        form_novalidate: command.form_novalidate,
+    }
+}
+
+fn browser_activation_kind(command: &BrowserCommandElement) -> String {
+    if let Some(command_value) = &command.command {
+        return command_value.clone();
+    }
+    if command.popover_target.is_some() {
+        let action = command.popover_target_action.as_deref().unwrap_or("toggle");
+        return format!("popover-{action}");
+    }
+    if command.href.is_some() {
+        return "navigation".to_string();
+    }
+    if let Some(control_type) = &command.control_type {
+        if matches!(
+            control_type.as_str(),
+            "submit" | "reset" | "button" | "image"
+        ) {
+            return format!("form-{control_type}");
+        }
+    }
+
+    command.command_kind.clone()
+}
+
+fn browser_activation_target_id(command: &BrowserCommandElement) -> Option<String> {
+    command
+        .command_for
+        .clone()
+        .or_else(|| command.popover_target.clone())
+        .or_else(|| command.aria_controls.first().cloned())
+}
+
+fn browser_activation_target_kind(
+    command: &BrowserCommandElement,
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> String {
+    if let Some(command_for) = &command.command_for {
+        if let Some(disclosure) = disclosures
+            .iter()
+            .find(|disclosure| disclosure.id.as_deref() == Some(command_for.as_str()))
+        {
+            return if disclosure.element == "dialog" {
+                "dialog"
+            } else {
+                "disclosure"
+            }
+            .to_string();
+        }
+        if popovers
+            .iter()
+            .any(|popover| popover.id.as_deref() == Some(command_for.as_str()))
+        {
+            return "popover".to_string();
+        }
+        return "command-target".to_string();
+    }
+    if let Some(popover_target) = &command.popover_target {
+        if popovers
+            .iter()
+            .any(|popover| popover.id.as_deref() == Some(popover_target.as_str()))
+        {
+            return "popover".to_string();
+        }
+        return "popover-target".to_string();
+    }
+    if !command.aria_controls.is_empty() {
+        return "controlled-region".to_string();
+    }
+    if command.href.is_some() {
+        return "navigation".to_string();
+    }
+    if command.form_owner.is_some()
+        || command.form_action.is_some()
+        || matches!(
+            command.control_type.as_deref(),
+            Some("submit" | "reset" | "image")
+        )
+    {
+        return "form".to_string();
+    }
+    if command.command_kind == "disclosure" {
+        return "disclosure".to_string();
+    }
+
+    "command".to_string()
+}
+
 fn browser_command_role(element: &Element) -> String {
     browser_authored_role(element).unwrap_or_else(|| {
         browser_content_role(&element.name)
@@ -19623,6 +19814,62 @@ mod tests {
         );
         assert!(render_tree.children[0].children[2].open);
         assert!(render_tree.children[0].children[3].open);
+    }
+
+    #[test]
+    fn browser_activation_descriptors_track_commands_popovers_and_disclosures() {
+        let document = parse_html(
+            "<body>\
+             <button id=menu aria-controls=panel aria-expanded=false command=show-modal commandfor=dialog onclick=showMenu()>Menu</button>\
+             <button id=toggle popovertarget=panel-pop popovertargetaction=show aria-expanded=false>Open panel</button>\
+             <div id=panel-pop popover=manual>Panel copy</div>\
+             <div id=action role=button tabindex=-1 aria-pressed=mixed onkeydown=keyAction()>Inline action</div>\
+             <dialog id=dialog open aria-label=\"Dialog\"><p>Dialog copy</p></dialog>\
+             <details id=more open><summary>More</summary><p>Extra</p></details>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.activation_descriptors.len(), 4);
+
+        let menu = &summary.activation_descriptors[0];
+        assert_eq!(menu.element, "button");
+        assert_eq!(menu.id.as_deref(), Some("menu"));
+        assert_eq!(menu.command_kind, "command");
+        assert_eq!(menu.activation_kind, "show-modal");
+        assert_eq!(menu.target_id.as_deref(), Some("dialog"));
+        assert_eq!(menu.target_kind, "dialog");
+        assert_eq!(menu.aria_controls, vec!["panel"]);
+        assert_eq!(menu.event_handlers, vec!["onclick"]);
+        assert_eq!(menu.handler_count, 1);
+        assert!(menu.focusable);
+
+        let toggle = &summary.activation_descriptors[1];
+        assert_eq!(toggle.id.as_deref(), Some("toggle"));
+        assert_eq!(toggle.command_kind, "popover");
+        assert_eq!(toggle.activation_kind, "popover-show");
+        assert_eq!(toggle.target_id.as_deref(), Some("panel-pop"));
+        assert_eq!(toggle.target_kind, "popover");
+        assert_eq!(toggle.popover_target.as_deref(), Some("panel-pop"));
+        assert_eq!(toggle.popover_target_action.as_deref(), Some("show"));
+
+        let action = &summary.activation_descriptors[2];
+        assert_eq!(action.id.as_deref(), Some("action"));
+        assert_eq!(action.command_kind, "button");
+        assert_eq!(action.activation_kind, "button");
+        assert_eq!(action.target_kind, "command");
+        assert_eq!(action.aria_pressed.as_deref(), Some("mixed"));
+        assert_eq!(action.tabindex.as_deref(), Some("-1"));
+        assert!(!action.focusable);
+        assert_eq!(action.event_handlers, vec!["onkeydown"]);
+
+        let summary_control = &summary.activation_descriptors[3];
+        assert_eq!(summary_control.element, "summary");
+        assert_eq!(summary_control.command_kind, "disclosure");
+        assert_eq!(summary_control.activation_kind, "disclosure");
+        assert_eq!(summary_control.target_kind, "disclosure");
+        assert_eq!(summary_control.text, "More");
+        assert!(summary_control.focusable);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,23 +1,23 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserAnchor, BrowserAriaCollection, BrowserAriaCollectionItem,
-    BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCommandElement,
-    BrowserComponentHydrationTarget, BrowserDataAttribute, BrowserDataAttributeDescriptor,
-    BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
-    BrowserDocumentMetadata, BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext,
-    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
-    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
-    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInteractiveElement, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
-    BrowserPopover, BrowserPopoverInvoker, BrowserRefresh, BrowserResource,
-    BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    parse_browser_document, BrowserActivationDescriptor, BrowserAnchor, BrowserAriaCollection,
+    BrowserAriaCollectionItem, BrowserAriaLiveRegion, BrowserAriaRange,
+    BrowserAriaRelationDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
+    BrowserDataAttribute, BrowserDataAttributeDescriptor, BrowserDatalistOption, BrowserDisclosure,
+    BrowserDisclosureStateDescriptor, BrowserDocument, BrowserDocumentMetadata,
+    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor,
+    BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor, BrowserForm, BrowserFormButton,
+    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
+    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
+    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
+    BrowserImageMapArea, BrowserImageSource, BrowserInteractiveElement, BrowserLink,
+    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
     BrowserScriptExecutionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
     BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
     BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
@@ -99,6 +99,8 @@ struct ExpectedBrowserDocument {
     section_landmarks: Vec<ExpectedSectionLandmark>,
     #[serde(default)]
     command_elements: Vec<ExpectedCommandElement>,
+    #[serde(default)]
+    activation_descriptors: Option<Vec<ExpectedActivationDescriptor>>,
     #[serde(default)]
     popovers: Vec<ExpectedPopover>,
     #[serde(default)]
@@ -1153,6 +1155,79 @@ struct ExpectedCommandElement {
     focusable: bool,
     #[serde(default)]
     disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedActivationDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    #[serde(default)]
+    authored_role: Option<String>,
+    command_kind: String,
+    activation_kind: String,
+    #[serde(default)]
+    target_id: Option<String>,
+    target_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    focusable: bool,
+    #[serde(default)]
+    tabindex: Option<String>,
+    #[serde(default)]
+    accesskey: Vec<String>,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    handler_count: usize,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    command_for: Option<String>,
+    #[serde(default)]
+    popover_target: Option<String>,
+    #[serde(default)]
+    popover_target_action: Option<String>,
+    #[serde(default)]
+    aria_controls: Vec<String>,
+    #[serde(default)]
+    aria_expanded: Option<String>,
+    #[serde(default)]
+    aria_haspopup: Option<String>,
+    #[serde(default)]
+    aria_pressed: Option<String>,
+    #[serde(default)]
+    aria_current: Option<String>,
+    #[serde(default)]
+    aria_disabled: Option<String>,
+    #[serde(default)]
+    control_type: Option<String>,
+    #[serde(default)]
+    href: Option<String>,
+    #[serde(default)]
+    resolved_href: Option<String>,
+    #[serde(default)]
+    effective_target: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    #[serde(default)]
+    form_action: Option<String>,
+    #[serde(default)]
+    resolved_form_action: Option<String>,
+    #[serde(default)]
+    form_method: Option<String>,
+    #[serde(default)]
+    form_target: Option<String>,
+    #[serde(default)]
+    form_novalidate: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2872,6 +2947,26 @@ fn browser_command_element_descriptor_metadata_tracks_activation_surfaces() {
 }
 
 #[test]
+fn browser_activation_descriptors_track_command_routes_and_state() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive activation fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive activation fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.activation_descriptors, expected.activation_descriptors,
+        "activation descriptors should preserve command, popover, disclosure, ARIA, focus, and inline handler routing metadata",
+    );
+}
+
+#[test]
 fn browser_popover_descriptor_metadata_tracks_hosts_and_invokers() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -4226,6 +4321,16 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedDisclosure::into_browser_disclosure)
             .collect();
+        let command_elements: Vec<_> = self
+            .command_elements
+            .into_iter()
+            .map(ExpectedCommandElement::into_browser_command_element)
+            .collect();
+        let popovers: Vec<_> = self
+            .popovers
+            .into_iter()
+            .map(ExpectedPopover::into_browser_popover)
+            .collect();
         let disclosure_state_descriptors = self
             .disclosure_state_descriptors
             .map(|descriptors| {
@@ -4237,6 +4342,17 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_disclosure_state_descriptors(&disclosures));
+        let activation_descriptors = self
+            .activation_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedActivationDescriptor::into_browser_activation_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                expected_activation_descriptors(&command_elements, &popovers, &disclosures)
+            });
 
         BrowserDocument {
             title: self.title,
@@ -4318,16 +4434,9 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedSectionLandmark::into_browser_section_landmark)
                 .collect(),
-            command_elements: self
-                .command_elements
-                .into_iter()
-                .map(ExpectedCommandElement::into_browser_command_element)
-                .collect(),
-            popovers: self
-                .popovers
-                .into_iter()
-                .map(ExpectedPopover::into_browser_popover)
-                .collect(),
+            command_elements,
+            activation_descriptors,
+            popovers,
             aria_collections: self
                 .aria_collections
                 .into_iter()
@@ -5038,6 +5147,150 @@ fn expected_disclosure_state_descriptor(
     }
 }
 
+fn expected_activation_descriptors(
+    commands: &[BrowserCommandElement],
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> Vec<BrowserActivationDescriptor> {
+    commands
+        .iter()
+        .map(|command| expected_activation_descriptor(command, popovers, disclosures))
+        .collect()
+}
+
+fn expected_activation_descriptor(
+    command: &BrowserCommandElement,
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> BrowserActivationDescriptor {
+    BrowserActivationDescriptor {
+        element: command.element.clone(),
+        id: command.id.clone(),
+        role: command.role.clone(),
+        authored_role: command.authored_role.clone(),
+        command_kind: command.command_kind.clone(),
+        activation_kind: expected_activation_kind(command),
+        target_id: expected_activation_target_id(command),
+        target_kind: expected_activation_target_kind(command, popovers, disclosures),
+        text: command.text.clone(),
+        accessible_name: command.accessible_name.clone(),
+        accessible_description: command.accessible_description.clone(),
+        disabled: command.disabled,
+        focusable: command.focusable,
+        tabindex: command.tabindex.clone(),
+        accesskey: command.accesskey.clone(),
+        event_handlers: command.event_handlers.clone(),
+        handler_count: command.event_handlers.len(),
+        command: command.command.clone(),
+        command_for: command.command_for.clone(),
+        popover_target: command.popover_target.clone(),
+        popover_target_action: command.popover_target_action.clone(),
+        aria_controls: command.aria_controls.clone(),
+        aria_expanded: command.aria_expanded.clone(),
+        aria_haspopup: command.aria_haspopup.clone(),
+        aria_pressed: command.aria_pressed.clone(),
+        aria_current: command.aria_current.clone(),
+        aria_disabled: command.aria_disabled.clone(),
+        control_type: command.control_type.clone(),
+        href: command.href.clone(),
+        resolved_href: command.resolved_href.clone(),
+        effective_target: command.effective_target.clone(),
+        form_owner: command.form_owner.clone(),
+        form_action: command.form_action.clone(),
+        resolved_form_action: command.resolved_form_action.clone(),
+        form_method: command.form_method.clone(),
+        form_target: command.form_target.clone(),
+        form_novalidate: command.form_novalidate,
+    }
+}
+
+fn expected_activation_kind(command: &BrowserCommandElement) -> String {
+    if let Some(command_value) = &command.command {
+        return command_value.clone();
+    }
+    if command.popover_target.is_some() {
+        let action = command.popover_target_action.as_deref().unwrap_or("toggle");
+        return format!("popover-{action}");
+    }
+    if command.href.is_some() {
+        return "navigation".to_string();
+    }
+    if let Some(control_type) = &command.control_type {
+        if matches!(
+            control_type.as_str(),
+            "submit" | "reset" | "button" | "image"
+        ) {
+            return format!("form-{control_type}");
+        }
+    }
+
+    command.command_kind.clone()
+}
+
+fn expected_activation_target_id(command: &BrowserCommandElement) -> Option<String> {
+    command
+        .command_for
+        .clone()
+        .or_else(|| command.popover_target.clone())
+        .or_else(|| command.aria_controls.first().cloned())
+}
+
+fn expected_activation_target_kind(
+    command: &BrowserCommandElement,
+    popovers: &[BrowserPopover],
+    disclosures: &[BrowserDisclosure],
+) -> String {
+    if let Some(command_for) = &command.command_for {
+        if let Some(disclosure) = disclosures
+            .iter()
+            .find(|disclosure| disclosure.id.as_deref() == Some(command_for.as_str()))
+        {
+            return if disclosure.element == "dialog" {
+                "dialog"
+            } else {
+                "disclosure"
+            }
+            .to_string();
+        }
+        if popovers
+            .iter()
+            .any(|popover| popover.id.as_deref() == Some(command_for.as_str()))
+        {
+            return "popover".to_string();
+        }
+        return "command-target".to_string();
+    }
+    if let Some(popover_target) = &command.popover_target {
+        if popovers
+            .iter()
+            .any(|popover| popover.id.as_deref() == Some(popover_target.as_str()))
+        {
+            return "popover".to_string();
+        }
+        return "popover-target".to_string();
+    }
+    if !command.aria_controls.is_empty() {
+        return "controlled-region".to_string();
+    }
+    if command.href.is_some() {
+        return "navigation".to_string();
+    }
+    if command.form_owner.is_some()
+        || command.form_action.is_some()
+        || matches!(
+            command.control_type.as_deref(),
+            Some("submit" | "reset" | "image")
+        )
+    {
+        return "form".to_string();
+    }
+    if command.command_kind == "disclosure" {
+        return "disclosure".to_string();
+    }
+
+    "command".to_string()
+}
+
 fn expected_script_execution_descriptors(
     scripts: &[BrowserScript],
 ) -> Vec<BrowserScriptExecutionDescriptor> {
@@ -5593,6 +5846,50 @@ impl ExpectedCommandElement {
             event_handlers: self.event_handlers,
             focusable: self.focusable,
             disabled: self.disabled,
+        }
+    }
+}
+
+impl ExpectedActivationDescriptor {
+    fn into_browser_activation_descriptor(self) -> BrowserActivationDescriptor {
+        BrowserActivationDescriptor {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            authored_role: self.authored_role,
+            command_kind: self.command_kind,
+            activation_kind: self.activation_kind,
+            target_id: self.target_id,
+            target_kind: self.target_kind,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            disabled: self.disabled,
+            focusable: self.focusable,
+            tabindex: self.tabindex,
+            accesskey: self.accesskey,
+            event_handlers: self.event_handlers,
+            handler_count: self.handler_count,
+            command: self.command,
+            command_for: self.command_for,
+            popover_target: self.popover_target,
+            popover_target_action: self.popover_target_action,
+            aria_controls: self.aria_controls,
+            aria_expanded: self.aria_expanded,
+            aria_haspopup: self.aria_haspopup,
+            aria_pressed: self.aria_pressed,
+            aria_current: self.aria_current,
+            aria_disabled: self.aria_disabled,
+            control_type: self.control_type,
+            href: self.href,
+            resolved_href: self.resolved_href,
+            effective_target: self.effective_target,
+            form_owner: self.form_owner,
+            form_action: self.form_action,
+            resolved_form_action: self.resolved_form_action,
+            form_method: self.form_method,
+            form_target: self.form_target,
+            form_novalidate: self.form_novalidate,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -47,6 +47,8 @@ lifecycle, and error/event-recovery concerns without evaluating script text.
 Disclosure-state descriptor cases pin details/dialog open state, grouped details
 names, summary text, dialog modal/closedby behavior, and accessible naming
 metadata as a flat browser-planning inventory.
+Activation descriptor cases pin command, popover, disclosure, ARIA, focus, and
+inline handler routing metadata as a flat activation-planning inventory.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1358,6 +1358,11 @@
           { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown"] },
           { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
         ],
+        "activation_descriptors": [
+          { "element": "button", "id": "menu", "role": "control", "command_kind": "command", "activation_kind": "show-modal", "target_id": "dialog", "target_kind": "dialog", "text": "Menu", "accessible_name": "Menu", "focusable": true, "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "handler_count": 1, "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "control_type": "submit" },
+          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "activation_kind": "button", "target_kind": "command", "text": "Inline action", "accessible_name": "Inline action", "tabindex": "-1", "event_handlers": ["onkeydown"], "handler_count": 1, "aria_pressed": "mixed", "aria_current": "page" },
+          { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "activation_kind": "disclosure", "target_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
+        ],
         "popovers": [
           { "element": "div", "id": "action", "role": "block", "text": "Inline action", "popover": "manual" }
         ],


### PR DESCRIPTION
## Summary
- add flat browser activation descriptors derived from command elements, popovers, and disclosures
- classify routes for dialog, disclosure, popover, ARIA-controlled, navigation, form, and command targets
- pin activation descriptor fixture expectations for the interactive browser-readiness case

## Tests
- cargo fmt -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_activation_descriptors_track_commands_popovers_and_disclosures
- cargo test -p coding-adventures-html-parser browser_activation_descriptors_track_command_routes_and_state
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser