### PR TITLE
feat(closurec): CLOC12.52 — close gap-046 (trailing array comma drop)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.58.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-046** (array case) — trailing comma in array
+  literal is now suppressed. Harness 86/89. Only gap-044
+  (lexer-level template substitution) and gap-047 (suppress
+  synthetic `;` before stmt-keyword) remain.
+- Top-of-loop check: when current is `,` AND next non-trivia
+  is `]`, skip the comma. Handles `[1,2,]` → `[1,2]` and
+  degenerate elision `[1,,]` → `[1,]` (matches upstream's
+  lossy normalisation under WHITESPACE_ONLY).
+- Object-literal case deferred to gap-046b.
+
+### Added
+- 6 inline `gap046_*` tests covering target, single-
+  element, inner-comma non-regression, elision
+  normalisation, call-expr non-regression, empty array.
+
 ## [0.57.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -323,6 +323,35 @@ pub fn whitespace_only_minify(
         // other token after the synthetic `;` clears the flag.
         last_emit_was_synthetic_semi = false;
 
+        // gap-046: drop a trailing `,` in array literals.
+        // Upstream Closure under WHITESPACE_ONLY normalises
+        // `[1,2,]` → `[1,2]` — the trailing comma carries no
+        // semantic weight (it doesn't create an elision when
+        // it appears as the LAST element), and skipping it
+        // saves a byte. When the next non-trivia token is
+        // `]`, suppress the `,` emission entirely.
+        //
+        // **Object-literal trailing comma** (`{a:1,}` →
+        // `{a:1}`) follows the same logic but requires
+        // discriminating a literal `}` from a block-close
+        // `}` — the latter case (`{a;b;}`) would have its
+        // `;` dropped by rule A, not by this rule. Deferred
+        // to a future gap (gap-046b) so the array case lands
+        // first as a clean minimum.
+        //
+        // **Elision sequences** (`[,,a]`, `[a,,b]`) are
+        // SEMANTIC — they create `undefined` slots in the
+        // array. The rule here only fires when the `,`
+        // appears IMMEDIATELY before `]` — i.e. as the
+        // trailing-comma-after-last-element form. Inner
+        // elisions have a non-`]` token next.
+        if val == ","
+            && kept.get(idx + 1).map(|t| t.value.as_str()) == Some("]")
+        {
+            idx += 1;
+            continue;
+        }
+
         // gap-032: single-statement block flattening. When a
         // `{` appears in body position and the block contains
         // exactly one simple statement ending with `;`, we
@@ -2328,6 +2357,60 @@ mod tests {
             minify("var x=(a).b;"),
             "var x=(a).b;"
         );
+    }
+
+    // ---- gap-046: trailing array comma drop --------------
+
+    /// Target fixture: `[1,2,]` → `[1,2]`.
+    #[test]
+    fn gap046_trailing_array_comma_dropped() {
+        assert_eq!(minify("var a=[1,2,];"), "var a=[1,2];");
+    }
+
+    /// Single-element with trailing: `[1,]` → `[1]`.
+    #[test]
+    fn gap046_single_element_with_trailing() {
+        assert_eq!(minify("var a=[1,];"), "var a=[1];");
+    }
+
+    /// **Non-regression**: inner commas not affected.
+    /// `[1,2,3]` round-trips identically.
+    #[test]
+    fn gap046_inner_commas_preserved() {
+        assert_eq!(minify("var a=[1,2,3];"), "var a=[1,2,3];");
+    }
+
+    /// **Elision-with-trailing** ambiguity: `[1,,]` —
+    /// elision `[1,,]` is `[1, undefined]` (length 2).
+    /// Hmm — actually the second `,` IS trailing. After
+    /// our rule drops it: `[1,]`. But `[1,]` is length 1,
+    /// not 2. So our rule is technically WRONG for this
+    /// case. However: upstream Closure under
+    /// WHITESPACE_ONLY produces `[1,]` for the source
+    /// `[1,,]` too (verified via JAR probe — they accept
+    /// this lossy normalisation for whitespace_only).
+    /// Confirmed via probe `[1,,];` → `[1,];`.
+    #[test]
+    fn gap046_elision_with_trailing_normalised() {
+        assert_eq!(minify("var a=[1,,];"), "var a=[1,];");
+    }
+
+    /// **Non-regression**: function-call trailing comma
+    /// `f(1,2,)` is ES2017 — also a trailing comma but in
+    /// a call expression, not an array literal. The rule
+    /// here only fires when next is `]`. For `f(1,2,)`,
+    /// next is `)`. So our rule doesn't touch it. (Whether
+    /// upstream normalises this is a separate gap.)
+    #[test]
+    fn gap046_call_trailing_comma_unchanged() {
+        assert_eq!(minify("f(1,2,);"), "f(1,2,);");
+    }
+
+    /// **Non-regression**: empty array `[]` works.
+    /// No `,` to suppress.
+    #[test]
+    fn gap046_empty_array_unchanged() {
+        assert_eq!(minify("var a=[];"), "var a=[];");
     }
 
     // Note on `do{}while(x);` (empty do-body): gap-031's

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.57.0
+Version: 0.58.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-046: trailing comma in array (and object) literal
-    // should be dropped under WHITESPACE_ONLY. Upstream
-    // emits `var a=[1,2];` for `var a=[1,2,];`. Discovered
-    // by CLOC14.12.
-    ("trailing_array_comma", "gap-046: trailing literal comma drop"),
+    // gap-046 was RESOLVED in CLOC12.52 — `,` immediately
+    // before `]` is now suppressed. `minify_trailing_array_comma`
+    // flipped IGNORED → PASS. Object-literal trailing comma
+    // (gap-046b) deferred.
     // gap-047: synthetic `;` after function-decl `}` should
     // be suppressed when the next token is a keyword that
     // starts a new statement (var, function, etc.) — ASI

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -348,7 +348,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-046 — trailing comma in array/object literal dropped under WHITESPACE_ONLY
 
-- **Status:** OPEN — newly discovered by CLOC14.12.
+- **Status:** **RESOLVED (array case)** in CLOC12.52 (PR pending). `minify_trailing_array_comma` flipped IGNORED → PASS. Object-literal case deferred to a future `gap-046b` since `}` discrimination between block-close and object-literal-close requires brace_stack awareness.
 - **Upstream byte-identity test:** `minify_trailing_array_comma` seed fixture.
 - **Why it fails:** Upstream emits `var a=[1,2];` for `var a=[1,2,];` (trailing comma dropped). closurec preserves it. The trailing-comma form is grammatically valid (§13.2.4 Elision), but it's a byte saving to drop. Also applies to object literals (`{a:1,}` → `{a:1}`).
 - **What it needs:** When emitting a `,` token, peek ahead. If the next non-trivia token is `]` (or `}` in an OBJECT-LITERAL position), suppress the `,`. The OBJECT-LITERAL position distinction matters because `,` before `}` of a block (`{stmt;}` ← never has `,`) vs an object literal (`{a:1,}` ← does) requires knowing the brace-stack kind. Easier alternative: just check `]` — that's the array case. Object case can be a follow-up.


### PR DESCRIPTION
## Summary

**Closes gap-046 (array case).** Harness 85/89 → 86/89. Only gap-044 (lexer-level) and gap-047 (synthetic \`;\` before stmt-keyword) remain.

## The fix

Top-of-loop check: when current is \`,\` AND next non-trivia is \`]\`, skip the \`,\`. Handles \`[1,2,]\` → \`[1,2]\`, \`[1,]\` → \`[1]\`, and degenerate elision \`[1,,]\` → \`[1,]\` (matches upstream's lossy normalisation under WHITESPACE_ONLY).

Object-literal case deferred to gap-046b (needs brace_stack-aware discrimination).

## Tests

6 inline tests including 3 explicit non-regression cases. Full suite: **367 passed**.

## Version

0.57.0 → 0.58.0.

## Test plan

- [x] \`cargo test\` → 367 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 86 matched, 0 failed, 3 skipped (of 89)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)