### PR TITLE
Add browser drag/drop descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness drag/drop descriptors now expose draggable state, drag/drop
+  handlers, pointer handler inventory, and blocked drag paths as a flat
+  browser-planning inventory.
 - Browser-readiness input-planning descriptors now expose text-entry hints,
   datalist suggestions, validation blockers, form ownership, and contenteditable
   editing hosts as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -865,6 +865,7 @@ pub struct BrowserDocument {
     pub focus_navigation_descriptors: Vec<BrowserFocusNavigationDescriptor>,
     pub keyboard_interaction_descriptors: Vec<BrowserKeyboardInteractionDescriptor>,
     pub input_planning_descriptors: Vec<BrowserInputPlanningDescriptor>,
+    pub drag_drop_descriptors: Vec<BrowserDragDropDescriptor>,
     pub disclosures: Vec<BrowserDisclosure>,
     pub disclosure_state_descriptors: Vec<BrowserDisclosureStateDescriptor>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
@@ -2380,6 +2381,31 @@ pub struct BrowserInputPlanningDescriptor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserDragDropDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub role: Option<String>,
+    pub authored_role: Option<String>,
+    pub drag_kind: String,
+    pub text: String,
+    pub draggable: Option<String>,
+    pub draggable_state: Option<String>,
+    pub drag_source: bool,
+    pub drop_target: bool,
+    pub drag_handlers: Vec<String>,
+    pub drop_handlers: Vec<String>,
+    pub pointer_handlers: Vec<String>,
+    pub handler_count: usize,
+    pub disabled: bool,
+    pub hidden: bool,
+    pub inert: bool,
+    pub aria_hidden: bool,
+    pub drag_blocked: bool,
+    pub drag_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserPopover {
     pub element: String,
     pub id: Option<String>,
@@ -2989,6 +3015,7 @@ impl BrowserDocument {
             browser_keyboard_interaction_descriptors(&summary.interactive_elements);
         summary.input_planning_descriptors =
             browser_input_planning_descriptors(&summary.forms, &summary.interactive_elements);
+        summary.drag_drop_descriptors = browser_drag_drop_descriptors(&summary);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -13185,6 +13212,305 @@ fn browser_text_entry_input_kind(text_entry: &BrowserFormTextEntry) -> &'static 
     }
 }
 
+fn browser_drag_drop_descriptors(document: &BrowserDocument) -> Vec<BrowserDragDropDescriptor> {
+    let mut descriptors = Vec::new();
+
+    for element in &document.interactive_elements {
+        let event_descriptor = browser_matching_event_descriptor(
+            &document.event_handler_descriptors,
+            &element.element,
+            element.id.as_deref(),
+        );
+        if browser_interactive_has_drag_drop_state(element, event_descriptor) {
+            descriptors.push(browser_drag_drop_descriptor_from_interactive(
+                element,
+                event_descriptor,
+            ));
+        }
+    }
+
+    for global in &document.global_state_descriptors {
+        if descriptors
+            .iter()
+            .any(|descriptor| descriptor.element == global.element && descriptor.id == global.id)
+        {
+            continue;
+        }
+        let event_descriptor = browser_matching_event_descriptor(
+            &document.event_handler_descriptors,
+            &global.element,
+            global.id.as_deref(),
+        );
+        if browser_global_has_drag_drop_state(global, event_descriptor) {
+            descriptors.push(browser_drag_drop_descriptor_from_global(
+                global,
+                event_descriptor,
+            ));
+        }
+    }
+
+    for event_descriptor in &document.event_handler_descriptors {
+        if event_descriptor.source != "element" {
+            continue;
+        }
+        if descriptors.iter().any(|descriptor| {
+            descriptor.element == event_descriptor.element && descriptor.id == event_descriptor.id
+        }) {
+            continue;
+        }
+        if browser_event_descriptor_has_drag_drop_state(event_descriptor) {
+            descriptors.push(browser_drag_drop_descriptor_from_event(event_descriptor));
+        }
+    }
+
+    descriptors
+}
+
+fn browser_matching_event_descriptor<'a>(
+    event_descriptors: &'a [BrowserEventHandlerDescriptor],
+    element: &str,
+    id: Option<&str>,
+) -> Option<&'a BrowserEventHandlerDescriptor> {
+    event_descriptors.iter().find(|descriptor| {
+        descriptor.source == "element"
+            && descriptor.element == element
+            && descriptor.id.as_deref() == id
+    })
+}
+
+fn browser_interactive_has_drag_drop_state(
+    element: &BrowserInteractiveElement,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> bool {
+    element.draggable.is_some()
+        || event_descriptor
+            .map(browser_event_descriptor_has_drag_drop_state)
+            .unwrap_or(false)
+}
+
+fn browser_global_has_drag_drop_state(
+    global: &BrowserGlobalStateDescriptor,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> bool {
+    global.draggable.is_some()
+        || event_descriptor
+            .map(browser_event_descriptor_has_drag_drop_state)
+            .unwrap_or(false)
+}
+
+fn browser_event_descriptor_has_drag_drop_state(
+    event_descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !browser_event_handlers_by_kind(&event_descriptor.event_handlers, browser_drag_event).is_empty()
+        || !browser_event_handlers_by_kind(&event_descriptor.event_handlers, browser_drop_event)
+            .is_empty()
+}
+
+fn browser_drag_drop_descriptor_from_interactive(
+    element: &BrowserInteractiveElement,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers = event_descriptor
+        .map(|descriptor| {
+            browser_event_handlers_by_kind(&descriptor.event_handlers, browser_drag_event)
+        })
+        .unwrap_or_default();
+    let drop_handlers = event_descriptor
+        .map(|descriptor| {
+            browser_event_handlers_by_kind(&descriptor.event_handlers, browser_drop_event)
+        })
+        .unwrap_or_default();
+    let pointer_handlers = event_descriptor
+        .map(|descriptor| descriptor.pointer_handlers.clone())
+        .unwrap_or_default();
+    let drag_block_reasons = browser_drag_block_reasons_for_interactive(element);
+    let drag_source = browser_draggable_source(element.draggable_state.as_deref());
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: element.element.clone(),
+        id: element.id.clone(),
+        classes: Vec::new(),
+        role: element.role.clone(),
+        authored_role: element.authored_role.clone(),
+        drag_kind: browser_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: element.text.clone(),
+        draggable: element.draggable.clone(),
+        draggable_state: element.draggable_state.clone(),
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers,
+        disabled: element.disabled,
+        hidden: element.hidden,
+        inert: element.inert,
+        aria_hidden: element.aria_hidden,
+        drag_blocked: !drag_block_reasons.is_empty(),
+        drag_block_reasons,
+    }
+}
+
+fn browser_drag_drop_descriptor_from_global(
+    global: &BrowserGlobalStateDescriptor,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers = event_descriptor
+        .map(|descriptor| {
+            browser_event_handlers_by_kind(&descriptor.event_handlers, browser_drag_event)
+        })
+        .unwrap_or_default();
+    let drop_handlers = event_descriptor
+        .map(|descriptor| {
+            browser_event_handlers_by_kind(&descriptor.event_handlers, browser_drop_event)
+        })
+        .unwrap_or_default();
+    let pointer_handlers = event_descriptor
+        .map(|descriptor| descriptor.pointer_handlers.clone())
+        .unwrap_or_default();
+    let drag_block_reasons = browser_drag_block_reasons_for_global(global);
+    let drag_source = browser_draggable_source(global.draggable_state.as_deref());
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: global.element.clone(),
+        id: global.id.clone(),
+        classes: global.classes.clone(),
+        role: browser_content_role(&global.element).map(ToOwned::to_owned),
+        authored_role: None,
+        drag_kind: browser_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: global.text.clone(),
+        draggable: global.draggable.clone(),
+        draggable_state: global.draggable_state.clone(),
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers,
+        disabled: false,
+        hidden: global.hidden,
+        inert: global.inert,
+        aria_hidden: false,
+        drag_blocked: !drag_block_reasons.is_empty(),
+        drag_block_reasons,
+    }
+}
+
+fn browser_drag_drop_descriptor_from_event(
+    event_descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers =
+        browser_event_handlers_by_kind(&event_descriptor.event_handlers, browser_drag_event);
+    let drop_handlers =
+        browser_event_handlers_by_kind(&event_descriptor.event_handlers, browser_drop_event);
+    let drag_block_reasons = Vec::new();
+    let drag_source = false;
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: event_descriptor.element.clone(),
+        id: event_descriptor.id.clone(),
+        classes: event_descriptor.classes.clone(),
+        role: event_descriptor.role.clone(),
+        authored_role: None,
+        drag_kind: browser_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &event_descriptor.pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: event_descriptor.text.clone(),
+        draggable: None,
+        draggable_state: None,
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers: event_descriptor.pointer_handlers.clone(),
+        disabled: false,
+        hidden: false,
+        inert: false,
+        aria_hidden: false,
+        drag_blocked: false,
+        drag_block_reasons,
+    }
+}
+
+fn browser_drag_block_reasons_for_interactive(element: &BrowserInteractiveElement) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if element.disabled {
+        reasons.push("disabled".to_string());
+    }
+    if element.hidden {
+        reasons.push("hidden".to_string());
+    }
+    if element.inert {
+        reasons.push("inert".to_string());
+    }
+    if element.aria_hidden {
+        reasons.push("aria-hidden".to_string());
+    }
+    if element.aria_disabled.as_deref() == Some("true") {
+        reasons.push("aria-disabled".to_string());
+    }
+    reasons
+}
+
+fn browser_drag_block_reasons_for_global(global: &BrowserGlobalStateDescriptor) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if global.hidden {
+        reasons.push("hidden".to_string());
+    }
+    if global.inert {
+        reasons.push("inert".to_string());
+    }
+    reasons
+}
+
+fn browser_draggable_source(draggable_state: Option<&str>) -> bool {
+    matches!(draggable_state, Some("true") | Some("auto"))
+}
+
+fn browser_drag_kind(
+    drag_source: bool,
+    drop_target: bool,
+    drag_handlers: &[String],
+    pointer_handlers: &[String],
+    drag_block_reasons: &[String],
+) -> String {
+    if !drag_block_reasons.is_empty() {
+        "blocked".to_string()
+    } else if drag_source && drop_target {
+        "drag-source-and-drop-target".to_string()
+    } else if drag_source {
+        "drag-source".to_string()
+    } else if drop_target {
+        "drop-target".to_string()
+    } else if !drag_handlers.is_empty() {
+        "drag-handler".to_string()
+    } else if !pointer_handlers.is_empty() {
+        "pointer-handler".to_string()
+    } else {
+        "metadata".to_string()
+    }
+}
+
 fn browser_command_role(element: &Element) -> String {
     browser_authored_role(element).unwrap_or_else(|| {
         browser_content_role(&element.name)
@@ -15028,6 +15354,17 @@ fn browser_pointer_event(handler: &str) -> bool {
             | "ondragover"
             | "ondrop"
             | "onwheel"
+    )
+}
+
+fn browser_drag_event(handler: &str) -> bool {
+    matches!(handler, "ondrag" | "ondragstart" | "ondragend")
+}
+
+fn browser_drop_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "ondragenter" | "ondragleave" | "ondragover" | "ondrop"
     )
 }
 
@@ -20629,6 +20966,63 @@ mod tests {
         assert_eq!(hidden.input_kind, "editing-host");
         assert!(hidden.input_blocked);
         assert_eq!(hidden.input_block_reasons, vec!["hidden"]);
+    }
+
+    #[test]
+    fn browser_drag_drop_descriptors_track_sources_targets_handlers_and_blockers() {
+        let document = parse_html(
+            "<body><main id=board ondragover=allowDrop() ondrop=dropCard()>Board</main>\
+             <div id=card draggable=true ondragstart=startDrag() ondragend=endDrag()>Card</div>\
+             <button id=target draggable=auto disabled ondragenter=enterDrop() ondrop=dropButton()>Target</button>\
+             <p id=secret hidden draggable=true>Secret</p></body>",
+        )
+        .unwrap();
+
+        let summary = BrowserDocument::from_document(&document);
+        assert_eq!(summary.drag_drop_descriptors.len(), 4);
+
+        let board = summary
+            .drag_drop_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("board"))
+            .expect("board drop target descriptor");
+        assert_eq!(board.drag_kind, "drop-target");
+        assert!(board.drop_target);
+        assert_eq!(board.drop_handlers, vec!["ondragover", "ondrop"]);
+        assert_eq!(board.handler_count, 2);
+
+        let card = summary
+            .drag_drop_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("card"))
+            .expect("card drag source descriptor");
+        assert_eq!(card.drag_kind, "drag-source");
+        assert_eq!(card.draggable.as_deref(), Some("true"));
+        assert_eq!(card.draggable_state.as_deref(), Some("true"));
+        assert!(card.drag_source);
+        assert_eq!(card.drag_handlers, vec!["ondragstart", "ondragend"]);
+        assert!(!card.drag_blocked);
+
+        let target = summary
+            .drag_drop_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("target"))
+            .expect("target drop descriptor");
+        assert_eq!(target.drag_kind, "blocked");
+        assert_eq!(target.draggable_state.as_deref(), Some("auto"));
+        assert!(target.drag_source);
+        assert!(target.drop_target);
+        assert_eq!(target.drop_handlers, vec!["ondragenter", "ondrop"]);
+        assert_eq!(target.drag_block_reasons, vec!["disabled"]);
+
+        let secret = summary
+            .drag_drop_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("secret"))
+            .expect("secret blocked drag descriptor");
+        assert_eq!(secret.drag_kind, "blocked");
+        assert!(secret.drag_source);
+        assert_eq!(secret.drag_block_reasons, vec!["hidden"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -4,12 +4,12 @@ use coding_adventures_html_parser::{
     BrowserAriaRelationDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
     BrowserDataAttribute, BrowserDataAttributeDescriptor, BrowserDatalistOption, BrowserDisclosure,
     BrowserDisclosureStateDescriptor, BrowserDocument, BrowserDocumentMetadata,
-    BrowserDocumentPolicyDescriptor, BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor,
-    BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor, BrowserFocusNavigationDescriptor,
-    BrowserForm, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
-    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
+    BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor, BrowserEmbeddedContext,
+    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
+    BrowserFocusNavigationDescriptor, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
+    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
+    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
+    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
     BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
@@ -135,6 +135,8 @@ struct ExpectedBrowserDocument {
     keyboard_interaction_descriptors: Option<Vec<ExpectedKeyboardInteractionDescriptor>>,
     #[serde(default)]
     input_planning_descriptors: Option<Vec<ExpectedInputPlanningDescriptor>>,
+    #[serde(default)]
+    drag_drop_descriptors: Option<Vec<ExpectedDragDropDescriptor>>,
     #[serde(default)]
     disclosures: Vec<ExpectedDisclosure>,
     #[serde(default)]
@@ -2135,6 +2137,50 @@ struct ExpectedInputPlanningDescriptor {
     input_blocked: bool,
     #[serde(default)]
     input_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDragDropDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    authored_role: Option<String>,
+    drag_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    draggable: Option<String>,
+    #[serde(default)]
+    draggable_state: Option<String>,
+    #[serde(default)]
+    drag_source: bool,
+    #[serde(default)]
+    drop_target: bool,
+    #[serde(default)]
+    drag_handlers: Vec<String>,
+    #[serde(default)]
+    drop_handlers: Vec<String>,
+    #[serde(default)]
+    pointer_handlers: Vec<String>,
+    #[serde(default)]
+    handler_count: usize,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    hidden: bool,
+    #[serde(default)]
+    inert: bool,
+    #[serde(default)]
+    aria_hidden: bool,
+    #[serde(default)]
+    drag_blocked: bool,
+    #[serde(default)]
+    drag_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4306,6 +4352,26 @@ fn browser_input_planning_descriptors_track_text_controls_and_editing_hints() {
 }
 
 #[test]
+fn browser_drag_drop_descriptors_track_draggable_state_handlers_and_blockers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "interactive-element-state-page")
+        .expect("interactive drag/drop fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("interactive drag/drop fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.drag_drop_descriptors,
+        case.expected.into_browser_document().drag_drop_descriptors,
+        "drag/drop descriptors should preserve draggable state, drag/drop handlers, pointer handlers, and blocked drag paths",
+    );
+}
+
+#[test]
 fn browser_global_state_descriptor_metadata_tracks_non_form_global_states() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -4551,6 +4617,16 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedEmbeddedContext::into_browser_embedded_context)
             .collect();
+        let event_handler_descriptors: Vec<_> = self
+            .event_handler_descriptors
+            .into_iter()
+            .map(ExpectedEventHandlerDescriptor::into_browser_event_handler_descriptor)
+            .collect();
+        let global_state_descriptors: Vec<_> = self
+            .global_state_descriptors
+            .into_iter()
+            .map(ExpectedGlobalStateDescriptor::into_browser_global_state_descriptor)
+            .collect();
         let resource_endpoint_descriptors = self
             .resource_endpoint_descriptors
             .map(|descriptors| {
@@ -4689,6 +4765,21 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_input_planning_descriptors(&forms, &interactive_elements));
+        let drag_drop_descriptors = self
+            .drag_drop_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedDragDropDescriptor::into_browser_drag_drop_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                expected_drag_drop_descriptors(
+                    &interactive_elements,
+                    &global_state_descriptors,
+                    &event_handler_descriptors,
+                )
+            });
 
         BrowserDocument {
             title: self.title,
@@ -4703,11 +4794,7 @@ impl ExpectedBrowserDocument {
             body_dir: self.body_dir,
             document_event_handlers: self.document_event_handlers,
             body_event_handlers: self.body_event_handlers,
-            event_handler_descriptors: self
-                .event_handler_descriptors
-                .into_iter()
-                .map(ExpectedEventHandlerDescriptor::into_browser_event_handler_descriptor)
-                .collect(),
+            event_handler_descriptors,
             body_text: self.body_text,
             metas: self
                 .metas
@@ -4813,6 +4900,7 @@ impl ExpectedBrowserDocument {
             focus_navigation_descriptors,
             keyboard_interaction_descriptors,
             input_planning_descriptors,
+            drag_drop_descriptors,
             disclosures,
             disclosure_state_descriptors,
             component_hydration_targets: self
@@ -4825,11 +4913,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedDataAttributeDescriptor::into_browser_data_attribute_descriptor)
                 .collect(),
-            global_state_descriptors: self
-                .global_state_descriptors
-                .into_iter()
-                .map(ExpectedGlobalStateDescriptor::into_browser_global_state_descriptor)
-                .collect(),
+            global_state_descriptors,
             structured_items: self
                 .structured_items
                 .into_iter()
@@ -6064,6 +6148,418 @@ fn expected_text_entry_input_kind(text_entry: &BrowserFormTextEntry) -> &'static
     }
 }
 
+fn expected_content_role(name: &str) -> Option<&'static str> {
+    match name {
+        "base" | "link" | "meta" | "param" | "script" | "style" | "template" | "title" => None,
+        "a" => Some("link"),
+        "area" => Some("image_map_area"),
+        "img" => Some("image"),
+        "map" => Some("image_map"),
+        "picture" => Some("picture"),
+        "source" => Some("media_source"),
+        "track" => Some("media_track"),
+        "iframe" | "frame" => Some("frame"),
+        "embed" => Some("embed"),
+        "object" => Some("object"),
+        "audio" | "video" => Some("media"),
+        "canvas" => Some("canvas"),
+        "slot" => Some("slot"),
+        "br" | "wbr" => Some("line_break"),
+        "hr" => Some("separator"),
+        "blockquote" => Some("quote_block"),
+        "q" => Some("quote"),
+        "data" => Some("data"),
+        "time" => Some("time"),
+        "mark" => Some("mark"),
+        "ins" => Some("inserted"),
+        "del" => Some("deleted"),
+        "ruby" => Some("ruby"),
+        "rb" => Some("ruby_base"),
+        "rt" => Some("ruby_text"),
+        "rp" => Some("ruby_fallback"),
+        "rtc" => Some("ruby_text_container"),
+        "bdi" => Some("bidi_isolate"),
+        "bdo" => Some("bidi_override"),
+        "figure" => Some("figure"),
+        "figcaption" => Some("figure_caption"),
+        "details" => Some("disclosure"),
+        "summary" => Some("disclosure_summary"),
+        "dialog" => Some("dialog"),
+        "search" => Some("search"),
+        "address" => Some("contact"),
+        "dl" => Some("description_list"),
+        "dt" => Some("description_term"),
+        "dd" => Some("description_details"),
+        "p" => Some("paragraph"),
+        "pre" | "plaintext" | "xmp" | "listing" => Some("preformatted"),
+        "article" => Some("article"),
+        "aside" => Some("aside"),
+        "footer" => Some("footer"),
+        "header" => Some("header"),
+        "hgroup" => Some("heading_group"),
+        "main" => Some("main"),
+        "nav" => Some("navigation"),
+        "section" => Some("section"),
+        "form" => Some("form"),
+        "fieldset" => Some("form_group"),
+        "label" => Some("label"),
+        "legend" => Some("legend"),
+        "meter" => Some("meter"),
+        "progress" => Some("progress"),
+        "input" | "button" | "select" | "textarea" => Some("control"),
+        "optgroup" => Some("option_group"),
+        "option" => Some("option"),
+        "ul" | "ol" | "menu" | "dir" => Some("list"),
+        "li" => Some("list_item"),
+        "table" => Some("table"),
+        "caption" => Some("table_caption"),
+        "colgroup" => Some("table_column_group"),
+        "col" => Some("table_column"),
+        "tbody" | "thead" | "tfoot" => Some("table_section"),
+        "tr" => Some("table_row"),
+        "td" | "th" => Some("table_cell"),
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Some("heading"),
+        name if expected_is_browser_block_element(name) => Some("block"),
+        _ => Some("inline"),
+    }
+}
+
+fn expected_is_browser_block_element(name: &str) -> bool {
+    matches!(
+        name,
+        "address"
+            | "article"
+            | "aside"
+            | "blockquote"
+            | "body"
+            | "center"
+            | "details"
+            | "dialog"
+            | "div"
+            | "fieldset"
+            | "figcaption"
+            | "figure"
+            | "footer"
+            | "header"
+            | "hgroup"
+            | "hr"
+            | "html"
+            | "legend"
+            | "main"
+            | "nav"
+            | "p"
+            | "plaintext"
+            | "pre"
+            | "section"
+            | "summary"
+            | "xmp"
+    )
+}
+
+fn expected_drag_drop_descriptors(
+    interactive_elements: &[BrowserInteractiveElement],
+    global_state_descriptors: &[BrowserGlobalStateDescriptor],
+    event_handler_descriptors: &[BrowserEventHandlerDescriptor],
+) -> Vec<BrowserDragDropDescriptor> {
+    let mut descriptors = Vec::new();
+
+    for element in interactive_elements {
+        let event_descriptor = expected_matching_event_descriptor(
+            event_handler_descriptors,
+            &element.element,
+            element.id.as_deref(),
+        );
+        if expected_interactive_has_drag_drop_state(element, event_descriptor) {
+            descriptors.push(expected_drag_drop_descriptor_from_interactive(
+                element,
+                event_descriptor,
+            ));
+        }
+    }
+
+    for global in global_state_descriptors {
+        if descriptors
+            .iter()
+            .any(|descriptor| descriptor.element == global.element && descriptor.id == global.id)
+        {
+            continue;
+        }
+        let event_descriptor = expected_matching_event_descriptor(
+            event_handler_descriptors,
+            &global.element,
+            global.id.as_deref(),
+        );
+        if expected_global_has_drag_drop_state(global, event_descriptor) {
+            descriptors.push(expected_drag_drop_descriptor_from_global(
+                global,
+                event_descriptor,
+            ));
+        }
+    }
+
+    for event_descriptor in event_handler_descriptors {
+        if event_descriptor.source != "element" {
+            continue;
+        }
+        if descriptors.iter().any(|descriptor| {
+            descriptor.element == event_descriptor.element && descriptor.id == event_descriptor.id
+        }) {
+            continue;
+        }
+        if expected_event_descriptor_has_drag_drop_state(event_descriptor) {
+            descriptors.push(expected_drag_drop_descriptor_from_event(event_descriptor));
+        }
+    }
+
+    descriptors
+}
+
+fn expected_matching_event_descriptor<'a>(
+    event_descriptors: &'a [BrowserEventHandlerDescriptor],
+    element: &str,
+    id: Option<&str>,
+) -> Option<&'a BrowserEventHandlerDescriptor> {
+    event_descriptors.iter().find(|descriptor| {
+        descriptor.source == "element"
+            && descriptor.element == element
+            && descriptor.id.as_deref() == id
+    })
+}
+
+fn expected_interactive_has_drag_drop_state(
+    element: &BrowserInteractiveElement,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> bool {
+    element.draggable.is_some()
+        || event_descriptor
+            .map(expected_event_descriptor_has_drag_drop_state)
+            .unwrap_or(false)
+}
+
+fn expected_global_has_drag_drop_state(
+    global: &BrowserGlobalStateDescriptor,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> bool {
+    global.draggable.is_some()
+        || event_descriptor
+            .map(expected_event_descriptor_has_drag_drop_state)
+            .unwrap_or(false)
+}
+
+fn expected_event_descriptor_has_drag_drop_state(
+    event_descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !expected_event_handlers_by_kind(&event_descriptor.event_handlers, expected_drag_event)
+        .is_empty()
+        || !expected_event_handlers_by_kind(&event_descriptor.event_handlers, expected_drop_event)
+            .is_empty()
+}
+
+fn expected_drag_drop_descriptor_from_interactive(
+    element: &BrowserInteractiveElement,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers = event_descriptor
+        .map(|descriptor| {
+            expected_event_handlers_by_kind(&descriptor.event_handlers, expected_drag_event)
+        })
+        .unwrap_or_default();
+    let drop_handlers = event_descriptor
+        .map(|descriptor| {
+            expected_event_handlers_by_kind(&descriptor.event_handlers, expected_drop_event)
+        })
+        .unwrap_or_default();
+    let pointer_handlers = event_descriptor
+        .map(|descriptor| descriptor.pointer_handlers.clone())
+        .unwrap_or_default();
+    let drag_block_reasons = expected_drag_block_reasons_for_interactive(element);
+    let drag_source = expected_draggable_source(element.draggable_state.as_deref());
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: element.element.clone(),
+        id: element.id.clone(),
+        classes: Vec::new(),
+        role: element.role.clone(),
+        authored_role: element.authored_role.clone(),
+        drag_kind: expected_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: element.text.clone(),
+        draggable: element.draggable.clone(),
+        draggable_state: element.draggable_state.clone(),
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers,
+        disabled: element.disabled,
+        hidden: element.hidden,
+        inert: element.inert,
+        aria_hidden: element.aria_hidden,
+        drag_blocked: !drag_block_reasons.is_empty(),
+        drag_block_reasons,
+    }
+}
+
+fn expected_drag_drop_descriptor_from_global(
+    global: &BrowserGlobalStateDescriptor,
+    event_descriptor: Option<&BrowserEventHandlerDescriptor>,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers = event_descriptor
+        .map(|descriptor| {
+            expected_event_handlers_by_kind(&descriptor.event_handlers, expected_drag_event)
+        })
+        .unwrap_or_default();
+    let drop_handlers = event_descriptor
+        .map(|descriptor| {
+            expected_event_handlers_by_kind(&descriptor.event_handlers, expected_drop_event)
+        })
+        .unwrap_or_default();
+    let pointer_handlers = event_descriptor
+        .map(|descriptor| descriptor.pointer_handlers.clone())
+        .unwrap_or_default();
+    let drag_block_reasons = expected_drag_block_reasons_for_global(global);
+    let drag_source = expected_draggable_source(global.draggable_state.as_deref());
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: global.element.clone(),
+        id: global.id.clone(),
+        classes: global.classes.clone(),
+        role: expected_content_role(&global.element).map(ToOwned::to_owned),
+        authored_role: None,
+        drag_kind: expected_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: global.text.clone(),
+        draggable: global.draggable.clone(),
+        draggable_state: global.draggable_state.clone(),
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers,
+        disabled: false,
+        hidden: global.hidden,
+        inert: global.inert,
+        aria_hidden: false,
+        drag_blocked: !drag_block_reasons.is_empty(),
+        drag_block_reasons,
+    }
+}
+
+fn expected_drag_drop_descriptor_from_event(
+    event_descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserDragDropDescriptor {
+    let drag_handlers =
+        expected_event_handlers_by_kind(&event_descriptor.event_handlers, expected_drag_event);
+    let drop_handlers =
+        expected_event_handlers_by_kind(&event_descriptor.event_handlers, expected_drop_event);
+    let drag_block_reasons = Vec::new();
+    let drag_source = false;
+    let drop_target = !drop_handlers.is_empty();
+
+    BrowserDragDropDescriptor {
+        element: event_descriptor.element.clone(),
+        id: event_descriptor.id.clone(),
+        classes: event_descriptor.classes.clone(),
+        role: event_descriptor.role.clone(),
+        authored_role: None,
+        drag_kind: expected_drag_kind(
+            drag_source,
+            drop_target,
+            &drag_handlers,
+            &event_descriptor.pointer_handlers,
+            &drag_block_reasons,
+        ),
+        text: event_descriptor.text.clone(),
+        draggable: None,
+        draggable_state: None,
+        drag_source,
+        drop_target,
+        handler_count: drag_handlers.len() + drop_handlers.len(),
+        drag_handlers,
+        drop_handlers,
+        pointer_handlers: event_descriptor.pointer_handlers.clone(),
+        disabled: false,
+        hidden: false,
+        inert: false,
+        aria_hidden: false,
+        drag_blocked: false,
+        drag_block_reasons,
+    }
+}
+
+fn expected_drag_block_reasons_for_interactive(element: &BrowserInteractiveElement) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if element.disabled {
+        reasons.push("disabled".to_string());
+    }
+    if element.hidden {
+        reasons.push("hidden".to_string());
+    }
+    if element.inert {
+        reasons.push("inert".to_string());
+    }
+    if element.aria_hidden {
+        reasons.push("aria-hidden".to_string());
+    }
+    if element.aria_disabled.as_deref() == Some("true") {
+        reasons.push("aria-disabled".to_string());
+    }
+    reasons
+}
+
+fn expected_drag_block_reasons_for_global(global: &BrowserGlobalStateDescriptor) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if global.hidden {
+        reasons.push("hidden".to_string());
+    }
+    if global.inert {
+        reasons.push("inert".to_string());
+    }
+    reasons
+}
+
+fn expected_draggable_source(draggable_state: Option<&str>) -> bool {
+    matches!(draggable_state, Some("true") | Some("auto"))
+}
+
+fn expected_drag_kind(
+    drag_source: bool,
+    drop_target: bool,
+    drag_handlers: &[String],
+    pointer_handlers: &[String],
+    drag_block_reasons: &[String],
+) -> String {
+    if !drag_block_reasons.is_empty() {
+        "blocked".to_string()
+    } else if drag_source && drop_target {
+        "drag-source-and-drop-target".to_string()
+    } else if drag_source {
+        "drag-source".to_string()
+    } else if drop_target {
+        "drop-target".to_string()
+    } else if !drag_handlers.is_empty() {
+        "drag-handler".to_string()
+    } else if !pointer_handlers.is_empty() {
+        "pointer-handler".to_string()
+    } else {
+        "metadata".to_string()
+    }
+}
+
 fn expected_tabindex_order(tabindex: Option<&str>) -> Option<i32> {
     tabindex.and_then(|tabindex| tabindex.trim().parse::<i32>().ok())
 }
@@ -6093,6 +6589,17 @@ fn expected_input_event(handler: &str) -> bool {
             | "oncompositionstart"
             | "oncompositionupdate"
             | "oncompositionend"
+    )
+}
+
+fn expected_drag_event(handler: &str) -> bool {
+    matches!(handler, "ondrag" | "ondragstart" | "ondragend")
+}
+
+fn expected_drop_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "ondragenter" | "ondragleave" | "ondragover" | "ondrop"
     )
 }
 
@@ -7341,6 +7848,34 @@ impl ExpectedInputPlanningDescriptor {
             aria_hidden: self.aria_hidden,
             input_blocked: self.input_blocked,
             input_block_reasons: self.input_block_reasons,
+        }
+    }
+}
+
+impl ExpectedDragDropDescriptor {
+    fn into_browser_drag_drop_descriptor(self) -> BrowserDragDropDescriptor {
+        BrowserDragDropDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            role: self.role,
+            authored_role: self.authored_role,
+            drag_kind: self.drag_kind,
+            text: self.text,
+            draggable: self.draggable,
+            draggable_state: self.draggable_state,
+            drag_source: self.drag_source,
+            drop_target: self.drop_target,
+            drag_handlers: self.drag_handlers,
+            drop_handlers: self.drop_handlers,
+            pointer_handlers: self.pointer_handlers,
+            handler_count: self.handler_count,
+            disabled: self.disabled,
+            hidden: self.hidden,
+            inert: self.inert,
+            aria_hidden: self.aria_hidden,
+            drag_blocked: self.drag_blocked,
+            drag_block_reasons: self.drag_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -55,6 +55,8 @@ Keyboard-interaction descriptor cases pin access keys, ARIA shortcuts, keyboard
 handlers, focus order, editing hosts, and blocked keyboard paths.
 Input-planning descriptor cases pin text-entry hints, datalist suggestions,
 validation blockers, form ownership, and contenteditable editing hosts.
+Drag/drop descriptor cases pin draggable state, drag/drop handler routing,
+pointer handler inventory, and hidden/inert/disabled blocked drag paths.
 Inline semantic cases pin machine-readable values, edits, quotes, phrase-level
 annotations, ruby annotation nodes, and bidi overrides.
 Media cases pin audio/video playback flags, preload/poster metadata, and

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1326,7 +1326,7 @@
     {
       "id": "interactive-element-state-page",
       "description": "Browser document summaries expose focus, editing, popover, command, hidden, inert, ARIA relation/state, and inline handler metadata as a flat interactive inventory.",
-      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel aria-owns=\"panel menu-popup\" aria-activedescendant=action aria-haspopup=menu aria-disabled=false tabindex=0 accesskey=\"m /\" aria-keyshortcuts=\"Alt+M /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog onclick=showMenu()>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help aria-live=polite aria-busy=true inert><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div id=action role=button tabindex=-1 aria-keyshortcuts=\"Enter Space\" aria-pressed=mixed aria-current=page aria-selected=false aria-invalid=spelling aria-required=true contenteditable=plaintext-only draggable=auto spellcheck=false translate=no popover=manual onkeydown=keyAction()>Inline action</div><p id=editable contenteditable spellcheck=true translate=yes>Editable copy</p></section><dialog id=dialog open aria-label=\"Dialog\" aria-modal=true accesskey=\"d x\"><p>Dialog copy</p></dialog><details id=more open><summary>More</summary><p>Extra</p></details><p id=secret hidden aria-keyshortcuts=H>Hidden copy</p><span id=decorative aria-hidden=true>Decorative</span><input id=disabled disabled value=no></main>",
+      "input": "<body><main id=app aria-label=\"App shell\"><button id=menu aria-expanded=false aria-controls=panel aria-owns=\"panel menu-popup\" aria-activedescendant=action aria-haspopup=menu aria-disabled=false tabindex=0 accesskey=\"m /\" aria-keyshortcuts=\"Alt+M /\" popovertarget=panel-pop popovertargetaction=toggle command=show-modal commandfor=dialog onclick=showMenu()>Menu</button><section id=panel role=region aria-labelledby=panel-title aria-describedby=panel-help aria-live=polite aria-busy=true inert ondragover=allowDrop() ondrop=dropPanel()><h2 id=panel-title>Settings</h2><p id=panel-help>Choose options</p><div id=action role=button tabindex=-1 aria-keyshortcuts=\"Enter Space\" aria-pressed=mixed aria-current=page aria-selected=false aria-invalid=spelling aria-required=true contenteditable=plaintext-only draggable=auto spellcheck=false translate=no popover=manual onkeydown=keyAction() ondragstart=startAction() ondragend=endAction()>Inline action</div><p id=editable contenteditable spellcheck=true translate=yes>Editable copy</p></section><dialog id=dialog open aria-label=\"Dialog\" aria-modal=true accesskey=\"d x\"><p>Dialog copy</p></dialog><details id=more open><summary>More</summary><p>Extra</p></details><p id=secret hidden aria-keyshortcuts=H draggable=true>Hidden copy</p><span id=decorative aria-hidden=true>Decorative</span><input id=disabled disabled value=no></main>",
       "expected": {
         "title": null,
         "base_href": null,
@@ -1336,7 +1336,8 @@
         "resources": [],
         "event_handler_descriptors": [
           { "element": "button", "id": "menu", "role": "control", "source": "element", "event_handlers": ["onclick"], "handler_count": 1, "activation_handlers": ["onclick"], "text": "Menu" },
-          { "element": "div", "id": "action", "role": "block", "source": "element", "event_handlers": ["onkeydown"], "handler_count": 1, "keyboard_handlers": ["onkeydown"], "text": "Inline action" }
+          { "element": "section", "id": "panel", "role": "section", "source": "element", "event_handlers": ["ondragover", "ondrop"], "handler_count": 2, "pointer_handlers": ["ondragover", "ondrop"], "text": "Settings Choose options Inline action Editable copy" },
+          { "element": "div", "id": "action", "role": "block", "source": "element", "event_handlers": ["onkeydown", "ondragstart", "ondragend"], "handler_count": 3, "keyboard_handlers": ["onkeydown"], "pointer_handlers": ["ondragstart", "ondragend"], "text": "Inline action" }
         ],
         "anchors": [
           { "id": "app", "name": null, "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative" },
@@ -1361,12 +1362,12 @@
         ],
         "command_elements": [
           { "element": "button", "id": "menu", "role": "control", "command_kind": "command", "text": "Menu", "accessible_name": "Menu", "control_type": "submit", "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "focusable": true },
-          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown"] },
+          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "text": "Inline action", "accessible_name": "Inline action", "aria_pressed": "mixed", "aria_current": "page", "tabindex": "-1", "event_handlers": ["onkeydown", "ondragstart", "ondragend"] },
           { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
         ],
         "activation_descriptors": [
           { "element": "button", "id": "menu", "role": "control", "command_kind": "command", "activation_kind": "show-modal", "target_id": "dialog", "target_kind": "dialog", "text": "Menu", "accessible_name": "Menu", "focusable": true, "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "handler_count": 1, "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "control_type": "submit" },
-          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "activation_kind": "button", "target_kind": "command", "text": "Inline action", "accessible_name": "Inline action", "tabindex": "-1", "event_handlers": ["onkeydown"], "handler_count": 1, "aria_pressed": "mixed", "aria_current": "page" },
+          { "element": "div", "id": "action", "role": "button", "authored_role": "button", "command_kind": "button", "activation_kind": "button", "target_kind": "command", "text": "Inline action", "accessible_name": "Inline action", "tabindex": "-1", "event_handlers": ["onkeydown", "ondragstart", "ondragend"], "handler_count": 3, "aria_pressed": "mixed", "aria_current": "page" },
           { "element": "summary", "role": "disclosure_summary", "command_kind": "disclosure", "activation_kind": "disclosure", "target_kind": "disclosure", "text": "More", "accessible_name": "More", "focusable": true }
         ],
         "popovers": [
@@ -1379,19 +1380,19 @@
         "images": [],
         "interactive_elements": [
           { "element": "button", "id": "menu", "role": "control", "text": "Menu", "accessible_name": "Menu", "aria_controls": ["panel"], "aria_owns": ["panel", "menu-popup"], "aria_activedescendant": "action", "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "aria_keyshortcuts": ["Alt+M", "/"], "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "focusable": true, "popover_target": "panel-pop", "popover_target_action": "toggle", "command": "show-modal", "command_for": "dialog" },
-          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "inert": true },
-          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "text": "Inline action", "aria_current": "page", "aria_pressed": "mixed", "aria_selected": "false", "aria_invalid": "spelling", "aria_required": "true", "aria_keyshortcuts": ["Enter", "Space"], "tabindex": "-1", "event_handlers": ["onkeydown"], "focusable": false, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "popover": "manual" },
+          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "event_handlers": ["ondragover", "ondrop"], "inert": true },
+          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "text": "Inline action", "aria_current": "page", "aria_pressed": "mixed", "aria_selected": "false", "aria_invalid": "spelling", "aria_required": "true", "aria_keyshortcuts": ["Enter", "Space"], "tabindex": "-1", "event_handlers": ["onkeydown", "ondragstart", "ondragend"], "focusable": false, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "popover": "manual" },
           { "element": "p", "id": "editable", "role": "paragraph", "text": "Editable copy", "focusable": true, "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes" },
           { "element": "dialog", "id": "dialog", "role": "dialog", "text": "Dialog copy", "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true", "open": true, "accesskey": ["d", "x"] },
           { "element": "details", "id": "more", "role": "disclosure", "text": "More Extra", "open": true },
           { "element": "summary", "role": "disclosure_summary", "text": "More" },
-          { "element": "p", "id": "secret", "role": "paragraph", "text": "Hidden copy", "aria_keyshortcuts": ["H"], "hidden": true },
+          { "element": "p", "id": "secret", "role": "paragraph", "text": "Hidden copy", "aria_keyshortcuts": ["H"], "draggable": "true", "draggable_state": "true", "hidden": true },
           { "element": "span", "id": "decorative", "role": "inline", "text": "Decorative", "aria_hidden": true }
         ],
         "focus_navigation_descriptors": [
           { "element": "button", "id": "menu", "role": "control", "focus_kind": "sequential", "focusable": true, "sequential_focus": true, "programmatic_focus": true, "tabindex": "0", "tabindex_order": 0, "accesskey": ["m", "/"], "event_handlers": ["onclick"], "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_activedescendant": "action", "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "text": "Menu" },
-          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "focus_kind": "blocked", "focus_blocked": true, "focus_block_reasons": ["inert"], "inert": true, "text": "Settings Choose options Inline action Editable copy" },
-          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "focus_kind": "editing-host", "programmatic_focus": true, "tabindex": "-1", "tabindex_order": -1, "event_handlers": ["onkeydown"], "contenteditable": "plaintext-only", "editing_mode": "plaintext", "text": "Inline action" },
+          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "focus_kind": "blocked", "focus_blocked": true, "focus_block_reasons": ["inert"], "event_handlers": ["ondragover", "ondrop"], "inert": true, "text": "Settings Choose options Inline action Editable copy" },
+          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "focus_kind": "editing-host", "programmatic_focus": true, "tabindex": "-1", "tabindex_order": -1, "event_handlers": ["onkeydown", "ondragstart", "ondragend"], "contenteditable": "plaintext-only", "editing_mode": "plaintext", "text": "Inline action" },
           { "element": "p", "id": "editable", "role": "paragraph", "focus_kind": "editing-host", "focusable": true, "sequential_focus": true, "programmatic_focus": true, "contenteditable": "", "editing_mode": "richtext", "text": "Editable copy" },
           { "element": "dialog", "id": "dialog", "role": "dialog", "focus_kind": "accesskey", "accesskey": ["d", "x"], "text": "Dialog copy" },
           { "element": "p", "id": "secret", "role": "paragraph", "focus_kind": "blocked", "focus_blocked": true, "focus_block_reasons": ["hidden"], "hidden": true, "text": "Hidden copy" },
@@ -1406,6 +1407,11 @@
           { "element": "p", "id": "secret", "role": "paragraph", "keyboard_kind": "blocked", "text": "Hidden copy", "aria_keyshortcuts": ["H"], "hidden": true, "keyboard_blocked": true, "keyboard_block_reasons": ["hidden"] },
           { "element": "span", "id": "decorative", "role": "inline", "keyboard_kind": "blocked", "text": "Decorative", "aria_hidden": true, "keyboard_blocked": true, "keyboard_block_reasons": ["aria-hidden"] }
         ],
+        "drag_drop_descriptors": [
+          { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "drag_kind": "blocked", "text": "Settings Choose options Inline action Editable copy", "drop_target": true, "drop_handlers": ["ondragover", "ondrop"], "pointer_handlers": ["ondragover", "ondrop"], "handler_count": 2, "inert": true, "drag_blocked": true, "drag_block_reasons": ["inert"] },
+          { "element": "div", "id": "action", "role": "block", "authored_role": "button", "drag_kind": "drag-source", "text": "Inline action", "draggable": "auto", "draggable_state": "auto", "drag_source": true, "drag_handlers": ["ondragstart", "ondragend"], "pointer_handlers": ["ondragstart", "ondragend"], "handler_count": 2 },
+          { "element": "p", "id": "secret", "role": "paragraph", "drag_kind": "blocked", "text": "Hidden copy", "draggable": "true", "draggable_state": "true", "drag_source": true, "hidden": true, "drag_blocked": true, "drag_block_reasons": ["hidden"] }
+        ],
         "disclosures": [
           { "element": "dialog", "id": "dialog", "text": "Dialog copy", "open": true, "accessible_name": "Dialog", "aria_label": "Dialog", "aria_modal": "true" },
           { "element": "details", "id": "more", "text": "More Extra", "summary_text": "More", "open": true, "accessible_name": "More" }
@@ -1419,7 +1425,7 @@
           { "element": "div", "id": "action", "tabindex": "-1", "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "text": "Inline action" },
           { "element": "p", "id": "editable", "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes", "text": "Editable copy" },
           { "element": "dialog", "id": "dialog", "accesskey": ["d", "x"], "text": "Dialog copy" },
-          { "element": "p", "id": "secret", "hidden": true, "text": "Hidden copy" }
+          { "element": "p", "id": "secret", "hidden": true, "draggable": "true", "draggable_state": "true", "text": "Hidden copy" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- add BrowserDragDropDescriptor extraction to browser document summaries
- track draggable state, drag/drop handlers, pointer handler inventory, and blocked drag paths
- pin drag/drop expectations in browser-readiness fixtures and docs

## Tests
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py && python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_drag_drop_descriptors
- cargo test -p coding-adventures-html-parser browser_focus_navigation_descriptors_track_focus_order_and_blockers
- cargo test -p coding-adventures-html-parser browser_readiness_cases_extract_browser_document_facts
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser