### PR TITLE
Enable ALGOL conditional expressions on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -683,7 +683,7 @@ impl Compiler {
         self.set_loc(node);
 
         if direct_tokens(node).iter().any(|t| t.value == "if") {
-            return Err(CompileError::Unsupported("conditional expressions".into()));
+            return self.emit_conditional_expr(node);
         }
 
         match node.rule_name.as_str() {
@@ -722,6 +722,105 @@ impl Compiler {
                 }
             }
         }
+    }
+
+    fn emit_conditional_expr(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
+        match node.rule_name.as_str() {
+            "arith_expr" => {
+                let cond_node = first_direct_node(node, "bool_expr").ok_or_else(|| {
+                    CompileError::Malformed("arithmetic conditional missing condition".into())
+                })?;
+                let then_node = first_direct_node(node, "simple_arith").ok_or_else(|| {
+                    CompileError::Malformed("arithmetic conditional missing then branch".into())
+                })?;
+                let else_node = direct_nodes(node)
+                    .into_iter()
+                    .find(|n| n.rule_name == "arith_expr")
+                    .ok_or_else(|| {
+                        CompileError::Malformed(
+                            "arithmetic conditional missing else branch".into(),
+                        )
+                    })?;
+                self.emit_conditional_branches(cond_node, then_node, else_node)
+            }
+            "bool_expr" => {
+                let bool_nodes: Vec<&GrammarASTNode> = direct_nodes(node)
+                    .into_iter()
+                    .filter(|n| n.rule_name == "bool_expr")
+                    .collect();
+                if bool_nodes.len() != 2 {
+                    return Err(CompileError::Malformed(
+                        "boolean conditional should have condition and else bool_expr".into(),
+                    ));
+                }
+                let then_node = first_direct_node(node, "simple_bool").ok_or_else(|| {
+                    CompileError::Malformed("boolean conditional missing then branch".into())
+                })?;
+                self.emit_conditional_branches(bool_nodes[0], then_node, bool_nodes[1])
+            }
+            other => Err(CompileError::Unsupported(format!(
+                "conditional expressions in {other}"
+            ))),
+        }
+    }
+
+    fn emit_conditional_branches(
+        &mut self,
+        cond_node: &GrammarASTNode,
+        then_node: &GrammarASTNode,
+        else_node: &GrammarASTNode,
+    ) -> Result<ExprValue, CompileError> {
+        let cond = self.emit_expr(cond_node)?;
+        if cond.ty != ScalarType::Boolean {
+            return Err(CompileError::Type(
+                "conditional expression condition must be boolean".into(),
+            ));
+        }
+
+        let else_label = self.fresh_label("expr_else");
+        let end_label = self.fresh_label("expr_end");
+        let dest = self.fresh_temp();
+
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(cond.slot), Operand::Var(else_label.clone())],
+            "void",
+        ));
+        let then_value = self.emit_expr(then_node)?;
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(then_value.slot)],
+            then_value.ty.iir(),
+        ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(end_label.clone())],
+            "void",
+        ));
+        self.emit_label(&else_label);
+        let else_value = self.emit_expr(else_node)?;
+        if then_value.ty != else_value.ty {
+            return Err(CompileError::Type(format!(
+                "conditional expression branches have types {} and {}",
+                then_value.ty.name(),
+                else_value.ty.name()
+            )));
+        }
+        self.emit(IIRInstr::new(
+            "mov",
+            Some(dest.clone()),
+            vec![Operand::Var(else_value.slot)],
+            else_value.ty.iir(),
+        ));
+        self.emit_label(&end_label);
+
+        Ok(ExprValue {
+            slot: dest,
+            ty: then_value.ty,
+        })
     }
 
     fn emit_bool_wrapper(&mut self, node: &GrammarASTNode) -> Result<ExprValue, CompileError> {
@@ -1375,6 +1474,18 @@ mod tests {
     fn compiles_and_runs_multi_element_for_list() {
         let src = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
         assert_eq!(run_i64(src), 39);
+    }
+
+    #[test]
+    fn compiles_and_runs_arithmetic_conditional_expression() {
+        let src = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i end";
+        assert_eq!(run_i64(src), 6);
+    }
+
+    #[test]
+    fn compiles_and_runs_boolean_conditional_expression() {
+        let src = "begin boolean flag; integer result; flag := true; if if flag then true else false then result := 42 else result := 1 end";
+        assert_eq!(run_i64(src), 42);
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -13,6 +13,8 @@ const ALGOL_FOR_WHILE: &str = "begin integer x, result; x := 6; result := 0; for
 
 const ALGOL_FOR_LIST: &str = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
 
+const ALGOL_COND_EXPR: &str = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -33,6 +35,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "for_list",
             compile_case(ALGOL_FOR_LIST, "algol_for_list_backend_compat"),
+        ),
+        (
+            "cond_expr",
+            compile_case(ALGOL_COND_EXPR, "algol_cond_expr_backend_compat"),
         ),
     ] {
         let checks = [
@@ -221,5 +227,44 @@ fn algol_for_list_lowers_to_wasm_jvm_clr_beam_and_llvm() {
     assert!(
         llvm.contains("br label"),
         "LLVM should lower for-list loop branches"
+    );
+}
+
+#[test]
+fn algol_conditional_expressions_lower_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_COND_EXPR, "algol_cond_expr_backend_compat");
+
+    let wasm =
+        iir_to_wasm::lower_iir_to_wasm(&module, &iir_to_wasm::IIRWasmConfig::new("AlgolCondExpr"))
+            .expect("ALGOL conditional-expression IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolCondExpr"),
+    )
+    .expect("ALGOL conditional-expression IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL conditional-expression IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam =
+        iir_to_beam::lower_iir_to_beam(&module, &iir_to_beam::IIRBeamConfig::new("algol_cond_expr"))
+            .expect("ALGOL conditional-expression IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm =
+        iir_to_llvm::lower_iir_to_llvm(&module, &iir_to_llvm::IIRLlvmConfig::new("algol_cond_expr"))
+            .expect("ALGOL conditional-expression IIR should lower to LLVM");
+    assert!(
+        llvm.contains("br i1"),
+        "LLVM should lower conditional expressions as branches"
     );
 }

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -83,3 +83,29 @@ fn algol_for_list_program_runs_through_generic_jit() {
     }
     assert_eq!(result.as_i64(), Some(39));
 }
+
+#[test]
+fn algol_conditional_expression_program_runs_through_generic_jit() {
+    let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
+    let mut module = compile_source(source, "algol_cond_expr_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(42));
+}

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -136,6 +136,20 @@ fn algol_for_list_emits_and_runs_on_wasm() {
     assert_eq!(result, vec![39], "ALGOL for-list should sum mixed elements");
 }
 
+#[test]
+fn algol_conditional_expressions_emit_and_run_on_wasm() {
+    let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_cond_expr")
+        .expect("ALGOL conditional expressions should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL conditional expressions)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL conditional-expression wasm must run");
+    assert_eq!(result, vec![42], "ALGOL conditional expressions should return 42");
+}
+
 /// The L3b-3a-3c capstone: a **cons** program compiles to WasmGC and runs
 /// end-to-end on the in-repo runtime. The uniform-anyref value model boxes the
 /// integer atoms as `i31ref`, allocates a `$LispyPair`, and unboxes the result


### PR DESCRIPTION
## Summary
- lower parsed ALGOL arithmetic and boolean `if ... then ... else ...` expressions into branchy IIR values
- reuse existing labels, `jmp_if_false`, `jmp`, and `mov` joins so every direct backend can consume the result
- add VM, GenericCirJit, direct WASM/JVM/CLR/BEAM/LLVM, and AOT/WASM runtime coverage

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol_conditional_expressions_emit_and_run_on_wasm`
- `cargo test -p iir-to-llvm`
- `git diff --check`

## Security review
- touched-file scan for `unsafe`, process/file/env/include APIs, and panic/unwrap hotspots found only existing-style test assertions in `jit_e2e.rs`
- no dependencies added; push reported existing default-branch Dependabot alerts unrelated to this branch
- `cargo audit` and `cargo deny` are not installed in this workspace, so those checks could not be run
