### PR TITLE
Add smart-home activation maintenance tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -37,9 +37,15 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation health planning:
   `smart_home.list_integration_activation_health` and
   `smart_home.get_integration_activation_health_summary`.
+- Added D18D handlers for D23A activation maintenance planning:
+  `smart_home.list_integration_activation_maintenance` and
+  `smart_home.get_integration_activation_maintenance_summary`.
 - Added D18D handlers for D23A grouped activation constraint planning:
   `smart_home.list_integration_activation_constraints` and
   `smart_home.get_integration_activation_constraint_summary`.
+- Added D18D handlers for D23A activation risk planning:
+  `smart_home.list_integration_activation_risk` and
+  `smart_home.get_integration_activation_risk_summary`.
 - Added D18D handlers for D23A integration activation dependency graph
   planning: `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -46,7 +46,9 @@ Chief of Staff job/session/agent
   -> activation-agenda list and summary reads for concrete work by rollout wave
   -> activation-runway list and summary reads for rollout-priority waves
   -> activation-health list and summary reads for priority-wave readiness status
+  -> activation-maintenance list and summary reads for combined wave health
   -> activation-constraint list and summary reads for grouped blockers/reviews
+  -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
   -> desired-state target set/clear through runtime authorization
@@ -85,8 +87,12 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_runway_summary`
 - `smart_home.list_integration_activation_health`
 - `smart_home.get_integration_activation_health_summary`
+- `smart_home.list_integration_activation_maintenance`
+- `smart_home.get_integration_activation_maintenance_summary`
 - `smart_home.list_integration_activation_constraints`
 - `smart_home.get_integration_activation_constraint_summary`
+- `smart_home.list_integration_activation_risk`
+- `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`
 - `smart_home.get_integration_activation_dependency_summary`
 - `smart_home.list_integration_readiness`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,30 +36,31 @@ use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
     activation_dependency_graph_from_reports, activation_health_from_candidates,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationRiskItem,
-    IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
-    IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
-    IntegrationActivationTarget, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    activation_maintenance_from_candidates, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_risk_from_candidates,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationRiskItem, IntegrationActivationRiskKind,
+    IntegrationActivationRiskSummary, IntegrationActivationRunwayStage,
+    IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
+    IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
@@ -186,6 +187,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_HEALTH_TOOL_ID: &str =
     "smart_home.list_integration_activation_health";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_health_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_maintenance";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_maintenance_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID: &str =
     "smart_home.list_integration_activation_constraints";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID: &str =
@@ -362,6 +367,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID => {
                     let query = integration_activation_health_query(&arguments)?;
                     Ok(get_integration_activation_health_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID => {
+                    let query = integration_activation_maintenance_query(&arguments)?;
+                    Ok(list_integration_activation_maintenance_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_maintenance_query(&arguments)?;
+                    Ok(get_integration_activation_maintenance_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID => {
                     let query = integration_activation_constraint_query(&arguments)?;
@@ -1267,6 +1280,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation health summary",
             "Return compact D23A priority-wave activation health counts for ready, review, blocked, and missing-prerequisite work.",
             integration_activation_health_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID,
+            "List smart-home integration activation maintenance",
+            "List D23A activation maintenance windows that combine priority-wave health, actions, constraints, risk, and dependency blockers.",
+            integration_activation_maintenance_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_maintenance", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_maintenance",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation maintenance summary",
+            "Return compact D23A activation maintenance rollups across priority waves, risk, blockers, dependency edges, and review work.",
+            integration_activation_maintenance_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3858,6 +3905,14 @@ struct IntegrationActivationHealthQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationMaintenanceQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    health_status: Option<IntegrationActivationHealthStatus>,
+    requires_attention: Option<bool>,
+    window_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationConstraintQuery {
     candidates: IntegrationActivationCandidateQuery,
     constraint_kind: Option<IntegrationActivationConstraintKind>,
@@ -3927,6 +3982,23 @@ fn integration_activation_health_query(
         health_status,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         stage_limit,
+    })
+}
+
+fn integration_activation_maintenance_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationMaintenanceQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let health_status = optional_string(arguments, "health_status")?
+        .or(optional_string(arguments, "maintenance_status")?)
+        .map(|label| parse_activation_health_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationMaintenanceQuery {
+        candidates,
+        health_status,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        window_limit: optional_u64(arguments, "window_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4190,6 +4262,31 @@ fn integration_activation_health_for_query(
     }
 
     (health, catalog_count)
+}
+
+fn integration_activation_maintenance_for_query(
+    query: &IntegrationActivationMaintenanceQuery,
+) -> (Vec<IntegrationActivationMaintenanceWindow>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut maintenance = activation_maintenance_from_candidates(
+        &catalog,
+        candidates,
+        &query.candidates.readiness.enabled_integrations,
+    );
+
+    if let Some(health_status) = query.health_status {
+        maintenance.retain(|window| window.health_status == health_status);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        maintenance.retain(|window| window.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.window_limit {
+        maintenance.truncate(limit);
+    }
+
+    (maintenance, catalog_count)
 }
 
 fn integration_activation_constraints_for_query(
@@ -4967,6 +5064,74 @@ fn get_integration_activation_health_summary_output_handler_output(
             (
                 "blocked_integrations",
                 integer(summary.blocked_integrations as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_maintenance_output_handler_output(
+    query: IntegrationActivationMaintenanceQuery,
+) -> ToolHandlerOutput {
+    let (maintenance, catalog_count) = integration_activation_maintenance_for_query(&query);
+    let summary = IntegrationActivationMaintenanceSummary::from_windows(maintenance.iter());
+    let count = maintenance.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_maintenance",
+            JsonValue::Array(
+                maintenance
+                    .iter()
+                    .map(activation_maintenance_window_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_maintenance_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_maintenance"),
+            ),
+            ("windows", integer(count as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+            (
+                "windows_with_blockers",
+                integer(summary.windows_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_maintenance_summary_output_handler_output(
+    query: IntegrationActivationMaintenanceQuery,
+) -> ToolHandlerOutput {
+    let (maintenance, _) = integration_activation_maintenance_for_query(&query);
+    let summary = IntegrationActivationMaintenanceSummary::from_windows(maintenance.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_maintenance_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_maintenance_summary"),
+            ),
+            ("total_windows", integer(summary.total_windows as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+            (
+                "windows_with_blockers",
+                integer(summary.windows_with_blockers as i64),
             ),
         ]),
     )
@@ -8458,6 +8623,237 @@ fn integration_activation_health_summary_json(
     ])
 }
 
+fn activation_maintenance_window_json(
+    window: &IntegrationActivationMaintenanceWindow,
+) -> JsonValue {
+    object([
+        ("priority", integer(window.priority as i64)),
+        ("health_status", string(window.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                window
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "ready_to_activate_integration_ids",
+            JsonValue::Array(
+                window
+                    .ready_to_activate_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "review_integration_ids",
+            JsonValue::Array(
+                window
+                    .review_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocked_integration_ids",
+            JsonValue::Array(
+                window
+                    .blocked_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(&window.candidate_summary),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(&window.action_summary),
+        ),
+        (
+            "constraint_summary",
+            integration_activation_constraint_summary_json(&window.constraint_summary),
+        ),
+        (
+            "risk_summary",
+            integration_activation_risk_summary_json(&window.risk_summary),
+        ),
+        (
+            "dependency_summary",
+            integration_activation_dependency_summary_json(&window.dependency_summary),
+        ),
+        (
+            "integration_count",
+            integer(window.integration_ids.len() as i64),
+        ),
+        (
+            "ready_to_activate_count",
+            integer(window.ready_to_activate_integration_ids.len() as i64),
+        ),
+        (
+            "review_count",
+            integer(window.review_integration_ids.len() as i64),
+        ),
+        (
+            "blocked_count",
+            integer(window.blocked_integration_ids.len() as i64),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(window.requires_attention()),
+        ),
+        ("has_ready_work", JsonValue::Bool(window.has_ready_work())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(window.has_activation_work()),
+        ),
+        ("has_review_work", JsonValue::Bool(window.has_review_work())),
+        ("has_blockers", JsonValue::Bool(window.has_blockers())),
+        ("has_risks", JsonValue::Bool(window.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(window.has_dependency_blockers()),
+        ),
+    ])
+}
+
+fn integration_activation_maintenance_summary_json(
+    summary: &IntegrationActivationMaintenanceSummary,
+) -> JsonValue {
+    object([
+        ("total_windows", integer(summary.total_windows as i64)),
+        (
+            "total_integrations",
+            integer(summary.total_integrations as i64),
+        ),
+        ("ready_windows", integer(summary.ready_windows as i64)),
+        ("review_windows", integer(summary.review_windows as i64)),
+        ("blocked_windows", integer(summary.blocked_windows as i64)),
+        ("empty_windows", integer(summary.empty_windows as i64)),
+        (
+            "activation_ready_integrations",
+            integer(summary.activation_ready_integrations as i64),
+        ),
+        (
+            "ready_to_activate_integrations",
+            integer(summary.ready_to_activate_integrations as i64),
+        ),
+        (
+            "review_integrations",
+            integer(summary.review_integrations as i64),
+        ),
+        (
+            "blocked_integrations",
+            integer(summary.blocked_integrations as i64),
+        ),
+        (
+            "windows_with_actions",
+            integer(summary.windows_with_actions as i64),
+        ),
+        (
+            "windows_with_activation_work",
+            integer(summary.windows_with_activation_work as i64),
+        ),
+        (
+            "windows_with_review_work",
+            integer(summary.windows_with_review_work as i64),
+        ),
+        (
+            "windows_with_blockers",
+            integer(summary.windows_with_blockers as i64),
+        ),
+        (
+            "windows_with_risks",
+            integer(summary.windows_with_risks as i64),
+        ),
+        (
+            "windows_with_dependency_blockers",
+            integer(summary.windows_with_dependency_blockers as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "activate_integration_actions",
+            integer(summary.activate_integration_actions as i64),
+        ),
+        (
+            "review_policy_actions",
+            integer(summary.review_policy_actions as i64),
+        ),
+        (
+            "blocking_constraints",
+            integer(summary.blocking_constraints as i64),
+        ),
+        (
+            "review_constraints",
+            integer(summary.review_constraints as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+    ])
+}
+
 fn activation_constraint_json(constraint: &IntegrationActivationConstraint) -> JsonValue {
     object([
         ("constraint_kind", string(constraint.kind.as_str())),
@@ -11845,6 +12241,33 @@ fn integration_activation_health_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_maintenance_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "window_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("health_status", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "maintenance_status",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_constraint_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -12008,7 +12431,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 73);
+        assert_eq!(definitions.len(), 75);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -12082,6 +12505,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID));
@@ -12197,7 +12626,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            65
+            67
         );
         assert_eq!(
             export
@@ -12293,6 +12722,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_HEALTH_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -12563,11 +13000,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(73))
+            Some(&integer(75))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(65))
+            Some(&integer(67))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -13448,6 +13885,157 @@ mod tests {
         );
         assert_eq!(
             field(activation_health_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_maintenance_request = request(
+            "call-list-integration-activation-maintenance",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_MAINTENANCE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("window_limit", integer(2)),
+            ]),
+            5_020,
+        );
+        let list_activation_maintenance_trace =
+            tool_runtime.invoke_with_events(&list_activation_maintenance_request);
+        assert!(list_activation_maintenance_trace.result.ok);
+        assert_eq!(
+            list_activation_maintenance_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_maintenance_output = list_activation_maintenance_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            field(list_activation_maintenance_output, "count"),
+            Some(&integer(2))
+        );
+        let activation_maintenance_summary =
+            field(list_activation_maintenance_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_maintenance_summary, "overall_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_maintenance_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_maintenance_summary, "windows_with_blockers").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_maintenance_summary, "total_actions").unwrap()).unwrap()
+                >= 1
+        );
+        let activation_maintenance = array_item(
+            field(list_activation_maintenance_output, "activation_maintenance").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_maintenance, "health_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_maintenance, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_maintenance, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_maintenance, "integration_count").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(field(activation_maintenance, "action_summary").is_some());
+        assert!(field(activation_maintenance, "constraint_summary").is_some());
+        assert!(field(activation_maintenance, "risk_summary").is_some());
+        assert!(field(activation_maintenance, "dependency_summary").is_some());
+
+        let activation_maintenance_summary_request = request(
+            "call-integration-activation-maintenance-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_MAINTENANCE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("maintenance_status", string("blocked")),
+            ]),
+            5_021,
+        );
+        let activation_maintenance_summary_trace =
+            tool_runtime.invoke_with_events(&activation_maintenance_summary_request);
+        assert!(activation_maintenance_summary_trace.result.ok);
+        assert_eq!(
+            activation_maintenance_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_maintenance_summary_output = activation_maintenance_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_maintenance_rollup =
+            field(activation_maintenance_summary_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_maintenance_rollup, "overall_status"),
+            Some(&string("blocked"))
+        );
+        assert!(
+            integer_value(field(activation_maintenance_rollup, "total_windows").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_maintenance_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_maintenance_rollup, "requires_attention"),
             Some(&JsonValue::Bool(true))
         );
 
@@ -15234,6 +15822,14 @@ mod tests {
             activation_health_summary_trace,
         );
         journal.record_trace(
+            list_activation_maintenance_request,
+            list_activation_maintenance_trace,
+        );
+        journal.record_trace(
+            activation_maintenance_summary_request,
+            activation_maintenance_summary_trace,
+        );
+        journal.record_trace(
             list_activation_constraints_request,
             list_activation_constraints_trace,
         );
@@ -15314,9 +15910,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 73);
-        assert_eq!(journal_summary.completed_count, 73);
-        assert_eq!(journal.audit_records().len(), 73);
+        assert_eq!(journal_summary.invocation_count, 75);
+        assert_eq!(journal_summary.completed_count, 75);
+        assert_eq!(journal.audit_records().len(), 75);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -41,9 +41,15 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_health` and
   `smart_home.get_integration_activation_health_summary` tool descriptors for
   read-only rollout-priority activation health planning.
+- `smart_home.list_integration_activation_maintenance` and
+  `smart_home.get_integration_activation_maintenance_summary` tool descriptors
+  for read-only combined activation maintenance planning.
 - `smart_home.list_integration_activation_constraints` and
   `smart_home.get_integration_activation_constraint_summary` tool descriptors
   for read-only grouped activation constraint planning.
+- `smart_home.list_integration_activation_risk` and
+  `smart_home.get_integration_activation_risk_summary` tool descriptors for
+  read-only policy-tier and policy-surface activation risk planning.
 - `smart_home.list_integration_activation_dependencies` and
   `smart_home.get_integration_activation_dependency_summary` tool descriptors
   for read-only activation dependency graph planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -64,8 +64,14 @@ Current scope:
   grouping and compact actionable/blocker summaries
 - D18D integration activation-health descriptors for priority-wave ready,
   review, blocked, and missing-prerequisite status summaries
+- D18D integration activation-maintenance descriptors for combined
+  priority-wave health, action, constraint, risk, and dependency summaries
 - D18D integration activation-constraint descriptors for grouped primitive,
   capability, dependency, and policy-review blocker summaries
+- D18D integration activation-risk descriptors for policy-tier and
+  policy-surface rollout risk summaries
+- D18D integration activation-dependency descriptors for prerequisite node and
+  edge rollups
 - D18D integration-readiness descriptors for bulk activation blocker reports
   and compact readiness rollups
 - D18D integration-readiness gap descriptors for grouped primitive,

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1469,6 +1469,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationRunwaySummary,
     ListIntegrationActivationHealth,
     GetIntegrationActivationHealthSummary,
+    ListIntegrationActivationMaintenance,
+    GetIntegrationActivationMaintenanceSummary,
     ListIntegrationActivationConstraints,
     GetIntegrationActivationConstraintSummary,
     ListIntegrationActivationRisk,
@@ -1584,6 +1586,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationHealthSummary => {
                 read_tool("smart_home.get_integration_activation_health_summary")
+            }
+            Self::ListIntegrationActivationMaintenance => {
+                read_tool("smart_home.list_integration_activation_maintenance")
+            }
+            Self::GetIntegrationActivationMaintenanceSummary => {
+                read_tool("smart_home.get_integration_activation_maintenance_summary")
             }
             Self::ListIntegrationActivationConstraints => {
                 read_tool("smart_home.list_integration_activation_constraints")
@@ -2242,6 +2250,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationRunwaySummary,
         SmartHomeTool::ListIntegrationActivationHealth,
         SmartHomeTool::GetIntegrationActivationHealthSummary,
+        SmartHomeTool::ListIntegrationActivationMaintenance,
+        SmartHomeTool::GetIntegrationActivationMaintenanceSummary,
         SmartHomeTool::ListIntegrationActivationConstraints,
         SmartHomeTool::GetIntegrationActivationConstraintSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
@@ -3086,7 +3096,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 73);
+        assert_eq!(catalog.len(), 75);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3194,6 +3204,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_health_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_maintenance"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_maintenance_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
@@ -3392,15 +3410,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 73);
-        assert_eq!(summary.read_tools, 65);
+        assert_eq!(summary.total_tools, 75);
+        assert_eq!(summary.read_tools, 67);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 65);
+        assert_eq!(summary.read_only_tier_tools, 67);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 73);
+        assert_eq!(summary.total_required_capabilities, 75);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -53,10 +53,17 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationHealthStage` and `IntegrationActivationHealthSummary`
   for compact ready, review, blocked, and missing-prerequisite priority-wave
   status rollups.
+- `IntegrationActivationMaintenanceWindow` and
+  `IntegrationActivationMaintenanceSummary` for combining priority-wave
+  health, actions, constraints, risk, and dependency blockers into compact
+  Chief planning windows.
 - `IntegrationActivationConstraint` and
   `IntegrationActivationConstraintSummary` for grouping unresolved primitive,
   capability, dependency, and policy-review surface work by affected
   integrations.
+- `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
+  grouping rollout candidates by policy tier and policy surface after applying
+  host-specific readiness context.
 - `IntegrationActivationDependencyGraph` plus node, edge, and summary types for
   exposing satisfied and blocking integration prerequisites in rollout plans.
 - Integration readiness reports that expose missing primitive families, missing

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -46,8 +46,12 @@ runtime and Chief of Staff tools a typed catalog for:
   with compact ready, review, and blocker rollups
 - activation health stages that add priority-wave ready, review, blocked, and
   missing-prerequisite gap rollups for compact platform status inspection
+- activation maintenance windows that combine priority-wave health, concrete
+  actions, constraints, policy risk, and dependency blockers for Chief planning
 - activation constraints that group unresolved primitive, capability,
   dependency, and policy-review surface work by affected integrations
+- activation risk rows that group rollout candidates by policy tier and policy
+  surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,
   and blocking edges after applying host-specific enabled-integration context
 - readiness reports that compare activation plans against available primitives,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1359,6 +1359,55 @@ pub struct IntegrationActivationHealthSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationMaintenanceWindow {
+    pub priority: u8,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub ready_to_activate_integration_ids: Vec<IntegrationId>,
+    pub review_integration_ids: Vec<IntegrationId>,
+    pub blocked_integration_ids: Vec<IntegrationId>,
+    pub candidate_summary: IntegrationActivationCandidateSummary,
+    pub action_summary: IntegrationActivationActionSummary,
+    pub constraint_summary: IntegrationActivationConstraintSummary,
+    pub risk_summary: IntegrationActivationRiskSummary,
+    pub dependency_summary: IntegrationActivationDependencySummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationMaintenanceSummary {
+    pub total_windows: usize,
+    pub total_integrations: usize,
+    pub ready_windows: usize,
+    pub review_windows: usize,
+    pub blocked_windows: usize,
+    pub empty_windows: usize,
+    pub activation_ready_integrations: usize,
+    pub ready_to_activate_integrations: usize,
+    pub review_integrations: usize,
+    pub blocked_integrations: usize,
+    pub windows_with_actions: usize,
+    pub windows_with_activation_work: usize,
+    pub windows_with_review_work: usize,
+    pub windows_with_blockers: usize,
+    pub windows_with_risks: usize,
+    pub windows_with_dependency_blockers: usize,
+    pub total_actions: usize,
+    pub activate_integration_actions: usize,
+    pub review_policy_actions: usize,
+    pub blocking_constraints: usize,
+    pub review_constraints: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub first_ready_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -1821,6 +1870,250 @@ impl IntegrationActivationHealthSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationMaintenanceWindow {
+    pub fn from_candidates(
+        catalog: &[IntegrationCatalogEntry],
+        priority: u8,
+        mut candidates: Vec<IntegrationActivationCandidate>,
+        enabled_integrations: &[IntegrationId],
+    ) -> Self {
+        candidates.sort_by(compare_activation_candidates);
+        let reports = candidates
+            .iter()
+            .map(|candidate| candidate.readiness_report.clone())
+            .collect::<Vec<_>>();
+        let integration_ids = candidates
+            .iter()
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let ready_to_activate_integration_ids = candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.recommendation
+                    == IntegrationActivationCandidateRecommendation::ReadyToActivate
+            })
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let review_integration_ids = candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.recommendation
+                    == IntegrationActivationCandidateRecommendation::NeedsHumanReview
+            })
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let blocked_integration_ids = candidates
+            .iter()
+            .filter(|candidate| candidate.is_blocked())
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let candidate_summary =
+            IntegrationActivationCandidateSummary::from_candidates(candidates.iter());
+        let action_summary = IntegrationActivationActionSummary::from_actions(
+            activation_actions_from_candidates(candidates.iter()).iter(),
+        );
+        let constraint_summary = IntegrationActivationConstraintSummary::from_constraints(
+            activation_constraints_from_candidates(catalog, candidates.iter()).iter(),
+        );
+        let risk_summary = IntegrationActivationRiskSummary::from_risks(
+            activation_risk_from_candidates(catalog, candidates.iter()).iter(),
+        );
+        let dependency_summary =
+            activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations)
+                .summary;
+        let health_status = activation_health_status_for_summary(&candidate_summary);
+
+        Self {
+            priority,
+            health_status,
+            integration_ids,
+            ready_to_activate_integration_ids,
+            review_integration_ids,
+            blocked_integration_ids,
+            candidate_summary,
+            action_summary,
+            constraint_summary,
+            risk_summary,
+            dependency_summary,
+        }
+    }
+
+    pub fn has_ready_work(&self) -> bool {
+        self.candidate_summary.ready_to_activate_candidates > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.action_summary.has_activation_work()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.candidate_summary.has_review_work()
+            || self.action_summary.has_review_work()
+            || self.constraint_summary.has_review_work()
+            || self.risk_summary.has_review_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.candidate_summary.has_blockers()
+            || self.action_summary.has_blockers()
+            || self.constraint_summary.has_blockers()
+            || self.risk_summary.has_blockers()
+            || self.dependency_summary.has_blocking_dependencies()
+    }
+
+    pub fn has_risks(&self) -> bool {
+        !self.risk_summary.is_empty()
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.dependency_summary.has_blocking_dependencies()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.health_status.requires_attention()
+            || self.has_review_work()
+            || self.has_blockers()
+            || self.risk_summary.requires_attention()
+    }
+}
+
+impl IntegrationActivationMaintenanceSummary {
+    pub fn from_windows<'a>(
+        windows: impl IntoIterator<Item = &'a IntegrationActivationMaintenanceWindow>,
+    ) -> Self {
+        let mut summary = Self {
+            total_windows: 0,
+            total_integrations: 0,
+            ready_windows: 0,
+            review_windows: 0,
+            blocked_windows: 0,
+            empty_windows: 0,
+            activation_ready_integrations: 0,
+            ready_to_activate_integrations: 0,
+            review_integrations: 0,
+            blocked_integrations: 0,
+            windows_with_actions: 0,
+            windows_with_activation_work: 0,
+            windows_with_review_work: 0,
+            windows_with_blockers: 0,
+            windows_with_risks: 0,
+            windows_with_dependency_blockers: 0,
+            total_actions: 0,
+            activate_integration_actions: 0,
+            review_policy_actions: 0,
+            blocking_constraints: 0,
+            review_constraints: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            first_ready_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_activation_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for window in windows {
+            summary.total_windows += 1;
+            summary.total_integrations += window.candidate_summary.total_candidates;
+            summary.activation_ready_integrations +=
+                window.candidate_summary.activation_ready_candidates;
+            summary.ready_to_activate_integrations +=
+                window.candidate_summary.ready_to_activate_candidates;
+            summary.review_integrations += window.candidate_summary.needs_human_review_candidates;
+            summary.blocked_integrations += window.candidate_summary.blocked_candidates;
+            summary.total_actions += window.action_summary.total_actions;
+            summary.activate_integration_actions +=
+                window.action_summary.activate_integration_actions;
+            summary.review_policy_actions += window.action_summary.review_policy_actions;
+            summary.blocking_constraints += window.constraint_summary.blocking_constraints;
+            summary.review_constraints += window.constraint_summary.review_constraints;
+            summary.total_risks += window.risk_summary.total_risks;
+            summary.total_dependency_edges += window.dependency_summary.total_edges;
+            summary.blocking_dependency_edges += window.dependency_summary.blocking_edges;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(window.candidate_summary.highest_policy_tier)
+                .max(window.action_summary.highest_policy_tier)
+                .max(window.constraint_summary.highest_policy_tier)
+                .max(window.risk_summary.highest_policy_tier)
+                .max(window.dependency_summary.highest_policy_tier);
+
+            match window.health_status {
+                IntegrationActivationHealthStatus::Ready => summary.ready_windows += 1,
+                IntegrationActivationHealthStatus::NeedsReview => summary.review_windows += 1,
+                IntegrationActivationHealthStatus::Blocked => summary.blocked_windows += 1,
+                IntegrationActivationHealthStatus::Empty => summary.empty_windows += 1,
+            }
+
+            if !window.action_summary.is_empty() {
+                summary.windows_with_actions += 1;
+            }
+            if window.has_activation_work() {
+                summary.windows_with_activation_work += 1;
+                summary.first_activation_priority =
+                    min_optional_priority(summary.first_activation_priority, Some(window.priority));
+            }
+            if window.has_ready_work() {
+                summary.first_ready_priority =
+                    min_optional_priority(summary.first_ready_priority, Some(window.priority));
+            }
+            if window.has_review_work() {
+                summary.windows_with_review_work += 1;
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(window.priority));
+            }
+            if window.has_blockers() {
+                summary.windows_with_blockers += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(window.priority));
+            }
+            if window.has_risks() {
+                summary.windows_with_risks += 1;
+            }
+            if window.has_dependency_blockers() {
+                summary.windows_with_dependency_blockers += 1;
+            }
+        }
+
+        summary.overall_status = activation_health_status_from_counts(
+            summary.ready_to_activate_integrations,
+            summary.review_integrations,
+            summary.blocked_integrations,
+        );
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_windows == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activate_integration_actions > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_integrations > 0
+            || self.review_policy_actions > 0
+            || self.review_constraints > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_integrations > 0
+            || self.blocking_constraints > 0
+            || self.blocking_dependency_edges > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.total_risks > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention() || self.has_review_work() || self.has_blockers()
     }
 }
 
@@ -4128,6 +4421,53 @@ pub fn activation_health_at_or_before_priority(
     ))
 }
 
+pub fn activation_maintenance_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationMaintenanceWindow> {
+    let mut windows_by_priority: BTreeMap<u8, Vec<IntegrationActivationCandidate>> =
+        BTreeMap::new();
+    for candidate in candidates {
+        windows_by_priority
+            .entry(candidate.readiness_report.priority)
+            .or_default()
+            .push(candidate);
+    }
+
+    windows_by_priority
+        .into_iter()
+        .map(|(priority, candidates)| {
+            IntegrationActivationMaintenanceWindow::from_candidates(
+                catalog,
+                priority,
+                candidates,
+                enabled_integrations,
+            )
+        })
+        .collect()
+}
+
+pub fn activation_maintenance_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationMaintenanceWindow> {
+    activation_maintenance_from_candidates(
+        catalog,
+        activation_candidates_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+        enabled_integrations,
+    )
+}
+
 pub fn activation_constraints_from_candidates<'a>(
     catalog: &[IntegrationCatalogEntry],
     candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
@@ -6308,6 +6648,73 @@ mod tests {
         assert!(summary.has_review_work());
         assert!(summary.has_blockers());
         assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn activation_maintenance_windows_roll_up_activation_work() {
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let enabled_integrations = vec![IntegrationId::trusted("mqtt")];
+        let candidates = activation_candidates_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &enabled_integrations,
+        );
+
+        let windows = activation_maintenance_from_candidates(
+            &catalog,
+            candidates.clone(),
+            &enabled_integrations,
+        );
+
+        assert!(!windows.is_empty());
+        assert!(windows.iter().all(|window| window.priority <= 2));
+        assert!(windows
+            .iter()
+            .any(IntegrationActivationMaintenanceWindow::has_blockers));
+        assert!(windows
+            .iter()
+            .any(IntegrationActivationMaintenanceWindow::has_review_work));
+        let first_blocked = windows.iter().find(|window| window.has_blockers()).unwrap();
+        assert!(!first_blocked.integration_ids.is_empty());
+        assert!(first_blocked.action_summary.total_actions > 0);
+        assert!(first_blocked.constraint_summary.total_constraints > 0);
+        assert!(first_blocked.risk_summary.total_risks > 0);
+
+        let summary = IntegrationActivationMaintenanceSummary::from_windows(windows.iter());
+        assert_eq!(summary.total_windows, windows.len());
+        assert_eq!(summary.total_integrations, candidates.len());
+        assert!(summary.total_actions > 0);
+        assert!(summary.blocking_constraints > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.total_dependency_edges > 0);
+        assert!(summary.windows_with_actions > 0);
+        assert!(summary.windows_with_blockers > 0);
+        assert!(summary.windows_with_review_work > 0);
+        assert!(summary.windows_with_risks > 0);
+        assert!(summary.requires_attention());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.has_risks());
+        assert!(!summary.is_empty());
+
+        let windows_from_catalog = activation_maintenance_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &enabled_integrations,
+        );
+        assert_eq!(windows, windows_from_catalog);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable integration activation maintenance windows that combine priority-wave health, actions, constraints, policy risk, and dependency summaries
- expose Chief-of-Staff read tools for listing activation maintenance windows and getting compact maintenance summaries
- update smart-home tool catalog descriptors, exact counts, docs, and end-to-end tool coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Cargo.lock generated during validation was removed.