### PR TITLE
feat(mccarthy-lisp): W1 — run McCarthy symbols on wasm (F6) (LANG77)

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.11.0] — 2026-06-09 — managed-backend symbol interning (LANG77 / McCarthy W1)
+
+### Added
+
+- **`intern_symbols_structural`** — the managed/uniform-reference twin of
+  `intern_symbols`. Interns each symbol literal (`const Var(name) : symbol`) to a
+  distinct integer in a reserved high range (`SYMBOL_ID_BASE = 2²⁹` + module-wide
+  id) and retypes it to `i32`, so a symbol flows like any integer atom: the
+  structural pass boxes it as an `i31ref` and `EQ` compares the payloads with
+  `i32.eq`. Distinct symbols get distinct values (`(EQ 'A 'B)` → nil), same
+  symbols share one (`(EQ 'A 'A)` → T), and the reserved range keeps symbols
+  disjoint from integer atoms (`(EQ 'A 5)` → nil). No new value type, no
+  polymorphic `EQ`. Reusable across WASM/JVM/CLR/BEAM (each adapts the encoding;
+  the WASM path uses the integer ids directly). 4 new tests.
+
 ## [0.10.0] — 2026-06-09 — `COND` lisp-truthiness (LANG77 / McCarthy L3b-3a-4d)
 
 ### Changed

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lib.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lib.rs
@@ -152,6 +152,11 @@ pub use lisp_repr_structural::lower_lisp_repr_structural;
 // so native symbols carry identity (for `EQ`) without runtime interning.
 // Runs before `lower_lisp_repr`.
 pub use symbol_intern::intern_symbols;
+// The managed-backend (uniform-reference) symbol interner (LANG77 / McCarthy
+// W1): interns symbol literals to distinct integers in a reserved range so they
+// box as `i31ref`s and `EQ` compares them with `i32.eq`. Twin of
+// `intern_symbols`. Run before `lower_lisp_repr_structural`.
+pub use symbol_intern::intern_symbols_structural;
 // Re-export the global/IO lowering entry point (LANG32).
 pub use global_io::lower_global_io;
 // Re-export the closure lowering entry point (LANG34).

--- a/code/packages/rust/iir-builtin-lowering/src/symbol_intern.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/symbol_intern.rs
@@ -44,6 +44,61 @@ const SYMBOL_HINT: &str = "symbol";
 /// The symbol tag (`lispy-runtime` `TAG_SYMBOL = 0b010`).
 const TAG_SYMBOL: i64 = 0b010;
 
+/// The base of the reserved **symbol id range** for the *managed* (uniform-ref)
+/// backends (WASM/JVM/CLR/BEAM) — see [`intern_symbols_structural`].
+///
+/// Those backends have no spare tag bit in their boxed-integer representation
+/// (a WASM `i31ref` is a bare 31-bit payload), so a symbol is interned to a
+/// distinct integer in a **high reserved range** that ordinary integer atoms do
+/// not reach. `2²⁹` carves the 31-bit space into integers `[−2²⁹, 2²⁹)` and
+/// symbol ids `[2²⁹, 2³⁰)`, so a symbol value can never equal an integer value
+/// — `(EQ 'A 5)` is `nil`. (A program that mixes symbols with integer atoms
+/// `≥ 2²⁹` is out of range, the documented analogue of the native `±2⁶⁰` limit;
+/// McCarthy 1.0 programs use small integers.)
+pub const SYMBOL_ID_BASE: i64 = 1 << 29;
+
+/// Intern every symbol literal to a distinct integer in the reserved symbol-id
+/// range, for the **managed / uniform-reference** backends (WASM today;
+/// JVM/CLR/BEAM as they land). The twin of [`intern_symbols`], which targets the
+/// native tagged-word model.
+///
+/// A frontend symbol literal is `const Var(name) : symbol`. We assign each
+/// distinct name a module-wide id (first-seen order, so one id per name across
+/// all functions — what makes cross-function `EQ` sound) and rewrite the const
+/// to `const Int(SYMBOL_ID_BASE + id) : i32`. From there the value flows like
+/// any integer atom: the structural representation pass boxes it as an `i31ref`,
+/// and `EQ` compares the payloads with `i32.eq` — so `(EQ 'A 'A)` is true,
+/// `(EQ 'A 'B)` is false, with no new value type or polymorphic `EQ`.
+///
+/// Run it **before** `lower_lisp_repr_structural` (so the pass sees a plain
+/// integer atom). Idempotent: a `const : symbol` that is already an `Int`
+/// (re-run) is left untouched; non-symbol consts are never touched.
+pub fn intern_symbols_structural(module: &mut IIRModule) {
+    let mut ids: HashMap<String, u32> = HashMap::new();
+    let mut next_id: u32 = 0;
+
+    for func in &mut module.functions {
+        for instr in &mut func.instructions {
+            if instr.op != "const" || instr.type_hint != SYMBOL_HINT {
+                continue;
+            }
+            let name = match instr.srcs.first() {
+                Some(Operand::Var(n)) => n.clone(),
+                _ => continue, // already interned (Int), or malformed — leave it.
+            };
+            let id = *ids.entry(name).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id
+            });
+            // The interned symbol value: a distinct integer in the reserved
+            // range. Retype to i32 so it boxes as an i31ref like an integer atom.
+            instr.srcs[0] = Operand::Int(SYMBOL_ID_BASE + id as i64);
+            instr.type_hint = "i32".to_string();
+        }
+    }
+}
+
 /// Intern every symbol literal in `module` to its tagged immediate, in place.
 ///
 /// Assigns ids in first-seen order across the **whole module** (so a name used
@@ -147,6 +202,71 @@ mod tests {
         let helper_bits = const_bits(&m, 0, "h");
         let main_bits = const_bits(&m, 1, "m");
         assert_eq!(helper_bits, main_bits, "same name across functions → same id");
+    }
+
+    // ── intern_symbols_structural (managed / uniform-ref backends) ────────────
+
+    #[test]
+    fn structural_distinct_names_get_distinct_reserved_ids() {
+        let f = IIRFunction::new(
+            "main",
+            vec![],
+            "any",
+            vec![sym_const("a", "A"), sym_const("a2", "A"), sym_const("b", "B")],
+        );
+        let mut m = module(vec![f]);
+        intern_symbols_structural(&mut m);
+        // A → SYMBOL_ID_BASE + 0 (twice), B → SYMBOL_ID_BASE + 1.
+        assert_eq!(const_bits(&m, 0, "a"), SYMBOL_ID_BASE, "first symbol id 0");
+        assert_eq!(const_bits(&m, 0, "a2"), SYMBOL_ID_BASE, "same name → same id");
+        assert_eq!(const_bits(&m, 0, "b"), SYMBOL_ID_BASE + 1, "B → id 1");
+        assert_ne!(const_bits(&m, 0, "a"), const_bits(&m, 0, "b"), "A ≠ B");
+    }
+
+    #[test]
+    fn structural_symbols_are_retyped_i32_and_disjoint_from_integers() {
+        let f = IIRFunction::new("main", vec![], "any", vec![sym_const("a", "A")]);
+        let mut m = module(vec![f]);
+        intern_symbols_structural(&mut m);
+        let instr = m.functions[0]
+            .instructions
+            .iter()
+            .find(|i| i.dest.as_deref() == Some("a"))
+            .unwrap();
+        assert_eq!(instr.type_hint, "i32", "interned symbol retyped to i32 (boxes as i31ref)");
+        // A symbol id is in the reserved high range, never reached by a small
+        // integer atom, so `(EQ 'A 5)` is false.
+        assert!(const_bits(&m, 0, "a") >= SYMBOL_ID_BASE, "symbol id in reserved range");
+    }
+
+    #[test]
+    fn structural_ids_are_module_wide() {
+        let helper = IIRFunction::new("helper", vec![], "any", vec![sym_const("h", "A")]);
+        let main = IIRFunction::new("main", vec![], "any", vec![sym_const("m", "A")]);
+        let mut m = module(vec![helper, main]);
+        intern_symbols_structural(&mut m);
+        assert_eq!(
+            const_bits(&m, 0, "h"),
+            const_bits(&m, 1, "m"),
+            "same name across functions → same id"
+        );
+    }
+
+    #[test]
+    fn structural_non_symbol_consts_untouched() {
+        let f = IIRFunction::new(
+            "main",
+            vec![],
+            "any",
+            vec![
+                IIRInstr::new("const", Some("i".into()), vec![Operand::Int(42)], "i64"),
+                IIRInstr::new("const", Some("n".into()), vec![Operand::Int(0)], "ref<LispyPair>"),
+            ],
+        );
+        let mut m = module(vec![f]);
+        intern_symbols_structural(&mut m);
+        assert_eq!(const_bits(&m, 0, "i"), 42, "i64 const untouched");
+        assert_eq!(const_bits(&m, 0, "n"), 0, "nil const untouched");
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `lang-aot`
 
+## 0.19.0 — 2026-06-09 — McCarthy → WebAssembly, **symbols** (LANG77 / W1)
+
+`compile_source_to_wasm` now runs `intern_symbols_structural` (before the repr
+pass), so McCarthy **symbols** (`QUOTE` / `'A`) work: each distinct symbol is a
+distinct interned value (boxed as `i31ref`), so `(EQ 'A 'A)` → T, `(EQ 'A 'B)` →
+nil, `(EQ 'A 5)` → nil. Symbols flow through cons cells and `COND` guards. With
+this, the WASM backend runs the full McCarthy core **plus symbols** (F1–F6);
+integer/cons/scalar programs are unaffected.
+
 ## 0.18.0 — 2026-06-09 — McCarthy → WebAssembly, **`COND`** (LANG77 / L3b-3a-4d)
 
 `compile_source_to_wasm` now compiles McCarthy's `COND` conditional with correct

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -7,10 +7,11 @@ end-to-end natively; symbol/cons backend support is L3b.)  As of L3b-3a-3c,
 `compile_source_to_wasm` also compiles McCarthy **cons** programs to a runnable
 WasmGC module — `(CAR (CONS 7 9))` → `7` on the in-repo `wasm-runtime` (integer
 atoms boxed as `i31ref`, the cons cell a `$LispyPair` struct) — and the McCarthy
-predicates and `COND`: `pair?`/`ATOM` (`(ATOM 5)` → 1; L3b-3a-4b), `EQ` atom
-equality (`(EQ 5 5)` → 1; L3b-3a-4c), and `COND` with lisp-truthiness
-(`(COND (0 7) (5 9))` → 7 — `0` is truthy; L3b-3a-4d). The McCarthy core —
-cons, `ATOM`, `EQ`, `COND` — now runs on the wasm backend.
+predicates, `COND`, and symbols: `pair?`/`ATOM` (`(ATOM 5)` → 1; L3b-3a-4b),
+`EQ` atom equality (`(EQ 5 5)` → 1; L3b-3a-4c), `COND` with lisp-truthiness
+(`(COND (0 7) (5 9))` → 7 — `0` is truthy; L3b-3a-4d), and symbols
+(`(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil; W1). The McCarthy core —
+cons, `ATOM`, `EQ`, `COND`, symbols — now runs on the wasm backend.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -399,6 +399,11 @@ pub fn compile_source_to_wasm(
     // Managed backends consume the structural cons form (not the native
     // runtime-call form). A no-op for a module without cons builtins.
     iir_builtin_lowering::lower_heap_builtins(&mut module);
+    // Intern symbol literals to distinct integers in a reserved range, so each
+    // distinct symbol is a unique value (boxed as `i31ref`) and `EQ` compares
+    // them with `i32.eq` — `(EQ 'A 'A)` true, `(EQ 'A 'B)` false (LANG77 / W1).
+    // A no-op for a module with no symbol literals. Before the repr pass.
+    iir_builtin_lowering::intern_symbols_structural(&mut module);
     // The two representation passes partition the module's functions:
     //   • heap-using functions → the structural pass boxes their integer atoms
     //     as `i31ref` and unboxes the entry result (uniform-anyref value model);

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -288,3 +288,28 @@ fn mccarthy_cond_runs_on_wasm() {
     assert_eq!(go("(COND ((EQ 1 1) 7) (5 9))"), vec![7]);
     assert_eq!(go("(COND ((EQ 1 2) 7) (5 9))"), vec![9]);
 }
+
+/// Symbols run on wasm (LANG77 W1 / F6): `QUOTE`/symbol literals are interned to
+/// distinct integers in a reserved range (boxed as `i31ref`), so `EQ` tells
+/// symbols apart — `(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil — disjoint from integers.
+#[test]
+fn mccarthy_symbols_run_on_wasm() {
+    let rt = WasmRuntime::new();
+    let go = |src: &str| {
+        let bytes = compile_source_to_wasm(Language::McCarthyLisp, src, "sym").expect("emit symbol");
+        rt.load_and_run(&bytes, "main", &[]).expect("run symbol")
+    };
+
+    // Same symbol is EQ; different symbols are not.
+    assert_eq!(go("(EQ 'A 'A)"), vec![1], "'A = 'A");
+    assert_eq!(go("(EQ 'A 'B)"), vec![0], "'A != 'B");
+    assert_eq!(go("(EQ 'FOO 'FOO)"), vec![1], "multi-char symbol");
+    // A symbol is an atom (not a cons).
+    assert_eq!(go("(ATOM 'A)"), vec![1], "'A is an atom");
+    // Symbols flow through cons cells.
+    assert_eq!(go("(EQ (CAR (CONS 'A 'B)) 'A)"), vec![1], "car of a cons of symbols");
+    // A symbol guard in COND.
+    assert_eq!(go("(COND ((EQ 'A 'B) 7) ((EQ 'X 'X) 9) (5 1))"), vec![9]);
+    // Symbol ids are disjoint from integer atoms.
+    assert_eq!(go("(EQ 'A 5)"), vec![0], "a symbol never equals an integer");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -59,7 +59,7 @@ representation + per-builtin backend lowering.
 |---------|----------|----|----|----|----|----|----|----|-------------|
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
-| **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | uniform-anyref |
+| **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
@@ -79,11 +79,13 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase A — finish WASM (the reference uniform-ref backend)
 
-- ☐ **W1 — WASM symbols (F6).** Lower `QUOTE`/symbol literals to interned
-  symbol *values* in the uniform-anyref model. Options: a distinct boxed symbol
-  object, or a reserved `i31` sub-range vs integers. `(EQ 'A 'A)` → T,
-  `(EQ 'A 'B)` → nil, end-to-end on `wasm-runtime`. Mirror the native
-  `intern_symbols` pass.
+- ✅ **W1 — WASM symbols (F6).** `iir-builtin-lowering::intern_symbols_structural`
+  (the managed twin of native `intern_symbols`) interns each symbol literal to a
+  distinct integer in a reserved range (`SYMBOL_ID_BASE = 2²⁹` + module-wide id),
+  retyped to `i32` so it boxes as an `i31ref` and `EQ` compares with `i32.eq` —
+  no new value type, no polymorphic `EQ`. `lang-aot::compile_source_to_wasm` runs
+  it before the repr pass. `(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil, `(EQ 'A 5)` → nil
+  (disjoint range), symbols through cons + `COND`, end-to-end on `wasm-runtime`.
 - ☐ **W2 — WASM `LAMBDA`/`LABEL`/user calls + recursion (F7).** Per-`LAMBDA`/
   `LABEL` wasm function; `call`; bound params as anyref locals; closure value if
   captured (env object). Recursion via the existing `call`. A recursive `LABEL`


### PR DESCRIPTION
## What & why

First worklist item from the [cross-platform matrix](code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md). Make McCarthy **symbols** (`QUOTE` / `'A`) work on the wasm backend: **`(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil**.

Before this, every symbol literal compiled to the same value (`'A` → 0), so distinct symbols wrongly compared **equal** — `(EQ 'A 'B)` returned 1.

## Change

**`iir-builtin-lowering` 0.11.0** — add **`intern_symbols_structural`**, the managed/uniform-reference twin of the native `intern_symbols`. It interns each symbol literal (`const Var(name) : symbol`) to a distinct integer in a **reserved high range** (`SYMBOL_ID_BASE = 2²⁹` + module-wide id) and retypes it to `i32`, so a symbol flows like any integer atom — the structural pass boxes it as an `i31ref` and `EQ` compares the payloads with `i32.eq`. **No new value type, no polymorphic `EQ`.** Distinct symbols → distinct values; same symbols share one; the reserved range keeps symbols disjoint from integers so `(EQ 'A 5)` → nil. (Encoding is wasm's integer ids; JVM/CLR/BEAM will reuse the id-assignment and adapt the encoding.)

**`lang-aot` 0.19.0** — `compile_source_to_wasm` runs the interner before the repr pass (no-op for symbol-free modules).

## Test plan

4 new unit tests (distinct/same ids, `i32` retype + reserved range, module-wide ids, non-symbol consts untouched) + a `wasm_emit` e2e: `(EQ 'A 'A)`→1, `(EQ 'A 'B)`→0, multi-char symbols, `(ATOM 'A)`→1, symbols-through-cons, COND-over-symbol-EQ, `(EQ 'A 5)`→0. Full suites green — `symbol_intern` 8, `wasm_emit` 17; integer/cons/scalar regression-tested; clippy clean.

## Security & safety

Security review **PASSED**: pure O(N) IIR rewrite; `srcs.first()` is Option-based (the one `srcs[0]` write is guarded by a prior `Some` match); `id as i64` is a widening cast; arithmetic and the HashMap are bounded by program size; no panics/OOB/overflow on adversarial IIR within practical limits. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **WASM F6 (symbols)** — ticked in the matrix. **Next: W2** (WASM `LAMBDA`/`LABEL`/recursion) completes the WASM backend, then the managed-backend replication to JVM/CLR/BEAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)