### PR TITLE
Add smart-home command result audit tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -46,6 +46,10 @@ All notable changes to this package will be documented in this file.
   handlers over the D23 runtime read facade so Chief of Staff jobs can inspect
   event-stream backlog pressure and checkpointed event history without draining
   subscriptions.
+- Added `smart_home.list_command_results` and
+  `smart_home.get_command_result_summary` handlers over the D23 runtime read
+  facade so Chief of Staff jobs can inspect accepted and failed command results
+  without owning a parallel command audit log.
 - Added `smart_home.list_authorization_decisions` and
   `smart_home.get_authorization_summary` handlers over the D23 runtime read
   facade so Chief of Staff jobs can inspect allow/deny audit history without

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -34,6 +34,7 @@ Chief of Staff job/session/agent
   -> scene inventory and scene detail reads
   -> discovery worker health and retry state in smart_home.observe_supervision
   -> event-log and subscription-backlog reads
+  -> typed command-result audit reads and summaries
   -> authorization decision audit reads and summaries
   -> capability grant ledger reads and summaries
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -72,6 +73,8 @@ Chief of Staff job/session/agent
 - `smart_home.unsubscribe`
 - `smart_home.list_subscriptions`
 - `smart_home.inspect_event_log`
+- `smart_home.list_command_results`
+- `smart_home.get_command_result_summary`
 - `smart_home.list_authorization_decisions`
 - `smart_home.get_authorization_summary`
 - `smart_home.list_capability_grants`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -18,10 +18,10 @@ use smart_home_core::{
     AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary, AuthorizationOutcome,
     AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityGrant,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
-    CommandResult, CommandStatus, CommandType, CorrelationId, Device, DeviceCommand, DeviceEvent,
-    DeviceEventType, DeviceId, EntityId, EntityKind, EventId, Health, IntegrationId, Metadata,
-    PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene, SceneAction, SceneId,
-    SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
+    CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device, DeviceCommand,
+    DeviceEvent, DeviceEventType, DeviceId, EntityId, EntityKind, EventId, Health, IntegrationId,
+    Metadata, PrivilegeTier, ProtocolFamily, ProtocolIdentifier, RuntimeKind, Scene, SceneAction,
+    SceneId, SceneScope, StateConfidence, StateDelta, StateSnapshot, StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     DiscoveryPairingAction, DiscoveryPairingPlan, DiscoveryPairingPlanOptions,
@@ -50,25 +50,26 @@ use smart_home_runtime::{
     ReconciliationReason, RuntimeAuthorizationDecisionQuery, RuntimeAuthorizationDecisionSort,
     RuntimeCapabilityGrantQuery, RuntimeCapabilityGrantScopeKind, RuntimeCapabilityGrantSort,
     RuntimeClearDesiredStateToolOutput, RuntimeClearDesiredStateToolRequest,
-    RuntimeCommandToolRequest, RuntimeCompletePairingToolOutput, RuntimeCompletePairingToolRequest,
-    RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest, RuntimeError, RuntimeEvent,
-    RuntimeEventCheckpoint, RuntimeEventDeliveryBatch, RuntimeEventFilter, RuntimeEventLogRecord,
-    RuntimeEventLogSummary, RuntimeEventQuery, RuntimeEventSort, RuntimePairBridgeToolOutput,
-    RuntimePairBridgeToolRequest, RuntimePairingPlanToolRequest, RuntimePairingSession,
-    RuntimePairingSessionId, RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery,
-    RuntimePairingSessionSort, RuntimePendingWorkSummary, RuntimePollEventsToolOutput,
-    RuntimePollEventsToolRequest, RuntimeReadSnapshot, RuntimeReadToolOutput,
-    RuntimeReadToolRequest, RuntimeReportEventToolOutput, RuntimeReportEventToolRequest,
-    RuntimeRoomQuery, RuntimeRoomSort, RuntimeRoomSummary, RuntimeSetDesiredStateToolOutput,
-    RuntimeSetDesiredStateToolRequest, RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest,
-    RuntimeSubscriptionBacklogStatus, RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary,
-    RuntimeSubscriptionQuery, RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort,
-    RuntimeSupervisionPlan, RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput,
-    RuntimeSupervisionToolRequest, RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput,
-    RuntimeUnsubscribeToolRequest, ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime,
-    SupervisedBridgeWorker, SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport,
-    WorkerHeartbeatDeadline, WorkerHeartbeatSchedule, WorkerRestartInstruction,
-    WorkerRestartReason, WorkerStatus,
+    RuntimeCommandResultQuery, RuntimeCommandResultRecord, RuntimeCommandResultSort,
+    RuntimeCommandResultSummary, RuntimeCommandToolRequest, RuntimeCompletePairingToolOutput,
+    RuntimeCompletePairingToolRequest, RuntimeDiscoverToolOutput, RuntimeDiscoverToolRequest,
+    RuntimeError, RuntimeEvent, RuntimeEventCheckpoint, RuntimeEventDeliveryBatch,
+    RuntimeEventFilter, RuntimeEventLogRecord, RuntimeEventLogSummary, RuntimeEventQuery,
+    RuntimeEventSort, RuntimePairBridgeToolOutput, RuntimePairBridgeToolRequest,
+    RuntimePairingPlanToolRequest, RuntimePairingSession, RuntimePairingSessionId,
+    RuntimePairingSessionInventorySummary, RuntimePairingSessionQuery, RuntimePairingSessionSort,
+    RuntimePendingWorkSummary, RuntimePollEventsToolOutput, RuntimePollEventsToolRequest,
+    RuntimeReadSnapshot, RuntimeReadToolOutput, RuntimeReadToolRequest,
+    RuntimeReportEventToolOutput, RuntimeReportEventToolRequest, RuntimeRoomQuery, RuntimeRoomSort,
+    RuntimeRoomSummary, RuntimeSetDesiredStateToolOutput, RuntimeSetDesiredStateToolRequest,
+    RuntimeSubscribeToolOutput, RuntimeSubscribeToolRequest, RuntimeSubscriptionBacklogStatus,
+    RuntimeSubscriptionId, RuntimeSubscriptionInventorySummary, RuntimeSubscriptionQuery,
+    RuntimeSubscriptionSnapshot, RuntimeSubscriptionSort, RuntimeSupervisionPlan,
+    RuntimeSupervisionPlanSummary, RuntimeSupervisionToolOutput, RuntimeSupervisionToolRequest,
+    RuntimeSupervisorSnapshot, RuntimeUnsubscribeToolOutput, RuntimeUnsubscribeToolRequest,
+    ScheduledDiscoveryWorkerSnapshot, SmartHomeRuntime, SupervisedBridgeWorker,
+    SupervisedWorkerQuery, SupervisedWorkerSort, SupervisionTickReport, WorkerHeartbeatDeadline,
+    WorkerHeartbeatSchedule, WorkerRestartInstruction, WorkerRestartReason, WorkerStatus,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -90,6 +91,9 @@ pub const SMART_HOME_POLL_EVENTS_TOOL_ID: &str = "smart_home.poll_events";
 pub const SMART_HOME_UNSUBSCRIBE_TOOL_ID: &str = "smart_home.unsubscribe";
 pub const SMART_HOME_LIST_SUBSCRIPTIONS_TOOL_ID: &str = "smart_home.list_subscriptions";
 pub const SMART_HOME_INSPECT_EVENT_LOG_TOOL_ID: &str = "smart_home.inspect_event_log";
+pub const SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID: &str = "smart_home.list_command_results";
+pub const SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_command_result_summary";
 pub const SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID: &str =
     "smart_home.list_authorization_decisions";
 pub const SMART_HOME_GET_AUTHORIZATION_SUMMARY_TOOL_ID: &str =
@@ -364,6 +368,31 @@ impl SmartHomeToolBridge {
                         .execute_read_tool(principal_id, request, now_ms)
                         .map_err(runtime_error)?;
                     Ok(read_output_handler_output(output, "inspect_event_log"))
+                }
+                SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID => {
+                    let query = command_result_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::ListCommandResults { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(output, "list_command_results"))
+                }
+                SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID => {
+                    let query = command_result_query(&arguments)?;
+                    let output = runtime
+                        .execute_read_tool(
+                            principal_id,
+                            RuntimeReadToolRequest::GetCommandResultSummary { query },
+                            now_ms,
+                        )
+                        .map_err(runtime_error)?;
+                    Ok(read_output_handler_output(
+                        output,
+                        "get_command_result_summary",
+                    ))
                 }
                 SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID => {
                     let query = authorization_decision_query(&arguments)?;
@@ -1007,6 +1036,8 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         unsubscribe_definition(),
         list_subscriptions_definition(),
         inspect_event_log_definition(),
+        list_command_results_definition(),
+        get_command_result_summary_definition(),
         list_authorization_decisions_definition(),
         get_authorization_summary_definition(),
         list_capability_grants_definition(),
@@ -1307,6 +1338,60 @@ fn inspect_event_log_definition() -> ToolDefinition {
                 SchemaProperty::new("count", JsonSchema::Integer),
             ],
             vec!["events", "summary", "count"],
+            false,
+        ),
+    )
+}
+
+fn command_result_query_schema() -> JsonSchema {
+    object_schema(
+        vec![
+            SchemaProperty::new("command_id", JsonSchema::String),
+            SchemaProperty::new("bridge_id", JsonSchema::String),
+            SchemaProperty::new("correlation_id", JsonSchema::String),
+            SchemaProperty::new("status", JsonSchema::String),
+            SchemaProperty::new("statuses", string_array_schema()),
+            SchemaProperty::new("from_checkpoint", JsonSchema::Integer),
+            SchemaProperty::new("sort", JsonSchema::String),
+            SchemaProperty::new("limit", JsonSchema::Integer),
+        ],
+        vec![],
+        false,
+    )
+}
+
+fn list_command_results_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID,
+        "List smart-home command results",
+        "List D23 smart-home command result events with checkpoint positions for command auditing.",
+        command_result_query_schema(),
+        object_schema(
+            vec![
+                SchemaProperty::new(
+                    "command_results",
+                    JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    },
+                ),
+                SchemaProperty::new("summary", JsonSchema::Any),
+                SchemaProperty::new("count", JsonSchema::Integer),
+            ],
+            vec!["command_results", "summary", "count"],
+            false,
+        ),
+    )
+}
+
+fn get_command_result_summary_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID,
+        "Summarize smart-home command results",
+        "Summarize D23 smart-home command results by status for command auditing.",
+        command_result_query_schema(),
+        object_schema(
+            vec![SchemaProperty::new("summary", JsonSchema::Any)],
+            vec!["summary"],
             false,
         ),
     )
@@ -2416,6 +2501,33 @@ fn inspect_event_log_request(
     Ok(RuntimeReadToolRequest::InspectEventLog { query })
 }
 
+fn command_result_query(arguments: &JsonValue) -> Result<RuntimeCommandResultQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut query = RuntimeCommandResultQuery::new();
+    if let Some(command_id) = optional_string(arguments, "command_id")? {
+        query = query.for_command(CommandId::trusted(command_id));
+    }
+    if let Some(bridge_id) = optional_string(arguments, "bridge_id")? {
+        query = query.for_bridge(BridgeId::trusted(bridge_id));
+    }
+    if let Some(correlation_id) = optional_string(arguments, "correlation_id")? {
+        query = query.for_correlation(CorrelationId::trusted(correlation_id));
+    }
+    for status in optional_string_list(arguments, "status", "statuses")? {
+        query = query.with_status(parse_command_status(&status)?);
+    }
+    if let Some(from_checkpoint) = optional_u64(arguments, "from_checkpoint")? {
+        query = query.from_checkpoint(RuntimeEventCheckpoint::from_next_sequence(from_checkpoint));
+    }
+    if let Some(sort) = optional_string(arguments, "sort")? {
+        query = query.sorted_by(parse_command_result_sort(&sort)?);
+    }
+    if let Some(limit) = optional_u64(arguments, "limit")? {
+        query = query.with_limit(limit as usize);
+    }
+    Ok(query)
+}
+
 fn authorization_decision_query(
     arguments: &JsonValue,
 ) -> Result<RuntimeAuthorizationDecisionQuery, ToolCallError> {
@@ -3159,6 +3271,17 @@ fn read_output_json(output: RuntimeReadToolOutput) -> JsonValue {
             ("summary", event_log_summary_json(&summary)),
             ("count", integer(entries.len() as i64)),
         ]),
+        RuntimeReadToolOutput::CommandResults { results, summary } => object([
+            (
+                "command_results",
+                JsonValue::Array(results.iter().map(command_result_record_json).collect()),
+            ),
+            ("summary", command_result_summary_json(&summary)),
+            ("count", integer(results.len() as i64)),
+        ]),
+        RuntimeReadToolOutput::CommandResultSummary { summary } => {
+            object([("summary", command_result_summary_json(&summary))])
+        }
         RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary } => object([
             (
                 "decisions",
@@ -5656,6 +5779,51 @@ fn event_log_record_json(record: &RuntimeEventLogRecord) -> JsonValue {
     ])
 }
 
+fn command_result_record_json(record: &RuntimeCommandResultRecord) -> JsonValue {
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        (
+            "next_checkpoint",
+            integer(record.next_checkpoint.next_sequence() as i64),
+        ),
+        ("command_result", command_result_json(&record.result)),
+    ])
+}
+
+fn command_result_summary_json(summary: &RuntimeCommandResultSummary) -> JsonValue {
+    object([
+        ("total_results", integer(summary.total_results as i64)),
+        ("accepted_results", integer(summary.accepted_results as i64)),
+        ("rejected_results", integer(summary.rejected_results as i64)),
+        (
+            "timed_out_results",
+            integer(summary.timed_out_results as i64),
+        ),
+        ("failed_results", integer(summary.failed_results as i64)),
+        ("failure_results", integer(summary.failure_results() as i64)),
+        (
+            "first_sequence",
+            summary
+                .first_sequence
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "latest_sequence",
+            summary
+                .latest_sequence
+                .map(|value| integer(value as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_checkpoint",
+            integer(summary.next_checkpoint.next_sequence() as i64),
+        ),
+        ("has_results", JsonValue::Bool(summary.has_results())),
+        ("has_failures", JsonValue::Bool(summary.has_failures())),
+    ])
+}
+
 fn event_log_summary_json(summary: &RuntimeEventLogSummary) -> JsonValue {
     object([
         ("total_events", integer(summary.total_events as i64)),
@@ -6225,6 +6393,19 @@ fn parse_event_sort(label: &str) -> Result<RuntimeEventSort, ToolCallError> {
     }
 }
 
+fn parse_command_result_sort(label: &str) -> Result<RuntimeCommandResultSort, ToolCallError> {
+    match label {
+        "sequence_asc" | "oldest_first" => Ok(RuntimeCommandResultSort::SequenceAsc),
+        "sequence_desc" | "newest_first" => Ok(RuntimeCommandResultSort::SequenceDesc),
+        "status_then_sequence_desc" | "status_then_newest" | "status" => {
+            Ok(RuntimeCommandResultSort::StatusThenSequenceDesc)
+        }
+        _ => Err(validation_error(format!(
+            "unknown command result sort `{label}`"
+        ))),
+    }
+}
+
 fn parse_room_sort(label: &str) -> Result<RuntimeRoomSort, ToolCallError> {
     match label {
         "room_id" | "id" => Ok(RuntimeRoomSort::RoomId),
@@ -6419,6 +6600,18 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "set_lock" => Ok(CommandType::SetLock),
         "set_thermostat_setpoint" => Ok(CommandType::SetThermostatSetpoint),
         _ => Err(validation_error(format!("unknown command_type `{label}`"))),
+    }
+}
+
+fn parse_command_status(label: &str) -> Result<CommandStatus, ToolCallError> {
+    match label {
+        "accepted" | "accept" => Ok(CommandStatus::Accepted),
+        "rejected" | "reject" => Ok(CommandStatus::Rejected),
+        "timed_out" | "timeout" | "timedout" => Ok(CommandStatus::TimedOut),
+        "failed" | "failure" => Ok(CommandStatus::Failed),
+        _ => Err(validation_error(format!(
+            "unknown command result status `{label}`"
+        ))),
     }
 }
 
@@ -7389,7 +7582,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 41);
+        assert_eq!(definitions.len(), 43);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -7433,6 +7626,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_INSPECT_EVENT_LOG_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID));
@@ -7482,7 +7681,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            33
+            35
         );
         assert_eq!(
             export
@@ -7504,6 +7703,10 @@ mod tests {
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_PAIRING_PLAN_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID).is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID).is_some()
+        );
         assert!(smart_home_tool_definition(SMART_HOME_COMPLETE_PAIRING_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_REPORT_EVENT_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_ROOMS_TOOL_ID).is_some());
@@ -8462,6 +8665,77 @@ mod tests {
             Some(&integer(1))
         );
 
+        let list_command_results_request = request(
+            "call-list-command-results",
+            SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID,
+            object([
+                ("bridge_id", string("bridge-1")),
+                ("status", string("accepted")),
+                ("sort", string("newest_first")),
+                ("limit", integer(1)),
+            ]),
+            1_102,
+        );
+        let list_command_results_trace =
+            tool_runtime.invoke_with_events(&list_command_results_request);
+        assert!(list_command_results_trace.result.ok);
+        let list_command_results_output =
+            list_command_results_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(list_command_results_output, "count"),
+            Some(&integer(1))
+        );
+        let command_result_record = array_item(
+            field(list_command_results_output, "command_results").unwrap(),
+            0,
+        )
+        .unwrap();
+        let command_result_sequence =
+            integer_value(field(command_result_record, "sequence").unwrap()).unwrap();
+        assert_eq!(
+            field(command_result_record, "next_checkpoint"),
+            Some(&integer(command_result_sequence + 1))
+        );
+        assert_eq!(
+            field(
+                field(command_result_record, "command_result").unwrap(),
+                "status"
+            ),
+            Some(&string("accepted"))
+        );
+        assert_eq!(
+            field(
+                field(list_command_results_output, "summary").unwrap(),
+                "accepted_results"
+            ),
+            Some(&integer(1))
+        );
+
+        let command_result_summary_request = request(
+            "call-command-result-summary",
+            SMART_HOME_GET_COMMAND_RESULT_SUMMARY_TOOL_ID,
+            object([("statuses", JsonValue::Array(vec![string("accepted")]))]),
+            1_102,
+        );
+        let command_result_summary_trace =
+            tool_runtime.invoke_with_events(&command_result_summary_request);
+        assert!(command_result_summary_trace.result.ok);
+        let command_result_summary_output =
+            command_result_summary_trace.result.output.as_ref().unwrap();
+        let command_result_summary = field(command_result_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(command_result_summary, "total_results"),
+            Some(&integer(1))
+        );
+        assert_eq!(
+            field(command_result_summary, "failure_results"),
+            Some(&integer(0))
+        );
+        assert_eq!(
+            field(command_result_summary, "has_failures"),
+            Some(&JsonValue::Bool(false))
+        );
+
         let list_authorization_request = request(
             "call-list-authorization-decisions",
             SMART_HOME_LIST_AUTHORIZATION_DECISIONS_TOOL_ID,
@@ -8775,6 +9049,8 @@ mod tests {
         journal.record_trace(pairing_sessions_request, pairing_sessions_trace);
         journal.record_trace(list_subscriptions_request, list_subscriptions_trace);
         journal.record_trace(inspect_event_log_request, inspect_event_log_trace);
+        journal.record_trace(list_command_results_request, list_command_results_trace);
+        journal.record_trace(command_result_summary_request, command_result_summary_trace);
         journal.record_trace(list_authorization_request, list_authorization_trace);
         journal.record_trace(authorization_summary_request, authorization_summary_trace);
         journal.record_trace(list_capability_grants_request, list_capability_grants_trace);
@@ -8790,9 +9066,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 41);
-        assert_eq!(journal_summary.completed_count, 41);
-        assert_eq!(journal.audit_records().len(), 41);
+        assert_eq!(journal_summary.invocation_count, 43);
+        assert_eq!(journal_summary.completed_count, 43);
+        assert_eq!(journal.audit_records().len(), 43);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);
@@ -8806,7 +9082,7 @@ mod tests {
         ));
         assert_eq!(
             runtime.registry().counts().authorization_decisions,
-            38,
+            40,
             "read, subscribe, poll, unsubscribe, pairing, ingest, and desired-state calls record tool authorization, while command records tool and command authorization"
         );
         assert_eq!(
@@ -8963,6 +9239,22 @@ mod tests {
         assert!(!unsupported_filter.result.ok);
         assert_eq!(
             unsupported_filter
+                .result
+                .error
+                .as_ref()
+                .map(|error| error.kind),
+            Some(ToolErrorKind::ToolValidationError)
+        );
+
+        let unknown_command_status = tool_runtime.invoke_with_events(&request(
+            "call-invalid-command-results",
+            SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID,
+            object([("status", string("vanished"))]),
+            1_000,
+        ));
+        assert!(!unknown_command_status.result.ok);
+        assert_eq!(
+            unknown_command_status
                 .result
                 .error
                 .as_ref()

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this package will be documented in this file.
   model-facing event subscription lifecycle control.
 - `smart_home.list_subscriptions` and `smart_home.inspect_event_log` tool
   descriptors for read-only event-stream backlog and replay-log inspection.
+- `smart_home.list_command_results` and
+  `smart_home.get_command_result_summary` tool descriptors for read-only
+  command-result audit views over runtime event history.
 - `smart_home.list_authorization_decisions` and
   `smart_home.get_authorization_summary` tool descriptors for read-only
   authorization-audit inspection.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -51,6 +51,8 @@ Current scope:
   unsubscribing from runtime event streams
 - D18D event observability tool descriptors for listing active subscriptions and
   inspecting checkpointed runtime event-log entries
+- D18D command-result observability descriptors for listing and summarizing
+  command results from checkpointed runtime event history
 - D18D authorization-audit tool descriptors for listing decisions and compact
   allow/deny summaries
 - D18D capability-grant tool descriptors for listing grant rows and compact

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1464,6 +1464,8 @@ pub enum SmartHomeTool {
     Unsubscribe,
     ListSubscriptions,
     InspectEventLog,
+    ListCommandResults,
+    GetCommandResultSummary,
     ListAuthorizationDecisions,
     GetAuthorizationSummary,
     ListCapabilityGrants,
@@ -1531,6 +1533,8 @@ impl SmartHomeTool {
             Self::Unsubscribe => read_tool("smart_home.unsubscribe"),
             Self::ListSubscriptions => read_tool("smart_home.list_subscriptions"),
             Self::InspectEventLog => read_tool("smart_home.inspect_event_log"),
+            Self::ListCommandResults => read_tool("smart_home.list_command_results"),
+            Self::GetCommandResultSummary => read_tool("smart_home.get_command_result_summary"),
             Self::ListAuthorizationDecisions => {
                 read_tool("smart_home.list_authorization_decisions")
             }
@@ -2109,6 +2113,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::Unsubscribe,
         SmartHomeTool::ListSubscriptions,
         SmartHomeTool::InspectEventLog,
+        SmartHomeTool::ListCommandResults,
+        SmartHomeTool::GetCommandResultSummary,
         SmartHomeTool::ListAuthorizationDecisions,
         SmartHomeTool::GetAuthorizationSummary,
         SmartHomeTool::ListCapabilityGrants,
@@ -2922,7 +2928,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 37);
+        assert_eq!(catalog.len(), 39);
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -3005,6 +3011,16 @@ mod tests {
             .any(|tool| tool.tool_id == "smart_home.inspect_event_log"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_command_results"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(
+            |tool| tool.tool_id == "smart_home.get_command_result_summary"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]
+        ));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_authorization_decisions"
             && tool.side_effects == ToolSideEffects::Read
@@ -3076,15 +3092,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 37);
-        assert_eq!(summary.read_tools, 29);
+        assert_eq!(summary.total_tools, 39);
+        assert_eq!(summary.read_tools, 31);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 29);
+        assert_eq!(summary.read_only_tier_tools, 31);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 37);
+        assert_eq!(summary.total_required_capabilities, 39);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this package will be documented in this file.
   from runtime read snapshots.
 - `RuntimeEventLogSummary` plus `event_log_summary()` for compact event-kind
   counts over selected runtime replay windows.
+- `RuntimeCommandResultQuery`, `RuntimeCommandResultRecord`, and
+  `RuntimeCommandResultSummary` plus authorized read-tool variants for typed
+  command-result audit views over runtime event history.
 - `RuntimeSubscriptionInventorySummary` plus `subscription_inventory_summary()`
   for compact event-stream filter coverage and backlog pressure checks.
 - `RuntimeEventBusHealthSummary` plus event-bus/runtime helpers for composed

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -15,6 +15,8 @@ Included surfaces:
 - read-side event-log and subscription backlog queries for dashboards, tools,
   and tests that need bounded runtime inspection
 - compact event-log summaries for selected replay windows and event kinds
+- typed command-result queries and summaries over checkpointed runtime event
+  history
 - bounded event-bus delivery peeking and draining for subscription polling
 - compact delivery-batch summaries for subscription polling results without
   exposing event payloads
@@ -74,7 +76,8 @@ Included surfaces:
 - D18D-facing read tool facade for listing bridges/devices/scenes, describing
   scenes, reading room topology summaries, reading aggregate topology coverage,
   reading entity state, describing capabilities, inspecting bridge health,
-  listing event subscriptions, inspecting event-log entries, reading
+  listing event subscriptions, inspecting event-log entries, listing and
+  summarizing command results, reading
   authorization decisions and summaries, reading capability grants and
   summaries, reading compact runtime snapshots, listing desired-state targets,
   listing pairing sessions, listing supervised bridge workers, reading worker

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -905,6 +905,187 @@ impl RuntimeEventLogSummary {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeCommandResultSort {
+    SequenceAsc,
+    SequenceDesc,
+    StatusThenSequenceDesc,
+}
+
+impl Default for RuntimeCommandResultSort {
+    fn default() -> Self {
+        Self::SequenceAsc
+    }
+}
+
+/// Read-side query for command results already captured in the runtime event log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCommandResultQuery {
+    pub command_id: Option<CommandId>,
+    pub bridge_id: Option<BridgeId>,
+    pub correlation_id: Option<CorrelationId>,
+    pub statuses: Vec<CommandStatus>,
+    pub from_checkpoint: RuntimeEventCheckpoint,
+    pub sort: RuntimeCommandResultSort,
+    pub limit: Option<usize>,
+}
+
+impl RuntimeCommandResultQuery {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_command(mut self, command_id: CommandId) -> Self {
+        self.command_id = Some(command_id);
+        self
+    }
+
+    pub fn for_bridge(mut self, bridge_id: BridgeId) -> Self {
+        self.bridge_id = Some(bridge_id);
+        self
+    }
+
+    pub fn for_correlation(mut self, correlation_id: CorrelationId) -> Self {
+        self.correlation_id = Some(correlation_id);
+        self
+    }
+
+    pub fn with_status(mut self, status: CommandStatus) -> Self {
+        self.statuses.push(status);
+        self
+    }
+
+    pub fn from_checkpoint(mut self, checkpoint: RuntimeEventCheckpoint) -> Self {
+        self.from_checkpoint = checkpoint;
+        self
+    }
+
+    pub fn sorted_by(mut self, sort: RuntimeCommandResultSort) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+impl Default for RuntimeCommandResultQuery {
+    fn default() -> Self {
+        Self {
+            command_id: None,
+            bridge_id: None,
+            correlation_id: None,
+            statuses: Vec::new(),
+            from_checkpoint: RuntimeEventCheckpoint::start(),
+            sort: RuntimeCommandResultSort::default(),
+            limit: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCommandResultRecord {
+    pub sequence: u64,
+    pub next_checkpoint: RuntimeEventCheckpoint,
+    pub result: CommandResult,
+}
+
+impl RuntimeCommandResultRecord {
+    pub fn from_entry(entry: RuntimeEventLogEntry<'_>) -> Option<Self> {
+        match entry.event {
+            RuntimeEvent::CommandResult(result) => Some(Self {
+                sequence: entry.sequence,
+                next_checkpoint: entry.next_checkpoint,
+                result: result.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Compact count view over selected command results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeCommandResultSummary {
+    pub total_results: usize,
+    pub accepted_results: usize,
+    pub rejected_results: usize,
+    pub timed_out_results: usize,
+    pub failed_results: usize,
+    pub first_sequence: Option<u64>,
+    pub latest_sequence: Option<u64>,
+    pub next_checkpoint: RuntimeEventCheckpoint,
+}
+
+impl Default for RuntimeCommandResultSummary {
+    fn default() -> Self {
+        Self {
+            total_results: 0,
+            accepted_results: 0,
+            rejected_results: 0,
+            timed_out_results: 0,
+            failed_results: 0,
+            first_sequence: None,
+            latest_sequence: None,
+            next_checkpoint: RuntimeEventCheckpoint::start(),
+        }
+    }
+}
+
+impl RuntimeCommandResultSummary {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn from_records<'a, I>(records: I) -> Self
+    where
+        I: IntoIterator<Item = &'a RuntimeCommandResultRecord>,
+    {
+        let mut summary = Self::empty();
+        for record in records {
+            summary.total_results += 1;
+            summary.first_sequence = Some(
+                summary
+                    .first_sequence
+                    .map(|sequence| sequence.min(record.sequence))
+                    .unwrap_or(record.sequence),
+            );
+            summary.latest_sequence = Some(
+                summary
+                    .latest_sequence
+                    .map(|sequence| sequence.max(record.sequence))
+                    .unwrap_or(record.sequence),
+            );
+            summary.next_checkpoint = RuntimeEventCheckpoint::from_next_sequence(
+                summary
+                    .latest_sequence
+                    .map(|sequence| sequence.saturating_add(1))
+                    .unwrap_or(0),
+            );
+            match record.result.status {
+                CommandStatus::Accepted => summary.accepted_results += 1,
+                CommandStatus::Rejected => summary.rejected_results += 1,
+                CommandStatus::TimedOut => summary.timed_out_results += 1,
+                CommandStatus::Failed => summary.failed_results += 1,
+            }
+        }
+        summary
+    }
+
+    pub fn has_results(&self) -> bool {
+        self.total_results > 0
+    }
+
+    pub fn failure_results(&self) -> usize {
+        self.rejected_results + self.timed_out_results + self.failed_results
+    }
+
+    pub fn has_failures(&self) -> bool {
+        self.failure_results() > 0
+    }
+}
+
 /// Read-side query for the runtime event log.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeEventQuery {
@@ -3584,6 +3765,12 @@ pub enum RuntimeReadToolRequest {
     InspectEventLog {
         query: RuntimeEventQuery,
     },
+    ListCommandResults {
+        query: RuntimeCommandResultQuery,
+    },
+    GetCommandResultSummary {
+        query: RuntimeCommandResultQuery,
+    },
     ListAuthorizationDecisions {
         query: RuntimeAuthorizationDecisionQuery,
     },
@@ -3632,6 +3819,8 @@ impl RuntimeReadToolRequest {
             Self::GetHealth { .. } => SmartHomeTool::GetHealth,
             Self::ListSubscriptions { .. } => SmartHomeTool::ListSubscriptions,
             Self::InspectEventLog { .. } => SmartHomeTool::InspectEventLog,
+            Self::ListCommandResults { .. } => SmartHomeTool::ListCommandResults,
+            Self::GetCommandResultSummary { .. } => SmartHomeTool::GetCommandResultSummary,
             Self::ListAuthorizationDecisions { .. } => SmartHomeTool::ListAuthorizationDecisions,
             Self::GetAuthorizationSummary { .. } => SmartHomeTool::GetAuthorizationSummary,
             Self::ListCapabilityGrants { .. } => SmartHomeTool::ListCapabilityGrants,
@@ -3960,6 +4149,13 @@ pub enum RuntimeReadToolOutput {
     EventLog {
         entries: Vec<RuntimeEventLogRecord>,
         summary: RuntimeEventLogSummary,
+    },
+    CommandResults {
+        results: Vec<RuntimeCommandResultRecord>,
+        summary: RuntimeCommandResultSummary,
+    },
+    CommandResultSummary {
+        summary: RuntimeCommandResultSummary,
     },
     AuthorizationDecisions {
         decisions: Vec<AuthorizationDecision>,
@@ -4312,6 +4508,49 @@ impl SmartHomeRuntime {
 
     pub fn event_bus_health_summary(&self) -> RuntimeEventBusHealthSummary {
         self.event_bus.health_summary()
+    }
+
+    pub fn query_command_results(
+        &self,
+        query: &RuntimeCommandResultQuery,
+    ) -> Vec<RuntimeCommandResultRecord> {
+        if query.limit == Some(0) {
+            return Vec::new();
+        }
+
+        let event_query = RuntimeEventQuery::new()
+            .matching(RuntimeEventFilter::Commands)
+            .from_checkpoint(query.from_checkpoint);
+        let mut results = self
+            .event_bus
+            .query_events(&event_query)
+            .into_iter()
+            .filter_map(RuntimeCommandResultRecord::from_entry)
+            .filter(|record| command_result_matches_query(&record.result, query))
+            .collect::<Vec<_>>();
+        match query.sort {
+            RuntimeCommandResultSort::SequenceAsc => {
+                results.sort_by(|left, right| left.sequence.cmp(&right.sequence));
+            }
+            RuntimeCommandResultSort::SequenceDesc => {
+                results.sort_by(|left, right| right.sequence.cmp(&left.sequence));
+            }
+            RuntimeCommandResultSort::StatusThenSequenceDesc => results.sort_by(|left, right| {
+                command_status_sort_rank(left.result.status)
+                    .cmp(&command_status_sort_rank(right.result.status))
+                    .then_with(|| right.sequence.cmp(&left.sequence))
+            }),
+        }
+        apply_limit(&mut results, query.limit);
+        results
+    }
+
+    pub fn command_result_summary(
+        &self,
+        query: &RuntimeCommandResultQuery,
+    ) -> RuntimeCommandResultSummary {
+        let results = self.query_command_results(query);
+        RuntimeCommandResultSummary::from_records(results.iter())
     }
 
     pub fn pairing_session(
@@ -5269,6 +5508,16 @@ impl SmartHomeRuntime {
                     .collect::<Vec<_>>();
                 let summary = self.event_bus.event_log_summary(&query);
                 Ok(RuntimeReadToolOutput::EventLog { entries, summary })
+            }
+            RuntimeReadToolRequest::ListCommandResults { query } => {
+                let results = self.query_command_results(&query);
+                let summary = RuntimeCommandResultSummary::from_records(results.iter());
+                Ok(RuntimeReadToolOutput::CommandResults { results, summary })
+            }
+            RuntimeReadToolRequest::GetCommandResultSummary { query } => {
+                Ok(RuntimeReadToolOutput::CommandResultSummary {
+                    summary: self.command_result_summary(&query),
+                })
             }
             RuntimeReadToolRequest::ListAuthorizationDecisions { query } => {
                 let decision_refs = self.query_authorization_decisions(&query);
@@ -6296,6 +6545,31 @@ fn pairing_session_matches_query(
             .is_none_or(|now_ms| session.is_expired_at(now_ms))
 }
 
+fn command_result_matches_query(result: &CommandResult, query: &RuntimeCommandResultQuery) -> bool {
+    query
+        .command_id
+        .as_ref()
+        .is_none_or(|command_id| &result.command_id == command_id)
+        && query
+            .bridge_id
+            .as_ref()
+            .is_none_or(|bridge_id| &result.bridge_id == bridge_id)
+        && query
+            .correlation_id
+            .as_ref()
+            .is_none_or(|correlation_id| &result.correlation_id == correlation_id)
+        && (query.statuses.is_empty() || query.statuses.contains(&result.status))
+}
+
+fn command_status_sort_rank(status: CommandStatus) -> u8 {
+    match status {
+        CommandStatus::Accepted => 0,
+        CommandStatus::Rejected => 1,
+        CommandStatus::TimedOut => 2,
+        CommandStatus::Failed => 3,
+    }
+}
+
 fn apply_limit<T>(items: &mut Vec<T>, limit: Option<usize>) {
     if let Some(limit) = limit {
         items.truncate(limit);
@@ -6711,6 +6985,73 @@ mod tests {
         assert!(!empty.has_events());
         assert!(!empty.has_command_results());
         assert!(!empty.has_supervision_events());
+    }
+
+    #[test]
+    fn command_result_queries_filter_sort_and_summarize_runtime_events() {
+        let mut runtime = runtime_with_entity(vec![Capability::light_on_off()]);
+        runtime
+            .event_bus_mut()
+            .publish(command_result_runtime_event("cmd-accepted"));
+        runtime
+            .event_bus_mut()
+            .publish(RuntimeEvent::CommandResult(CommandResult {
+                command_id: CommandId::trusted("cmd-failed"),
+                status: CommandStatus::Failed,
+                bridge_id: BridgeId::trusted("bridge-1"),
+                correlation_id: CorrelationId::trusted("corr-failed"),
+                message: Some("integration dispatch failed".to_string()),
+            }));
+
+        let newest_failure = runtime.query_command_results(
+            &RuntimeCommandResultQuery::new()
+                .for_bridge(BridgeId::trusted("bridge-1"))
+                .for_correlation(CorrelationId::trusted("corr-failed"))
+                .with_status(CommandStatus::Failed)
+                .sorted_by(RuntimeCommandResultSort::SequenceDesc)
+                .with_limit(1),
+        );
+
+        assert_eq!(newest_failure.len(), 1);
+        assert_eq!(newest_failure[0].sequence, 1);
+        assert_eq!(
+            newest_failure[0].next_checkpoint,
+            RuntimeEventCheckpoint::from_next_sequence(2)
+        );
+        assert_eq!(
+            newest_failure[0].result.command_id,
+            CommandId::trusted("cmd-failed")
+        );
+
+        let summary = runtime.command_result_summary(
+            &RuntimeCommandResultQuery::new()
+                .for_bridge(BridgeId::trusted("bridge-1"))
+                .sorted_by(RuntimeCommandResultSort::StatusThenSequenceDesc),
+        );
+
+        assert_eq!(
+            summary,
+            RuntimeCommandResultSummary {
+                total_results: 2,
+                accepted_results: 1,
+                rejected_results: 0,
+                timed_out_results: 0,
+                failed_results: 1,
+                first_sequence: Some(0),
+                latest_sequence: Some(1),
+                next_checkpoint: RuntimeEventCheckpoint::from_next_sequence(2),
+            }
+        );
+        assert!(summary.has_results());
+        assert_eq!(summary.failure_results(), 1);
+        assert!(summary.has_failures());
+
+        let empty = runtime.query_command_results(
+            &RuntimeCommandResultQuery::new()
+                .for_command(CommandId::trusted("unknown"))
+                .with_limit(0),
+        );
+        assert!(empty.is_empty());
     }
 
     #[test]
@@ -9359,11 +9700,35 @@ mod tests {
                 1_508,
             )
             .unwrap();
+        let command_results = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::ListCommandResults {
+                    query: RuntimeCommandResultQuery::new()
+                        .for_bridge(BridgeId::trusted("bridge-1"))
+                        .with_status(CommandStatus::Accepted)
+                        .sorted_by(RuntimeCommandResultSort::SequenceDesc)
+                        .with_limit(1),
+                },
+                1_509,
+            )
+            .unwrap();
+        let command_result_summary = runtime
+            .execute_read_tool(
+                principal.clone(),
+                RuntimeReadToolRequest::GetCommandResultSummary {
+                    query: RuntimeCommandResultQuery::new()
+                        .for_command(CommandId::trusted("command-1"))
+                        .with_status(CommandStatus::Accepted),
+                },
+                1_510,
+            )
+            .unwrap();
         let snapshot = runtime
             .execute_read_tool(
                 principal.clone(),
                 RuntimeReadToolRequest::GetRuntimeSnapshot,
-                1_509,
+                1_511,
             )
             .unwrap();
         let desired_states = runtime
@@ -9375,7 +9740,7 @@ mod tests {
                         .with_capability(CapabilityId::trusted("light.on_off"))
                         .sorted_by(DesiredStateSort::CommandTimeoutDesc),
                 },
-                1_510,
+                1_512,
             )
             .unwrap();
         let pairing_sessions = runtime
@@ -9387,21 +9752,21 @@ mod tests {
                         .with_status(PairingSessionStatus::PendingUserPresence)
                         .sorted_by(RuntimePairingSessionSort::ExpiresAt),
                 },
-                1_511,
+                1_513,
             )
             .unwrap();
         let supervision_plan = runtime
             .execute_read_tool(
                 principal.clone(),
                 RuntimeReadToolRequest::GetSupervisionPlan,
-                1_512,
+                1_514,
             )
             .unwrap();
         let observation = runtime
             .execute_read_tool(
                 principal.clone(),
                 RuntimeReadToolRequest::ObserveSupervision,
-                1_513,
+                1_515,
             )
             .unwrap();
         let workers = runtime
@@ -9410,10 +9775,10 @@ mod tests {
                 RuntimeReadToolRequest::ListWorkers {
                     query: SupervisedWorkerQuery::new()
                         .with_status(WorkerStatus::Starting)
-                        .overdue_at(1_514)
+                        .overdue_at(1_516)
                         .sorted_by(SupervisedWorkerSort::HeartbeatDueAt),
                 },
-                1_514,
+                1_516,
             )
             .unwrap();
         let heartbeat_schedule = runtime
@@ -9421,10 +9786,10 @@ mod tests {
                 principal,
                 RuntimeReadToolRequest::GetWorkerHeartbeatSchedule {
                     bridge_id: Some(BridgeId::trusted("bridge-1")),
-                    due_at_or_before_ms: Some(1_515),
+                    due_at_or_before_ms: Some(1_517),
                     limit: Some(1),
                 },
-                1_515,
+                1_517,
             )
             .unwrap();
         let authorization_decisions = runtime
@@ -9437,7 +9802,7 @@ mod tests {
                         .sorted_by(RuntimeAuthorizationDecisionSort::DecidedAtDesc)
                         .with_limit(2),
                 },
-                1_516,
+                1_518,
             )
             .unwrap();
         let authorization_summary = runtime
@@ -9448,7 +9813,7 @@ mod tests {
                         .for_principal(AgentId::trusted("agent:observer"))
                         .with_outcome(AuthorizationOutcome::Allowed),
                 },
-                1_517,
+                1_519,
             )
             .unwrap();
         let capability_grants = runtime
@@ -9461,7 +9826,7 @@ mod tests {
                         .with_scope_kind(RuntimeCapabilityGrantScopeKind::Capability)
                         .with_capability(CapabilityId::trusted("smart_home.read")),
                 },
-                1_518,
+                1_520,
             )
             .unwrap();
         let capability_grant_summary = runtime
@@ -9472,7 +9837,7 @@ mod tests {
                         .with_status(CapabilityGrantStatus::Active)
                         .with_scope_kind(RuntimeCapabilityGrantScopeKind::Capability),
                 },
-                1_519,
+                1_521,
             )
             .unwrap();
         let rooms = runtime
@@ -9483,14 +9848,14 @@ mod tests {
                         .for_room("kitchen")
                         .sorted_by(RuntimeRoomSort::SceneCountDesc),
                 },
-                1_520,
+                1_522,
             )
             .unwrap();
         let topology_summary = runtime
             .execute_read_tool(
                 AgentId::trusted("agent:observer"),
                 RuntimeReadToolRequest::GetTopologySummary,
-                1_521,
+                1_523,
             )
             .unwrap();
         runtime
@@ -9507,7 +9872,7 @@ mod tests {
                         .overdue_at(1_522)
                         .sorted_by(DiscoveryWorkerSort::NextDueAt),
                 },
-                1_522,
+                1_524,
             )
             .unwrap();
         runtime
@@ -9523,7 +9888,7 @@ mod tests {
                         .fresh_only(true)
                         .with_ttl_ms(1_000),
                 },
-                1_523,
+                1_525,
             )
             .unwrap();
         let pairing_plan = runtime
@@ -9541,7 +9906,7 @@ mod tests {
                                 .limited_to(1),
                         ),
                 },
-                1_524,
+                1_526,
             )
             .unwrap();
 
@@ -9620,9 +9985,30 @@ mod tests {
                 && summary.command_results == 1
         ));
         assert!(matches!(
+            command_results,
+            RuntimeReadToolOutput::CommandResults {
+                results,
+                summary,
+            } if results.len() == 1
+                && results[0].sequence == 0
+                && results[0].result.command_id == CommandId::trusted("command-1")
+                && results[0].result.status == CommandStatus::Accepted
+                && summary.total_results == 1
+                && summary.accepted_results == 1
+                && !summary.has_failures()
+        ));
+        assert!(matches!(
+            command_result_summary,
+            RuntimeReadToolOutput::CommandResultSummary { summary }
+                if summary.total_results == 1
+                    && summary.accepted_results == 1
+                    && summary.failure_results() == 0
+                    && summary.next_checkpoint == RuntimeEventCheckpoint::from_next_sequence(1)
+        ));
+        assert!(matches!(
             snapshot,
             RuntimeReadToolOutput::RuntimeSnapshot(snapshot)
-                if snapshot.generated_at_ms == 1_509
+                if snapshot.generated_at_ms == 1_511
                     && snapshot.pairing_session_count == 1
                     && snapshot.desired_state_count == 1
                     && snapshot.desired_capability_count == 1
@@ -9654,7 +10040,7 @@ mod tests {
         assert!(matches!(
             supervision_plan,
             RuntimeReadToolOutput::SupervisionPlan(plan)
-                if plan.generated_at_ms == 1_512
+                if plan.generated_at_ms == 1_514
                     && plan.action_count() == 1
                     && plan.summary().worker_restart_count == 1
                     && plan.worker_restart_plan.len() == 1
@@ -9662,7 +10048,7 @@ mod tests {
         assert!(matches!(
             observation,
             RuntimeReadToolOutput::SupervisionObservation(observation)
-                if observation.generated_at_ms == 1_513
+                if observation.generated_at_ms == 1_515
                     && observation.worker_restart_count() == 1
                     && observation.due_worker_deadline_count() == 1
                     && observation.next_worker_heartbeat_due_at_ms() == Some(1_100)
@@ -9673,24 +10059,24 @@ mod tests {
                 if workers.len() == 1
                     && workers[0].bridge_id == BridgeId::trusted("bridge-1")
                     && workers[0].status == WorkerStatus::Starting
-                    && summary.generated_at_ms == 1_514
+                    && summary.generated_at_ms == 1_516
                     && summary.worker_count == 1
                     && summary.restart_due_count == 1
         ));
         assert!(matches!(
             heartbeat_schedule,
             RuntimeReadToolOutput::WorkerHeartbeatSchedule(schedule)
-                if schedule.generated_at_ms == 1_515
+                if schedule.generated_at_ms == 1_517
                     && schedule.len() == 1
                     && schedule.next_due_at_ms() == Some(1_100)
                     && schedule.deadlines[0].bridge_id == BridgeId::trusted("bridge-1")
-                    && schedule.deadlines[0].is_due_at(1_515)
+                    && schedule.deadlines[0].is_due_at(1_517)
         ));
         assert!(matches!(
             authorization_decisions,
             RuntimeReadToolOutput::AuthorizationDecisions { decisions, summary }
                 if decisions.len() == 2
-                    && decisions[0].decided_at_ms == 1_516
+                    && decisions[0].decided_at_ms == 1_518
                     && decisions[0].subject == AuthorizationSubject::Tool(
                         SmartHomeTool::ListAuthorizationDecisions
                     )
@@ -9701,10 +10087,10 @@ mod tests {
         assert!(matches!(
             authorization_summary,
             RuntimeReadToolOutput::AuthorizationSummary { summary }
-                if summary.total_decisions == 18
-                    && summary.allowed_decisions == 18
+                if summary.total_decisions == 20
+                    && summary.allowed_decisions == 20
                     && summary.denied_decisions == 0
-                    && summary.tool_decisions == 18
+                    && summary.tool_decisions == 20
         ));
         assert!(matches!(
             capability_grants,
@@ -9757,7 +10143,7 @@ mod tests {
                     && workers[0].worker_id == DiscoveryWorkerId::trusted("hue-mdns-worker")
                     && workers[0].kind == DiscoveryWorkerKind::MdnsScan
                     && workers[0].is_due
-                    && summary.generated_at_ms == 1_522
+                    && summary.generated_at_ms == 1_524
                     && summary.worker_count == 1
                     && summary.due_worker_count == 1
         ));
@@ -9768,7 +10154,7 @@ mod tests {
                 ttl_ms,
                 record_summary,
                 signal_summary,
-            } if generated_at_ms == 1_523
+            } if generated_at_ms == 1_525
                 && ttl_ms == 1_000
                 && record_summary.total == 1
                 && record_summary.fresh == 1
@@ -9781,7 +10167,7 @@ mod tests {
                 plan,
                 summary,
             } if ttl_ms == 1_000
-                && plan.generated_at_ms == 1_524
+                && plan.generated_at_ms == 1_526
                 && plan.targets.len() == 1
                 && plan.targets[0].bridge_id
                     == BridgeId::trusted("hue.bridge.001788fffediscovered")
@@ -9790,7 +10176,7 @@ mod tests {
                 && summary.actionable == 1
                 && summary.requires_human_action == 1
         ));
-        assert_eq!(runtime.registry().counts().authorization_decisions, 25);
+        assert_eq!(runtime.registry().counts().authorization_decisions, 27);
         assert!(runtime
             .registry()
             .authorization_decisions()


### PR DESCRIPTION
## Summary
- add core/runtime descriptors and read-side query types for command-result audit views over the runtime event log
- expose Chief D18D tools smart_home.list_command_results and smart_home.get_command_result_summary as read-only adapters
- cover runtime filtering/summaries and Chief end-to-end command-result audit output

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools

Post-rebase spot check:
- cargo test -p smart-home-core
- cargo test -p smart-home-runtime
- cargo test -p chief-of-staff-smart-home-tools