### PR TITLE
[codex] Add ADJ100 defensible HLE rerun findings

### DIFF
--- a/code/specs/data/adj100-defensible-hle-reruns/FINDINGS.md
+++ b/code/specs/data/adj100-defensible-hle-reruns/FINDINGS.md
@@ -1,0 +1,139 @@
+# ADJ100 - Defensible HLE reruns: FINDINGS
+
+**Status: pilot complete.** Two 10-item reruns over the frozen ADJ99 HLE set.
+
+The clarified thesis is not "framework must drastically improve accuracy." It is:
+
+> The framework should preserve reasonable accuracy while sharply reducing wrong accepted answers and
+> making every accepted answer auditable from input bytes, source bytes, and executed programs.
+
+## Headline
+
+| run | sample | blind correct | framework mechanical correct | strict accepted | strict correct | wrong accepted |
+|---|---:|---:|---:|---:|---:|---:|
+| run 1 | items 1-10 | 3/10 | 4/10 | 3/10 | 2/3 | 1 |
+| run 2 | items 11-20 | 1/10 | 4/10 | 3/10 | 3/3 | 0 |
+
+Run 2 is the cleanest expression of the clarified goal: the framework improved mechanical accuracy over
+blind, accepted fewer answers, and had **zero wrong accepted answers**.
+
+Run 1 is the cautionary case: a prompt-only or too-permissive framework can still accept a defensible-
+looking but gold-wrong result. The parent verifier must be strict enough to reject weak source chains,
+unresolved conventions, and source/program disagreement.
+
+## What changed after clarification
+
+The earlier framing over-emphasized raw accuracy lift. Under that framing, the first full run looked
+mixed: framework mechanical accuracy was only modestly above blind and strict acceptance was low.
+
+After clarification, the useful metric became:
+
+- how many answers are accepted;
+- how many accepted answers are correct;
+- how many wrong answers are accepted;
+- whether rejected answers carry repairable reasons.
+
+That makes the framework look more promising, because it converts many low-confidence answers into
+explicit rejects instead of polished guesses.
+
+## Run 1 texture
+
+Run 1 used items 1-10. Summary:
+
+- blind baseline: 3/10;
+- framework mechanical: 4/10 after equivalence adjustment;
+- strict accepted: 3/10;
+- strict correct: 2/3;
+- wrong accepted: 1.
+
+Important observations:
+
+- The artist item should have been rejected: source association pointed to Chagall, but exact quote
+  provenance did not establish attribution; gold was Eduardo Chillida.
+- The economics item exposed a benchmark disagreement: the framework derived `H - S` from standard
+  profit/loss definitions, while gold was `H-T`. Under the run's acceptance rule this was accepted and
+  wrong; this is the wrong-accepted failure to avoid.
+- Formal/programmatic items were strongest: IP ACL, graph Cheeger constant, pavement thickness, and
+  hard-core cavity energy had executable derivations or close executable checks.
+- PDF provenance remained brittle. Raw PDF bytes often did not contain literal quote strings until a
+  text-extraction adapter was used.
+
+## Run 2 texture
+
+Run 2 used items 11-20. Summary:
+
+- blind baseline: 1/10;
+- framework mechanical: 4/10;
+- strict accepted: 3/10;
+- strict correct: 3/3;
+- wrong accepted: 0.
+
+Accepted:
+
+- Spanish poetry attribution: source bytes matched the Spanish lines and identified Leon Felipe /
+  `El nino de Vallecas`.
+- Genetics recombination: a small enumerator derived 30 and documented the orientation/haploid-sequence
+  assumptions.
+- Aerofoil lift ratio: one-vortex/mirror-image program derived `7/5 = 1.4`; model assumptions were
+  explicit and close enough to the prompt.
+
+Rejected but informative:
+
+- Coding/printf item: strict C-string provenance rejected the short-object `printf` trick, while gold
+  assumes a contest/platform byte layout and asks for the little-endian `s` value.
+- Molecule design: RDKit verified the gold-like SMILES satisfies many descriptors but has one carbonyl,
+  directly conflicting with the prompt's "avoid carbonyls" bytes.
+- Representation theory: executable count produced 9, gold was 8; convention not resolved, so reject.
+- GPU number format: NF4 codebook/rounding/saturation were missing from input bytes; reject.
+- Minecraft: framework assumed a witch/glowstone route, gold was Snow Block; world/version/mechanics
+  were under-specified, so reject.
+- Puntland vessel: framework matched gold mechanically, but parent could not fetch source bytes for the
+  cited vessel without relying on a dataset mirror or search snippet, so it was downgraded from strict
+  acceptance.
+
+## What we learned
+
+1. **The framework is a precision filter, not just an accuracy engine.**
+   It should say "unsupported" when bytes, rules, or conventions are missing.
+
+2. **Wrong-accepted is the key failure metric.**
+   Run 2's `0` wrong accepted answers is more important than accepting all 10.
+
+3. **Executable derivations are the strongest wins.**
+   Enumeration, descriptor checks, bit/float simulations, graph counts, and simple physics models are
+   where the framework can turn reasoning into auditable programs.
+
+4. **Prompt/gold conflicts become visible.**
+   The molecule item is the clearest case: gold appears to violate an explicit negative constraint.
+   The framework should surface that conflict, not hide it.
+
+5. **Convention gaps need first-class representation.**
+   NF4 semantics, C platform assumptions, representation-theory inclusion rules, and Minecraft version
+   mechanics all changed the answer. If the convention is not grounded, strict acceptance should fail.
+
+6. **Parent enforcement is non-negotiable.**
+   Agent-generated "CAS-like" output is not enough. The parent must own source fetch, quote verification,
+   program execution, source/program storage, and final acceptance.
+
+## Recommended next step
+
+Turn this pilot into a reusable acceptance harness:
+
+- a CAS writer for input/source/program/output bytes;
+- source adapters for HTML, PDF text layers, and rendered pages;
+- a program runner with captured stdout/stderr hashes;
+- an acceptance schema with `accepted`, `rejected_reason`, `convention_gap`, `source_gap`, and
+  `would_flip_if`;
+- a scorer that reports both mechanical accuracy and wrong-accepted rate.
+
+The target metric for future runs should be:
+
+```text
+wrong_accepted_rate = wrong_strict_accepted / strict_accepted
+accepted_correct_rate = correct_strict_accepted / strict_accepted
+coverage = strict_accepted / total
+mechanical_accuracy = framework_gold_matches / total
+```
+
+The desired direction is not maximum coverage at all costs. It is higher coverage while keeping
+`wrong_accepted_rate` near zero.

--- a/code/specs/data/adj100-defensible-hle-reruns/PROTOCOL.md
+++ b/code/specs/data/adj100-defensible-hle-reruns/PROTOCOL.md
@@ -1,0 +1,52 @@
+# ADJ100 protocol
+
+## Clarified success metric
+
+The primary goal is **defensible and auditable work**:
+
+- reduce wrong accepted answers;
+- expose unsupported or convention-dependent answers;
+- keep mechanical accuracy from collapsing;
+- make accepted answers inspectable through input bytes, source bytes, and executed programs.
+
+Raw accuracy is still reported, but it is secondary. A framework answer can be mechanically correct and
+still fail strict acceptance if the parent cannot verify the bytes or rule assumptions that support it.
+
+## Workflow
+
+1. Use the frozen ADJ99 HLE item set from `code/specs/data/adj99-hle100-run/items_100.json`.
+2. Hide gold answers from blind and framework agents.
+3. Run a blind baseline agent on raw question text only.
+4. Run framework proposal agents on raw question text only. Do not provide domain labels.
+5. Require framework proposal agents to:
+   - decompose input into typed IR spans;
+   - mark discarded bytes with reasons;
+   - provide URLs and exact quote strings for external facts;
+   - write programs for arithmetic, logic, enumeration, simulation, or descriptor checks.
+6. Parent verifier owns acceptance:
+   - store input bytes in CAS;
+   - fetch source bytes into CAS;
+   - verify proposed quotes against fetched bytes or recorded extracted text;
+   - execute programs and store source/output bytes;
+   - reject answers with missing source bytes, unresolved conventions, or unsupported assumptions.
+7. Score against gold only after the answer and strict-acceptance decision are fixed.
+
+## Labels
+
+- `blind_correct`: blind answer matches gold under the manual/equivalence scorer.
+- `framework_mechanical_correct`: framework candidate matches gold, regardless of strict acceptance.
+- `strict_accept`: parent accepts the framework answer as defensible.
+- `strict_correct`: strict-accepted answer also matches gold.
+- `wrong_accepted`: strict-accepted answer does not match gold. This is the most important failure
+  metric for the clarified goal.
+
+## Known limitations
+
+- This is a 20-item pilot, not a statistically stable benchmark.
+- Source fetching was not fully hermetic. In run 2, a broad parent web search surfaced a Hugging Face
+  HLE-style mirror for one item; that source was not used as accepted evidence, and the item was
+  downgraded from strict acceptance when source bytes could not be fetched elsewhere.
+- PDF and rendered-document provenance still needs a stronger adapter that maps extracted text spans
+  back to stable source bytes.
+- Some benchmark gold answers appear to rely on hidden conventions, platform assumptions, or prompt/gold
+  conflicts. The strict framework should reject these until the convention is byte-grounded.

--- a/code/specs/data/adj100-defensible-hle-reruns/README.md
+++ b/code/specs/data/adj100-defensible-hle-reruns/README.md
@@ -1,0 +1,23 @@
+# ADJ100 - Defensible HLE reruns
+
+Goal: re-run two 10-item HLE pilots with the clarified target that the framework should produce
+**defensible and auditable work**, not necessarily a large raw-accuracy win.
+
+The framework is evaluated as a parent-enforced acceptance pipeline:
+
+- blind baseline: answer from the raw question only;
+- framework proposal: decompose input bytes into typed IR, propose sources, and write programs;
+- parent verifier: store input/source/program bytes in CAS, fetch and check source quote bytes, execute
+  programs, and decide whether an answer is strict-accepted;
+- gold scoring: compare only after answers and acceptance decisions are fixed.
+
+## Artifacts
+
+- `FINDINGS.md` - headline conclusions and item-level texture.
+- `PROTOCOL.md` - the stricter acceptance rule used for the reruns.
+- `run1_audit.json` - first 10-item rerun, items 1-10 from the frozen ADJ99 HLE set.
+- `run2_audit.json` - second 10-item rerun, items 11-20 from the frozen ADJ99 HLE set.
+
+The large temporary CAS/source/program directories were intentionally not committed. These summaries
+preserve the run outcomes, acceptance decisions, and notable provenance failures while keeping the PR
+small enough to review.

--- a/code/specs/data/adj100-defensible-hle-reruns/run1_audit.json
+++ b/code/specs/data/adj100-defensible-hle-reruns/run1_audit.json
@@ -1,0 +1,154 @@
+{
+  "blind_correct": 3,
+  "blind_n": 10,
+  "framework_mechanical_correct_auto": 3,
+  "framework_mechanical_correct_adjusted": 4,
+  "framework_n": 10,
+  "strict_accept_count": 3,
+  "strict_correct_count": 2,
+  "source_spider_audit": "/tmp/adj-hle10-full-framework/verified/source_spider_audit.json",
+  "pdf_text_audit": "/tmp/adj-hle10-full-framework/verified/pdf_text_audit.json",
+  "arxiv_pdf_text_audit": "/tmp/adj-hle10-full-framework/verified/arxiv_pdf_text_audit.json",
+  "items": [
+    {
+      "id": "672597fcf6",
+      "gold": "42.",
+      "blind_answer": "|N|",
+      "blind_correct": false,
+      "framework_answer": "|N|",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Source text was fetched/extracted and contradicts the shard candidate for the stated smooth-covering condition; answer not accepted as maximum against gold.",
+      "program_stdout": [
+        "{'candidate': '|N|', 'note': 'framework proposal selected smooth-covering equality with |N|'}"
+      ]
+    },
+    {
+      "id": "672a27f5d3",
+      "gold": "pi^2",
+      "blind_answer": "No universal numerical constant; Pi(0,0)=-g(E_F)=...",
+      "blind_correct": false,
+      "framework_answer": "No unique numerical value is defined at exact k=0; normalized q->0 limit is 1.0.",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": false,
+      "strict_reason": "No byte-clean source resolved exact k=0 versus limit and normalization to benchmark pi^2.",
+      "program_stdout": [
+        "{'exact_q_zero_status': 'undefined_by_static_sum', 'normalized_static_limit_q_to_0': 1.0, 'unnormalized_static_limit_form': '-m*k_F/(pi^2*hbar^2)'}"
+      ]
+    },
+    {
+      "id": "66eaed13c4",
+      "gold": "172.20.0.0 0.0.255.255",
+      "blind_answer": "172.20.0.0 0.0.255.255 (single covering entry)",
+      "blind_correct": true,
+      "framework_answer": "172.20.0.0 0.0.255.255",
+      "framework_auto_correct": true,
+      "framework_adjusted_correct": true,
+      "strict_accept": true,
+      "strict_reason": "Input bytes, wildcard source quotes, and covering-entry program are byte/program verified.",
+      "program_stdout": [
+        "{\"answer\": \"172.20.0.0 0.0.255.255\", \"networks\": [\"172.20.96.0/19\", \"172.20.128.0/19\"]}"
+      ]
+    },
+    {
+      "id": "673722a1f3",
+      "gold": "Eduardo Chillida.",
+      "blind_answer": "Marc Chagall",
+      "blind_correct": false,
+      "framework_answer": "Marc Chagall",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Shard candidate used weak Chagall association; no exact full-quote attribution source bytes. Spider found only weak Eduardo/Instagram index bytes, insufficient.",
+      "program_stdout": [
+        "{'candidate': 'Marc Chagall', 'warning': 'exact quote attribution was not verified in a non-social source by the shard'}"
+      ]
+    },
+    {
+      "id": "6736f62aaf",
+      "gold": "H-T",
+      "blind_answer": "H - S",
+      "blind_correct": false,
+      "framework_answer": "H - S",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": true,
+      "strict_reason": "Input definitions, OpenStax profit/loss source bytes, and program support H-S; benchmark gold says H-T, so accepted but gold-incorrect.",
+      "program_stdout": [
+        "{'profit_expression': 'S - H', 'classification': 'loss', 'area_representation': 'H - S'}"
+      ]
+    },
+    {
+      "id": "67180400ff",
+      "gold": "Yes,they are",
+      "blind_answer": "No",
+      "blind_correct": false,
+      "framework_answer": "No; neither polynucleotides nor homopolynucleotides are structurally polysaccharides under monomer/linkage definitions.",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Definitions were only partially source-byte verified and the intended structural interpretation remains unresolved; shard conflicts with benchmark gold.",
+      "program_stdout": [
+        "{'polynucleotide_is_polysaccharide': False, 'homopolynucleotide_is_polysaccharide': False, 'reason': 'nucleotide polymer versus monosaccharide polymer definition'}"
+      ]
+    },
+    {
+      "id": "67008a05ad",
+      "gold": "\\( \\langle n \\rangle\\approx 0.424 \\)",
+      "blind_answer": "0.358",
+      "blind_correct": false,
+      "framework_answer": "0.848",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Grand-partition source terms were PDF-text verified but the mean-field convention/factor producing 0.424 was not resolved; shard program gives 0.848.",
+      "program_stdout": [
+        "{\"z_total\": 12, \"occupancy\": 0.8480958210694133, \"rounded_3dp\": \"0.848\"}"
+      ]
+    },
+    {
+      "id": "67173a11ff",
+      "gold": "305 mm",
+      "blind_answer": "~190 mm",
+      "blind_correct": false,
+      "framework_answer": "306 mm, practically about 305 mm within chart precision",
+      "framework_auto_correct": true,
+      "framework_adjusted_correct": true,
+      "strict_accept": false,
+      "strict_reason": "Program lands near gold, but required Burmister chart/rigid-flexible rules were not fully source-byte verified; chart digitization is hand-entered.",
+      "program_stdout": [
+        "{\"required_thickness_mm\": 306.24761653970154, \"rounded\": 306}"
+      ]
+    },
+    {
+      "id": "6717eeddd6",
+      "gold": "$\\frac{1}{2n - 1}$",
+      "blind_answer": "1/(2n - 1)",
+      "blind_correct": true,
+      "framework_answer": "1/(2n-1)",
+      "framework_auto_correct": true,
+      "framework_adjusted_correct": true,
+      "strict_accept": true,
+      "strict_reason": "Input, basic graph rule source bytes/PDF text, and program support candidate; proof is still lighter than a formal all-n proof but accepted for this run.",
+      "program_stdout": [
+        "{'candidate': '1/(2n-1)', 'numeric_check_n_101': '1/201'}"
+      ]
+    },
+    {
+      "id": "676cc5d177",
+      "gold": "$4\\omega-4J(\\cos(\\pi/7)+\\cos(3\\pi/7))$",
+      "blind_answer": "4 omega - 4J[cos(pi/7)+cos(3pi/7)]",
+      "blind_correct": true,
+      "framework_answer": "4*omega - 4*J*(cos(pi/7)+cos(3*pi/7))",
+      "framework_auto_correct": false,
+      "framework_adjusted_correct": true,
+      "strict_accept": false,
+      "strict_reason": "Program/eigenvalue and arXiv hard-core source text support the answer, but the operator/ring derivation is not recursively byte-closed enough for strict acceptance.",
+      "program_stdout": [
+        "{'basis_size': 35, 'min_hopping_eigenvalue': -4.493959207434933, 'energy': '4*omega + (-4.493959207434933)*J', 'benchmark_equivalent': '4*omega-4*J*(cos(pi/7)+cos(3*pi/7))'}"
+      ]
+    }
+  ]
+}

--- a/code/specs/data/adj100-defensible-hle-reruns/run2_audit.json
+++ b/code/specs/data/adj100-defensible-hle-reruns/run2_audit.json
@@ -1,0 +1,287 @@
+{
+  "sample": "items_11_to_20",
+  "contamination_note": "Parent broad web search surfaced a HuggingFace HLE-style mirror for the Puntland item; it was not used as accepted evidence. Subagents were instructed not to use benchmark/dataset/solution sites.",
+  "blind_correct": 1,
+  "framework_mechanical_correct": 4,
+  "strict_accepted": 3,
+  "strict_correct": 3,
+  "wrong_accepted": 0,
+  "items": [
+    {
+      "id": "672e24f117",
+      "gold": "Y7960791205542063980",
+      "blind_answer": "N1",
+      "blind_correct": false,
+      "framework_answer": "N1",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected: C-standard provenance says the printf format trick is undefined/non-portable, while benchmark gold assumes contest/platform byte layout. This is an ambiguity fork, not a clean accepted answer."
+    },
+    {
+      "id": "673634d362",
+      "gold": "León Felipe. \"El niño de Vallecas\"",
+      "blind_answer": "Rafael Alberti; The Burial of the Count of Orgaz",
+      "blind_correct": false,
+      "framework_answer": "León Felipe; El niño de Vallecas",
+      "framework_correct": true,
+      "strict_accept": true,
+      "strict_reason": "Accepted: source quotes identify León Felipe and connect the poem to El niño de Vallecas; translation mismatch is tolerable because Spanish lines match."
+    },
+    {
+      "id": "6708c1dc2f",
+      "gold": "MV Celtic Horizon",
+      "blind_answer": "MV Sea Lion",
+      "blind_correct": false,
+      "framework_answer": "MV Celtic Horizon",
+      "framework_correct": true,
+      "strict_accept": false,
+      "strict_reason": "Rejected for strict provenance: framework answer matches gold and search snippets, but the parent could not fetch source bytes containing the vessel name without relying on benchmark/dataset mirror or unfetched snippet text."
+    },
+    {
+      "id": "66ecfd03e7",
+      "gold": "30",
+      "blind_answer": "26",
+      "blind_correct": false,
+      "framework_answer": "30",
+      "framework_correct": true,
+      "strict_accept": true,
+      "strict_reason": "Accepted: enumerator derives 30 from input assumptions; interpretation risk is documented but matches gold."
+    },
+    {
+      "id": "67253f2c13",
+      "gold": "O=c1cc(-c2ccc(O)cc2)oc2cc(O)cc(O)c12",
+      "blind_answer": "Oc1cc(O)c2oc(=C(c3cc(O)ccc3)O)cc2c1",
+      "blind_correct": false,
+      "framework_answer": "UNSUPPORTED: carbonyl-free SMILES not established; checked gold-like carbonyl candidate violates prompt",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected/unsupported: RDKit program verifies the gold-like C15H10O5 candidate has one carbonyl, violating explicit input bytes that say avoid carbonyls."
+    },
+    {
+      "id": "67572db350",
+      "gold": "1.4",
+      "blind_answer": "1.4",
+      "blind_correct": true,
+      "framework_answer": "1.4",
+      "framework_correct": true,
+      "strict_accept": true,
+      "strict_reason": "Accepted: one-vortex/mirror-image program gives 7/5=1.4; model assumptions are explicit and match the prompt wording closely enough."
+    },
+    {
+      "id": "66e8e473f5",
+      "gold": "8",
+      "blind_answer": "9",
+      "blind_correct": false,
+      "framework_answer": "9",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected: executable count gives 9, but gold is 8; likely hidden convention excludes the trivial singleton or another representation case. Framework should not accept without resolving convention."
+    },
+    {
+      "id": "671ec6d8a6",
+      "gold": "\\sum_F |\\sum_m \\O_F^m(t_p)d_F^m|^2",
+      "blind_answer": "first-order TDPT cross-section formula, not benchmark form",
+      "blind_correct": false,
+      "framework_answer": "sigma(t_p)=K*sum_j[d_j^2+nearest-neighbor interference...]",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected: source-derived formula family is plausible but prompt lacks enough constants/conventions; answer does not collapse to benchmark gold form."
+    },
+    {
+      "id": "6726425100",
+      "gold": "76",
+      "blind_answer": "-20",
+      "blind_correct": false,
+      "framework_answer": "-20",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected: nf4 codebook/rounding/saturation are missing from input bytes; program result -20 is assumption-heavy and gold is 76."
+    },
+    {
+      "id": "671683479e",
+      "gold": "Snow Block",
+      "blind_answer": "Glowstone",
+      "blind_correct": false,
+      "framework_answer": "Glowstone",
+      "framework_correct": false,
+      "strict_accept": false,
+      "strict_reason": "Rejected: framework path assumes witch/glowstone route; gold is Snow Block, so the Minecraft world/version/mechanics are unresolved."
+    }
+  ],
+  "program_results": [
+    {
+      "id": "672e24f117",
+      "path": "/tmp/adj-hle10-run2/programs/672e24f117.py",
+      "returncode": 0,
+      "stdout": "7960791205542063980",
+      "stderr": "",
+      "output_sha256": "b8d9534c303960739beccbba9aec642d3489177d266930de75df2482560305ac"
+    },
+    {
+      "id": "66ecfd03e7",
+      "path": "/tmp/adj-hle10-run2/programs/66ecfd03e7.py",
+      "returncode": 0,
+      "stdout": "30\n['00000', '00001', '00010', '00011', '00100', '00101', '00110', '00111', '01000', '01001', '01011', '01100', '01101', '01110', '01111', '10000', '10001', '10010', '10011', '10100', '10110', '10111', '11000', '11001', '11010', '11011', '11100', '11101', '11110', '11111']",
+      "stderr": "",
+      "output_sha256": "1c89165307948d46a70c5a41a6ebbf8652fd313390586dd071bf15862f4e5de6"
+    },
+    {
+      "id": "67253f2c13",
+      "path": "/tmp/adj-hle10-run2/programs/67253f2c13.py",
+      "returncode": 0,
+      "stdout": "C15H10O5 270.05282342000004 20 0 0 100 3 5 1 3 3 1",
+      "stderr": "",
+      "output_sha256": "bd900dc6e5f439101ff0464d50530a6e4416f1a4c1cf4ead9aa9002f23dbb1b8"
+    },
+    {
+      "id": "67572db350",
+      "path": "/tmp/adj-hle10-run2/programs/67572db350.py",
+      "returncode": 0,
+      "stdout": "1.4 7/5",
+      "stderr": "",
+      "output_sha256": "33ca10fc74d9137fef3d26c7be3444c69c501811fc631263d4c6a4e8f4920c30"
+    },
+    {
+      "id": "66e8e473f5",
+      "path": "/tmp/adj-hle10-run2/programs/66e8e473f5.py",
+      "returncode": 0,
+      "stdout": "9 [(1,), (2,), (2, 3), (2, 9), (3,), (6,), (6, 9), (9,), (18,)]",
+      "stderr": "",
+      "output_sha256": "d4746d97a9836b8f9100ae77f1017ce145a3703949e094591fe1757d1ab7b1e1"
+    },
+    {
+      "id": "6726425100",
+      "path": "/tmp/adj-hle10-run2/programs/6726425100.py",
+      "returncode": 0,
+      "stdout": "2.0 56.75 56.8125 -20",
+      "stderr": "",
+      "output_sha256": "940694ede664900e9a7704964b1f79155bd80480887d16bdeea78cf0a68aa99e"
+    },
+    {
+      "id": "671683479e",
+      "path": "/tmp/adj-hle10-run2/programs/671683479e.py",
+      "returncode": 0,
+      "stdout": "{'assumed_route': 'witch drops glowstone dust -> craft glowstone', 'candidate': 'Glowstone', 'risk': 'version/world assumptions unresolved'}",
+      "stderr": "",
+      "output_sha256": "cd081dc6a4714a8a1f67e8ecd84f8055dcf7ce0bb7922a3afadeb5a6ad68d804"
+    }
+  ],
+  "source_results": [
+    {
+      "id": "673634d362",
+      "url": "https://www.fundacionsoycomotu.org/la-responsabilidad-humana-poema-pie-para-el-nino-de-vallecas-de-velazquez/",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "De aquí no se va nadie. Nadie.",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 104008
+        },
+        {
+          "quote": "Ni el místico ni el suicida.",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 104046
+        },
+        {
+          "quote": "León Felipe",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 102630
+        }
+      ],
+      "sha256": "f2850117df3d12602150d50bf3e6cd9e1270795e714dc59a8d67f36b484faac3",
+      "bytes": 168394
+    },
+    {
+      "id": "673634d362",
+      "url": "https://www.museodelprado.es/en/the-collection/art-work/the-boy-from-vallecas-francisco-lezcano/5a304c42-2eee-49da-b34e-3468b8cb7fb0",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "The Boy from Vallecas",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 56
+        },
+        {
+          "quote": "Diego Rodríguez de Silva y Velázquez",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 120742
+        }
+      ],
+      "sha256": "7fa7ef352d8eda8854fa5fae6dec1904b30989057c537f11dca3c1f1130feba4",
+      "bytes": 406294
+    },
+    {
+      "id": "6708c1dc2f",
+      "url": "https://dokumen.pub/private-anti-piracy-navies-how-warships-for-hire-are-changing-maritime-security-9780739173336-9780739173329.html",
+      "fetch_ok": false,
+      "quotes": [],
+      "error": "<HTTPError 403: 'Forbidden'>"
+    },
+    {
+      "id": "67572db350",
+      "url": "https://pressbooks.online.ucf.edu/aerodynamicstext/chapter/chapter-5-theory-of-airfoil-aerodynamics/",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "line vortex is positioned at the 1/4 chord",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 87005
+        },
+        {
+          "quote": "flow tangency is enforced at the 3/4 chord",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 87052
+        }
+      ],
+      "sha256": "6b96e998ff373e6891b3116ed02898a6662ad37d687d937e2928ffa12d74c918",
+      "bytes": 179439
+    },
+    {
+      "id": "67572db350",
+      "url": "https://mdolab-openaerostruct.readthedocs-hosted.com/en/latest/advanced_features/ground_effect.html",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "mirroring a second copy of the mesh across the ground plane",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 7838
+        }
+      ],
+      "sha256": "18849d2952d6e34b089b29afc8d2665aa850f8a677f77a79670a5014169a08b6",
+      "bytes": 28331
+    },
+    {
+      "id": "67253f2c13",
+      "url": "https://www.rdkit.org/docs/source/rdkit.Chem.Descriptors.html",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "The exact molecular weight of the molecule",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 5209
+        },
+        {
+          "quote": "The number of valence electrons the molecule has",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 16279
+        }
+      ],
+      "sha256": "dc2904db2c37dbace11002557eaeff796a3d59a610c38ec07ed07a4733dafbb7",
+      "bytes": 26563
+    },
+    {
+      "id": "6726425100",
+      "url": "https://docs.riscv.org/reference/isa/unpriv/bfloat16.html",
+      "fetch_ok": true,
+      "quotes": [
+        {
+          "quote": "round to nearest, ties to even",
+          "raw_byte_exact_casefold": true,
+          "byte_start": 41343
+        }
+      ],
+      "sha256": "d6733ee578f84804805f3af16e31e03923c81bfb563c975ef25a0b3e379a0800",
+      "bytes": 72475
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds ADJ100, a compact write-up of two 10-item HLE reruns after clarifying that the goal is defensible and auditable work rather than a large raw-accuracy win.

The new report records:

- the stricter parent-enforced acceptance protocol;
- run 1 and run 2 headline metrics;
- item-level texture on accepted and rejected answers;
- compact machine-readable audit summaries for both reruns.

## Key finding

The useful metric is `wrong_accepted`, not just raw accuracy. Run 2 accepted fewer framework answers, but accepted answers were clean: `3/3` strict-correct with `0` wrong accepted. The report frames the framework as a precision/defensibility filter rather than a pure accuracy engine.

## Validation

- Parsed `run1_audit.json` and `run2_audit.json` with `python3 -m json.tool`.
- Markdown-only/spec-data change; no package tests were run.