### PR TITLE
Enable ALGOL dynamic for step values on the IIR chain

### DIFF
--- a/code/packages/rust/algol-iir-compiler/src/lib.rs
+++ b/code/packages/rust/algol-iir-compiler/src/lib.rs
@@ -580,10 +580,6 @@ impl Compiler {
                 "for bounds and step must be integer".into(),
             ));
         }
-        let step_const = const_i64_from_node(arith_nodes[1])
-            .ok_or_else(|| CompileError::Unsupported("non-constant for step values".into()))?;
-        let cmp_op = if step_const >= 0 { "cmp_le" } else { "cmp_ge" };
-
         self.emit(IIRInstr::new(
             "mov",
             Some(var_name.to_string()),
@@ -591,22 +587,72 @@ impl Compiler {
             "i64",
         ));
 
+        let zero = self.emit_const(ScalarType::Integer, Operand::Int(0));
         let loop_label = self.fresh_label("for_loop");
+        let negative_check_label = self.fresh_label("for_negative_check");
+        let body_label = self.fresh_label("for_body");
         let end_label = self.fresh_label("for_end");
         self.emit_label(&loop_label);
-        let cond = self.fresh_temp();
+
+        let step_non_negative = self.fresh_temp();
         self.emit(IIRInstr::new(
-            cmp_op,
-            Some(cond.clone()),
-            vec![Operand::Var(var_name.to_string()), Operand::Var(limit.slot)],
+            "cmp_ge",
+            Some(step_non_negative.clone()),
+            vec![Operand::Var(step.slot.clone()), Operand::Var(zero)],
             "bool",
         ));
         self.emit(IIRInstr::new(
             "jmp_if_false",
             None,
-            vec![Operand::Var(cond), Operand::Var(end_label.clone())],
+            vec![
+                Operand::Var(step_non_negative),
+                Operand::Var(negative_check_label.clone()),
+            ],
             "void",
         ));
+
+        let positive_cond = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_le",
+            Some(positive_cond.clone()),
+            vec![
+                Operand::Var(var_name.to_string()),
+                Operand::Var(limit.slot.clone()),
+            ],
+            "bool",
+        ));
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(positive_cond), Operand::Var(end_label.clone())],
+            "void",
+        ));
+        self.emit(IIRInstr::new(
+            "jmp",
+            None,
+            vec![Operand::Var(body_label.clone())],
+            "void",
+        ));
+
+        self.emit_label(&negative_check_label);
+        let negative_cond = self.fresh_temp();
+        self.emit(IIRInstr::new(
+            "cmp_ge",
+            Some(negative_cond.clone()),
+            vec![
+                Operand::Var(var_name.to_string()),
+                Operand::Var(limit.slot.clone()),
+            ],
+            "bool",
+        ));
+        self.emit(IIRInstr::new(
+            "jmp_if_false",
+            None,
+            vec![Operand::Var(negative_cond), Operand::Var(end_label.clone())],
+            "void",
+        ));
+
+        self.emit_label(&body_label);
         self.emit_statement(body)?;
         let next = self.fresh_temp();
         self.emit(IIRInstr::new(
@@ -1456,23 +1502,6 @@ fn operator_from_token(token: &Token) -> Option<&'static str> {
     }
 }
 
-fn const_i64_from_node(node: &GrammarASTNode) -> Option<i64> {
-    let mut sign = 1i64;
-    let mut literal: Option<i64> = None;
-    for token in recursive_tokens(node) {
-        match (token.effective_type_name(), token.value.as_str()) {
-            ("PLUS", _) => {}
-            ("MINUS", _) if literal.is_none() => sign = -sign,
-            ("INTEGER_LIT", _) if literal.is_none() => {
-                literal = token.value.parse::<i64>().ok();
-            }
-            ("LPAREN", _) | ("RPAREN", _) => {}
-            _ => return None,
-        }
-    }
-    literal.map(|n| sign * n)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1506,6 +1535,12 @@ mod tests {
     fn compiles_and_runs_for_step_until_sum() {
         let src = "begin integer i, result; result := 0; for i := 1 step 1 until 10 do result := result + i end";
         assert_eq!(run_i64(src), 55);
+    }
+
+    #[test]
+    fn compiles_and_runs_dynamic_for_step_until() {
+        let src = "begin integer i, stepvalue, result; result := 0; stepvalue := 2; for i := 1 step stepvalue until 5 do result := result + i; stepvalue := 0 - stepvalue; for i := 5 step stepvalue until 1 do result := result + i end";
+        assert_eq!(run_i64(src), 18);
     }
 
     #[test]

--- a/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/backend_compat.rs
@@ -13,6 +13,8 @@ const ALGOL_FOR_WHILE: &str = "begin integer x, result; x := 6; result := 0; for
 
 const ALGOL_FOR_LIST: &str = "begin integer i, result; i := 0; result := 0; for i := 1 step 1 until 3, 10, i + 1 while i < 13 do result := result + i end";
 
+const ALGOL_DYNAMIC_STEP: &str = "begin integer i, stepvalue, result; result := 0; stepvalue := 2; for i := 1 step stepvalue until 5 do result := result + i; stepvalue := 0 - stepvalue; for i := 5 step stepvalue until 1 do result := result + i end";
+
 const ALGOL_COND_EXPR: &str = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
 
 const ALGOL_NESTED_BLOCKS: &str = "begin integer x, result; boolean flag; x := 1; flag := true; result := 0; begin integer x; boolean flag; x := 10; flag := false; begin integer x; x := 31; if not flag then result := x else result := 1 end; result := result + x end; if flag then result := result + x else result := 0 end";
@@ -37,6 +39,10 @@ fn algol_iir_validates_for_every_direct_backend() {
         (
             "for_list",
             compile_case(ALGOL_FOR_LIST, "algol_for_list_backend_compat"),
+        ),
+        (
+            "dynamic_step",
+            compile_case(ALGOL_DYNAMIC_STEP, "algol_dynamic_step_backend_compat"),
         ),
         (
             "cond_expr",
@@ -233,6 +239,64 @@ fn algol_for_list_lowers_to_wasm_jvm_clr_beam_and_llvm() {
     assert!(
         llvm.contains("br label"),
         "LLVM should lower for-list loop branches"
+    );
+}
+
+#[test]
+fn algol_dynamic_step_lowers_to_wasm_jvm_clr_beam_and_llvm() {
+    let module = compile_case(ALGOL_DYNAMIC_STEP, "algol_dynamic_step_backend_compat");
+    let main = module.get_function("main").expect("main exists");
+    assert!(
+        main.instructions
+            .iter()
+            .any(|instr| instr.op == "cmp_le"),
+        "dynamic step should emit a positive-step bound check"
+    );
+    assert!(
+        main.instructions
+            .iter()
+            .any(|instr| instr.op == "cmp_ge"),
+        "dynamic step should emit runtime step-sign and negative-step checks"
+    );
+
+    let wasm = iir_to_wasm::lower_iir_to_wasm(
+        &module,
+        &iir_to_wasm::IIRWasmConfig::new("AlgolDynamicStep"),
+    )
+    .expect("ALGOL dynamic-step IIR should lower to WASM");
+    let wasm_bytes = iir_to_wasm::encode_module(&wasm).expect("WASM module should encode");
+    assert!(wasm_bytes.starts_with(b"\0asm"));
+
+    let jvm = iir_to_jvm_class_file::lower_iir_to_jvm(
+        &module,
+        &iir_to_jvm_class_file::IIRJvmConfig::new("AlgolDynamicStep"),
+    )
+    .expect("ALGOL dynamic-step IIR should lower to JVM");
+    assert!(!jvm.methods.is_empty());
+
+    let clr = iir_to_cil_bytecode::lower_iir_to_cil(
+        &module,
+        &iir_to_cil_bytecode::IIRClrConfig::default(),
+    )
+    .expect("ALGOL dynamic-step IIR should lower to CLR");
+    assert!(!clr.methods.is_empty());
+
+    let beam = iir_to_beam::lower_iir_to_beam(
+        &module,
+        &iir_to_beam::IIRBeamConfig::new("algol_dynamic_step"),
+    )
+    .expect("ALGOL dynamic-step IIR should lower to BEAM");
+    let beam_bytes = iir_to_beam::encode_beam(&beam);
+    assert!(beam_bytes.starts_with(b"FOR1"));
+
+    let llvm = iir_to_llvm::lower_iir_to_llvm(
+        &module,
+        &iir_to_llvm::IIRLlvmConfig::new("algol_dynamic_step"),
+    )
+    .expect("ALGOL dynamic-step IIR should lower to LLVM");
+    assert!(
+        llvm.contains("br i1"),
+        "LLVM should lower dynamic-step checks as conditional branches"
     );
 }
 

--- a/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
+++ b/code/packages/rust/algol-iir-compiler/tests/jit_e2e.rs
@@ -85,6 +85,32 @@ fn algol_for_list_program_runs_through_generic_jit() {
 }
 
 #[test]
+fn algol_dynamic_step_program_runs_through_generic_jit() {
+    let source = "begin integer i, stepvalue, result; result := 0; stepvalue := 2; for i := 1 step stepvalue until 5 do result := result + i; stepvalue := 0 - stepvalue; for i := 5 step stepvalue until 1 do result := result + i end";
+    let mut module = compile_source(source, "algol_dynamic_step_jit").expect("ALGOL should compile");
+    let main = module.get_function("main").expect("main exists");
+    assert_eq!(
+        main.type_status,
+        interpreter_ir::FunctionTypeStatus::FullyTyped
+    );
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new();
+    let error_handle = backend.error_handle();
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .expect("JIT execution should succeed")
+        .unwrap_or(Value::Null);
+
+    if let Some(err) = error_handle.lock().unwrap().clone() {
+        panic!("GenericCirJit reported an error: {err}");
+    }
+    assert_eq!(result.as_i64(), Some(18));
+}
+
+#[test]
 fn algol_conditional_expression_program_runs_through_generic_jit() {
     let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
     let mut module = compile_source(source, "algol_cond_expr_jit").expect("ALGOL should compile");

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -137,6 +137,20 @@ fn algol_for_list_emits_and_runs_on_wasm() {
 }
 
 #[test]
+fn algol_dynamic_step_emits_and_runs_on_wasm() {
+    let source = "begin integer i, stepvalue, result; result := 0; stepvalue := 2; for i := 1 step stepvalue until 5 do result := result + i; stepvalue := 0 - stepvalue; for i := 5 step stepvalue until 1 do result := result + i end";
+    let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_dynamic_step")
+        .expect("ALGOL dynamic-step loop should emit wasm");
+    assert_wellformed(&bytes, "(ALGOL dynamic step)");
+
+    let rt = WasmRuntime::new();
+    let result = rt
+        .load_and_run(&bytes, "main", &[])
+        .expect("ALGOL dynamic-step wasm must run");
+    assert_eq!(result, vec![18], "ALGOL dynamic step should sum both directions");
+}
+
+#[test]
 fn algol_conditional_expressions_emit_and_run_on_wasm() {
     let source = "begin boolean flag; integer i, result; flag := true; result := 0; for i := if flag then 1 else 4 step 1 until if flag then 3 else 4 do result := result + i; if if result = 6 then flag else false then result := 42 else result := result end";
     let bytes = compile_source_to_wasm(Language::Algol60, source, "algol_cond_expr")


### PR DESCRIPTION
## Summary
- remove the ALGOL compiler's constant-only restriction for `for ... step ... until` step expressions
- lower runtime step signs into portable IIR: branch on `step >= 0`, then use positive `<=` or negative `>=` bound checks
- cover positive and negative dynamic-step loops through VM, GenericCirJit, direct WASM/JVM/CLR/BEAM/LLVM, and AOT/WASM runtime

## Tests
- `cargo test -p algol-iir-compiler`
- `cargo test -p lang-aot algol_dynamic_step_emits_and_runs_on_wasm`
- `cargo test -p iir-to-llvm`
- `git diff --check`

## Security review
- touched-file scan for `unsafe`, process/file/env/include APIs, and panic/unwrap hotspots found only existing-style JIT test assertions plus the new matching test assertion
- no dependencies added; push reported existing default-branch Dependabot alerts unrelated to this branch
- `cargo audit` and `cargo deny` are not installed in this workspace, so those checks could not be run
