### PR TITLE
Add Hue client summary predicates

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Hue snapshot summaries for compact resource-family, relationship-ref, scene
-  action, and state-projection coverage over typed CLIP v2 snapshots.
+  action, and state-projection coverage over typed CLIP v2 snapshots, plus
+  relationship and scene-state predicates.
 - Hue event-stream summaries for compact retry-hint, record, resource-item, and
-  resource-type coverage over parsed Server-Sent Events batches.
+  resource-type coverage over parsed Server-Sent Events batches, plus typed-item
+  and multi-type predicates.
 - `HueClient::get_grouped_light_state_updates` for room/zone aggregate-light
   state reads through the facade.
 - Unified Hue state update extraction from full snapshots and event-stream

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -13,14 +13,14 @@ Included surfaces:
 - resource snapshot and collection requests
 - typed aggregate resource snapshots from a single CLIP v2 snapshot envelope
 - resource snapshot summaries for resource-family, owner ref, scene action, and
-  state projection coverage
+  state projection coverage, with relationship and scene-state predicates
 - resource-specific reads
 - structured command request bodies from `hue-core`
 - command-plan execution through the `HueClient` facade
 - event-stream request shape
 - event-stream batch parsing from Server-Sent Events data frames
 - event-stream summaries for retry hints, record coverage, resource items, and
-  resource-type coverage
+  resource-type coverage, with typed-item and multi-type predicates
 - incremental event-stream decoding for split Server-Sent Events chunks
 - Hue v2 envelope/error parsing
 - Hue bridge resource decoding for paired bridge identity and time zone data

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -296,6 +296,14 @@ impl HueSnapshotSummary {
         self.scene_actions > 0
     }
 
+    pub fn has_relationship_refs(&self) -> bool {
+        self.device_service_refs > 0 || self.area_child_refs > 0 || self.area_service_refs > 0
+    }
+
+    pub fn has_scene_state_projection(&self) -> bool {
+        self.stateful_scene_actions > 0 || self.desired_scene_state_fields > 0
+    }
+
     pub fn has_sensor_or_input_resources(&self) -> bool {
         self.motion_resources > 0 || self.button_resources > 0
     }
@@ -410,6 +418,30 @@ impl HueEventStreamSummary {
 
     pub fn has_unknown_resource_items(&self) -> bool {
         self.unknown_resource_items > 0
+    }
+
+    pub fn typed_resource_item_count(&self) -> usize {
+        self.total_resource_items
+            .saturating_sub(self.unknown_resource_items)
+    }
+
+    pub fn has_typed_resource_items(&self) -> bool {
+        self.typed_resource_item_count() > 0
+    }
+
+    pub fn has_multiple_resource_types(&self) -> bool {
+        usize::from(self.bridge_resource_items > 0)
+            + usize::from(self.device_resource_items > 0)
+            + usize::from(self.light_resource_items > 0)
+            + usize::from(self.grouped_light_resource_items > 0)
+            + usize::from(self.room_resource_items > 0)
+            + usize::from(self.zone_resource_items > 0)
+            + usize::from(self.scene_resource_items > 0)
+            + usize::from(self.motion_resource_items > 0)
+            + usize::from(self.button_resource_items > 0)
+            + usize::from(self.smart_scene_resource_items > 0)
+            + usize::from(self.unknown_resource_items > 0)
+            > 1
     }
 
     fn record_resource_item(&mut self, resource: &JsonValue) {
@@ -2048,6 +2080,9 @@ mod tests {
         assert!(summary.has_resource_items());
         assert!(summary.has_empty_records());
         assert!(summary.has_unknown_resource_items());
+        assert_eq!(summary.typed_resource_item_count(), 2);
+        assert!(summary.has_typed_resource_items());
+        assert!(summary.has_multiple_resource_types());
 
         let empty = HueEventStreamSummary::empty();
         assert!(empty.is_empty());
@@ -2055,6 +2090,9 @@ mod tests {
         assert!(!empty.has_resource_items());
         assert!(!empty.has_empty_records());
         assert!(!empty.has_unknown_resource_items());
+        assert_eq!(empty.typed_resource_item_count(), 0);
+        assert!(!empty.has_typed_resource_items());
+        assert!(!empty.has_multiple_resource_types());
     }
 
     #[test]
@@ -2514,6 +2552,8 @@ mod tests {
         assert!(summary.has_lighting_resources());
         assert!(summary.has_area_resources());
         assert!(summary.has_scene_actions());
+        assert!(summary.has_relationship_refs());
+        assert!(summary.has_scene_state_projection());
         assert!(summary.has_sensor_or_input_resources());
         assert!(summary.has_state_projection());
 
@@ -2522,6 +2562,8 @@ mod tests {
         assert!(!empty.has_lighting_resources());
         assert!(!empty.has_area_resources());
         assert!(!empty.has_scene_actions());
+        assert!(!empty.has_relationship_refs());
+        assert!(!empty.has_scene_state_projection());
         assert!(!empty.has_sensor_or_input_resources());
         assert!(!empty.has_state_projection());
     }


### PR DESCRIPTION
## Summary
- add Hue snapshot summary predicates for relationship refs and scene-state projection coverage
- add Hue event-stream helpers for typed resource item counts and multi-type coverage
- document the added package-facing summary helpers

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\hue-client\\Cargo.toml
- CARGO_TARGET_DIR=C:\\tmp\\codex-hue-client-summary-predicates-target cargo test --manifest-path code\\packages\\rust\\hue-client\\Cargo.toml -- --nocapture