### PR TITLE
feat(closurec): CLOC12.49 — close gap-042 (do-keyword arms body_position_next)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.55.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-042** — `do` keyword now arms
+  `body_position_next = true`. `do{a;}while(x);` flattens
+  via gap-032 to `do a;while(x);` matching upstream.
+  Harness 55/57 → 56/57. Only gap-043 left.
+
+Unlike `if`/`while`/`for` whose body slot opens after
+their `)`, `do`'s body opens IMMEDIATELY after the keyword
+(per §13.7.2). A one-keyword branch mirroring `else`.
+
+### Added
+- 2 inline `gap042_*` tests (single-stmt flatten target +
+  multi-stmt non-regression).
+
+### Documented (orthogonal, not fixed here)
+- Empty-body `do{}while(x);` produces `do; while(x);` —
+  the synthetic `;` from gap-031 doesn't update
+  `prev_emitted_tok`, leaving `needs_separator` to see
+  word-like(do, while). Future gap.
+
 ## [0.54.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -733,6 +733,17 @@ pub fn whitespace_only_minify(
             // apply.
             body_position_next = true;
             at_stmt_boundary = false;
+        } else if val == "do" {
+            // gap-042: `do` opens the do-statement's body
+            // slot IMMEDIATELY (unlike `if`/`while`/`for`
+            // which open it after the `)` of the head). Per
+            // §13.7.2: `DoWhileStatement → do Statement
+            // while ( Expression ) ;`. By arming
+            // body_position_next here, gap-032's
+            // single-statement flatten fires on
+            // `do{a;}while(x);` → `do a;while(x);`.
+            body_position_next = true;
+            at_stmt_boundary = false;
         } else {
             // Any other token consumes the body slot (the
             // body of `if(x)y();` is `y()`, so once we emit
@@ -2041,6 +2052,38 @@ mod tests {
     fn gap040_float_left_alone() {
         assert_eq!(minify("var x=1.5;"), "var x=1.5;");
     }
+
+    // ---- gap-042: do-keyword arms body_position_next -----
+
+    /// Target fixture: `do{a;}while(x);` flattens via gap-032.
+    #[test]
+    fn gap042_do_while_single_stmt_flattens() {
+        assert_eq!(
+            minify("do{a;}while(x);"),
+            "do a;while(x);"
+        );
+    }
+
+    /// Multi-statement do-body does NOT flatten (gap-032's
+    /// eligibility check requires exactly 1 `;` at depth 0).
+    #[test]
+    fn gap042_do_while_multi_stmt_does_not_flatten() {
+        assert_eq!(
+            minify("do{a();b();}while(x);"),
+            "do{a();b()}while(x);"
+        );
+    }
+
+    // Note on `do{}while(x);` (empty do-body): gap-031's
+    // empty-body collapse fires, producing `do;while(x);`
+    // in principle. But the synthetic `;` emission doesn't
+    // update `prev_emitted_tok`, so `needs_separator`
+    // computes word-like(do, while) → true → inserts a
+    // spurious space, producing `do; while(x);`. This is a
+    // SEPARATE latent issue (will be filed as a future
+    // gap) and orthogonal to the do-keyword arming gap-042
+    // is closing. A test for it would belong with the fix
+    // for the prev_emitted_tok update.
 
     // ---- gap-039: tagged template separator --------------
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.54.0
+Version: 0.55.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,12 +85,10 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-042: `do` keyword should arm body_position_next
-    // so that single-statement do-bodies flatten via
-    // gap-032 (just like `if`/`while`/`for`). Upstream
-    // emits `do a;while(x);` for `do{a;}while(x);`.
-    // Discovered by CLOC14.8.
-    ("do_while", "gap-042: do-keyword should arm body_position_next"),
+    // gap-042 was RESOLVED in CLOC12.49 — `do` keyword now
+    // arms body_position_next, so gap-032's single-statement
+    // flatten fires on `do{a;}while(x);` → `do a;while(x);`.
+    // `minify_do_while` flipped IGNORED → PASS.
     // gap-043: CLI quote-choice optimisation for string
     // literals. Upstream switches to `'` when content has
     // escaped `"` characters (saves the backslash). The

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -315,9 +315,8 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-042 — `do` keyword should arm body_position_next
 
-- **Status:** OPEN — newly discovered by CLOC14.8.
-- **Upstream byte-identity test:** `minify_do_while` seed fixture.
-- **Why it fails:** Upstream emits `do a;while(x);` for `do{a;}while(x);`. closurec emits `do{a}while(x);`. The state machine arms `body_position_next = true` for `if`/`while`/`for` (and indirectly for `else`), but not for `do`. As a result gap-032's single-statement flatten doesn't fire on the do-body.
+- **Status:** **RESOLVED** in CLOC12.49 (PR pending). `minify_do_while` flipped IGNORED → PASS. Harness 56/57 (only gap-043 left).
+- **Resolution:** Added `else if val == "do"` branch arming `body_position_next = true`. Unlike `if`/`while`/`for` which arm via the `next_paren_is_control_flow_head` mechanism (their body opens after `)`), `do` opens its body slot IMMEDIATELY per §13.7.2. gap-032's single-statement flatten then fires correctly. 2 inline tests added; also documented a separate latent issue with empty-body do-while (`do{}while(x);` produces a spurious space between `;` and `while`) that's a `prev_emitted_tok` update bug in gap-031, orthogonal to this gap.
 - **What it needs:** Add `do` to the keyword arm list (alongside `if`/`while`/`for`) — but note `do` arms body_position_next IMMEDIATELY (no following `(`), unlike the others. Insert at the right `else if val == "do"` branch arming `body_position_next = true`.
 
 ### gap-043 — CLI quote-choice optimisation


### PR DESCRIPTION
## Summary

**Closes gap-042.** Harness 55/57 → 56/57. Only gap-043 left.

## The fix

Tiny one-keyword branch — \`else if val == \"do\"\` arms \`body_position_next = true\`. Unlike if/while/for whose body opens after their \`)\`, \`do\`'s body opens IMMEDIATELY (per §13.7.2). gap-032's flatten then fires.

\`do{a;}while(x);\` → \`do a;while(x);\` (verified vs JAR).

## Tests

2 inline tests: single-stmt target + multi-stmt non-regression.

## Documented orthogonal latent issue

Empty-body \`do{}while(x);\` exposes a separate bug (gap-031's synthetic \`;\` doesn't update \`prev_emitted_tok\`). Documented in test module for a future gap.

## Version

0.54.0 → 0.55.0.

## Test plan

- [x] \`cargo test\` → 349 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 56 matched, 0 failed, 1 skipped (of 57)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)