### PR TITLE
Add smart-home activation candidate tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for bulk D23A integration activation-plan planning:
   `smart_home.list_integration_activation_plans` and
   `smart_home.get_integration_activation_plan_summary`.
+- Added D18D handlers for ranked D23A integration activation candidate
+  planning: `smart_home.list_integration_activation_candidates` and
+  `smart_home.get_integration_activation_candidate_summary`.
 - Added D18D handlers for bulk D23A integration readiness planning:
   `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -38,6 +38,7 @@ Chief of Staff job/session/agent
   -> authorization decision audit reads and summaries
   -> capability grant ledger reads and summaries
   -> activation-plan list and summary reads for D23A rollout planning
+  -> activation-candidate list and summary reads for ranked rollout planning
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
@@ -59,6 +60,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_tool_catalog_summary`
 - `smart_home.list_integration_activation_plans`
 - `smart_home.get_integration_activation_plan_summary`
+- `smart_home.list_integration_activation_candidates`
+- `smart_home.get_integration_activation_candidate_summary`
 - `smart_home.list_integration_readiness`
 - `smart_home.get_integration_readiness_summary`
 - `smart_home.list_integration_readiness_gaps`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -33,16 +33,19 @@ use smart_home_discovery::{
     DiscoveryWorkerId, DiscoveryWorkerKind, PairingRequirement,
 };
 use smart_home_integration_catalog::{
-    activation_plan_for_entry, activation_plans_at_or_before_priority, describe_primitive_family,
+    activation_candidates_at_or_before_priority, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, describe_primitive_family,
     ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
     find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
     primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
     readiness_gap_inventory_from_reports, readiness_report_for_plan,
     readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
     ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationTarget,
-    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
-    IntegrationPolicySurface, IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationTarget, IntegrationCatalogEntry,
+    IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
     IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogItem,
     PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
@@ -135,6 +138,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID: &str =
     "smart_home.list_integration_activation_plans";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_plan_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID: &str =
+    "smart_home.list_integration_activation_candidates";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_candidate_summary";
 pub const SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID: &str =
     "smart_home.list_integration_readiness";
 pub const SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID: &str =
@@ -221,6 +228,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID => {
                     let query = integration_activation_plan_query(&arguments)?;
                     Ok(get_integration_activation_plan_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID => {
+                    let query = integration_activation_candidate_query(&arguments)?;
+                    Ok(list_integration_activation_candidates_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_candidate_query(&arguments)?;
+                    Ok(get_integration_activation_candidate_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
@@ -830,6 +845,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation plan summary",
             "Return compact D23A activation-plan rollups for target shape, review, primitive, capability, and dependency planning.",
             integration_activation_plan_query_schema(false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID,
+            "List smart-home integration activation candidates",
+            "List ranked D23A activation candidates after applying host-specific primitive, capability, and dependency readiness context.",
+            integration_activation_candidate_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "activation_candidates",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_candidates", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation candidate summary",
+            "Return compact D23A activation candidate rollups for ready, review, and blocked rollout work.",
+            integration_activation_candidate_query_schema(false),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3112,6 +3159,26 @@ struct IntegrationReadinessGapQuery {
     limit_per_kind: Option<usize>,
 }
 
+#[derive(Debug, Clone)]
+struct IntegrationActivationCandidateQuery {
+    readiness: IntegrationReadinessQuery,
+    recommendation: Option<IntegrationActivationCandidateRecommendation>,
+}
+
+fn integration_activation_candidate_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationCandidateQuery, ToolCallError> {
+    let readiness = integration_readiness_query(arguments)?;
+    let recommendation = optional_string(arguments, "recommendation")?
+        .map(|label| parse_activation_candidate_recommendation(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationCandidateQuery {
+        readiness,
+        recommendation,
+    })
+}
+
 fn integration_readiness_query(
     arguments: &JsonValue,
 ) -> Result<IntegrationReadinessQuery, ToolCallError> {
@@ -3180,6 +3247,41 @@ fn integration_readiness_gap_inventory_for_query(
         readiness_gap_inventory_from_reports(reports.iter()),
         catalog_count,
     )
+}
+
+fn integration_activation_candidates_for_query(
+    query: &IntegrationActivationCandidateQuery,
+) -> (Vec<IntegrationActivationCandidate>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let mut candidates = activation_candidates_at_or_before_priority(
+        &catalog,
+        query.readiness.priority_at_or_before,
+        &query.readiness.available_primitives,
+        &query.readiness.allowed_capabilities,
+        &query.readiness.enabled_integrations,
+    );
+
+    if let Some(recommendation) = query.recommendation {
+        candidates.retain(|candidate| candidate.recommendation == recommendation);
+    }
+    if let Some(activation_ready) = query.readiness.activation_ready {
+        candidates.retain(|candidate| candidate.activation_ready() == activation_ready);
+    }
+    if let Some(requires_human_review) = query.readiness.requires_human_review {
+        candidates.retain(|candidate| candidate.requires_human_review() == requires_human_review);
+    }
+    if let Some(cloud_required) = query.readiness.cloud_required {
+        candidates.retain(|candidate| candidate.readiness_report.cloud_required == cloud_required);
+    }
+    if let Some(local_only) = query.readiness.local_only {
+        candidates.retain(|candidate| candidate.readiness_report.local_only == local_only);
+    }
+    if let Some(limit) = query.readiness.limit {
+        candidates.truncate(limit);
+    }
+
+    (candidates, catalog_count)
 }
 
 fn limited_slice<T>(items: &[T], limit: Option<usize>) -> &[T] {
@@ -3380,6 +3482,67 @@ fn get_integration_activation_plan_summary_output_handler_output(
             (
                 "plans_requiring_human_review",
                 integer(summary.plans_requiring_human_review as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_candidates_output_handler_output(
+    query: IntegrationActivationCandidateQuery,
+) -> ToolHandlerOutput {
+    let (candidates, catalog_count) = integration_activation_candidates_for_query(&query);
+    let summary = IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+    let count = candidates.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_candidates",
+            JsonValue::Array(candidates.iter().map(activation_candidate_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_candidate_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_candidates"),
+            ),
+            ("count", integer(count as i64)),
+            (
+                "blocked_candidates",
+                integer(summary.blocked_candidates as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_candidate_summary_output_handler_output(
+    query: IntegrationActivationCandidateQuery,
+) -> ToolHandlerOutput {
+    let (candidates, _) = integration_activation_candidates_for_query(&query);
+    let summary = IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_candidate_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_candidate_summary"),
+            ),
+            ("total_candidates", integer(summary.total_candidates as i64)),
+            (
+                "blocked_candidates",
+                integer(summary.blocked_candidates as i64),
             ),
         ]),
     )
@@ -5835,6 +5998,111 @@ fn integration_activation_plan_summary_json(
     ])
 }
 
+fn activation_candidate_json(candidate: &IntegrationActivationCandidate) -> JsonValue {
+    object([
+        (
+            "requested_integration_id",
+            string(candidate.readiness_report.requested_integration_id.as_str()),
+        ),
+        (
+            "display_name",
+            string(&candidate.readiness_report.display_name),
+        ),
+        (
+            "recommendation",
+            string(activation_candidate_recommendation_label(
+                candidate.recommendation,
+            )),
+        ),
+        ("blocker_count", integer(candidate.blocker_count as i64)),
+        (
+            "activation_ready",
+            JsonValue::Bool(candidate.activation_ready()),
+        ),
+        ("is_actionable", JsonValue::Bool(candidate.is_actionable())),
+        ("is_blocked", JsonValue::Bool(candidate.is_blocked())),
+        (
+            "requires_human_review",
+            JsonValue::Bool(candidate.requires_human_review()),
+        ),
+        (
+            "readiness_report",
+            readiness_report_json(&candidate.readiness_report),
+        ),
+    ])
+}
+
+fn integration_activation_candidate_summary_json(
+    summary: &IntegrationActivationCandidateSummary,
+) -> JsonValue {
+    object([
+        ("total_candidates", integer(summary.total_candidates as i64)),
+        (
+            "ready_to_activate_candidates",
+            integer(summary.ready_to_activate_candidates as i64),
+        ),
+        (
+            "needs_human_review_candidates",
+            integer(summary.needs_human_review_candidates as i64),
+        ),
+        (
+            "blocked_candidates",
+            integer(summary.blocked_candidates as i64),
+        ),
+        (
+            "activation_ready_candidates",
+            integer(summary.activation_ready_candidates as i64),
+        ),
+        (
+            "candidates_requiring_human_review",
+            integer(summary.candidates_requiring_human_review as i64),
+        ),
+        (
+            "candidates_missing_primitives",
+            integer(summary.candidates_missing_primitives as i64),
+        ),
+        (
+            "candidates_missing_capabilities",
+            integer(summary.candidates_missing_capabilities as i64),
+        ),
+        (
+            "candidates_missing_dependencies",
+            integer(summary.candidates_missing_dependencies as i64),
+        ),
+        ("direct_targets", integer(summary.direct_targets as i64)),
+        (
+            "delegated_integration_targets",
+            integer(summary.delegated_integration_targets as i64),
+        ),
+        (
+            "delegated_standard_targets",
+            integer(summary.delegated_standard_targets as i64),
+        ),
+        (
+            "local_only_candidates",
+            integer(summary.local_only_candidates as i64),
+        ),
+        (
+            "cloud_required_candidates",
+            integer(summary.cloud_required_candidates as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_actionable_candidates",
+            JsonValue::Bool(summary.has_actionable_candidates()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+    ])
+}
+
 fn readiness_report_json(report: &IntegrationReadinessReport) -> JsonValue {
     object([
         (
@@ -7833,6 +8101,37 @@ fn parse_activation_target_kind(label: &str) -> Result<ActivationTargetKind, Too
     }
 }
 
+fn parse_activation_candidate_recommendation(
+    label: &str,
+) -> Result<IntegrationActivationCandidateRecommendation, ToolCallError> {
+    match label {
+        "ready_to_activate" | "ready" | "activate" => {
+            Ok(IntegrationActivationCandidateRecommendation::ReadyToActivate)
+        }
+        "needs_human_review" | "human_review" | "review" => {
+            Ok(IntegrationActivationCandidateRecommendation::NeedsHumanReview)
+        }
+        "blocked_on_prerequisites" | "blocked" | "prerequisites" => {
+            Ok(IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation candidate recommendation `{label}`"
+        ))),
+    }
+}
+
+fn activation_candidate_recommendation_label(
+    recommendation: IntegrationActivationCandidateRecommendation,
+) -> &'static str {
+    match recommendation {
+        IntegrationActivationCandidateRecommendation::ReadyToActivate => "ready_to_activate",
+        IntegrationActivationCandidateRecommendation::NeedsHumanReview => "needs_human_review",
+        IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites => {
+            "blocked_on_prerequisites"
+        }
+    }
+}
+
 fn integration_category_label(category: IntegrationCategory) -> &'static str {
     match category {
         IntegrationCategory::ProtocolStandard => "protocol_standard",
@@ -8434,6 +8733,19 @@ fn integration_activation_plan_query_schema(include_limit: bool) -> JsonSchema {
     object_schema(properties, Vec::new(), false)
 }
 
+fn integration_activation_candidate_query_schema(include_limit: bool) -> JsonSchema {
+    let mut schema = integration_readiness_query_schema(include_limit);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("recommendation", JsonSchema::String));
+    }
+    schema
+}
+
 fn integration_readiness_query_schema(include_limit: bool) -> JsonSchema {
     let mut properties = vec![
         SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
@@ -8538,7 +8850,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 51);
+        assert_eq!(definitions.len(), 53);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -8564,6 +8876,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID));
@@ -8661,7 +8979,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            43
+            45
         );
         assert_eq!(
             export
@@ -8693,6 +9011,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -8939,11 +9265,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(51))
+            Some(&integer(53))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(43))
+            Some(&integer(45))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -9024,6 +9350,124 @@ mod tests {
         assert_eq!(
             field(activation_plan_rollup, "has_review_work"),
             Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_candidates_request = request(
+            "call-list-integration-activation-candidates",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("recommendation", string("blocked_on_prerequisites")),
+                ("limit", integer(3)),
+            ]),
+            4_997,
+        );
+        let list_activation_candidates_trace =
+            tool_runtime.invoke_with_events(&list_activation_candidates_request);
+        assert!(list_activation_candidates_trace.result.ok);
+        assert_eq!(
+            list_activation_candidates_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_candidates_output = list_activation_candidates_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_activation_candidates_output, "count"),
+            Some(&integer(3))
+        );
+        let activation_candidate_summary =
+            field(list_activation_candidates_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_candidate_summary, "blocked_candidates"),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(activation_candidate_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_candidate = array_item(
+            field(list_activation_candidates_output, "activation_candidates").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_candidate, "recommendation"),
+            Some(&string("blocked_on_prerequisites"))
+        );
+        assert_eq!(
+            field(activation_candidate, "is_blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(integer_value(field(activation_candidate, "blocker_count").unwrap()).unwrap() >= 1);
+
+        let activation_candidate_summary_request = request(
+            "call-integration-activation-candidate-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            4_998,
+        );
+        let activation_candidate_summary_trace =
+            tool_runtime.invoke_with_events(&activation_candidate_summary_request);
+        assert!(activation_candidate_summary_trace.result.ok);
+        assert_eq!(
+            activation_candidate_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_candidate_summary_output = activation_candidate_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_candidate_rollup =
+            field(activation_candidate_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_candidate_rollup, "total_candidates").unwrap()).unwrap()
+                >= 3
+        );
+        assert_eq!(
+            field(activation_candidate_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_candidate_rollup, "has_review_work"),
+            Some(&JsonValue::Bool(false))
         );
 
         let list_integration_readiness_request = request(
@@ -10398,6 +10842,14 @@ mod tests {
             activation_plan_summary_trace,
         );
         journal.record_trace(
+            list_activation_candidates_request,
+            list_activation_candidates_trace,
+        );
+        journal.record_trace(
+            activation_candidate_summary_request,
+            activation_candidate_summary_trace,
+        );
+        journal.record_trace(
             list_integration_readiness_request,
             list_integration_readiness_trace,
         );
@@ -10457,9 +10909,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 51);
-        assert_eq!(journal_summary.completed_count, 51);
-        assert_eq!(journal.audit_records().len(), 51);
+        assert_eq!(journal_summary.invocation_count, 53);
+        assert_eq!(journal_summary.completed_count, 53);
+        assert_eq!(journal.audit_records().len(), 53);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_plans` and
   `smart_home.get_integration_activation_plan_summary` tool descriptors for
   read-only activation-plan listing and compact rollout plan summaries.
+- `smart_home.list_integration_activation_candidates` and
+  `smart_home.get_integration_activation_candidate_summary` tool descriptors
+  for read-only ranked activation candidate planning.
 - `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary` tool descriptors for read-only
   integration activation blocker planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -52,6 +52,8 @@ Current scope:
   inspection
 - D18D integration activation-plan descriptors for bulk rollout plan listing
   and compact activation-plan rollups
+- D18D integration activation-candidate descriptors for ranked ready, review,
+  and blocked rollout planning
 - D18D integration-readiness descriptors for bulk activation blocker reports
   and compact readiness rollups
 - D18D integration-readiness gap descriptors for grouped primitive,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1453,6 +1453,8 @@ pub enum SmartHomeTool {
     GetToolCatalogSummary,
     ListIntegrationActivationPlans,
     GetIntegrationActivationPlanSummary,
+    ListIntegrationActivationCandidates,
+    GetIntegrationActivationCandidateSummary,
     ListIntegrationReadiness,
     GetIntegrationReadinessSummary,
     ListIntegrationReadinessGaps,
@@ -1514,6 +1516,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationPlanSummary => {
                 read_tool("smart_home.get_integration_activation_plan_summary")
+            }
+            Self::ListIntegrationActivationCandidates => {
+                read_tool("smart_home.list_integration_activation_candidates")
+            }
+            Self::GetIntegrationActivationCandidateSummary => {
+                read_tool("smart_home.get_integration_activation_candidate_summary")
             }
             Self::ListIntegrationReadiness => read_tool("smart_home.list_integration_readiness"),
             Self::GetIntegrationReadinessSummary => {
@@ -2138,6 +2146,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetToolCatalogSummary,
         SmartHomeTool::ListIntegrationActivationPlans,
         SmartHomeTool::GetIntegrationActivationPlanSummary,
+        SmartHomeTool::ListIntegrationActivationCandidates,
+        SmartHomeTool::GetIntegrationActivationCandidateSummary,
         SmartHomeTool::ListIntegrationReadiness,
         SmartHomeTool::GetIntegrationReadinessSummary,
         SmartHomeTool::ListIntegrationReadinessGaps,
@@ -2976,7 +2986,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 51);
+        assert_eq!(catalog.len(), 53);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3012,6 +3022,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_plan_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_candidates"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_candidate_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3194,15 +3212,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 51);
-        assert_eq!(summary.read_tools, 43);
+        assert_eq!(summary.total_tools, 53);
+        assert_eq!(summary.read_tools, 45);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 43);
+        assert_eq!(summary.read_only_tier_tools, 45);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 51);
+        assert_eq!(summary.total_required_capabilities, 53);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationPlanSummary` for compact direct/delegated target,
   review, local/cloud, dependency, primitive, and capability rollups over
   activation-plan sets.
+- `IntegrationActivationCandidate` and `IntegrationActivationCandidateSummary`
+  for ranking ready, human-review, and blocked activation work after applying
+  host-specific readiness context.
 - Integration readiness reports that expose missing primitive families, missing
   capability grants, and missing delegated integrations before activation.
 - Integration readiness summaries for compact activation-ready, blocker,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -30,6 +30,8 @@ runtime and Chief of Staff tools a typed catalog for:
   standard-backed products into primitive/capability/auth/policy requirements
 - activation plan summaries that count direct/delegated targets, review work,
   local/cloud boundaries, dependencies, and unique primitive/capability needs
+- activation candidates that rank ready, human-review, and blocked rollout work
+  after applying host-specific primitive, capability, and dependency context
 - readiness reports that compare activation plans against available primitives,
   allowed capabilities, and already-enabled dependency integrations
 - readiness summaries that roll activation blockers, review requirements, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -683,6 +683,39 @@ pub struct IntegrationReadinessReport {
     pub cloud_required: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationCandidateRecommendation {
+    ReadyToActivate,
+    NeedsHumanReview,
+    BlockedOnPrerequisites,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationCandidate {
+    pub readiness_report: IntegrationReadinessReport,
+    pub recommendation: IntegrationActivationCandidateRecommendation,
+    pub blocker_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationCandidateSummary {
+    pub total_candidates: usize,
+    pub ready_to_activate_candidates: usize,
+    pub needs_human_review_candidates: usize,
+    pub blocked_candidates: usize,
+    pub activation_ready_candidates: usize,
+    pub candidates_requiring_human_review: usize,
+    pub candidates_missing_primitives: usize,
+    pub candidates_missing_capabilities: usize,
+    pub candidates_missing_dependencies: usize,
+    pub direct_targets: usize,
+    pub delegated_integration_targets: usize,
+    pub delegated_standard_targets: usize,
+    pub local_only_candidates: usize,
+    pub cloud_required_candidates: usize,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationReadinessSummary {
     pub total_reports: usize,
@@ -952,6 +985,12 @@ impl IntegrationReadinessReport {
         !self.activation_ready()
     }
 
+    pub fn missing_prerequisite_count(&self) -> usize {
+        self.missing_primitives.len()
+            + self.missing_capabilities.len()
+            + self.missing_dependencies.len()
+    }
+
     pub fn missing_primitive(&self, primitive: PrimitiveFamily) -> bool {
         self.missing_primitives.contains(&primitive)
     }
@@ -973,6 +1012,140 @@ impl IntegrationReadinessReport {
             &self.activation_target,
             IntegrationActivationTarget::DelegatedIntegration(target) if target == integration_id
         )
+    }
+}
+
+impl IntegrationActivationCandidateRecommendation {
+    fn from_report(report: &IntegrationReadinessReport) -> Self {
+        if report.is_blocked() {
+            Self::BlockedOnPrerequisites
+        } else if report.requires_human_review {
+            Self::NeedsHumanReview
+        } else {
+            Self::ReadyToActivate
+        }
+    }
+
+    pub fn is_actionable(self) -> bool {
+        matches!(self, Self::ReadyToActivate | Self::NeedsHumanReview)
+    }
+}
+
+impl IntegrationActivationCandidate {
+    pub fn from_report(report: IntegrationReadinessReport) -> Self {
+        let blocker_count = report.missing_prerequisite_count();
+        let recommendation = IntegrationActivationCandidateRecommendation::from_report(&report);
+        Self {
+            readiness_report: report,
+            recommendation,
+            blocker_count,
+        }
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.readiness_report.activation_ready()
+    }
+
+    pub fn is_actionable(&self) -> bool {
+        self.recommendation.is_actionable()
+    }
+
+    pub fn is_blocked(&self) -> bool {
+        self.recommendation == IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites
+    }
+
+    pub fn requires_human_review(&self) -> bool {
+        self.readiness_report.requires_human_review
+    }
+}
+
+impl IntegrationActivationCandidateSummary {
+    pub fn from_candidates<'a>(
+        candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+    ) -> Self {
+        let mut summary = Self {
+            total_candidates: 0,
+            ready_to_activate_candidates: 0,
+            needs_human_review_candidates: 0,
+            blocked_candidates: 0,
+            activation_ready_candidates: 0,
+            candidates_requiring_human_review: 0,
+            candidates_missing_primitives: 0,
+            candidates_missing_capabilities: 0,
+            candidates_missing_dependencies: 0,
+            direct_targets: 0,
+            delegated_integration_targets: 0,
+            delegated_standard_targets: 0,
+            local_only_candidates: 0,
+            cloud_required_candidates: 0,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for candidate in candidates {
+            summary.total_candidates += 1;
+            match candidate.recommendation {
+                IntegrationActivationCandidateRecommendation::ReadyToActivate => {
+                    summary.ready_to_activate_candidates += 1
+                }
+                IntegrationActivationCandidateRecommendation::NeedsHumanReview => {
+                    summary.needs_human_review_candidates += 1
+                }
+                IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites => {
+                    summary.blocked_candidates += 1
+                }
+            }
+            if candidate.activation_ready() {
+                summary.activation_ready_candidates += 1;
+            }
+            if candidate.requires_human_review() {
+                summary.candidates_requiring_human_review += 1;
+            }
+            if !candidate.readiness_report.missing_primitives.is_empty() {
+                summary.candidates_missing_primitives += 1;
+            }
+            if !candidate.readiness_report.missing_capabilities.is_empty() {
+                summary.candidates_missing_capabilities += 1;
+            }
+            if !candidate.readiness_report.missing_dependencies.is_empty() {
+                summary.candidates_missing_dependencies += 1;
+            }
+            match &candidate.readiness_report.activation_target {
+                IntegrationActivationTarget::Direct => summary.direct_targets += 1,
+                IntegrationActivationTarget::DelegatedIntegration(_) => {
+                    summary.delegated_integration_targets += 1
+                }
+                IntegrationActivationTarget::DelegatedStandards(_) => {
+                    summary.delegated_standard_targets += 1
+                }
+            }
+            if candidate.readiness_report.local_only {
+                summary.local_only_candidates += 1;
+            }
+            if candidate.readiness_report.cloud_required {
+                summary.cloud_required_candidates += 1;
+            }
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(candidate.readiness_report.highest_policy_tier);
+        }
+
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_candidates == 0
+    }
+
+    pub fn has_actionable_candidates(&self) -> bool {
+        self.ready_to_activate_candidates > 0 || self.needs_human_review_candidates > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_candidates > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.needs_human_review_candidates > 0
     }
 }
 
@@ -2061,6 +2234,36 @@ pub fn readiness_reports_at_or_before_priority(
         .collect()
 }
 
+pub fn activation_candidates_from_reports<'a>(
+    reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
+) -> Vec<IntegrationActivationCandidate> {
+    let mut candidates = reports
+        .into_iter()
+        .cloned()
+        .map(IntegrationActivationCandidate::from_report)
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(compare_activation_candidates);
+    candidates
+}
+
+pub fn activation_candidates_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationCandidate> {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_candidates_from_reports(reports.iter())
+}
+
 pub fn readiness_gap_inventory_from_reports<'a>(
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
 ) -> IntegrationReadinessGapInventory {
@@ -3038,6 +3241,30 @@ fn sort_query_results(entries: &mut Vec<&IntegrationCatalogEntry>, sort: Integra
     }
 }
 
+fn compare_activation_candidates(
+    left: &IntegrationActivationCandidate,
+    right: &IntegrationActivationCandidate,
+) -> Ordering {
+    left.recommendation
+        .cmp(&right.recommendation)
+        .then_with(|| {
+            left.readiness_report
+                .priority
+                .cmp(&right.readiness_report.priority)
+        })
+        .then_with(|| left.blocker_count.cmp(&right.blocker_count))
+        .then_with(|| {
+            left.readiness_report
+                .display_name
+                .cmp(&right.readiness_report.display_name)
+        })
+        .then_with(|| {
+            left.readiness_report
+                .requested_integration_id
+                .cmp(&right.readiness_report.requested_integration_id)
+        })
+}
+
 fn compare_by_priority_then_name(
     left: &IntegrationCatalogEntry,
     right: &IntegrationCatalogEntry,
@@ -3431,6 +3658,81 @@ mod tests {
         assert!(report.local_only);
         assert!(!report.cloud_required);
         assert_eq!(report.highest_policy_tier, PrivilegeTier::HumanApproval);
+    }
+
+    #[test]
+    fn activation_candidates_rank_ready_review_and_blocked_work() {
+        let catalog = first_party_catalog();
+        let hue = find_entry(&catalog, &IntegrationId::trusted("hue")).unwrap();
+        let tasmota = find_entry(&catalog, &IntegrationId::trusted("tasmota")).unwrap();
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let review_report = readiness_report_for_integration(
+            &catalog,
+            &hue.integration_id,
+            &hue.required_primitives,
+            &hue.required_capabilities,
+            &[],
+        )
+        .unwrap();
+        let blocked_report = readiness_report_for_integration(
+            &catalog,
+            &tasmota.integration_id,
+            &[],
+            &[CapabilityId::trusted("smart_home.read")],
+            &[],
+        )
+        .unwrap();
+
+        assert!(review_report.activation_ready());
+        assert!(review_report.requires_human_review);
+        assert!(blocked_report.is_blocked());
+
+        let candidates = activation_candidates_from_reports(
+            [blocked_report, review_report, ready_report].iter(),
+        );
+
+        assert_eq!(
+            candidates[0].recommendation,
+            IntegrationActivationCandidateRecommendation::ReadyToActivate
+        );
+        assert_eq!(
+            candidates[1].recommendation,
+            IntegrationActivationCandidateRecommendation::NeedsHumanReview
+        );
+        assert_eq!(
+            candidates[2].recommendation,
+            IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites
+        );
+        assert!(candidates[0].is_actionable());
+        assert!(candidates[2].is_blocked());
+        assert!(candidates[2].blocker_count > 0);
+
+        let summary = IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+        assert_eq!(summary.total_candidates, 3);
+        assert_eq!(summary.ready_to_activate_candidates, 1);
+        assert_eq!(summary.needs_human_review_candidates, 1);
+        assert_eq!(summary.blocked_candidates, 1);
+        assert_eq!(summary.activation_ready_candidates, 2);
+        assert_eq!(summary.candidates_requiring_human_review, 2);
+        assert!(summary.candidates_missing_primitives > 0);
+        assert!(summary.candidates_missing_capabilities > 0);
+        assert!(summary.candidates_missing_dependencies > 0);
+        assert!(summary.has_actionable_candidates());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(!summary.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared activation candidate ranking and summary models to the smart-home integration catalog
- expose D18D descriptors for listing activation candidates and candidate summaries
- wire Chief smart-home tool handlers, schemas, JSON outputs, docs, and end-to-end coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools