### PR TITLE
feat(closurec): CLOC12.51 — close gap-045 (single-arg arrow drops parens)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.57.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-045** — single-argument arrow function drops
+  its enclosing parens. Harness now 79/81; only gap-044
+  (template substitution, lexer-level) remains open.
+- Added a top-of-loop pattern detector: when the current
+  token is `(` AND `kept[idx+1]` is a Name AND
+  `kept[idx+2]` is `)` AND `kept[idx+3]` is `=>`, emit just
+  the IDENT and `=>`, advancing idx by 4. Both parens are
+  skipped — the `(` push and `)` pop both bypassed, leaving
+  paren_stack net-zero.
+- Composes with `async` keyword: `var f=async(x)=>x+1;` →
+  `var f=async x=>x+1;`. The `async` keyword + Name IDENT
+  pair triggers `needs_separator` (both word-like → space).
+- Added `is_simple_identifier_token` helper that returns
+  true only for `TokenType::Name` — keywords, punctuation,
+  strings, and numbers all fail. This filters out
+  destructuring (`{`), rest (`...`), and reserved-word
+  param names.
+
+### Added
+
+8 inline `gap045_*` tests:
+- target single-arg arrow + async composition
+- 6 non-regression cases: zero-arg, multi-arg, default,
+  rest, destructuring, `(x).y` member access (not arrow)
+
+### Pre-push security review
+
+Verdict PASS. Traced 6 concerns: paren_stack balance,
+other stack non-interaction, false-positive on `(x).y`,
+async composition + needs_separator interaction, future
+template-substitution composition, prev_emitted_tok stored
+as the `=>` token (PUNCT) to avoid spurious space after
+IDENT body.
+
 ## [0.56.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -250,6 +250,68 @@ pub fn whitespace_only_minify(
         let tok = kept[idx];
         let val = tok.value.as_str();
 
+        // gap-045: single-arg arrow function — drop the
+        // enclosing parens around a bare-identifier param.
+        // Pattern: `(`, IDENT, `)`, `=>` — when matched,
+        // emit IDENT + `=>` directly, advancing past all 4
+        // tokens. Eligibility deliberately excludes:
+        //   - zero args (`()=>...` — next-after-`(` is `)`)
+        //   - destructuring (`({x})=>...`, `([x])=>...`)
+        //   - rest (`(...args)=>...` — next is `...`)
+        //   - default values (`(x=1)=>...` — `)` is at idx+4 not +2)
+        //   - multiple args (`(x,y)=>...` — `)` is at idx+4+)
+        //   - typed params (TS) — multiple tokens between
+        //     the `(` and `)`.
+        // The check `is_simple_identifier_token` ensures the
+        // single token between parens is a NAME (not a
+        // keyword or operator).
+        //
+        // Composes with `async` keyword: `async(x)=>...` →
+        // `async x=>...`. The `async` is emitted before the
+        // `(`, and our shape-detection runs ON the `(` —
+        // so `async` ends up with `prev_emitted_tok = async`
+        // when IDENT is emitted, triggering needs_separator
+        // (KEYWORD + NAME) → space inserted. Correct.
+        if val == "("
+            && is_simple_identifier_token(kept.get(idx + 1).copied())
+            && kept.get(idx + 2).map(|t| t.value.as_str()) == Some(")")
+            && kept.get(idx + 3).map(|t| t.value.as_str()) == Some("=>")
+        {
+            let ident = kept[idx + 1];
+            // Emit IDENT with separator if needed.
+            if let Some(prev) = prev_emitted_tok {
+                if needs_separator(prev, ident) {
+                    out.push(' ');
+                }
+            }
+            out.push_str(&ident.value);
+            prev_emitted_tok = Some(ident);
+            // Emit `=>` — never needs a separator with an
+            // IDENT prefix (`=` is PUNCTUATION).
+            out.push_str("=>");
+            // Update state machine for the now-emitted `=>`:
+            // body-position semantics don't apply here (arrow
+            // body opens differently), but at_stmt_boundary
+            // and body_position_next should reset to "we are
+            // mid-expression".
+            at_stmt_boundary = false;
+            body_position_next = false;
+            // Synthetic emit shouldn't be flagged as one for
+            // rule-C dedup purposes — it's not a `;`.
+            last_emit_was_synthetic_semi = false;
+            // `=>` token is a punctuation; track it as prev
+            // for the next iteration's needs_separator. We
+            // can't store the original token because we
+            // skipped it; reuse the IDENT slot — the next
+            // token's needs_separator call will see word-like
+            // IDENT as prev. For `x=>y` next is `y` (NAME),
+            // word-like(NAME, NAME) → space. WRONG. So set
+            // prev_emitted_tok to the `=>` token instead.
+            prev_emitted_tok = Some(kept[idx + 3]);
+            idx += 4;
+            continue;
+        }
+
         // Rule C: dedup source `;` directly after our
         // synthetic `;` from rule B.
         if val == ";" && last_emit_was_synthetic_semi {
@@ -773,6 +835,28 @@ fn is_keyword_function(tok: &lexer::token::Token) -> bool {
             || upper.starts_with("KEYWORD");
     }
     true
+}
+
+/// gap-045: True iff this token is a simple bare IDENT
+/// (TokenType::Name) — i.e. a candidate single-arg arrow
+/// parameter. Returns false for NONE input, for keywords,
+/// punctuation, and any non-NAME token type.
+///
+/// The arrow-paren-drop pattern requires a bare identifier
+/// because:
+///   - `(x)=>...` legal (single param name)
+///   - `({x})=>...` destructuring — `{` is PUNCT, not Name
+///   - `(...args)=>...` rest — `...` is PUNCT, not Name
+///   - `(true)=>...` is a SyntaxError (reserved word as
+///     param name); even if the lexer tagged `true` as
+///     Keyword, this check rejects it.
+///   - `(x=1)=>...` default value — `(`, IDENT, `=`, ... —
+///     the position-2 check (next is `)`) catches this.
+fn is_simple_identifier_token(tok: Option<&lexer::token::Token>) -> bool {
+    let Some(t) = tok else {
+        return false;
+    };
+    matches!(t.type_, lexer::token::TokenType::Name)
 }
 
 /// True iff this token is a numeric literal (NUMBER token).
@@ -2152,6 +2236,97 @@ mod tests {
         assert_eq!(
             minify(r#"var x="\"'";"#),
             r#"var x="\"'";"#
+        );
+    }
+
+    // ---- gap-045: single-arg arrow drops parens ----------
+
+    /// Target fixture in compact form: `(x)=>x+1` →
+    /// `x=>x+1`.
+    #[test]
+    fn gap045_single_arg_arrow_drops_parens() {
+        assert_eq!(
+            minify("var f=(x)=>x+1;"),
+            "var f=x=>x+1;"
+        );
+    }
+
+    /// Composes with `async` keyword: `async(x)=>x+1` →
+    /// `async x=>x+1`. The separator between `async` and
+    /// the now-bare IDENT is inserted by `needs_separator`
+    /// (KEYWORD + NAME → space).
+    #[test]
+    fn gap045_async_single_arg_arrow() {
+        assert_eq!(
+            minify("var f=async(x)=>x+1;"),
+            "var f=async x=>x+1;"
+        );
+    }
+
+    /// **Non-regression**: zero-arg arrow `()=>x` stays as
+    /// `()=>x`. The `(` is followed by `)` not IDENT, so
+    /// the gap-045 pattern doesn't match.
+    #[test]
+    fn gap045_zero_arg_arrow_unchanged() {
+        assert_eq!(
+            minify("var f=()=>1;"),
+            "var f=()=>1;"
+        );
+    }
+
+    /// **Non-regression**: multi-arg arrow `(x,y)=>x+y`
+    /// stays parenthesised. The token at idx+2 is `,` not
+    /// `)`, so the pattern doesn't match.
+    #[test]
+    fn gap045_multi_arg_arrow_unchanged() {
+        assert_eq!(
+            minify("var f=(x,y)=>x+y;"),
+            "var f=(x,y)=>x+y;"
+        );
+    }
+
+    /// **Non-regression**: default-value arrow `(x=1)=>x`
+    /// stays parenthesised. The token at idx+2 is `=` not
+    /// `)`.
+    #[test]
+    fn gap045_default_arg_arrow_unchanged() {
+        assert_eq!(
+            minify("var f=(x=1)=>x;"),
+            "var f=(x=1)=>x;"
+        );
+    }
+
+    /// **Non-regression**: rest-arg arrow `(...args)=>args`
+    /// stays parenthesised. The token at idx+1 is `...`
+    /// (PUNCT, not Name) — `is_simple_identifier_token`
+    /// returns false.
+    #[test]
+    fn gap045_rest_arg_arrow_unchanged() {
+        assert_eq!(
+            minify("var f=(...args)=>args;"),
+            "var f=(...args)=>args;"
+        );
+    }
+
+    /// **Non-regression**: destructuring-arg arrow
+    /// `({x})=>x` stays parenthesised. The token at idx+1
+    /// is `{` (PUNCT, not Name).
+    #[test]
+    fn gap045_destruct_arg_arrow_unchanged() {
+        assert_eq!(
+            minify("var f=({x})=>x;"),
+            "var f=({x})=>x;"
+        );
+    }
+
+    /// **Non-regression**: `(x)` followed by `.` (member
+    /// access on a parenthesised expression) — NOT an
+    /// arrow. The token at idx+3 is `.` not `=>`.
+    #[test]
+    fn gap045_parens_not_arrow_unchanged() {
+        assert_eq!(
+            minify("var x=(a).b;"),
+            "var x=(a).b;"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.56.0
+Version: 0.57.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,9 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-045: single-argument arrow function should drop
-    // its enclosing parens (`(x)=>...` → `x=>...`). Upstream
-    // normalises this; closurec preserves the source form.
-    // Discovered by CLOC14.11.
-    ("arrow_async", "gap-045: single-arg arrow drops parens"),
+    // gap-045 was RESOLVED in CLOC12.51 — token-level
+    // pattern detect for `(`, IDENT, `)`, `=>` skips both
+    // parens. `minify_arrow_async` flipped IGNORED → PASS.
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -340,7 +340,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-045 — single-argument arrow function should drop enclosing parens
 
-- **Status:** OPEN — newly discovered by CLOC14.11.
+- **Status:** **RESOLVED** in CLOC12.51 (PR pending). `minify_arrow_async` flipped IGNORED → PASS. Harness now 79/81; only gap-044 (template substitution, lexer-level) remains open.
 - **Upstream byte-identity test:** `minify_arrow_async` seed fixture.
 - **Why it fails:** Upstream emits `var f=async x=>x+1;` for `var f=async(x)=>x+1;` (drops the parens). closurec preserves the source form `(x)`. The arrow-function grammar §15.3.1 permits single-identifier parameter without parens — upstream normalises to the parens-less form because it's shorter (saves 2 bytes).
 - **What it needs:** A token-level pattern detector: when seeing `(`, IDENT, `)`, `=>`, peek ahead and if the shape matches a single-bare-identifier arrow head, drop the `(` and `)` tokens. Care must be taken NOT to drop parens around: (a) typed parameters (`(x: T)=>...` — TS only, but our lexer might emit them), (b) default values (`(x=1)=>...`), (c) rest parameters (`(...args)=>...`), (d) destructuring (`({x})=>...`), (e) zero arguments (`()=>...`). The eligibility test is "exactly one IDENT token between matching `(` and `)`, followed by `=>`".


### PR DESCRIPTION
## Summary

**Closes gap-045.** Harness 78/81 → 79/81. Only gap-044 (template substitution, lexer-level) remains open.

## The fix

Top-of-loop pattern detector: when current is \`(\` AND next is Name AND idx+2 is \`)\` AND idx+3 is \`=>\`, emit just IDENT and \`=>\`, advance idx by 4. Both parens skipped — push/pop both bypassed, paren_stack net-zero.

Composes with \`async\`: \`async(x)=>x+1\` → \`async x=>x+1\` (space inserted by \`needs_separator\` between two word-like tokens).

## Eligibility filter

\`is_simple_identifier_token\` returns true only for \`TokenType::Name\` — filters out destructuring, rest, reserved-word params, zero-arg, multi-arg, default values.

## Pre-push security review

PASS. Traced 6 concerns: paren_stack balance, other stack non-interaction, false-positive \`(x).y\`, async composition, future template substitution, prev_emitted_tok stored as \`=>\` (PUNCT) to avoid spurious post-IDENT space.

## Tests

8 inline tests including 6 non-regression cases. Full suite: **361 passed**.

## Version

0.56.0 → 0.57.0.

## Test plan

- [x] \`cargo test\` → 361 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 79 matched, 0 failed, 2 skipped (of 81)
- [x] Security review → PASS
- [ ] CI green

## Marathon

WHITESPACE_ONLY surface now at single-gap-open (gap-044, lexer-level). 6 100% milestones, 15 gaps closed in whitespace_only/CLI, 1 lexer gap open. State-machine implementation has reached comprehensive coverage of common ES2015-2021 syntactic shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)