### PR TITLE
Add Z-Wave command summary request helpers

### DIFF
--- a/code/packages/rust/zwave-command-classes/CHANGELOG.md
+++ b/code/packages/rust/zwave-command-classes/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Command-class command parse/encode primitives.
-- Body-free command summaries for logs and interview diagnostics.
+- Body-free command summaries for logs and interview diagnostics, including
+  payload-free and Get/Set/Report helper predicates.
 - Get/set builders for binary switch, multilevel switch, and door lock command
   classes.
 - Value-report parsing for common actuator and sensor command classes.

--- a/code/packages/rust/zwave-command-classes/README.md
+++ b/code/packages/rust/zwave-command-classes/README.md
@@ -9,7 +9,8 @@ correlation, inclusion, or S2 security.
 Included surfaces:
 
 - command-class command parse/encode helpers
-- body-free command summaries for logs and interview diagnostics
+- body-free command summaries for logs and interview diagnostics, including
+  payload-free and Get/Set/Report helper predicates
 - binary switch, multilevel switch, and door lock get/set builders, plus
   battery and meter get builders
 - command-class interview descriptors for state-query commands and D23

--- a/code/packages/rust/zwave-command-classes/src/lib.rs
+++ b/code/packages/rust/zwave-command-classes/src/lib.rs
@@ -126,6 +126,18 @@ impl ZWaveCommandSummary {
         self.payload_len > 0
     }
 
+    pub fn is_payload_free(self) -> bool {
+        self.payload_len == 0
+    }
+
+    pub fn is_get(self) -> bool {
+        self.command_kind == ZWaveCommandKind::Get
+    }
+
+    pub fn is_set(self) -> bool {
+        self.command_kind == ZWaveCommandKind::Set
+    }
+
     pub fn is_report(self) -> bool {
         self.command_kind == ZWaveCommandKind::Report
     }
@@ -1165,6 +1177,9 @@ mod tests {
             }
         );
         assert!(summary.has_payload());
+        assert!(!summary.is_payload_free());
+        assert!(!summary.is_get());
+        assert!(summary.is_set());
         assert!(summary.is_request());
         assert!(!summary.is_report());
     }
@@ -1207,16 +1222,22 @@ mod tests {
         let summary = command.summary();
 
         assert_eq!(summary.command_kind, ZWaveCommandKind::Report);
+        assert!(!summary.is_get());
+        assert!(!summary.is_set());
         assert!(summary.is_report());
         assert!(!summary.is_request());
     }
 
     #[test]
     fn set_builders_normalize_values() {
+        let basic_summary = basic_get().summary();
         assert_eq!(
             basic_get().encode().unwrap(),
             vec![CommandClassId::BASIC.0 as u8, BASIC_GET]
         );
+        assert!(basic_summary.is_get());
+        assert!(!basic_summary.is_set());
+        assert!(basic_summary.is_payload_free());
         assert_eq!(binary_switch_set(false).payload, vec![0x00]);
         assert_eq!(multilevel_switch_set(100).payload, vec![99]);
         assert_eq!(door_lock_operation_set(true).payload, vec![0xff]);


### PR DESCRIPTION
## Summary
- add Z-Wave command summary predicates for payload-free commands, Get requests, and Set requests
- cover the new helpers in command-summary and command-builder tests
- document the richer command-summary helper surface

## Tests
- cargo fmt --manifest-path code\\packages\\rust\\zwave-command-classes\\Cargo.toml
- CARGO_TARGET_DIR=C:\\tmp\\codex-zwave-command-summary-request-helpers-target cargo test --manifest-path code\\packages\\rust\\zwave-command-classes\\Cargo.toml -- --nocapture