### PR TITLE
Add Hue command plan summary helpers

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this package will be documented in this file.
   Hue success and link-button error responses, produce Vault secret payloads,
   and hand off only non-secret completion metadata.
 - Hue command summaries and command-plan rollups for payload-free write-surface
-  telemetry.
+  telemetry, including light-surface and color-temperature helper predicates.
 - Grouped-light color-temperature command projection from normalized D23 state
   deltas.
 - Hue command planning from normalized D23 `StateDelta` records for direct and

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -14,7 +14,7 @@ packages a typed surface for:
 - Hue command plans that retain generated requests and ignored capabilities for
   reconciliation telemetry
 - Hue command summaries for payload-free command planning and read-model
-  telemetry
+  telemetry, including light-surface and color-temperature helper predicates
 - Hue application registration requests and discovered-bridge pairing plans
 - Hue application registration local-HTTP request plans, response parsing, and
   no-secret Vault handoff metadata for physical-presence pairing

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -715,8 +715,24 @@ impl HueCommandPlanSummary {
         self.light_commands > 0 || self.grouped_light_commands > 0
     }
 
+    pub fn lighting_write_count(&self) -> usize {
+        self.light_commands + self.grouped_light_commands
+    }
+
+    pub fn has_direct_light_commands(&self) -> bool {
+        self.light_commands > 0
+    }
+
     pub fn has_group_commands(&self) -> bool {
         self.grouped_light_commands > 0
+    }
+
+    pub fn mixes_direct_and_grouped_light_writes(&self) -> bool {
+        self.light_commands > 0 && self.grouped_light_commands > 0
+    }
+
+    pub fn has_color_temperature_writes(&self) -> bool {
+        self.color_temperature_commands > 0
     }
 
     pub fn has_scene_recalls(&self) -> bool {
@@ -2476,13 +2492,23 @@ mod tests {
             }
         );
         assert!(summary.has_lighting_writes());
+        assert_eq!(summary.lighting_write_count(), 6);
+        assert!(summary.has_direct_light_commands());
         assert!(summary.has_group_commands());
+        assert!(summary.mixes_direct_and_grouped_light_writes());
+        assert!(summary.has_color_temperature_writes());
         assert!(summary.has_scene_recalls());
         assert!(summary.touches_multiple_surfaces());
 
         let empty = HueCommandPlanSummary::empty();
         assert!(empty.is_empty());
         assert!(!empty.has_lighting_writes());
+        assert_eq!(empty.lighting_write_count(), 0);
+        assert!(!empty.has_direct_light_commands());
+        assert!(!empty.has_group_commands());
+        assert!(!empty.mixes_direct_and_grouped_light_writes());
+        assert!(!empty.has_color_temperature_writes());
+        assert!(!empty.has_scene_recalls());
         assert!(!empty.touches_multiple_surfaces());
     }
 


### PR DESCRIPTION
## Summary
- add Hue command-plan summary helpers for lighting write counts, direct light commands, grouped/direct mixes, and color-temperature writes
- cover the helper predicates in existing command-plan summary tests
- document the richer command-plan telemetry helper surface

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml
- CARGO_TARGET_DIR=C:\\tmp\\codex-hue-command-plan-summary-helpers-target cargo test --manifest-path code\\packages\\rust\\hue-core\\Cargo.toml -- --nocapture