### PR TITLE
Add smart-home primitive coverage planning tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A ecosystem platform coverage planning:
   `smart_home.list_integration_platform_coverage` and
   `smart_home.get_integration_platform_coverage_summary`.
+- Added D18D handlers for D23A primitive coverage gap planning:
+  `smart_home.list_integration_primitive_coverage` and
+  `smart_home.get_integration_primitive_coverage_summary`.
 - Added D18D handlers for bulk D23A integration activation-plan planning:
   `smart_home.list_integration_activation_plans` and
   `smart_home.get_integration_activation_plan_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -39,6 +39,7 @@ Chief of Staff job/session/agent
   -> capability grant ledger reads and summaries
   -> policy-surface inventory and summary reads for review planning
   -> ecosystem platform coverage and summary reads for primitive planning
+  -> primitive coverage gap list and summary reads for backlog planning
   -> activation-plan list and summary reads for D23A rollout planning
   -> activation-candidate list and summary reads for ranked rollout planning
   -> activation-action list and summary reads for concrete unblock/activate work
@@ -68,6 +69,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_policy_surface_summary`
 - `smart_home.list_integration_platform_coverage`
 - `smart_home.get_integration_platform_coverage_summary`
+- `smart_home.list_integration_primitive_coverage`
+- `smart_home.get_integration_primitive_coverage_summary`
 - `smart_home.list_integration_activation_plans`
 - `smart_home.get_integration_activation_plan_summary`
 - `smart_home.list_integration_activation_candidates`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -57,8 +57,8 @@ use smart_home_integration_catalog::{
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
-    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogItem,
-    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
+    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -152,6 +152,10 @@ pub const SMART_HOME_LIST_INTEGRATION_PLATFORM_COVERAGE_TOOL_ID: &str =
     "smart_home.list_integration_platform_coverage";
 pub const SMART_HOME_GET_INTEGRATION_PLATFORM_COVERAGE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_platform_coverage_summary";
+pub const SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID: &str =
+    "smart_home.list_integration_primitive_coverage";
+pub const SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_primitive_coverage_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID: &str =
     "smart_home.list_integration_activation_plans";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAN_SUMMARY_TOOL_ID: &str =
@@ -272,6 +276,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_PLATFORM_COVERAGE_SUMMARY_TOOL_ID => {
                     let query = integration_platform_coverage_query(&arguments)?;
                     Ok(get_integration_platform_coverage_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID => {
+                    let query = integration_primitive_coverage_query(&arguments)?;
+                    Ok(list_integration_primitive_coverage_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID => {
+                    let query = integration_primitive_coverage_query(&arguments)?;
+                    Ok(get_integration_primitive_coverage_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID => {
                     let query = integration_activation_plan_query(&arguments)?;
@@ -976,6 +990,45 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration platform coverage summary",
             "Return compact D23A ecosystem platform coverage rollups for primitive-backlog planning.",
             integration_platform_coverage_query_schema(false),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID,
+            "List smart-home integration primitive coverage",
+            "List D23A primitive-backlog ecosystem coverage rows and filter uncovered or thinly covered primitives.",
+            integration_primitive_coverage_query_schema(true),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "primitive_coverage",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                    SchemaProperty::new("source_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "primitive_coverage",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                    "source_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID,
+            "Get smart-home integration primitive coverage summary",
+            "Return compact D23A primitive-backlog coverage rollups for ecosystem and rollout planning.",
+            integration_primitive_coverage_query_schema(false),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3471,6 +3524,66 @@ fn integration_platform_coverage_for_query(
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationPrimitiveCoverageQuery {
+    priority_at_or_before: u8,
+    primitives: Vec<PrimitiveFamily>,
+    minimum_source_count: Option<usize>,
+    maximum_source_count: Option<usize>,
+    only_uncovered: Option<bool>,
+    limit: Option<usize>,
+}
+
+fn integration_primitive_coverage_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationPrimitiveCoverageQuery, ToolCallError> {
+    let _ = expect_object(arguments)?;
+    let mut primitives = Vec::new();
+    for primitive in optional_string_list(arguments, "primitive", "primitives")? {
+        primitives.push(parse_primitive_family(&primitive)?);
+    }
+
+    Ok(IntegrationPrimitiveCoverageQuery {
+        priority_at_or_before: optional_u8(arguments, "priority_at_or_before")?.unwrap_or(u8::MAX),
+        primitives,
+        minimum_source_count: optional_u64(arguments, "minimum_source_count")?
+            .map(|value| value as usize),
+        maximum_source_count: optional_u64(arguments, "maximum_source_count")?
+            .map(|value| value as usize),
+        only_uncovered: optional_bool(arguments, "only_uncovered")?,
+        limit: optional_u64(arguments, "limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_primitive_coverage_for_query(
+    query: &IntegrationPrimitiveCoverageQuery,
+) -> (Vec<PrimitiveBacklogCoverageItem>, usize, usize) {
+    let catalog = first_party_catalog();
+    let sources = ecosystem_survey_sources();
+    let catalog_count = catalog.len();
+    let source_count = sources.len();
+    let mut coverage =
+        primitive_backlog_with_ecosystem_coverage(&catalog, &sources, query.priority_at_or_before);
+
+    if !query.primitives.is_empty() {
+        coverage.retain(|item| query.primitives.contains(&item.primitive));
+    }
+    if let Some(minimum_source_count) = query.minimum_source_count {
+        coverage.retain(|item| item.source_count >= minimum_source_count);
+    }
+    if let Some(maximum_source_count) = query.maximum_source_count {
+        coverage.retain(|item| item.source_count <= maximum_source_count);
+    }
+    if let Some(only_uncovered) = query.only_uncovered {
+        coverage.retain(|item| (item.source_count == 0) == only_uncovered);
+    }
+    if let Some(limit) = query.limit {
+        coverage.truncate(limit);
+    }
+
+    (coverage, catalog_count, source_count)
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationPlanQuery {
     priority_at_or_before: u8,
     target_kind: Option<ActivationTargetKind>,
@@ -4140,6 +4253,67 @@ fn get_integration_platform_coverage_summary_output_handler_output(
             (
                 "covered_backlog_primitives",
                 integer(summary.covered_backlog_primitives as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_primitive_coverage_output_handler_output(
+    query: IntegrationPrimitiveCoverageQuery,
+) -> ToolHandlerOutput {
+    let (coverage, catalog_count, source_count) = integration_primitive_coverage_for_query(&query);
+    let summary = PrimitiveBacklogCoverageSummary::from_items(coverage.iter());
+    let count = coverage.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "primitive_coverage",
+            JsonValue::Array(
+                coverage
+                    .iter()
+                    .map(primitive_backlog_coverage_json)
+                    .collect(),
+            ),
+        ),
+        ("summary", primitive_backlog_coverage_summary_json(&summary)),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+        ("source_count", integer(source_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_primitive_coverage")),
+            ("count", integer(count as i64)),
+            (
+                "uncovered_primitives",
+                integer(summary.uncovered_primitives as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_primitive_coverage_summary_output_handler_output(
+    query: IntegrationPrimitiveCoverageQuery,
+) -> ToolHandlerOutput {
+    let (coverage, _, _) = integration_primitive_coverage_for_query(&query);
+    let summary = PrimitiveBacklogCoverageSummary::from_items(coverage.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        primitive_backlog_coverage_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_primitive_coverage_summary"),
+            ),
+            ("total_primitives", integer(summary.total_primitives as i64)),
+            (
+                "uncovered_primitives",
+                integer(summary.uncovered_primitives as i64),
             ),
         ]),
     )
@@ -8058,6 +8232,67 @@ fn primitive_backlog_coverage_json(item: &PrimitiveBacklogCoverageItem) -> JsonV
     ])
 }
 
+fn primitive_backlog_coverage_summary_json(summary: &PrimitiveBacklogCoverageSummary) -> JsonValue {
+    object([
+        ("total_primitives", integer(summary.total_primitives as i64)),
+        ("total_entries", integer(summary.total_entries as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "covered_primitives",
+            integer(summary.covered_primitives as i64),
+        ),
+        (
+            "uncovered_primitives",
+            integer(summary.uncovered_primitives as i64),
+        ),
+        (
+            "single_source_primitives",
+            integer(summary.single_source_primitives as i64),
+        ),
+        (
+            "multi_platform_primitives",
+            integer(summary.multi_platform_primitives as i64),
+        ),
+        (
+            "total_source_references",
+            integer(summary.total_source_references as i64),
+        ),
+        (
+            "total_platform_references",
+            integer(summary.total_platform_references as i64),
+        ),
+        (
+            "first_uncovered_priority",
+            summary
+                .first_uncovered_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_single_source_priority",
+            summary
+                .first_single_source_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "broadest_platform_count",
+            integer(summary.broadest_platform_count as i64),
+        ),
+        (
+            "has_uncovered_primitives",
+            JsonValue::Bool(summary.has_uncovered_primitives()),
+        ),
+        (
+            "has_single_source_primitives",
+            JsonValue::Bool(summary.has_single_source_primitives()),
+        ),
+    ])
+}
+
 fn ecosystem_source_json(source: &EcosystemSurveySource) -> JsonValue {
     object([
         ("platform", string(source.platform.as_str())),
@@ -10460,6 +10695,22 @@ fn integration_platform_coverage_query_schema(include_limit: bool) -> JsonSchema
     object_schema(properties, Vec::new(), false)
 }
 
+fn integration_primitive_coverage_query_schema(include_limit: bool) -> JsonSchema {
+    let mut properties = vec![
+        SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
+        SchemaProperty::new("primitive", JsonSchema::String),
+        SchemaProperty::new("primitives", string_array_schema()),
+        SchemaProperty::new("minimum_source_count", JsonSchema::Integer),
+        SchemaProperty::new("maximum_source_count", JsonSchema::Integer),
+        SchemaProperty::new("only_uncovered", JsonSchema::Boolean),
+    ];
+    if include_limit {
+        properties.push(SchemaProperty::new("limit", JsonSchema::Integer));
+    }
+
+    object_schema(properties, Vec::new(), false)
+}
+
 fn integration_activation_plan_query_schema(include_limit: bool) -> JsonSchema {
     let mut properties = vec![
         SchemaProperty::new("priority_at_or_before", JsonSchema::Integer),
@@ -10664,7 +10915,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 65);
+        assert_eq!(definitions.len(), 67);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -10696,6 +10947,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_PLATFORM_COVERAGE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLANS_TOOL_ID));
@@ -10829,7 +11086,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            57
+            59
         );
         assert_eq!(
             export
@@ -10869,6 +11126,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_PLATFORM_COVERAGE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -11163,11 +11428,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(65))
+            Some(&integer(67))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(57))
+            Some(&integer(59))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -11308,6 +11573,84 @@ mod tests {
         assert_eq!(
             field(platform_coverage_rollup, "has_uncovered_backlog_primitives"),
             Some(&JsonValue::Bool(true))
+        );
+
+        let list_primitive_coverage_request = request(
+            "call-list-integration-primitive-coverage",
+            SMART_HOME_LIST_INTEGRATION_PRIMITIVE_COVERAGE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(1)),
+                ("minimum_source_count", integer(1)),
+                ("maximum_source_count", integer(1)),
+                ("limit", integer(3)),
+            ]),
+            1_000,
+        );
+        let list_primitive_coverage_trace =
+            tool_runtime.invoke_with_events(&list_primitive_coverage_request);
+        assert!(list_primitive_coverage_trace.result.ok);
+        assert_eq!(
+            list_primitive_coverage_trace.summary().progress_event_count,
+            1
+        );
+        let list_primitive_coverage_output = list_primitive_coverage_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let primitive_coverage_count =
+            integer_value(field(list_primitive_coverage_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&primitive_coverage_count));
+        assert_eq!(
+            array_len(field(list_primitive_coverage_output, "primitive_coverage").unwrap()),
+            Some(primitive_coverage_count as usize)
+        );
+        let primitive_coverage_summary = field(list_primitive_coverage_output, "summary").unwrap();
+        assert_eq!(
+            field(primitive_coverage_summary, "has_single_source_primitives"),
+            Some(&JsonValue::Bool(true))
+        );
+        let primitive_coverage = array_item(
+            field(list_primitive_coverage_output, "primitive_coverage").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(field(primitive_coverage, "source_count"), Some(&integer(1)));
+
+        let primitive_coverage_summary_request = request(
+            "call-integration-primitive-coverage-summary",
+            SMART_HOME_GET_INTEGRATION_PRIMITIVE_COVERAGE_SUMMARY_TOOL_ID,
+            object([("priority_at_or_before", integer(1))]),
+            1_001,
+        );
+        let primitive_coverage_summary_trace =
+            tool_runtime.invoke_with_events(&primitive_coverage_summary_request);
+        assert!(primitive_coverage_summary_trace.result.ok);
+        assert_eq!(
+            primitive_coverage_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let primitive_coverage_summary_output = primitive_coverage_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let primitive_coverage_rollup =
+            field(primitive_coverage_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(primitive_coverage_rollup, "total_primitives").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(primitive_coverage_rollup, "has_uncovered_primitives"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(primitive_coverage_rollup, "broadest_platform_count").unwrap())
+                .unwrap()
+                >= 2
         );
 
         let list_activation_plans_request = request(
@@ -13352,6 +13695,14 @@ mod tests {
             platform_coverage_summary_request,
             platform_coverage_summary_trace,
         );
+        journal.record_trace(
+            list_primitive_coverage_request,
+            list_primitive_coverage_trace,
+        );
+        journal.record_trace(
+            primitive_coverage_summary_request,
+            primitive_coverage_summary_trace,
+        );
         journal.record_trace(list_activation_plans_request, list_activation_plans_trace);
         journal.record_trace(
             activation_plan_summary_request,
@@ -13451,9 +13802,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 65);
-        assert_eq!(journal_summary.completed_count, 65);
-        assert_eq!(journal.audit_records().len(), 65);
+        assert_eq!(journal_summary.invocation_count, 67);
+        assert_eq!(journal_summary.completed_count, 67);
+        assert_eq!(journal.audit_records().len(), 67);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1455,6 +1455,8 @@ pub enum SmartHomeTool {
     GetIntegrationPolicySurfaceSummary,
     ListIntegrationPlatformCoverage,
     GetIntegrationPlatformCoverageSummary,
+    ListIntegrationPrimitiveCoverage,
+    GetIntegrationPrimitiveCoverageSummary,
     ListIntegrationActivationPlans,
     GetIntegrationActivationPlanSummary,
     ListIntegrationActivationCandidates,
@@ -1534,6 +1536,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationPlatformCoverageSummary => {
                 read_tool("smart_home.get_integration_platform_coverage_summary")
+            }
+            Self::ListIntegrationPrimitiveCoverage => {
+                read_tool("smart_home.list_integration_primitive_coverage")
+            }
+            Self::GetIntegrationPrimitiveCoverageSummary => {
+                read_tool("smart_home.get_integration_primitive_coverage_summary")
             }
             Self::ListIntegrationActivationPlans => {
                 read_tool("smart_home.list_integration_activation_plans")
@@ -2196,6 +2204,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationPolicySurfaceSummary,
         SmartHomeTool::ListIntegrationPlatformCoverage,
         SmartHomeTool::GetIntegrationPlatformCoverageSummary,
+        SmartHomeTool::ListIntegrationPrimitiveCoverage,
+        SmartHomeTool::GetIntegrationPrimitiveCoverageSummary,
         SmartHomeTool::ListIntegrationActivationPlans,
         SmartHomeTool::GetIntegrationActivationPlanSummary,
         SmartHomeTool::ListIntegrationActivationCandidates,
@@ -3046,7 +3056,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 65);
+        assert_eq!(catalog.len(), 67);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3090,6 +3100,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_platform_coverage_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_primitive_coverage"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_primitive_coverage_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
@@ -3320,15 +3338,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 65);
-        assert_eq!(summary.read_tools, 57);
+        assert_eq!(summary.total_tools, 67);
+        assert_eq!(summary.read_tools, 59);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 57);
+        assert_eq!(summary.read_only_tier_tools, 59);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 65);
+        assert_eq!(summary.total_required_capabilities, 67);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this package will be documented in this file.
   Home, Google Home, Alexa, Z-Wave Alliance, and Thread Group.
 - Ecosystem primitive coverage reports that map surveyed platforms onto rollout
   backlog primitive families.
+- Primitive coverage summary helpers for counting uncovered, single-source, and
+  multi-platform primitive-backlog rows.
 - Ecosystem platform coverage item and summary helpers that show which surveyed
   platform lessons overlap a priority-bounded reusable primitive backlog.
 - Query helpers for integration id, category, connectivity, capability,

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -26,6 +26,8 @@ runtime and Chief of Staff tools a typed catalog for:
   to reusable primitive-family hints
 - ecosystem primitive coverage reports that connect those survey sources to
   rollout backlog primitives
+- primitive coverage summaries that identify uncovered, single-source, and
+  multi-platform primitive-backlog rows
 - ecosystem platform coverage rollups that show which surveyed platform
   lessons overlap a priority-bounded reusable primitive backlog
 - primitive backlog planning for prioritizing the shared families needed by a

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -625,6 +625,95 @@ impl PrimitiveBacklogCoverageItem {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrimitiveBacklogCoverageSummary {
+    pub total_primitives: usize,
+    pub total_entries: usize,
+    pub unique_integrations: usize,
+    pub covered_primitives: usize,
+    pub uncovered_primitives: usize,
+    pub single_source_primitives: usize,
+    pub multi_platform_primitives: usize,
+    pub total_source_references: usize,
+    pub total_platform_references: usize,
+    pub first_uncovered_priority: Option<u8>,
+    pub first_single_source_priority: Option<u8>,
+    pub broadest_platform_count: usize,
+}
+
+impl PrimitiveBacklogCoverageSummary {
+    pub fn from_items<'a>(
+        items: impl IntoIterator<Item = &'a PrimitiveBacklogCoverageItem>,
+    ) -> Self {
+        let mut summary = Self {
+            total_primitives: 0,
+            total_entries: 0,
+            unique_integrations: 0,
+            covered_primitives: 0,
+            uncovered_primitives: 0,
+            single_source_primitives: 0,
+            multi_platform_primitives: 0,
+            total_source_references: 0,
+            total_platform_references: 0,
+            first_uncovered_priority: None,
+            first_single_source_priority: None,
+            broadest_platform_count: 0,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for item in items {
+            summary.total_primitives += 1;
+            summary.total_entries += item.entry_count;
+            summary.total_source_references += item.source_count;
+            summary.total_platform_references += item.platform_count();
+            summary.broadest_platform_count =
+                summary.broadest_platform_count.max(item.platform_count());
+
+            if item.source_count == 0 {
+                summary.uncovered_primitives += 1;
+                summary.first_uncovered_priority = Some(
+                    summary
+                        .first_uncovered_priority
+                        .map_or(item.highest_priority, |priority| {
+                            priority.min(item.highest_priority)
+                        }),
+                );
+            } else {
+                summary.covered_primitives += 1;
+            }
+
+            if item.source_count == 1 {
+                summary.single_source_primitives += 1;
+                summary.first_single_source_priority = Some(
+                    summary
+                        .first_single_source_priority
+                        .map_or(item.highest_priority, |priority| {
+                            priority.min(item.highest_priority)
+                        }),
+                );
+            }
+            if item.platform_count() >= 2 {
+                summary.multi_platform_primitives += 1;
+            }
+
+            for integration_id in &item.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary
+    }
+
+    pub fn has_uncovered_primitives(&self) -> bool {
+        self.uncovered_primitives > 0
+    }
+
+    pub fn has_single_source_primitives(&self) -> bool {
+        self.single_source_primitives > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EcosystemPlatformCoverageItem {
     pub platform: EcosystemSurveyPlatform,
     pub display_name: &'static str,
@@ -4720,6 +4809,29 @@ mod tests {
         assert!(coverage
             .iter()
             .all(|item| item.source_count == item.platform_count()));
+    }
+
+    #[test]
+    fn primitive_backlog_coverage_summary_highlights_rollout_gaps() {
+        let catalog = first_party_catalog();
+        let sources = ecosystem_survey_sources();
+        let coverage = primitive_backlog_with_ecosystem_coverage(&catalog, &sources, 1);
+        let summary = PrimitiveBacklogCoverageSummary::from_items(coverage.iter());
+
+        assert_eq!(summary.total_primitives, coverage.len());
+        assert!(summary.total_entries >= coverage.len());
+        assert!(summary.unique_integrations >= 5);
+        assert!(summary.covered_primitives > 0);
+        assert!(summary.uncovered_primitives > 0);
+        assert!(summary.single_source_primitives > 0);
+        assert!(summary.multi_platform_primitives > 0);
+        assert!(summary.total_source_references >= summary.covered_primitives);
+        assert!(summary.total_platform_references >= summary.total_source_references);
+        assert!(summary.first_uncovered_priority.is_some());
+        assert!(summary.first_single_source_priority.is_some());
+        assert!(summary.broadest_platform_count >= 2);
+        assert!(summary.has_uncovered_primitives());
+        assert!(summary.has_single_source_primitives());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add catalog-owned primitive backlog coverage summaries for covered, uncovered, single-source, and multi-platform primitive rows.
- Expose read-only Chief tools for listing primitive coverage rows and fetching compact primitive coverage summaries.
- Update shared smart-home tool catalog counts, bridge e2e coverage, and package docs.

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools