### PR TITLE
Add smart-home activation runway tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for ranked D23A integration activation candidate
   planning: `smart_home.list_integration_activation_candidates` and
   `smart_home.get_integration_activation_candidate_summary`.
+- Added D18D handlers for D23A rollout-priority activation runway planning:
+  `smart_home.list_integration_activation_runway` and
+  `smart_home.get_integration_activation_runway_summary`.
 - Added D18D handlers for bulk D23A integration readiness planning:
   `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -39,6 +39,7 @@ Chief of Staff job/session/agent
   -> capability grant ledger reads and summaries
   -> activation-plan list and summary reads for D23A rollout planning
   -> activation-candidate list and summary reads for ranked rollout planning
+  -> activation-runway list and summary reads for rollout-priority waves
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
@@ -62,6 +63,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_plan_summary`
 - `smart_home.list_integration_activation_candidates`
 - `smart_home.get_integration_activation_candidate_summary`
+- `smart_home.list_integration_activation_runway`
+- `smart_home.get_integration_activation_runway_summary`
 - `smart_home.list_integration_readiness`
 - `smart_home.get_integration_readiness_summary`
 - `smart_home.list_integration_readiness_gaps`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,16 +34,17 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_candidates_at_or_before_priority, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, describe_primitive_family,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationTarget, IntegrationCatalogEntry,
+    activation_plans_at_or_before_priority, activation_runway_from_candidates,
+    describe_primitive_family, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
@@ -142,6 +143,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID: &str =
     "smart_home.list_integration_activation_candidates";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_candidate_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID: &str =
+    "smart_home.list_integration_activation_runway";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_runway_summary";
 pub const SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID: &str =
     "smart_home.list_integration_readiness";
 pub const SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID: &str =
@@ -236,6 +241,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_candidate_query(&arguments)?;
                     Ok(get_integration_activation_candidate_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID => {
+                    let query = integration_activation_runway_query(&arguments)?;
+                    Ok(list_integration_activation_runway_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_runway_query(&arguments)?;
+                    Ok(get_integration_activation_runway_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
@@ -877,6 +892,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation candidate summary",
             "Return compact D23A activation candidate rollups for ready, review, and blocked rollout work.",
             integration_activation_candidate_query_schema(false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID,
+            "List smart-home integration activation runway",
+            "Group D23A activation candidates by rollout priority wave using host-specific primitive, capability, and dependency readiness context.",
+            integration_activation_runway_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "activation_runway",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_runway", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation runway summary",
+            "Return compact D23A rollout-priority runway rollups for actionable, review, and blocked activation waves.",
+            integration_activation_runway_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3165,6 +3212,13 @@ struct IntegrationActivationCandidateQuery {
     recommendation: Option<IntegrationActivationCandidateRecommendation>,
 }
 
+#[derive(Debug, Clone)]
+struct IntegrationActivationRunwayQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    stage_limit: Option<usize>,
+    candidates_per_stage_limit: Option<usize>,
+}
+
 fn integration_activation_candidate_query(
     arguments: &JsonValue,
 ) -> Result<IntegrationActivationCandidateQuery, ToolCallError> {
@@ -3176,6 +3230,21 @@ fn integration_activation_candidate_query(
     Ok(IntegrationActivationCandidateQuery {
         readiness,
         recommendation,
+    })
+}
+
+fn integration_activation_runway_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationRunwayQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let stage_limit = optional_u64(arguments, "stage_limit")?.map(|value| value as usize);
+    let candidates_per_stage_limit =
+        optional_u64(arguments, "candidates_per_stage_limit")?.map(|value| value as usize);
+
+    Ok(IntegrationActivationRunwayQuery {
+        candidates,
+        stage_limit,
+        candidates_per_stage_limit,
     })
 }
 
@@ -3282,6 +3351,27 @@ fn integration_activation_candidates_for_query(
     }
 
     (candidates, catalog_count)
+}
+
+fn integration_activation_runway_for_query(
+    query: &IntegrationActivationRunwayQuery,
+) -> (Vec<IntegrationActivationRunwayStage>, usize) {
+    let (candidates, catalog_count) =
+        integration_activation_candidates_for_query(&query.candidates);
+    let mut runway = activation_runway_from_candidates(candidates);
+
+    if let Some(limit) = query.candidates_per_stage_limit {
+        for stage in &mut runway {
+            stage.candidates.truncate(limit);
+            stage.summary =
+                IntegrationActivationCandidateSummary::from_candidates(stage.candidates.iter());
+        }
+    }
+    if let Some(limit) = query.stage_limit {
+        runway.truncate(limit);
+    }
+
+    (runway, catalog_count)
 }
 
 fn limited_slice<T>(items: &[T], limit: Option<usize>) -> &[T] {
@@ -3544,6 +3634,59 @@ fn get_integration_activation_candidate_summary_output_handler_output(
                 "blocked_candidates",
                 integer(summary.blocked_candidates as i64),
             ),
+        ]),
+    )
+}
+
+fn list_integration_activation_runway_output_handler_output(
+    query: IntegrationActivationRunwayQuery,
+) -> ToolHandlerOutput {
+    let (runway, catalog_count) = integration_activation_runway_for_query(&query);
+    let summary = IntegrationActivationRunwaySummary::from_stages(runway.iter());
+    let count = runway.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_runway",
+            JsonValue::Array(runway.iter().map(activation_runway_stage_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_runway_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_runway")),
+            ("stages", integer(count as i64)),
+            ("total_candidates", integer(summary.total_candidates as i64)),
+            ("blocked_stages", integer(summary.blocked_stages as i64)),
+        ]),
+    )
+}
+
+fn get_integration_activation_runway_summary_output_handler_output(
+    query: IntegrationActivationRunwayQuery,
+) -> ToolHandlerOutput {
+    let (runway, _) = integration_activation_runway_for_query(&query);
+    let summary = IntegrationActivationRunwaySummary::from_stages(runway.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_runway_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_runway_summary"),
+            ),
+            ("total_stages", integer(summary.total_stages as i64)),
+            ("blocked_stages", integer(summary.blocked_stages as i64)),
         ]),
     )
 }
@@ -6099,6 +6242,91 @@ fn integration_activation_candidate_summary_json(
         (
             "has_review_work",
             JsonValue::Bool(summary.has_review_work()),
+        ),
+    ])
+}
+
+fn activation_runway_stage_json(stage: &IntegrationActivationRunwayStage) -> JsonValue {
+    object([
+        ("priority", integer(stage.priority as i64)),
+        (
+            "activation_candidates",
+            JsonValue::Array(
+                stage
+                    .candidates
+                    .iter()
+                    .map(activation_candidate_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_candidate_summary_json(&stage.summary),
+        ),
+        ("count", integer(stage.candidates.len() as i64)),
+        (
+            "has_actionable_candidates",
+            JsonValue::Bool(stage.has_actionable_candidates()),
+        ),
+        ("has_blockers", JsonValue::Bool(stage.has_blockers())),
+        ("has_review_work", JsonValue::Bool(stage.has_review_work())),
+    ])
+}
+
+fn integration_activation_runway_summary_json(
+    summary: &IntegrationActivationRunwaySummary,
+) -> JsonValue {
+    object([
+        ("total_stages", integer(summary.total_stages as i64)),
+        ("total_candidates", integer(summary.total_candidates as i64)),
+        (
+            "actionable_stages",
+            integer(summary.actionable_stages as i64),
+        ),
+        ("ready_stages", integer(summary.ready_stages as i64)),
+        ("review_stages", integer(summary.review_stages as i64)),
+        ("blocked_stages", integer(summary.blocked_stages as i64)),
+        (
+            "first_actionable_priority",
+            summary
+                .first_actionable_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_ready_priority",
+            summary
+                .next_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(&summary.candidate_summary),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_actionable_stage",
+            JsonValue::Bool(summary.has_actionable_stage()),
+        ),
+        (
+            "has_blocked_stage",
+            JsonValue::Bool(summary.has_blocked_stage()),
+        ),
+        (
+            "has_review_stage",
+            JsonValue::Bool(summary.has_review_stage()),
         ),
     ])
 }
@@ -8746,6 +8974,23 @@ fn integration_activation_candidate_query_schema(include_limit: bool) -> JsonSch
     schema
 }
 
+fn integration_activation_runway_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("stage_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new(
+            "candidates_per_stage_limit",
+            JsonSchema::Integer,
+        ));
+    }
+    schema
+}
+
 fn integration_readiness_query_schema(include_limit: bool) -> JsonSchema {
     let mut properties = vec![
         SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
@@ -8850,7 +9095,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 53);
+        assert_eq!(definitions.len(), 55);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -8882,6 +9127,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID));
@@ -8979,7 +9230,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            45
+            47
         );
         assert_eq!(
             export
@@ -9019,6 +9270,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -9265,11 +9524,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(53))
+            Some(&integer(55))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(45))
+            Some(&integer(47))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -9468,6 +9727,118 @@ mod tests {
         assert_eq!(
             field(activation_candidate_rollup, "has_review_work"),
             Some(&JsonValue::Bool(false))
+        );
+
+        let list_activation_runway_request = request(
+            "call-list-integration-activation-runway",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("stage_limit", integer(2)),
+                ("candidates_per_stage_limit", integer(2)),
+            ]),
+            4_999,
+        );
+        let list_activation_runway_trace =
+            tool_runtime.invoke_with_events(&list_activation_runway_request);
+        assert!(list_activation_runway_trace.result.ok);
+        assert_eq!(
+            list_activation_runway_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_runway_output =
+            list_activation_runway_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(list_activation_runway_output, "count"),
+            Some(&integer(2))
+        );
+        let activation_runway_summary = field(list_activation_runway_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_runway_summary, "total_stages"),
+            Some(&integer(2))
+        );
+        assert_eq!(
+            field(activation_runway_summary, "has_blocked_stage"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_runway_stage = array_item(
+            field(list_activation_runway_output, "activation_runway").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_runway_stage, "priority"),
+            Some(&integer(0))
+        );
+        assert!(integer_value(field(activation_runway_stage, "count").unwrap()).unwrap() >= 1);
+        assert_eq!(
+            field(activation_runway_stage, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_runway_summary_request = request(
+            "call-integration-activation-runway-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_000,
+        );
+        let activation_runway_summary_trace =
+            tool_runtime.invoke_with_events(&activation_runway_summary_request);
+        assert!(activation_runway_summary_trace.result.ok);
+        assert_eq!(
+            activation_runway_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_runway_summary_output = activation_runway_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_runway_rollup = field(activation_runway_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_runway_rollup, "total_candidates").unwrap()).unwrap()
+                >= 3
+        );
+        assert_eq!(
+            field(activation_runway_rollup, "has_blocked_stage"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            optional_field(activation_runway_rollup, "first_blocked_priority")
+                .and_then(integer_value)
+                .is_some()
         );
 
         let list_integration_readiness_request = request(
@@ -10849,6 +11220,11 @@ mod tests {
             activation_candidate_summary_request,
             activation_candidate_summary_trace,
         );
+        journal.record_trace(list_activation_runway_request, list_activation_runway_trace);
+        journal.record_trace(
+            activation_runway_summary_request,
+            activation_runway_summary_trace,
+        );
         journal.record_trace(
             list_integration_readiness_request,
             list_integration_readiness_trace,
@@ -10909,9 +11285,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 53);
-        assert_eq!(journal_summary.completed_count, 53);
-        assert_eq!(journal.audit_records().len(), 53);
+        assert_eq!(journal_summary.invocation_count, 55);
+        assert_eq!(journal_summary.completed_count, 55);
+        assert_eq!(journal.audit_records().len(), 55);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_candidates` and
   `smart_home.get_integration_activation_candidate_summary` tool descriptors
   for read-only ranked activation candidate planning.
+- `smart_home.list_integration_activation_runway` and
+  `smart_home.get_integration_activation_runway_summary` tool descriptors for
+  read-only rollout-priority activation wave planning.
 - `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary` tool descriptors for read-only
   integration activation blocker planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -54,6 +54,8 @@ Current scope:
   and compact activation-plan rollups
 - D18D integration activation-candidate descriptors for ranked ready, review,
   and blocked rollout planning
+- D18D integration activation-runway descriptors for rollout-priority wave
+  grouping and compact actionable/blocker summaries
 - D18D integration-readiness descriptors for bulk activation blocker reports
   and compact readiness rollups
 - D18D integration-readiness gap descriptors for grouped primitive,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1455,6 +1455,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationPlanSummary,
     ListIntegrationActivationCandidates,
     GetIntegrationActivationCandidateSummary,
+    ListIntegrationActivationRunway,
+    GetIntegrationActivationRunwaySummary,
     ListIntegrationReadiness,
     GetIntegrationReadinessSummary,
     ListIntegrationReadinessGaps,
@@ -1522,6 +1524,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationCandidateSummary => {
                 read_tool("smart_home.get_integration_activation_candidate_summary")
+            }
+            Self::ListIntegrationActivationRunway => {
+                read_tool("smart_home.list_integration_activation_runway")
+            }
+            Self::GetIntegrationActivationRunwaySummary => {
+                read_tool("smart_home.get_integration_activation_runway_summary")
             }
             Self::ListIntegrationReadiness => read_tool("smart_home.list_integration_readiness"),
             Self::GetIntegrationReadinessSummary => {
@@ -2148,6 +2156,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationPlanSummary,
         SmartHomeTool::ListIntegrationActivationCandidates,
         SmartHomeTool::GetIntegrationActivationCandidateSummary,
+        SmartHomeTool::ListIntegrationActivationRunway,
+        SmartHomeTool::GetIntegrationActivationRunwaySummary,
         SmartHomeTool::ListIntegrationReadiness,
         SmartHomeTool::GetIntegrationReadinessSummary,
         SmartHomeTool::ListIntegrationReadinessGaps,
@@ -2986,7 +2996,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 53);
+        assert_eq!(catalog.len(), 55);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3030,6 +3040,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_candidate_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_runway"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_runway_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3212,15 +3230,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 53);
-        assert_eq!(summary.read_tools, 45);
+        assert_eq!(summary.total_tools, 55);
+        assert_eq!(summary.read_tools, 47);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 45);
+        assert_eq!(summary.read_only_tier_tools, 47);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 53);
+        assert_eq!(summary.total_required_capabilities, 55);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationCandidate` and `IntegrationActivationCandidateSummary`
   for ranking ready, human-review, and blocked activation work after applying
   host-specific readiness context.
+- `IntegrationActivationRunwayStage` and `IntegrationActivationRunwaySummary`
+  for grouping activation candidates by rollout priority wave and identifying
+  actionable, review, and blocked stages.
 - Integration readiness reports that expose missing primitive families, missing
   capability grants, and missing delegated integrations before activation.
 - Integration readiness summaries for compact activation-ready, blocker,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -32,6 +32,8 @@ runtime and Chief of Staff tools a typed catalog for:
   local/cloud boundaries, dependencies, and unique primitive/capability needs
 - activation candidates that rank ready, human-review, and blocked rollout work
   after applying host-specific primitive, capability, and dependency context
+- activation runway stages that group those candidates by rollout priority wave
+  with compact ready, review, and blocker rollups
 - readiness reports that compare activation plans against available primitives,
   allowed capabilities, and already-enabled dependency integrations
 - readiness summaries that roll activation blockers, review requirements, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -717,6 +717,28 @@ pub struct IntegrationActivationCandidateSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRunwayStage {
+    pub priority: u8,
+    pub candidates: Vec<IntegrationActivationCandidate>,
+    pub summary: IntegrationActivationCandidateSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRunwaySummary {
+    pub total_stages: usize,
+    pub total_candidates: usize,
+    pub actionable_stages: usize,
+    pub ready_stages: usize,
+    pub review_stages: usize,
+    pub blocked_stages: usize,
+    pub first_actionable_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub next_ready_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub candidate_summary: IntegrationActivationCandidateSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationReadinessSummary {
     pub total_reports: usize,
     pub activation_ready_reports: usize,
@@ -1146,6 +1168,100 @@ impl IntegrationActivationCandidateSummary {
 
     pub fn has_review_work(&self) -> bool {
         self.needs_human_review_candidates > 0
+    }
+}
+
+impl IntegrationActivationRunwayStage {
+    pub fn from_candidates(
+        priority: u8,
+        mut candidates: Vec<IntegrationActivationCandidate>,
+    ) -> Self {
+        candidates.sort_by(compare_activation_candidates);
+        let summary = IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+        Self {
+            priority,
+            candidates,
+            summary,
+        }
+    }
+
+    pub fn has_actionable_candidates(&self) -> bool {
+        self.summary.has_actionable_candidates()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.summary.has_review_work()
+    }
+}
+
+impl IntegrationActivationRunwaySummary {
+    pub fn from_stages<'a>(
+        stages: impl IntoIterator<Item = &'a IntegrationActivationRunwayStage>,
+    ) -> Self {
+        let stages = stages.into_iter().collect::<Vec<_>>();
+        let candidate_summary = IntegrationActivationCandidateSummary::from_candidates(
+            stages.iter().flat_map(|stage| stage.candidates.iter()),
+        );
+        let mut summary = Self {
+            total_stages: 0,
+            total_candidates: candidate_summary.total_candidates,
+            actionable_stages: 0,
+            ready_stages: 0,
+            review_stages: 0,
+            blocked_stages: 0,
+            first_actionable_priority: None,
+            first_blocked_priority: None,
+            next_ready_priority: None,
+            highest_policy_tier: candidate_summary.highest_policy_tier,
+            candidate_summary,
+        };
+
+        for stage in stages {
+            summary.total_stages += 1;
+            if stage.has_actionable_candidates() {
+                summary.actionable_stages += 1;
+                if summary.first_actionable_priority.is_none() {
+                    summary.first_actionable_priority = Some(stage.priority);
+                }
+            }
+            if stage.summary.ready_to_activate_candidates > 0 {
+                summary.ready_stages += 1;
+                if summary.next_ready_priority.is_none() {
+                    summary.next_ready_priority = Some(stage.priority);
+                }
+            }
+            if stage.has_review_work() {
+                summary.review_stages += 1;
+            }
+            if stage.has_blockers() {
+                summary.blocked_stages += 1;
+                if summary.first_blocked_priority.is_none() {
+                    summary.first_blocked_priority = Some(stage.priority);
+                }
+            }
+        }
+
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_stages == 0
+    }
+
+    pub fn has_actionable_stage(&self) -> bool {
+        self.actionable_stages > 0
+    }
+
+    pub fn has_blocked_stage(&self) -> bool {
+        self.blocked_stages > 0
+    }
+
+    pub fn has_review_stage(&self) -> bool {
+        self.review_stages > 0
     }
 }
 
@@ -2262,6 +2378,41 @@ pub fn activation_candidates_at_or_before_priority(
         enabled_integrations,
     );
     activation_candidates_from_reports(reports.iter())
+}
+
+pub fn activation_runway_from_candidates(
+    candidates: Vec<IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationRunwayStage> {
+    let mut stages_by_priority: BTreeMap<u8, Vec<IntegrationActivationCandidate>> = BTreeMap::new();
+    for candidate in candidates {
+        stages_by_priority
+            .entry(candidate.readiness_report.priority)
+            .or_default()
+            .push(candidate);
+    }
+
+    stages_by_priority
+        .into_iter()
+        .map(|(priority, candidates)| {
+            IntegrationActivationRunwayStage::from_candidates(priority, candidates)
+        })
+        .collect()
+}
+
+pub fn activation_runway_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationRunwayStage> {
+    activation_runway_from_candidates(activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
 }
 
 pub fn readiness_gap_inventory_from_reports<'a>(
@@ -3732,6 +3883,81 @@ mod tests {
         assert!(summary.has_actionable_candidates());
         assert!(summary.has_blockers());
         assert!(summary.has_review_work());
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_runway_groups_candidates_by_priority_wave() {
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 2,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_bridge"),
+            display_name: "Review Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_sensor"),
+            display_name: "Blocked Sensor".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: vec![PrimitiveFamily::Mqtt],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::LowRisk,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [ready_report, review_report, blocked_report].iter(),
+        );
+
+        let stages = activation_runway_from_candidates(candidates);
+
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0].priority, 1);
+        assert_eq!(stages[0].summary.total_candidates, 2);
+        assert_eq!(stages[0].summary.needs_human_review_candidates, 1);
+        assert_eq!(stages[0].summary.blocked_candidates, 1);
+        assert!(stages[0].has_actionable_candidates());
+        assert!(stages[0].has_blockers());
+        assert!(stages[0].has_review_work());
+        assert_eq!(stages[1].priority, 2);
+        assert_eq!(stages[1].summary.ready_to_activate_candidates, 1);
+
+        let summary = IntegrationActivationRunwaySummary::from_stages(stages.iter());
+        assert_eq!(summary.total_stages, 2);
+        assert_eq!(summary.total_candidates, 3);
+        assert_eq!(summary.actionable_stages, 2);
+        assert_eq!(summary.ready_stages, 1);
+        assert_eq!(summary.review_stages, 1);
+        assert_eq!(summary.blocked_stages, 1);
+        assert_eq!(summary.first_actionable_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(1));
+        assert_eq!(summary.next_ready_priority, Some(2));
+        assert_eq!(summary.candidate_summary.total_candidates, 3);
+        assert!(summary.has_actionable_stage());
+        assert!(summary.has_blocked_stage());
+        assert!(summary.has_review_stage());
         assert!(!summary.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- add shared activation runway stage and summary models that group activation candidates by rollout priority wave
- expose read-only D18D descriptors for activation runway listing and summary tools
- wire Chief smart-home handlers, JSON outputs, schemas, docs, and end-to-end journal coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools