### PR TITLE
Add smart-home activation agenda tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for concrete D23A integration activation action
   planning: `smart_home.list_integration_activation_actions` and
   `smart_home.get_integration_activation_action_summary`.
+- Added D18D handlers for D23A priority-wave activation agendas:
+  `smart_home.list_integration_activation_agenda` and
+  `smart_home.get_integration_activation_agenda_summary`.
 - Added D18D handlers for D23A rollout-priority activation runway planning:
   `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -40,6 +40,7 @@ Chief of Staff job/session/agent
   -> activation-plan list and summary reads for D23A rollout planning
   -> activation-candidate list and summary reads for ranked rollout planning
   -> activation-action list and summary reads for concrete unblock/activate work
+  -> activation-agenda list and summary reads for concrete work by rollout wave
   -> activation-runway list and summary reads for rollout-priority waves
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
@@ -66,6 +67,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_candidate_summary`
 - `smart_home.list_integration_activation_actions`
 - `smart_home.get_integration_activation_action_summary`
+- `smart_home.list_integration_activation_agenda`
+- `smart_home.get_integration_activation_agenda_summary`
 - `smart_home.list_integration_activation_runway`
 - `smart_home.get_integration_activation_runway_summary`
 - `smart_home.list_integration_readiness`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -33,19 +33,21 @@ use smart_home_discovery::{
     DiscoveryWorkerId, DiscoveryWorkerKind, PairingRequirement,
 };
 use smart_home_integration_catalog::{
-    activation_actions_from_candidates, activation_candidates_at_or_before_priority,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
-    IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    activation_actions_from_candidates, activation_agenda_from_candidates,
+    activation_candidates_at_or_before_priority, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_runway_from_candidates,
+    describe_primitive_family, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
@@ -149,6 +151,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ACTIONS_TOOL_ID: &str =
     "smart_home.list_integration_activation_actions";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_action_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID: &str =
+    "smart_home.list_integration_activation_agenda";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_agenda_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID: &str =
     "smart_home.list_integration_activation_runway";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID: &str =
@@ -257,6 +263,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_action_query(&arguments)?;
                     Ok(get_integration_activation_action_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID => {
+                    let query = integration_activation_agenda_query(&arguments)?;
+                    Ok(list_integration_activation_agenda_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_agenda_query(&arguments)?;
+                    Ok(get_integration_activation_agenda_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID => {
                     let query = integration_activation_runway_query(&arguments)?;
@@ -940,6 +956,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation action summary",
             "Return compact D23A activation action rollups for activate, review, primitive, capability, and dependency work.",
             integration_activation_action_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID,
+            "List smart-home integration activation agenda",
+            "Group concrete D23A activation actions by rollout priority wave using host-specific readiness context.",
+            integration_activation_agenda_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "activation_agenda",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_agenda", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation agenda summary",
+            "Return compact D23A priority-wave agenda rollups for candidates and concrete activation actions.",
+            integration_activation_agenda_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3268,6 +3316,14 @@ struct IntegrationActivationActionQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationAgendaQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    stage_limit: Option<usize>,
+    candidates_per_stage_limit: Option<usize>,
+    actions_per_stage_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRunwayQuery {
     candidates: IntegrationActivationCandidateQuery,
     stage_limit: Option<usize>,
@@ -3316,6 +3372,24 @@ fn integration_activation_action_query(
         candidates,
         action_kind,
         action_limit,
+    })
+}
+
+fn integration_activation_agenda_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationAgendaQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let stage_limit = optional_u64(arguments, "stage_limit")?.map(|value| value as usize);
+    let candidates_per_stage_limit =
+        optional_u64(arguments, "candidates_per_stage_limit")?.map(|value| value as usize);
+    let actions_per_stage_limit =
+        optional_u64(arguments, "actions_per_stage_limit")?.map(|value| value as usize);
+
+    Ok(IntegrationActivationAgendaQuery {
+        candidates,
+        stage_limit,
+        candidates_per_stage_limit,
+        actions_per_stage_limit,
     })
 }
 
@@ -3460,6 +3534,35 @@ fn integration_activation_actions_for_query(
     }
 
     (actions, catalog_count)
+}
+
+fn integration_activation_agenda_for_query(
+    query: &IntegrationActivationAgendaQuery,
+) -> (Vec<IntegrationActivationAgendaStage>, usize) {
+    let (candidates, catalog_count) =
+        integration_activation_candidates_for_query(&query.candidates);
+    let mut agenda = activation_agenda_from_candidates(candidates);
+
+    if query.candidates_per_stage_limit.is_some() || query.actions_per_stage_limit.is_some() {
+        for stage in &mut agenda {
+            if let Some(limit) = query.candidates_per_stage_limit {
+                stage.candidates.truncate(limit);
+                stage.candidate_summary =
+                    IntegrationActivationCandidateSummary::from_candidates(stage.candidates.iter());
+                stage.actions = activation_actions_from_candidates(stage.candidates.iter());
+            }
+            if let Some(limit) = query.actions_per_stage_limit {
+                stage.actions.truncate(limit);
+            }
+            stage.action_summary =
+                IntegrationActivationActionSummary::from_actions(stage.actions.iter());
+        }
+    }
+    if let Some(limit) = query.stage_limit {
+        agenda.truncate(limit);
+    }
+
+    (agenda, catalog_count)
 }
 
 fn limited_slice<T>(items: &[T], limit: Option<usize>) -> &[T] {
@@ -3783,6 +3886,66 @@ fn get_integration_activation_action_summary_output_handler_output(
             (
                 "blocked_integration_count",
                 integer(summary.blocked_integration_count as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_agenda_output_handler_output(
+    query: IntegrationActivationAgendaQuery,
+) -> ToolHandlerOutput {
+    let (agenda, catalog_count) = integration_activation_agenda_for_query(&query);
+    let summary = IntegrationActivationAgendaSummary::from_stages(agenda.iter());
+    let count = agenda.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_agenda",
+            JsonValue::Array(agenda.iter().map(activation_agenda_stage_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_agenda_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_agenda")),
+            ("stages", integer(count as i64)),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "stages_with_blockers",
+                integer(summary.stages_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_agenda_summary_output_handler_output(
+    query: IntegrationActivationAgendaQuery,
+) -> ToolHandlerOutput {
+    let (agenda, _) = integration_activation_agenda_for_query(&query);
+    let summary = IntegrationActivationAgendaSummary::from_stages(agenda.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_agenda_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_agenda_summary"),
+            ),
+            ("total_stages", integer(summary.total_stages as i64)),
+            ("total_actions", integer(summary.total_actions as i64)),
+            (
+                "stages_with_blockers",
+                integer(summary.stages_with_blockers as i64),
             ),
         ]),
     )
@@ -6510,6 +6673,111 @@ fn integration_activation_action_summary_json(
         (
             "highest_policy_tier",
             string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+    ])
+}
+
+fn activation_agenda_stage_json(stage: &IntegrationActivationAgendaStage) -> JsonValue {
+    object([
+        ("priority", integer(stage.priority as i64)),
+        (
+            "activation_candidates",
+            JsonValue::Array(
+                stage
+                    .candidates
+                    .iter()
+                    .map(activation_candidate_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(&stage.candidate_summary),
+        ),
+        (
+            "activation_actions",
+            JsonValue::Array(stage.actions.iter().map(activation_action_json).collect()),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(&stage.action_summary),
+        ),
+        ("candidate_count", integer(stage.candidates.len() as i64)),
+        ("action_count", integer(stage.actions.len() as i64)),
+        (
+            "has_actionable_candidates",
+            JsonValue::Bool(stage.has_actionable_candidates()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(stage.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(stage.has_blockers())),
+        ("has_review_work", JsonValue::Bool(stage.has_review_work())),
+    ])
+}
+
+fn integration_activation_agenda_summary_json(
+    summary: &IntegrationActivationAgendaSummary,
+) -> JsonValue {
+    object([
+        ("total_stages", integer(summary.total_stages as i64)),
+        ("total_candidates", integer(summary.total_candidates as i64)),
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "stages_with_activation_work",
+            integer(summary.stages_with_activation_work as i64),
+        ),
+        (
+            "stages_with_blockers",
+            integer(summary.stages_with_blockers as i64),
+        ),
+        (
+            "stages_with_review_work",
+            integer(summary.stages_with_review_work as i64),
+        ),
+        (
+            "first_action_priority",
+            summary
+                .first_action_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_priority",
+            summary
+                .first_blocker_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(&summary.candidate_summary),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(&summary.action_summary),
         ),
         ("is_empty", JsonValue::Bool(summary.is_empty())),
         (
@@ -9301,6 +9569,27 @@ fn integration_activation_action_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_agenda_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("stage_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new(
+            "candidates_per_stage_limit",
+            JsonSchema::Integer,
+        ));
+        properties.push(SchemaProperty::new(
+            "actions_per_stage_limit",
+            JsonSchema::Integer,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_runway_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -9422,7 +9711,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 57);
+        assert_eq!(definitions.len(), 59);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -9460,6 +9749,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID));
@@ -9563,7 +9858,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            49
+            51
         );
         assert_eq!(
             export
@@ -9611,6 +9906,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_ACTION_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -9865,11 +10168,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(57))
+            Some(&integer(59))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(49))
+            Some(&integer(51))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -10187,6 +10490,123 @@ mod tests {
                 .is_some()
         );
 
+        let list_activation_agenda_request = request(
+            "call-list-integration-activation-agenda",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_AGENDA_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("stage_limit", integer(2)),
+                ("candidates_per_stage_limit", integer(2)),
+                ("actions_per_stage_limit", integer(3)),
+            ]),
+            5_001,
+        );
+        let list_activation_agenda_trace =
+            tool_runtime.invoke_with_events(&list_activation_agenda_request);
+        assert!(list_activation_agenda_trace.result.ok);
+        assert_eq!(
+            list_activation_agenda_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_agenda_output =
+            list_activation_agenda_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(list_activation_agenda_output, "count"),
+            Some(&integer(2))
+        );
+        let activation_agenda_summary = field(list_activation_agenda_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_agenda_summary, "total_stages"),
+            Some(&integer(2))
+        );
+        assert_eq!(
+            field(activation_agenda_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_agenda_stage = array_item(
+            field(list_activation_agenda_output, "activation_agenda").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_agenda_stage, "priority"),
+            Some(&integer(0))
+        );
+        assert!(
+            integer_value(field(activation_agenda_stage, "candidate_count").unwrap()).unwrap() >= 1
+        );
+        assert!(
+            integer_value(field(activation_agenda_stage, "action_count").unwrap()).unwrap() >= 1
+        );
+        assert_eq!(
+            field(activation_agenda_stage, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_agenda_summary_request = request(
+            "call-integration-activation-agenda-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_AGENDA_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+            ]),
+            5_002,
+        );
+        let activation_agenda_summary_trace =
+            tool_runtime.invoke_with_events(&activation_agenda_summary_request);
+        assert!(activation_agenda_summary_trace.result.ok);
+        assert_eq!(
+            activation_agenda_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_agenda_summary_output = activation_agenda_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_agenda_rollup = field(activation_agenda_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_agenda_rollup, "total_actions").unwrap()).unwrap() >= 3
+        );
+        assert_eq!(
+            field(activation_agenda_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            optional_field(activation_agenda_rollup, "first_blocker_priority")
+                .and_then(integer_value)
+                .is_some()
+        );
+
         let list_activation_runway_request = request(
             "call-list-integration-activation-runway",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID,
@@ -10209,7 +10629,7 @@ mod tests {
                 ("stage_limit", integer(2)),
                 ("candidates_per_stage_limit", integer(2)),
             ]),
-            5_001,
+            5_003,
         );
         let list_activation_runway_trace =
             tool_runtime.invoke_with_events(&list_activation_runway_request);
@@ -10268,7 +10688,7 @@ mod tests {
                     JsonValue::Array(vec![string("smart_home.read")]),
                 ),
             ]),
-            5_002,
+            5_004,
         );
         let activation_runway_summary_trace =
             tool_runtime.invoke_with_events(&activation_runway_summary_request);
@@ -11686,6 +12106,11 @@ mod tests {
             activation_action_summary_request,
             activation_action_summary_trace,
         );
+        journal.record_trace(list_activation_agenda_request, list_activation_agenda_trace);
+        journal.record_trace(
+            activation_agenda_summary_request,
+            activation_agenda_summary_trace,
+        );
         journal.record_trace(list_activation_runway_request, list_activation_runway_trace);
         journal.record_trace(
             activation_runway_summary_request,
@@ -11751,9 +12176,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 57);
-        assert_eq!(journal_summary.completed_count, 57);
-        assert_eq!(journal.audit_records().len(), 57);
+        assert_eq!(journal_summary.invocation_count, 59);
+        assert_eq!(journal_summary.completed_count, 59);
+        assert_eq!(journal.audit_records().len(), 59);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -29,6 +29,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_actions` and
   `smart_home.get_integration_activation_action_summary` tool descriptors for
   read-only concrete activation action planning.
+- `smart_home.list_integration_activation_agenda` and
+  `smart_home.get_integration_activation_agenda_summary` tool descriptors for
+  read-only priority-wave activation action planning.
 - `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary` tool descriptors for
   read-only rollout-priority activation wave planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -56,6 +56,8 @@ Current scope:
   and blocked rollout planning
 - D18D integration activation-action descriptors for concrete activate,
   policy-review, primitive, capability, and dependency work planning
+- D18D integration activation-agenda descriptors for grouping concrete action
+  work by rollout-priority wave
 - D18D integration activation-runway descriptors for rollout-priority wave
   grouping and compact actionable/blocker summaries
 - D18D integration-readiness descriptors for bulk activation blocker reports

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1457,6 +1457,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationCandidateSummary,
     ListIntegrationActivationActions,
     GetIntegrationActivationActionSummary,
+    ListIntegrationActivationAgenda,
+    GetIntegrationActivationAgendaSummary,
     ListIntegrationActivationRunway,
     GetIntegrationActivationRunwaySummary,
     ListIntegrationReadiness,
@@ -1532,6 +1534,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationActionSummary => {
                 read_tool("smart_home.get_integration_activation_action_summary")
+            }
+            Self::ListIntegrationActivationAgenda => {
+                read_tool("smart_home.list_integration_activation_agenda")
+            }
+            Self::GetIntegrationActivationAgendaSummary => {
+                read_tool("smart_home.get_integration_activation_agenda_summary")
             }
             Self::ListIntegrationActivationRunway => {
                 read_tool("smart_home.list_integration_activation_runway")
@@ -2166,6 +2174,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationCandidateSummary,
         SmartHomeTool::ListIntegrationActivationActions,
         SmartHomeTool::GetIntegrationActivationActionSummary,
+        SmartHomeTool::ListIntegrationActivationAgenda,
+        SmartHomeTool::GetIntegrationActivationAgendaSummary,
         SmartHomeTool::ListIntegrationActivationRunway,
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
         SmartHomeTool::ListIntegrationReadiness,
@@ -3006,7 +3016,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 57);
+        assert_eq!(catalog.len(), 59);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3058,6 +3068,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_action_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_agenda"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_agenda_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
@@ -3248,15 +3266,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 57);
-        assert_eq!(summary.read_tools, 49);
+        assert_eq!(summary.total_tools, 59);
+        assert_eq!(summary.read_tools, 51);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 49);
+        assert_eq!(summary.read_only_tier_tools, 51);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 57);
+        assert_eq!(summary.total_required_capabilities, 59);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationAction` and `IntegrationActivationActionSummary` for
   converting activation candidates into concrete activate, policy-review,
   primitive, capability, and dependency work items.
+- `IntegrationActivationAgendaStage` and `IntegrationActivationAgendaSummary`
+  for grouping activation candidates and concrete action work by rollout
+  priority wave.
 - `IntegrationActivationRunwayStage` and `IntegrationActivationRunwaySummary`
   for grouping activation candidates by rollout priority wave and identifying
   actionable, review, and blocked stages.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -34,6 +34,8 @@ runtime and Chief of Staff tools a typed catalog for:
   after applying host-specific primitive, capability, and dependency context
 - activation actions that turn ready/review/blocker candidates into concrete
   activate, policy-review, primitive, capability, and dependency work items
+- activation agenda stages that combine candidates and concrete actions by
+  rollout priority wave for bounded Chief-of-Staff planning
 - activation runway stages that group those candidates by rollout priority wave
   with compact ready, review, and blocker rollups
 - readiness reports that compare activation plans against available primitives,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -756,6 +756,31 @@ pub struct IntegrationActivationActionSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationAgendaStage {
+    pub priority: u8,
+    pub candidates: Vec<IntegrationActivationCandidate>,
+    pub candidate_summary: IntegrationActivationCandidateSummary,
+    pub actions: Vec<IntegrationActivationAction>,
+    pub action_summary: IntegrationActivationActionSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationAgendaSummary {
+    pub total_stages: usize,
+    pub total_candidates: usize,
+    pub total_actions: usize,
+    pub stages_with_activation_work: usize,
+    pub stages_with_blockers: usize,
+    pub stages_with_review_work: usize,
+    pub first_action_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_blocker_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub candidate_summary: IntegrationActivationCandidateSummary,
+    pub action_summary: IntegrationActivationActionSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationRunwayStage {
     pub priority: u8,
     pub candidates: Vec<IntegrationActivationCandidate>,
@@ -1395,6 +1420,124 @@ impl IntegrationActivationActionSummary {
 
     pub fn has_review_work(&self) -> bool {
         self.review_policy_actions > 0
+    }
+}
+
+impl IntegrationActivationAgendaStage {
+    pub fn from_candidates(
+        priority: u8,
+        mut candidates: Vec<IntegrationActivationCandidate>,
+    ) -> Self {
+        candidates.sort_by(compare_activation_candidates);
+        let candidate_summary =
+            IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+        let actions = activation_actions_from_candidates(candidates.iter());
+        let action_summary = IntegrationActivationActionSummary::from_actions(actions.iter());
+
+        Self {
+            priority,
+            candidates,
+            candidate_summary,
+            actions,
+            action_summary,
+        }
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.action_summary.has_activation_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.action_summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.action_summary.has_review_work()
+    }
+
+    pub fn has_actionable_candidates(&self) -> bool {
+        self.candidate_summary.has_actionable_candidates()
+    }
+}
+
+impl IntegrationActivationAgendaSummary {
+    pub fn from_stages<'a>(
+        stages: impl IntoIterator<Item = &'a IntegrationActivationAgendaStage>,
+    ) -> Self {
+        let mut candidates = Vec::new();
+        let mut actions = Vec::new();
+        let empty_candidates = Vec::<&IntegrationActivationCandidate>::new();
+        let empty_actions = Vec::<&IntegrationActivationAction>::new();
+        let mut summary = Self {
+            total_stages: 0,
+            total_candidates: 0,
+            total_actions: 0,
+            stages_with_activation_work: 0,
+            stages_with_blockers: 0,
+            stages_with_review_work: 0,
+            first_action_priority: None,
+            first_activation_priority: None,
+            first_blocker_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            candidate_summary: IntegrationActivationCandidateSummary::from_candidates(
+                empty_candidates,
+            ),
+            action_summary: IntegrationActivationActionSummary::from_actions(empty_actions),
+        };
+
+        for stage in stages {
+            summary.total_stages += 1;
+            summary.total_candidates += stage.candidates.len();
+            summary.total_actions += stage.actions.len();
+            if stage.has_activation_work() {
+                summary.stages_with_activation_work += 1;
+            }
+            if stage.has_blockers() {
+                summary.stages_with_blockers += 1;
+            }
+            if stage.has_review_work() {
+                summary.stages_with_review_work += 1;
+            }
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(stage.action_summary.highest_policy_tier)
+                .max(stage.candidate_summary.highest_policy_tier);
+            summary.first_action_priority = min_optional_priority(
+                summary.first_action_priority,
+                stage.action_summary.first_action_priority,
+            );
+            summary.first_activation_priority = min_optional_priority(
+                summary.first_activation_priority,
+                stage.action_summary.first_activation_priority,
+            );
+            summary.first_blocker_priority = min_optional_priority(
+                summary.first_blocker_priority,
+                stage.action_summary.first_blocker_priority,
+            );
+            candidates.extend(stage.candidates.iter());
+            actions.extend(stage.actions.iter());
+        }
+
+        summary.candidate_summary =
+            IntegrationActivationCandidateSummary::from_candidates(candidates);
+        summary.action_summary = IntegrationActivationActionSummary::from_actions(actions);
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_stages == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.stages_with_activation_work > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.stages_with_blockers > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.stages_with_review_work > 0
     }
 }
 
@@ -2664,6 +2807,41 @@ pub fn activation_actions_at_or_before_priority(
     activation_actions_from_candidates(candidates.iter())
 }
 
+pub fn activation_agenda_from_candidates(
+    candidates: Vec<IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationAgendaStage> {
+    let mut stages_by_priority: BTreeMap<u8, Vec<IntegrationActivationCandidate>> = BTreeMap::new();
+    for candidate in candidates {
+        stages_by_priority
+            .entry(candidate.readiness_report.priority)
+            .or_default()
+            .push(candidate);
+    }
+
+    stages_by_priority
+        .into_iter()
+        .map(|(priority, candidates)| {
+            IntegrationActivationAgendaStage::from_candidates(priority, candidates)
+        })
+        .collect()
+}
+
+pub fn activation_agenda_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationAgendaStage> {
+    activation_agenda_from_candidates(activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
+}
+
 pub fn activation_runway_from_candidates(
     candidates: Vec<IntegrationActivationCandidate>,
 ) -> Vec<IntegrationActivationRunwayStage> {
@@ -3720,6 +3898,14 @@ fn compare_activation_actions(
         })
 }
 
+fn min_optional_priority(left: Option<u8>, right: Option<u8>) -> Option<u8> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(priority), None) | (None, Some(priority)) => Some(priority),
+        (None, None) => None,
+    }
+}
+
 fn compare_by_priority_then_name(
     left: &IntegrationCatalogEntry,
     right: &IntegrationCatalogEntry,
@@ -4351,6 +4537,87 @@ mod tests {
         assert_eq!(summary.first_action_priority, Some(1));
         assert_eq!(summary.first_activation_priority, Some(2));
         assert_eq!(summary.first_blocker_priority, Some(1));
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_agenda_groups_actions_by_rollout_wave() {
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 2,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_bridge"),
+            display_name: "Review Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_sensor"),
+            display_name: "Blocked Sensor".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 1,
+            missing_primitives: vec![PrimitiveFamily::Mqtt],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::LowRisk,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [ready_report, review_report, blocked_report].iter(),
+        );
+
+        let agenda = activation_agenda_from_candidates(candidates);
+
+        assert_eq!(agenda.len(), 2);
+        assert_eq!(agenda[0].priority, 1);
+        assert_eq!(agenda[0].candidate_summary.total_candidates, 2);
+        assert_eq!(agenda[0].action_summary.total_actions, 4);
+        assert_eq!(agenda[0].action_summary.review_policy_actions, 1);
+        assert_eq!(agenda[0].action_summary.provide_primitive_actions, 1);
+        assert!(agenda[0].has_blockers());
+        assert!(agenda[0].has_review_work());
+        assert!(!agenda[0].has_activation_work());
+        assert_eq!(agenda[1].priority, 2);
+        assert_eq!(agenda[1].candidate_summary.ready_to_activate_candidates, 1);
+        assert_eq!(agenda[1].action_summary.activate_integration_actions, 1);
+        assert!(agenda[1].has_activation_work());
+
+        let summary = IntegrationActivationAgendaSummary::from_stages(agenda.iter());
+        assert_eq!(summary.total_stages, 2);
+        assert_eq!(summary.total_candidates, 3);
+        assert_eq!(summary.total_actions, 5);
+        assert_eq!(summary.stages_with_activation_work, 1);
+        assert_eq!(summary.stages_with_blockers, 1);
+        assert_eq!(summary.stages_with_review_work, 1);
+        assert_eq!(summary.first_action_priority, Some(1));
+        assert_eq!(summary.first_activation_priority, Some(2));
+        assert_eq!(summary.first_blocker_priority, Some(1));
+        assert_eq!(summary.candidate_summary.total_candidates, 3);
+        assert_eq!(summary.action_summary.total_actions, 5);
         assert!(summary.has_activation_work());
         assert!(summary.has_blockers());
         assert!(summary.has_review_work());


### PR DESCRIPTION
## Summary
- add shared integration activation agenda stages and summaries that group candidates plus concrete action work by rollout priority wave
- expose two shared-core read descriptors for activation agenda listing and summary tools
- wire Chief-of-Staff D18D handlers, bounded agenda query limits, JSON output, docs, and end-to-end runtime coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
- git diff --check

Generated code/packages/rust/Cargo.lock was removed before commit.