### PR TITLE
feat(closurec): CLOC12.53 — close gap-047 (suppress synthetic `;` before stmt-keyword)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.59.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-047** — synthetic `;` after a `}` is now
+  suppressed when the next non-trivia token is a
+  statement-starting keyword. ASI cleanly covers that
+  boundary; the `;` is wasted bytes. Harness now **87/89**
+  — **only gap-044 (lexer-level template substitution)
+  remains open**.
+- Added a 5th branch to the `}` 4-way decision machine
+  (gap-030/033/041): when `next_is_stmt_keyword`, neither
+  emit nor defer.
+- Keyword set: `var`, `let`, `const`, `function`, `class`,
+  `if`, `for`, `while`, `do`, `switch`, `try`, `return`,
+  `throw`, `break`, `continue`, `import`, `export`.
+- **EOF (None)** is NOT in the set — the gap-030 trailing
+  `;` after a final function-decl is preserved.
+
+### Added
+
+7 inline `gap047_*` tests including 5 explicit non-
+regression cases (EOF still emits, close-brace defer
+preserved, Other-block unaffected, return keyword,
+trychain continuation).
+
 ## [0.58.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -568,6 +568,42 @@ pub fn whitespace_only_minify(
             let next_is_close_brace = next_val == Some("}");
             let next_is_chain_continuation =
                 matches!(next_val, Some("catch") | Some("finally"));
+            // gap-047: ASI cleanly covers the boundary
+            // between `}` and a new statement-starting
+            // keyword — no synthetic `;` is needed.
+            // Upstream Closure under WHITESPACE_ONLY emits
+            //   `function add(a,b){return a+b}var sum=add(2,3);`
+            // for a source that has both a function decl and
+            // a subsequent `var`. Without this suppression
+            // we emit `function add(a,b){return a+b};var sum=...;`
+            // — the extra `;` is a wasted byte.
+            //
+            // The keyword set is the closed list of tokens
+            // that grammatically START a new statement and
+            // CANNOT continue the previous expression. This
+            // is the safety guarantee: omitting the `;` here
+            // is always parser-correct because there's no
+            // way for `}` followed by these keywords to
+            // semantically join into a single statement.
+            //
+            // Notably ABSENT: identifier-like names
+            // (`x`, `foo`, etc.) — could be a free expression
+            // that grammar-fuses with the preceding `}` in
+            // some constructs (e.g., function expressions vs
+            // declarations). Keeping `;` here is safer. EOF
+            // (next_val == None) also keeps the `;` per
+            // gap-030's original rule for cases like
+            // `function f(){}` (no trailing context).
+            let next_is_stmt_keyword = matches!(
+                next_val,
+                Some("var") | Some("let") | Some("const")
+                    | Some("function") | Some("class")
+                    | Some("if") | Some("for") | Some("while")
+                    | Some("do") | Some("switch") | Some("try")
+                    | Some("return") | Some("throw")
+                    | Some("break") | Some("continue")
+                    | Some("import") | Some("export")
+            );
             let kind_wants_semi = match kind {
                 BlockKind::Function => true,
                 BlockKind::Class => true,    // gap-034
@@ -612,6 +648,13 @@ pub fn whitespace_only_minify(
             } else if next_is_chain_continuation {
                 // Carry the deferred forward past the chain
                 // boundary; nothing emits here.
+                emit_semi = false;
+            } else if next_is_stmt_keyword {
+                // gap-047: ASI covers the boundary. No `;`
+                // needed. Drop both the kind-wants-semi and
+                // any deferred pending — the next statement
+                // can stand on its own without us.
+                deferred_synthetic_semi = false;
                 emit_semi = false;
             } else {
                 // Emit if either we owe one OR a deferred
@@ -2411,6 +2454,95 @@ mod tests {
     #[test]
     fn gap046_empty_array_unchanged() {
         assert_eq!(minify("var a=[];"), "var a=[];");
+    }
+
+    // ---- gap-047: suppress `;` before stmt-keyword -------
+
+    /// Target case: function decl followed by `var`.
+    #[test]
+    fn gap047_function_then_var_no_semi() {
+        assert_eq!(
+            minify("function f(){a;}var x=1;"),
+            "function f(){a}var x=1;"
+        );
+    }
+
+    /// Class decl followed by `function`: the class's
+    /// trailing `;` (gap-034) is suppressed. But the
+    /// outermost `function g(){}` at EOF still gets its own
+    /// `;` from gap-030's EOF case (no suppression).
+    #[test]
+    fn gap047_class_then_function_no_semi() {
+        assert_eq!(
+            minify("class C{}function g(){}"),
+            "class C{}function g(){};"
+        );
+    }
+
+    /// **EOF (None) → keep `;`**. The single-statement
+    /// fixture `function add(a,b){return a+b;}` was passing
+    /// at the harness level with output
+    /// `function add(a,b){return a+b};` and that behaviour
+    /// must not change. EOF doesn't match any keyword and
+    /// is NOT in the suppression set.
+    #[test]
+    fn gap047_function_at_eof_keeps_semi() {
+        assert_eq!(
+            minify("function add(a,b){return a+b;}"),
+            "function add(a,b){return a+b};"
+        );
+    }
+
+    /// **`}` next → still defer (gap-041)**. The gap-047
+    /// keyword check is separate from the close-brace defer.
+    /// `function f(){function g(){}}` should still hoist
+    /// the single `;` to the outermost `}`.
+    #[test]
+    fn gap047_close_brace_next_still_defers() {
+        assert_eq!(
+            minify("function f(){function g(){}}"),
+            "function f(){function g(){}};"
+        );
+    }
+
+    /// **Non-regression**: an Other-block close followed by
+    /// `var` doesn't ever emit a `;` regardless of gap-047
+    /// (because `kind_wants_semi == false`). This is the
+    /// natural shape `if(x){...}var y;` which works
+    /// pre-gap-047 too. Verifies the change doesn't regress
+    /// it.
+    #[test]
+    fn gap047_other_block_then_var_unchanged() {
+        // Multi-statement if-body so gap-032 doesn't flatten.
+        assert_eq!(
+            minify("if(x){a();b();}var y=1;"),
+            "if(x){a();b()}var y=1;"
+        );
+    }
+
+    /// **Non-regression**: `return` keyword in suppression
+    /// list. Inner function-decl's trailing `;` (would be
+    /// gap-030) is suppressed because next is `return`.
+    /// The outer function's `;` at EOF still fires.
+    #[test]
+    fn gap047_function_then_return_no_semi() {
+        assert_eq!(
+            minify("function f(){function g(){}return 1;}"),
+            "function f(){function g(){}return 1};"
+        );
+    }
+
+    /// **Non-regression**: catch/finally are NOT in the
+    /// gap-047 suppression set — they're handled via
+    /// `next_is_chain_continuation` (a separate branch).
+    /// Test verifies the TryChain rule still fires
+    /// correctly.
+    #[test]
+    fn gap047_trychain_continuation_unaffected() {
+        assert_eq!(
+            minify("try{a;}catch(e){b;}"),
+            "try{a}catch(e){b};"
+        );
     }
 
     // Note on `do{}while(x);` (empty do-body): gap-031's

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.58.0
+Version: 0.59.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -94,13 +94,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // before `]` is now suppressed. `minify_trailing_array_comma`
     // flipped IGNORED → PASS. Object-literal trailing comma
     // (gap-046b) deferred.
-    // gap-047: synthetic `;` after function-decl `}` should
-    // be suppressed when the next token is a keyword that
-    // starts a new statement (var, function, etc.) — ASI
-    // covers the boundary. Upstream emits
-    // `function add(a,b){return a+b}var sum=add(2,3);` for
-    // a multi-line input. Discovered by CLOC14.12.
-    ("multi_line_func", "gap-047: suppress trailing `;` before stmt-keyword"),
+    // gap-047 was RESOLVED in CLOC12.53 — `}` handler now
+    // adds a 5th branch in its decision: when next non-trivia
+    // is a statement-starting keyword, no synthetic `;` is
+    // emitted (ASI covers the boundary). `minify_multi_line_func`
+    // flipped IGNORED → PASS.
 ];
 
 /// Walk `tests/diff/` and collect every directory whose name

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -355,7 +355,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-047 — suppress synthetic `;` after function-decl `}` before statement-starting keyword
 
-- **Status:** OPEN — newly discovered by CLOC14.12.
+- **Status:** **RESOLVED** in CLOC12.53 (PR pending). `minify_multi_line_func` flipped IGNORED → PASS. Harness now 87/89 — **only gap-044 (lexer-level template substitution) remains open**.
 - **Upstream byte-identity test:** `minify_multi_line_func` seed fixture.
 - **Why it fails:** Upstream emits `function add(a,b){return a+b}var sum=add(2,3);` for a multi-line input. closurec emits `function add(a,b){return a+b};var sum=add(2,3);` — the gap-030 synthetic `;` after the function-decl `}` is unneeded because `var` (and other statement-starting keywords) can never grammatically fuse with the preceding `}`. ASI safety doesn't require the `;`.
 - **What it needs:** Extend the gap-030 trailing-`;` rule (and its gap-041 deferred-`;` cousin) with a peek-ahead suppression: if the next non-trivia token is a statement-starting keyword (`var`, `let`, `const`, `function`, `class`, `if`, `for`, `while`, `do`, `switch`, `try`, `return`, `throw`, `break`, `continue`), suppress the synthetic `;`. EOF stays at the SOURCE EOF behaviour (gap-030 still fires there).


### PR DESCRIPTION
## Summary

**Closes gap-047.** Harness 86/89 → **87/89**. Only gap-044 (lexer-level template substitution) remains open.

## The fix

5th branch in the \`}\` handler's decision machine: when next non-trivia is a statement-starting keyword, ASI cleanly covers the boundary — no synthetic \`;\` needed and any deferred pending is also dropped.

Keyword set: \`var\`/\`let\`/\`const\`/\`function\`/\`class\`/\`if\`/\`for\`/\`while\`/\`do\`/\`switch\`/\`try\`/\`return\`/\`throw\`/\`break\`/\`continue\`/\`import\`/\`export\`.

EOF preserved (None doesn't match any keyword) — gap-030 trailing \`;\` after final function-decl still fires.

## Pre-push security review

PASS. Traced 5 concerns including EOF, TryChain interaction, deferred+suppression composition, suppression-set completeness, sloppy-mode identifier edges.

## Tests

7 inline tests including 5 explicit non-regression cases. Full suite **374 passed**.

## Version

0.58.0 → 0.59.0.

## Test plan

- [x] \`cargo test\` → 374 passed, 0 failed
- [x] \`cargo test --test diff_minify\` → 87 matched, 0 failed, 2 skipped (of 89)
- [x] Security review → PASS
- [ ] CI green

## Marathon

WHITESPACE_ONLY surface has been completely covered across 16 closed gaps (gap-030 through gap-047 minus gap-044). 7 100% milestones reached. Harness now 87/89 with only the deeper grammar gap remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)