### PR TITLE
Add smart-home activation action tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for ranked D23A integration activation candidate
   planning: `smart_home.list_integration_activation_candidates` and
   `smart_home.get_integration_activation_candidate_summary`.
+- Added D18D handlers for concrete D23A integration activation action
+  planning: `smart_home.list_integration_activation_actions` and
+  `smart_home.get_integration_activation_action_summary`.
 - Added D18D handlers for D23A rollout-priority activation runway planning:
   `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -39,6 +39,7 @@ Chief of Staff job/session/agent
   -> capability grant ledger reads and summaries
   -> activation-plan list and summary reads for D23A rollout planning
   -> activation-candidate list and summary reads for ranked rollout planning
+  -> activation-action list and summary reads for concrete unblock/activate work
   -> activation-runway list and summary reads for rollout-priority waves
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
@@ -63,6 +64,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_plan_summary`
 - `smart_home.list_integration_activation_candidates`
 - `smart_home.get_integration_activation_candidate_summary`
+- `smart_home.list_integration_activation_actions`
+- `smart_home.get_integration_activation_action_summary`
 - `smart_home.list_integration_activation_runway`
 - `smart_home.get_integration_activation_runway_summary`
 - `smart_home.list_integration_readiness`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -33,15 +33,17 @@ use smart_home_discovery::{
     DiscoveryWorkerId, DiscoveryWorkerKind, PairingRequirement,
 };
 use smart_home_integration_catalog::{
-    activation_candidates_at_or_before_priority, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_runway_from_candidates,
-    describe_primitive_family, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationCandidate,
+    activation_actions_from_candidates, activation_candidates_at_or_before_priority,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_runway_from_candidates, describe_primitive_family,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
+    IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationCandidate,
     IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
     IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
@@ -143,6 +145,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CANDIDATES_TOOL_ID: &str =
     "smart_home.list_integration_activation_candidates";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_candidate_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_actions";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_action_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID: &str =
     "smart_home.list_integration_activation_runway";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID: &str =
@@ -241,6 +247,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_candidate_query(&arguments)?;
                     Ok(get_integration_activation_candidate_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID => {
+                    let query = integration_activation_action_query(&arguments)?;
+                    Ok(list_integration_activation_actions_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_action_query(&arguments)?;
+                    Ok(get_integration_activation_action_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID => {
                     let query = integration_activation_runway_query(&arguments)?;
@@ -892,6 +908,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation candidate summary",
             "Return compact D23A activation candidate rollups for ready, review, and blocked rollout work.",
             integration_activation_candidate_query_schema(false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID,
+            "List smart-home integration activation actions",
+            "List concrete D23A activation actions derived from ready, review, and blocked integration candidates.",
+            integration_activation_action_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "activation_actions",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_actions", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation action summary",
+            "Return compact D23A activation action rollups for activate, review, primitive, capability, and dependency work.",
+            integration_activation_action_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3213,6 +3261,13 @@ struct IntegrationActivationCandidateQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationActionQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    action_kind: Option<IntegrationActivationActionKind>,
+    action_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRunwayQuery {
     candidates: IntegrationActivationCandidateQuery,
     stage_limit: Option<usize>,
@@ -3245,6 +3300,22 @@ fn integration_activation_runway_query(
         candidates,
         stage_limit,
         candidates_per_stage_limit,
+    })
+}
+
+fn integration_activation_action_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationActionQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let action_kind = optional_string(arguments, "action_kind")?
+        .map(|label| parse_activation_action_kind(&label))
+        .transpose()?;
+    let action_limit = optional_u64(arguments, "action_limit")?.map(|value| value as usize);
+
+    Ok(IntegrationActivationActionQuery {
+        candidates,
+        action_kind,
+        action_limit,
     })
 }
 
@@ -3372,6 +3443,23 @@ fn integration_activation_runway_for_query(
     }
 
     (runway, catalog_count)
+}
+
+fn integration_activation_actions_for_query(
+    query: &IntegrationActivationActionQuery,
+) -> (Vec<IntegrationActivationAction>, usize) {
+    let (candidates, catalog_count) =
+        integration_activation_candidates_for_query(&query.candidates);
+    let mut actions = activation_actions_from_candidates(candidates.iter());
+
+    if let Some(action_kind) = query.action_kind {
+        actions.retain(|action| action.kind == action_kind);
+    }
+    if let Some(limit) = query.action_limit {
+        actions.truncate(limit);
+    }
+
+    (actions, catalog_count)
 }
 
 fn limited_slice<T>(items: &[T], limit: Option<usize>) -> &[T] {
@@ -3633,6 +3721,68 @@ fn get_integration_activation_candidate_summary_output_handler_output(
             (
                 "blocked_candidates",
                 integer(summary.blocked_candidates as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_actions_output_handler_output(
+    query: IntegrationActivationActionQuery,
+) -> ToolHandlerOutput {
+    let (actions, catalog_count) = integration_activation_actions_for_query(&query);
+    let summary = IntegrationActivationActionSummary::from_actions(actions.iter());
+    let count = actions.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_actions",
+            JsonValue::Array(actions.iter().map(activation_action_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_action_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_actions")),
+            ("count", integer(count as i64)),
+            (
+                "activate_integration_actions",
+                integer(summary.activate_integration_actions as i64),
+            ),
+            (
+                "provide_primitive_actions",
+                integer(summary.provide_primitive_actions as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_action_summary_output_handler_output(
+    query: IntegrationActivationActionQuery,
+) -> ToolHandlerOutput {
+    let (actions, _) = integration_activation_actions_for_query(&query);
+    let summary = IntegrationActivationActionSummary::from_actions(actions.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_action_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_action_summary"),
+            ),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "blocked_integration_count",
+                integer(summary.blocked_integration_count as i64),
             ),
         ]),
     )
@@ -6246,6 +6396,134 @@ fn integration_activation_candidate_summary_json(
     ])
 }
 
+fn activation_action_json(action: &IntegrationActivationAction) -> JsonValue {
+    object([
+        (
+            "action_kind",
+            string(activation_action_kind_label(action.kind)),
+        ),
+        (
+            "requested_integration_id",
+            string(action.requested_integration_id.as_str()),
+        ),
+        ("display_name", string(&action.display_name)),
+        ("priority", integer(action.priority as i64)),
+        (
+            "recommendation",
+            string(activation_candidate_recommendation_label(
+                action.recommendation,
+            )),
+        ),
+        (
+            "primitive",
+            action
+                .primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "capability_id",
+            action
+                .capability_id
+                .as_ref()
+                .map(|capability_id| string(capability_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependency_integration_id",
+            action
+                .dependency_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(action.highest_policy_tier)),
+        ),
+        (
+            "blocks_activation",
+            JsonValue::Bool(action.blocks_activation()),
+        ),
+        ("is_activation", JsonValue::Bool(action.is_activation())),
+    ])
+}
+
+fn integration_activation_action_summary_json(
+    summary: &IntegrationActivationActionSummary,
+) -> JsonValue {
+    object([
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "activate_integration_actions",
+            integer(summary.activate_integration_actions as i64),
+        ),
+        (
+            "review_policy_actions",
+            integer(summary.review_policy_actions as i64),
+        ),
+        (
+            "provide_primitive_actions",
+            integer(summary.provide_primitive_actions as i64),
+        ),
+        (
+            "grant_capability_actions",
+            integer(summary.grant_capability_actions as i64),
+        ),
+        (
+            "enable_dependency_actions",
+            integer(summary.enable_dependency_actions as i64),
+        ),
+        (
+            "actionable_integration_count",
+            integer(summary.actionable_integration_count as i64),
+        ),
+        (
+            "blocked_integration_count",
+            integer(summary.blocked_integration_count as i64),
+        ),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "first_action_priority",
+            summary
+                .first_action_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_priority",
+            summary
+                .first_blocker_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+    ])
+}
+
 fn activation_runway_stage_json(stage: &IntegrationActivationRunwayStage) -> JsonValue {
     object([
         ("priority", integer(stage.priority as i64)),
@@ -8360,6 +8638,41 @@ fn activation_candidate_recommendation_label(
     }
 }
 
+fn parse_activation_action_kind(
+    label: &str,
+) -> Result<IntegrationActivationActionKind, ToolCallError> {
+    match label {
+        "activate_integration" | "activate" | "ready" => {
+            Ok(IntegrationActivationActionKind::ActivateIntegration)
+        }
+        "review_policy" | "review" | "human_review" => {
+            Ok(IntegrationActivationActionKind::ReviewPolicy)
+        }
+        "provide_primitive" | "primitive" | "install_primitive" => {
+            Ok(IntegrationActivationActionKind::ProvidePrimitive)
+        }
+        "grant_capability" | "capability" | "grant" => {
+            Ok(IntegrationActivationActionKind::GrantCapability)
+        }
+        "enable_dependency" | "dependency" | "enable_integration" => {
+            Ok(IntegrationActivationActionKind::EnableDependency)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation action kind `{label}`"
+        ))),
+    }
+}
+
+fn activation_action_kind_label(kind: IntegrationActivationActionKind) -> &'static str {
+    match kind {
+        IntegrationActivationActionKind::ActivateIntegration => "activate_integration",
+        IntegrationActivationActionKind::ReviewPolicy => "review_policy",
+        IntegrationActivationActionKind::ProvidePrimitive => "provide_primitive",
+        IntegrationActivationActionKind::GrantCapability => "grant_capability",
+        IntegrationActivationActionKind::EnableDependency => "enable_dependency",
+    }
+}
+
 fn integration_category_label(category: IntegrationCategory) -> &'static str {
     match category {
         IntegrationCategory::ProtocolStandard => "protocol_standard",
@@ -8974,6 +9287,20 @@ fn integration_activation_candidate_query_schema(include_limit: bool) -> JsonSch
     schema
 }
 
+fn integration_activation_action_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("action_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("action_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_runway_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -9095,7 +9422,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 55);
+        assert_eq!(definitions.len(), 57);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -9127,6 +9454,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID));
@@ -9230,7 +9563,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            47
+            49
         );
         assert_eq!(
             export
@@ -9270,6 +9603,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_CANDIDATE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -9524,11 +9865,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(55))
+            Some(&integer(57))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(47))
+            Some(&integer(49))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -9729,6 +10070,123 @@ mod tests {
             Some(&JsonValue::Bool(false))
         );
 
+        let list_activation_actions_request = request(
+            "call-list-integration-activation-actions",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("action_kind", string("provide_primitive")),
+                ("action_limit", integer(3)),
+            ]),
+            4_999,
+        );
+        let list_activation_actions_trace =
+            tool_runtime.invoke_with_events(&list_activation_actions_request);
+        assert!(list_activation_actions_trace.result.ok);
+        assert_eq!(
+            list_activation_actions_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_actions_output = list_activation_actions_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_activation_actions_output, "count"),
+            Some(&integer(3))
+        );
+        let activation_action = array_item(
+            field(list_activation_actions_output, "activation_actions").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_action, "action_kind"),
+            Some(&string("provide_primitive"))
+        );
+        assert!(matches!(
+            field(activation_action, "primitive"),
+            Some(JsonValue::String(_))
+        ));
+        assert_eq!(
+            field(activation_action, "blocks_activation"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_action_summary = field(list_activation_actions_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_action_summary, "provide_primitive_actions"),
+            Some(&integer(3))
+        );
+        assert_eq!(
+            field(activation_action_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_action_summary_request = request(
+            "call-integration-activation-action-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_000,
+        );
+        let activation_action_summary_trace =
+            tool_runtime.invoke_with_events(&activation_action_summary_request);
+        assert!(activation_action_summary_trace.result.ok);
+        assert_eq!(
+            activation_action_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_action_summary_output = activation_action_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_action_rollup = field(activation_action_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_action_rollup, "total_actions").unwrap()).unwrap() >= 3
+        );
+        assert_eq!(
+            field(activation_action_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            optional_field(activation_action_rollup, "first_blocker_priority")
+                .and_then(integer_value)
+                .is_some()
+        );
+
         let list_activation_runway_request = request(
             "call-list-integration-activation-runway",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID,
@@ -9751,7 +10209,7 @@ mod tests {
                 ("stage_limit", integer(2)),
                 ("candidates_per_stage_limit", integer(2)),
             ]),
-            4_999,
+            5_001,
         );
         let list_activation_runway_trace =
             tool_runtime.invoke_with_events(&list_activation_runway_request);
@@ -9810,7 +10268,7 @@ mod tests {
                     JsonValue::Array(vec![string("smart_home.read")]),
                 ),
             ]),
-            5_000,
+            5_002,
         );
         let activation_runway_summary_trace =
             tool_runtime.invoke_with_events(&activation_runway_summary_request);
@@ -11220,6 +11678,14 @@ mod tests {
             activation_candidate_summary_request,
             activation_candidate_summary_trace,
         );
+        journal.record_trace(
+            list_activation_actions_request,
+            list_activation_actions_trace,
+        );
+        journal.record_trace(
+            activation_action_summary_request,
+            activation_action_summary_trace,
+        );
         journal.record_trace(list_activation_runway_request, list_activation_runway_trace);
         journal.record_trace(
             activation_runway_summary_request,
@@ -11285,9 +11751,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 55);
-        assert_eq!(journal_summary.completed_count, 55);
-        assert_eq!(journal.audit_records().len(), 55);
+        assert_eq!(journal_summary.invocation_count, 57);
+        assert_eq!(journal_summary.completed_count, 57);
+        assert_eq!(journal.audit_records().len(), 57);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_candidates` and
   `smart_home.get_integration_activation_candidate_summary` tool descriptors
   for read-only ranked activation candidate planning.
+- `smart_home.list_integration_activation_actions` and
+  `smart_home.get_integration_activation_action_summary` tool descriptors for
+  read-only concrete activation action planning.
 - `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary` tool descriptors for
   read-only rollout-priority activation wave planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -54,6 +54,8 @@ Current scope:
   and compact activation-plan rollups
 - D18D integration activation-candidate descriptors for ranked ready, review,
   and blocked rollout planning
+- D18D integration activation-action descriptors for concrete activate,
+  policy-review, primitive, capability, and dependency work planning
 - D18D integration activation-runway descriptors for rollout-priority wave
   grouping and compact actionable/blocker summaries
 - D18D integration-readiness descriptors for bulk activation blocker reports

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1455,6 +1455,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationPlanSummary,
     ListIntegrationActivationCandidates,
     GetIntegrationActivationCandidateSummary,
+    ListIntegrationActivationActions,
+    GetIntegrationActivationActionSummary,
     ListIntegrationActivationRunway,
     GetIntegrationActivationRunwaySummary,
     ListIntegrationReadiness,
@@ -1524,6 +1526,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationCandidateSummary => {
                 read_tool("smart_home.get_integration_activation_candidate_summary")
+            }
+            Self::ListIntegrationActivationActions => {
+                read_tool("smart_home.list_integration_activation_actions")
+            }
+            Self::GetIntegrationActivationActionSummary => {
+                read_tool("smart_home.get_integration_activation_action_summary")
             }
             Self::ListIntegrationActivationRunway => {
                 read_tool("smart_home.list_integration_activation_runway")
@@ -2156,6 +2164,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationPlanSummary,
         SmartHomeTool::ListIntegrationActivationCandidates,
         SmartHomeTool::GetIntegrationActivationCandidateSummary,
+        SmartHomeTool::ListIntegrationActivationActions,
+        SmartHomeTool::GetIntegrationActivationActionSummary,
         SmartHomeTool::ListIntegrationActivationRunway,
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
         SmartHomeTool::ListIntegrationReadiness,
@@ -2996,7 +3006,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 55);
+        assert_eq!(catalog.len(), 57);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3040,6 +3050,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_candidate_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_actions"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_action_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
@@ -3230,15 +3248,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 55);
-        assert_eq!(summary.read_tools, 47);
+        assert_eq!(summary.total_tools, 57);
+        assert_eq!(summary.read_tools, 49);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 47);
+        assert_eq!(summary.read_only_tier_tools, 49);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 55);
+        assert_eq!(summary.total_required_capabilities, 57);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationCandidate` and `IntegrationActivationCandidateSummary`
   for ranking ready, human-review, and blocked activation work after applying
   host-specific readiness context.
+- `IntegrationActivationAction` and `IntegrationActivationActionSummary` for
+  converting activation candidates into concrete activate, policy-review,
+  primitive, capability, and dependency work items.
 - `IntegrationActivationRunwayStage` and `IntegrationActivationRunwaySummary`
   for grouping activation candidates by rollout priority wave and identifying
   actionable, review, and blocked stages.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -32,6 +32,8 @@ runtime and Chief of Staff tools a typed catalog for:
   local/cloud boundaries, dependencies, and unique primitive/capability needs
 - activation candidates that rank ready, human-review, and blocked rollout work
   after applying host-specific primitive, capability, and dependency context
+- activation actions that turn ready/review/blocker candidates into concrete
+  activate, policy-review, primitive, capability, and dependency work items
 - activation runway stages that group those candidates by rollout priority wave
   with compact ready, review, and blocker rollups
 - readiness reports that compare activation plans against available primitives,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -690,6 +690,15 @@ pub enum IntegrationActivationCandidateRecommendation {
     BlockedOnPrerequisites,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationActionKind {
+    ActivateIntegration,
+    ReviewPolicy,
+    ProvidePrimitive,
+    GrantCapability,
+    EnableDependency,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationCandidate {
     pub readiness_report: IntegrationReadinessReport,
@@ -713,6 +722,36 @@ pub struct IntegrationActivationCandidateSummary {
     pub delegated_standard_targets: usize,
     pub local_only_candidates: usize,
     pub cloud_required_candidates: usize,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationAction {
+    pub kind: IntegrationActivationActionKind,
+    pub requested_integration_id: IntegrationId,
+    pub display_name: String,
+    pub priority: u8,
+    pub recommendation: IntegrationActivationCandidateRecommendation,
+    pub primitive: Option<PrimitiveFamily>,
+    pub capability_id: Option<CapabilityId>,
+    pub dependency_integration_id: Option<IntegrationId>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationActionSummary {
+    pub total_actions: usize,
+    pub activate_integration_actions: usize,
+    pub review_policy_actions: usize,
+    pub provide_primitive_actions: usize,
+    pub grant_capability_actions: usize,
+    pub enable_dependency_actions: usize,
+    pub actionable_integration_count: usize,
+    pub blocked_integration_count: usize,
+    pub unique_integrations: usize,
+    pub first_action_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_blocker_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
 }
 
@@ -1168,6 +1207,194 @@ impl IntegrationActivationCandidateSummary {
 
     pub fn has_review_work(&self) -> bool {
         self.needs_human_review_candidates > 0
+    }
+}
+
+impl IntegrationActivationActionKind {
+    fn sort_rank(self) -> u8 {
+        match self {
+            Self::ActivateIntegration => 0,
+            Self::ReviewPolicy => 1,
+            Self::ProvidePrimitive => 2,
+            Self::GrantCapability => 3,
+            Self::EnableDependency => 4,
+        }
+    }
+}
+
+impl IntegrationActivationAction {
+    pub fn activate(candidate: &IntegrationActivationCandidate) -> Self {
+        Self::from_candidate(
+            candidate,
+            IntegrationActivationActionKind::ActivateIntegration,
+        )
+    }
+
+    pub fn review_policy(candidate: &IntegrationActivationCandidate) -> Self {
+        Self::from_candidate(candidate, IntegrationActivationActionKind::ReviewPolicy)
+    }
+
+    pub fn provide_primitive(
+        candidate: &IntegrationActivationCandidate,
+        primitive: PrimitiveFamily,
+    ) -> Self {
+        Self {
+            primitive: Some(primitive),
+            ..Self::from_candidate(candidate, IntegrationActivationActionKind::ProvidePrimitive)
+        }
+    }
+
+    pub fn grant_capability(
+        candidate: &IntegrationActivationCandidate,
+        capability_id: CapabilityId,
+    ) -> Self {
+        Self {
+            capability_id: Some(capability_id),
+            ..Self::from_candidate(candidate, IntegrationActivationActionKind::GrantCapability)
+        }
+    }
+
+    pub fn enable_dependency(
+        candidate: &IntegrationActivationCandidate,
+        dependency_integration_id: IntegrationId,
+    ) -> Self {
+        Self {
+            dependency_integration_id: Some(dependency_integration_id),
+            ..Self::from_candidate(candidate, IntegrationActivationActionKind::EnableDependency)
+        }
+    }
+
+    pub fn is_activation(&self) -> bool {
+        self.kind == IntegrationActivationActionKind::ActivateIntegration
+    }
+
+    pub fn blocks_activation(&self) -> bool {
+        !self.is_activation()
+    }
+
+    fn from_candidate(
+        candidate: &IntegrationActivationCandidate,
+        kind: IntegrationActivationActionKind,
+    ) -> Self {
+        Self {
+            kind,
+            requested_integration_id: candidate.readiness_report.requested_integration_id.clone(),
+            display_name: candidate.readiness_report.display_name.clone(),
+            priority: candidate.readiness_report.priority,
+            recommendation: candidate.recommendation,
+            primitive: None,
+            capability_id: None,
+            dependency_integration_id: None,
+            highest_policy_tier: candidate.readiness_report.highest_policy_tier,
+        }
+    }
+}
+
+impl IntegrationActivationActionSummary {
+    pub fn from_actions<'a>(
+        actions: impl IntoIterator<Item = &'a IntegrationActivationAction>,
+    ) -> Self {
+        let mut unique_integrations = BTreeSet::new();
+        let mut actionable_integrations = BTreeSet::new();
+        let mut blocked_integrations = BTreeSet::new();
+        let mut summary = Self {
+            total_actions: 0,
+            activate_integration_actions: 0,
+            review_policy_actions: 0,
+            provide_primitive_actions: 0,
+            grant_capability_actions: 0,
+            enable_dependency_actions: 0,
+            actionable_integration_count: 0,
+            blocked_integration_count: 0,
+            unique_integrations: 0,
+            first_action_priority: None,
+            first_activation_priority: None,
+            first_blocker_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for action in actions {
+            summary.total_actions += 1;
+            unique_integrations.insert(action.requested_integration_id.clone());
+            summary.first_action_priority = Some(
+                summary
+                    .first_action_priority
+                    .map_or(action.priority, |priority| priority.min(action.priority)),
+            );
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(action.highest_policy_tier);
+            match action.kind {
+                IntegrationActivationActionKind::ActivateIntegration => {
+                    summary.activate_integration_actions += 1;
+                    actionable_integrations.insert(action.requested_integration_id.clone());
+                    summary.first_activation_priority = Some(
+                        summary
+                            .first_activation_priority
+                            .map_or(action.priority, |priority| priority.min(action.priority)),
+                    );
+                }
+                IntegrationActivationActionKind::ReviewPolicy => {
+                    summary.review_policy_actions += 1;
+                    blocked_integrations.insert(action.requested_integration_id.clone());
+                    summary.first_blocker_priority = Some(
+                        summary
+                            .first_blocker_priority
+                            .map_or(action.priority, |priority| priority.min(action.priority)),
+                    );
+                }
+                IntegrationActivationActionKind::ProvidePrimitive => {
+                    summary.provide_primitive_actions += 1;
+                    blocked_integrations.insert(action.requested_integration_id.clone());
+                    summary.first_blocker_priority = Some(
+                        summary
+                            .first_blocker_priority
+                            .map_or(action.priority, |priority| priority.min(action.priority)),
+                    );
+                }
+                IntegrationActivationActionKind::GrantCapability => {
+                    summary.grant_capability_actions += 1;
+                    blocked_integrations.insert(action.requested_integration_id.clone());
+                    summary.first_blocker_priority = Some(
+                        summary
+                            .first_blocker_priority
+                            .map_or(action.priority, |priority| priority.min(action.priority)),
+                    );
+                }
+                IntegrationActivationActionKind::EnableDependency => {
+                    summary.enable_dependency_actions += 1;
+                    blocked_integrations.insert(action.requested_integration_id.clone());
+                    summary.first_blocker_priority = Some(
+                        summary
+                            .first_blocker_priority
+                            .map_or(action.priority, |priority| priority.min(action.priority)),
+                    );
+                }
+            }
+        }
+
+        summary.unique_integrations = unique_integrations.len();
+        summary.actionable_integration_count = actionable_integrations.len();
+        summary.blocked_integration_count = blocked_integrations.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_actions == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activate_integration_actions > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.review_policy_actions > 0
+            || self.provide_primitive_actions > 0
+            || self.grant_capability_actions > 0
+            || self.enable_dependency_actions > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_policy_actions > 0
     }
 }
 
@@ -2380,6 +2607,63 @@ pub fn activation_candidates_at_or_before_priority(
     activation_candidates_from_reports(reports.iter())
 }
 
+pub fn activation_actions_from_candidates<'a>(
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationAction> {
+    let mut actions = Vec::new();
+
+    for candidate in candidates {
+        if candidate.activation_ready() {
+            if candidate.requires_human_review() {
+                actions.push(IntegrationActivationAction::review_policy(candidate));
+            } else {
+                actions.push(IntegrationActivationAction::activate(candidate));
+            }
+        }
+
+        for primitive in &candidate.readiness_report.missing_primitives {
+            actions.push(IntegrationActivationAction::provide_primitive(
+                candidate, *primitive,
+            ));
+        }
+        for capability_id in &candidate.readiness_report.missing_capabilities {
+            actions.push(IntegrationActivationAction::grant_capability(
+                candidate,
+                capability_id.clone(),
+            ));
+        }
+        for integration_id in &candidate.readiness_report.missing_dependencies {
+            actions.push(IntegrationActivationAction::enable_dependency(
+                candidate,
+                integration_id.clone(),
+            ));
+        }
+        if candidate.is_blocked() && candidate.requires_human_review() {
+            actions.push(IntegrationActivationAction::review_policy(candidate));
+        }
+    }
+
+    actions.sort_by(compare_activation_actions);
+    actions
+}
+
+pub fn activation_actions_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationAction> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_actions_from_candidates(candidates.iter())
+}
+
 pub fn activation_runway_from_candidates(
     candidates: Vec<IntegrationActivationCandidate>,
 ) -> Vec<IntegrationActivationRunwayStage> {
@@ -3416,6 +3700,26 @@ fn compare_activation_candidates(
         })
 }
 
+fn compare_activation_actions(
+    left: &IntegrationActivationAction,
+    right: &IntegrationActivationAction,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.kind.sort_rank().cmp(&right.kind.sort_rank()))
+        .then_with(|| left.display_name.cmp(&right.display_name))
+        .then_with(|| {
+            left.requested_integration_id
+                .cmp(&right.requested_integration_id)
+        })
+        .then_with(|| left.primitive.cmp(&right.primitive))
+        .then_with(|| left.capability_id.cmp(&right.capability_id))
+        .then_with(|| {
+            left.dependency_integration_id
+                .cmp(&right.dependency_integration_id)
+        })
+}
+
 fn compare_by_priority_then_name(
     left: &IntegrationCatalogEntry,
     right: &IntegrationCatalogEntry,
@@ -3958,6 +4262,98 @@ mod tests {
         assert!(summary.has_actionable_stage());
         assert!(summary.has_blocked_stage());
         assert!(summary.has_review_stage());
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_actions_explain_ready_review_and_blocker_work() {
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 2,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_bridge"),
+            display_name: "Review Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_sensor"),
+            display_name: "Blocked Sensor".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 1,
+            missing_primitives: vec![PrimitiveFamily::Mqtt],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::LowRisk,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [ready_report, review_report, blocked_report].iter(),
+        );
+
+        let actions = activation_actions_from_candidates(candidates.iter());
+
+        assert_eq!(actions.len(), 5);
+        assert_eq!(
+            actions[0].kind,
+            IntegrationActivationActionKind::ReviewPolicy
+        );
+        assert_eq!(
+            actions[1].kind,
+            IntegrationActivationActionKind::ProvidePrimitive
+        );
+        assert_eq!(
+            actions[2].kind,
+            IntegrationActivationActionKind::GrantCapability
+        );
+        assert_eq!(
+            actions[3].kind,
+            IntegrationActivationActionKind::EnableDependency
+        );
+        assert_eq!(
+            actions[4].kind,
+            IntegrationActivationActionKind::ActivateIntegration
+        );
+        assert!(actions[0].blocks_activation());
+        assert!(actions[4].is_activation());
+
+        let summary = IntegrationActivationActionSummary::from_actions(actions.iter());
+        assert_eq!(summary.total_actions, 5);
+        assert_eq!(summary.activate_integration_actions, 1);
+        assert_eq!(summary.review_policy_actions, 1);
+        assert_eq!(summary.provide_primitive_actions, 1);
+        assert_eq!(summary.grant_capability_actions, 1);
+        assert_eq!(summary.enable_dependency_actions, 1);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.actionable_integration_count, 1);
+        assert_eq!(summary.blocked_integration_count, 2);
+        assert_eq!(summary.first_action_priority, Some(1));
+        assert_eq!(summary.first_activation_priority, Some(2));
+        assert_eq!(summary.first_blocker_priority, Some(1));
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
         assert!(!summary.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- add shared integration activation action types and summaries that convert ready/review/blocked candidates into concrete activate, policy-review, primitive, capability, and dependency work
- expose two shared-core read descriptors for activation action listing and summary tools
- wire Chief-of-Staff D18D handlers, JSON output, filters, docs, and end-to-end runtime coverage for the new action tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
- git diff --check

Generated code/packages/rust/Cargo.lock was removed before commit.