### PR TITLE
feat(closurec): CLOC12.48 — close gap-040 (numeric separator + scientific) — HARNESS 49/49

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.54.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-040** — numeric separator stripping +
+  scientific shortest-form normalisation. **Harness now
+  reports `49 matched, 0 failed, 0 skipped (of 49 total)`
+  — fifth 100% milestone today** (17/17, 25/25, 33/33,
+  41/41, 49/49).
+- Extended `normalize_number_value()` to consider three
+  candidates: cleaned form (with `_` stripped), decimal,
+  and scientific. Picks the shortest with tie-break order
+  decimal > cleaned > scientific.
+- Added `scientific_form_of(n)` helper: for `n = m × 10^e`
+  with `m % 10 ≠ 0` and `e ≥ 1`, returns `Some("{m}E{e}")`.
+- Decimal source (no radix prefix) is now also considered
+  for normalisation — `1000` → `1E3`, `12000` → `12E3`.
+- Underscores in source are stripped before parsing
+  (`u128::from_str_radix` doesn't accept ES2021 numeric
+  separators).
+- Floating-point and exponential-source literals (anything
+  containing `.`, `e`, `E`) hit the early-return branch and
+  stay verbatim — those normalisations are separate gaps.
+
+### Added
+
+12 new `gap040_*` inline tests covering:
+- separator + scientific (`1_000`, `1_000_000`)
+- separator without trailing zeros (`1_234_567`)
+- hex + separator (`0xff_ff`)
+- bare decimal → scientific (`1000`)
+- decimal/scientific tie (`100`)
+- tiny decimal stays (`10`)
+- multi-digit mantissa scientific (`12000` → `12E3`)
+- mantissa-exponent tie (`1234500`)
+- zero/no-norm/float non-regression
+
+### Verified against upstream JAR
+
+All worked examples in the function docstring were verified
+against `closure-compiler-v20240317.jar` directly during
+implementation. Boundary cases confirmed:
+- `1000` → `1E3` (sci strictly shorter)
+- `100` → `100` (decimal-sci tie → decimal)
+- `12000` → `12E3` (multi-digit mantissa)
+- `1234500` → `1234500` (cleaned-decimal-sci tie → decimal)
+- `0xff_ff` → `65535` (decimal strictly shortest)
+
 ## [0.53.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -784,60 +784,87 @@ fn is_number_literal(tok: &lexer::token::Token) -> bool {
     matches!(tok.type_, lexer::token::TokenType::Number)
 }
 
-/// gap-038: rewrite hex / octal / binary integer literals to
-/// their decimal form when decimal is no longer than source.
+/// gap-038 + gap-040: rewrite numeric integer literals to
+/// their shortest representation among the three candidates
+/// {cleaned source form, decimal form, scientific form},
+/// matching upstream Closure's WHITESPACE_ONLY behaviour.
 ///
-/// Upstream Closure under WHITESPACE_ONLY normalises numeric
-/// literals to a shortest-form representation. For non-BigInt
-/// hex/oct/bin literals, the decimal form is chosen iff its
-/// string length is **less than or equal to** the source-form
-/// length — i.e. tie-breaks go to decimal.
+/// **The candidates:**
+///   - **Cleaned**: original `value` with ES2021 numeric
+///     separators (`_`) stripped. For hex/oct/bin, this
+///     keeps the radix prefix; for decimal, this is the
+///     plain digit run.
+///   - **Decimal**: `n.to_string()` — the canonical base-10
+///     form.
+///   - **Scientific**: when `n = m × 10^e` with `m % 10 ≠ 0`
+///     and `e ≥ 1`, the form `"{m}E{e}"`. None if `n == 0`
+///     or `e == 0`.
 ///
-/// **Worked examples** (verified against
-/// `closure-compiler-v20240317.jar`):
-///   `0xff`         (4 chars) → `255`             (3 chars) → DECIMAL wins
-///   `0xfff`        (5 chars) → `4095`            (4 chars) → DECIMAL wins
-///   `0xffffffff`  (10 chars) → `4294967295`     (10 chars) → DECIMAL wins (tie)
-///   `0xfffffffff` (11 chars) → `68719476735`    (11 chars) → DECIMAL wins (tie)
-///   `0xffffffffffff` (14 chars) → `281474976710655` (15 chars) → HEX wins
-///   `0o777`        (5 chars) → `511`             (3 chars) → DECIMAL wins
-///   `0b1010`       (6 chars) → `10`              (2 chars) → DECIMAL wins
+/// **Tie-break order** (when lengths are equal): decimal >
+/// cleaned > scientific. Verified against
+/// `closure-compiler-v20240317.jar` for boundary cases:
+///   - `0xffffffff` (10 cleaned hex) = `4294967295` (10
+///     decimal) → DECIMAL wins.
+///   - `100` (3 decimal) = `1E2` (3 scientific) → DECIMAL
+///     wins.
+///
+/// **Worked examples** (all verified against the JAR):
+///   `0xff` (4)       → `255` (3) → DECIMAL
+///   `0xffffffffffff` (14) → `281474976710655` (15) → CLEANED HEX
+///   `1_000` (5)      → cleaned `1000` (4), sci `1E3` (3) → SCIENTIFIC
+///   `1_000_000` (9)  → cleaned `1000000` (7), sci `1E6` (3) → SCIENTIFIC
+///   `1_234_567` (9)  → cleaned `1234567` (7), no sci → CLEANED
+///   `0xff_ff` (7)    → cleaned `0xffff` (6), decimal `65535` (5) → DECIMAL
+///   `12000` (5)      → sci `12E3` (4) → SCIENTIFIC
+///   `1234500` (7)    → sci `12345E2` (7) → DECIMAL (tie)
 ///
 /// **Not handled (left for follow-up gaps):**
-///   - BigInt literals (anything ending in `n`) need
-///     arbitrary-precision arithmetic. `0xfn` stays as
-///     `0xfn` rather than becoming `15n`.
-///   - Decimal floating-point normalisation: `0.5` → `.5`,
-///     `1e3` → `1E3`, `10.0` → `10`. These are different
-///     rules in different parts of the upstream code path.
-///   - Numbers that exceed `u128::MAX` parse as `None` and
-///     stay verbatim.
+///   - BigInt literals (suffix `n`) need bigint arithmetic.
+///   - Decimal floating-point shortest-form (`0.5` → `.5`,
+///     `10.0` → `10`).
+///   - Numbers exceeding `u128::MAX` stay verbatim.
 fn normalize_number_value(value: &str) -> String {
     // BigInt — defer to a future gap.
     if value.ends_with('n') {
         return value.to_string();
     }
-    // Try each radix prefix in turn. The prefixes are
-    // case-insensitive per §12.8.3.
-    let parsed: Option<u128> = if let Some(rest) = value
+    // gap-040: strip ES2021 numeric separators (`_`).
+    // `u128::from_str_radix` doesn't accept them; this also
+    // makes the cleaned form a candidate for shortest-form
+    // comparison.
+    let cleaned = if value.contains('_') {
+        value.replace('_', "")
+    } else {
+        value.to_string()
+    };
+    // Try each radix prefix in turn. Prefixes are
+    // case-insensitive per §12.8.3. The decimal branch
+    // (no radix prefix) also feeds into shortest-form for
+    // gap-040 — bare-decimal source can still be shorter
+    // in scientific form (e.g. `1000` → `1E3`).
+    let parsed: Option<u128> = if let Some(rest) = cleaned
         .strip_prefix("0x")
-        .or_else(|| value.strip_prefix("0X"))
+        .or_else(|| cleaned.strip_prefix("0X"))
     {
         u128::from_str_radix(rest, 16).ok()
-    } else if let Some(rest) = value
+    } else if let Some(rest) = cleaned
         .strip_prefix("0o")
-        .or_else(|| value.strip_prefix("0O"))
+        .or_else(|| cleaned.strip_prefix("0O"))
     {
         u128::from_str_radix(rest, 8).ok()
-    } else if let Some(rest) = value
+    } else if let Some(rest) = cleaned
         .strip_prefix("0b")
-        .or_else(|| value.strip_prefix("0B"))
+        .or_else(|| cleaned.strip_prefix("0B"))
     {
         u128::from_str_radix(rest, 2).ok()
+    } else if cleaned.chars().all(|c| c.is_ascii_digit()) {
+        // Bare decimal integer.
+        cleaned.parse::<u128>().ok()
     } else {
-        // Decimal or no radix prefix — leave alone. Decimal
-        // floating-point shortest-form is a separate concern
-        // (see function doc).
+        // Has a `.` or `e`/`E` or other non-integer
+        // character — leave alone. Decimal floating-point
+        // shortest-form (e.g. `0.5` → `.5`) is a separate
+        // future gap.
         return value.to_string();
     };
 
@@ -845,15 +872,49 @@ fn normalize_number_value(value: &str) -> String {
         // Doesn't fit in u128 — leave verbatim.
         return value.to_string();
     };
+
     let decimal = n.to_string();
-    // `<= value.len()` because upstream tie-breaks to decimal
-    // (verified via JAR probe: `0xffffffff` (10) → `4294967295` (10)
-    // → DECIMAL wins).
-    if decimal.len() <= value.len() {
+    let scientific = scientific_form_of(n);
+
+    // Pick shortest. Tie-break order: decimal > cleaned >
+    // scientific (verified via JAR probes for the boundary
+    // cases — see function-level doc).
+    let cleaned_len = cleaned.len();
+    let decimal_len = decimal.len();
+    let sci_len = scientific.as_ref().map(|s| s.len()).unwrap_or(usize::MAX);
+
+    let min_len = cleaned_len.min(decimal_len).min(sci_len);
+    if decimal_len == min_len {
         decimal
+    } else if cleaned_len == min_len {
+        cleaned
     } else {
-        value.to_string()
+        scientific.unwrap()
     }
+}
+
+/// gap-040: scientific shortest-form helper. For an integer
+/// `n = m × 10^e` with `m % 10 ≠ 0` and `e ≥ 1`, returns
+/// `Some("{m}E{e}")`. Returns `None` when `n == 0` or `e ==
+/// 0` (the latter because `"{n}E0"` is always longer than
+/// just `"{n}"`).
+///
+/// Upstream uses uppercase `E` (verified by JAR probes:
+/// `1e3` → `1E3`, `2e10` → `2E10`).
+fn scientific_form_of(n: u128) -> Option<String> {
+    if n == 0 {
+        return None;
+    }
+    let mut m = n;
+    let mut e: u32 = 0;
+    while m % 10 == 0 {
+        m /= 10;
+        e += 1;
+    }
+    if e == 0 {
+        return None;
+    }
+    Some(format!("{}E{}", m, e))
 }
 
 /// True iff this token came from a string-literal rule. The
@@ -1891,6 +1952,94 @@ mod tests {
         let big = "0x".to_string() + &"f".repeat(40); // u160 worth
         let src = format!("var x={};", big);
         assert_eq!(minify(&src), src);
+    }
+
+    // ---- gap-040: numeric separator + scientific ---------
+
+    /// Target fixture: `1_000_000` → `1E6`.
+    /// Stripped to `1000000` (7 chars), scientific `1E6`
+    /// (3 chars) → scientific wins.
+    #[test]
+    fn gap040_separator_scientific_million() {
+        assert_eq!(minify("var x=1_000_000;"), "var x=1E6;");
+    }
+
+    /// `1_000` → `1E3`. Decimal `1000` (4), sci `1E3` (3).
+    #[test]
+    fn gap040_separator_scientific_thousand() {
+        assert_eq!(minify("var x=1_000;"), "var x=1E3;");
+    }
+
+    /// `1_234_567` → `1234567`. No trailing zeros, no
+    /// scientific candidate. Cleaned (7) = decimal (7),
+    /// decimal wins on tie.
+    #[test]
+    fn gap040_separator_no_trailing_zeros() {
+        assert_eq!(minify("var x=1_234_567;"), "var x=1234567;");
+    }
+
+    /// `0xff_ff` → `65535`. Cleaned hex (6), decimal (5),
+    /// no sci → decimal.
+    #[test]
+    fn gap040_hex_with_separator() {
+        assert_eq!(minify("var x=0xff_ff;"), "var x=65535;");
+    }
+
+    /// Bare decimal `1000` → `1E3`. Cleaned (4) = decimal
+    /// (4), sci (3) → sci.
+    #[test]
+    fn gap040_bare_decimal_to_scientific() {
+        assert_eq!(minify("var x=1000;"), "var x=1E3;");
+    }
+
+    /// Tie: `100` decimal (3) ties with `1E2` scientific (3).
+    /// Decimal wins on tie.
+    #[test]
+    fn gap040_decimal_scientific_tie_picks_decimal() {
+        assert_eq!(minify("var x=100;"), "var x=100;");
+    }
+
+    /// `10` → `10`. Decimal (2) < sci `1E1` (3).
+    #[test]
+    fn gap040_tiny_decimal_unchanged() {
+        assert_eq!(minify("var x=10;"), "var x=10;");
+    }
+
+    /// `12000` → `12E3`. Mantissa not 1; verifies general
+    /// scientific form. Cleaned (5), decimal (5), sci `12E3`
+    /// (4) → sci wins.
+    #[test]
+    fn gap040_scientific_with_multi_digit_mantissa() {
+        assert_eq!(minify("var x=12000;"), "var x=12E3;");
+    }
+
+    /// `1234500` (7 chars) ties with sci `12345E2` (7
+    /// chars). Decimal wins on tie.
+    #[test]
+    fn gap040_decimal_sci_tie_picks_decimal() {
+        assert_eq!(minify("var x=1234500;"), "var x=1234500;");
+    }
+
+    /// **Non-regression**: `0` is the trivial case.
+    /// Scientific helper returns None for `n == 0`.
+    #[test]
+    fn gap040_zero_unchanged() {
+        assert_eq!(minify("var x=0;"), "var x=0;");
+    }
+
+    /// **Non-regression**: decimal source without trailing
+    /// zeros is unchanged.
+    #[test]
+    fn gap040_decimal_no_normalization() {
+        assert_eq!(minify("var x=12345;"), "var x=12345;");
+    }
+
+    /// **Non-regression**: floating-point literals are NOT
+    /// touched — they hit the early `return value.to_string()`
+    /// branch because they contain `.` (or `e`/`E`).
+    #[test]
+    fn gap040_float_left_alone() {
+        assert_eq!(minify("var x=1.5;"), "var x=1.5;");
     }
 
     // ---- gap-039: tagged template separator --------------

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.53.0
+Version: 0.54.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,11 +85,12 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-040: numeric separator + scientific shortest-form.
-    // Upstream emits `var x=1E6;` for `var x=1_000_000;` —
-    // BOTH stripping underscores AND switching to scientific
-    // notation when shorter. Discovered by CLOC14.7.
-    ("numeric_separator", "gap-040: numeric separator + scientific shortest-form"),
+    // gap-040 was RESOLVED in CLOC12.48 — `normalize_number_value`
+    // now strips `_` separators and considers scientific
+    // notation alongside decimal/cleaned-hex in the
+    // shortest-form comparison. `minify_numeric_separator`
+    // flipped IGNORED → PASS. Harness back to 49/49 — fifth
+    // 100% milestone today.
     // gap-041 was RESOLVED in CLOC12.47 — synthetic `;`
     // emission now peeks ahead and suppresses when the next
     // non-trivia token is `}`. `minify_nested_function`

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -297,7 +297,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-040 — numeric separator + scientific shortest-form
 
-- **Status:** OPEN — newly discovered by CLOC14.7.
+- **Status:** **RESOLVED** in CLOC12.48 (PR pending). `minify_numeric_separator` flipped IGNORED → PASS. **Harness now 49/49 PASS — fifth 100% milestone today** (after 17/17, 25/25, 33/33, 41/41).
 - **Upstream byte-identity test:** `minify_numeric_separator` seed fixture.
 - **Why it fails:** Upstream emits `var x=1E6;` for `var x=1_000_000;`. closurec preserves the underscored literal verbatim. This is TWO normalisations stacked:
   1. Strip ES2021 numeric separators (`_`) from the literal.


### PR DESCRIPTION
## Summary

🎯 **FIFTH 100% MILESTONE today.** Harness 48/49 → **49/49 PASS**.

Today's progression:
- 17/17 at CLOC12.42
- 25/25 at CLOC12.43
- 33/33 at CLOC12.45
- 41/41 at CLOC12.46
- **49/49** at CLOC12.48 ← this PR

## What's new

\`normalize_number_value\` now considers three candidates: cleaned (with \`_\` stripped), decimal, and scientific. Picks shortest with tie-break order **decimal > cleaned > scientific**.

Bare decimal source (no radix prefix) is now also normalised: \`1000\` → \`1E3\`, \`12000\` → \`12E3\`.

## Verified against JAR

- \`1_000_000\` → \`1E6\`
- \`0xff_ff\` → \`65535\`
- \`1234500\` → \`1234500\` (multi-way tie → decimal)
- \`100\` → \`100\` (decimal-sci tie → decimal)
- \`12000\` → \`12E3\` (multi-digit mantissa)

## Tests

12 new \`gap040_*\` inline tests including 3 explicit non-regression cases. Full suite: **347 passed, 0 failed**.

## Security review

PASS. Traced 8 concerns + 3 additional edge cases (\`_123\`, \`0x_10\`, \`1_0\`).

## Version

0.53.0 → 0.54.0.

## Test plan

- [x] \`cargo test\` → 347 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 49 matched, 0 failed, 0 skipped (of 49)
- [x] Security review → PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)