### PR TITLE
Add smart-home activation dependency tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A rollout-priority activation runway planning:
   `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary`.
+- Added D18D handlers for D23A integration activation dependency graph
+  planning: `smart_home.list_integration_activation_dependencies` and
+  `smart_home.get_integration_activation_dependency_summary`.
 - Added D18D handlers for bulk D23A integration readiness planning:
   `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -42,6 +42,7 @@ Chief of Staff job/session/agent
   -> activation-action list and summary reads for concrete unblock/activate work
   -> activation-agenda list and summary reads for concrete work by rollout wave
   -> activation-runway list and summary reads for rollout-priority waves
+  -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
   -> non-mutating supervision plan previews
@@ -71,6 +72,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_agenda_summary`
 - `smart_home.list_integration_activation_runway`
 - `smart_home.get_integration_activation_runway_summary`
+- `smart_home.list_integration_activation_dependencies`
+- `smart_home.get_integration_activation_dependency_summary`
 - `smart_home.list_integration_readiness`
 - `smart_home.get_integration_readiness_summary`
 - `smart_home.list_integration_readiness_gaps`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,20 +34,22 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
-    activation_candidates_at_or_before_priority, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_runway_from_candidates,
-    describe_primitive_family, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    activation_candidates_at_or_before_priority, activation_dependency_graph_from_reports,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_runway_from_candidates, describe_primitive_family,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
+    IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
@@ -159,6 +161,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID: &str =
     "smart_home.list_integration_activation_runway";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_runway_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID: &str =
+    "smart_home.list_integration_activation_dependencies";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_dependency_summary";
 pub const SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID: &str =
     "smart_home.list_integration_readiness";
 pub const SMART_HOME_GET_INTEGRATION_READINESS_SUMMARY_TOOL_ID: &str =
@@ -283,6 +289,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID => {
                     let query = integration_activation_runway_query(&arguments)?;
                     Ok(get_integration_activation_runway_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID => {
+                    let query = integration_activation_dependency_query(&arguments)?;
+                    Ok(list_integration_activation_dependencies_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_dependency_query(&arguments)?;
+                    Ok(get_integration_activation_dependency_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID => {
                     let query = integration_readiness_query(&arguments)?;
@@ -1020,6 +1034,46 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation runway summary",
             "Return compact D23A rollout-priority runway rollups for actionable, review, and blocked activation waves.",
             integration_activation_runway_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID,
+            "List smart-home integration activation dependencies",
+            "List D23A integration activation dependency nodes and prerequisite edges using host-specific readiness context.",
+            integration_activation_dependency_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("dependency_nodes", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("dependency_edges", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("node_count", JsonSchema::Integer),
+                    SchemaProperty::new("edge_count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "dependency_nodes",
+                    "dependency_edges",
+                    "summary",
+                    "node_count",
+                    "edge_count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation dependency summary",
+            "Return compact D23A activation dependency graph counts for satisfied and blocking prerequisite edges.",
+            integration_activation_dependency_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3330,6 +3384,14 @@ struct IntegrationActivationRunwayQuery {
     candidates_per_stage_limit: Option<usize>,
 }
 
+#[derive(Debug, Clone)]
+struct IntegrationActivationDependencyQuery {
+    readiness: IntegrationReadinessQuery,
+    blocking_only: bool,
+    node_limit: Option<usize>,
+    edge_limit: Option<usize>,
+}
+
 fn integration_activation_candidate_query(
     arguments: &JsonValue,
 ) -> Result<IntegrationActivationCandidateQuery, ToolCallError> {
@@ -3356,6 +3418,18 @@ fn integration_activation_runway_query(
         candidates,
         stage_limit,
         candidates_per_stage_limit,
+    })
+}
+
+fn integration_activation_dependency_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationDependencyQuery, ToolCallError> {
+    let readiness = integration_readiness_query(arguments)?;
+    Ok(IntegrationActivationDependencyQuery {
+        readiness,
+        blocking_only: optional_bool(arguments, "blocking_only")?.unwrap_or(false),
+        node_limit: optional_u64(arguments, "node_limit")?.map(|value| value as usize),
+        edge_limit: optional_u64(arguments, "edge_limit")?.map(|value| value as usize),
     })
 }
 
@@ -3461,6 +3535,32 @@ fn integration_readiness_gap_inventory_for_query(
         readiness_gap_inventory_from_reports(reports.iter()),
         catalog_count,
     )
+}
+
+fn integration_activation_dependency_graph_for_query(
+    query: &IntegrationActivationDependencyQuery,
+) -> (IntegrationActivationDependencyGraph, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (reports, _) = integration_readiness_reports_for_query(&query.readiness);
+    let mut graph = activation_dependency_graph_from_reports(
+        &catalog,
+        reports.iter(),
+        &query.readiness.enabled_integrations,
+    );
+
+    if query.blocking_only {
+        graph.edges.retain(|edge| edge.blocks_activation);
+    }
+    if let Some(limit) = query.node_limit {
+        graph.nodes.truncate(limit);
+    }
+    if let Some(limit) = query.edge_limit {
+        graph.edges.truncate(limit);
+    }
+    graph.summary = IntegrationActivationDependencySummary::from_graph(&graph.nodes, &graph.edges);
+
+    (graph, catalog_count)
 }
 
 fn integration_activation_candidates_for_query(
@@ -4000,6 +4100,84 @@ fn get_integration_activation_runway_summary_output_handler_output(
             ),
             ("total_stages", integer(summary.total_stages as i64)),
             ("blocked_stages", integer(summary.blocked_stages as i64)),
+        ]),
+    )
+}
+
+fn list_integration_activation_dependencies_output_handler_output(
+    query: IntegrationActivationDependencyQuery,
+) -> ToolHandlerOutput {
+    let (graph, catalog_count) = integration_activation_dependency_graph_for_query(&query);
+    let node_count = graph.nodes.len();
+    let edge_count = graph.edges.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "dependency_nodes",
+            JsonValue::Array(
+                graph
+                    .nodes
+                    .iter()
+                    .map(activation_dependency_node_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_edges",
+            JsonValue::Array(
+                graph
+                    .edges
+                    .iter()
+                    .map(activation_dependency_edge_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_dependency_summary_json(&graph.summary),
+        ),
+        ("node_count", integer(node_count as i64)),
+        ("edge_count", integer(edge_count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_dependencies"),
+            ),
+            ("nodes", integer(node_count as i64)),
+            ("edges", integer(edge_count as i64)),
+            (
+                "blocking_edges",
+                integer(graph.summary.blocking_edges as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_dependency_summary_output_handler_output(
+    query: IntegrationActivationDependencyQuery,
+) -> ToolHandlerOutput {
+    let (graph, _) = integration_activation_dependency_graph_for_query(&query);
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_dependency_summary_json(&graph.summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_dependency_summary"),
+            ),
+            ("total_edges", integer(graph.summary.total_edges as i64)),
+            (
+                "blocking_edges",
+                integer(graph.summary.blocking_edges as i64),
+            ),
         ]),
     )
 }
@@ -6877,6 +7055,156 @@ fn integration_activation_runway_summary_json(
     ])
 }
 
+fn activation_dependency_node_json(node: &IntegrationActivationDependencyNode) -> JsonValue {
+    object([
+        ("integration_id", string(node.integration_id.as_str())),
+        ("display_name", string(&node.display_name)),
+        ("priority", integer(node.priority as i64)),
+        (
+            "activation_target",
+            activation_target_json(&node.activation_target),
+        ),
+        (
+            "depends_on_integrations",
+            JsonValue::Array(
+                node.depends_on_integrations
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "dependent_integration_ids",
+            JsonValue::Array(
+                node.dependent_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "missing_dependencies",
+            JsonValue::Array(
+                node.missing_dependencies
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_count",
+            integer(node.depends_on_integrations.len() as i64),
+        ),
+        (
+            "dependent_count",
+            integer(node.dependent_integration_ids.len() as i64),
+        ),
+        (
+            "missing_dependency_count",
+            integer(node.missing_dependencies.len() as i64),
+        ),
+        ("enabled", JsonValue::Bool(node.enabled)),
+        ("activation_ready", JsonValue::Bool(node.activation_ready)),
+        (
+            "requires_human_review",
+            JsonValue::Bool(node.requires_human_review),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(node.highest_policy_tier)),
+        ),
+    ])
+}
+
+fn activation_dependency_edge_json(edge: &IntegrationActivationDependencyEdge) -> JsonValue {
+    object([
+        (
+            "dependency_integration_id",
+            string(edge.dependency_integration_id.as_str()),
+        ),
+        (
+            "dependent_integration_id",
+            string(edge.dependent_integration_id.as_str()),
+        ),
+        (
+            "dependency_display_name",
+            edge.dependency_display_name
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependent_display_name",
+            string(&edge.dependent_display_name),
+        ),
+        (
+            "dependency_priority",
+            edge.dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependent_priority",
+            integer(edge.dependent_priority as i64),
+        ),
+        ("satisfied", JsonValue::Bool(edge.satisfied)),
+        ("blocks_activation", JsonValue::Bool(edge.blocks_activation)),
+    ])
+}
+
+fn integration_activation_dependency_summary_json(
+    summary: &IntegrationActivationDependencySummary,
+) -> JsonValue {
+    object([
+        ("total_nodes", integer(summary.total_nodes as i64)),
+        ("enabled_nodes", integer(summary.enabled_nodes as i64)),
+        (
+            "activation_ready_nodes",
+            integer(summary.activation_ready_nodes as i64),
+        ),
+        ("blocked_nodes", integer(summary.blocked_nodes as i64)),
+        (
+            "nodes_with_dependencies",
+            integer(summary.nodes_with_dependencies as i64),
+        ),
+        (
+            "nodes_with_dependents",
+            integer(summary.nodes_with_dependents as i64),
+        ),
+        (
+            "nodes_with_missing_dependencies",
+            integer(summary.nodes_with_missing_dependencies as i64),
+        ),
+        ("total_edges", integer(summary.total_edges as i64)),
+        ("satisfied_edges", integer(summary.satisfied_edges as i64)),
+        ("blocking_edges", integer(summary.blocking_edges as i64)),
+        (
+            "unknown_dependency_edges",
+            integer(summary.unknown_dependency_edges as i64),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_dependency_edges",
+            JsonValue::Bool(summary.has_dependency_edges()),
+        ),
+        (
+            "has_blocking_dependencies",
+            JsonValue::Bool(summary.has_blocking_dependencies()),
+        ),
+    ])
+}
+
 fn readiness_report_json(report: &IntegrationReadinessReport) -> JsonValue {
     object([
         (
@@ -9607,6 +9935,26 @@ fn integration_activation_runway_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_dependency_query_schema() -> JsonSchema {
+    let mut schema = integration_readiness_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "node_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("edge_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("blocking_only", JsonSchema::Boolean));
+    }
+    schema
+}
+
 fn integration_readiness_query_schema(include_limit: bool) -> JsonSchema {
     let mut properties = vec![
         SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
@@ -9711,7 +10059,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 59);
+        assert_eq!(definitions.len(), 61);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -9761,6 +10109,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_READINESS_TOOL_ID));
@@ -9858,7 +10212,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            51
+            53
         );
         assert_eq!(
             export
@@ -9922,6 +10276,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -10168,11 +10530,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(59))
+            Some(&integer(61))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(51))
+            Some(&integer(53))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -10717,6 +11079,135 @@ mod tests {
             optional_field(activation_runway_rollup, "first_blocked_priority")
                 .and_then(integer_value)
                 .is_some()
+        );
+
+        let list_activation_dependencies_request = request(
+            "call-list-integration-activation-dependencies",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+            ]),
+            5_005,
+        );
+        let list_activation_dependencies_trace =
+            tool_runtime.invoke_with_events(&list_activation_dependencies_request);
+        assert!(list_activation_dependencies_trace.result.ok);
+        assert_eq!(
+            list_activation_dependencies_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_dependencies_output = list_activation_dependencies_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert!(
+            integer_value(field(list_activation_dependencies_output, "node_count").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(list_activation_dependencies_output, "edge_count").unwrap())
+                .unwrap()
+                >= 2
+        );
+        assert!(
+            array_len(field(list_activation_dependencies_output, "dependency_nodes").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            array_len(field(list_activation_dependencies_output, "dependency_edges").unwrap())
+                .unwrap()
+                >= 2
+        );
+        let activation_dependency_summary =
+            field(list_activation_dependencies_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_dependency_summary, "satisfied_edges").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_dependency_summary, "blocking_edges").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_dependency_summary, "has_blocking_dependencies"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_dependency_summary_request = request(
+            "call-integration-activation-dependency-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("blocking_only", JsonValue::Bool(true)),
+                ("edge_limit", integer(2)),
+            ]),
+            5_006,
+        );
+        let activation_dependency_summary_trace =
+            tool_runtime.invoke_with_events(&activation_dependency_summary_request);
+        assert!(activation_dependency_summary_trace.result.ok);
+        assert_eq!(
+            activation_dependency_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_dependency_summary_output = activation_dependency_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_dependency_rollup =
+            field(activation_dependency_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_dependency_rollup, "total_edges").unwrap()).unwrap()
+                <= 2
+        );
+        assert_eq!(
+            field(activation_dependency_rollup, "has_blocking_dependencies"),
+            Some(&JsonValue::Bool(true))
         );
 
         let list_integration_readiness_request = request(
@@ -12117,6 +12608,14 @@ mod tests {
             activation_runway_summary_trace,
         );
         journal.record_trace(
+            list_activation_dependencies_request,
+            list_activation_dependencies_trace,
+        );
+        journal.record_trace(
+            activation_dependency_summary_request,
+            activation_dependency_summary_trace,
+        );
+        journal.record_trace(
             list_integration_readiness_request,
             list_integration_readiness_trace,
         );
@@ -12176,9 +12675,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 59);
-        assert_eq!(journal_summary.completed_count, 59);
-        assert_eq!(journal.audit_records().len(), 59);
+        assert_eq!(journal_summary.invocation_count, 61);
+        assert_eq!(journal_summary.completed_count, 61);
+        assert_eq!(journal.audit_records().len(), 61);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary` tool descriptors for
   read-only rollout-priority activation wave planning.
+- `smart_home.list_integration_activation_dependencies` and
+  `smart_home.get_integration_activation_dependency_summary` tool descriptors
+  for read-only activation dependency graph planning.
 - `smart_home.list_integration_readiness` and
   `smart_home.get_integration_readiness_summary` tool descriptors for read-only
   integration activation blocker planning.

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1461,6 +1461,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationAgendaSummary,
     ListIntegrationActivationRunway,
     GetIntegrationActivationRunwaySummary,
+    ListIntegrationActivationDependencies,
+    GetIntegrationActivationDependencySummary,
     ListIntegrationReadiness,
     GetIntegrationReadinessSummary,
     ListIntegrationReadinessGaps,
@@ -1546,6 +1548,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationRunwaySummary => {
                 read_tool("smart_home.get_integration_activation_runway_summary")
+            }
+            Self::ListIntegrationActivationDependencies => {
+                read_tool("smart_home.list_integration_activation_dependencies")
+            }
+            Self::GetIntegrationActivationDependencySummary => {
+                read_tool("smart_home.get_integration_activation_dependency_summary")
             }
             Self::ListIntegrationReadiness => read_tool("smart_home.list_integration_readiness"),
             Self::GetIntegrationReadinessSummary => {
@@ -2178,6 +2186,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationAgendaSummary,
         SmartHomeTool::ListIntegrationActivationRunway,
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
+        SmartHomeTool::ListIntegrationActivationDependencies,
+        SmartHomeTool::GetIntegrationActivationDependencySummary,
         SmartHomeTool::ListIntegrationReadiness,
         SmartHomeTool::GetIntegrationReadinessSummary,
         SmartHomeTool::ListIntegrationReadinessGaps,
@@ -3016,7 +3026,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 59);
+        assert_eq!(catalog.len(), 61);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3259,6 +3269,14 @@ mod tests {
             == "smart_home.get_worker_heartbeat_schedule"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_dependencies"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_dependency_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3266,15 +3284,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 59);
-        assert_eq!(summary.read_tools, 51);
+        assert_eq!(summary.total_tools, 61);
+        assert_eq!(summary.read_tools, 53);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 51);
+        assert_eq!(summary.read_only_tier_tools, 53);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 59);
+        assert_eq!(summary.total_required_capabilities, 61);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationRunwayStage` and `IntegrationActivationRunwaySummary`
   for grouping activation candidates by rollout priority wave and identifying
   actionable, review, and blocked stages.
+- `IntegrationActivationDependencyGraph` plus node, edge, and summary types for
+  exposing satisfied and blocking integration prerequisites in rollout plans.
 - Integration readiness reports that expose missing primitive families, missing
   capability grants, and missing delegated integrations before activation.
 - Integration readiness summaries for compact activation-ready, blocker,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -38,6 +38,8 @@ runtime and Chief of Staff tools a typed catalog for:
   rollout priority wave for bounded Chief-of-Staff planning
 - activation runway stages that group those candidates by rollout priority wave
   with compact ready, review, and blocker rollups
+- activation dependency graphs that expose prerequisite nodes, satisfied edges,
+  and blocking edges after applying host-specific enabled-integration context
 - readiness reports that compare activation plans against available primitives,
   allowed capabilities, and already-enabled dependency integrations
 - readiness summaries that roll activation blockers, review requirements, and

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -856,6 +856,57 @@ pub struct IntegrationReadinessGapInventory {
     pub dependency_gaps: Vec<IntegrationReadinessDependencyGap>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDependencyNode {
+    pub integration_id: IntegrationId,
+    pub display_name: String,
+    pub priority: u8,
+    pub activation_target: IntegrationActivationTarget,
+    pub depends_on_integrations: Vec<IntegrationId>,
+    pub dependent_integration_ids: Vec<IntegrationId>,
+    pub missing_dependencies: Vec<IntegrationId>,
+    pub enabled: bool,
+    pub activation_ready: bool,
+    pub requires_human_review: bool,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDependencyEdge {
+    pub dependency_integration_id: IntegrationId,
+    pub dependent_integration_id: IntegrationId,
+    pub dependency_display_name: Option<String>,
+    pub dependent_display_name: String,
+    pub dependency_priority: Option<u8>,
+    pub dependent_priority: u8,
+    pub satisfied: bool,
+    pub blocks_activation: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDependencyGraph {
+    pub nodes: Vec<IntegrationActivationDependencyNode>,
+    pub edges: Vec<IntegrationActivationDependencyEdge>,
+    pub summary: IntegrationActivationDependencySummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDependencySummary {
+    pub total_nodes: usize,
+    pub enabled_nodes: usize,
+    pub activation_ready_nodes: usize,
+    pub blocked_nodes: usize,
+    pub nodes_with_dependencies: usize,
+    pub nodes_with_dependents: usize,
+    pub nodes_with_missing_dependencies: usize,
+    pub total_edges: usize,
+    pub satisfied_edges: usize,
+    pub blocking_edges: usize,
+    pub unknown_dependency_edges: usize,
+    pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -1057,6 +1108,91 @@ impl IntegrationReadinessGapInventory {
 
     pub fn total_unique_gaps(&self) -> usize {
         self.primitive_gap_count() + self.capability_gap_count() + self.dependency_gap_count()
+    }
+}
+
+impl IntegrationActivationDependencySummary {
+    pub fn from_graph(
+        nodes: &[IntegrationActivationDependencyNode],
+        edges: &[IntegrationActivationDependencyEdge],
+    ) -> Self {
+        let mut summary = Self {
+            total_nodes: nodes.len(),
+            enabled_nodes: 0,
+            activation_ready_nodes: 0,
+            blocked_nodes: 0,
+            nodes_with_dependencies: 0,
+            nodes_with_dependents: 0,
+            nodes_with_missing_dependencies: 0,
+            total_edges: edges.len(),
+            satisfied_edges: 0,
+            blocking_edges: 0,
+            unknown_dependency_edges: 0,
+            first_blocked_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for node in nodes {
+            if node.enabled {
+                summary.enabled_nodes += 1;
+            }
+            if node.activation_ready {
+                summary.activation_ready_nodes += 1;
+            } else {
+                summary.blocked_nodes += 1;
+                summary.first_blocked_priority = Some(
+                    summary
+                        .first_blocked_priority
+                        .map_or(node.priority, |priority| priority.min(node.priority)),
+                );
+            }
+            if !node.depends_on_integrations.is_empty() {
+                summary.nodes_with_dependencies += 1;
+            }
+            if !node.dependent_integration_ids.is_empty() {
+                summary.nodes_with_dependents += 1;
+            }
+            if !node.missing_dependencies.is_empty() {
+                summary.nodes_with_missing_dependencies += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(node.highest_policy_tier);
+        }
+
+        for edge in edges {
+            if edge.satisfied {
+                summary.satisfied_edges += 1;
+            }
+            if edge.blocks_activation {
+                summary.blocking_edges += 1;
+            }
+            if edge.dependency_display_name.is_none() {
+                summary.unknown_dependency_edges += 1;
+            }
+        }
+
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_nodes == 0
+    }
+
+    pub fn has_dependency_edges(&self) -> bool {
+        self.total_edges > 0
+    }
+
+    pub fn has_blocking_dependencies(&self) -> bool {
+        self.blocking_edges > 0
+    }
+}
+
+impl IntegrationActivationDependencyGraph {
+    pub fn is_empty(&self) -> bool {
+        self.summary.is_empty()
+    }
+
+    pub fn has_blocking_dependencies(&self) -> bool {
+        self.summary.has_blocking_dependencies()
     }
 }
 
@@ -2877,6 +3013,98 @@ pub fn activation_runway_at_or_before_priority(
     ))
 }
 
+pub fn activation_dependency_graph_from_reports<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationActivationDependencyGraph {
+    let reports = reports.into_iter().cloned().collect::<Vec<_>>();
+    let mut dependent_ids_by_dependency: BTreeMap<IntegrationId, BTreeSet<IntegrationId>> =
+        BTreeMap::new();
+    let mut edges = Vec::new();
+
+    for report in &reports {
+        for dependency_id in activation_dependency_ids_for_report(catalog, report) {
+            dependent_ids_by_dependency
+                .entry(dependency_id.clone())
+                .or_default()
+                .insert(report.requested_integration_id.clone());
+            let dependency = find_entry(catalog, &dependency_id);
+            let satisfied = enabled_integrations
+                .iter()
+                .any(|enabled| enabled == &dependency_id);
+            edges.push(IntegrationActivationDependencyEdge {
+                dependency_integration_id: dependency_id,
+                dependent_integration_id: report.requested_integration_id.clone(),
+                dependency_display_name: dependency.map(|entry| entry.display_name.clone()),
+                dependent_display_name: report.display_name.clone(),
+                dependency_priority: dependency.map(|entry| entry.priority),
+                dependent_priority: report.priority,
+                satisfied,
+                blocks_activation: !satisfied,
+            });
+        }
+    }
+
+    let mut nodes = reports
+        .iter()
+        .map(|report| {
+            let integration_id = report.requested_integration_id.clone();
+            let mut depends_on_integrations = activation_dependency_ids_for_report(catalog, report);
+            depends_on_integrations.sort();
+            depends_on_integrations.dedup();
+            let dependent_integration_ids = dependent_ids_by_dependency
+                .remove(&integration_id)
+                .map(|ids| ids.into_iter().collect())
+                .unwrap_or_default();
+            let enabled = enabled_integrations
+                .iter()
+                .any(|enabled| enabled == &integration_id);
+
+            IntegrationActivationDependencyNode {
+                integration_id,
+                display_name: report.display_name.clone(),
+                priority: report.priority,
+                activation_target: report.activation_target.clone(),
+                depends_on_integrations,
+                dependent_integration_ids,
+                missing_dependencies: report.missing_dependencies.clone(),
+                enabled,
+                activation_ready: report.activation_ready(),
+                requires_human_review: report.requires_human_review,
+                highest_policy_tier: report.highest_policy_tier,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    nodes.sort_by(compare_activation_dependency_nodes);
+    edges.sort_by(compare_activation_dependency_edges);
+    let summary = IntegrationActivationDependencySummary::from_graph(&nodes, &edges);
+
+    IntegrationActivationDependencyGraph {
+        nodes,
+        edges,
+        summary,
+    }
+}
+
+pub fn activation_dependency_graph_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> IntegrationActivationDependencyGraph {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations)
+}
+
 pub fn readiness_gap_inventory_from_reports<'a>(
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
 ) -> IntegrationReadinessGapInventory {
@@ -3808,6 +4036,24 @@ fn missing_dependencies_for_plan(
         .collect()
 }
 
+fn activation_dependency_ids_for_report(
+    catalog: &[IntegrationCatalogEntry],
+    report: &IntegrationReadinessReport,
+) -> Vec<IntegrationId> {
+    let mut dependencies =
+        activation_plan_for_integration(catalog, &report.requested_integration_id)
+            .map(|plan| plan.depends_on_integrations)
+            .unwrap_or_default();
+    if let IntegrationActivationTarget::DelegatedIntegration(target) = &report.activation_target {
+        if !dependencies.contains(target) {
+            dependencies.push(target.clone());
+        }
+    }
+    dependencies.sort();
+    dependencies.dedup();
+    dependencies
+}
+
 fn dedupe_policy_surfaces(
     surfaces: Vec<IntegrationPolicySurface>,
 ) -> Vec<IntegrationPolicySurface> {
@@ -3892,6 +4138,36 @@ fn compare_activation_actions(
         })
         .then_with(|| left.primitive.cmp(&right.primitive))
         .then_with(|| left.capability_id.cmp(&right.capability_id))
+        .then_with(|| {
+            left.dependency_integration_id
+                .cmp(&right.dependency_integration_id)
+        })
+}
+
+fn compare_activation_dependency_nodes(
+    left: &IntegrationActivationDependencyNode,
+    right: &IntegrationActivationDependencyNode,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.display_name.cmp(&right.display_name))
+        .then_with(|| left.integration_id.cmp(&right.integration_id))
+}
+
+fn compare_activation_dependency_edges(
+    left: &IntegrationActivationDependencyEdge,
+    right: &IntegrationActivationDependencyEdge,
+) -> Ordering {
+    left.dependent_priority
+        .cmp(&right.dependent_priority)
+        .then_with(|| {
+            left.dependent_display_name
+                .cmp(&right.dependent_display_name)
+        })
+        .then_with(|| {
+            left.dependent_integration_id
+                .cmp(&right.dependent_integration_id)
+        })
         .then_with(|| {
             left.dependency_integration_id
                 .cmp(&right.dependency_integration_id)
@@ -4721,6 +4997,76 @@ mod tests {
             && gap
                 .requested_integration_ids
                 .contains(&IntegrationId::trusted("tasmota"))));
+    }
+
+    #[test]
+    fn activation_dependency_graph_tracks_satisfied_and_blocking_edges() {
+        let catalog = first_party_catalog();
+        let available_primitives = all_primitive_families().to_vec();
+        let allowed_capabilities = vec![
+            CapabilityId::trusted("smart_home.read"),
+            CapabilityId::trusted("smart_home.command.light"),
+        ];
+        let graph = activation_dependency_graph_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[IntegrationId::trusted("mqtt")],
+        );
+
+        assert!(!graph.is_empty());
+        assert!(graph.summary.has_dependency_edges());
+        assert!(graph.summary.satisfied_edges > 0);
+        assert!(graph.summary.blocking_edges > 0);
+        assert!(graph.summary.nodes_with_dependencies > 0);
+        assert!(graph.summary.nodes_with_dependents > 0);
+        assert!(graph.summary.nodes_with_missing_dependencies > 0);
+
+        let tasmota = graph
+            .nodes
+            .iter()
+            .find(|node| node.integration_id == IntegrationId::trusted("tasmota"))
+            .unwrap();
+        assert!(tasmota
+            .depends_on_integrations
+            .contains(&IntegrationId::trusted("mqtt")));
+        assert!(tasmota.missing_dependencies.is_empty());
+
+        let tapo = graph
+            .nodes
+            .iter()
+            .find(|node| node.integration_id == IntegrationId::trusted("tplink_tapo"))
+            .unwrap();
+        assert!(tapo
+            .missing_dependencies
+            .contains(&IntegrationId::trusted("tplink")));
+
+        let satisfied = graph
+            .edges
+            .iter()
+            .find(|edge| {
+                edge.dependent_integration_id == IntegrationId::trusted("tasmota")
+                    && edge.dependency_integration_id == IntegrationId::trusted("mqtt")
+            })
+            .unwrap();
+        assert!(satisfied.satisfied);
+        assert!(!satisfied.blocks_activation);
+
+        let blocked = graph
+            .edges
+            .iter()
+            .find(|edge| {
+                edge.dependent_integration_id == IntegrationId::trusted("tplink_tapo")
+                    && edge.dependency_integration_id == IntegrationId::trusted("tplink")
+            })
+            .unwrap();
+        assert!(!blocked.satisfied);
+        assert!(blocked.blocks_activation);
+        assert_eq!(
+            blocked.dependency_display_name.as_deref(),
+            Some("TP-Link Smart Home")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add smart-home integration activation dependency graph nodes, edges, summaries, and catalog helpers
- expose Chief-of-Staff read-only tools for listing activation dependencies and dependency summaries
- register shared smart-home core descriptors and document the new D23A planning surface

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
- git diff --check