### PR TITLE
Add smart-home activation review tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -43,6 +43,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A grouped activation constraint planning:
   `smart_home.list_integration_activation_constraints` and
   `smart_home.get_integration_activation_constraint_summary`.
+- Added D18D handlers for D23A activation human-review queue planning:
+  `smart_home.list_integration_activation_reviews` and
+  `smart_home.get_integration_activation_review_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -48,6 +48,7 @@ Chief of Staff job/session/agent
   -> activation-health list and summary reads for priority-wave readiness status
   -> activation-maintenance list and summary reads for combined wave health
   -> activation-constraint list and summary reads for grouped blockers/reviews
+  -> activation-review list and summary reads for human-review queue planning
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -91,6 +92,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_maintenance_summary`
 - `smart_home.list_integration_activation_constraints`
 - `smart_home.get_integration_activation_constraint_summary`
+- `smart_home.list_integration_activation_reviews`
+- `smart_home.get_integration_activation_review_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -37,30 +37,32 @@ use smart_home_integration_catalog::{
     activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
     activation_dependency_graph_from_reports, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_risk_from_candidates,
-    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationRiskItem, IntegrationActivationRiskKind,
-    IntegrationActivationRiskSummary, IntegrationActivationRunwayStage,
-    IntegrationActivationRunwaySummary, IntegrationActivationTarget, IntegrationCatalogEntry,
-    IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    activation_plans_at_or_before_priority, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
+    IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
+    IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
+    IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
+    IntegrationActivationTarget, IntegrationCatalogEntry, IntegrationCatalogQuery,
+    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
     IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
@@ -195,6 +197,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONSTRAINTS_TOOL_ID: &str =
     "smart_home.list_integration_activation_constraints";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_constraint_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_reviews";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_review_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -383,6 +389,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID => {
                     let query = integration_activation_constraint_query(&arguments)?;
                     Ok(get_integration_activation_constraint_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID => {
+                    let query = integration_activation_review_query(&arguments)?;
+                    Ok(list_integration_activation_reviews_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_review_query(&arguments)?;
+                    Ok(get_integration_activation_review_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1348,6 +1364,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation constraint summary",
             "Return compact D23A activation constraint counts for blockers, policy-review work, affected integrations, and first rollout priorities.",
             integration_activation_constraint_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID,
+            "List smart-home integration activation reviews",
+            "List D23A activation human-review queue entries with readiness blockers, policy surfaces, and review-ready status.",
+            integration_activation_review_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_reviews", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_reviews",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation review summary",
+            "Return compact D23A activation human-review queue counts for review-ready and blocked rollout work.",
+            integration_activation_review_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3922,6 +3972,17 @@ struct IntegrationActivationConstraintQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationReviewQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    required_tier: Option<PrivilegeTier>,
+    policy_surface: Option<IntegrationPolicySurface>,
+    review_ready: Option<bool>,
+    blocked_only: Option<bool>,
+    requires_attention: Option<bool>,
+    review_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4019,6 +4080,28 @@ fn integration_activation_constraint_query(
             "constraint_requires_human_review",
         )?,
         constraint_limit: optional_u64(arguments, "constraint_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_review_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationReviewQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let required_tier = optional_string(arguments, "required_tier")?
+        .map(|tier| parse_privilege_tier(&tier))
+        .transpose()?;
+    let policy_surface = optional_string(arguments, "policy_surface")?
+        .map(|surface| parse_policy_surface(&surface))
+        .transpose()?;
+
+    Ok(IntegrationActivationReviewQuery {
+        candidates,
+        required_tier,
+        policy_surface,
+        review_ready: optional_bool(arguments, "review_ready")?,
+        blocked_only: optional_bool(arguments, "blocked_only")?,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        review_limit: optional_u64(arguments, "review_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4311,6 +4394,36 @@ fn integration_activation_constraints_for_query(
     }
 
     (constraints, catalog_count)
+}
+
+fn integration_activation_reviews_for_query(
+    query: &IntegrationActivationReviewQuery,
+) -> (Vec<IntegrationActivationReviewItem>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut reviews = activation_reviews_from_candidates(&catalog, candidates.iter());
+
+    if let Some(required_tier) = query.required_tier {
+        reviews.retain(|review| review.required_tier == required_tier);
+    }
+    if let Some(policy_surface) = query.policy_surface {
+        reviews.retain(|review| review.policy_surfaces.contains(&policy_surface));
+    }
+    if let Some(review_ready) = query.review_ready {
+        reviews.retain(|review| review.review_ready() == review_ready);
+    }
+    if let Some(blocked_only) = query.blocked_only {
+        reviews.retain(|review| review.has_blockers() == blocked_only);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        reviews.retain(|review| review.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.review_limit {
+        reviews.truncate(limit);
+    }
+
+    (reviews, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -5204,6 +5317,72 @@ fn get_integration_activation_constraint_summary_output_handler_output(
             (
                 "review_constraints",
                 integer(summary.review_constraints as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_reviews_output_handler_output(
+    query: IntegrationActivationReviewQuery,
+) -> ToolHandlerOutput {
+    let (reviews, catalog_count) = integration_activation_reviews_for_query(&query);
+    let summary = IntegrationActivationReviewSummary::from_reviews(reviews.iter());
+    let count = reviews.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_reviews",
+            JsonValue::Array(reviews.iter().map(activation_review_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_review_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_reviews")),
+            ("reviews", integer(count as i64)),
+            (
+                "review_ready_integrations",
+                integer(summary.review_ready_integrations as i64),
+            ),
+            (
+                "blocked_review_integrations",
+                integer(summary.blocked_review_integrations as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_review_summary_output_handler_output(
+    query: IntegrationActivationReviewQuery,
+) -> ToolHandlerOutput {
+    let (reviews, _) = integration_activation_reviews_for_query(&query);
+    let summary = IntegrationActivationReviewSummary::from_reviews(reviews.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_review_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_review_summary"),
+            ),
+            ("total_reviews", integer(summary.total_reviews as i64)),
+            (
+                "review_ready_integrations",
+                integer(summary.review_ready_integrations as i64),
+            ),
+            (
+                "blocked_review_integrations",
+                integer(summary.blocked_review_integrations as i64),
             ),
         ]),
     )
@@ -8965,6 +9144,191 @@ fn integration_activation_constraint_summary_json(
     ])
 }
 
+fn activation_review_json(review: &IntegrationActivationReviewItem) -> JsonValue {
+    object([
+        (
+            "integration_id",
+            string(review.requested_integration_id.as_str()),
+        ),
+        (
+            "requested_integration_id",
+            string(review.requested_integration_id.as_str()),
+        ),
+        ("display_name", string(&review.display_name)),
+        ("priority", integer(review.priority as i64)),
+        (
+            "activation_target",
+            activation_target_json(&review.activation_target),
+        ),
+        (
+            "recommendation",
+            string(activation_candidate_recommendation_label(
+                review.recommendation,
+            )),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(review.required_tier)),
+        ),
+        (
+            "policy_surfaces",
+            JsonValue::Array(
+                review
+                    .policy_surfaces
+                    .iter()
+                    .map(|surface| string(surface.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "missing_primitives",
+            JsonValue::Array(
+                review
+                    .missing_primitives
+                    .iter()
+                    .map(|primitive| string(primitive.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "missing_capability_ids",
+            JsonValue::Array(
+                review
+                    .missing_capabilities
+                    .iter()
+                    .map(|capability_id| string(capability_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "missing_dependencies",
+            JsonValue::Array(
+                review
+                    .missing_dependencies
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        ("blocker_count", integer(review.blocker_count as i64)),
+        ("local_only", JsonValue::Bool(review.local_only)),
+        ("cloud_required", JsonValue::Bool(review.cloud_required)),
+        (
+            "activation_ready",
+            JsonValue::Bool(review.activation_ready()),
+        ),
+        ("review_ready", JsonValue::Bool(review.review_ready())),
+        ("is_blocked", JsonValue::Bool(review.is_blocked())),
+        (
+            "has_policy_surfaces",
+            JsonValue::Bool(review.has_policy_surfaces()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(review.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_review_summary_json(
+    summary: &IntegrationActivationReviewSummary,
+) -> JsonValue {
+    object([
+        ("total_reviews", integer(summary.total_reviews as i64)),
+        (
+            "review_ready_integrations",
+            integer(summary.review_ready_integrations as i64),
+        ),
+        (
+            "blocked_review_integrations",
+            integer(summary.blocked_review_integrations as i64),
+        ),
+        (
+            "reviews_missing_primitives",
+            integer(summary.reviews_missing_primitives as i64),
+        ),
+        (
+            "reviews_missing_capabilities",
+            integer(summary.reviews_missing_capabilities as i64),
+        ),
+        (
+            "reviews_missing_dependencies",
+            integer(summary.reviews_missing_dependencies as i64),
+        ),
+        ("direct_targets", integer(summary.direct_targets as i64)),
+        (
+            "delegated_integration_targets",
+            integer(summary.delegated_integration_targets as i64),
+        ),
+        (
+            "delegated_standard_targets",
+            integer(summary.delegated_standard_targets as i64),
+        ),
+        (
+            "local_only_reviews",
+            integer(summary.local_only_reviews as i64),
+        ),
+        (
+            "cloud_required_reviews",
+            integer(summary.cloud_required_reviews as i64),
+        ),
+        (
+            "reviews_with_policy_surfaces",
+            integer(summary.reviews_with_policy_surfaces as i64),
+        ),
+        (
+            "reviews_without_policy_surfaces",
+            integer(summary.reviews_without_policy_surfaces as i64),
+        ),
+        (
+            "unique_policy_surfaces",
+            integer(summary.unique_policy_surfaces as i64),
+        ),
+        ("total_blockers", integer(summary.total_blockers as i64)),
+        (
+            "read_only_reviews",
+            integer(summary.read_only_reviews as i64),
+        ),
+        ("low_risk_reviews", integer(summary.low_risk_reviews as i64)),
+        (
+            "human_approval_reviews",
+            integer(summary.human_approval_reviews as i64),
+        ),
+        (
+            "high_risk_reviews",
+            integer(summary.high_risk_reviews as i64),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_review_ready_work",
+            JsonValue::Bool(summary.has_review_ready_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -12287,6 +12651,32 @@ fn integration_activation_constraint_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_review_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "review_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("required_tier", JsonSchema::String));
+        properties.push(SchemaProperty::new("policy_surface", JsonSchema::String));
+        properties.push(SchemaProperty::new("review_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -12431,7 +12821,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 75);
+        assert_eq!(definitions.len(), 77);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -12517,6 +12907,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID));
@@ -12626,7 +13022,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            67
+            69
         );
         assert_eq!(
             export
@@ -12738,6 +13134,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_CONSTRAINT_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -13000,11 +13404,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(75))
+            Some(&integer(77))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(67))
+            Some(&integer(69))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -14159,6 +14563,126 @@ mod tests {
         );
         assert_eq!(
             field(activation_constraint_rollup, "has_review_work"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_reviews_request = request(
+            "call-list-integration-activation-reviews",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("review_limit", integer(3)),
+            ]),
+            5_009,
+        );
+        let list_activation_reviews_trace =
+            tool_runtime.invoke_with_events(&list_activation_reviews_request);
+        assert!(list_activation_reviews_trace.result.ok);
+        assert_eq!(
+            list_activation_reviews_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_reviews_output = list_activation_reviews_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_review_count =
+            integer_value(field(list_activation_reviews_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_review_count));
+        let activation_review_summary = field(list_activation_reviews_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_review_summary, "total_reviews").unwrap()).unwrap() >= 1
+        );
+        assert!(
+            integer_value(
+                field(activation_review_summary, "reviews_with_policy_surfaces").unwrap()
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_review_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_review = array_item(
+            field(list_activation_reviews_output, "activation_reviews").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_review, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(matches!(
+            field(activation_review, "recommendation"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(matches!(
+            field(activation_review, "required_tier"),
+            Some(JsonValue::String(_))
+        ));
+
+        let activation_review_summary_request = request(
+            "call-integration-activation-review-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            5_010,
+        );
+        let activation_review_summary_trace =
+            tool_runtime.invoke_with_events(&activation_review_summary_request);
+        assert!(activation_review_summary_trace.result.ok);
+        assert_eq!(
+            activation_review_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_review_summary_output = activation_review_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_review_rollup = field(activation_review_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_review_rollup, "blocked_review_integrations").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_review_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
         );
 
@@ -15837,6 +16361,14 @@ mod tests {
             activation_constraint_summary_request,
             activation_constraint_summary_trace,
         );
+        journal.record_trace(
+            list_activation_reviews_request,
+            list_activation_reviews_trace,
+        );
+        journal.record_trace(
+            activation_review_summary_request,
+            activation_review_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -15910,9 +16442,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 75);
-        assert_eq!(journal_summary.completed_count, 75);
-        assert_eq!(journal.audit_records().len(), 75);
+        assert_eq!(journal_summary.invocation_count, 77);
+        assert_eq!(journal_summary.completed_count, 77);
+        assert_eq!(journal.audit_records().len(), 77);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_constraints` and
   `smart_home.get_integration_activation_constraint_summary` tool descriptors
   for read-only grouped activation constraint planning.
+- `smart_home.list_integration_activation_reviews` and
+  `smart_home.get_integration_activation_review_summary` tool descriptors for
+  read-only human-review queue planning.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -68,6 +68,8 @@ Current scope:
   priority-wave health, action, constraint, risk, and dependency summaries
 - D18D integration activation-constraint descriptors for grouped primitive,
   capability, dependency, and policy-review blocker summaries
+- D18D integration activation-review descriptors for read-only human-review
+  queue entries and compact review-ready/blocker summaries
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1473,6 +1473,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationMaintenanceSummary,
     ListIntegrationActivationConstraints,
     GetIntegrationActivationConstraintSummary,
+    ListIntegrationActivationReviews,
+    GetIntegrationActivationReviewSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1598,6 +1600,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationConstraintSummary => {
                 read_tool("smart_home.get_integration_activation_constraint_summary")
+            }
+            Self::ListIntegrationActivationReviews => {
+                read_tool("smart_home.list_integration_activation_reviews")
+            }
+            Self::GetIntegrationActivationReviewSummary => {
+                read_tool("smart_home.get_integration_activation_review_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2254,6 +2262,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationMaintenanceSummary,
         SmartHomeTool::ListIntegrationActivationConstraints,
         SmartHomeTool::GetIntegrationActivationConstraintSummary,
+        SmartHomeTool::ListIntegrationActivationReviews,
+        SmartHomeTool::GetIntegrationActivationReviewSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3096,7 +3106,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 75);
+        assert_eq!(catalog.len(), 77);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3220,6 +3230,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_constraint_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_reviews"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_review_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3410,15 +3428,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 75);
-        assert_eq!(summary.read_tools, 67);
+        assert_eq!(summary.total_tools, 77);
+        assert_eq!(summary.read_tools, 69);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 67);
+        assert_eq!(summary.read_only_tier_tools, 69);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 75);
+        assert_eq!(summary.total_required_capabilities, 77);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to this package will be documented in this file.
   `IntegrationActivationConstraintSummary` for grouping unresolved primitive,
   capability, dependency, and policy-review surface work by affected
   integrations.
+- `IntegrationActivationReviewItem` and `IntegrationActivationReviewSummary`
+  for exposing human-review queue entries with review-ready and blocked
+  rollups.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -50,6 +50,9 @@ runtime and Chief of Staff tools a typed catalog for:
   actions, constraints, policy risk, and dependency blockers for Chief planning
 - activation constraints that group unresolved primitive, capability,
   dependency, and policy-review surface work by affected integrations
+- activation review queue entries that separate review-ready integrations from
+  human-review integrations still blocked by primitives, capabilities, or
+  dependencies
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1173,6 +1173,49 @@ pub struct IntegrationActivationRiskSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReviewItem {
+    pub requested_integration_id: IntegrationId,
+    pub display_name: String,
+    pub priority: u8,
+    pub activation_target: IntegrationActivationTarget,
+    pub recommendation: IntegrationActivationCandidateRecommendation,
+    pub blocker_count: usize,
+    pub missing_primitives: Vec<PrimitiveFamily>,
+    pub missing_capabilities: Vec<CapabilityId>,
+    pub missing_dependencies: Vec<IntegrationId>,
+    pub policy_surfaces: Vec<IntegrationPolicySurface>,
+    pub required_tier: PrivilegeTier,
+    pub local_only: bool,
+    pub cloud_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReviewSummary {
+    pub total_reviews: usize,
+    pub review_ready_integrations: usize,
+    pub blocked_review_integrations: usize,
+    pub reviews_missing_primitives: usize,
+    pub reviews_missing_capabilities: usize,
+    pub reviews_missing_dependencies: usize,
+    pub direct_targets: usize,
+    pub delegated_integration_targets: usize,
+    pub delegated_standard_targets: usize,
+    pub local_only_reviews: usize,
+    pub cloud_required_reviews: usize,
+    pub reviews_with_policy_surfaces: usize,
+    pub reviews_without_policy_surfaces: usize,
+    pub unique_policy_surfaces: usize,
+    pub total_blockers: usize,
+    pub read_only_reviews: usize,
+    pub low_risk_reviews: usize,
+    pub human_approval_reviews: usize,
+    pub high_risk_reviews: usize,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationAgendaStage {
     pub priority: u8,
     pub candidates: Vec<IntegrationActivationCandidate>,
@@ -2358,6 +2401,178 @@ impl IntegrationActivationRiskSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.has_review_work() || self.has_blockers()
+    }
+}
+
+impl IntegrationActivationReviewItem {
+    fn from_candidate(
+        catalog: &[IntegrationCatalogEntry],
+        candidate: &IntegrationActivationCandidate,
+    ) -> Option<Self> {
+        if !candidate.requires_human_review() {
+            return None;
+        }
+
+        let report = &candidate.readiness_report;
+        let mut policy_surfaces = find_entry(catalog, &report.requested_integration_id)
+            .map(IntegrationCatalogEntry::policy_surfaces)
+            .unwrap_or_default();
+        policy_surfaces.sort();
+        policy_surfaces.dedup();
+        let required_tier = policy_surfaces
+            .iter()
+            .fold(report.highest_policy_tier, |tier, surface| {
+                tier.max(surface.required_tier())
+            });
+
+        Some(Self {
+            requested_integration_id: report.requested_integration_id.clone(),
+            display_name: report.display_name.clone(),
+            priority: report.priority,
+            activation_target: report.activation_target.clone(),
+            recommendation: candidate.recommendation,
+            blocker_count: candidate.blocker_count,
+            missing_primitives: report.missing_primitives.clone(),
+            missing_capabilities: report.missing_capabilities.clone(),
+            missing_dependencies: report.missing_dependencies.clone(),
+            policy_surfaces,
+            required_tier,
+            local_only: report.local_only,
+            cloud_required: report.cloud_required,
+        })
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.missing_primitives.is_empty()
+            && self.missing_capabilities.is_empty()
+            && self.missing_dependencies.is_empty()
+    }
+
+    pub fn review_ready(&self) -> bool {
+        self.activation_ready()
+            && self.recommendation == IntegrationActivationCandidateRecommendation::NeedsHumanReview
+    }
+
+    pub fn is_blocked(&self) -> bool {
+        self.recommendation == IntegrationActivationCandidateRecommendation::BlockedOnPrerequisites
+            || !self.activation_ready()
+    }
+
+    pub fn has_policy_surfaces(&self) -> bool {
+        !self.policy_surfaces.is_empty()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.is_blocked()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        true
+    }
+}
+
+impl IntegrationActivationReviewSummary {
+    pub fn from_reviews<'a>(
+        reviews: impl IntoIterator<Item = &'a IntegrationActivationReviewItem>,
+    ) -> Self {
+        let mut policy_surfaces = BTreeSet::new();
+        let mut summary = Self {
+            total_reviews: 0,
+            review_ready_integrations: 0,
+            blocked_review_integrations: 0,
+            reviews_missing_primitives: 0,
+            reviews_missing_capabilities: 0,
+            reviews_missing_dependencies: 0,
+            direct_targets: 0,
+            delegated_integration_targets: 0,
+            delegated_standard_targets: 0,
+            local_only_reviews: 0,
+            cloud_required_reviews: 0,
+            reviews_with_policy_surfaces: 0,
+            reviews_without_policy_surfaces: 0,
+            unique_policy_surfaces: 0,
+            total_blockers: 0,
+            read_only_reviews: 0,
+            low_risk_reviews: 0,
+            human_approval_reviews: 0,
+            high_risk_reviews: 0,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for review in reviews {
+            summary.total_reviews += 1;
+            if review.review_ready() {
+                summary.review_ready_integrations += 1;
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(review.priority));
+            }
+            if review.is_blocked() {
+                summary.blocked_review_integrations += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(review.priority));
+            }
+            if !review.missing_primitives.is_empty() {
+                summary.reviews_missing_primitives += 1;
+            }
+            if !review.missing_capabilities.is_empty() {
+                summary.reviews_missing_capabilities += 1;
+            }
+            if !review.missing_dependencies.is_empty() {
+                summary.reviews_missing_dependencies += 1;
+            }
+            match &review.activation_target {
+                IntegrationActivationTarget::Direct => summary.direct_targets += 1,
+                IntegrationActivationTarget::DelegatedIntegration(_) => {
+                    summary.delegated_integration_targets += 1
+                }
+                IntegrationActivationTarget::DelegatedStandards(_) => {
+                    summary.delegated_standard_targets += 1
+                }
+            }
+            if review.local_only {
+                summary.local_only_reviews += 1;
+            }
+            if review.cloud_required {
+                summary.cloud_required_reviews += 1;
+            }
+            if review.has_policy_surfaces() {
+                summary.reviews_with_policy_surfaces += 1;
+            } else {
+                summary.reviews_without_policy_surfaces += 1;
+            }
+            for surface in &review.policy_surfaces {
+                policy_surfaces.insert(*surface);
+            }
+            summary.total_blockers += review.blocker_count;
+            match review.required_tier {
+                PrivilegeTier::ReadOnly => summary.read_only_reviews += 1,
+                PrivilegeTier::LowRisk => summary.low_risk_reviews += 1,
+                PrivilegeTier::HumanApproval => summary.human_approval_reviews += 1,
+                PrivilegeTier::HighRisk => summary.high_risk_reviews += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(review.required_tier);
+        }
+
+        summary.unique_policy_surfaces = policy_surfaces.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_reviews == 0
+    }
+
+    pub fn has_review_ready_work(&self) -> bool {
+        self.review_ready_integrations > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_review_integrations > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.total_reviews > 0
     }
 }
 
@@ -4709,6 +4924,36 @@ pub fn activation_risk_at_or_before_priority(
     activation_risk_from_candidates(catalog, candidates.iter())
 }
 
+pub fn activation_reviews_from_candidates<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+) -> Vec<IntegrationActivationReviewItem> {
+    let mut reviews = candidates
+        .into_iter()
+        .filter_map(|candidate| IntegrationActivationReviewItem::from_candidate(catalog, candidate))
+        .collect::<Vec<_>>();
+
+    reviews.sort_by(compare_activation_reviews);
+    reviews
+}
+
+pub fn activation_reviews_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationReviewItem> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_reviews_from_candidates(catalog, candidates.iter())
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -5905,6 +6150,20 @@ fn compare_activation_risks(
         .then_with(|| left.risk_id.cmp(&right.risk_id))
 }
 
+fn compare_activation_reviews(
+    left: &IntegrationActivationReviewItem,
+    right: &IntegrationActivationReviewItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.required_tier.cmp(&left.required_tier))
+        .then_with(|| left.display_name.cmp(&right.display_name))
+        .then_with(|| {
+            left.requested_integration_id
+                .cmp(&right.requested_integration_id)
+        })
+}
+
 fn compare_activation_dependency_nodes(
     left: &IntegrationActivationDependencyNode,
     right: &IntegrationActivationDependencyNode,
@@ -6850,6 +7109,116 @@ mod tests {
             &[],
         );
         assert_eq!(risks, risks_from_catalog);
+    }
+
+    #[test]
+    fn activation_reviews_queue_ready_and_blocked_human_review_work() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+
+        let reviews = activation_reviews_from_candidates(&[], candidates.iter());
+
+        assert_eq!(reviews.len(), 2);
+        let review_ready = reviews
+            .iter()
+            .find(|review| review.requested_integration_id.as_str() == "review_ready_bridge")
+            .unwrap();
+        assert!(review_ready.activation_ready());
+        assert!(review_ready.review_ready());
+        assert!(!review_ready.has_blockers());
+        assert!(review_ready.requires_attention());
+        assert_eq!(review_ready.required_tier, PrivilegeTier::HumanApproval);
+        let blocked_review = reviews
+            .iter()
+            .find(|review| review.requested_integration_id.as_str() == "blocked_review_camera")
+            .unwrap();
+        assert!(!blocked_review.activation_ready());
+        assert!(!blocked_review.review_ready());
+        assert!(blocked_review.has_blockers());
+        assert_eq!(blocked_review.blocker_count, 3);
+        assert_eq!(blocked_review.required_tier, PrivilegeTier::HighRisk);
+
+        let summary = IntegrationActivationReviewSummary::from_reviews(reviews.iter());
+        assert_eq!(summary.total_reviews, 2);
+        assert_eq!(summary.review_ready_integrations, 1);
+        assert_eq!(summary.blocked_review_integrations, 1);
+        assert_eq!(summary.reviews_missing_primitives, 1);
+        assert_eq!(summary.reviews_missing_capabilities, 1);
+        assert_eq!(summary.reviews_missing_dependencies, 1);
+        assert_eq!(summary.total_blockers, 3);
+        assert_eq!(summary.first_review_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(2));
+        assert_eq!(summary.local_only_reviews, 1);
+        assert_eq!(summary.cloud_required_reviews, 1);
+        assert_eq!(summary.human_approval_reviews, 1);
+        assert_eq!(summary.high_risk_reviews, 1);
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert!(summary.has_review_ready_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_reviews = activation_reviews_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_reviews
+            .iter()
+            .any(IntegrationActivationReviewItem::has_policy_surfaces));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-level integration activation review queue items and summaries for review-ready vs blocked human-review work
- expose smart_home.list_integration_activation_reviews and smart_home.get_integration_activation_review_summary in shared core and Chief tools
- document the new review queue surface and cover it in catalog/core/Chief tests

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools