### PR TITLE
Add smart-home activation constraint tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation health planning:
   `smart_home.list_integration_activation_health` and
   `smart_home.get_integration_activation_health_summary`.
+- Added D18D handlers for D23A grouped activation constraint planning:
+  `smart_home.list_integration_activation_constraints` and
+  `smart_home.get_integration_activation_constraint_summary`.
 - Added D18D handlers for D23A integration activation dependency graph
   planning: `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -46,6 +46,7 @@ Chief of Staff job/session/agent
   -> activation-agenda list and summary reads for concrete work by rollout wave
   -> activation-runway list and summary reads for rollout-priority waves
   -> activation-health list and summary reads for priority-wave readiness status
+  -> activation-constraint list and summary reads for grouped blockers/reviews
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
@@ -84,6 +85,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_runway_summary`
 - `smart_home.list_integration_activation_health`
 - `smart_home.get_integration_activation_health_summary`
+- `smart_home.list_integration_activation_constraints`
+- `smart_home.get_integration_activation_constraint_summary`
 - `smart_home.list_integration_activation_dependencies`
 - `smart_home.get_integration_activation_dependency_summary`
 - `smart_home.list_integration_readiness`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,10 +34,10 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
-    activation_candidates_at_or_before_priority, activation_dependency_graph_from_reports,
-    activation_health_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_runway_from_candidates,
-    describe_primitive_family, ecosystem_platform_coverage,
+    activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
+    activation_dependency_graph_from_reports, activation_health_from_candidates,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
     ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
     find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
     primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
@@ -49,11 +49,13 @@ use smart_home_integration_catalog::{
     IntegrationActivationActionKind, IntegrationActivationActionSummary,
     IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
     IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
     IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
@@ -182,6 +184,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID: &str =
     "smart_home.list_integration_activation_health";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_health_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_constraints";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_constraint_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID: &str =
     "smart_home.list_integration_activation_dependencies";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPENDENCY_SUMMARY_TOOL_ID: &str =
@@ -350,6 +356,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID => {
                     let query = integration_activation_health_query(&arguments)?;
                     Ok(get_integration_activation_health_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID => {
+                    let query = integration_activation_constraint_query(&arguments)?;
+                    Ok(list_integration_activation_constraints_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_constraint_query(&arguments)?;
+                    Ok(get_integration_activation_constraint_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID => {
                     let query = integration_activation_dependency_query(&arguments)?;
@@ -1237,6 +1251,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation health summary",
             "Return compact D23A priority-wave activation health counts for ready, review, blocked, and missing-prerequisite work.",
             integration_activation_health_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID,
+            "List smart-home integration activation constraints",
+            "List grouped D23A activation constraints across missing primitives, missing capability grants, unsatisfied integration dependencies, and policy-review surfaces.",
+            integration_activation_constraint_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_constraints", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_constraints",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation constraint summary",
+            "Return compact D23A activation constraint counts for blockers, policy-review work, affected integrations, and first rollout priorities.",
+            integration_activation_constraint_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3765,6 +3813,15 @@ struct IntegrationActivationHealthQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationConstraintQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    constraint_kind: Option<IntegrationActivationConstraintKind>,
+    blocking_only: Option<bool>,
+    constraint_requires_human_review: Option<bool>,
+    constraint_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationDependencyQuery {
     readiness: IntegrationReadinessQuery,
     blocking_only: bool,
@@ -3815,6 +3872,26 @@ fn integration_activation_health_query(
         health_status,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         stage_limit,
+    })
+}
+
+fn integration_activation_constraint_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationConstraintQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let constraint_kind = optional_string(arguments, "constraint_kind")?
+        .map(|label| parse_activation_constraint_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationConstraintQuery {
+        candidates,
+        constraint_kind,
+        blocking_only: optional_bool(arguments, "blocking_only")?,
+        constraint_requires_human_review: optional_bool(
+            arguments,
+            "constraint_requires_human_review",
+        )?,
+        constraint_limit: optional_u64(arguments, "constraint_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4034,6 +4111,30 @@ fn integration_activation_health_for_query(
     }
 
     (health, catalog_count)
+}
+
+fn integration_activation_constraints_for_query(
+    query: &IntegrationActivationConstraintQuery,
+) -> (Vec<IntegrationActivationConstraint>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut constraints = activation_constraints_from_candidates(&catalog, candidates.iter());
+
+    if let Some(kind) = query.constraint_kind {
+        constraints.retain(|constraint| constraint.kind == kind);
+    }
+    if let Some(blocking_only) = query.blocking_only {
+        constraints.retain(|constraint| constraint.blocks_activation == blocking_only);
+    }
+    if let Some(requires_human_review) = query.constraint_requires_human_review {
+        constraints.retain(|constraint| constraint.requires_human_review == requires_human_review);
+    }
+    if let Some(limit) = query.constraint_limit {
+        constraints.truncate(limit);
+    }
+
+    (constraints, catalog_count)
 }
 
 fn integration_activation_actions_for_query(
@@ -4760,6 +4861,78 @@ fn get_integration_activation_health_summary_output_handler_output(
             (
                 "blocked_integrations",
                 integer(summary.blocked_integrations as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_constraints_output_handler_output(
+    query: IntegrationActivationConstraintQuery,
+) -> ToolHandlerOutput {
+    let (constraints, catalog_count) = integration_activation_constraints_for_query(&query);
+    let summary = IntegrationActivationConstraintSummary::from_constraints(constraints.iter());
+    let count = constraints.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_constraints",
+            JsonValue::Array(constraints.iter().map(activation_constraint_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_constraint_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_constraints"),
+            ),
+            ("constraints", integer(count as i64)),
+            (
+                "blocking_constraints",
+                integer(summary.blocking_constraints as i64),
+            ),
+            (
+                "review_constraints",
+                integer(summary.review_constraints as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_constraint_summary_output_handler_output(
+    query: IntegrationActivationConstraintQuery,
+) -> ToolHandlerOutput {
+    let (constraints, _) = integration_activation_constraints_for_query(&query);
+    let summary = IntegrationActivationConstraintSummary::from_constraints(constraints.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_constraint_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_constraint_summary"),
+            ),
+            (
+                "total_constraints",
+                integer(summary.total_constraints as i64),
+            ),
+            (
+                "blocking_constraints",
+                integer(summary.blocking_constraints as i64),
+            ),
+            (
+                "review_constraints",
+                integer(summary.review_constraints as i64),
             ),
         ]),
     )
@@ -8113,6 +8286,117 @@ fn integration_activation_health_summary_json(
     ])
 }
 
+fn activation_constraint_json(constraint: &IntegrationActivationConstraint) -> JsonValue {
+    object([
+        ("constraint_kind", string(constraint.kind.as_str())),
+        ("constraint_id", string(&constraint.constraint_id)),
+        ("display_name", string(&constraint.display_name)),
+        (
+            "highest_priority",
+            integer(constraint.highest_priority as i64),
+        ),
+        (
+            "affected_integration_ids",
+            JsonValue::Array(
+                constraint
+                    .affected_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "affected_integration_count",
+            integer(constraint.affected_integration_count() as i64),
+        ),
+        (
+            "blocks_activation",
+            JsonValue::Bool(constraint.blocks_activation),
+        ),
+        (
+            "requires_human_review",
+            JsonValue::Bool(constraint.requires_human_review),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(constraint.highest_policy_tier)),
+        ),
+        (
+            "policy_surfaces",
+            JsonValue::Array(
+                constraint
+                    .policy_surfaces
+                    .iter()
+                    .map(|surface| string(surface.as_str()))
+                    .collect(),
+            ),
+        ),
+    ])
+}
+
+fn integration_activation_constraint_summary_json(
+    summary: &IntegrationActivationConstraintSummary,
+) -> JsonValue {
+    object([
+        (
+            "total_constraints",
+            integer(summary.total_constraints as i64),
+        ),
+        (
+            "blocking_constraints",
+            integer(summary.blocking_constraints as i64),
+        ),
+        (
+            "review_constraints",
+            integer(summary.review_constraints as i64),
+        ),
+        (
+            "primitive_constraints",
+            integer(summary.primitive_constraints as i64),
+        ),
+        (
+            "capability_constraints",
+            integer(summary.capability_constraints as i64),
+        ),
+        (
+            "dependency_constraints",
+            integer(summary.dependency_constraints as i64),
+        ),
+        (
+            "policy_review_constraints",
+            integer(summary.policy_review_constraints as i64),
+        ),
+        (
+            "affected_integrations",
+            integer(summary.affected_integrations as i64),
+        ),
+        (
+            "first_blocking_priority",
+            summary
+                .first_blocking_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+    ])
+}
+
 fn activation_dependency_node_json(node: &IntegrationActivationDependencyNode) -> JsonValue {
     object([
         ("integration_id", string(node.integration_id.as_str())),
@@ -10392,6 +10676,28 @@ fn parse_activation_health_status(
     }
 }
 
+fn parse_activation_constraint_kind(
+    label: &str,
+) -> Result<IntegrationActivationConstraintKind, ToolCallError> {
+    match label {
+        "primitive" | "missing_primitive" | "primitives" => {
+            Ok(IntegrationActivationConstraintKind::Primitive)
+        }
+        "capability" | "missing_capability" | "capabilities" | "grant" => {
+            Ok(IntegrationActivationConstraintKind::Capability)
+        }
+        "dependency" | "missing_dependency" | "dependencies" => {
+            Ok(IntegrationActivationConstraintKind::Dependency)
+        }
+        "policy_review" | "policy" | "human_review" | "review" => {
+            Ok(IntegrationActivationConstraintKind::PolicyReview)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation constraint kind `{label}`"
+        ))),
+    }
+}
+
 fn activation_candidate_recommendation_label(
     recommendation: IntegrationActivationCandidateRecommendation,
 ) -> &'static str {
@@ -11169,6 +11475,25 @@ fn integration_activation_health_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_constraint_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("constraint_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("blocking_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "constraint_requires_human_review",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("constraint_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_dependency_query_schema() -> JsonSchema {
     let mut schema = integration_readiness_query_schema(true);
     if let JsonSchema::Object {
@@ -11293,7 +11618,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 69);
+        assert_eq!(definitions.len(), 71);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -11367,6 +11692,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID));
@@ -11470,7 +11801,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            61
+            63
         );
         assert_eq!(
             export
@@ -11566,6 +11897,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -11820,11 +12159,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(69))
+            Some(&integer(71))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(61))
+            Some(&integer(63))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -12708,6 +13047,129 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_constraints_request = request(
+            "call-list-integration-activation-constraints",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("blocking_only", JsonValue::Bool(true)),
+                ("constraint_limit", integer(3)),
+            ]),
+            5_007,
+        );
+        let list_activation_constraints_trace =
+            tool_runtime.invoke_with_events(&list_activation_constraints_request);
+        assert!(list_activation_constraints_trace.result.ok);
+        assert_eq!(
+            list_activation_constraints_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_constraints_output = list_activation_constraints_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_activation_constraints_output, "count"),
+            Some(&integer(3))
+        );
+        let activation_constraint_summary =
+            field(list_activation_constraints_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_constraint_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_constraint_summary, "blocking_constraints").unwrap())
+                .unwrap()
+                >= 1
+        );
+        let activation_constraint = array_item(
+            field(list_activation_constraints_output, "activation_constraints").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_constraint, "blocks_activation"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(matches!(
+            field(activation_constraint, "constraint_kind"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(
+            integer_value(field(activation_constraint, "affected_integration_count").unwrap())
+                .unwrap()
+                >= 1
+        );
+
+        let activation_constraint_summary_request = request(
+            "call-integration-activation-constraint-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("constraint_kind", string("policy_review")),
+            ]),
+            5_008,
+        );
+        let activation_constraint_summary_trace =
+            tool_runtime.invoke_with_events(&activation_constraint_summary_request);
+        assert!(activation_constraint_summary_trace.result.ok);
+        assert_eq!(
+            activation_constraint_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_constraint_summary_output = activation_constraint_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_constraint_rollup =
+            field(activation_constraint_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(
+                field(activation_constraint_rollup, "policy_review_constraints").unwrap()
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_constraint_rollup, "has_review_work"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_dependencies_request = request(
             "call-list-integration-activation-dependencies",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPENDENCIES_TOOL_ID,
@@ -12732,7 +13194,7 @@ mod tests {
                     JsonValue::Array(vec![string("mqtt")]),
                 ),
             ]),
-            5_007,
+            5_009,
         );
         let list_activation_dependencies_trace =
             tool_runtime.invoke_with_events(&list_activation_dependencies_request);
@@ -12810,7 +13272,7 @@ mod tests {
                 ("blocking_only", JsonValue::Bool(true)),
                 ("edge_limit", integer(2)),
             ]),
-            5_008,
+            5_010,
         );
         let activation_dependency_summary_trace =
             tool_runtime.invoke_with_events(&activation_dependency_summary_request);
@@ -14255,6 +14717,14 @@ mod tests {
             activation_health_summary_trace,
         );
         journal.record_trace(
+            list_activation_constraints_request,
+            list_activation_constraints_trace,
+        );
+        journal.record_trace(
+            activation_constraint_summary_request,
+            activation_constraint_summary_trace,
+        );
+        journal.record_trace(
             list_activation_dependencies_request,
             list_activation_dependencies_trace,
         );
@@ -14322,9 +14792,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 69);
-        assert_eq!(journal_summary.completed_count, 69);
-        assert_eq!(journal.audit_records().len(), 69);
+        assert_eq!(journal_summary.invocation_count, 71);
+        assert_eq!(journal_summary.completed_count, 71);
+        assert_eq!(journal.audit_records().len(), 71);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_health` and
   `smart_home.get_integration_activation_health_summary` tool descriptors for
   read-only rollout-priority activation health planning.
+- `smart_home.list_integration_activation_constraints` and
+  `smart_home.get_integration_activation_constraint_summary` tool descriptors
+  for read-only grouped activation constraint planning.
 - `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary` tool descriptors
   for read-only activation dependency graph planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -64,6 +64,8 @@ Current scope:
   grouping and compact actionable/blocker summaries
 - D18D integration activation-health descriptors for priority-wave ready,
   review, blocked, and missing-prerequisite status summaries
+- D18D integration activation-constraint descriptors for grouped primitive,
+  capability, dependency, and policy-review blocker summaries
 - D18D integration-readiness descriptors for bulk activation blocker reports
   and compact readiness rollups
 - D18D integration-readiness gap descriptors for grouped primitive,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1469,6 +1469,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationRunwaySummary,
     ListIntegrationActivationHealth,
     GetIntegrationActivationHealthSummary,
+    ListIntegrationActivationConstraints,
+    GetIntegrationActivationConstraintSummary,
     ListIntegrationActivationDependencies,
     GetIntegrationActivationDependencySummary,
     ListIntegrationReadiness,
@@ -1580,6 +1582,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationHealthSummary => {
                 read_tool("smart_home.get_integration_activation_health_summary")
+            }
+            Self::ListIntegrationActivationConstraints => {
+                read_tool("smart_home.list_integration_activation_constraints")
+            }
+            Self::GetIntegrationActivationConstraintSummary => {
+                read_tool("smart_home.get_integration_activation_constraint_summary")
             }
             Self::ListIntegrationActivationDependencies => {
                 read_tool("smart_home.list_integration_activation_dependencies")
@@ -2226,6 +2234,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
         SmartHomeTool::ListIntegrationActivationHealth,
         SmartHomeTool::GetIntegrationActivationHealthSummary,
+        SmartHomeTool::ListIntegrationActivationConstraints,
+        SmartHomeTool::GetIntegrationActivationConstraintSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
         SmartHomeTool::GetIntegrationActivationDependencySummary,
         SmartHomeTool::ListIntegrationReadiness,
@@ -3066,7 +3076,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 69);
+        assert_eq!(catalog.len(), 71);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3166,6 +3176,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_health_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_constraints"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_constraint_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3356,15 +3374,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 69);
-        assert_eq!(summary.read_tools, 61);
+        assert_eq!(summary.total_tools, 71);
+        assert_eq!(summary.read_tools, 63);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 61);
+        assert_eq!(summary.read_only_tier_tools, 63);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 69);
+        assert_eq!(summary.total_required_capabilities, 71);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -53,6 +53,10 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationHealthStage` and `IntegrationActivationHealthSummary`
   for compact ready, review, blocked, and missing-prerequisite priority-wave
   status rollups.
+- `IntegrationActivationConstraint` and
+  `IntegrationActivationConstraintSummary` for grouping unresolved primitive,
+  capability, dependency, and policy-review surface work by affected
+  integrations.
 - `IntegrationActivationDependencyGraph` plus node, edge, and summary types for
   exposing satisfied and blocking integration prerequisites in rollout plans.
 - Integration readiness reports that expose missing primitive families, missing

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -46,6 +46,8 @@ runtime and Chief of Staff tools a typed catalog for:
   with compact ready, review, and blocker rollups
 - activation health stages that add priority-wave ready, review, blocked, and
   missing-prerequisite gap rollups for compact platform status inspection
+- activation constraints that group unresolved primitive, capability,
+  dependency, and policy-review surface work by affected integrations
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,
   and blocking edges after applying host-specific enabled-integration context
 - readiness reports that compare activation plans against available primitives,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1033,6 +1033,14 @@ pub enum IntegrationActivationActionKind {
     EnableDependency,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationConstraintKind {
+    Primitive,
+    Capability,
+    Dependency,
+    PolicyReview,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationCandidate {
     pub readiness_report: IntegrationReadinessReport,
@@ -1086,6 +1094,34 @@ pub struct IntegrationActivationActionSummary {
     pub first_action_priority: Option<u8>,
     pub first_activation_priority: Option<u8>,
     pub first_blocker_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationConstraint {
+    pub kind: IntegrationActivationConstraintKind,
+    pub constraint_id: String,
+    pub display_name: String,
+    pub highest_priority: u8,
+    pub affected_integration_ids: Vec<IntegrationId>,
+    pub blocks_activation: bool,
+    pub requires_human_review: bool,
+    pub highest_policy_tier: PrivilegeTier,
+    pub policy_surfaces: Vec<IntegrationPolicySurface>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationConstraintSummary {
+    pub total_constraints: usize,
+    pub blocking_constraints: usize,
+    pub review_constraints: usize,
+    pub primitive_constraints: usize,
+    pub capability_constraints: usize,
+    pub dependency_constraints: usize,
+    pub policy_review_constraints: usize,
+    pub affected_integrations: usize,
+    pub first_blocking_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
 }
 
@@ -1738,6 +1774,97 @@ impl IntegrationActivationHealthSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationConstraintKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Primitive => "primitive",
+            Self::Capability => "capability",
+            Self::Dependency => "dependency",
+            Self::PolicyReview => "policy_review",
+        }
+    }
+}
+
+impl IntegrationActivationConstraint {
+    pub fn affected_integration_count(&self) -> usize {
+        self.affected_integration_ids.len()
+    }
+}
+
+impl IntegrationActivationConstraintSummary {
+    pub fn from_constraints<'a>(
+        constraints: impl IntoIterator<Item = &'a IntegrationActivationConstraint>,
+    ) -> Self {
+        let mut affected_integrations = BTreeSet::new();
+        let mut summary = Self {
+            total_constraints: 0,
+            blocking_constraints: 0,
+            review_constraints: 0,
+            primitive_constraints: 0,
+            capability_constraints: 0,
+            dependency_constraints: 0,
+            policy_review_constraints: 0,
+            affected_integrations: 0,
+            first_blocking_priority: None,
+            first_review_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for constraint in constraints {
+            summary.total_constraints += 1;
+            if constraint.blocks_activation {
+                summary.blocking_constraints += 1;
+                summary.first_blocking_priority = min_optional_priority(
+                    summary.first_blocking_priority,
+                    Some(constraint.highest_priority),
+                );
+            }
+            if constraint.requires_human_review {
+                summary.review_constraints += 1;
+                summary.first_review_priority = min_optional_priority(
+                    summary.first_review_priority,
+                    Some(constraint.highest_priority),
+                );
+            }
+            match constraint.kind {
+                IntegrationActivationConstraintKind::Primitive => {
+                    summary.primitive_constraints += 1
+                }
+                IntegrationActivationConstraintKind::Capability => {
+                    summary.capability_constraints += 1
+                }
+                IntegrationActivationConstraintKind::Dependency => {
+                    summary.dependency_constraints += 1
+                }
+                IntegrationActivationConstraintKind::PolicyReview => {
+                    summary.policy_review_constraints += 1
+                }
+            }
+            for integration_id in &constraint.affected_integration_ids {
+                affected_integrations.insert(integration_id.clone());
+            }
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(constraint.highest_policy_tier);
+        }
+
+        summary.affected_integrations = affected_integrations.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_constraints == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocking_constraints > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_constraints > 0
     }
 }
 
@@ -3727,6 +3854,174 @@ pub fn activation_health_at_or_before_priority(
     ))
 }
 
+pub fn activation_constraints_from_candidates<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationConstraint> {
+    let candidates = candidates.into_iter().collect::<Vec<_>>();
+    let policy_tier_by_integration = candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.readiness_report.requested_integration_id.clone(),
+                candidate.readiness_report.highest_policy_tier,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let gap_inventory = readiness_gap_inventory_from_reports(
+        candidates
+            .iter()
+            .map(|candidate| &candidate.readiness_report),
+    );
+    let mut constraints = Vec::new();
+
+    for gap in gap_inventory.primitive_gaps {
+        let primitive = describe_primitive_family(gap.primitive);
+        constraints.push(IntegrationActivationConstraint {
+            kind: IntegrationActivationConstraintKind::Primitive,
+            constraint_id: format!("primitive:{}", gap.primitive.as_str()),
+            display_name: primitive.display_name.to_string(),
+            highest_priority: gap.highest_priority,
+            highest_policy_tier: highest_policy_tier_for_integrations(
+                &gap.integration_ids,
+                &policy_tier_by_integration,
+            ),
+            affected_integration_ids: gap.integration_ids,
+            blocks_activation: true,
+            requires_human_review: false,
+            policy_surfaces: Vec::new(),
+        });
+    }
+
+    for gap in gap_inventory.capability_gaps {
+        constraints.push(IntegrationActivationConstraint {
+            kind: IntegrationActivationConstraintKind::Capability,
+            constraint_id: format!("capability:{}", gap.capability_id.as_str()),
+            display_name: gap.capability_id.as_str().to_string(),
+            highest_priority: gap.highest_priority,
+            highest_policy_tier: highest_policy_tier_for_integrations(
+                &gap.integration_ids,
+                &policy_tier_by_integration,
+            ),
+            affected_integration_ids: gap.integration_ids,
+            blocks_activation: true,
+            requires_human_review: false,
+            policy_surfaces: Vec::new(),
+        });
+    }
+
+    for gap in gap_inventory.dependency_gaps {
+        constraints.push(IntegrationActivationConstraint {
+            kind: IntegrationActivationConstraintKind::Dependency,
+            constraint_id: format!("dependency:{}", gap.integration_id.as_str()),
+            display_name: gap.integration_id.as_str().to_string(),
+            highest_priority: gap.highest_priority,
+            highest_policy_tier: highest_policy_tier_for_integrations(
+                &gap.requested_integration_ids,
+                &policy_tier_by_integration,
+            ),
+            affected_integration_ids: gap.requested_integration_ids,
+            blocks_activation: true,
+            requires_human_review: false,
+            policy_surfaces: Vec::new(),
+        });
+    }
+
+    let mut policy_review_constraints: BTreeMap<
+        Option<IntegrationPolicySurface>,
+        (u8, BTreeSet<IntegrationId>, PrivilegeTier),
+    > = BTreeMap::new();
+
+    for candidate in candidates {
+        if !candidate.requires_human_review() {
+            continue;
+        }
+
+        let policy_surfaces = find_entry(
+            catalog,
+            &candidate.readiness_report.requested_integration_id,
+        )
+        .map(IntegrationCatalogEntry::policy_surfaces)
+        .unwrap_or_default();
+
+        if policy_surfaces.is_empty() {
+            let (highest_priority, integration_ids, highest_policy_tier) =
+                policy_review_constraints.entry(None).or_insert((
+                    candidate.readiness_report.priority,
+                    BTreeSet::new(),
+                    candidate.readiness_report.highest_policy_tier,
+                ));
+            *highest_priority = (*highest_priority).min(candidate.readiness_report.priority);
+            integration_ids.insert(candidate.readiness_report.requested_integration_id.clone());
+            *highest_policy_tier =
+                (*highest_policy_tier).max(candidate.readiness_report.highest_policy_tier);
+            continue;
+        }
+
+        for surface in policy_surfaces {
+            let (highest_priority, integration_ids, highest_policy_tier) =
+                policy_review_constraints.entry(Some(surface)).or_insert((
+                    candidate.readiness_report.priority,
+                    BTreeSet::new(),
+                    surface.required_tier(),
+                ));
+            *highest_priority = (*highest_priority).min(candidate.readiness_report.priority);
+            integration_ids.insert(candidate.readiness_report.requested_integration_id.clone());
+            *highest_policy_tier = (*highest_policy_tier)
+                .max(surface.required_tier())
+                .max(candidate.readiness_report.highest_policy_tier);
+        }
+    }
+
+    for (surface, (highest_priority, integration_ids, highest_policy_tier)) in
+        policy_review_constraints
+    {
+        let (constraint_id, display_name, policy_surfaces) = match surface {
+            Some(surface) => (
+                format!("policy_review:{}", surface.as_str()),
+                surface.as_str().to_string(),
+                vec![surface],
+            ),
+            None => (
+                "policy_review:human_approval".to_string(),
+                "human_approval".to_string(),
+                Vec::new(),
+            ),
+        };
+        constraints.push(IntegrationActivationConstraint {
+            kind: IntegrationActivationConstraintKind::PolicyReview,
+            constraint_id,
+            display_name,
+            highest_priority,
+            affected_integration_ids: integration_ids.into_iter().collect(),
+            blocks_activation: false,
+            requires_human_review: true,
+            highest_policy_tier,
+            policy_surfaces,
+        });
+    }
+
+    constraints.sort_by(compare_activation_constraints);
+    constraints
+}
+
+pub fn activation_constraints_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationConstraint> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_constraints_from_candidates(catalog, candidates.iter())
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -4840,6 +5135,17 @@ fn activation_health_status_from_counts(
     }
 }
 
+fn highest_policy_tier_for_integrations(
+    integration_ids: &[IntegrationId],
+    policy_tier_by_integration: &BTreeMap<IntegrationId, PrivilegeTier>,
+) -> PrivilegeTier {
+    integration_ids
+        .iter()
+        .filter_map(|integration_id| policy_tier_by_integration.get(integration_id).copied())
+        .max()
+        .unwrap_or(PrivilegeTier::ReadOnly)
+}
+
 fn compare_activation_candidates(
     left: &IntegrationActivationCandidate,
     right: &IntegrationActivationCandidate,
@@ -4882,6 +5188,22 @@ fn compare_activation_actions(
             left.dependency_integration_id
                 .cmp(&right.dependency_integration_id)
         })
+}
+
+fn compare_activation_constraints(
+    left: &IntegrationActivationConstraint,
+    right: &IntegrationActivationConstraint,
+) -> Ordering {
+    left.highest_priority
+        .cmp(&right.highest_priority)
+        .then_with(|| left.kind.cmp(&right.kind))
+        .then_with(|| {
+            right
+                .affected_integration_ids
+                .len()
+                .cmp(&left.affected_integration_ids.len())
+        })
+        .then_with(|| left.constraint_id.cmp(&right.constraint_id))
 }
 
 fn compare_activation_dependency_nodes(
@@ -5618,6 +5940,73 @@ mod tests {
         assert!(summary.has_review_work());
         assert!(summary.has_blockers());
         assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_constraints_group_readiness_and_policy_review_work() {
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let candidates = activation_candidates_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+
+        let constraints = activation_constraints_from_candidates(&catalog, candidates.iter());
+
+        assert!(constraints.iter().any(|constraint| constraint.kind
+            == IntegrationActivationConstraintKind::Primitive
+            && constraint.blocks_activation));
+        assert!(constraints.iter().any(|constraint| constraint.kind
+            == IntegrationActivationConstraintKind::Capability
+            && constraint.blocks_activation));
+        assert!(constraints.iter().any(|constraint| constraint.kind
+            == IntegrationActivationConstraintKind::Dependency
+            && constraint.blocks_activation));
+        let policy_review = constraints
+            .iter()
+            .find(|constraint| constraint.kind == IntegrationActivationConstraintKind::PolicyReview)
+            .unwrap();
+        assert!(policy_review.requires_human_review);
+        assert!(!policy_review.blocks_activation);
+        assert!(!policy_review.policy_surfaces.is_empty());
+        assert_eq!(
+            policy_review.kind.as_str(),
+            IntegrationActivationConstraintKind::PolicyReview.as_str()
+        );
+
+        let summary = IntegrationActivationConstraintSummary::from_constraints(constraints.iter());
+        assert_eq!(summary.total_constraints, constraints.len());
+        assert!(summary.blocking_constraints >= 3);
+        assert!(summary.review_constraints > 0);
+        assert!(summary.primitive_constraints > 0);
+        assert!(summary.capability_constraints > 0);
+        assert!(summary.dependency_constraints > 0);
+        assert!(summary.policy_review_constraints > 0);
+        assert!(summary.affected_integrations > 0);
+        assert!(summary.first_blocking_priority <= Some(2));
+        assert!(summary.first_review_priority <= Some(2));
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(!summary.is_empty());
+
+        let constraints_from_catalog = activation_constraints_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert_eq!(constraints, constraints_from_catalog);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-owned activation constraint grouping for primitive, capability, dependency, and policy-review blockers
- expose the constraint list/summary as shared smart-home core descriptors and Chief D18D tools
- cover constraint output in the Chief end-to-end smart-home tool journal and package docs

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools