### PR TITLE
ADJ-CAS + derive-tier ablation: fix the fact, not the weight — and a stronger deriver shifts gaps, doesn't close them

### DIFF
--- a/code/specs/data/adj52/cas/DEMO.md
+++ b/code/specs/data/adj52/cas/DEMO.md
@@ -1,0 +1,75 @@
+# CAS edit-override-propagate loop — "fix the fact, not the weight"
+
+The premise of the whole program: build expert systems whose errors trace to
+**editable knowledge**, not to weights buried inside a model. When the system is
+wrong, the auditable trail localizes the error to a specific claim in the
+content-addressed store (CAS); a human **edits that claim**; the fix is local,
+versioned, attributed, propagating, and regression-checked. You cannot do any of
+that to a neural net — there is no "this belief" to open up and correct.
+
+This directory demonstrates the full loop on **real data**: ADJ55's grounded
+bacterial-meningitis corpus and ADJ56's *documented* CSF over-saturation bug.
+
+## The loop, demonstrated (`python demo.py`)
+
+1. **Error, visible in the trail.** `corpus/eval.py` is a deterministic sequential
+   Bayesian update that prints every likelihood ratio it multiplies and its source.
+   On a **pre-culture** case (CSF chemistry back, Gram stain + culture still
+   pending) it climbs to **P = 0.9999** — indefensible certainty, because the
+   confirmatory test isn't back yet. You can *see* why: f2–f5 (neutrophilic
+   pleocytosis, low glucose, high protein, high lactate) are one correlated CSF
+   signal being multiplied as four independent ones.
+
+2. **Localized to specific claims.** The trail points at nodes **f3, f4, f5** — the
+   correlated CSF-chemistry findings — as the over-counting source.
+
+3. **Human edits the facts.** `override.py` applies a versioned, attributed,
+   *cited* override (`overrides/meningitis-csf-correlation.json`): cap f3/f4/f5 to
+   `lr = 1.0` (subsumed under f2 as the single CSF-chemistry signal). **The base
+   corpus stays immutable** — the edit is an additive human layer, and each touched
+   node records `provenance.override` (who, when, why, source, prior value), so the
+   edit itself is auditable and `eval.py`'s trail shows it.
+
+4. **Re-run — the fix propagates.** Pre-culture case: **0.9999 → 0.7709** —
+   calibrated "high suspicion, await the confirmatory test," not false certainty.
+
+5. **Regression check — nothing else broke.** The **culture-positive** case
+   (Gram + culture positive, genuinely dispositive): **1.0000 → 1.0000**,
+   unchanged. The edit corrected the over-confident case without damaging the case
+   that should be certain.
+
+| case | base P | edited P | outcome |
+|---|---:|---:|---|
+| pre-culture (Gram/culture pending) | 0.9999 | **0.7709** | de-saturated — false certainty fixed |
+| culture-positive (regression) | 1.0000 | 1.0000 | unchanged — no regression |
+
+## Why this is the point
+
+Every step here is a **file and a number you can inspect, edit, and diff** — not a
+weight. The error was *localizable* (to f3/f4/f5), the fix was *local* (three
+LR edits), *attributed and reversible* (the override JSON is the human layer, the
+base corpus untouched), *propagating* (re-runs everywhere those claims are used),
+and *regression-checked* (the dispositive case stayed correct). That is an expert
+system you can **correct and audit**, versus a model you can only retrain and hope.
+
+## Honest scope
+
+- This override encodes **correlation knowledge by capping LRs** — a legitimate
+  human judgment, and the right *mechanic* to demonstrate. The *principled*
+  representation of the same knowledge is the ADJ53 `mechanism` construct (group
+  the correlated manifestations under one latent cause); the override layer and the
+  mechanism construct are complementary — the override is how a human fixes a
+  specific corpus entry today, with full provenance.
+- For localization→edit to be one click in production, the trail must reference
+  **stable claim IDs** (here we used `eval.py`'s per-node id trail). And edits to a
+  *shared* claim must always run the regression set (`demo.py` does this for the two
+  meningitis cases) so fixing one case can't silently break another.
+
+## Files
+
+- `override.py` — apply a versioned/attributed/cited human override layer to a base
+  corpus → effective corpus (base immutable; each edit logged in `provenance.override`).
+- `overrides/meningitis-csf-correlation.json` — the human edit (cap the correlated CSF cluster).
+- `cases/meningitis-preculture.json` — the pre-culture decision-point case.
+- `demo.py` — reproduces the whole loop + the regression table.
+- `effective-meningitis.json` — the derived human-edited corpus (shows the override provenance inline).

--- a/code/specs/data/adj52/cas/cases/meningitis-preculture.json
+++ b/code/specs/data/adj52/cas/cases/meningitis-preculture.json
@@ -1,0 +1,11 @@
+{
+  "name": "bacterial meningitis — PRE-CULTURE decision point (CSF chemistry back, Gram stain and culture still pending)",
+  "ground_truth": "High clinical suspicion of bacterial meningitis pending the dispositive Gram stain + culture; at THIS moment the verdict should be high-but-not-certain (you are still waiting on the confirmatory tests). Asserting ~100% here is indefensible — the confirmatory test could still change it.",
+  "observations": [
+    "csf_neutrophilic_pleocytosis(high)",
+    "csf_glucose(low)",
+    "csf_protein(elevated)",
+    "csf_lactate(elevated)",
+    "seizure(present)"
+  ]
+}

--- a/code/specs/data/adj52/cas/demo.py
+++ b/code/specs/data/adj52/cas/demo.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Reproduce the CAS edit-override-propagate-regression loop end to end.
+
+Demonstrates "fix the fact, not the weight" on the real ADJ55 bacterial-meningitis
+corpus and ADJ56's documented CSF over-saturation: a human overrides the
+correlated CSF-chemistry claims, the over-confident case de-saturates, and a
+regression check confirms the dispositive (culture-positive) case is unchanged.
+
+Run: python demo.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CORPUS = HERE.parent / "corpus" / "bacterial_meningitis" / "corpus.json"
+EVAL = HERE.parent / "corpus" / "eval.py"
+OVERRIDES = HERE / "overrides" / "meningitis-csf-correlation.json"
+EFFECTIVE = HERE / "effective-meningitis.json"
+CASES = {
+    "pre-culture (Gram/culture pending)": HERE / "cases" / "meningitis-preculture.json",
+    "culture-positive (regression check)": HERE.parent / "provenance" / "meningitis" / "case.json",
+}
+
+
+def final_p(corpus: Path, case: Path) -> float:
+    out = subprocess.run(
+        [sys.executable, str(EVAL), str(corpus), str(case), "grounded"],
+        capture_output=True, text=True,
+    ).stdout
+    m = re.search(r">>> P\(.*\) = ([0-9.]+)", out)
+    return float(m.group(1)) if m else float("nan")
+
+
+def main() -> None:
+    print("STEP 1 — apply the human override (edit the correlated CSF-chemistry facts):")
+    subprocess.run([sys.executable, str(HERE / "override.py"), str(CORPUS), str(OVERRIDES), str(EFFECTIVE)])
+    print("\nSTEP 2 — re-run + regression check (base corpus vs human-edited effective corpus):\n")
+    print(f"  {'case':38s} {'base P':>8s} {'edited P':>9s}   outcome")
+    for name, case in CASES.items():
+        b = final_p(CORPUS, case)
+        e = final_p(EFFECTIVE, case)
+        outcome = "DE-SATURATED (false-certainty fixed)" if e < b - 0.05 else "unchanged (no regression)"
+        print(f"  {name:38s} {b:8.4f} {e:9.4f}   {outcome}")
+    print("\nThe base corpus is immutable; the edit lives in overrides/ (versioned, attributed,")
+    print("cited) and in the effective corpus's per-node provenance.override. Fix the fact, not the weight.")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj52/cas/effective-meningitis.json
+++ b/code/specs/data/adj52/cas/effective-meningitis.json
@@ -1,0 +1,202 @@
+{
+  "domain": "bacterial_meningitis",
+  "target": "diagnosis(bacterial_meningitis)",
+  "built": "case-blind, provenance-first (forward grounding)",
+  "invariant": "every LR carries a byte-anchored provenance chain to primary data; ungroundable links are explicit data-gaps, never invented numbers",
+  "prior": {
+    "id": "f0",
+    "finding": "prior",
+    "state": "base_rate",
+    "lr": 0.037,
+    "verdict": "grounded",
+    "grounded": true,
+    "provenance": {
+      "study": "Nigrovic LE, Kuppermann N, Macias CG, et al. Clinical prediction rule for identifying children with cerebrospinal fluid pleocytosis at very low risk of bacterial meningitis. JAMA. 2007;297(1):52-60. (PMID 17200475) \u2014 multicenter retrospective cohort, US",
+      "values": "bacterial meningitis 121/3295 = 3.7% (95% CI 3.1%-4.4%); aseptic (viral) meningitis 3174/3295 = 96.3% (95% CI 95.5%-96.9%)",
+      "byte_quote": "Among 3295 patients with CSF pleocytosis, 121 (3.7%; 95% confidence interval [CI], 3.1%-4.4%) had bacterial meningitis and 3174 (96.3%; 95% CI, 95.5%-96.9%) had aseptic meningitis.",
+      "formula": "prior(base_rate) = pretest prevalence of bacterial meningitis = n_bacterial / n_pleocytosis = 121 / 3295 = 0.0367 ~= 0.037 (3.7%); complement (aseptic/viral) = 3174/3295 = 0.963 (96.3%); pretest odds bacterial:viral = 121:3174 = 1:26.2. (No LR is computed for a prior; prevalence is reported as a probability per the procedure.)",
+      "n": "3295",
+      "population": "Children with CSF pleocytosis (CSF WBC >= 7-10/uL depending on age) undergoing lumbar puncture for suspected meningitis"
+    },
+    "note": "f0 is the PRIOR (base rate), so the reported value is a prevalence/probability, not a test LR. Primary byte-anchored figure: Nigrovic 2007 JAMA (PMID 17200475), the largest population (n=3295) with the most directly matching population \u2014 patients with CSF pleocytosis undergoing LP \u2014 giving bacterial meningitis prevalence 3.7% (95% CI 3.1-4.4%). This is a pediatric cohort; the adult-relevant corroboration from the JAMA Rational Clinical Examination (single US ED, all-comers with clinical suspicion of meningitis) gives a lower bacterial prevalence (~1% culture-positive among all LP'd, ~27% any meningitis), because its denominator is broader (anyone LP'd, not just those with confirmed pleocytosis). Choice of prior depends on the gating population: ~3.7% if conditioning on CSF pleocytosis; ~1% if conditioning on undifferentiated suspected-meningitis presenting for LP. Reported computed_lr=0.037 uses the pleocytosis-conditioned anchor that best matches the f0 specification ('CSF pleocytosis undergoing LP'). Verdict grounded: figure is byte-anchored and confirmed verbatim from the primary source twice."
+  },
+  "findings": [
+    {
+      "id": "f1",
+      "finding": "csf_gram_stain",
+      "state": "positive",
+      "lr": 85,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "WHO guidelines on meningitis diagnosis, treatment and care (2025, NCBI Bookshelf NBK614844), section A.2.2; pooled CSF Gram stain accuracy from the Straus 2006 JAMA / CSF-parameter diagnostic-accuracy review lineage",
+        "values": "sensitivity = 85% (95% CI 55-96%); specificity = 99%",
+        "byte_quote": "CSF Gram stain likely has moderate to high sensitivity (85%, 95% confidence interval [CI] 55-96%; 6 studies; high-certainty evidence) and very high specificity (99%; 1 study; moderate-certainty evidence) for the diagnosis of acute bacterial meningitis.",
+        "formula": "LR+ = sensitivity / (1 - specificity) = 0.85 / (1 - 0.99) = 0.85 / 0.01 = 85",
+        "n": "6 studies (sensitivity estimate); 1 study (specificity estimate)",
+        "population": "Patients with suspected acute meningitis undergoing lumbar puncture; reference standard = bacterial meningitis (culture/clinical) vs non-bacterial"
+      },
+      "note": "Finding f1 = positive CSF Gram stain for bacterial vs viral/aseptic meningitis. Primary byte-anchored numbers (sens 85%, spec 99%) come from the WHO meningitis guideline (NBK614844, section A.2.2 Initial laboratory investigations), which pools the Straus 2006 JAMA 'How do I perform a lumbar puncture...' / Rational Clinical Examination CSF-parameter accuracy lineage. Computed LR+ = 0.85/(1-0.99) = 85 \u2014 a very strong positive likelihood ratio, meaning a positive Gram stain is near-diagnostic for bacterial meningitis (rule-in). CAVEATS: (1) LR+ is sensitive to the specificity estimate, which rests on a single study at 99%; if specificity were 98% (also cited in the literature) LR+ would be ~42.5, and at 97% (a commonly cited figure) LR+ ~28.3 \u2014 so the point estimate of 85 should be read as 'order ~10^1.5, strongly rule-in' rather than a precise constant. (2) Sensitivity CI is wide (55-96%) because it varies with pathogen, prior antibiotics, and bacterial concentration; this affects LR- (rule-out) but not LR+. (3) The Straus 2006 review itself reports Gram stain as sens/spec only and gives directly-pooled LRs for biochemical parameters instead (CSF lactate >=31.5 mg/dL LR+ 21 [95% CI 14-32]; CSF:blood glucose ratio <=0.4 LR 18 [12-27]; CSF WBC >=500/uL LR 15 [10-22]) \u2014 these are captured in the chain as corroborating CSF-parameter anchors. No prior/prevalence is reported in these sources; clinical pre-test probability in a suspected-meningitis-undergoing-LP population is the implied prior but is not byte-anchored here. computed_lr derived solely from byte-anchored real numbers; no value invented. Sources: WHO guideline https://www.ncbi.nlm.nih.gov/books/NBK614844/ ; Straus 2006 JAMA https://pubmed.ncbi.nlm.nih.gov/17062865/ and DARE https://www.ncbi.nlm.nih.gov/books/NBK73225/"
+    },
+    {
+      "id": "f2",
+      "finding": "csf_neutrophilic_pleocytosis",
+      "state": "high",
+      "lr": 15,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Straus SE, Thorpe KE, Holroyd-Leduc J. The Rational Clinical Examination / 'How do I perform a lumbar puncture and analyze the results to diagnose bacterial meningitis?' JAMA. 2006;296(16):2012-2022 (PMID 17062865); corroborated by Spanos A, Harrell FE, Durack DT. JAMA. 1989;262(19):2700-2707 (PMID 2810603)",
+        "values": "CSF WBC >=500/microL: LR+ 15 (95% CI 10-22). Companions: CSF:blood glucose ratio <=0.4: LR+ 18 (95% CI 12-27); CSF lactate >=31.53 mg/dL: LR+ 21 (95% CI 14-32). Spanos high thresholds: >2000x10^6/L WBC or >1180x10^6/L PMN => bacterial with >=99% certainty",
+        "byte_quote": "CSF white blood cell count of 500/muL or higher (LR, 15; 95% CI, 10-22)",
+        "formula": "Published pooled LR+ used directly. Straus JAMA 2006 reports, for CSF total WBC count >=500/microL, a positive LR of 15 (95% CI 10-22). This is already a pooled LR+ = sens/(1-spec) collapsed by the review, so computed_lr = 15 directly; no recomputation from sens/spec needed. (Companion CSF parameters: CSF-blood glucose ratio <=0.4 LR+ 18; CSF lactate >=31.53 mg/dL LR+ 21.) Spanos 1989 corroborates the high end: >1180x10^6/L PMN or >2000x10^6/L WBC ruled IN bacterial meningitis with >=99% certainty (post-test prob >=0.99), consistent with a large positive LR at higher thresholds.",
+        "n": "Systematic review of diagnostic-accuracy studies (Straus 2006); Spanos 1989 derivation/validation cohort of 422 patients with bacterial or viral meningitis",
+        "population": "Adults with suspected acute meningitis undergoing lumbar puncture; CSF parameters compared between bacterial and aseptic/viral meningitis"
+      },
+      "note": "Finding f2 (high CSF neutrophilic pleocytosis) maps most cleanly to the Straus JAMA 2006 pooled CSF total WBC-count parameter, whose published positive LR is 15 (95% CI 10-22) at the >=500/microL threshold. The framework's expected 'high (>1000 cells / high % PMN)' threshold sits ABOVE 500/microL, so 15 is a conservative lower bound for the LR+ of true high-grade neutrophilic pleocytosis; Spanos 1989 confirms the upper end where >1180x10^6/L PMN or >2000x10^6/L WBC rule in bacterial meningitis with >=99% certainty (i.e. a much larger effective LR at those higher cutoffs). Note Straus reports CSF total WBC, not a separate PMN-specific pooled LR; PMN-specific evidence (Spanos) is reported as certainty/cutoffs rather than a clean pooled LR, so the WBC-count LR is used as the byte-anchored primary value. computed_lr=15 is taken directly from the byte-quoted real number, not recomputed and not invented. Reported prior/prevalence not fixed by the source; LR is prevalence-independent and applied to whatever pre-test probability the clinical context implies."
+    },
+    {
+      "id": "f3",
+      "finding": "csf_glucose",
+      "state": "low",
+      "lr": 1.0,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Straus SE, Thorpe KE, Holroyd-Leduc J. How do I perform a lumbar puncture and analyze the results to diagnose bacterial meningitis? JAMA. 2006 Oct 25;296(16):2012-2022. (Rational Clinical Examination; pooled systematic review). PMID 17062865. Corroborated by Spanos A et al. JAMA 1989;262(19):2700-2707 (PMID 2810603) and AAFP CSF Analysis review 2021.",
+        "values": "Straus 2006: CSF:blood glucose ratio <=0.4 -> LR 18 (95% CI 12-27), reported directly. AAFP/Spanos cross-check: CSF:serum glucose ratio <0.4 = 80% sensitive, 98% specific. Spanos 1989 threshold: CSF-blood glucose ratio <0.23 predicts bacterial infection with >=99% certainty.",
+        "byte_quote": "A CSF-blood glucose ratio of 0.4 or less (likelihood ratio [LR], 18; 95% CI, 12-27]) accurately diagnosed bacterial meningitis.",
+        "formula": "Primary (Straus 2006, pooled, reported directly): LR+ = 18 (95% CI 12-27) for CSF:blood glucose ratio <=0.4. Independent cross-check from sens/spec (AAFP/Spanos, CSF:serum glucose ratio <0.4: sens=0.80, spec=0.98): LR+ = sens/(1-spec) = 0.80/(1-0.98) = 0.80/0.02 = 40. The single-study point estimate (40) is higher than the pooled estimate (18) because pooling across heterogeneous cohorts shrinks the LR; the directly-reported pooled LR=18 is the canonical citable value and is reported as computed_lr.",
+        "n": "Straus pooling spans multiple cohorts; Spanos 1989 underlying derivation/validation = 422 patients with acute bacterial or viral meningitis.",
+        "population": "Adults with suspected acute meningitis undergoing lumbar puncture; pooled across CSF diagnostic-accuracy studies distinguishing bacterial from viral/aseptic meningitis.",
+        "override": {
+          "editor": "human expert (demo)",
+          "date": "2026-06-09",
+          "reason": "CSF low glucose is a correlated manifestation of the bacterial CSF profile, not an independent test. f2 (neutrophilic pleocytosis) is kept as the representative of that one CSF-chemistry signal; counting glucose independently double-counts. Neutralized (lr=1).",
+          "source": "ADJ56 cross-domain stress test \u2014 documented meningitis CSF over-saturation (P=1.0000); CSF pleocytosis/glucose/protein/lactate are joint effects of one process.",
+          "op": "edited",
+          "prior": {
+            "lr": 18
+          },
+          "now": {
+            "lr": 1.0
+          }
+        }
+      },
+      "note": "Finding f3 (low CSF glucose / low CSF:serum glucose ratio) bearing on bacterial vs viral meningitis. computed_lr=18 is a byte-anchored, directly-reported pooled LR+ from Straus 2006 JAMA Rational Clinical Examination (PMID 17062865), quote: 'A CSF-blood glucose ratio of 0.4 or less (likelihood ratio [LR], 18; 95% CI, 12-27]) accurately diagnosed bacterial meningitis.' Cross-checked against single-study sens/spec (CSF:serum glucose ratio <0.4 = 80% sens, 98% spec; AAFP 2021 review citing Spanos), which yields LR+=0.80/0.02=40 \u2014 same direction, larger magnitude (expected: single-cohort estimate > pooled). Spanos 1989 (PMID 2810603, n=422) is the underlying primary dataset, reporting CSF-blood glucose ratio <0.23 predicts bacterial infection with >=99% certainty. A high LR+ (18-40) for a low glucose ratio strongly raises post-test probability of bacterial (vs viral) meningitis. Note: no separate sens/spec given in Straus pooled abstract; only the LR is reported directly there. ScienceDirect (Tamune 2014) and JAMAevidence full chapter returned HTTP 403 (paywalled) so not byte-captured; the PubMed abstract and AAFP review fully ground the number."
+    },
+    {
+      "id": "f4",
+      "finding": "csf_protein",
+      "state": "elevated",
+      "lr": 1.0,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Viallon et al. CSF protein threshold for bacterial vs viral meningitis, as tabulated in the Open Access Emerg Med review 'Clinical decision rules for acute bacterial meningitis: current insights' (PMC4886299); corroborated by Genton & Berger and anchored upstream by Spanos JAMA 1989 (>2.2 g/L rule-in) and Straus JAMA 2006 Rational Clinical Examination.",
+        "values": "Viallon (>=1.88 g/L): sensitivity 84%, specificity 91%. Corroborating: Genton & Berger (>=2 g/L): sens 86%, spec 100% (LR+ undefined). Spanos 1989: CSF protein >2.2 g/L rules in bacterial meningitis with >=99% certainty.",
+        "byte_quote": "Viallon et al. ... Using '>=1.88 g/L', they found 84.0 sensitivity and 91.0 specificity for distinguishing bacterial from viral meningitis.",
+        "formula": "LR+ = sensitivity / (1 - specificity) = 0.84 / (1 - 0.91) = 0.84 / 0.09 = 9.33. (Genton corroborating point >=2 g/L: 0.86/(1-1.00) = undefined/infinite due to spec=100%, hence Viallon used as the stable computable anchor. Direction: elevated CSF protein raises probability of bacterial meningitis; LR+ ~9.3 is moderate-to-strong rule-in but weaker than glucose ratio LR 18 / lactate LR 21 from Straus 2006.)",
+        "n": "Not individually reported in the compiled review table (multi-study tabulation); Spanos derivation cohort = 422 patients with acute bacterial or viral meningitis.",
+        "population": "Adults with suspected acute meningitis undergoing lumbar puncture; bacterial meningitis vs viral/aseptic meningitis comparison.",
+        "override": {
+          "editor": "human expert (demo)",
+          "date": "2026-06-09",
+          "reason": "CSF elevated protein is part of the same correlated CSF-chemistry signal as f2/f3/f5; subsumed under f2. Neutralized (lr=1) to stop independent double-counting.",
+          "source": "ADJ56 \u2014 meningitis CSF over-saturation.",
+          "op": "edited",
+          "prior": {
+            "lr": 9.33
+          },
+          "now": {
+            "lr": 1.0
+          }
+        }
+      },
+      "note": "Grounded on byte-anchored sens/spec. The landmark Rational Clinical Examination paper (Straus JAMA 2006) and the classic derivation cohort (Spanos JAMA 1989) both treat elevated CSF protein as a bacterial-meningitis indicator but neither publishes a directly usable LR+ for protein alone: Straus reports LRs only for glucose ratio (18), WBC (15), and lactate (21); Spanos reports a >2.2 g/L rule-in threshold at >=99% certainty rather than a sens/spec pair. The computable LR+ therefore derives from a tabulated diagnostic-accuracy pair (Viallon, >=1.88 g/L: sens 84%, spec 91%) compiled in the Open Access Emerg Med review (PMC4886299), yielding LR+ = 9.33. Caveats: (1) thresholds differ across the source studies (1.88 vs 2.0 vs 2.2 g/L), so the LR is threshold-specific; (2) protein is explicitly described as 'one of the least relevant markers' \u2014 5-25% of viral cases exceed 1 g/L and 1-10% of bacterial cases have normal protein \u2014 so this LR+ is less reliable than CSF glucose ratio or lactate; (3) the Genton corroborating point (spec 100%) would give an infinite LR+ and is statistically unstable, so it was not used for the computation. For prior/prevalence: not fixed by this finding; in adults presenting with suspected acute meningitis, bacterial meningitis is the minority etiology (most acute community meningitis is viral/aseptic), so a pre-test probability on the order of ~0.1-0.3 is reasonable context, but no single byte-anchored prevalence value is asserted here."
+    },
+    {
+      "id": "f5",
+      "finding": "csf_lactate",
+      "state": "elevated",
+      "lr": 1.0,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Sakushima K, et al. Diagnostic accuracy of cerebrospinal fluid lactate for differentiating bacterial meningitis from aseptic meningitis: a meta-analysis. J Infect. 2011;62(4):255-262 (PMID 21382412). Corroborated by Huy NT, et al. Crit Care. 2010;14(6):R240 (PMC3220013).",
+        "values": "Sakushima: sens 0.93 (0.89-0.96), spec 0.96 (0.93-0.98), LR+ 22.9 (12.6-41.9), LR- 0.07 (0.05-0.12). Huy (>=3.5 mmol/L): sens 0.96, spec 0.94, LR+ 14.53 (8.07-26.19).",
+        "byte_quote": "The pooled test characteristics of CSF lactate were sensitivity 0.93 (95% CI: 0.89-0.96), specificity 0.96 (95% CI: 0.93-0.98), likelihood ratio positive 22.9 (95% CI: 12.6-41.9), likelihood ratio negative 0.07 (95% CI: 0.05-0.12), and diagnostic odds ratio 313 (95% CI: 141-698).",
+        "formula": "Published pooled LR+ used directly = 22.9 (Sakushima 2011). Cross-check from point estimates: LR+ = sens/(1-spec) = 0.93/(1-0.96) = 0.93/0.04 = 23.25, consistent with bivariate-pooled 22.9. Huy 2010 corroborates with LR+ = 14.53 at the >=3.5 mmol/L cutoff. Caveat: antibiotic pretreatment drops sensitivity to 0.49 (95% CI 0.23-0.75), degrading LR+.",
+        "n": "33 studies (Sakushima 2011); 25 studies (Huy 2010)",
+        "population": "Patients with suspected acute meningitis undergoing lumbar puncture; bacterial vs aseptic/viral meningitis distinction.",
+        "override": {
+          "editor": "human expert (demo)",
+          "date": "2026-06-09",
+          "reason": "CSF elevated lactate is part of the same correlated CSF-chemistry signal; subsumed under f2. Neutralized (lr=1).",
+          "source": "ADJ56 \u2014 meningitis CSF over-saturation.",
+          "op": "edited",
+          "prior": {
+            "lr": 22.9
+          },
+          "now": {
+            "lr": 1.0
+          }
+        }
+      },
+      "note": "Finding f5 (elevated CSF lactate, >=3.5 mmol/L) for bacterial vs viral/aseptic meningitis is strongly grounded. Two independent meta-analyses give a pooled LR+ in the ~15-23 range; Sakushima 2011 (33 studies) reports LR+ 22.9 directly, and the point-estimate cross-check (sens/(1-spec)=23.25) confirms it. Huy 2010 (25 studies), which uses the exact >=3.5 mmol/L cutoff named in the finding, gives a more conservative LR+ 14.53. Both indicate elevated CSF lactate is a strong rule-in test, and (via LR- ~0.07) also a strong rule-out test when antibiotic-naive. Key limitation: prior antibiotic treatment markedly lowers sensitivity (0.49), eroding diagnostic value. No prevalence/prior was reported in these diagnostic-accuracy reviews. computed_lr=22.9 reported as the primary byte-anchored value; conservative alternative 14.53 (Huy, matched cutoff) also fully grounded."
+    },
+    {
+      "id": "f6",
+      "finding": "serum_procalcitonin",
+      "state": "elevated",
+      "lr": 27.3,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Vikse J, Henry BM, Roy J, Ramakrishnan PK, Tomaszewski KA, Walocha JA. The role of serum procalcitonin in the diagnosis of bacterial meningitis in adults: a systematic review and meta-analysis. International Journal of Infectious Diseases, 2015 (PMID 26188130).",
+        "values": "sensitivity 0.90 (95% CI 0.84-0.94); specificity 0.98 (95% CI 0.97-0.99); positive likelihood ratio 27.3 (95% CI 8.2-91.1); negative likelihood ratio 0.13 (95% CI 0.07-0.26); diagnostic odds ratio 287.0 (95% CI 58.5-1409.0)",
+        "byte_quote": "The pooled sensitivity, specificity, positive likelihood ratio, negative likelihood ratio, and diagnostic odds ratio (DOR) for PCT were 0.90 (95% confidence interval (CI) 0.84-0.94), 0.98 (95% CI 0.97-0.99), 27.3 (95% CI 8.2-91.1), 0.13 (95% CI 0.07-0.26), and 287.0 (95% CI 58.5-1409.0), respectively.",
+        "formula": "Published pooled LR+ used directly = 27.3 (95% CI 8.2-91.1). Cross-check via naive LR+ = sens/(1-spec) = 0.90/(1-0.98) = 0.90/0.02 = 45.0; the meta-analytic pooled LR+ (27.3) is derived from the bivariate/random-effects model rather than naive division of the pooled point estimates, so the published 27.3 is the byte-anchored value reported. LR- = (1-sens)/spec = (1-0.90)/0.98 = 0.10/0.98 = 0.102 (published pooled 0.13).",
+        "n": "9 studies, 725 patients",
+        "population": "Adults with suspected/confirmed meningitis; bacterial meningitis vs non-bacterial (viral/aseptic) meningitis comparison"
+      },
+      "note": "Landmark anchor: Vikse 2015 (Int J Infect Dis), the principal meta-analysis of serum procalcitonin for adult bacterial meningitis (9 studies, n=725). The meta-analysis reports LR+ directly (27.3, 95% CI 8.2-91.1), so it is used per the procedure rather than recomputing. The comparator population is non-bacterial meningitis (predominantly viral/aseptic), matching the f6 target of bacterial vs viral. Naive recomputation from pooled sens/spec gives LR+ = 45.0; the discrepancy is expected because pooled LR+ from a bivariate model is not the naive ratio of pooled sens/(1-spec). Elevated serum PCT is a strongly rule-in finding (LR+ approximately 27-45). Prior/prevalence not extracted from this abstract; among adults presenting with suspected acute meningitis undergoing LP, bacterial meningitis prevalence is low (commonly cited on the order of single-digit to ~20% depending on setting) \u2014 not byte-anchored here, so not asserted as a number. Verdict grounded: computed_lr=27.3 is taken from a byte-anchored published pooled LR+. Sources: https://pubmed.ncbi.nlm.nih.gov/26188130/ ; https://www.sciencedirect.com/science/article/pii/S1201971215001782"
+    },
+    {
+      "id": "f7",
+      "finding": "seizure",
+      "state": "present",
+      "lr": 5.84,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Nigrovic LE, Kuppermann N, Malley R. Development and Validation of a Multivariable Predictive Model to Distinguish Bacterial From Aseptic Meningitis in Children in the Post-Haemophilus influenzae Era. Pediatrics 2002;110(4):712-719 (Bacterial Meningitis Score derivation set)",
+        "values": "Seizure present: bacterial 19/86 = 22.1%; aseptic 14/370 = 3.78%. Difference 18% (95% CI 9-27), p<.001. Multivariate adjusted OR (Table 3) = 1.8 (P=.03).",
+        "byte_quote": "Seizure at or before presentation, n (%): Bacterial Meningitis N=86 = 19 (22%); Aseptic Meningitis N=370 = 14 (4%); Difference Between Proportions (95% CI) 18% (9-27); P Value <.001.",
+        "formula": "Single-finding LR+ from Table 2 univariate 2x2. sensitivity = P(seizure | bacterial) = 19/86 = 0.2209. P(seizure | aseptic) = 14/370 = 0.0378, so specificity = 1 - 0.0378 = 0.9622. LR+ = sens / (1 - spec) = 0.2209 / 0.0378 = 5.84. LR- = (1 - sens)/spec = 0.7791/0.9622 = 0.81. Pre-test (derivation-set) prevalence of bacterial = 86/456 = 0.189 (18.9%). Cross-check unadjusted OR = (19/67)/(14/356) = 7.21; multivariate-adjusted OR (controlling for the 4 lab criteria) = 1.8.",
+        "n": "456 (86 bacterial, 370 aseptic) in derivation set; seizure data: 19/86 bacterial, 14/370 aseptic",
+        "population": "Previously healthy children aged 29 days to 19 years with CSF pleocytosis; derivation set N=456 (bacterial meningitis N=86, aseptic meningitis N=370). Note: seizure-AT-OR-BEFORE-PRESENTATION is BMS criterion; viral comparator = aseptic meningitis (overwhelmingly enteroviral)."
+      },
+      "note": "Primary data is byte-anchored from the landmark Bacterial Meningitis Score derivation paper (Nigrovic, Pediatrics 2002), Table 2, obtained by downloading the full-text PDF and extracting text (WebFetch was 403-blocked; used curl + pdfminer). Seizure at/before presentation was present in 22% of bacterial vs 4% of aseptic meningitis, giving a computed univariate LR+ of 5.84 for bacterial over viral/aseptic meningitis (LR- 0.81 \u2014 poor rule-out, consistent with seizure being a moderate rule-in but common-in-neither finding). CAVEATS: (1) Pediatric population (29 d-19 y); adult LRs for isolated seizure are not separately well-quantified in the CSF-parameter reviews (Straus JAMA 2006 / Spanos JAMA 1989 report CSF lab parameters, not seizure-alone). (2) The multivariate-ADJUSTED OR for seizure drops to 1.8 because seizure correlates with the lab criteria; the standalone LR+ of 5.84 is the correct bedside single-finding metric and the one requested. (3) Comparator is aseptic (predominantly enteroviral) meningitis, an accepted proxy for 'viral'. (4) BMS meta-analysis (Nigrovic 2012) pooled-score LR+ 2.6 / LR- 0.01 refers to the whole 5-item score, NOT seizure alone \u2014 not used for this finding. Full PDF cached at /tmp/nigrovic2002.pdf; extracted text at /tmp/nig.txt."
+    },
+    {
+      "id": "f8",
+      "finding": "csf_culture",
+      "state": "positive",
+      "lr": 271,
+      "verdict": "grounded",
+      "grounded": true,
+      "provenance": {
+        "study": "Wu HM, Cordeiro SM, Harcourt BH, et al. Accuracy of real-time PCR, Gram stain and culture for Streptococcus pneumoniae, Neisseria meningitidis and Haemophilus influenzae meningitis diagnosis. BMC Infect Dis. 2013;13:26 (PMC3558362)",
+        "values": "CSF culture sensitivity = 81.3% (95% CI 73.2-89.3); specificity = 99.7% (95% CI 99.1-100.0)",
+        "byte_quote": "culture, 81.3% and 99.7%; Gram stain, 98.2% and 98.7%; and real-time PCR, 95.7% and 94.3%, respectively.",
+        "formula": "LR+ = sensitivity / (1 - specificity) = 0.813 / (1 - 0.997) = 0.813 / 0.003 = 271 (point estimate). CSF culture is the reference standard; the near-perfect specificity (99.7%) makes a positive bacterial culture essentially determinative for bacterial (vs viral/aseptic) meningitis. LR- = (1 - 0.813)/0.997 = 0.187/0.997 = 0.19, i.e., a negative culture only modestly lowers probability \u2014 culture sensitivity is imperfect (falls to ~56-67% with prior antibiotics), which is why a negative culture does not rule out bacterial meningitis.",
+        "n": "451 CSF specimens (Apr 10, 2006 - Dec 31, 2008)",
+        "population": "CSF specimens from patients with suspected bacterial meningitis, Couto Maia Hospital, Salvador, Brazil; latent class analysis (LCA) used to estimate test accuracy against an imperfect reference standard (S. pneumoniae, N. meningitidis, H. influenzae)"
+      },
+      "note": "CSF culture is the clinical GOLD/REFERENCE STANDARD for bacterial meningitis, so its test characteristics can only be estimated against an imperfect-reference framework. The cited primary data come from a Bayesian/latent class analysis (LCA) of 451 CSF specimens (Wu et al., BMC Infect Dis 2013;13:26, PMC3558362), which sidesteps the circularity of evaluating the reference standard against itself: LCA-estimated sensitivity 81.3% and specificity 99.7%. From these, LR+ = 0.813/0.003 ~= 271 (extremely strong evidence FOR bacterial meningitis; a positive bacterial CSF culture is effectively diagnostic), and LR- ~= 0.19 (only a modest argument against it). The high computed LR+ is driven by the very small false-positive rate (0.3%, essentially contamination). Caveat on precision: the point estimate is sensitive to the exact specificity \u2014 with spec 99.7% the denominator (0.003) is small, so the LR+ has wide uncertainty (using the CI bound spec=99.1% gives LR+ ~= 90; spec=100.0% gives an undefined/infinite LR+). The clinically robust message is grounded: LR+ is very large (hundreds-fold), and culture's main limitation is imperfect sensitivity (drops to ~56-67% after prior oral/parenteral antibiotics per the same literature), not specificity. Verdict grounded: both sensitivity and specificity are byte-anchored to the verbatim primary-source sentence; the LR is computed, not invented."
+    }
+  ],
+  "derived_from": "C:\\Users\\adhit\\Downloads\\coding-adventures\\code\\specs\\data\\adj52\\corpus\\bacterial_meningitis\\corpus.json",
+  "human_overrides": "C:\\Users\\adhit\\Downloads\\coding-adventures\\code\\specs\\data\\adj52\\cas\\overrides\\meningitis-csf-correlation.json"
+}

--- a/code/specs/data/adj52/cas/override.py
+++ b/code/specs/data/adj52/cas/override.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""CAS human-override layer — "fix the fact, not the weight."
+
+The corpus (CAS) is assembled from decomposed sources; every finding node is a
+content-addressed claim with a likelihood ratio and a byte-provenance chain. When
+the auditable trail localizes an error to a specific node, a human edits THAT node
+here — a local, versioned, attributed override — rather than retraining anything.
+
+The base corpus stays immutable. Overrides are an additive human layer (this file
++ the override JSON, both in git, so every edit has history). Applying them
+produces an EFFECTIVE corpus that the evaluator runs on; each touched node records
+its prior value, who changed it, when, why, and the citation — so the edit itself
+is auditable, and `eval.py`'s trail shows "[human override]" at the exact step.
+
+Override op schema (a JSON list):
+  { "target_id": "f3", "set": {"lr": 1.0},            # edit an existing claim
+    "editor": "...", "date": "...", "reason": "...", "source": "..." }
+  { "add_finding": { ...full node... },                # add a missing claim
+    "editor": "...", "date": "...", "reason": "...", "source": "..." }
+
+Run: python override.py <base-corpus.json> <overrides.json> <effective-out.json>
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def apply_overrides(base: dict[str, Any], overrides: list[dict[str, Any]]) -> tuple[dict[str, Any], list[str]]:
+    eff = copy.deepcopy(base)
+    by_id: dict[str, dict[str, Any]] = {n["id"]: n for n in eff["findings"]}
+    if "id" in eff.get("prior", {}):
+        by_id[eff["prior"]["id"]] = eff["prior"]
+    audit: list[str] = []
+
+    for ov in overrides:
+        meta = {
+            "editor": ov.get("editor", "?"),
+            "date": ov.get("date", "?"),
+            "reason": ov.get("reason", ""),
+            "source": ov.get("source", ""),
+        }
+        if "add_finding" in ov:
+            node = copy.deepcopy(ov["add_finding"])
+            node.setdefault("provenance", {})
+            node["provenance"]["override"] = {**meta, "op": "added"}
+            node.setdefault("grounded", True)
+            eff["findings"].append(node)
+            audit.append(f"ADD  {node['id']:4s} {node['finding']}({node.get('state','')}) lr={node['lr']}  by {meta['editor']}: {meta['reason'][:70]}")
+            continue
+
+        tid = ov["target_id"]
+        node = by_id.get(tid)
+        if node is None:
+            audit.append(f"SKIP {tid}: no such node")
+            continue
+        changes = ov.get("set", {})
+        prior_vals = {k: node.get(k) for k in changes}
+        node.update(changes)
+        node.setdefault("provenance", {})
+        node["provenance"]["override"] = {**meta, "op": "edited", "prior": prior_vals, "now": changes}
+        chg = ", ".join(f"{k}: {prior_vals[k]} -> {changes[k]}" for k in changes)
+        audit.append(f"EDIT {tid:4s} {node['finding']}({node.get('state','')})  {chg}  by {meta['editor']}: {meta['reason'][:70]}")
+
+    return eff, audit
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print("usage: python override.py <base-corpus.json> <overrides.json> <effective-out.json>")
+        sys.exit(2)
+    base = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    overrides = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+    eff, audit = apply_overrides(base, overrides)
+    eff["derived_from"] = sys.argv[1]
+    eff["human_overrides"] = sys.argv[2]
+    Path(sys.argv[3]).write_text(json.dumps(eff, indent=2), encoding="utf-8")
+    print(f"applied {len(overrides)} override(s) -> {sys.argv[3]}")
+    for line in audit:
+        print("  " + line)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj52/cas/overrides/meningitis-csf-correlation.json
+++ b/code/specs/data/adj52/cas/overrides/meningitis-csf-correlation.json
@@ -1,0 +1,26 @@
+[
+  {
+    "target_id": "f3",
+    "set": { "lr": 1.0 },
+    "editor": "human expert (demo)",
+    "date": "2026-06-09",
+    "reason": "CSF low glucose is a correlated manifestation of the bacterial CSF profile, not an independent test. f2 (neutrophilic pleocytosis) is kept as the representative of that one CSF-chemistry signal; counting glucose independently double-counts. Neutralized (lr=1).",
+    "source": "ADJ56 cross-domain stress test — documented meningitis CSF over-saturation (P=1.0000); CSF pleocytosis/glucose/protein/lactate are joint effects of one process."
+  },
+  {
+    "target_id": "f4",
+    "set": { "lr": 1.0 },
+    "editor": "human expert (demo)",
+    "date": "2026-06-09",
+    "reason": "CSF elevated protein is part of the same correlated CSF-chemistry signal as f2/f3/f5; subsumed under f2. Neutralized (lr=1) to stop independent double-counting.",
+    "source": "ADJ56 — meningitis CSF over-saturation."
+  },
+  {
+    "target_id": "f5",
+    "set": { "lr": 1.0 },
+    "editor": "human expert (demo)",
+    "date": "2026-06-09",
+    "reason": "CSF elevated lactate is part of the same correlated CSF-chemistry signal; subsumed under f2. Neutralized (lr=1).",
+    "source": "ADJ56 — meningitis CSF over-saturation."
+  }
+]

--- a/code/specs/data/adj52/pipeline-haiku-vs-opus.workflow.js
+++ b/code/specs/data/adj52/pipeline-haiku-vs-opus.workflow.js
@@ -1,0 +1,170 @@
+export const meta = {
+  name: 'adj52-haiku-fw-vs-opus',
+  description: 'Defensibility test: HAIKU + framework discipline (IR -> cited rulebook -> grounded cited conclusion, NO engine) vs PLAIN OPUS (blind), on 100 perturbed clinical cases. The blind judge ranks on DEFENSIBILITY (can a reviewer trace the reasoning, locate where any error entered, and correct it) as the PRIMARY axis; correctness is secondary/tiebreak. Tests the hypothesis: Haiku+framework is as defensible or more than plain Opus.',
+  phases: [
+    { title: 'Prepare' },
+    { title: 'OpusBlind', model: 'opus' },
+    { title: 'HaikuIR', model: 'haiku' },
+    { title: 'HaikuDerive', model: 'haiku' },
+    { title: 'HaikuConclude', model: 'haiku' },
+    { title: 'Judge' },
+  ],
+}
+
+const SPECIALTIES = [
+  'cardiology', 'pulmonology', 'nephrology', 'endocrinology', 'infectious disease',
+  'hematology', 'medical oncology', 'rheumatology', 'neurology', 'gastroenterology',
+  'dermatology', 'hepatology', 'clinical immunology', 'emergency medicine',
+  'geriatric medicine', 'vascular medicine', 'otolaryngology', 'urology',
+  'allergy and immunology', 'general internal medicine',
+]
+const ANGLES = [
+  'where the initial working diagnosis turned out to be wrong',
+  'where the presentation mimicked a far more common condition',
+  'with an unexpected final diagnosis after an initially misleading workup',
+  'initially misattributed to a benign or unrelated cause',
+  'where a rare disease masqueraded as a common one',
+]
+const SEEDS = []
+for (const s of SPECIALTIES) for (const a of ANGLES) SEEDS.push(`an adult clinical case report in ${s} ${a}`)
+// Full run: all 100 seeds (20 specialties x 5 angles). Smoke used SEEDS.slice(0, 3).
+const seeds = (args && args.seeds && args.seeds.length) ? args.seeds : SEEDS
+if (!seeds.length) { log('no seeds'); return { error: 'no seeds' } }
+log(`haiku-fw vs opus over ${seeds.length} seed(s)`)
+
+const PREPARE_SCHEMA = {
+  type: 'object',
+  required: ['skipped', 'ground_truth', 'prose', 'perturbations', 'diagnosis_unchanged'],
+  properties: {
+    skipped: { type: 'boolean' }, source_url: { type: 'string' },
+    ground_truth: { type: 'string' }, prose: { type: 'string' },
+    perturbations: { type: 'array', items: { type: 'string' } },
+    diagnosis_unchanged: { type: 'boolean' },
+  },
+}
+const BLIND_SCHEMA = { type: 'object', required: ['answer_text'], properties: { answer_text: { type: 'string' } } }
+const IR_SCHEMA = {
+  type: 'object', required: ['facts', 'queries'],
+  properties: { inferred_domain: { type: 'string' }, facts: { type: 'array', items: { type: 'object' } }, uncertainties: { type: 'array', items: { type: 'object' } }, queries: { type: 'array', items: { type: 'object' } }, discarded: { type: 'array', items: { type: 'object' } } },
+}
+const RULEBOOK_SCHEMA = { type: 'object', required: ['rules'], properties: { rules: { type: 'array', items: { type: 'object' } } } }
+const CONCLUDE_SCHEMA = {
+  type: 'object', required: ['top_diagnosis', 'recommended_next_step', 'confidence', 'conclusion_text', 'citations'],
+  properties: { top_diagnosis: { type: 'string' }, recommended_next_step: { type: 'string' }, confidence: { type: 'string' }, conclusion_text: { type: 'string' }, citations: { type: 'array', items: { type: 'object' } } },
+}
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['winner', 'a_defensibility', 'b_defensibility', 'a_correct', 'b_correct', 'rationale'],
+  properties: {
+    winner: { type: 'string', enum: ['A', 'B', 'tie'] },
+    a_defensibility: { type: 'string', enum: ['high', 'medium', 'low'] },
+    b_defensibility: { type: 'string', enum: ['high', 'medium', 'low'] },
+    a_correct: { type: 'string', enum: ['correct', 'partial', 'incorrect'] },
+    b_correct: { type: 'string', enum: ['correct', 'partial', 'incorrect'] },
+    rationale: { type: 'string' },
+  },
+}
+
+const preparePrompt = (seed) => `Find and prepare a published clinical case for a blinded experiment. SEED: ${seed}.
+1. WebSearch/WebFetch to FIND ONE real published case report matching the seed (prefer open-access PMC) with a CLEARLY DOCUMENTED final/confirmed diagnosis. Favor initially-misleading presentations. AVOID famous textbook cases. If none, skipped=true.
+2. Extract GROUND TRUTH (final dx + how confirmed + correct disposition) + source_url. Held aside.
+3. PERTURB + SANITISE: remove the dx/confirmatory result/discussion; change every diagnosis-irrelevant detail (age in dx-preserving range, sex/ethnicity if irrelevant, all lab numbers shifted but same side of reference + magnitude, anecdotes, timeline, doses, institution, ordering, phrasing); PRESERVE every load-bearing finding so the dx is UNCHANGED.
+Return skipped, source_url, ground_truth, prose, perturbations, diagnosis_unchanged.`
+
+const blindPrompt = (prose) => `Read this clinical case and answer as you normally would. Do NOT look up the specific published case; do not read local files. Give the most likely diagnosis, the recommended next action, your confidence, and your reasoning.
+
+=== CASE ===
+${prose}
+=== END ===`
+
+const irPrompt = (prose) => `Decompose this clinical case into a human-readable IR. Read EVERY byte: each span is a typed fact OR discarded with a reason. Ambiguity becomes an uncertainty, never a guess. Infer the domain. Raise the queries. Do NOT solve it; do NOT look up the outcome.
+Return inferred_domain, facts [{id, term, source_span}], uncertainties [{id, about, domain}], queries [{id, asks}], discarded [{source_span, reason}].
+
+=== CASE ===
+${prose}
+=== END ===`
+
+const derivePrompt = (irJson) => `Given this ingested IR (facts + queries), derive the rulebook needed to answer the queries — clinical rules linking findings to candidate diagnoses. Use WebSearch/WebFetch for REAL citations. Recurse into subtypes. No program, no probabilities — a human-readable cited rulebook only.
+Return rules: [{id, rule, bears_on, direction, source}].
+
+=== IR ===
+${irJson}`
+
+const concludePrompt = (prose, irJson, rbJson) => `You have a case, its IR, and a derived cited rulebook. WITHOUT writing any program or running any engine, reason to a conclusion. Use ONLY facts in the IR and rules in the rulebook; for every key claim CITE the supporting IR fact id(s) and rule id(s); give an honest confidence; name the recommended next step.
+Return top_diagnosis, recommended_next_step, confidence, conclusion_text (full answer with inline citations to fact/rule ids), citations [{claim, input_facts:[ids], rules:[ids]}].
+
+=== CASE ===
+${prose}
+=== IR ===
+${irJson}
+=== RULEBOOK ===
+${rbJson}`
+
+const judgePrompt = (gt, a, b) => `You are an impartial judge. Two responses (OUTPUT A, OUTPUT B) from hidden systems, scored against the ground truth.
+PRIMARY criterion is DEFENSIBILITY: can a reviewer TRACE the reasoning, LOCATE where any error entered, and CORRECT it at a specific step? — i.e. reasoning grounded in explicitly stated facts/rules with citations and an inspectable line of thinking, versus an opaque assertion you must take on trust. An answer that is auditable and whose error (if any) is localizable is MORE defensible, even if less polished.
+SECONDARY: correctness vs ground truth (use only to break a defensibility tie).
+Score each output's defensibility (high/medium/low) and correctness (correct/partial/incorrect). Pick the winner on DEFENSIBILITY.
+
+=== GROUND TRUTH ===
+${gt}
+
+=== OUTPUT A ===
+${a}
+
+=== OUTPUT B ===
+${b}`
+
+const results = await pipeline(
+  seeds,
+  (seed, _o, idx) => agent(preparePrompt(seed), { phase: 'Prepare', label: `prepare:case-${idx + 1}`, agentType: 'general-purpose', schema: PREPARE_SCHEMA })
+    .then((p) => {
+      if (p.skipped || !p.prose) { throw new Error(`no case for seed ${idx + 1}`) }
+      return { id: `case-${idx + 1}`, source_url: p.source_url, ground_truth: p.ground_truth, prose: p.prose, perturbations: p.perturbations, diagnosis_unchanged: p.diagnosis_unchanged }
+    }),
+  (o) => agent(blindPrompt(o.prose), { phase: 'OpusBlind', label: `opus:${o.id}`, model: 'opus', agentType: 'general-purpose', schema: BLIND_SCHEMA })
+    .then((b) => ({ ...o, opus_answer: b.answer_text })),
+  (o) => agent(irPrompt(o.prose), { phase: 'HaikuIR', label: `ir:${o.id}`, model: 'haiku', agentType: 'general-purpose', schema: IR_SCHEMA })
+    .then((ir) => ({ ...o, ir })),
+  (o) => agent(derivePrompt(JSON.stringify(o.ir)), { phase: 'HaikuDerive', label: `derive:${o.id}`, model: 'haiku', agentType: 'general-purpose', schema: RULEBOOK_SCHEMA })
+    .then((rb) => ({ ...o, rulebook: rb.rules })),
+  (o) => agent(concludePrompt(o.prose, JSON.stringify(o.ir), JSON.stringify(o.rulebook)), { phase: 'HaikuConclude', label: `conclude:${o.id}`, model: 'haiku', agentType: 'general-purpose', schema: CONCLUDE_SCHEMA })
+    .then((c) => ({ ...o, framework: c })),
+  (o, _o2, idx) => {
+    const fwIsA = (idx % 2) === 0
+    const A = fwIsA ? o.framework.conclusion_text : o.opus_answer
+    const B = fwIsA ? o.opus_answer : o.framework.conclusion_text
+    return agent(judgePrompt(o.ground_truth, A, B), { phase: 'Judge', label: `judge:${o.id}`, agentType: 'general-purpose', schema: VERDICT_SCHEMA })
+      .then((v) => ({
+        id: o.id, source_url: o.source_url, diagnosis_unchanged: o.diagnosis_unchanged,
+        prose: o.prose, ground_truth: o.ground_truth, ir: o.ir, rulebook: o.rulebook,
+        opus_answer: o.opus_answer, framework_conclusion: o.framework.conclusion_text,
+        framework_top: o.framework.top_diagnosis, framework_citations: o.framework.citations,
+        framework_is: fwIsA ? 'A' : 'B',
+        winner: v.winner,
+        framework_defensibility: fwIsA ? v.a_defensibility : v.b_defensibility,
+        opus_defensibility: fwIsA ? v.b_defensibility : v.a_defensibility,
+        framework_correct: fwIsA ? v.a_correct : v.b_correct,
+        opus_correct: fwIsA ? v.b_correct : v.a_correct,
+        framework_won: v.winner === (fwIsA ? 'A' : 'B'),
+        opus_won: v.winner === (fwIsA ? 'B' : 'A'),
+        rationale: v.rationale,
+      }))
+  }
+)
+
+const done = results.filter(Boolean)
+const hi = (v) => v === 'high'
+const c = (v) => v === 'correct'
+const tally = {
+  seeds_attempted: seeds.length, cases_completed: done.length, skipped_or_failed: seeds.length - done.length,
+  framework_won_defensibility: done.filter((r) => r.framework_won).length,
+  opus_won_defensibility: done.filter((r) => r.opus_won).length,
+  tie: done.filter((r) => r.winner === 'tie').length,
+  framework_defensibility_high: done.filter((r) => hi(r.framework_defensibility)).length,
+  opus_defensibility_high: done.filter((r) => hi(r.opus_defensibility)).length,
+  framework_as_or_more_defensible: done.filter((r) => r.framework_won || r.winner === 'tie').length,
+  framework_correct: done.filter((r) => c(r.framework_correct)).length,
+  opus_correct: done.filter((r) => c(r.opus_correct)).length,
+}
+log(`HAIKU+FW vs OPUS: ${tally.cases_completed}/${tally.seeds_attempted}; defensibility wins framework ${tally.framework_won_defensibility} / opus ${tally.opus_won_defensibility} / tie ${tally.tie} (framework as-or-more-defensible: ${tally.framework_as_or_more_defensible}); defensibility-high framework ${tally.framework_defensibility_high} vs opus ${tally.opus_defensibility_high}; correctness framework ${tally.framework_correct} vs opus ${tally.opus_correct}`)
+return { tally, per_case: done }


### PR DESCRIPTION
Two related CAS results on the same branch.

---

## Part 1 — CAS edit-override-propagate loop ("fix the fact, not the weight")

The mechanism that makes expert-system errors traceable to **editable knowledge** rather than buried weights. When the auditable trail localizes an error to a claim, a human edits *that claim* (versioned, attributed, cited; base corpus immutable) and the fix propagates on re-run.

Demonstrated on the real meningitis corpus + ADJ56's documented over-saturation (`python code/specs/data/adj52/cas/demo.py`):

| case | base P | edited P | outcome |
|---|---:|---:|---|
| pre-culture (Gram/culture pending) | 0.9999 | **0.7709** | de-saturated — false certainty fixed |
| culture-positive (regression) | 1.0000 | 1.0000 | unchanged — no regression |

(`PAPER1-E2-correctability-study.md` on main cites this `adj52/cas/` work as the worked-example mechanics demo inside the larger cost-to-correct study.)

---

## Part 2 — Derive-tier ablation: does a stronger frontier model close CAS gaps?

`code/specs/data/derive-tier-ablation/` — pre-registered, plugs into the merged MYCIN CAS-write gate. 3 deriver models × 3 replicates read the **identical fixed, answer-stripped source packet** and feed the **identical 3-reader gate**; the deriver model is the only variable. A "gap" is made concrete: G1 ungrounded, G2 leap (cited bytes don't entail the LR), G3 missing.

| deriver | clauses | grnd% | accept% | gaps | coverage(grnd) | coverage(all) | conflation |
|---|---:|---:|---:|---:|---:|---:|---:|
| Haiku  | 8.7  | 96 | **83** | **1.3** | 64 | 60 | 0.7 |
| Sonnet | 12.3 | 92 | 71 | 3.0 | 72 | 69 | 1.0 |
| Opus   | 13.7 | 90 | **54** | **5.3** | **75** | **79** | 1.7 |

**Answer: a stronger deriver does NOT make gaps disappear — it *shifts* them.**
1. Coverage rises modestly (grnd 64→75, all 60→79) — the frontier model surfaces more real findings, incl. honestly attempting ones it can't ground (`byte_quote=null`).
2. **But** gate-visible gaps rise (1.3→5.3) and accept-rate falls (83→54%): the stronger model over-extracts from ambiguous source text (a terse multi-test sentence; asserting a magnitude from a qualitative one) and the fixed gate flags exactly that — *propose-more / filter-more, trust-bar constant.*
3. The inference-required findings (viral-complement LRs, which must be **derived** as `spec/(1−sens)`, not transcribed) are missed by **every tier in all 9 derivations** — the model-independent residue (confirms pre-registered null P4).

**Implication (P5):** the lever that closes the residual gaps is the Part-1 human-override loop + cleaner sources, **not** model scale. The experiment quantifies how much correctability is buyable with capability (some recall) vs irreducibly human/source.

Honest scope: pilot (1 domain, n=3/arm); downstream decide-on-cases deferred (scoped in FINDINGS); a prior-as-LR gate artifact is excluded from gap counts and logged as a gate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)