### PR TITLE
Enable ALGOL nested block scopes on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! The first slice is intentionally conservative: it supports scalar
 //! `integer` and `boolean` programs only. ALGOL features that need a richer
-//! runtime model, such as arrays, procedures, strings, reals, switches, nested
-//! declaration scopes, and by-name calls, fail with explicit errors instead of
+//! runtime model, such as arrays, procedures, strings, reals, switches, and
+//! by-name calls, fail with explicit errors instead of
 //! silently producing partial IR.
 
 #![warn(missing_docs)]
@@ -141,6 +141,12 @@ struct ExprValue {
     ty: ScalarType,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VarBinding {
+    slot: String,
+    ty: ScalarType,
+}
+
 #[derive(Debug, Clone)]
 enum Piece<'a> {
     Node(&'a GrammarASTNode),
@@ -151,7 +157,8 @@ struct Compiler {
     instrs: Vec<IIRInstr>,
     source_map: Vec<SourceLoc>,
     current_loc: Cell<SourceLoc>,
-    vars: HashMap<String, ScalarType>,
+    scopes: Vec<HashMap<String, VarBinding>>,
+    scope_counter: usize,
     temp_counter: usize,
     label_counter: usize,
     register_names: HashSet<String>,
@@ -165,7 +172,8 @@ impl Default for Compiler {
             instrs: Vec::new(),
             source_map: Vec::new(),
             current_loc: Cell::new(SourceLoc::SYNTHETIC),
-            vars: HashMap::new(),
+            scopes: vec![HashMap::new()],
+            scope_counter: 0,
             temp_counter: 0,
             label_counter: 0,
             register_names: HashSet::new(),
@@ -185,8 +193,13 @@ impl Compiler {
             }
         }
 
-        let (return_type, return_src) = match self.vars.get("result").copied() {
-            Some(ty) => (ty.iir(), Operand::Var("result".to_string())),
+        let (return_type, return_src) = match self
+            .scopes
+            .first()
+            .and_then(|scope| scope.get("result"))
+            .cloned()
+        {
+            Some(binding) => (binding.ty.iir(), Operand::Var(binding.slot)),
             None => {
                 self.emit(IIRInstr::new(
                     "const",
@@ -228,14 +241,8 @@ impl Compiler {
     fn emit_block(&mut self, node: &GrammarASTNode, is_root: bool) -> Result<(), CompileError> {
         self.set_loc(node);
 
-        if !is_root
-            && direct_nodes(node)
-                .iter()
-                .any(|n| n.rule_name == "declaration")
-        {
-            return Err(CompileError::Unsupported(
-                "nested block declarations and lexical scope".into(),
-            ));
+        if !is_root {
+            self.push_scope();
         }
 
         for child in direct_nodes(node) {
@@ -247,6 +254,9 @@ impl Compiler {
             if child.rule_name == "statement" {
                 self.emit_statement(child)?;
             }
+        }
+        if !is_root {
+            self.pop_scope();
         }
         Ok(())
     }
@@ -273,15 +283,10 @@ impl Compiler {
             .filter(|t| t.effective_type_name() == "NAME")
             .map(|t| t.value.clone())
         {
-            if self.vars.insert(name.clone(), ty).is_some() {
-                return Err(CompileError::Type(format!(
-                    "duplicate declaration for {name:?}"
-                )));
-            }
-            self.register_names.insert(name.clone());
+            let slot = self.declare_var(&name, ty)?;
             self.emit(IIRInstr::new(
                 "const",
-                Some(name),
+                Some(slot),
                 vec![ty.default_operand()],
                 ty.iir(),
             ));
@@ -378,19 +383,19 @@ impl Compiler {
             let var_node = first_direct_node(left, "variable")
                 .ok_or_else(|| CompileError::Malformed("left_part has no variable".into()))?;
             let name = self.simple_variable_name(var_node)?;
-            let expected = self.require_var(&name)?;
-            if expected != rhs.ty {
+            let binding = self.require_var(&name)?;
+            if binding.ty != rhs.ty {
                 return Err(CompileError::Type(format!(
                     "cannot assign {} expression to {} variable {name:?}",
                     rhs.ty.name(),
-                    expected.name()
+                    binding.ty.name()
                 )));
             }
             self.emit(IIRInstr::new(
                 "mov",
-                Some(name),
+                Some(binding.slot),
                 vec![Operand::Var(rhs.slot.clone())],
-                expected.iir(),
+                binding.ty.iir(),
             ));
         }
         Ok(())
@@ -475,8 +480,8 @@ impl Compiler {
             .find(|t| t.effective_type_name() == "NAME")
             .map(|t| t.value.clone())
             .ok_or_else(|| CompileError::Malformed("for_stmt missing loop variable".into()))?;
-        let var_ty = self.require_var(&var_name)?;
-        if var_ty != ScalarType::Integer {
+        let var_binding = self.require_var(&var_name)?;
+        if var_binding.ty != ScalarType::Integer {
             return Err(CompileError::Type(format!(
                 "for variable {var_name:?} must be integer"
             )));
@@ -497,7 +502,7 @@ impl Compiler {
             .ok_or_else(|| CompileError::Malformed("for_stmt missing body statement".into()))?;
 
         for elem in elems {
-            self.emit_for_element(&var_name, elem, body)?;
+            self.emit_for_element(&var_binding.slot, elem, body)?;
         }
         Ok(())
     }
@@ -689,8 +694,11 @@ impl Compiler {
         match node.rule_name.as_str() {
             "variable" => {
                 let name = self.simple_variable_name(node)?;
-                let ty = self.require_var(&name)?;
-                Ok(ExprValue { slot: name, ty })
+                let binding = self.require_var(&name)?;
+                Ok(ExprValue {
+                    slot: binding.slot,
+                    ty: binding.ty,
+                })
             }
             "proc_call" => Err(CompileError::Unsupported(
                 "procedure calls in expressions".into(),
@@ -910,8 +918,11 @@ impl Compiler {
             }
             ("NAME", _) => {
                 let name = token.value.clone();
-                let ty = self.require_var(&name)?;
-                Ok(ExprValue { slot: name, ty })
+                let binding = self.require_var(&name)?;
+                Ok(ExprValue {
+                    slot: binding.slot,
+                    ty: binding.ty,
+                })
             }
             _ => Err(CompileError::Malformed(format!(
                 "unexpected atom token {} {:?}",
@@ -1189,10 +1200,49 @@ impl Compiler {
         name
     }
 
-    fn require_var(&self, name: &str) -> Result<ScalarType, CompileError> {
-        self.vars
-            .get(name)
-            .copied()
+    fn push_scope(&mut self) {
+        self.scope_counter += 1;
+        self.scopes.push(HashMap::new());
+    }
+
+    fn pop_scope(&mut self) {
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
+    }
+
+    fn declare_var(&mut self, name: &str, ty: ScalarType) -> Result<String, CompileError> {
+        let slot = if self.scopes.len() == 1 {
+            name.to_string()
+        } else {
+            format!("__algol_s{}_{}", self.scope_counter, name)
+        };
+        let current = self
+            .scopes
+            .last_mut()
+            .expect("compiler always keeps a root scope");
+        if current.contains_key(name) {
+            return Err(CompileError::Type(format!(
+                "duplicate declaration for {name:?}"
+            )));
+        }
+        current.insert(
+            name.to_string(),
+            VarBinding {
+                slot: slot.clone(),
+                ty,
+            },
+        );
+        self.register_names.insert(slot.clone());
+        Ok(slot)
+    }
+
+    fn require_var(&self, name: &str) -> Result<VarBinding, CompileError> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.get(name))
+            .cloned()
             .ok_or_else(|| CompileError::Type(format!("use of undeclared variable {name:?}")))
     }
 
@@ -1485,6 +1535,12 @@ mod tests {
     #[test]
     fn compiles_and_runs_boolean_conditional_expression() {
         let src = "begin boolean flag; integer result; flag := true; if if flag then true else false then result := 42 else result := 1 end";
+        assert_eq!(run_i64(src), 42);
+    }
+
+    #[test]
+    fn compiles_and_runs_nested_block_shadowing() {
+        let src = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
         assert_eq!(run_i64(src), 42);
     }
 

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -15,6 +15,8 @@ const ALGOL_FOR_LIST: &str = "begin integer i, result; i := 0; result := 0; for 
 
 const ALGOL_COND_EXPR: &str = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
 
+const ALGOL_NESTED_BLOCKS: &str = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
+
 fn compile_case(source: &str, module_name: &str) -> interpreter_ir::IIRModule {
     compile_source(source, module_name).expect("ALGOL source should compile")
 }
@@ -39,6 +41,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "cond_expr",
             compile_case(ALGOL_COND_EXPR, "algol_cond_expr_backend_compat"),
+        ),
+        (
+            "nested_blocks",
+            compile_case(ALGOL_NESTED_BLOCKS, "algol_nested_blocks_backend_compat"),
         ),
     ] {
         let checks = [
@@ -267,4 +273,55 @@ fn algol_conditional_expressions_lower_to_wasm_jvm_clr_beam_and_llvm() {
         llvm.contains("br i1"),
         "LLVM should lower conditional expressions as branches"
     );
+}
+
+#[test]
+fn algol_nested_blocks_lower_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_NESTED_BLOCKS, "algol_nested_blocks_backend_compat");
+    assert!(
+        module
+            .functions
+            .iter()
+            .flat_map(|func| func.instructions.iter())
+            .filter_map(|instr| instr.dest.as_deref())
+            .any(|dest| dest.starts_with("__algol_s")),
+        "ALGOL nested blocks should allocate scoped IIR slots for shadowed locals"
+    );
+
+    let wasm = iir_to_wasm::lower_iir_to_wasm(
+        &module,
+        &iir_to_wasm::IIRWasmConfig::new("AlgolNestedBlocks"),
+    )
+    .expect("ALGOL nested-block IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolNestedBlocks"),
+    )
+    .expect("ALGOL nested-block IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL nested-block IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam = iir_to_beam::lower_iir_to_beam(
+        &module,
+        &iir_to_beam::IIRBeamConfig::new("algol_nested_blocks"),
+    )
+    .expect("ALGOL nested-block IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm = iir_to_llvm::lower_iir_to_llvm(
+        &module,
+        &iir_to_llvm::IIRLlvmConfig::new("algol_nested_blocks"),
+    )
+    .expect("ALGOL nested-block IIR should lower to LLVM");
+    assert!(llvm.contains("define i64 @main()"));
 }

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -109,3 +109,29 @@ fn algol_conditional_expression_program_runs_through_generic_jit() {
     }
     assert_eq!(result.as_i64(), Some(42));
 }
+
+#[test]
+fn algol_nested_block_program_runs_through_generic_jit() {
+    let source = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
+    let mut module = compile_source(source, "algol_nested_blocks_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(42));
+}

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -150,6 +150,20 @@ fn algol_conditional_expressions_emit_and_run_on_wasm() {
     assert_eq!(result, vec![42], "ALGOL conditional expressions should return 42");
 }
 
+#[test]
+fn algol_nested_blocks_emit_and_run_on_wasm() {
+    let source = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_nested_blocks")
+        .expect("ALGOL nested blocks should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL nested blocks)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL nested-block wasm must run");
+    assert_eq!(result, vec![42], "ALGOL nested blocks should return 42");
+}
+
 /// The L3b-3a-3c capstone: a **cons** program compiles to WasmGC and runs
 /// end-to-end on the in-repo runtime. The uniform-anyref value model boxes the
 /// integer atoms as `i31ref`, allocates a `$LispyPair`, and unboxes the result


### PR DESCRIPTION
## Summary
- replace the ALGOL compiler's flat variable table with a lexical scope stack
- allow nested scalar block declarations with shadowing by lowering locals to scoped IIR slots
- keep root variables ABI-stable, including `result` as the `main` return source
- add VM, GenericCirJit, direct WASM/JVM/CLR/BEAM/LLVM, and AOT/WASM runtime coverage

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol_nested_blocks_emit_and_run_on_wasm`
- `cargo test -p iir-to-llvm`
- `git diff --check`

## Security review
- touched-file scan for `unsafe`, process/file/env/include APIs, and panic/unwrap hotspots found only existing-style JIT test assertions plus the new matching test assertion
- no dependencies added; push reported existing default-branch Dependabot alerts unrelated to this branch
- `cargo audit` and `cargo deny` are not installed in this workspace, so those checks could not be run
