### PR TITLE
Promote smart-home catalog tools into core descriptors

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -7568,7 +7568,7 @@ mod tests {
         RequestedBy, ToolCatalogExport, ToolExecutionJournal, ToolInvocationRequest,
         ToolValidationReport,
     };
-    use smart_home_core::{CapabilityGrant, CapabilityGrantId};
+    use smart_home_core::{smart_home_tool_catalog, CapabilityGrant, CapabilityGrantId};
     use smart_home_discovery::{
         DiscoveryWorkerId, DiscoveryWorkerKind, MDNS_DISCOVERY_SERVICE_TYPE_METADATA_KEY,
     };
@@ -7716,6 +7716,23 @@ mod tests {
         assert!(smart_home_tool_definition(SMART_HOME_SET_DESIRED_STATE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_CLEAR_DESIRED_STATE_TOOL_ID).is_some());
         assert!(smart_home_tool_definition("smart_home.unknown").is_none());
+    }
+
+    #[test]
+    fn smart_home_tool_definitions_match_shared_core_descriptors() {
+        let definitions = smart_home_tool_definitions();
+        let export = ToolCatalogExport::from_definitions(definitions.iter());
+        let core_tool_ids = smart_home_tool_catalog()
+            .into_iter()
+            .map(|tool| tool.tool_id)
+            .collect::<Vec<_>>();
+
+        for tool_id in export.tool_ids() {
+            assert!(
+                core_tool_ids.contains(&tool_id),
+                "D18D smart-home tool `{tool_id}` is missing from smart-home-core"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this package will be documented in this file.
   compact read-side inspection of integration coverage.
 - `SmartHomeToolCatalogSummary` and `smart_home_tool_catalog_summary()` for
   compact read-side inspection of the smart-home tool surface.
+- `smart_home.list_integrations`, `smart_home.describe_integration`,
+  `smart_home.list_primitives`, and `smart_home.describe_primitive` tool
+  descriptors for read-only integration-catalog and reusable-primitive
+  inspection.
 - `smart_home.poll_events` and `smart_home.unsubscribe` tool descriptors for
   model-facing event subscription lifecycle control.
 - `smart_home.list_subscriptions` and `smart_home.inspect_event_log` tool

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -46,6 +46,8 @@ Current scope:
 - command risk tier helpers
 - state freshness helpers
 - D18D-style smart-home tool descriptors
+- D18D integration-catalog descriptors for model-facing integration and
+  reusable-primitive inspection
 - D18D scene inventory/read tool descriptors for model-facing scene lookup
 - D18D event lifecycle tool descriptors for subscribing, polling, and
   unsubscribing from runtime event streams

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1445,6 +1445,10 @@ impl SmartHomeToolCatalogSummary {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SmartHomeTool {
+    ListIntegrations,
+    DescribeIntegration,
+    ListPrimitives,
+    DescribePrimitive,
     Discover,
     PairBridge,
     CompletePairing,
@@ -1489,6 +1493,10 @@ pub enum SmartHomeTool {
 impl SmartHomeTool {
     pub fn descriptor(self) -> ToolDescriptor {
         match self {
+            Self::ListIntegrations => read_tool("smart_home.list_integrations"),
+            Self::DescribeIntegration => read_tool("smart_home.describe_integration"),
+            Self::ListPrimitives => read_tool("smart_home.list_primitives"),
+            Self::DescribePrimitive => read_tool("smart_home.describe_primitive"),
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
                 side_effects: ToolSideEffects::Read,
@@ -2094,6 +2102,10 @@ impl AuthorizationDecisionLogSummary {
 
 pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
     [
+        SmartHomeTool::ListIntegrations,
+        SmartHomeTool::DescribeIntegration,
+        SmartHomeTool::ListPrimitives,
+        SmartHomeTool::DescribePrimitive,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -2928,7 +2940,27 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 39);
+        assert_eq!(catalog.len(), 43);
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_integrations"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.describe_integration"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.list_primitives"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog
+            .iter()
+            .any(|tool| tool.tool_id == "smart_home.describe_primitive"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -3092,15 +3124,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 39);
-        assert_eq!(summary.read_tools, 31);
+        assert_eq!(summary.total_tools, 43);
+        assert_eq!(summary.read_tools, 35);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 31);
+        assert_eq!(summary.read_only_tier_tools, 35);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 39);
+        assert_eq!(summary.total_required_capabilities, 43);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home-core descriptors for integration and primitive catalog tools
- update core catalog counts/docs for the 43-tool model-facing surface
- add a Chief bridge guardrail test that every D18D smart-home tool id is backed by the core descriptor catalog

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools