### PR TITLE
Add smart-home activation health tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A rollout-priority activation runway planning:
   `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary`.
+- Added D18D handlers for D23A activation health planning:
+  `smart_home.list_integration_activation_health` and
+  `smart_home.get_integration_activation_health_summary`.
 - Added D18D handlers for D23A integration activation dependency graph
   planning: `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -45,6 +45,7 @@ Chief of Staff job/session/agent
   -> activation-action list and summary reads for concrete unblock/activate work
   -> activation-agenda list and summary reads for concrete work by rollout wave
   -> activation-runway list and summary reads for rollout-priority waves
+  -> activation-health list and summary reads for priority-wave readiness status
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
@@ -81,6 +82,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_agenda_summary`
 - `smart_home.list_integration_activation_runway`
 - `smart_home.get_integration_activation_runway_summary`
+- `smart_home.list_integration_activation_health`
+- `smart_home.get_integration_activation_health_summary`
 - `smart_home.list_integration_activation_dependencies`
 - `smart_home.get_integration_activation_dependency_summary`
 - `smart_home.list_integration_readiness`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -35,8 +35,9 @@ use smart_home_discovery::{
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_candidates_at_or_before_priority, activation_dependency_graph_from_reports,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    activation_health_from_candidates, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_runway_from_candidates,
+    describe_primitive_family, ecosystem_platform_coverage,
     ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
     find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
     primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
@@ -50,8 +51,9 @@ use smart_home_integration_catalog::{
     IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
     IntegrationActivationCandidateSummary, IntegrationActivationDependencyEdge,
     IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    IntegrationActivationDependencySummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
@@ -176,6 +178,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNWAY_TOOL_ID: &str =
     "smart_home.list_integration_activation_runway";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_runway_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID: &str =
+    "smart_home.list_integration_activation_health";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_health_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID: &str =
     "smart_home.list_integration_activation_dependencies";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID: &str =
@@ -334,6 +340,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID => {
                     let query = integration_activation_runway_query(&arguments)?;
                     Ok(get_integration_activation_runway_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID => {
+                    let query = integration_activation_health_query(&arguments)?;
+                    Ok(list_integration_activation_health_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_health_query(&arguments)?;
+                    Ok(get_integration_activation_health_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID => {
                     let query = integration_activation_dependency_query(&arguments)?;
@@ -1189,6 +1205,38 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation runway summary",
             "Return compact D23A rollout-priority runway rollups for actionable, review, and blocked activation waves.",
             integration_activation_runway_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID,
+            "List smart-home integration activation health",
+            "List D23A priority-wave activation health rows with ready, review, blocked, and missing-prerequisite gap rollups.",
+            integration_activation_health_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new(
+                        "activation_health",
+                        JsonSchema::Array {
+                            items: Box::new(JsonSchema::Any),
+                        },
+                    ),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_health", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation health summary",
+            "Return compact D23A priority-wave activation health counts for ready, review, blocked, and missing-prerequisite work.",
+            integration_activation_health_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3709,6 +3757,14 @@ struct IntegrationActivationRunwayQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationHealthQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    health_status: Option<IntegrationActivationHealthStatus>,
+    requires_attention: Option<bool>,
+    stage_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationDependencyQuery {
     readiness: IntegrationReadinessQuery,
     blocking_only: bool,
@@ -3742,6 +3798,23 @@ fn integration_activation_runway_query(
         candidates,
         stage_limit,
         candidates_per_stage_limit,
+    })
+}
+
+fn integration_activation_health_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationHealthQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let health_status = optional_string(arguments, "health_status")?
+        .map(|label| parse_activation_health_status(&label))
+        .transpose()?;
+    let stage_limit = optional_u64(arguments, "stage_limit")?.map(|value| value as usize);
+
+    Ok(IntegrationActivationHealthQuery {
+        candidates,
+        health_status,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        stage_limit,
     })
 }
 
@@ -3941,6 +4014,26 @@ fn integration_activation_runway_for_query(
     }
 
     (runway, catalog_count)
+}
+
+fn integration_activation_health_for_query(
+    query: &IntegrationActivationHealthQuery,
+) -> (Vec<IntegrationActivationHealthStage>, usize) {
+    let (candidates, catalog_count) =
+        integration_activation_candidates_for_query(&query.candidates);
+    let mut health = activation_health_from_candidates(candidates);
+
+    if let Some(health_status) = query.health_status {
+        health.retain(|stage| stage.health_status == health_status);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        health.retain(|stage| stage.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.stage_limit {
+        health.truncate(limit);
+    }
+
+    (health, catalog_count)
 }
 
 fn integration_activation_actions_for_query(
@@ -4609,6 +4702,65 @@ fn get_integration_activation_runway_summary_output_handler_output(
             ),
             ("total_stages", integer(summary.total_stages as i64)),
             ("blocked_stages", integer(summary.blocked_stages as i64)),
+        ]),
+    )
+}
+
+fn list_integration_activation_health_output_handler_output(
+    query: IntegrationActivationHealthQuery,
+) -> ToolHandlerOutput {
+    let (health, catalog_count) = integration_activation_health_for_query(&query);
+    let summary = IntegrationActivationHealthSummary::from_stages(health.iter());
+    let count = health.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_health",
+            JsonValue::Array(health.iter().map(activation_health_stage_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_health_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_health")),
+            ("stages", integer(count as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+            (
+                "blocked_integrations",
+                integer(summary.blocked_integrations as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_health_summary_output_handler_output(
+    query: IntegrationActivationHealthQuery,
+) -> ToolHandlerOutput {
+    let (health, _) = integration_activation_health_for_query(&query);
+    let summary = IntegrationActivationHealthSummary::from_stages(health.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_health_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_health_summary"),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+            (
+                "blocked_integrations",
+                integer(summary.blocked_integrations as i64),
+            ),
         ]),
     )
 }
@@ -7769,6 +7921,198 @@ fn integration_activation_runway_summary_json(
     ])
 }
 
+fn activation_health_stage_json(stage: &IntegrationActivationHealthStage) -> JsonValue {
+    object([
+        ("priority", integer(stage.priority as i64)),
+        ("health_status", string(stage.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                stage
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "ready_to_activate_integration_ids",
+            JsonValue::Array(
+                stage
+                    .ready_to_activate_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "review_integration_ids",
+            JsonValue::Array(
+                stage
+                    .review_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocked_integration_ids",
+            JsonValue::Array(
+                stage
+                    .blocked_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(&stage.candidate_summary),
+        ),
+        (
+            "gap_summary",
+            integration_readiness_gap_summary_json(&stage.gap_inventory),
+        ),
+        (
+            "primitive_gaps",
+            JsonValue::Array(
+                stage
+                    .gap_inventory
+                    .primitive_gaps
+                    .iter()
+                    .map(primitive_gap_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "capability_gaps",
+            JsonValue::Array(
+                stage
+                    .gap_inventory
+                    .capability_gaps
+                    .iter()
+                    .map(capability_gap_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_gaps",
+            JsonValue::Array(
+                stage
+                    .gap_inventory
+                    .dependency_gaps
+                    .iter()
+                    .map(dependency_gap_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "ready_to_activate_count",
+            integer(stage.ready_to_activate_integration_ids.len() as i64),
+        ),
+        (
+            "review_count",
+            integer(stage.review_integration_ids.len() as i64),
+        ),
+        (
+            "blocked_count",
+            integer(stage.blocked_integration_ids.len() as i64),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(stage.requires_attention()),
+        ),
+        ("has_ready_work", JsonValue::Bool(stage.has_ready_work())),
+        ("has_review_work", JsonValue::Bool(stage.has_review_work())),
+        ("has_blockers", JsonValue::Bool(stage.has_blockers())),
+    ])
+}
+
+fn integration_activation_health_summary_json(
+    summary: &IntegrationActivationHealthSummary,
+) -> JsonValue {
+    object([
+        ("total_stages", integer(summary.total_stages as i64)),
+        (
+            "total_integrations",
+            integer(summary.total_integrations as i64),
+        ),
+        ("ready_stages", integer(summary.ready_stages as i64)),
+        ("review_stages", integer(summary.review_stages as i64)),
+        ("blocked_stages", integer(summary.blocked_stages as i64)),
+        ("empty_stages", integer(summary.empty_stages as i64)),
+        (
+            "activation_ready_integrations",
+            integer(summary.activation_ready_integrations as i64),
+        ),
+        (
+            "ready_to_activate_integrations",
+            integer(summary.ready_to_activate_integrations as i64),
+        ),
+        (
+            "review_integrations",
+            integer(summary.review_integrations as i64),
+        ),
+        (
+            "blocked_integrations",
+            integer(summary.blocked_integrations as i64),
+        ),
+        (
+            "primitive_gap_count",
+            integer(summary.primitive_gap_count as i64),
+        ),
+        (
+            "capability_gap_count",
+            integer(summary.capability_gap_count as i64),
+        ),
+        (
+            "dependency_gap_count",
+            integer(summary.dependency_gap_count as i64),
+        ),
+        (
+            "total_unique_gaps",
+            integer(summary.total_unique_gaps as i64),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+        ("has_ready_work", JsonValue::Bool(summary.has_ready_work())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+    ])
+}
+
 fn activation_dependency_node_json(node: &IntegrationActivationDependencyNode) -> JsonValue {
     object([
         ("integration_id", string(node.integration_id.as_str())),
@@ -10032,6 +10376,22 @@ fn parse_activation_candidate_recommendation(
     }
 }
 
+fn parse_activation_health_status(
+    label: &str,
+) -> Result<IntegrationActivationHealthStatus, ToolCallError> {
+    match label {
+        "ready" | "ready_to_activate" => Ok(IntegrationActivationHealthStatus::Ready),
+        "needs_review" | "review" | "human_review" => {
+            Ok(IntegrationActivationHealthStatus::NeedsReview)
+        }
+        "blocked" | "blocked_on_prerequisites" => Ok(IntegrationActivationHealthStatus::Blocked),
+        "empty" => Ok(IntegrationActivationHealthStatus::Empty),
+        _ => Err(validation_error(format!(
+            "unknown activation health status `{label}`"
+        ))),
+    }
+}
+
 fn activation_candidate_recommendation_label(
     recommendation: IntegrationActivationCandidateRecommendation,
 ) -> &'static str {
@@ -10791,6 +11151,24 @@ fn integration_activation_runway_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_health_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("health_status", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("stage_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_dependency_query_schema() -> JsonSchema {
     let mut schema = integration_readiness_query_schema(true);
     if let JsonSchema::Object {
@@ -10915,7 +11293,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 67);
+        assert_eq!(definitions.len(), 69);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -10983,6 +11361,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID));
@@ -11086,7 +11470,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            59
+            61
         );
         assert_eq!(
             export
@@ -11174,6 +11558,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNWAY_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -11428,11 +11820,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(67))
+            Some(&integer(69))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(59))
+            Some(&integer(61))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -12193,6 +12585,129 @@ mod tests {
                 .is_some()
         );
 
+        let list_activation_health_request = request(
+            "call-list-integration-activation-health",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("stage_limit", integer(2)),
+            ]),
+            5_005,
+        );
+        let list_activation_health_trace =
+            tool_runtime.invoke_with_events(&list_activation_health_request);
+        assert!(list_activation_health_trace.result.ok);
+        assert_eq!(
+            list_activation_health_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_health_output =
+            list_activation_health_trace.result.output.as_ref().unwrap();
+        assert_eq!(
+            field(list_activation_health_output, "count"),
+            Some(&integer(2))
+        );
+        let activation_health_summary = field(list_activation_health_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_health_summary, "overall_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_health_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_health_summary, "total_unique_gaps").unwrap()).unwrap()
+                >= 1
+        );
+        let activation_health_stage = array_item(
+            field(list_activation_health_output, "activation_health").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_health_stage, "health_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_health_stage, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_health_stage, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_health_stage, "blocked_count").unwrap()).unwrap() >= 1
+        );
+
+        let activation_health_summary_request = request(
+            "call-integration-activation-health-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("health_status", string("blocked")),
+            ]),
+            5_006,
+        );
+        let activation_health_summary_trace =
+            tool_runtime.invoke_with_events(&activation_health_summary_request);
+        assert!(activation_health_summary_trace.result.ok);
+        assert_eq!(
+            activation_health_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_health_summary_output = activation_health_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_health_rollup = field(activation_health_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_health_rollup, "overall_status"),
+            Some(&string("blocked"))
+        );
+        assert!(
+            integer_value(field(activation_health_rollup, "blocked_integrations").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_health_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_dependencies_request = request(
             "call-list-integration-activation-dependencies",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID,
@@ -12217,7 +12732,7 @@ mod tests {
                     JsonValue::Array(vec![string("mqtt")]),
                 ),
             ]),
-            5_005,
+            5_007,
         );
         let list_activation_dependencies_trace =
             tool_runtime.invoke_with_events(&list_activation_dependencies_request);
@@ -12295,7 +12810,7 @@ mod tests {
                 ("blocking_only", JsonValue::Bool(true)),
                 ("edge_limit", integer(2)),
             ]),
-            5_006,
+            5_008,
         );
         let activation_dependency_summary_trace =
             tool_runtime.invoke_with_events(&activation_dependency_summary_request);
@@ -13734,6 +14249,11 @@ mod tests {
             activation_runway_summary_request,
             activation_runway_summary_trace,
         );
+        journal.record_trace(list_activation_health_request, list_activation_health_trace);
+        journal.record_trace(
+            activation_health_summary_request,
+            activation_health_summary_trace,
+        );
         journal.record_trace(
             list_activation_dependencies_request,
             list_activation_dependencies_trace,
@@ -13802,9 +14322,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 67);
-        assert_eq!(journal_summary.completed_count, 67);
-        assert_eq!(journal.audit_records().len(), 67);
+        assert_eq!(journal_summary.invocation_count, 69);
+        assert_eq!(journal_summary.completed_count, 69);
+        assert_eq!(journal.audit_records().len(), 69);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_runway` and
   `smart_home.get_integration_activation_runway_summary` tool descriptors for
   read-only rollout-priority activation wave planning.
+- `smart_home.list_integration_activation_health` and
+  `smart_home.get_integration_activation_health_summary` tool descriptors for
+  read-only rollout-priority activation health planning.
 - `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary` tool descriptors
   for read-only activation dependency graph planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -62,6 +62,8 @@ Current scope:
   work by rollout-priority wave
 - D18D integration activation-runway descriptors for rollout-priority wave
   grouping and compact actionable/blocker summaries
+- D18D integration activation-health descriptors for priority-wave ready,
+  review, blocked, and missing-prerequisite status summaries
 - D18D integration-readiness descriptors for bulk activation blocker reports
   and compact readiness rollups
 - D18D integration-readiness gap descriptors for grouped primitive,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1467,6 +1467,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationAgendaSummary,
     ListIntegrationActivationRunway,
     GetIntegrationActivationRunwaySummary,
+    ListIntegrationActivationHealth,
+    GetIntegrationActivationHealthSummary,
     ListIntegrationActivationDependencies,
     GetIntegrationActivationDependencySummary,
     ListIntegrationReadiness,
@@ -1572,6 +1574,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationRunwaySummary => {
                 read_tool("smart_home.get_integration_activation_runway_summary")
+            }
+            Self::ListIntegrationActivationHealth => {
+                read_tool("smart_home.list_integration_activation_health")
+            }
+            Self::GetIntegrationActivationHealthSummary => {
+                read_tool("smart_home.get_integration_activation_health_summary")
             }
             Self::ListIntegrationActivationDependencies => {
                 read_tool("smart_home.list_integration_activation_dependencies")
@@ -2216,6 +2224,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationAgendaSummary,
         SmartHomeTool::ListIntegrationActivationRunway,
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
+        SmartHomeTool::ListIntegrationActivationHealth,
+        SmartHomeTool::GetIntegrationActivationHealthSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
         SmartHomeTool::GetIntegrationActivationDependencySummary,
         SmartHomeTool::ListIntegrationReadiness,
@@ -3056,7 +3066,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 67);
+        assert_eq!(catalog.len(), 69);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3148,6 +3158,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_runway_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_health"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_health_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3338,15 +3356,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 67);
-        assert_eq!(summary.read_tools, 59);
+        assert_eq!(summary.total_tools, 69);
+        assert_eq!(summary.read_tools, 61);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 59);
+        assert_eq!(summary.read_only_tier_tools, 61);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 67);
+        assert_eq!(summary.total_required_capabilities, 69);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationRunwayStage` and `IntegrationActivationRunwaySummary`
   for grouping activation candidates by rollout priority wave and identifying
   actionable, review, and blocked stages.
+- `IntegrationActivationHealthStage` and `IntegrationActivationHealthSummary`
+  for compact ready, review, blocked, and missing-prerequisite priority-wave
+  status rollups.
 - `IntegrationActivationDependencyGraph` plus node, edge, and summary types for
   exposing satisfied and blocking integration prerequisites in rollout plans.
 - Integration readiness reports that expose missing primitive families, missing

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -44,6 +44,8 @@ runtime and Chief of Staff tools a typed catalog for:
   rollout priority wave for bounded Chief-of-Staff planning
 - activation runway stages that group those candidates by rollout priority wave
   with compact ready, review, and blocker rollups
+- activation health stages that add priority-wave ready, review, blocked, and
+  missing-prerequisite gap rollups for compact platform status inspection
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,
   and blocking edges after applying host-specific enabled-integration context
 - readiness reports that compare activation plans against available primitives,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1002,6 +1002,29 @@ pub enum IntegrationActivationCandidateRecommendation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationHealthStatus {
+    Ready,
+    NeedsReview,
+    Blocked,
+    Empty,
+}
+
+impl IntegrationActivationHealthStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NeedsReview => "needs_review",
+            Self::Blocked => "blocked",
+            Self::Empty => "empty",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::NeedsReview | Self::Blocked)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationActionKind {
     ActivateIntegration,
     ReviewPolicy,
@@ -1216,6 +1239,41 @@ pub struct IntegrationActivationDependencySummary {
     pub unknown_dependency_edges: usize,
     pub first_blocked_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationHealthStage {
+    pub priority: u8,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub ready_to_activate_integration_ids: Vec<IntegrationId>,
+    pub review_integration_ids: Vec<IntegrationId>,
+    pub blocked_integration_ids: Vec<IntegrationId>,
+    pub candidate_summary: IntegrationActivationCandidateSummary,
+    pub gap_inventory: IntegrationReadinessGapInventory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationHealthSummary {
+    pub total_stages: usize,
+    pub total_integrations: usize,
+    pub ready_stages: usize,
+    pub review_stages: usize,
+    pub blocked_stages: usize,
+    pub empty_stages: usize,
+    pub activation_ready_integrations: usize,
+    pub ready_to_activate_integrations: usize,
+    pub review_integrations: usize,
+    pub blocked_integrations: usize,
+    pub primitive_gap_count: usize,
+    pub capability_gap_count: usize,
+    pub dependency_gap_count: usize,
+    pub total_unique_gaps: usize,
+    pub first_ready_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
 }
 
 impl IntegrationActivationPlanSummary {
@@ -1504,6 +1562,182 @@ impl IntegrationActivationDependencyGraph {
 
     pub fn has_blocking_dependencies(&self) -> bool {
         self.summary.has_blocking_dependencies()
+    }
+}
+
+impl IntegrationActivationHealthStage {
+    pub fn from_candidates(
+        priority: u8,
+        mut candidates: Vec<IntegrationActivationCandidate>,
+    ) -> Self {
+        candidates.sort_by(compare_activation_candidates);
+        let candidate_summary =
+            IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+        let reports = candidates
+            .iter()
+            .map(|candidate| candidate.readiness_report.clone())
+            .collect::<Vec<_>>();
+        let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+        let integration_ids = candidates
+            .iter()
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let ready_to_activate_integration_ids = candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.recommendation
+                    == IntegrationActivationCandidateRecommendation::ReadyToActivate
+            })
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let review_integration_ids = candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.recommendation
+                    == IntegrationActivationCandidateRecommendation::NeedsHumanReview
+            })
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let blocked_integration_ids = candidates
+            .iter()
+            .filter(|candidate| candidate.is_blocked())
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let health_status = activation_health_status_for_summary(&candidate_summary);
+
+        Self {
+            priority,
+            health_status,
+            integration_ids,
+            ready_to_activate_integration_ids,
+            review_integration_ids,
+            blocked_integration_ids,
+            candidate_summary,
+            gap_inventory,
+        }
+    }
+
+    pub fn has_ready_work(&self) -> bool {
+        self.candidate_summary.ready_to_activate_candidates > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.candidate_summary.needs_human_review_candidates > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.candidate_summary.blocked_candidates > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.health_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationHealthSummary {
+    pub fn from_stages<'a>(
+        stages: impl IntoIterator<Item = &'a IntegrationActivationHealthStage>,
+    ) -> Self {
+        let mut primitive_gaps = BTreeSet::new();
+        let mut capability_gaps = BTreeSet::new();
+        let mut dependency_gaps = BTreeSet::new();
+        let mut summary = Self {
+            total_stages: 0,
+            total_integrations: 0,
+            ready_stages: 0,
+            review_stages: 0,
+            blocked_stages: 0,
+            empty_stages: 0,
+            activation_ready_integrations: 0,
+            ready_to_activate_integrations: 0,
+            review_integrations: 0,
+            blocked_integrations: 0,
+            primitive_gap_count: 0,
+            capability_gap_count: 0,
+            dependency_gap_count: 0,
+            total_unique_gaps: 0,
+            first_ready_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for stage in stages {
+            summary.total_stages += 1;
+            summary.total_integrations += stage.candidate_summary.total_candidates;
+            summary.activation_ready_integrations +=
+                stage.candidate_summary.activation_ready_candidates;
+            summary.ready_to_activate_integrations +=
+                stage.candidate_summary.ready_to_activate_candidates;
+            summary.review_integrations += stage.candidate_summary.needs_human_review_candidates;
+            summary.blocked_integrations += stage.candidate_summary.blocked_candidates;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(stage.candidate_summary.highest_policy_tier);
+
+            if stage.candidate_summary.is_empty() {
+                summary.empty_stages += 1;
+            }
+            if stage.has_ready_work() {
+                summary.ready_stages += 1;
+                summary.first_ready_priority =
+                    min_optional_priority(summary.first_ready_priority, Some(stage.priority));
+            }
+            if stage.has_review_work() {
+                summary.review_stages += 1;
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(stage.priority));
+            }
+            if stage.has_blockers() {
+                summary.blocked_stages += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(stage.priority));
+            }
+
+            for gap in &stage.gap_inventory.primitive_gaps {
+                primitive_gaps.insert(gap.primitive);
+            }
+            for gap in &stage.gap_inventory.capability_gaps {
+                capability_gaps.insert(gap.capability_id.clone());
+            }
+            for gap in &stage.gap_inventory.dependency_gaps {
+                dependency_gaps.insert(gap.integration_id.clone());
+            }
+        }
+
+        summary.primitive_gap_count = primitive_gaps.len();
+        summary.capability_gap_count = capability_gaps.len();
+        summary.dependency_gap_count = dependency_gaps.len();
+        summary.total_unique_gaps = summary.primitive_gap_count
+            + summary.capability_gap_count
+            + summary.dependency_gap_count;
+        summary.overall_status = activation_health_status_from_counts(
+            summary.ready_to_activate_integrations,
+            summary.review_integrations,
+            summary.blocked_integrations,
+        );
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_stages == 0
+    }
+
+    pub fn has_ready_work(&self) -> bool {
+        self.ready_to_activate_integrations > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_integrations > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_integrations > 0 || self.total_unique_gaps > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention()
     }
 }
 
@@ -3458,6 +3692,41 @@ pub fn activation_runway_at_or_before_priority(
     ))
 }
 
+pub fn activation_health_from_candidates(
+    candidates: Vec<IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationHealthStage> {
+    let mut stages_by_priority: BTreeMap<u8, Vec<IntegrationActivationCandidate>> = BTreeMap::new();
+    for candidate in candidates {
+        stages_by_priority
+            .entry(candidate.readiness_report.priority)
+            .or_default()
+            .push(candidate);
+    }
+
+    stages_by_priority
+        .into_iter()
+        .map(|(priority, candidates)| {
+            IntegrationActivationHealthStage::from_candidates(priority, candidates)
+        })
+        .collect()
+}
+
+pub fn activation_health_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationHealthStage> {
+    activation_health_from_candidates(activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -4545,6 +4814,32 @@ fn sort_query_results(entries: &mut Vec<&IntegrationCatalogEntry>, sort: Integra
     }
 }
 
+fn activation_health_status_for_summary(
+    summary: &IntegrationActivationCandidateSummary,
+) -> IntegrationActivationHealthStatus {
+    activation_health_status_from_counts(
+        summary.ready_to_activate_candidates,
+        summary.needs_human_review_candidates,
+        summary.blocked_candidates,
+    )
+}
+
+fn activation_health_status_from_counts(
+    ready_to_activate_count: usize,
+    review_count: usize,
+    blocked_count: usize,
+) -> IntegrationActivationHealthStatus {
+    if blocked_count > 0 {
+        IntegrationActivationHealthStatus::Blocked
+    } else if review_count > 0 {
+        IntegrationActivationHealthStatus::NeedsReview
+    } else if ready_to_activate_count > 0 {
+        IntegrationActivationHealthStatus::Ready
+    } else {
+        IntegrationActivationHealthStatus::Empty
+    }
+}
+
 fn compare_activation_candidates(
     left: &IntegrationActivationCandidate,
     right: &IntegrationActivationCandidate,
@@ -5218,6 +5513,110 @@ mod tests {
         assert!(summary.has_actionable_stage());
         assert!(summary.has_blocked_stage());
         assert!(summary.has_review_stage());
+        assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_health_rolls_up_priority_stage_attention() {
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 2,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_bridge"),
+            display_name: "Review Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_sensor"),
+            display_name: "Blocked Sensor".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 1,
+            missing_primitives: vec![PrimitiveFamily::Mqtt],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::LowRisk,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [ready_report, review_report, blocked_report].iter(),
+        );
+
+        let health = activation_health_from_candidates(candidates);
+
+        assert_eq!(health.len(), 2);
+        assert_eq!(health[0].priority, 1);
+        assert_eq!(
+            health[0].health_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(health[0].requires_attention());
+        assert!(health[0].has_review_work());
+        assert!(health[0].has_blockers());
+        assert_eq!(health[0].candidate_summary.total_candidates, 2);
+        assert_eq!(health[0].gap_inventory.primitive_gap_count(), 1);
+        assert_eq!(health[0].gap_inventory.capability_gap_count(), 1);
+        assert_eq!(health[0].gap_inventory.dependency_gap_count(), 1);
+        assert!(health[0]
+            .blocked_integration_ids
+            .contains(&IntegrationId::trusted("blocked_sensor")));
+        assert!(health[0]
+            .review_integration_ids
+            .contains(&IntegrationId::trusted("review_bridge")));
+        assert_eq!(health[1].priority, 2);
+        assert_eq!(
+            health[1].health_status,
+            IntegrationActivationHealthStatus::Ready
+        );
+        assert!(health[1]
+            .ready_to_activate_integration_ids
+            .contains(&IntegrationId::trusted("read_only_probe")));
+
+        let summary = IntegrationActivationHealthSummary::from_stages(health.iter());
+        assert_eq!(summary.total_stages, 2);
+        assert_eq!(summary.total_integrations, 3);
+        assert_eq!(summary.ready_stages, 1);
+        assert_eq!(summary.review_stages, 1);
+        assert_eq!(summary.blocked_stages, 1);
+        assert_eq!(summary.ready_to_activate_integrations, 1);
+        assert_eq!(summary.review_integrations, 1);
+        assert_eq!(summary.blocked_integrations, 1);
+        assert_eq!(summary.primitive_gap_count, 1);
+        assert_eq!(summary.capability_gap_count, 1);
+        assert_eq!(summary.dependency_gap_count, 1);
+        assert_eq!(summary.total_unique_gaps, 3);
+        assert_eq!(summary.first_ready_priority, Some(2));
+        assert_eq!(summary.first_review_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(1));
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.requires_attention());
+        assert!(summary.has_ready_work());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
         assert!(!summary.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- add catalog-owned activation health stages and summaries for rollout priority waves
- expose smart_home.list_integration_activation_health and smart_home.get_integration_activation_health_summary in shared core descriptors
- wire the thin Chief smart-home adapter, JSON output, schemas, docs, and end-to-end bridge coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools