### PR TITLE
Enable ALGOL for-while loops on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -494,14 +494,28 @@ impl Compiler {
             ));
         }
         let elem = elems[0];
+        let body = direct_nodes(node)
+            .into_iter()
+            .find(|n| n.rule_name == "statement")
+            .ok_or_else(|| CompileError::Malformed("for_stmt missing body statement".into()))?;
+
         if direct_tokens(elem).iter().any(|t| t.value == "while") {
-            return Err(CompileError::Unsupported("for while elements".into()));
+            return self.emit_for_while(&var_name, elem, body);
         }
         if !direct_tokens(elem).iter().any(|t| t.value == "step") {
             return Err(CompileError::Unsupported(
                 "single-value for elements outside step/until form".into(),
             ));
         }
+        self.emit_for_step_until(&var_name, elem, body)
+    }
+
+    fn emit_for_step_until(
+        &mut self,
+        var_name: &str,
+        elem: &GrammarASTNode,
+        body: &GrammarASTNode,
+    ) -> Result<(), CompileError> {
         let arith_nodes: Vec<&GrammarASTNode> = direct_nodes(elem)
             .into_iter()
             .filter(|n| n.rule_name == "arith_expr")
@@ -527,14 +541,9 @@ impl Compiler {
             .ok_or_else(|| CompileError::Unsupported("non-constant for step values".into()))?;
         let cmp_op = if step_const >= 0 { "cmp_le" } else { "cmp_ge" };
 
-        let body = direct_nodes(node)
-            .into_iter()
-            .find(|n| n.rule_name == "statement")
-            .ok_or_else(|| CompileError::Malformed("for_stmt missing body statement".into()))?;
-
         self.emit(IIRInstr::new(
             "mov",
-            Some(var_name.clone()),
+            Some(var_name.to_string()),
             vec![Operand::Var(start.slot)],
             "i64",
         ));
@@ -546,7 +555,7 @@ impl Compiler {
         self.emit(IIRInstr::new(
             cmp_op,
             Some(cond.clone()),
-            vec![Operand::Var(var_name.clone()), Operand::Var(limit.slot)],
+            vec![Operand::Var(var_name.to_string()), Operand::Var(limit.slot)],
             "bool",
         ));
         self.emit(IIRInstr::new(
@@ -560,15 +569,68 @@ impl Compiler {
         self.emit(IIRInstr::new(
             "add",
             Some(next.clone()),
-            vec![Operand::Var(var_name.clone()), Operand::Var(step.slot)],
+            vec![Operand::Var(var_name.to_string()), Operand::Var(step.slot)],
             "i64",
         ));
         self.emit(IIRInstr::new(
             "mov",
-            Some(var_name),
+            Some(var_name.to_string()),
             vec![Operand::Var(next)],
             "i64",
         ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(loop_label)],
+            "void",
+        ));
+        self.emit_label(&end_label);
+        Ok(())
+    }
+
+    fn emit_for_while(
+        &mut self,
+        var_name: &str,
+        elem: &GrammarASTNode,
+        body: &GrammarASTNode,
+    ) -> Result<(), CompileError> {
+        let arith_node = direct_nodes(elem)
+            .into_iter()
+            .find(|n| n.rule_name == "arith_expr")
+            .ok_or_else(|| CompileError::Malformed("while for element missing value".into()))?;
+        let cond_node = first_direct_node(elem, "bool_expr")
+            .ok_or_else(|| CompileError::Malformed("while for element missing condition".into()))?;
+
+        let loop_label = self.fresh_label("for_while_loop");
+        let end_label = self.fresh_label("for_while_end");
+        self.emit_label(&loop_label);
+
+        let value = self.emit_expr(arith_node)?;
+        if value.ty != ScalarType::Integer {
+            return Err(CompileError::Type(
+                "for while value expression must be integer".into(),
+            ));
+        }
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(var_name.to_string()),
+            vec![Operand::Var(value.slot)],
+            "i64",
+        ));
+
+        let cond = self.emit_expr(cond_node)?;
+        if cond.ty != ScalarType::Boolean {
+            return Err(CompileError::Type(
+                "for while condition must be boolean".into(),
+            ));
+        }
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(cond.slot), Operand::Var(end_label.clone())],
+            "void",
+        ));
+        self.emit_statement(body)?;
         self.emit(IIRInstr::new(
             "jmp",
             None,
@@ -1257,6 +1319,12 @@ mod tests {
     fn compiles_and_runs_for_step_until_sum() {
         let src = "begin integer i, result; result := 0; for i := 1 step 1 until 10 do result := result + i end";
         assert_eq!(run_i64(src), 55);
+    }
+
+    #[test]
+    fn compiles_and_runs_for_while_sum() {
+        let src = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
+        assert_eq!(run_i64(src), 15);
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -9,6 +9,8 @@ const ALGOL_MOD: &str = "begin integer result; result := 17 mod 5 end";
 
 const ALGOL_BOOL_OPS: &str = "begin boolean a, b; integer result; a := true; b := false; if (a and not b) and ((b impl a) eqv (a or b)) then result := 42 else result := 1 end";
 
+const ALGOL_FOR_WHILE: &str = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -21,6 +23,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "bool_ops",
             compile_case(ALGOL_BOOL_OPS, "algol_bool_ops_backend_compat"),
+        ),
+        (
+            "for_while",
+            compile_case(ALGOL_FOR_WHILE, "algol_for_while_backend_compat"),
         ),
     ] {
         let checks = [
@@ -128,4 +134,47 @@ fn algol_boolean_ops_lower_to_wasm_jvm_clr_beam_and_llvm() {
             .expect("ALGOL boolean IIR should lower to LLVM");
     assert!(llvm.contains("and i1"), "LLVM should lower ALGOL and as i1 and");
     assert!(llvm.contains("or i1"), "LLVM should lower ALGOL or as i1 or");
+}
+
+#[test]
+fn algol_for_while_lowers_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_FOR_WHILE, "algol_for_while_backend_compat");
+
+    let wasm =
+        iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolForWhile"))
+            .expect("ALGOL for-while IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolForWhile"),
+    )
+    .expect("ALGOL for-while IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL for-while IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam = iir_to_beam::lower_iir_to_beam(
+        &module,
+        &iir_to_beam::IIRBeamConfig::new("algol_for_while"),
+    )
+    .expect("ALGOL for-while IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm = iir_to_llvm::lower_iir_to_llvm(
+        &module,
+        &iir_to_llvm::IIRLlvmConfig::new("algol_for_while"),
+    )
+    .expect("ALGOL for-while IIR should lower to LLVM");
+    assert!(
+        llvm.contains("br label"),
+        "LLVM should lower for-while loop branches"
+    );
 }

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -31,3 +31,29 @@ fn algol_scalar_program_runs_through_generic_jit() {
     }
     assert_eq!(result.as_i64(), Some(21));
 }
+
+#[test]
+fn algol_for_while_program_runs_through_generic_jit() {
+    let source = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
+    let mut module = compile_source(source, "algol_for_while_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(15));
+}

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -108,6 +108,20 @@ fn algol_for_loop_emits_and_runs_on_wasm() {
     assert_eq!(result, vec![21], "ALGOL loop should sum 1..6");
 }
 
+#[test]
+fn algol_for_while_emits_and_runs_on_wasm() {
+    let source = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_for_while")
+        .expect("ALGOL for-while loop should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL for-while sum)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL for-while wasm must run");
+    assert_eq!(result, vec![15], "ALGOL for-while should sum 5..1");
+}
+
 /// The L3b-3a-3c capstone: a **cons** program compiles to WasmGC and runs
 /// end-to-end on the in-repo runtime. The uniform-anyref value model boxes the
 /// integer atoms as `i31ref`, allocates a `$LispyPair`, and unboxes the result


### PR DESCRIPTION
## Summary
- Lower ALGOL `for v := expr while condition do ...` elements into portable IIR using existing labels, moves, boolean conditions, and branches.
- Keep multi-element and single-value for-list forms explicitly unsupported for later semantics work.
- Add VM, GenericCirJit, direct backend, LLVM, and AOT/WASM runtime coverage for the new loop form.

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol_for_while_emits_and_runs_on_wasm`
- `cargo test -p iir-to-llvm`
- `cargo test -p algol-iir-compiler for_while`
- `git diff --check`

## Security review
- Scanned touched files for `unsafe`, process/file/env/network primitives, and embedded includes; no new production-risk surfaces introduced.
- `cargo audit` and `cargo deny` are not installed in this workspace, so dependency advisory checks could not be run locally.
- Push reported existing default-branch Dependabot alerts; this PR does not add dependencies.