### PR TITLE
feat(closurec): CLOC12.57 — close gap-050 (`new X()` → `new X`)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.62.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-050** — empty constructor arg-list elision.
+  `new Foo()` → `new Foo` when followed by anything OTHER than
+  member-access (`.`, `[`), chained call (`(`), or tagged
+  template (`` ` ``). Those four cases would change parse
+  precedence and are kept verbatim.
+
+### Added
+
+Token-level peephole right before the existing arrow-fn
+parens-drop optimisation in `whitespace_only.rs`. Triggers when
+`kept[idx-2] == "new"` AND `kept[idx-1]` is a simple identifier
+AND the bracket pair is empty AND the follower is safe.
+
+8 inline `gap050_*` tests including 5 explicit non-regression
+cases (with-args, member-access, bracket-access, chained call,
+paren-expr-constructor).
+
 ## [0.61.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -272,6 +272,58 @@ pub fn whitespace_only_minify(
         // so `async` ends up with `prev_emitted_tok = async`
         // when IDENT is emitted, triggering needs_separator
         // (KEYWORD + NAME) → space inserted. Correct.
+        // gap-050: `new IDENT ( )` → `new IDENT`. Empty
+        // constructor arg-list elision. Upstream Closure
+        // normalises `new Foo()` to `new Foo` because the
+        // two NewExpression forms are operationally
+        // equivalent in ECMAScript.
+        //
+        // Safety: we must NOT drop when the result would
+        // syntactically fuse with what follows the
+        // dropped `()`. Specifically:
+        //   - `new Foo().bar` ≠ `new Foo.bar`
+        //     (left: member-access on constructed object;
+        //     right: NewExpression on the member `Foo.bar`)
+        //   - `new Foo()[x]` ≠ `new Foo[x]`
+        //     (same family — element-access on result vs.
+        //     constructor of `Foo[x]`)
+        //   - `new Foo()()` ≠ `new Foo()`
+        //     (left: invoke constructed object as fn;
+        //     right: lose the chained call entirely)
+        //   - `new Foo()` ` `tag` ≠ `new Foo` ` `tag`
+        //     (tagged template — tighter than NewExpression)
+        //
+        // Conservative gate: kept[idx-2] == "new", kept[idx-1]
+        // is a simple identifier, kept[idx+1] == ")", and
+        // kept[idx+2] is none of {`(`, `.`, `[`, `` ` ``}.
+        // Other followers (`;`, `}`, `,`, EOF, infix
+        // operators like `+`, `instanceof`, etc.) all bind
+        // LOOSER than NewExpression and therefore are safe.
+        let next2_starts_with_backtick = kept
+            .get(idx + 2)
+            .map(|t| t.value.starts_with('`'))
+            .unwrap_or(false);
+        let next2_blocks_drop = matches!(
+            kept.get(idx + 2).map(|t| t.value.as_str()),
+            Some("(") | Some(".") | Some("[")
+        ) || next2_starts_with_backtick;
+        if val == "("
+            && idx >= 2
+            && kept[idx - 2].value == "new"
+            && is_simple_identifier_token(Some(kept[idx - 1]))
+            && kept.get(idx + 1).map(|t| t.value.as_str()) == Some(")")
+            && !next2_blocks_drop
+        {
+            // Skip both `(` and `)`. State machine
+            // unchanged — these tokens were going to be
+            // ignored for at_stmt_boundary /
+            // body_position_next purposes anyway (parens
+            // around an empty arg list don't open a body
+            // slot).
+            idx += 2;
+            continue;
+        }
+
         if val == "("
             && is_simple_identifier_token(kept.get(idx + 1).copied())
             && kept.get(idx + 2).map(|t| t.value.as_str()) == Some(")")
@@ -2627,6 +2679,94 @@ mod tests {
         assert_eq!(
             minify("function f(){if(x){a();}else{b();}}"),
             "function f(){if(x)a();else b()};"
+        );
+    }
+
+    // ---- gap-050: `new X()` → `new X` empty-paren drop --
+
+    /// Target case: bare `new Foo()` at top level.
+    #[test]
+    fn gap050_new_call_drops_empty_parens() {
+        assert_eq!(
+            minify("var x=new Foo();"),
+            "var x=new Foo;"
+        );
+    }
+
+    /// `new Foo()` inside a function body still drops.
+    #[test]
+    fn gap050_new_call_in_function_body_drops() {
+        assert_eq!(
+            minify("function f(){return new Bar();}"),
+            "function f(){return new Bar};"
+        );
+    }
+
+    /// **Non-regression**: `new Foo(a)` (NON-empty arg
+    /// list) keeps parens — they're not redundant.
+    #[test]
+    fn gap050_new_call_with_args_unchanged() {
+        assert_eq!(
+            minify("var x=new Foo(a);"),
+            "var x=new Foo(a);"
+        );
+    }
+
+    /// **Non-regression**: `new Foo().bar` — dropping the
+    /// `()` would change parse to `new Foo.bar` (different
+    /// constructor). Must keep parens.
+    #[test]
+    fn gap050_new_call_then_member_keeps_parens() {
+        assert_eq!(
+            minify("var x=new Foo().bar;"),
+            "var x=new Foo().bar;"
+        );
+    }
+
+    /// **Non-regression**: `new Foo()[x]` — same family;
+    /// element-access on result vs constructor of `Foo[x]`.
+    #[test]
+    fn gap050_new_call_then_bracket_keeps_parens() {
+        assert_eq!(
+            minify("var x=new Foo()[0];"),
+            "var x=new Foo()[0];"
+        );
+    }
+
+    /// **Non-regression**: `new Foo()()` — chained call on
+    /// result. Dropping would lose the chained call.
+    #[test]
+    fn gap050_new_call_then_call_keeps_parens() {
+        assert_eq!(
+            minify("var x=new Foo()();"),
+            "var x=new Foo()();"
+        );
+    }
+
+    /// **Non-regression**: `new Foo() + 1` — `+` binds
+    /// looser than NewExpression, so dropping is safe.
+    /// Verifies the peephole DOES drop here.
+    #[test]
+    fn gap050_new_call_then_plus_drops() {
+        assert_eq!(
+            minify("var x=new Foo()+1;"),
+            "var x=new Foo+1;"
+        );
+    }
+
+    /// **Non-regression**: `new` keyword followed by a
+    /// non-identifier (e.g. `new (expr)`) is NOT
+    /// targeted by this peephole — kept[idx-1] isn't a
+    /// simple identifier.
+    #[test]
+    fn gap050_new_with_paren_expr_unchanged() {
+        // `new (Foo||Bar)()` — paren expression for
+        // constructor selection. The empty `()` after the
+        // paren-close is NOT what we target (idx-1 is `)`,
+        // not an identifier).
+        assert_eq!(
+            minify("var x=new (Foo||Bar)();"),
+            "var x=new(Foo||Bar)();"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.61.0
+Version: 0.62.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,9 +90,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-050: `new Foo()` with empty arg list should
-    // drop the parens to `new Foo`. Discovered by CLOC14.14.
-    ("new_expr", "gap-050: `new X()` → `new X` (empty-paren drop)"),
+    // gap-050 was RESOLVED in CLOC12.57 — token-level
+    // peephole drops the empty `()` after `new IDENT`
+    // when the follower is safe. `minify_new_expr`
+    // flipped IGNORED → PASS.
     // gap-048 was RESOLVED in CLOC12.55 — BigInt token
     // path now strips ES2021 `_` numeric separators.
     // `minify_bigint_separator` flipped IGNORED → PASS.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -388,13 +388,12 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-050 — `new X()` with empty arg list drops parens
 
-- **Status:** OPEN — newly discovered by CLOC14.14.
+- **Status:** **RESOLVED** in CLOC12.57 (PR pending). `minify_new_expr` flips IGNORED → PASS.
 - **Upstream byte-identity test:** `minify_new_expr` seed fixture.
 - **Input:** `var x = new Foo();`
 - **Upstream:** `var x=new Foo;` (parens stripped)
-- **closurec:** `var x=new Foo();`
-- **Why it fails:** ECMAScript grammar accepts `new X` (no args) and `new X()` (empty args) as equivalent. Closure normalizes to the shorter `new X`. closurec passes the parens through verbatim.
-- **What it needs:** Token-level peephole: when sequence `new IDENT ( )` is emitted, suppress the `(` and `)`. Safe regardless of continuation — `new X` and `new X()` are operationally equivalent forms.
+- **Why it failed:** closurec's whitespace_only re-stitcher passed `(` and `)` through verbatim for `new Foo()`.
+- **Fix:** Token-level peephole at `(` — when `kept[idx-2] == "new"` AND `kept[idx-1]` is a simple identifier AND `kept[idx+1] == ")"` AND `kept[idx+2]` is none of {`(`, `.`, `[`, `` ` ``}, skip both tokens. The forbidden followers bind tighter than NewExpression (member access, chained call, tagged template) — dropping `()` before them would change parse precedence. All looser-binding tokens (`;`, `}`, `,`, `+`, `instanceof`, etc.) are safe.
 
 ### gap-046b — object-literal trailing comma drop
 


### PR DESCRIPTION
## Summary

**Closes gap-050.** Stacks on #5254 (CLOC14.14 fixture).

Token-level peephole: when `kept[idx-2] == "new"` AND `kept[idx-1]` is a simple identifier AND `kept[idx+1] == ")"` AND `kept[idx+2]` is none of {`(`, `.`, `[`, `` ` ``}, skip both `(` and `)`.

The 4 blocked followers bind tighter than NewExpression; dropping `()` before them would change parse. All looser-binding followers are safe.

## Pre-push security review

PASS — verified across 7 cases: member preservation, chain preservation, tagged-template preservation, looser-precedence drop, paren-expr-constructor, EOF case, state machine.

## Tests

8 inline `gap050_*` tests covering target case + 5 explicit non-regression cases. Full suite: **387 passed**.

## Version

0.61.0 → 0.62.0.

## Stacking

After #5254 lands, rebase resolves: IGNORE list drops `new_expr` entry (was added in #5254 as OPEN); spec gap-050 status flips from OPEN → RESOLVED.

When both merge: harness → **102/104**. Only gap-044 (lexer templates) and gap-046b (object trailing comma) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)