### PR TITLE
Add Thread MLE status TLV helper

### DIFF
--- a/code/packages/rust/thread-mle/CHANGELOG.md
+++ b/code/packages/rust/thread-mle/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Thread role, MLE command, TLV, scan-mask, and mode primitives.
+- Typed MLE Status TLV helpers for validating and extracting raw status codes.
 - MLE message parser/encoder and a deterministic parent/child attach-state
   skeleton for simulator-first Thread work.
 - Typed Leader Data TLV helpers plus opaque Network Data extraction from MLE

--- a/code/packages/rust/thread-mle/README.md
+++ b/code/packages/rust/thread-mle/README.md
@@ -9,6 +9,7 @@ This crate starts the D27 Thread control-plane layer above 6LoWPAN:
 - common MLE TLV ids
 - MLE message/TLV parsing and encoding
 - scan-mask and mode bit helpers
+- typed Status TLV helpers
 - typed Leader Data TLV helpers and opaque Network Data extraction
 - Thread Network Data TLV parsing/encoding with stable-bit preservation
 - typed Prefix TLV projection with nested Network Data sub-TLVs

--- a/code/packages/rust/thread-mle/src/lib.rs
+++ b/code/packages/rust/thread-mle/src/lib.rs
@@ -694,6 +694,37 @@ impl Connectivity {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MleStatus {
+    pub code: u8,
+}
+
+impl MleStatus {
+    pub const ENCODED_LEN: usize = 1;
+
+    pub fn parse(value: &[u8]) -> Result<Self, MleError> {
+        if value.len() != Self::ENCODED_LEN {
+            return Err(MleError::InvalidTlvLength {
+                tlv_type: TlvType::Status,
+                expected: Self::ENCODED_LEN,
+                actual: value.len(),
+            });
+        }
+        Ok(Self { code: value[0] })
+    }
+
+    pub fn encode(self) -> [u8; Self::ENCODED_LEN] {
+        [self.code]
+    }
+
+    pub fn to_tlv(self) -> Tlv {
+        Tlv {
+            tlv_type: TlvType::Status,
+            value: self.encode().to_vec(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MleMessage {
     pub command: MleCommand,
@@ -1341,6 +1372,13 @@ pub fn connectivity_from_message(message: &MleMessage) -> Result<Option<Connecti
         .transpose()
 }
 
+pub fn status_from_message(message: &MleMessage) -> Result<Option<MleStatus>, MleError> {
+    message
+        .find_tlv(TlvType::Status)
+        .map(|tlv| MleStatus::parse(&tlv.value))
+        .transpose()
+}
+
 pub fn version_is_newer(candidate: u8, current: u8) -> bool {
     let distance = candidate.wrapping_sub(current);
     distance != 0 && distance < 128
@@ -1483,6 +1521,43 @@ mod tests {
 
         assert_eq!(ScanMask::parse(scan.encode()), scan);
         assert_eq!(Mode::parse(mode.encode()), mode);
+    }
+
+    #[test]
+    fn status_tlv_round_trips_and_extracts_from_message() {
+        let status = MleStatus { code: 0x01 };
+        let message = MleMessage {
+            command: MleCommand::ChildIdResponse,
+            tlvs: vec![status.to_tlv()],
+        };
+
+        assert_eq!(MleStatus::parse(&status.encode()).unwrap(), status);
+        assert_eq!(status.to_tlv().tlv_type, TlvType::Status);
+        assert_eq!(status_from_message(&message).unwrap(), Some(status));
+        assert_eq!(
+            MleMessage::parse(&message.encode().unwrap()).unwrap(),
+            message
+        );
+    }
+
+    #[test]
+    fn status_tlv_rejects_wrong_length() {
+        assert_eq!(
+            MleStatus::parse(&[]),
+            Err(MleError::InvalidTlvLength {
+                tlv_type: TlvType::Status,
+                expected: MleStatus::ENCODED_LEN,
+                actual: 0,
+            })
+        );
+        assert_eq!(
+            MleStatus::parse(&[0x01, 0x02]),
+            Err(MleError::InvalidTlvLength {
+                tlv_type: TlvType::Status,
+                expected: MleStatus::ENCODED_LEN,
+                actual: 2,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a typed Thread MLE Status TLV helper that validates the one-byte status payload and preserves the raw code
- add extraction from parsed MLE messages through status_from_message
- document the new low-level Thread MLE status helper

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\thread-mle\\Cargo.toml
- CARGO_TARGET_DIR=C:\\tmp\\codex-thread-mle-status-tlv-target cargo test --manifest-path code\\packages\\rust\\thread-mle\\Cargo.toml -- --nocapture