### PR TITLE
feat(closurec): CLOC12.56 — close gap-049 (flattened for-body `;` suppression)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.61.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-049** — gap-032's single-statement flatten now
+  peeks the token after the closing `}`. When the next token
+  is another `}`, the trailing `;` is suppressed from the
+  inline emission.
+- `function f(){for(var v of a){a;}}` → `function f(){for(var v of a)a};`
+  (was: `function f(){for(var v of a)a;};`)
+- Affects all loop/conditional flattening: `for`, `for-of`,
+  `for-in`, `for-await-of`, `while`, `if` (and the inner arm
+  of `if-else`). All produce one byte less when wrapped in a
+  function body or another block.
+
+### Fixed
+
+`gap032_nested_if_does_not_flatten` expectation tightened —
+`if(x){if(y){a();}}` now produces `if(x){if(y)a()}` (15 bytes)
+instead of `if(x){if(y)a();}` (17 bytes). Both are valid JS;
+the new form is one byte closer to upstream's
+`if(x)if(y)a();` (16 bytes, requires also flattening through
+the outer `if` keyword — a separate future improvement).
+
+### Added
+
+6 inline `gap049_*` tests covering for-of/for-in/while
+flattening + 3 explicit non-regression cases (top-level
+flatten preserves `;`, if-else inside function suppresses
+correctly).
+
 ## [0.60.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -436,8 +436,29 @@ pub fn whitespace_only_minify(
                     && semi_count == 1
                     && last_before_close == ";";
                 if eligible {
+                    // gap-049: if the next token AFTER the
+                    // closing `}` is itself a `}` (outer
+                    // block boundary), the inlined trailing
+                    // `;` is redundant — Rule A would drop
+                    // a source `;` at this position, and
+                    // logically the inline `;` is occupying
+                    // exactly that slot. Without this
+                    // suppression we'd emit
+                    //   `function f(){for(var v of a)a;};`
+                    // when upstream Closure produces
+                    //   `function f(){for(var v of a)a};`.
+                    //
+                    // The check has to happen here (inside
+                    // the flatten) because once the
+                    // contents are pre-emitted, the main
+                    // state machine doesn't re-scan them
+                    // and Rule A only fires on tokens still
+                    // in `kept`.
+                    let next_after_close =
+                        kept.get(close_idx + 1).map(|t| t.value.as_str());
+                    let drop_trailing_semi = next_after_close == Some("}");
                     // Pre-emit content tokens (idx+1 ..
-                    // close_idx). Each token gets the same
+                    // emit_end). Each token gets the same
                     // separator + quoting treatment as the
                     // main loop, but the state machine isn't
                     // run on them — they're carried through
@@ -445,7 +466,15 @@ pub fn whitespace_only_minify(
                     // verified the contents are a single
                     // simple statement with no nested
                     // structure.
-                    for content_idx in (idx + 1)..close_idx {
+                    let emit_end = if drop_trailing_semi {
+                        // close_idx - 1 is the trailing `;`
+                        // (verified by `last_before_close ==
+                        // ";"` in the eligibility check).
+                        close_idx - 1
+                    } else {
+                        close_idx
+                    };
+                    for content_idx in (idx + 1)..emit_end {
                         let t = kept[content_idx];
                         if let Some(prev) = prev_emitted_tok {
                             if needs_separator(prev, t) {
@@ -1829,14 +1858,20 @@ mod tests {
         // so the outer block stays wrapped. The INNER
         // if-body, however, IS a single statement and DOES
         // get flattened by gap-032 — so `{a();}` becomes
-        // `a();`. The inner-flatten's `;` survives the
-        // outer block's closing `}` because the synthetic
-        // `;` from gap-032's pre-emit path bypasses rule A.
-        // Output is `if(x){if(y)a();}` — valid JS, just
-        // slightly less minimal than upstream might produce.
+        // `a();`. **gap-049 (CLOC12.56) further improves
+        // this**: the inner flatten now peeks the next
+        // token after its closing `}`. Since the outer
+        // block's `}` follows, the trailing `;` is
+        // suppressed. Output is `if(x){if(y)a()}` — one
+        // byte shorter than before (was `if(x){if(y)a();}`).
+        // Upstream Closure emits `if(x)if(y)a();` which is
+        // also more aggressive than us (it flattens the
+        // outer block too); matching that requires letting
+        // the outer flatten see through `if` keywords,
+        // which would be a separate future gap.
         assert_eq!(
             minify("if(x){if(y){a();}}"),
-            "if(x){if(y)a();}"
+            "if(x){if(y)a()}"
         );
     }
 
@@ -2531,6 +2566,68 @@ mod tests {
     #[test]
     fn gap046_empty_array_unchanged() {
         assert_eq!(minify("var a=[];"), "var a=[];");
+    }
+
+    // ---- gap-049: flattened for-body `;` suppression ----
+
+    /// Target case: for-of body flatten next to outer `}`.
+    #[test]
+    fn gap049_for_of_flat_drops_trailing_semi() {
+        assert_eq!(
+            minify("function f(){for(var v of a){a;}}"),
+            "function f(){for(var v of a)a};"
+        );
+    }
+
+    /// for-in body flatten — same family as for-of.
+    #[test]
+    fn gap049_for_in_flat_drops_trailing_semi() {
+        assert_eq!(
+            minify("function f(){for(var k in o){use(k);}}"),
+            "function f(){for(var k in o)use(k)};"
+        );
+    }
+
+    /// while-body flatten next to outer `}`.
+    #[test]
+    fn gap049_while_flat_drops_trailing_semi() {
+        assert_eq!(
+            minify("function f(){while(x){a();}}"),
+            "function f(){while(x)a()};"
+        );
+    }
+
+    /// **Non-regression**: flattened body NOT next to a
+    /// `}` keeps its `;`. `for(...) a();` at top level
+    /// still ends with `;` because next is EOF (gap-049
+    /// requires next-after-close to be specifically `}`).
+    #[test]
+    fn gap049_for_at_top_level_keeps_semi() {
+        assert_eq!(
+            minify("for(var v of a){a;}"),
+            "for(var v of a)a;"
+        );
+    }
+
+    /// **Non-regression**: if-body flattened at top level
+    /// keeps its `;` for the same reason.
+    #[test]
+    fn gap049_if_at_top_level_keeps_semi() {
+        assert_eq!(
+            minify("if(x){a();}"),
+            "if(x)a();"
+        );
+    }
+
+    /// **Non-regression**: if-else where the else-arm is
+    /// flattened next to outer `}`. The `;` of the else-arm
+    /// should still be suppressed.
+    #[test]
+    fn gap049_if_else_inside_function_drops_semi() {
+        assert_eq!(
+            minify("function f(){if(x){a();}else{b();}}"),
+            "function f(){if(x)a();else b()};"
+        );
     }
 
     // ---- gap-047: suppress `;` before stmt-keyword -------

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.60.0
+Version: 0.61.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -93,11 +93,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // gap-048 was RESOLVED in CLOC12.55 — BigInt token
     // path now strips ES2021 `_` numeric separators.
     // `minify_bigint_separator` flipped IGNORED → PASS.
-    // gap-049: flattened single-stmt for-body keeps
-    // stray `;` before outer `}`. Reproduces with regular
-    // `for(var v of a){a;}` inside a function — not
-    // for-await-of-specific. Discovered by CLOC14.13.
-    ("for_await_of", "gap-049: flattened for-body trailing `;` before `}`"),
+    // gap-049 was RESOLVED in CLOC12.56 — gap-032's
+    // flatten now peeks the token after the closing `}`;
+    // if it's another `}`, the trailing `;` is suppressed
+    // from the inline emission. `minify_for_await_of`
+    // flipped IGNORED → PASS.
     // gap-046 was RESOLVED in CLOC12.52 — `,` immediately
     // before `]` is now suppressed. `minify_trailing_array_comma`
     // flipped IGNORED → PASS. Object-literal trailing comma

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -378,3 +378,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **closurec:** `function f(){for(var v of a)a;};`
 - **Why it fails:** gap-032's single-stmt block-flatten unwraps `{a;}` → `a;`, but the resulting `;` between the for-body's last statement and the outer function-`}` is NOT dropped by Rule A. Rule A drops source `;` before `}`, but this `;` survives. Probable cause: gap-032's flatten happens after Rule A's pass (or in a different pipeline stage), so Rule A doesn't see this position again. Confirmed NOT specific to `for-await-of` — reproduces with plain `for-of`, `for-in`, and likely `if`/`while`/`do` flattened bodies.
 - **What it needs:** Either (1) re-run Rule A after gap-032 flatten, or (2) gap-032 itself peeks the next-after token; if it's `}`, drop the trailing `;` from the flattened content. Approach (2) is more local — the flatten knows exactly what it's emitting and what comes after.
+
+### gap-049 — flattened single-stmt for-body keeps trailing `;` before `}`
+
+- **Status:** **RESOLVED** in CLOC12.56 (PR pending). `minify_for_await_of` flipped IGNORED → PASS. Also tightened `gap032_nested_if_does_not_flatten` expectation (improvement: `if(x){if(y)a()}` instead of `if(x){if(y)a();}` — one byte shorter, still valid JS).
+- **Upstream byte-identity test:** `minify_for_await_of` seed fixture (general repro: `function f(){for(var v of a){a;}}`).
+- **Why it failed:** gap-032's flatten emitted content `(idx+1)..close_idx` verbatim, which always includes the trailing `;`. When the next token after the closing `}` was itself a `}`, that `;` became redundant — Rule A would have dropped a source `;` at that position, but Rule A doesn't re-scan pre-emitted content.
+- **Fix:** In gap-032's eligible branch, peek `kept.get(close_idx + 1)`. If it equals `}`, set emit_end to `close_idx - 1` (exclude the trailing `;` from the inline emission). The eligibility check already verified `last_before_close == ";"`, so this index is always the redundant `;`.


### PR DESCRIPTION
## Summary

**Closes gap-049.** \`minify_for_await_of\` flips IGNORED → PASS. When #5246 also lands, harness becomes **94/95** — **only gap-044 (lexer-level template substitution) remains**.

## Fix

gap-032's eligible-flatten branch now peeks the token after the closing \`}\`. When it's another \`}\`, the trailing \`;\` is excluded from the inline emission.

\`function f(){for(var v of a){a;}}\` → \`function f(){for(var v of a)a};\` (was: \`...a;};\`).

Applies to all flatten-eligible bodies: \`for\`/\`for-of\`/\`for-in\`/\`for-await-of\`/\`while\`/single-arm \`if\`/\`else\` inside wrapping blocks.

## Pre-push security review

PASS — verified index safety, EOF case, stmt-keyword case, empty-body edge case, side effects unchanged.

## Tests

6 inline \`gap049_*\` tests. Updated \`gap032_nested_if_does_not_flatten\` expectation (1 byte shorter, valid JS, still doesn't match upstream's even more aggressive flatten through outer \`if\`).

Full suite: **379 passed**.

## Version

0.59.0 → 0.60.0.

## Stacking

After #5245 (MERGED) and #5246 (in flight). #5246 also bumps to 0.60.0 — rebase may need to bump to 0.61.0 if #5246 merges first.

## Test plan

- [x] All inline tests pass
- [x] Harness fixture \`for_await_of\` flipped from IGNORED to PASS
- [x] Security review PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)