### PR TITLE
Enable ALGOL for-list elements on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -488,26 +488,64 @@ impl Compiler {
             .into_iter()
             .filter(|n| n.rule_name == "for_elem")
             .collect();
-        if elems.len() != 1 {
-            return Err(CompileError::Unsupported(
-                "multi-element ALGOL for lists".into(),
-            ));
+        if elems.is_empty() {
+            return Err(CompileError::Malformed("for_list has no elements".into()));
         }
-        let elem = elems[0];
         let body = direct_nodes(node)
             .into_iter()
             .find(|n| n.rule_name == "statement")
             .ok_or_else(|| CompileError::Malformed("for_stmt missing body statement".into()))?;
 
-        if direct_tokens(elem).iter().any(|t| t.value == "while") {
-            return self.emit_for_while(&var_name, elem, body);
+        for elem in elems {
+            self.emit_for_element(&var_name, elem, body)?;
         }
-        if !direct_tokens(elem).iter().any(|t| t.value == "step") {
-            return Err(CompileError::Unsupported(
-                "single-value for elements outside step/until form".into(),
+        Ok(())
+    }
+
+    fn emit_for_element(
+        &mut self,
+        var_name: &str,
+        elem: &GrammarASTNode,
+        body: &GrammarASTNode,
+    ) -> Result<(), CompileError> {
+        if direct_tokens(elem).iter().any(|t| t.value == "while") {
+            return self.emit_for_while(var_name, elem, body);
+        }
+        if direct_tokens(elem).iter().any(|t| t.value == "step") {
+            return self.emit_for_step_until(var_name, elem, body);
+        }
+        self.emit_for_once(var_name, elem, body)
+    }
+
+    fn emit_for_once(
+        &mut self,
+        var_name: &str,
+        elem: &GrammarASTNode,
+        body: &GrammarASTNode,
+    ) -> Result<(), CompileError> {
+        let arith_nodes: Vec<&GrammarASTNode> = direct_nodes(elem)
+            .into_iter()
+            .filter(|n| n.rule_name == "arith_expr")
+            .collect();
+        if arith_nodes.len() != 1 {
+            return Err(CompileError::Malformed(
+                "single-value for element should have one value".into(),
             ));
         }
-        self.emit_for_step_until(&var_name, elem, body)
+
+        let value = self.emit_expr(arith_nodes[0])?;
+        if value.ty != ScalarType::Integer {
+            return Err(CompileError::Type(
+                "single-value for element must be integer".into(),
+            ));
+        }
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(var_name.to_string()),
+            vec![Operand::Var(value.slot)],
+            "i64",
+        ));
+        self.emit_statement(body)
     }
 
     fn emit_for_step_until(
@@ -1325,6 +1363,18 @@ mod tests {
     fn compiles_and_runs_for_while_sum() {
         let src = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
         assert_eq!(run_i64(src), 15);
+    }
+
+    #[test]
+    fn compiles_and_runs_single_value_for_element() {
+        let src = "begin integer i, result; for i := 2 do result := 40 + i end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn compiles_and_runs_multi_element_for_list() {
+        let src = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
+        assert_eq!(run_i64(src), 39);
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -11,6 +11,8 @@ const ALGOL_BOOL_OPS: &str = "begin boolean a, b; integer result; a := true; b :
 
 const ALGOL_FOR_WHILE: &str = "begin integer x, result; x := 6; result := 0; for x := x - 1 while x > 0 do result := result + x end";
 
+const ALGOL_FOR_LIST: &str = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -27,6 +29,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "for_while",
             compile_case(ALGOL_FOR_WHILE, "algol_for_while_backend_compat"),
+        ),
+        (
+            "for_list",
+            compile_case(ALGOL_FOR_LIST, "algol_for_list_backend_compat"),
         ),
     ] {
         let checks = [
@@ -176,5 +182,44 @@ fn algol_for_while_lowers_to_wasm_jvm_clr_beam_and_llvm() {
     assert!(
         llvm.contains("br label"),
         "LLVM should lower for-while loop branches"
+    );
+}
+
+#[test]
+fn algol_for_list_lowers_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_FOR_LIST, "algol_for_list_backend_compat");
+
+    let wasm =
+        iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolForList"))
+            .expect("ALGOL for-list IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolForList"),
+    )
+    .expect("ALGOL for-list IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL for-list IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam =
+        iir_to_beam::lower_iir_to_beam(&module, &iir_to_beam::IIRBeamConfig::new("algol_for_list"))
+            .expect("ALGOL for-list IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm =
+        iir_to_llvm::lower_iir_to_llvm(&module, &iir_to_llvm::IIRLlvmConfig::new("algol_for_list"))
+            .expect("ALGOL for-list IIR should lower to LLVM");
+    assert!(
+        llvm.contains("br label"),
+        "LLVM should lower for-list loop branches"
     );
 }

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -57,3 +57,29 @@ fn algol_for_while_program_runs_through_generic_jit() {
     }
     assert_eq!(result.as_i64(), Some(15));
 }
+
+#[test]
+fn algol_for_list_program_runs_through_generic_jit() {
+    let source = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
+    let mut module = compile_source(source, "algol_for_list_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(39));
+}

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -122,6 +122,20 @@ fn algol_for_while_emits_and_runs_on_wasm() {
     assert_eq!(result, vec![15], "ALGOL for-while should sum 5..1");
 }
 
+#[test]
+fn algol_for_list_emits_and_runs_on_wasm() {
+    let source = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_for_list")
+        .expect("ALGOL for-list loop should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL for-list sum)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL for-list wasm must run");
+    assert_eq!(result, vec![39], "ALGOL for-list should sum mixed elements");
+}
+
 /// The L3b-3a-3c capstone: a **cons** program compiles to WasmGC and runs
 /// end-to-end on the in-repo runtime. The uniform-anyref value model boxes the
 /// integer atoms as `i31ref`, allocates a `$LispyPair`, and unboxes the result


### PR DESCRIPTION
## Summary
- Lower scalar ALGOL single-value `for` elements like `for i := expr do ...`.
- Lower multi-element ALGOL for-lists by dispatching each element in order, reusing the existing step/until and while lowering paths.
- Add VM, GenericCirJit, direct backend, LLVM, and AOT/WASM runtime coverage for a mixed step/single/while for-list.

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol_for_list_emits_and_runs_on_wasm`
- `cargo test -p iir-to-llvm`
- `git diff --check`

## Security review
- Scanned touched files for `unsafe`, process/file/env/network primitives, and embedded includes; no new production-risk surfaces introduced.
- `cargo audit` and `cargo deny` are not installed in this workspace, so dependency advisory checks could not be run locally.
- Push reported existing default-branch Dependabot alerts; this PR does not add dependencies.