### PR TITLE
feat(closurec): CLOC12.50 — close gap-043 (CLI quote-choice) — HARNESS 57/57

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.56.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-043** — CLI quote-choice optimisation for
+  string literals. **Harness now 57/57 PASS — sixth 100%
+  milestone today** (17/17 → 25/25 → 33/33 → 41/41 → 49/49
+  → 57/57).
+- Added `emit_quoted_string(out, content)`: counts `"` vs
+  `'` occurrences in content. When `"` count > `'` count,
+  switches to single-quoted form (no `\"` escape needed
+  for the content's `"`). Otherwise default to double
+  (tie-break per upstream's `CodePrinter`).
+- Mirrors the logic in `closure-emitter`'s
+  `choose_quote_and_escape` (closed CLOC12 gap-026). The
+  CLI path uses an independent copy because it doesn't go
+  through the AST.
+- Both string-emit sites in the WHITESPACE_ONLY path now
+  call `emit_quoted_string` (main loop + gap-032 pre-emit).
+
+### Added
+
+4 new `gap043_*` inline tests:
+- `gap043_no_quotes_in_content_picks_double` — default
+  case
+- `gap043_single_quotes_only_stay_double` — no escape
+  savings from switching
+- `gap043_more_double_switches_to_single` — target case
+  (one `"`, no `'`)
+- `gap043_tie_picks_double` — tie-break verification
+
 ## [0.55.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -362,11 +362,7 @@ pub fn whitespace_only_minify(
                             }
                         }
                         if is_string_literal(t) {
-                            out.push('"');
-                            push_quoted_string_content(
-                                &mut out, &t.value,
-                            );
-                            out.push('"');
+                            emit_quoted_string(&mut out, &t.value);
                         } else if is_number_literal(t) {
                             out.push_str(&normalize_number_value(&t.value));
                         } else {
@@ -462,9 +458,7 @@ pub fn whitespace_only_minify(
             }
         }
         if is_string_literal(tok) {
-            out.push('"');
-            push_quoted_string_content(&mut out, &tok.value);
-            out.push('"');
+            emit_quoted_string(&mut out, &tok.value);
         } else if is_number_literal(tok) {
             // gap-038: rewrite hex/oct/bin literals to
             // decimal when decimal is no longer than source.
@@ -964,6 +958,50 @@ fn push_quoted_string_content(out: &mut String, content: &str) {
             '\t' => out.push_str("\\t"),
             other => out.push(other),
         }
+    }
+}
+
+/// gap-043: pick the shorter delimiter for a string literal.
+/// Upstream Closure (under WHITESPACE_ONLY) re-quotes string
+/// literals to minimise the escape weight: when content has
+/// more `"` than `'`, switch to single-quoted form (so the
+/// `"` chars stay unescaped); otherwise keep double-quoted.
+/// Ties go to double per upstream's `CodePrinter` (verified
+/// by the JAR probe `'a'` → `"a"`).
+///
+/// This function emits the complete `"..."` or `'...'`
+/// sequence (delimiters + content) to `out`, with all
+/// content characters appropriately escaped for the chosen
+/// quote style. Backslash/control-char escapes are
+/// independent of quote choice.
+///
+/// Mirrors the logic in `closure-emitter`'s
+/// `choose_quote_and_escape` (closed CLOC12 gap-026). The
+/// AST emitter goes through that path; the CLI WHITESPACE_ONLY
+/// path uses this independent copy because it doesn't build
+/// an AST.
+fn emit_quoted_string(out: &mut String, content: &str) {
+    let dq = content.chars().filter(|c| *c == '"').count();
+    let sq = content.chars().filter(|c| *c == '\'').count();
+    if dq > sq {
+        // Single-quote wins — escape `\` and `'`.
+        out.push('\'');
+        for c in content.chars() {
+            match c {
+                '\'' => out.push_str("\\'"),
+                '\\' => out.push_str("\\\\"),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                other => out.push(other),
+            }
+        }
+        out.push('\'');
+    } else {
+        // Double-quote (default, tie-break).
+        out.push('"');
+        push_quoted_string_content(out, content);
+        out.push('"');
     }
 }
 
@@ -2071,6 +2109,49 @@ mod tests {
         assert_eq!(
             minify("do{a();b();}while(x);"),
             "do{a();b()}while(x);"
+        );
+    }
+
+    // ---- gap-043: CLI quote-choice optimisation ----------
+
+    /// **No quotes in content**: defaults to double quotes
+    /// (the existing behaviour). Tie-break to double per
+    /// upstream's `CodePrinter`.
+    #[test]
+    fn gap043_no_quotes_in_content_picks_double() {
+        assert_eq!(minify("var x=\"hello\";"), "var x=\"hello\";");
+    }
+
+    /// **Content has single quotes**: stick with double
+    /// (no escape savings from switching).
+    #[test]
+    fn gap043_single_quotes_only_stay_double() {
+        assert_eq!(
+            minify("var x=\"a'b'c\";"),
+            "var x=\"a'b'c\";"
+        );
+    }
+
+    /// **Content has more double than single quotes**:
+    /// switch to single-quoted form to avoid `\"` escapes.
+    /// This is the target fixture's case in compact form.
+    #[test]
+    fn gap043_more_double_switches_to_single() {
+        // Source contains escaped `"` (one) and no `'`.
+        // After switching to single quotes, the `"` no
+        // longer needs escaping.
+        assert_eq!(
+            minify(r#"var x="\"";"#),
+            r#"var x='"';"#
+        );
+    }
+
+    /// **Tie**: both `"` and `'` appear once. Double wins.
+    #[test]
+    fn gap043_tie_picks_double() {
+        assert_eq!(
+            minify(r#"var x="\"'";"#),
+            r#"var x="\"'";"#
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.55.0
+Version: 0.56.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -89,13 +89,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // arms body_position_next, so gap-032's single-statement
     // flatten fires on `do{a;}while(x);` → `do a;while(x);`.
     // `minify_do_while` flipped IGNORED → PASS.
-    // gap-043: CLI quote-choice optimisation for string
-    // literals. Upstream switches to `'` when content has
-    // escaped `"` characters (saves the backslash). The
-    // AST emitter has this (gap-026 closed in CLOC12.11)
-    // but the CLI WHITESPACE_ONLY path doesn't reuse that
-    // logic. Discovered by CLOC14.8.
-    ("escape_chars", "gap-043: CLI quote-choice"),
+    // gap-043 was RESOLVED in CLOC12.50 — `emit_quoted_string`
+    // helper picks the optimal delimiter (`"` vs `'`) based
+    // on which appears more in the content. `minify_escape_chars`
+    // flipped IGNORED → PASS. **Harness back to 57/57 — sixth
+    // 100% milestone today.**
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -321,7 +321,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-043 — CLI quote-choice optimisation
 
-- **Status:** OPEN — newly discovered by CLOC14.8.
+- **Status:** **RESOLVED** in CLOC12.50 (PR pending). `minify_escape_chars` flipped IGNORED → PASS. **Harness back to 57/57 — sixth 100% milestone today** (after 17/17, 25/25, 33/33, 41/41, 49/49).
 - **Upstream byte-identity test:** `minify_escape_chars` seed fixture.
 - **Why it fails:** Upstream switches between `"` and `'` based on which yields a shorter output (escapes fewer chars). closurec's CLI WHITESPACE_ONLY path always uses `"` via `push_quoted_string_content`. The AST emitter already has this logic (gap-026 closed in CLOC12.11), but the CLI doesn't go through the AST.
 - **What it needs:** Lift `pick_better_quote` and `push_quoted_string_content` logic from closure-emitter into a shared module (or duplicate it carefully) and call it from `whitespace_only.rs`. Counting rule: prefer the quote style that requires fewer escape sequences; tie-break to the source-form's quote.


### PR DESCRIPTION
## Summary

🎯 **SIXTH 100% MILESTONE today.** Harness 56/57 → **57/57 PASS**.

Today's progression:
- 17/17 (CLOC12.42) → 25/25 (CLOC12.43) → 33/33 (CLOC12.45)
- 41/41 (CLOC12.46) → 49/49 (CLOC12.48) → **57/57** (CLOC12.50) ← this PR

## What's new

Added \`emit_quoted_string(out, content)\`: counts \`\"\` vs \`'\` chars in content. When \`\"\` count > \`'\` count, wrap with \`'..'\` (no need to escape content's \`\"\`). Otherwise default to double (tie → double).

Mirrors AST emitter's \`choose_quote_and_escape\` (gap-026/CLOC12.11). The CLI path uses an independent copy because it doesn't go through the AST.

Both string-emit sites (main loop + gap-032 pre-emit) route through this.

## Tests

4 new \`gap043_*\` inline tests + target fixture passes. Full suite: **353 passed**.

## Security review

PASS. Traced 5 concerns including pre-existing escape-completeness limitation acknowledged in docstrings.

## Version

0.55.0 → 0.56.0.

## Test plan

- [x] \`cargo test\` → 353 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 57 matched, 0 failed, 0 skipped (of 57)
- [x] Security review → PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)