### PR TITLE
Add smart-home policy surface planning tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for compact shared-core catalog summaries:
   `smart_home.get_integration_catalog_summary` and
   `smart_home.get_tool_catalog_summary`.
+- Added D18D handlers for D23A integration policy-surface planning:
+  `smart_home.list_integration_policy_surfaces` and
+  `smart_home.get_integration_policy_surface_summary`.
 - Added D18D handlers for bulk D23A integration activation-plan planning:
   `smart_home.list_integration_activation_plans` and
   `smart_home.get_integration_activation_plan_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -37,6 +37,7 @@ Chief of Staff job/session/agent
   -> typed command-result audit reads and summaries
   -> authorization decision audit reads and summaries
   -> capability grant ledger reads and summaries
+  -> policy-surface inventory and summary reads for review planning
   -> activation-plan list and summary reads for D23A rollout planning
   -> activation-candidate list and summary reads for ranked rollout planning
   -> activation-action list and summary reads for concrete unblock/activate work
@@ -62,6 +63,8 @@ Chief of Staff job/session/agent
 - `smart_home.describe_primitive`
 - `smart_home.get_integration_catalog_summary`
 - `smart_home.get_tool_catalog_summary`
+- `smart_home.list_integration_policy_surfaces`
+- `smart_home.get_integration_policy_surface_summary`
 - `smart_home.list_integration_activation_plans`
 - `smart_home.get_integration_activation_plan_summary`
 - `smart_home.list_integration_activation_candidates`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -38,20 +38,22 @@ use smart_home_integration_catalog::{
     activation_plan_for_entry, activation_plans_at_or_before_priority,
     activation_runway_from_candidates, describe_primitive_family,
     ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemSurveySource, ImplementationStatus,
-    IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
     IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogItem,
@@ -141,6 +143,10 @@ pub const SMART_HOME_DESCRIBE_PRIMITIVE_TOOL_ID: &str = "smart_home.describe_pri
 pub const SMART_HOME_GET_INTEGRATION_CATALOG_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_catalog_summary";
 pub const SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID: &str = "smart_home.get_tool_catalog_summary";
+pub const SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID: &str =
+    "smart_home.list_integration_policy_surfaces";
+pub const SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_policy_surface_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID: &str =
     "smart_home.list_integration_activation_plans";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID: &str =
@@ -241,6 +247,16 @@ impl SmartHomeToolBridge {
                 ),
                 SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID => {
                     Ok(get_tool_catalog_summary_output_handler_output(&arguments)?)
+                }
+                SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID => {
+                    let query = integration_policy_surface_query(&arguments)?;
+                    Ok(list_integration_policy_surfaces_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID => {
+                    let query = integration_policy_surface_query(&arguments)?;
+                    Ok(get_integration_policy_surface_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID => {
                     let query = integration_activation_plan_query(&arguments)?;
@@ -874,6 +890,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home tool catalog summary",
             "Return compact D18D smart-home tool descriptor counts from the shared smart-home core catalog.",
             object_schema(vec![], vec![], false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID,
+            "List smart-home integration policy surfaces",
+            "List D23A policy-surface planning inventory grouped across integration catalog entries.",
+            integration_policy_surface_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "policy_surfaces",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["policy_surfaces", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID,
+            "Get smart-home integration policy surface summary",
+            "Return compact D23A policy-surface rollups for review, cloud, local, and privilege-tier planning.",
+            integration_policy_surface_query_schema(false),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3260,6 +3308,54 @@ fn integration_catalog_query(
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationPolicySurfaceQuery {
+    priority_at_or_before: u8,
+    surfaces: Vec<IntegrationPolicySurface>,
+    minimum_required_tier: Option<PrivilegeTier>,
+    limit: Option<usize>,
+}
+
+fn integration_policy_surface_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationPolicySurfaceQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut surfaces = Vec::new();
+    for surface in optional_string_list(arguments, "policy_surface", "policy_surfaces")? {
+        surfaces.push(parse_policy_surface(&surface)?);
+    }
+
+    Ok(IntegrationPolicySurfaceQuery {
+        priority_at_or_before: optional_u8(arguments, "priority_at_or_before")?.unwrap_or(u8::MAX),
+        surfaces,
+        minimum_required_tier: optional_string(arguments, "minimum_required_tier")?
+            .map(|tier| parse_privilege_tier(&tier))
+            .transpose()?,
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_policy_surface_inventory_for_query(
+    query: &IntegrationPolicySurfaceQuery,
+) -> (Vec<IntegrationPolicySurfaceInventoryItem>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let mut inventory =
+        policy_surface_inventory_at_or_before_priority(&catalog, query.priority_at_or_before);
+
+    if !query.surfaces.is_empty() {
+        inventory.retain(|item| query.surfaces.contains(&item.surface));
+    }
+    if let Some(minimum_required_tier) = query.minimum_required_tier {
+        inventory.retain(|item| item.required_tier >= minimum_required_tier);
+    }
+    if let Some(limit) = query.limit {
+        inventory.truncate(limit);
+    }
+
+    (inventory, catalog_count)
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationPlanQuery {
     priority_at_or_before: u8,
     target_kind: Option<ActivationTargetKind>,
@@ -3807,6 +3903,66 @@ fn get_tool_catalog_summary_output_handler_output(
                     ("total_tools", integer(summary.total_tools as i64)),
                 ]),
             ),
+    )
+}
+
+fn list_integration_policy_surfaces_output_handler_output(
+    query: IntegrationPolicySurfaceQuery,
+) -> ToolHandlerOutput {
+    let (inventory, catalog_count) = integration_policy_surface_inventory_for_query(&query);
+    let summary = IntegrationPolicySurfaceSummary::from_inventory(inventory.iter());
+    let count = inventory.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "policy_surfaces",
+            JsonValue::Array(
+                inventory
+                    .iter()
+                    .map(policy_surface_inventory_item_json)
+                    .collect(),
+            ),
+        ),
+        ("summary", integration_policy_surface_summary_json(&summary)),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_policy_surfaces")),
+            ("count", integer(count as i64)),
+            (
+                "human_review_surface_entries",
+                integer(summary.human_review_surface_entries as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_policy_surface_summary_output_handler_output(
+    query: IntegrationPolicySurfaceQuery,
+) -> ToolHandlerOutput {
+    let (inventory, _) = integration_policy_surface_inventory_for_query(&query);
+    let summary = IntegrationPolicySurfaceSummary::from_inventory(inventory.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_policy_surface_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_policy_surface_summary"),
+            ),
+            ("total_surfaces", integer(summary.total_surfaces as i64)),
+            (
+                "human_review_surface_entries",
+                integer(summary.human_review_surface_entries as i64),
+            ),
+        ]),
     )
 }
 
@@ -6321,6 +6477,99 @@ fn tool_catalog_summary_json(summary: &SmartHomeToolCatalogSummary) -> JsonValue
         (
             "approval_gated_tool_count",
             integer(summary.approval_gated_tool_count() as i64),
+        ),
+    ])
+}
+
+fn policy_surface_inventory_item_json(item: &IntegrationPolicySurfaceInventoryItem) -> JsonValue {
+    object([
+        ("policy_surface", string(item.surface.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(item.required_tier)),
+        ),
+        ("highest_priority", integer(item.highest_priority as i64)),
+        ("entry_count", integer(item.entry_count as i64)),
+        ("local_entry_count", integer(item.local_entry_count as i64)),
+        ("cloud_entry_count", integer(item.cloud_entry_count as i64)),
+        (
+            "human_review_entry_count",
+            integer(item.human_review_entry_count as i64),
+        ),
+        (
+            "requires_human_review",
+            JsonValue::Bool(item.requires_human_review()),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                item.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+    ])
+}
+
+fn integration_policy_surface_summary_json(summary: &IntegrationPolicySurfaceSummary) -> JsonValue {
+    object([
+        ("total_surfaces", integer(summary.total_surfaces as i64)),
+        (
+            "total_surface_entries",
+            integer(summary.total_surface_entries as i64),
+        ),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "local_surface_entries",
+            integer(summary.local_surface_entries as i64),
+        ),
+        (
+            "cloud_surface_entries",
+            integer(summary.cloud_surface_entries as i64),
+        ),
+        (
+            "human_review_surface_entries",
+            integer(summary.human_review_surface_entries as i64),
+        ),
+        (
+            "read_only_surfaces",
+            integer(summary.read_only_surfaces as i64),
+        ),
+        (
+            "low_risk_surfaces",
+            integer(summary.low_risk_surfaces as i64),
+        ),
+        (
+            "human_approval_surfaces",
+            integer(summary.human_approval_surfaces as i64),
+        ),
+        (
+            "high_risk_surfaces",
+            integer(summary.high_risk_surfaces as i64),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "has_high_risk_surface",
+            JsonValue::Bool(summary.has_high_risk_surface()),
         ),
     ])
 }
@@ -9116,6 +9365,18 @@ fn parse_policy_surface(label: &str) -> Result<IntegrationPolicySurface, ToolCal
     }
 }
 
+fn parse_privilege_tier(label: &str) -> Result<PrivilegeTier, ToolCallError> {
+    match label {
+        "read_only" | "readonly" | "read" => Ok(PrivilegeTier::ReadOnly),
+        "low_risk" | "low" => Ok(PrivilegeTier::LowRisk),
+        "human_approval" | "human_review" | "review" => Ok(PrivilegeTier::HumanApproval),
+        "high_risk" | "high" => Ok(PrivilegeTier::HighRisk),
+        _ => Err(validation_error(format!(
+            "unknown privilege tier `{label}`"
+        ))),
+    }
+}
+
 fn parse_discovery_mechanism(label: &str) -> Result<DiscoveryMechanism, ToolCallError> {
     match label {
         "mdns" => Ok(DiscoveryMechanism::Mdns),
@@ -9855,6 +10116,20 @@ fn integration_catalog_query_schema() -> JsonSchema {
     )
 }
 
+fn integration_policy_surface_query_schema(include_limit: bool) -> JsonSchema {
+    let mut properties = vec![
+        SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
+        SchemaProperty::new("policy_surface", JsonSchema::String),
+        SchemaProperty::new("policy_surfaces", string_array_schema()),
+        SchemaProperty::new("minimum_required_tier", JsonSchema::String),
+    ];
+    if include_limit {
+        properties.push(SchemaProperty::new("limit", JsonSchema::Integer));
+    }
+
+    object_schema(properties, Vec::new(), false)
+}
+
 fn integration_activation_plan_query_schema(include_limit: bool) -> JsonSchema {
     let mut properties = vec![
         SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
@@ -10059,7 +10334,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 61);
+        assert_eq!(definitions.len(), 63);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -10079,6 +10354,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID));
@@ -10212,7 +10493,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            53
+            55
         );
         assert_eq!(
             export
@@ -10238,6 +10519,14 @@ mod tests {
                 .is_some()
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_TOOL_CATALOG_SUMMARY_TOOL_ID).is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID
+        )
+        .is_some());
         assert!(
             smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID)
                 .is_some()
@@ -10530,15 +10819,78 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(61))
+            Some(&integer(63))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(53))
+            Some(&integer(55))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
             Some(&integer(8))
+        );
+
+        let list_policy_surfaces_request = request(
+            "call-list-integration-policy-surfaces",
+            SMART_HOME_LIST_INTEGRATION_POLICY_SURFACES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                ("minimum_required_tier", string("human_approval")),
+                ("limit", integer(4)),
+            ]),
+            996,
+        );
+        let list_policy_surfaces_trace =
+            tool_runtime.invoke_with_events(&list_policy_surfaces_request);
+        assert!(list_policy_surfaces_trace.result.ok);
+        assert_eq!(list_policy_surfaces_trace.summary().progress_event_count, 1);
+        let list_policy_surfaces_output =
+            list_policy_surfaces_trace.result.output.as_ref().unwrap();
+        let policy_surface_count =
+            integer_value(field(list_policy_surfaces_output, "count").unwrap()).unwrap();
+        assert!((1..=4).contains(&policy_surface_count));
+        assert_eq!(
+            array_len(field(list_policy_surfaces_output, "policy_surfaces").unwrap()),
+            Some(policy_surface_count as usize)
+        );
+        let policy_surface_summary = field(list_policy_surfaces_output, "summary").unwrap();
+        assert_eq!(
+            field(policy_surface_summary, "has_review_work"),
+            Some(&JsonValue::Bool(true))
+        );
+        let policy_surface = array_item(
+            field(list_policy_surfaces_output, "policy_surfaces").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_ne!(
+            field(policy_surface, "required_tier"),
+            Some(&string("read_only"))
+        );
+
+        let policy_surface_summary_request = request(
+            "call-integration-policy-surface-summary",
+            SMART_HOME_GET_INTEGRATION_POLICY_SURFACE_SUMMARY_TOOL_ID,
+            object([("priority_at_or_before", integer(2))]),
+            997,
+        );
+        let policy_surface_summary_trace =
+            tool_runtime.invoke_with_events(&policy_surface_summary_request);
+        assert!(policy_surface_summary_trace.result.ok);
+        assert_eq!(
+            policy_surface_summary_trace.summary().progress_event_count,
+            1
+        );
+        let policy_surface_summary_output =
+            policy_surface_summary_trace.result.output.as_ref().unwrap();
+        let policy_surface_rollup = field(policy_surface_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(policy_surface_rollup, "highest_policy_tier"),
+            Some(&string("high_risk"))
+        );
+        assert_eq!(
+            field(policy_surface_rollup, "has_high_risk_surface"),
+            Some(&JsonValue::Bool(true))
         );
 
         let list_activation_plans_request = request(
@@ -12576,6 +12928,8 @@ mod tests {
             integration_catalog_summary_trace,
         );
         journal.record_trace(tool_catalog_summary_request, tool_catalog_summary_trace);
+        journal.record_trace(list_policy_surfaces_request, list_policy_surfaces_trace);
+        journal.record_trace(policy_surface_summary_request, policy_surface_summary_trace);
         journal.record_trace(list_activation_plans_request, list_activation_plans_trace);
         journal.record_trace(
             activation_plan_summary_request,
@@ -12675,9 +13029,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 61);
-        assert_eq!(journal_summary.completed_count, 61);
-        assert_eq!(journal.audit_records().len(), 61);
+        assert_eq!(journal_summary.invocation_count, 63);
+        assert_eq!(journal_summary.completed_count, 63);
+        assert_eq!(journal.audit_records().len(), 63);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.get_integration_catalog_summary` and
   `smart_home.get_tool_catalog_summary` tool descriptors for compact read-only
   catalog rollups.
+- `smart_home.list_integration_policy_surfaces` and
+  `smart_home.get_integration_policy_surface_summary` tool descriptors for
+  read-only policy-surface planning rollups.
 - `smart_home.list_integration_activation_plans` and
   `smart_home.get_integration_activation_plan_summary` tool descriptors for
   read-only activation-plan listing and compact rollout plan summaries.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -50,6 +50,8 @@ Current scope:
   reusable-primitive inspection
 - D18D catalog-summary descriptors for compact integration and tool surface
   inspection
+- D18D integration policy-surface descriptors for read-only review, cloud,
+  local, and privilege-tier planning rollups
 - D18D integration activation-plan descriptors for bulk rollout plan listing
   and compact activation-plan rollups
 - D18D integration activation-candidate descriptors for ranked ready, review,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1451,6 +1451,8 @@ pub enum SmartHomeTool {
     DescribePrimitive,
     GetIntegrationCatalogSummary,
     GetToolCatalogSummary,
+    ListIntegrationPolicySurfaces,
+    GetIntegrationPolicySurfaceSummary,
     ListIntegrationActivationPlans,
     GetIntegrationActivationPlanSummary,
     ListIntegrationActivationCandidates,
@@ -1519,6 +1521,12 @@ impl SmartHomeTool {
                 read_tool("smart_home.get_integration_catalog_summary")
             }
             Self::GetToolCatalogSummary => read_tool("smart_home.get_tool_catalog_summary"),
+            Self::ListIntegrationPolicySurfaces => {
+                read_tool("smart_home.list_integration_policy_surfaces")
+            }
+            Self::GetIntegrationPolicySurfaceSummary => {
+                read_tool("smart_home.get_integration_policy_surface_summary")
+            }
             Self::ListIntegrationActivationPlans => {
                 read_tool("smart_home.list_integration_activation_plans")
             }
@@ -2176,6 +2184,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::DescribePrimitive,
         SmartHomeTool::GetIntegrationCatalogSummary,
         SmartHomeTool::GetToolCatalogSummary,
+        SmartHomeTool::ListIntegrationPolicySurfaces,
+        SmartHomeTool::GetIntegrationPolicySurfaceSummary,
         SmartHomeTool::ListIntegrationActivationPlans,
         SmartHomeTool::GetIntegrationActivationPlanSummary,
         SmartHomeTool::ListIntegrationActivationCandidates,
@@ -3026,7 +3036,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 61);
+        assert_eq!(catalog.len(), 63);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3056,6 +3066,14 @@ mod tests {
             .any(|tool| tool.tool_id == "smart_home.get_tool_catalog_summary"
                 && tool.side_effects == ToolSideEffects::Read
                 && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_policy_surfaces"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_policy_surface_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_activation_plans"
             && tool.side_effects == ToolSideEffects::Read
@@ -3284,15 +3302,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 61);
-        assert_eq!(summary.read_tools, 53);
+        assert_eq!(summary.total_tools, 63);
+        assert_eq!(summary.read_tools, 55);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 53);
+        assert_eq!(summary.read_only_tier_tools, 55);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 61);
+        assert_eq!(summary.total_required_capabilities, 63);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -58,6 +58,9 @@ All notable changes to this package will be documented in this file.
 - Computed policy-surface helpers so Chief of Staff tools can identify camera,
   entry-access, climate, energy, cloud, credential, radio-network, and local
   actuation review boundaries before activating integrations.
+- `IntegrationPolicySurfaceInventoryItem`, `IntegrationPolicySurfaceSummary`,
+  and policy-surface inventory helpers for compact review, cloud, local, and
+  privilege-tier planning rollups.
 - Composable bounded integration catalog queries for combining priority,
   primitive, capability, policy, protocol, local/cloud, and virtual alias
   selectors in read-only D18D tools.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -16,6 +16,8 @@ runtime and Chief of Staff tools a typed catalog for:
 - target entity kind hints
 - computed D21/D18D policy surfaces for privacy, credentials, cloud accounts,
   local actuation, entry access, radio networks, and infrastructure control
+- policy-surface inventory and summary rollups for review, cloud, local, and
+  privilege-tier planning
 - read-only D18D tool descriptors for listing/describing integrations and
   primitive families
 - typed ecosystem-survey source rows that map Home Assistant, Hubitat, Homey

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -625,6 +625,112 @@ impl PrimitiveBacklogCoverageItem {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationPolicySurfaceInventoryItem {
+    pub surface: IntegrationPolicySurface,
+    pub required_tier: PrivilegeTier,
+    pub highest_priority: u8,
+    pub entry_count: usize,
+    pub local_entry_count: usize,
+    pub cloud_entry_count: usize,
+    pub human_review_entry_count: usize,
+    pub integration_ids: Vec<IntegrationId>,
+}
+
+impl IntegrationPolicySurfaceInventoryItem {
+    pub fn includes_integration(&self, integration_id: &IntegrationId) -> bool {
+        self.integration_ids
+            .iter()
+            .any(|candidate| candidate == integration_id)
+    }
+
+    pub fn requires_human_review(&self) -> bool {
+        self.required_tier >= PrivilegeTier::HumanApproval
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationPolicySurfaceSummary {
+    pub total_surfaces: usize,
+    pub total_surface_entries: usize,
+    pub unique_integrations: usize,
+    pub local_surface_entries: usize,
+    pub cloud_surface_entries: usize,
+    pub human_review_surface_entries: usize,
+    pub read_only_surfaces: usize,
+    pub low_risk_surfaces: usize,
+    pub human_approval_surfaces: usize,
+    pub high_risk_surfaces: usize,
+    pub first_review_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+impl IntegrationPolicySurfaceSummary {
+    pub fn from_inventory<'a>(
+        items: impl IntoIterator<Item = &'a IntegrationPolicySurfaceInventoryItem>,
+    ) -> Self {
+        let mut summary = Self {
+            total_surfaces: 0,
+            total_surface_entries: 0,
+            unique_integrations: 0,
+            local_surface_entries: 0,
+            cloud_surface_entries: 0,
+            human_review_surface_entries: 0,
+            read_only_surfaces: 0,
+            low_risk_surfaces: 0,
+            human_approval_surfaces: 0,
+            high_risk_surfaces: 0,
+            first_review_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for item in items {
+            summary.total_surfaces += 1;
+            summary.total_surface_entries += item.entry_count;
+            summary.local_surface_entries += item.local_entry_count;
+            summary.cloud_surface_entries += item.cloud_entry_count;
+            summary.human_review_surface_entries += item.human_review_entry_count;
+            match item.required_tier {
+                PrivilegeTier::ReadOnly => summary.read_only_surfaces += 1,
+                PrivilegeTier::LowRisk => summary.low_risk_surfaces += 1,
+                PrivilegeTier::HumanApproval => summary.human_approval_surfaces += 1,
+                PrivilegeTier::HighRisk => summary.high_risk_surfaces += 1,
+            }
+            if item.requires_human_review() {
+                summary.first_review_priority = Some(
+                    summary
+                        .first_review_priority
+                        .map_or(item.highest_priority, |priority| {
+                            priority.min(item.highest_priority)
+                        }),
+                );
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(item.required_tier);
+            for integration_id in &item.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_surfaces == 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.human_approval_surfaces > 0
+            || self.high_risk_surfaces > 0
+            || self.human_review_surface_entries > 0
+    }
+
+    pub fn has_high_risk_surface(&self) -> bool {
+        self.high_risk_surfaces > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IntegrationActivationTarget {
     Direct,
     DelegatedIntegration(IntegrationId),
@@ -2800,6 +2906,81 @@ pub fn primitive_backlog_with_ecosystem_coverage(
             }
         })
         .collect()
+}
+
+pub fn policy_surface_inventory(
+    catalog: &[IntegrationCatalogEntry],
+) -> Vec<IntegrationPolicySurfaceInventoryItem> {
+    policy_surface_inventory_at_or_before_priority(catalog, u8::MAX)
+}
+
+pub fn policy_surface_inventory_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+) -> Vec<IntegrationPolicySurfaceInventoryItem> {
+    #[derive(Default)]
+    struct SurfaceAccumulator {
+        highest_priority: u8,
+        local_entry_count: usize,
+        cloud_entry_count: usize,
+        human_review_entry_count: usize,
+        integration_ids: Vec<IntegrationId>,
+    }
+
+    let mut by_surface: BTreeMap<IntegrationPolicySurface, SurfaceAccumulator> = BTreeMap::new();
+
+    for entry in catalog.iter().filter(|entry| entry.priority <= priority) {
+        let surfaces = entry.policy_surfaces();
+        let local_only = entry_local_only(entry);
+        let cloud_required = entry_cloud_required(entry);
+        let requires_human_review = entry.highest_policy_tier() >= PrivilegeTier::HumanApproval;
+
+        for surface in surfaces {
+            let accumulator = by_surface.entry(surface).or_insert(SurfaceAccumulator {
+                highest_priority: entry.priority,
+                ..SurfaceAccumulator::default()
+            });
+            accumulator.highest_priority = accumulator.highest_priority.min(entry.priority);
+            if local_only {
+                accumulator.local_entry_count += 1;
+            }
+            if cloud_required {
+                accumulator.cloud_entry_count += 1;
+            }
+            if requires_human_review {
+                accumulator.human_review_entry_count += 1;
+            }
+            if !accumulator.integration_ids.contains(&entry.integration_id) {
+                accumulator
+                    .integration_ids
+                    .push(entry.integration_id.clone());
+            }
+        }
+    }
+
+    let mut inventory = by_surface
+        .into_iter()
+        .map(
+            |(surface, accumulator)| IntegrationPolicySurfaceInventoryItem {
+                surface,
+                required_tier: surface.required_tier(),
+                highest_priority: accumulator.highest_priority,
+                entry_count: accumulator.integration_ids.len(),
+                local_entry_count: accumulator.local_entry_count,
+                cloud_entry_count: accumulator.cloud_entry_count,
+                human_review_entry_count: accumulator.human_review_entry_count,
+                integration_ids: accumulator.integration_ids,
+            },
+        )
+        .collect::<Vec<_>>();
+    inventory.sort_by(|left, right| {
+        left.highest_priority
+            .cmp(&right.highest_priority)
+            .then_with(|| right.required_tier.cmp(&left.required_tier))
+            .then_with(|| right.entry_count.cmp(&left.entry_count))
+            .then_with(|| left.surface.cmp(&right.surface))
+    });
+    inventory
 }
 
 pub fn activation_plan_for_integration(
@@ -5162,6 +5343,36 @@ mod tests {
         assert!(local_actuators
             .iter()
             .any(|entry| entry.integration_id == IntegrationId::trusted("mqtt")));
+    }
+
+    #[test]
+    fn policy_surface_inventory_rolls_up_review_boundaries() {
+        let catalog = first_party_catalog();
+        let inventory = policy_surface_inventory(&catalog);
+        let entry_access = inventory
+            .iter()
+            .find(|item| item.surface == IntegrationPolicySurface::EntryAccess)
+            .unwrap();
+        let credentialed_cloud = inventory
+            .iter()
+            .find(|item| item.surface == IntegrationPolicySurface::CredentialedCloud)
+            .unwrap();
+        let summary = IntegrationPolicySurfaceSummary::from_inventory(&inventory);
+
+        assert_eq!(entry_access.required_tier, PrivilegeTier::HighRisk);
+        assert!(entry_access.includes_integration(&IntegrationId::trusted("zwave")));
+        assert!(entry_access.human_review_entry_count >= 1);
+        assert_eq!(
+            credentialed_cloud.required_tier,
+            PrivilegeTier::HumanApproval
+        );
+        assert!(credentialed_cloud.cloud_entry_count >= 1);
+        assert!(summary.total_surfaces >= 4);
+        assert!(summary.unique_integrations >= 4);
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert!(summary.has_review_work());
+        assert!(summary.has_high_risk_surface());
+        assert_eq!(summary.first_review_priority, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared smart-home integration policy-surface inventory and summary rollups
- expose read-only D18D tools for listing policy surfaces and fetching compact policy-surface summaries
- update shared smart-home tool catalog descriptors and package docs for the new read-only planning surface

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools