### PR TITLE
Add Hue snapshot summary surface helpers

### DIFF
--- a/code/packages/rust/hue-client/CHANGELOG.md
+++ b/code/packages/rust/hue-client/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - Hue snapshot summaries for compact resource-family, relationship-ref, scene
   action, and state-projection coverage over typed CLIP v2 snapshots, plus
-  relationship and scene-state predicates.
+  relationship, scene-state, projectable-surface, and partial-lighting
+  predicates.
 - Hue event-stream summaries for compact retry-hint, record, resource-item, and
   resource-type coverage over parsed Server-Sent Events batches, plus typed-item
   and multi-type predicates.

--- a/code/packages/rust/hue-client/README.md
+++ b/code/packages/rust/hue-client/README.md
@@ -13,7 +13,8 @@ Included surfaces:
 - resource snapshot and collection requests
 - typed aggregate resource snapshots from a single CLIP v2 snapshot envelope
 - resource snapshot summaries for resource-family, owner ref, scene action, and
-  state projection coverage, with relationship and scene-state predicates
+  state projection coverage, with relationship, scene-state, projectable-surface,
+  and partial-lighting predicates
 - resource-specific reads
 - structured command request bodies from `hue-core`
 - command-plan execution through the `HueClient` facade

--- a/code/packages/rust/hue-client/src/lib.rs
+++ b/code/packages/rust/hue-client/src/lib.rs
@@ -288,8 +288,20 @@ impl HueSnapshotSummary {
         self.light_resources > 0 || self.grouped_light_resources > 0
     }
 
+    pub fn lighting_resource_count(&self) -> usize {
+        self.light_resources + self.grouped_light_resources
+    }
+
+    pub fn mixes_direct_and_grouped_light_resources(&self) -> bool {
+        self.light_resources > 0 && self.grouped_light_resources > 0
+    }
+
     pub fn has_area_resources(&self) -> bool {
         self.room_resources > 0 || self.zone_resources > 0
+    }
+
+    pub fn area_resource_count(&self) -> usize {
+        self.room_resources + self.zone_resources
     }
 
     pub fn has_scene_actions(&self) -> bool {
@@ -308,12 +320,33 @@ impl HueSnapshotSummary {
         self.motion_resources > 0 || self.button_resources > 0
     }
 
+    pub fn sensor_or_input_resource_count(&self) -> usize {
+        self.motion_resources + self.button_resources
+    }
+
+    pub fn projectable_resource_count(&self) -> usize {
+        self.lighting_resource_count()
+            + self.scene_resources
+            + self.sensor_or_input_resource_count()
+    }
+
+    pub fn has_projectable_resources(&self) -> bool {
+        self.projectable_resource_count() > 0
+    }
+
     pub fn has_state_projection(&self) -> bool {
         self.stateful_light_resources > 0
             || self.stateful_grouped_light_resources > 0
             || self.motion_resources_with_state > 0
             || self.button_resources_with_state > 0
             || self.stateful_scene_actions > 0
+    }
+
+    pub fn has_partial_lighting_state_projection(&self) -> bool {
+        let lighting_resources = self.lighting_resource_count();
+        let stateful_lighting_resources =
+            self.stateful_light_resources + self.stateful_grouped_light_resources;
+        stateful_lighting_resources > 0 && stateful_lighting_resources < lighting_resources
     }
 }
 
@@ -2550,22 +2583,46 @@ mod tests {
         );
         assert!(!summary.is_empty());
         assert!(summary.has_lighting_resources());
+        assert_eq!(summary.lighting_resource_count(), 2);
+        assert!(summary.mixes_direct_and_grouped_light_resources());
         assert!(summary.has_area_resources());
+        assert_eq!(summary.area_resource_count(), 2);
         assert!(summary.has_scene_actions());
         assert!(summary.has_relationship_refs());
         assert!(summary.has_scene_state_projection());
         assert!(summary.has_sensor_or_input_resources());
+        assert_eq!(summary.sensor_or_input_resource_count(), 2);
+        assert_eq!(summary.projectable_resource_count(), 5);
+        assert!(summary.has_projectable_resources());
         assert!(summary.has_state_projection());
+        assert!(!summary.has_partial_lighting_state_projection());
 
         let empty = HueSnapshotSummary::empty();
         assert!(empty.is_empty());
         assert!(!empty.has_lighting_resources());
+        assert_eq!(empty.lighting_resource_count(), 0);
+        assert!(!empty.mixes_direct_and_grouped_light_resources());
         assert!(!empty.has_area_resources());
+        assert_eq!(empty.area_resource_count(), 0);
         assert!(!empty.has_scene_actions());
         assert!(!empty.has_relationship_refs());
         assert!(!empty.has_scene_state_projection());
         assert!(!empty.has_sensor_or_input_resources());
+        assert_eq!(empty.sensor_or_input_resource_count(), 0);
+        assert_eq!(empty.projectable_resource_count(), 0);
+        assert!(!empty.has_projectable_resources());
         assert!(!empty.has_state_projection());
+        assert!(!empty.has_partial_lighting_state_projection());
+
+        let partial_lighting = HueSnapshotSummary {
+            light_resources: 2,
+            grouped_light_resources: 1,
+            stateful_light_resources: 1,
+            ..HueSnapshotSummary::empty()
+        };
+        assert_eq!(partial_lighting.lighting_resource_count(), 3);
+        assert!(partial_lighting.mixes_direct_and_grouped_light_resources());
+        assert!(partial_lighting.has_partial_lighting_state_projection());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Hue snapshot summary count helpers for lighting, area, sensor/input, and projectable resources
- add predicates for mixed direct/grouped lighting resources and partial lighting state projection
- document the expanded snapshot-summary telemetry surface

## Tests
- CARGO_TARGET_DIR=C:\\tmp\\codex-hue-snapshot-summary-surface-helpers-target cargo test --manifest-path code\\packages\\rust\\hue-client\\Cargo.toml -- --nocapture