### PR TITLE
Add smart-home integration readiness summary tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for compact shared-core catalog summaries:
   `smart_home.get_integration_catalog_summary` and
   `smart_home.get_tool_catalog_summary`.
+- Added D18D handlers for bulk D23A integration readiness planning:
+  `smart_home.list_integration_readiness` and
+  `smart_home.get_integration_readiness_summary`.
 - Added D18D smart-home tool definitions and in-memory handlers over
   `SmartHomeRuntime`.
 - Added an end-to-end Hue-style fixture test that lists devices, commands a

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -56,6 +56,8 @@ Chief of Staff job/session/agent
 - `smart_home.describe_primitive`
 - `smart_home.get_integration_catalog_summary`
 - `smart_home.get_tool_catalog_summary`
+- `smart_home.list_integration_readiness`
+- `smart_home.get_integration_readiness_summary`
 - `smart_home.discover`
 - `smart_home.list_discovery_workers`
 - `smart_home.get_discovery_summary`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -37,12 +37,12 @@ use smart_home_integration_catalog::{
     ecosystem_survey_sources, entries_requiring_primitive, find_entry, first_party_catalog,
     primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
     primitive_family_descriptors, query_integrations, readiness_report_for_plan,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationPlan,
-    IntegrationActivationTarget, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
-    IntegrationReadinessReport, PrimitiveBacklogCoverageItem, PrimitiveBacklogItem,
-    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
+    IntegrationActivationPlan, IntegrationActivationTarget, IntegrationCatalogEntry,
+    IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    IntegrationReadinessReport, IntegrationReadinessSummary, PrimitiveBacklogCoverageItem,
+    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -128,6 +128,10 @@ pub const SMART_HOME_DESCRIBE_PRIMITIVE_TOOL_ID: &str = "smart_home.describe_pri
 pub const SMART_HOME_GET_INTEGRATION_CATALOG_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_catalog_summary";
 pub const SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID: &str = "smart_home.get_tool_catalog_summary";
+pub const SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID: &str =
+    "smart_home.list_integration_readiness";
+pub const SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_readiness_summary";
 
 /// Shared, mutable smart-home runtime handle for in-process D18D handlers.
 pub type SharedSmartHomeRuntime = Rc<RefCell<SmartHomeRuntime>>;
@@ -196,6 +200,16 @@ impl SmartHomeToolBridge {
                 ),
                 SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID => {
                     Ok(get_tool_catalog_summary_output_handler_output(&arguments)?)
+                }
+                SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(list_integration_readiness_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID => {
+                    let query = integration_readiness_query(&arguments)?;
+                    Ok(get_integration_readiness_summary_output_handler_output(
+                        query,
+                    ))
                 }
                 SMART_HOME_DISCOVER_TOOL_ID => {
                     let request = discover_request(&arguments)?;
@@ -753,6 +767,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home tool catalog summary",
             "Return compact D18D smart-home tool descriptor counts from the shared smart-home core catalog.",
             object_schema(vec![], vec![], false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID,
+            "List smart-home integration readiness",
+            "List D23A integration activation readiness reports for the supplied primitive, capability, and dependency context.",
+            integration_readiness_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "readiness_reports",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["readiness_reports", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID,
+            "Get smart-home integration readiness summary",
+            "Return a compact readiness rollup for D23A integration activation planning in the supplied context.",
+            integration_readiness_query_schema(false),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -2866,6 +2912,68 @@ fn integration_catalog_query(
     Ok(query)
 }
 
+#[derive(Debug, Clone)]
+struct IntegrationReadinessQuery {
+    priority_at_or_before: u8,
+    available_primitives: Vec<PrimitiveFamily>,
+    allowed_capabilities: Vec<CapabilityId>,
+    enabled_integrations: Vec<IntegrationId>,
+    activation_ready: Option<bool>,
+    requires_human_review: Option<bool>,
+    cloud_required: Option<bool>,
+    local_only: Option<bool>,
+    limit: Option<usize>,
+}
+
+fn integration_readiness_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationReadinessQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    Ok(IntegrationReadinessQuery {
+        priority_at_or_before: optional_u8(arguments, "priority_at_or_before")?.unwrap_or(u8::MAX),
+        available_primitives: optional_primitive_list(arguments, "available_primitives")?,
+        allowed_capabilities: optional_capability_id_list(arguments, "allowed_capability_ids")?,
+        enabled_integrations: optional_integration_id_list(arguments, "enabled_integrations")?,
+        activation_ready: optional_bool(arguments, "activation_ready")?,
+        requires_human_review: optional_bool(arguments, "requires_human_review")?,
+        cloud_required: optional_bool(arguments, "cloud_required")?,
+        local_only: optional_bool(arguments, "local_only")?,
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_readiness_reports_for_query(
+    query: &IntegrationReadinessQuery,
+) -> (Vec<IntegrationReadinessReport>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let mut reports = readiness_reports_at_or_before_priority(
+        &catalog,
+        query.priority_at_or_before,
+        &query.available_primitives,
+        &query.allowed_capabilities,
+        &query.enabled_integrations,
+    );
+
+    if let Some(activation_ready) = query.activation_ready {
+        reports.retain(|report| report.activation_ready() == activation_ready);
+    }
+    if let Some(requires_human_review) = query.requires_human_review {
+        reports.retain(|report| report.requires_human_review == requires_human_review);
+    }
+    if let Some(cloud_required) = query.cloud_required {
+        reports.retain(|report| report.cloud_required == cloud_required);
+    }
+    if let Some(local_only) = query.local_only {
+        reports.retain(|report| report.local_only == local_only);
+    }
+    if let Some(limit) = query.limit {
+        reports.truncate(limit);
+    }
+
+    (reports, catalog_count)
+}
+
 fn list_integrations_output_handler_output(query: IntegrationCatalogQuery) -> ToolHandlerOutput {
     let catalog = first_party_catalog();
     let entries = query_integrations(&catalog, &query);
@@ -3001,6 +3109,52 @@ fn get_tool_catalog_summary_output_handler_output(
                     ("total_tools", integer(summary.total_tools as i64)),
                 ]),
             ),
+    )
+}
+
+fn list_integration_readiness_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let (reports, catalog_count) = integration_readiness_reports_for_query(&query);
+    let summary = IntegrationReadinessSummary::from_reports(reports.iter());
+    let count = reports.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "readiness_reports",
+            JsonValue::Array(reports.iter().map(readiness_report_json).collect()),
+        ),
+        ("summary", integration_readiness_summary_json(&summary)),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_readiness")),
+            ("count", integer(count as i64)),
+            ("blocked_reports", integer(summary.blocked_reports as i64)),
+        ]),
+    )
+}
+
+fn get_integration_readiness_summary_output_handler_output(
+    query: IntegrationReadinessQuery,
+) -> ToolHandlerOutput {
+    let (reports, _) = integration_readiness_reports_for_query(&query);
+    let summary = IntegrationReadinessSummary::from_reports(reports.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_readiness_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("get_integration_readiness_summary")),
+            ("total_reports", integer(summary.total_reports as i64)),
+            ("blocked_reports", integer(summary.blocked_reports as i64)),
+        ]),
     )
 }
 
@@ -5341,6 +5495,69 @@ fn readiness_report_json(report: &IntegrationReadinessReport) -> JsonValue {
     ])
 }
 
+fn integration_readiness_summary_json(summary: &IntegrationReadinessSummary) -> JsonValue {
+    object([
+        ("total_reports", integer(summary.total_reports as i64)),
+        (
+            "activation_ready_reports",
+            integer(summary.activation_ready_reports as i64),
+        ),
+        ("blocked_reports", integer(summary.blocked_reports as i64)),
+        (
+            "reports_requiring_human_review",
+            integer(summary.reports_requiring_human_review as i64),
+        ),
+        (
+            "cloud_required_reports",
+            integer(summary.cloud_required_reports as i64),
+        ),
+        (
+            "local_only_reports",
+            integer(summary.local_only_reports as i64),
+        ),
+        ("direct_targets", integer(summary.direct_targets as i64)),
+        (
+            "delegated_integration_targets",
+            integer(summary.delegated_integration_targets as i64),
+        ),
+        (
+            "delegated_standard_targets",
+            integer(summary.delegated_standard_targets as i64),
+        ),
+        (
+            "reports_missing_primitives",
+            integer(summary.reports_missing_primitives as i64),
+        ),
+        (
+            "reports_missing_capabilities",
+            integer(summary.reports_missing_capabilities as i64),
+        ),
+        (
+            "reports_missing_dependencies",
+            integer(summary.reports_missing_dependencies as i64),
+        ),
+        (
+            "unique_missing_primitives",
+            integer(summary.unique_missing_primitives as i64),
+        ),
+        (
+            "unique_missing_capabilities",
+            integer(summary.unique_missing_capabilities as i64),
+        ),
+        (
+            "unique_missing_dependencies",
+            integer(summary.unique_missing_dependencies as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("all_ready", JsonValue::Bool(summary.all_ready())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+    ])
+}
+
 fn activation_target_json(target: &IntegrationActivationTarget) -> JsonValue {
     match target {
         IntegrationActivationTarget::Direct => object([("kind", string("direct"))]),
@@ -7674,6 +7891,24 @@ fn integration_catalog_query_schema() -> JsonSchema {
     )
 }
 
+fn integration_readiness_query_schema(include_limit: bool) -> JsonSchema {
+    let mut properties = vec![
+        SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
+        SchemaProperty::new("available_primitives", string_array_schema()),
+        SchemaProperty::new("allowed_capability_ids", string_array_schema()),
+        SchemaProperty::new("enabled_integrations", string_array_schema()),
+        SchemaProperty::new("activation_ready", JsonSchema::Boolean),
+        SchemaProperty::new("requires_human_review", JsonSchema::Boolean),
+        SchemaProperty::new("cloud_required", JsonSchema::Boolean),
+        SchemaProperty::new("local_only", JsonSchema::Boolean),
+    ];
+    if include_limit {
+        properties.push(SchemaProperty::new("limit", JsonSchema::Integer));
+    }
+
+    object_schema(properties, Vec::new(), false)
+}
+
 fn empty_object_schema() -> JsonSchema {
     object_schema(Vec::new(), Vec::new(), false)
 }
@@ -7742,7 +7977,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 45);
+        assert_eq!(definitions.len(), 47);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -7762,6 +7997,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_DISCOVER_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -7847,7 +8088,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            37
+            39
         );
         assert_eq!(
             export
@@ -7873,6 +8114,13 @@ mod tests {
                 .is_some()
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID).is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID).is_some()
+        );
+        assert!(
+            smart_home_tool_definition(SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID)
+                .is_some()
+        );
         assert!(smart_home_tool_definition(SMART_HOME_GET_PAIRING_PLAN_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_COMMAND_RESULTS_TOOL_ID).is_some());
         assert!(
@@ -8102,15 +8350,116 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(45))
+            Some(&integer(47))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(37))
+            Some(&integer(39))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
             Some(&integer(8))
+        );
+
+        let list_integration_readiness_request = request(
+            "call-list-integration-readiness",
+            SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+                ("limit", integer(3)),
+            ]),
+            996,
+        );
+        let list_integration_readiness_trace =
+            tool_runtime.invoke_with_events(&list_integration_readiness_request);
+        assert!(list_integration_readiness_trace.result.ok);
+        assert_eq!(
+            list_integration_readiness_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_integration_readiness_output = list_integration_readiness_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_integration_readiness_output, "count"),
+            Some(&integer(3))
+        );
+        let readiness_summary = field(list_integration_readiness_output, "summary").unwrap();
+        assert_eq!(field(readiness_summary, "total_reports"), Some(&integer(3)));
+        assert_eq!(
+            field(readiness_summary, "blocked_reports"),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(readiness_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(readiness_summary, "unique_missing_primitives").unwrap()).unwrap()
+                >= 1
+        );
+
+        let integration_readiness_summary_request = request(
+            "call-integration-readiness-summary",
+            SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("activation_ready", JsonValue::Bool(false)),
+            ]),
+            997,
+        );
+        let integration_readiness_summary_trace =
+            tool_runtime.invoke_with_events(&integration_readiness_summary_request);
+        assert!(integration_readiness_summary_trace.result.ok);
+        assert_eq!(
+            integration_readiness_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let integration_readiness_summary_output = integration_readiness_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let readiness_rollup = field(integration_readiness_summary_output, "summary").unwrap();
+        assert!(integer_value(field(readiness_rollup, "total_reports").unwrap()).unwrap() >= 3);
+        assert_eq!(
+            field(readiness_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
         );
 
         let list_request = request(
@@ -9276,6 +9625,14 @@ mod tests {
             integration_catalog_summary_trace,
         );
         journal.record_trace(tool_catalog_summary_request, tool_catalog_summary_trace);
+        journal.record_trace(
+            list_integration_readiness_request,
+            list_integration_readiness_trace,
+        );
+        journal.record_trace(
+            integration_readiness_summary_request,
+            integration_readiness_summary_trace,
+        );
         journal.record_trace(list_request, list_trace);
         journal.record_trace(list_rooms_request, list_rooms_trace);
         journal.record_trace(list_scenes_request, list_scenes_trace);
@@ -9320,9 +9677,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 45);
-        assert_eq!(journal_summary.completed_count, 45);
-        assert_eq!(journal.audit_records().len(), 45);
+        assert_eq!(journal_summary.invocation_count, 47);
+        assert_eq!(journal_summary.completed_count, 47);
+        assert_eq!(journal.audit_records().len(), 47);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.get_integration_catalog_summary` and
   `smart_home.get_tool_catalog_summary` tool descriptors for compact read-only
   catalog rollups.
+- `smart_home.list_integration_readiness` and
+  `smart_home.get_integration_readiness_summary` tool descriptors for read-only
+  integration activation blocker planning.
 - `smart_home.poll_events` and `smart_home.unsubscribe` tool descriptors for
   model-facing event subscription lifecycle control.
 - `smart_home.list_subscriptions` and `smart_home.inspect_event_log` tool

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -50,6 +50,8 @@ Current scope:
   reusable-primitive inspection
 - D18D catalog-summary descriptors for compact integration and tool surface
   inspection
+- D18D integration-readiness descriptors for bulk activation blocker reports
+  and compact readiness rollups
 - D18D scene inventory/read tool descriptors for model-facing scene lookup
 - D18D event lifecycle tool descriptors for subscribing, polling, and
   unsubscribing from runtime event streams

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1451,6 +1451,8 @@ pub enum SmartHomeTool {
     DescribePrimitive,
     GetIntegrationCatalogSummary,
     GetToolCatalogSummary,
+    ListIntegrationReadiness,
+    GetIntegrationReadinessSummary,
     Discover,
     PairBridge,
     CompletePairing,
@@ -1503,6 +1505,10 @@ impl SmartHomeTool {
                 read_tool("smart_home.get_integration_catalog_summary")
             }
             Self::GetToolCatalogSummary => read_tool("smart_home.get_tool_catalog_summary"),
+            Self::ListIntegrationReadiness => read_tool("smart_home.list_integration_readiness"),
+            Self::GetIntegrationReadinessSummary => {
+                read_tool("smart_home.get_integration_readiness_summary")
+            }
             Self::Discover => ToolDescriptor {
                 tool_id: "smart_home.discover",
                 side_effects: ToolSideEffects::Read,
@@ -2114,6 +2120,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::DescribePrimitive,
         SmartHomeTool::GetIntegrationCatalogSummary,
         SmartHomeTool::GetToolCatalogSummary,
+        SmartHomeTool::ListIntegrationReadiness,
+        SmartHomeTool::GetIntegrationReadinessSummary,
         SmartHomeTool::Discover,
         SmartHomeTool::PairBridge,
         SmartHomeTool::CompletePairing,
@@ -2948,7 +2956,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 45);
+        assert_eq!(catalog.len(), 47);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -2978,6 +2986,15 @@ mod tests {
             .any(|tool| tool.tool_id == "smart_home.get_tool_catalog_summary"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(
+            |tool| tool.tool_id == "smart_home.list_integration_readiness"
+                && tool.side_effects == ToolSideEffects::Read
+                && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]
+        ));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_readiness_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert_eq!(command.side_effects, ToolSideEffects::External);
         assert_eq!(
             command.required_capabilities,
@@ -3141,15 +3158,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 45);
-        assert_eq!(summary.read_tools, 37);
+        assert_eq!(summary.total_tools, 47);
+        assert_eq!(summary.read_tools, 39);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 37);
+        assert_eq!(summary.read_only_tier_tools, 39);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 45);
+        assert_eq!(summary.total_required_capabilities, 47);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this package will be documented in this file.
   dependencies, and review tiers before enabling an integration.
 - Integration readiness reports that expose missing primitive families, missing
   capability grants, and missing delegated integrations before activation.
+- Integration readiness summaries for compact activation-ready, blocker,
+  review, cloud, local, and delegated-target rollups.
 - Computed policy-surface helpers so Chief of Staff tools can identify camera,
   entry-access, climate, energy, cloud, credential, radio-network, and local
   actuation review boundaries before activating integrations.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -30,6 +30,8 @@ runtime and Chief of Staff tools a typed catalog for:
   standard-backed products into primitive/capability/auth/policy requirements
 - readiness reports that compare activation plans against available primitives,
   allowed capabilities, and already-enabled dependency integrations
+- readiness summaries that roll activation blockers, review requirements, and
+  delegated targets into compact planner counts
 - composable bounded catalog queries for D18D read tools that need to combine
   priority, primitive, capability, policy, protocol, local/cloud, and virtual
   alias selectors

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -665,6 +665,118 @@ pub struct IntegrationReadinessReport {
     pub cloud_required: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationReadinessSummary {
+    pub total_reports: usize,
+    pub activation_ready_reports: usize,
+    pub blocked_reports: usize,
+    pub reports_requiring_human_review: usize,
+    pub cloud_required_reports: usize,
+    pub local_only_reports: usize,
+    pub direct_targets: usize,
+    pub delegated_integration_targets: usize,
+    pub delegated_standard_targets: usize,
+    pub reports_missing_primitives: usize,
+    pub reports_missing_capabilities: usize,
+    pub reports_missing_dependencies: usize,
+    pub unique_missing_primitives: usize,
+    pub unique_missing_capabilities: usize,
+    pub unique_missing_dependencies: usize,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+impl IntegrationReadinessSummary {
+    pub fn from_reports<'a>(
+        reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
+    ) -> Self {
+        let mut summary = Self {
+            total_reports: 0,
+            activation_ready_reports: 0,
+            blocked_reports: 0,
+            reports_requiring_human_review: 0,
+            cloud_required_reports: 0,
+            local_only_reports: 0,
+            direct_targets: 0,
+            delegated_integration_targets: 0,
+            delegated_standard_targets: 0,
+            reports_missing_primitives: 0,
+            reports_missing_capabilities: 0,
+            reports_missing_dependencies: 0,
+            unique_missing_primitives: 0,
+            unique_missing_capabilities: 0,
+            unique_missing_dependencies: 0,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+        let mut missing_primitives = BTreeSet::new();
+        let mut missing_capabilities = BTreeSet::new();
+        let mut missing_dependencies = BTreeSet::new();
+
+        for report in reports {
+            summary.total_reports += 1;
+            if report.activation_ready() {
+                summary.activation_ready_reports += 1;
+            } else {
+                summary.blocked_reports += 1;
+            }
+            if report.requires_human_review {
+                summary.reports_requiring_human_review += 1;
+            }
+            if report.cloud_required {
+                summary.cloud_required_reports += 1;
+            }
+            if report.local_only {
+                summary.local_only_reports += 1;
+            }
+            match &report.activation_target {
+                IntegrationActivationTarget::Direct => summary.direct_targets += 1,
+                IntegrationActivationTarget::DelegatedIntegration(_) => {
+                    summary.delegated_integration_targets += 1
+                }
+                IntegrationActivationTarget::DelegatedStandards(_) => {
+                    summary.delegated_standard_targets += 1
+                }
+            }
+            if !report.missing_primitives.is_empty() {
+                summary.reports_missing_primitives += 1;
+            }
+            if !report.missing_capabilities.is_empty() {
+                summary.reports_missing_capabilities += 1;
+            }
+            if !report.missing_dependencies.is_empty() {
+                summary.reports_missing_dependencies += 1;
+            }
+            for primitive in &report.missing_primitives {
+                missing_primitives.insert(*primitive);
+            }
+            for capability_id in &report.missing_capabilities {
+                missing_capabilities.insert(capability_id.clone());
+            }
+            for integration_id in &report.missing_dependencies {
+                missing_dependencies.insert(integration_id.clone());
+            }
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(report.highest_policy_tier);
+        }
+
+        summary.unique_missing_primitives = missing_primitives.len();
+        summary.unique_missing_capabilities = missing_capabilities.len();
+        summary.unique_missing_dependencies = missing_dependencies.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_reports == 0
+    }
+
+    pub fn all_ready(&self) -> bool {
+        self.total_reports > 0 && self.blocked_reports == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_reports > 0
+    }
+}
+
 impl IntegrationReadinessReport {
     pub fn activation_ready(&self) -> bool {
         self.missing_primitives.is_empty()
@@ -3096,6 +3208,18 @@ mod tests {
         assert!(hue.missing_capability(&CapabilityId::trusted("smart_home.command.light")));
         assert!(tasmota.missing_primitive(PrimitiveFamily::Mqtt));
         assert!(tasmota.missing_dependency(&IntegrationId::trusted("mqtt")));
+
+        let summary = IntegrationReadinessSummary::from_reports(reports.iter());
+        assert_eq!(summary.total_reports, reports.len());
+        assert!(summary.has_blockers());
+        assert!(summary.blocked_reports > 0);
+        assert!(summary.reports_missing_primitives > 0);
+        assert!(summary.reports_missing_capabilities > 0);
+        assert!(summary.reports_missing_dependencies > 0);
+        assert!(summary.unique_missing_primitives > 0);
+        assert!(summary.unique_missing_capabilities > 0);
+        assert!(summary.unique_missing_dependencies > 0);
+        assert!(!summary.all_ready());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-level `IntegrationReadinessSummary` aggregation for D23A readiness reports
- expose core D18D descriptors for bulk integration readiness listing and summary tools
- wire Chief handlers, JSON outputs, docs, and end-to-end audit coverage for the new read-only tools

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools