### PR TITLE
Add smart-home activation approval tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation human-review queue planning:
   `smart_home.list_integration_activation_reviews` and
   `smart_home.get_integration_activation_review_summary`.
+- Added D18D handlers for D23A activation approval packet planning:
+  `smart_home.list_integration_activation_approvals` and
+  `smart_home.get_integration_activation_approval_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -49,6 +49,7 @@ Chief of Staff job/session/agent
   -> activation-maintenance list and summary reads for combined wave health
   -> activation-constraint list and summary reads for grouped blockers/reviews
   -> activation-review list and summary reads for human-review queue planning
+  -> activation-approval list and summary reads for bundled approval packets
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -94,6 +95,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_constraint_summary`
 - `smart_home.list_integration_activation_reviews`
 - `smart_home.get_integration_activation_review_summary`
+- `smart_home.list_integration_activation_approvals`
+- `smart_home.get_integration_activation_approval_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,30 +34,32 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
-    activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
-    activation_dependency_graph_from_reports, activation_health_from_candidates,
-    activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
+    activation_approval_packets_from_candidates, activation_candidates_at_or_before_priority,
+    activation_constraints_from_candidates, activation_dependency_graph_from_reports,
+    activation_health_from_candidates, activation_maintenance_from_candidates,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
     IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
@@ -201,6 +203,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_REVIEWS_TOOL_ID: &str =
     "smart_home.list_integration_activation_reviews";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_review_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_approvals";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_approval_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -399,6 +405,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID => {
                     let query = integration_activation_review_query(&arguments)?;
                     Ok(get_integration_activation_review_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID => {
+                    let query = integration_activation_approval_query(&arguments)?;
+                    Ok(list_integration_activation_approvals_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_approval_query(&arguments)?;
+                    Ok(get_integration_activation_approval_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1398,6 +1414,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation review summary",
             "Return compact D23A activation human-review queue counts for review-ready and blocked rollout work.",
             integration_activation_review_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID,
+            "List smart-home integration activation approvals",
+            "List D23A human-approval packets that bundle activation review rows with actions, constraints, risk, and dependency blockers.",
+            integration_activation_approval_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_approvals", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_approvals",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation approval summary",
+            "Return compact D23A activation approval packet counts for approval-ready and blocked human decision work.",
+            integration_activation_approval_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -3983,6 +4033,17 @@ struct IntegrationActivationReviewQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationApprovalQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    required_tier: Option<PrivilegeTier>,
+    policy_surface: Option<IntegrationPolicySurface>,
+    approval_ready: Option<bool>,
+    blocked_only: Option<bool>,
+    requires_attention: Option<bool>,
+    approval_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4102,6 +4163,28 @@ fn integration_activation_review_query(
         blocked_only: optional_bool(arguments, "blocked_only")?,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         review_limit: optional_u64(arguments, "review_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_approval_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationApprovalQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let required_tier = optional_string(arguments, "required_tier")?
+        .map(|tier| parse_privilege_tier(&tier))
+        .transpose()?;
+    let policy_surface = optional_string(arguments, "policy_surface")?
+        .map(|surface| parse_policy_surface(&surface))
+        .transpose()?;
+
+    Ok(IntegrationActivationApprovalQuery {
+        candidates,
+        required_tier,
+        policy_surface,
+        approval_ready: optional_bool(arguments, "approval_ready")?,
+        blocked_only: optional_bool(arguments, "blocked_only")?,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        approval_limit: optional_u64(arguments, "approval_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4424,6 +4507,40 @@ fn integration_activation_reviews_for_query(
     }
 
     (reviews, catalog_count)
+}
+
+fn integration_activation_approvals_for_query(
+    query: &IntegrationActivationApprovalQuery,
+) -> (Vec<IntegrationActivationApprovalPacket>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut packets = activation_approval_packets_from_candidates(
+        &catalog,
+        candidates.iter(),
+        &query.candidates.readiness.enabled_integrations,
+    );
+
+    if let Some(required_tier) = query.required_tier {
+        packets.retain(|packet| packet.required_tier() == required_tier);
+    }
+    if let Some(policy_surface) = query.policy_surface {
+        packets.retain(|packet| packet.review.policy_surfaces.contains(&policy_surface));
+    }
+    if let Some(approval_ready) = query.approval_ready {
+        packets.retain(|packet| packet.approval_ready() == approval_ready);
+    }
+    if let Some(blocked_only) = query.blocked_only {
+        packets.retain(|packet| packet.has_blockers() == blocked_only);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        packets.retain(|packet| packet.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.approval_limit {
+        packets.truncate(limit);
+    }
+
+    (packets, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -5384,6 +5501,71 @@ fn get_integration_activation_review_summary_output_handler_output(
                 "blocked_review_integrations",
                 integer(summary.blocked_review_integrations as i64),
             ),
+        ]),
+    )
+}
+
+fn list_integration_activation_approvals_output_handler_output(
+    query: IntegrationActivationApprovalQuery,
+) -> ToolHandlerOutput {
+    let (packets, catalog_count) = integration_activation_approvals_for_query(&query);
+    let summary = IntegrationActivationApprovalSummary::from_packets(packets.iter());
+    let count = packets.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_approvals",
+            JsonValue::Array(
+                packets
+                    .iter()
+                    .map(activation_approval_packet_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_approval_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_approvals")),
+            ("approval_packets", integer(count as i64)),
+            (
+                "approval_ready_packets",
+                integer(summary.approval_ready_packets as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
+        ]),
+    )
+}
+
+fn get_integration_activation_approval_summary_output_handler_output(
+    query: IntegrationActivationApprovalQuery,
+) -> ToolHandlerOutput {
+    let (packets, _) = integration_activation_approvals_for_query(&query);
+    let summary = IntegrationActivationApprovalSummary::from_packets(packets.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_approval_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_approval_summary"),
+            ),
+            ("total_packets", integer(summary.total_packets as i64)),
+            (
+                "approval_ready_packets",
+                integer(summary.approval_ready_packets as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
         ]),
     )
 }
@@ -9329,6 +9511,237 @@ fn integration_activation_review_summary_json(
     ])
 }
 
+fn activation_approval_packet_json(packet: &IntegrationActivationApprovalPacket) -> JsonValue {
+    object([
+        (
+            "integration_id",
+            string(packet.requested_integration_id().as_str()),
+        ),
+        (
+            "requested_integration_id",
+            string(packet.requested_integration_id().as_str()),
+        ),
+        ("display_name", string(packet.display_name())),
+        ("priority", integer(packet.priority() as i64)),
+        (
+            "activation_target",
+            activation_target_json(&packet.review.activation_target),
+        ),
+        (
+            "recommendation",
+            string(activation_candidate_recommendation_label(
+                packet.review.recommendation,
+            )),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(packet.required_tier())),
+        ),
+        (
+            "policy_surfaces",
+            JsonValue::Array(
+                packet
+                    .review
+                    .policy_surfaces
+                    .iter()
+                    .map(|surface| string(surface.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "review_ready",
+            JsonValue::Bool(packet.review.review_ready()),
+        ),
+        ("approval_ready", JsonValue::Bool(packet.approval_ready())),
+        ("has_blockers", JsonValue::Bool(packet.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(packet.requires_attention()),
+        ),
+        ("review", activation_review_json(&packet.review)),
+        (
+            "actions",
+            JsonValue::Array(packet.actions.iter().map(activation_action_json).collect()),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(&packet.action_summary),
+        ),
+        (
+            "constraints",
+            JsonValue::Array(
+                packet
+                    .constraints
+                    .iter()
+                    .map(activation_constraint_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "constraint_summary",
+            integration_activation_constraint_summary_json(&packet.constraint_summary),
+        ),
+        (
+            "risks",
+            JsonValue::Array(packet.risks.iter().map(activation_risk_json).collect()),
+        ),
+        (
+            "risk_summary",
+            integration_activation_risk_summary_json(&packet.risk_summary),
+        ),
+        (
+            "dependency_nodes",
+            JsonValue::Array(
+                packet
+                    .dependency_graph
+                    .nodes
+                    .iter()
+                    .map(activation_dependency_node_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_edges",
+            JsonValue::Array(
+                packet
+                    .dependency_graph
+                    .edges
+                    .iter()
+                    .map(activation_dependency_edge_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_summary",
+            integration_activation_dependency_summary_json(&packet.dependency_graph.summary),
+        ),
+    ])
+}
+
+fn integration_activation_approval_summary_json(
+    summary: &IntegrationActivationApprovalSummary,
+) -> JsonValue {
+    object([
+        ("total_packets", integer(summary.total_packets as i64)),
+        (
+            "approval_ready_packets",
+            integer(summary.approval_ready_packets as i64),
+        ),
+        ("blocked_packets", integer(summary.blocked_packets as i64)),
+        (
+            "local_only_packets",
+            integer(summary.local_only_packets as i64),
+        ),
+        (
+            "cloud_required_packets",
+            integer(summary.cloud_required_packets as i64),
+        ),
+        (
+            "packets_with_policy_surfaces",
+            integer(summary.packets_with_policy_surfaces as i64),
+        ),
+        (
+            "packets_without_policy_surfaces",
+            integer(summary.packets_without_policy_surfaces as i64),
+        ),
+        (
+            "unique_policy_surfaces",
+            integer(summary.unique_policy_surfaces as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "activate_integration_actions",
+            integer(summary.activate_integration_actions as i64),
+        ),
+        (
+            "review_policy_actions",
+            integer(summary.review_policy_actions as i64),
+        ),
+        (
+            "provide_primitive_actions",
+            integer(summary.provide_primitive_actions as i64),
+        ),
+        (
+            "grant_capability_actions",
+            integer(summary.grant_capability_actions as i64),
+        ),
+        (
+            "enable_dependency_actions",
+            integer(summary.enable_dependency_actions as i64),
+        ),
+        (
+            "total_constraints",
+            integer(summary.total_constraints as i64),
+        ),
+        (
+            "blocking_constraints",
+            integer(summary.blocking_constraints as i64),
+        ),
+        (
+            "review_constraints",
+            integer(summary.review_constraints as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "policy_tier_risks",
+            integer(summary.policy_tier_risks as i64),
+        ),
+        (
+            "policy_surface_risks",
+            integer(summary.policy_surface_risks as i64),
+        ),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "read_only_packets",
+            integer(summary.read_only_packets as i64),
+        ),
+        ("low_risk_packets", integer(summary.low_risk_packets as i64)),
+        (
+            "human_approval_packets",
+            integer(summary.human_approval_packets as i64),
+        ),
+        (
+            "high_risk_packets",
+            integer(summary.high_risk_packets as i64),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -12677,6 +13090,32 @@ fn integration_activation_review_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_approval_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "approval_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("required_tier", JsonSchema::String));
+        properties.push(SchemaProperty::new("policy_surface", JsonSchema::String));
+        properties.push(SchemaProperty::new("approval_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -12821,7 +13260,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 77);
+        assert_eq!(definitions.len(), 79);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -12913,6 +13352,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID));
@@ -13022,7 +13467,7 @@ mod tests {
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            69
+            71
         );
         assert_eq!(
             export
@@ -13041,6 +13486,14 @@ mod tests {
             1
         );
         assert!(smart_home_tool_definition(SMART_HOME_GET_STATE_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID
+        )
+        .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_DISCOVERY_SUMMARY_TOOL_ID).is_some());
         assert!(
@@ -13404,11 +13857,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(77))
+            Some(&integer(79))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(69))
+            Some(&integer(71))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -14683,6 +15136,129 @@ mod tests {
         );
         assert_eq!(
             field(activation_review_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_approvals_request = request(
+            "call-list-integration-activation-approvals",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("approval_limit", integer(3)),
+            ]),
+            5_011,
+        );
+        let list_activation_approvals_trace =
+            tool_runtime.invoke_with_events(&list_activation_approvals_request);
+        assert!(list_activation_approvals_trace.result.ok);
+        assert_eq!(
+            list_activation_approvals_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_approvals_output = list_activation_approvals_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_approval_count =
+            integer_value(field(list_activation_approvals_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_approval_count));
+        let activation_approval_summary =
+            field(list_activation_approvals_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_approval_summary, "total_packets").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_approval_summary, "review_policy_actions").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_approval_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_approval = array_item(
+            field(list_activation_approvals_output, "activation_approvals").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_approval, "review").is_some());
+        assert!(field(activation_approval, "action_summary").is_some());
+        assert!(field(activation_approval, "constraint_summary").is_some());
+        assert!(field(activation_approval, "risk_summary").is_some());
+        assert!(field(activation_approval, "dependency_summary").is_some());
+        assert!(matches!(
+            field(activation_approval, "approval_ready"),
+            Some(JsonValue::Bool(_))
+        ));
+
+        let activation_approval_summary_request = request(
+            "call-integration-activation-approval-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            5_012,
+        );
+        let activation_approval_summary_trace =
+            tool_runtime.invoke_with_events(&activation_approval_summary_request);
+        assert!(activation_approval_summary_trace.result.ok);
+        assert_eq!(
+            activation_approval_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_approval_summary_output = activation_approval_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_approval_rollup =
+            field(activation_approval_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_approval_rollup, "blocked_packets").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_approval_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
         );
 
@@ -16369,6 +16945,14 @@ mod tests {
             activation_review_summary_request,
             activation_review_summary_trace,
         );
+        journal.record_trace(
+            list_activation_approvals_request,
+            list_activation_approvals_trace,
+        );
+        journal.record_trace(
+            activation_approval_summary_request,
+            activation_approval_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -16442,9 +17026,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 77);
-        assert_eq!(journal_summary.completed_count, 77);
-        assert_eq!(journal.audit_records().len(), 77);
+        assert_eq!(journal_summary.invocation_count, 79);
+        assert_eq!(journal_summary.completed_count, 79);
+        assert_eq!(journal.audit_records().len(), 79);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -50,6 +50,10 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_reviews` and
   `smart_home.get_integration_activation_review_summary` tool descriptors for
   read-only human-review queue planning.
+- `smart_home.list_integration_activation_approvals` and
+  `smart_home.get_integration_activation_approval_summary` tool descriptors
+  for read-only human-decision packet planning across review rows, actions,
+  constraints, risk, and dependency blockers.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -70,6 +70,9 @@ Current scope:
   capability, dependency, and policy-review blocker summaries
 - D18D integration activation-review descriptors for read-only human-review
   queue entries and compact review-ready/blocker summaries
+- D18D integration activation-approval descriptors for bundled human-decision
+  packets that combine review rows with actions, constraints, risk, and
+  dependency blockers
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1475,6 +1475,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationConstraintSummary,
     ListIntegrationActivationReviews,
     GetIntegrationActivationReviewSummary,
+    ListIntegrationActivationApprovals,
+    GetIntegrationActivationApprovalSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1606,6 +1608,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationReviewSummary => {
                 read_tool("smart_home.get_integration_activation_review_summary")
+            }
+            Self::ListIntegrationActivationApprovals => {
+                read_tool("smart_home.list_integration_activation_approvals")
+            }
+            Self::GetIntegrationActivationApprovalSummary => {
+                read_tool("smart_home.get_integration_activation_approval_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2264,6 +2272,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationConstraintSummary,
         SmartHomeTool::ListIntegrationActivationReviews,
         SmartHomeTool::GetIntegrationActivationReviewSummary,
+        SmartHomeTool::ListIntegrationActivationApprovals,
+        SmartHomeTool::GetIntegrationActivationApprovalSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3106,7 +3116,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 77);
+        assert_eq!(catalog.len(), 79);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3238,6 +3248,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_review_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_approvals"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_approval_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3428,15 +3446,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 77);
-        assert_eq!(summary.read_tools, 69);
+        assert_eq!(summary.total_tools, 79);
+        assert_eq!(summary.read_tools, 71);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 69);
+        assert_eq!(summary.read_only_tier_tools, 71);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 77);
+        assert_eq!(summary.total_required_capabilities, 79);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -64,6 +64,10 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationReviewItem` and `IntegrationActivationReviewSummary`
   for exposing human-review queue entries with review-ready and blocked
   rollups.
+- `IntegrationActivationApprovalPacket` and
+  `IntegrationActivationApprovalSummary` for bundling review rows with concrete
+  actions, grouped constraints, policy risk, and dependency blockers before a
+  human approval request.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -53,6 +53,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation review queue entries that separate review-ready integrations from
   human-review integrations still blocked by primitives, capabilities, or
   dependencies
+- activation approval packets that bundle each human-review row with its
+  concrete actions, grouped constraints, policy risk, and dependency blockers
+  for approval preparation
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1216,6 +1216,51 @@ pub struct IntegrationActivationReviewSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationApprovalPacket {
+    pub review: IntegrationActivationReviewItem,
+    pub actions: Vec<IntegrationActivationAction>,
+    pub action_summary: IntegrationActivationActionSummary,
+    pub constraints: Vec<IntegrationActivationConstraint>,
+    pub constraint_summary: IntegrationActivationConstraintSummary,
+    pub risks: Vec<IntegrationActivationRiskItem>,
+    pub risk_summary: IntegrationActivationRiskSummary,
+    pub dependency_graph: IntegrationActivationDependencyGraph,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationApprovalSummary {
+    pub total_packets: usize,
+    pub approval_ready_packets: usize,
+    pub blocked_packets: usize,
+    pub local_only_packets: usize,
+    pub cloud_required_packets: usize,
+    pub packets_with_policy_surfaces: usize,
+    pub packets_without_policy_surfaces: usize,
+    pub unique_policy_surfaces: usize,
+    pub total_actions: usize,
+    pub activate_integration_actions: usize,
+    pub review_policy_actions: usize,
+    pub provide_primitive_actions: usize,
+    pub grant_capability_actions: usize,
+    pub enable_dependency_actions: usize,
+    pub total_constraints: usize,
+    pub blocking_constraints: usize,
+    pub review_constraints: usize,
+    pub total_risks: usize,
+    pub policy_tier_risks: usize,
+    pub policy_surface_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub read_only_packets: usize,
+    pub low_risk_packets: usize,
+    pub human_approval_packets: usize,
+    pub high_risk_packets: usize,
+    pub first_approval_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationAgendaStage {
     pub priority: u8,
     pub candidates: Vec<IntegrationActivationCandidate>,
@@ -2573,6 +2618,187 @@ impl IntegrationActivationReviewSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.total_reviews > 0
+    }
+}
+
+impl IntegrationActivationApprovalPacket {
+    fn from_candidate(
+        catalog: &[IntegrationCatalogEntry],
+        candidate: &IntegrationActivationCandidate,
+        enabled_integrations: &[IntegrationId],
+    ) -> Option<Self> {
+        let review = IntegrationActivationReviewItem::from_candidate(catalog, candidate)?;
+        let actions = activation_actions_from_candidates(std::iter::once(candidate));
+        let action_summary = IntegrationActivationActionSummary::from_actions(actions.iter());
+        let constraints =
+            activation_constraints_from_candidates(catalog, std::iter::once(candidate));
+        let constraint_summary =
+            IntegrationActivationConstraintSummary::from_constraints(constraints.iter());
+        let risks = activation_risk_from_candidates(catalog, std::iter::once(candidate));
+        let risk_summary = IntegrationActivationRiskSummary::from_risks(risks.iter());
+        let dependency_graph = activation_dependency_graph_from_reports(
+            catalog,
+            std::iter::once(&candidate.readiness_report),
+            enabled_integrations,
+        );
+
+        Some(Self {
+            review,
+            actions,
+            action_summary,
+            constraints,
+            constraint_summary,
+            risks,
+            risk_summary,
+            dependency_graph,
+        })
+    }
+
+    pub fn requested_integration_id(&self) -> &IntegrationId {
+        &self.review.requested_integration_id
+    }
+
+    pub fn display_name(&self) -> &str {
+        &self.review.display_name
+    }
+
+    pub fn priority(&self) -> u8 {
+        self.review.priority
+    }
+
+    pub fn required_tier(&self) -> PrivilegeTier {
+        self.review.required_tier
+    }
+
+    pub fn approval_ready(&self) -> bool {
+        self.review.review_ready()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.review.has_blockers()
+            || self.constraint_summary.has_blockers()
+            || self.dependency_graph.has_blocking_dependencies()
+    }
+
+    pub fn has_policy_surfaces(&self) -> bool {
+        self.review.has_policy_surfaces()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        true
+    }
+}
+
+impl IntegrationActivationApprovalSummary {
+    pub fn from_packets<'a>(
+        packets: impl IntoIterator<Item = &'a IntegrationActivationApprovalPacket>,
+    ) -> Self {
+        let mut policy_surfaces = BTreeSet::new();
+        let mut summary = Self {
+            total_packets: 0,
+            approval_ready_packets: 0,
+            blocked_packets: 0,
+            local_only_packets: 0,
+            cloud_required_packets: 0,
+            packets_with_policy_surfaces: 0,
+            packets_without_policy_surfaces: 0,
+            unique_policy_surfaces: 0,
+            total_actions: 0,
+            activate_integration_actions: 0,
+            review_policy_actions: 0,
+            provide_primitive_actions: 0,
+            grant_capability_actions: 0,
+            enable_dependency_actions: 0,
+            total_constraints: 0,
+            blocking_constraints: 0,
+            review_constraints: 0,
+            total_risks: 0,
+            policy_tier_risks: 0,
+            policy_surface_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            read_only_packets: 0,
+            low_risk_packets: 0,
+            human_approval_packets: 0,
+            high_risk_packets: 0,
+            first_approval_priority: None,
+            first_blocked_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for packet in packets {
+            summary.total_packets += 1;
+            if packet.approval_ready() {
+                summary.approval_ready_packets += 1;
+                summary.first_approval_priority =
+                    min_optional_priority(summary.first_approval_priority, Some(packet.priority()));
+            }
+            if packet.has_blockers() {
+                summary.blocked_packets += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(packet.priority()));
+            }
+            if packet.review.local_only {
+                summary.local_only_packets += 1;
+            }
+            if packet.review.cloud_required {
+                summary.cloud_required_packets += 1;
+            }
+            if packet.has_policy_surfaces() {
+                summary.packets_with_policy_surfaces += 1;
+            } else {
+                summary.packets_without_policy_surfaces += 1;
+            }
+            for surface in &packet.review.policy_surfaces {
+                policy_surfaces.insert(*surface);
+            }
+
+            summary.total_actions += packet.action_summary.total_actions;
+            summary.activate_integration_actions +=
+                packet.action_summary.activate_integration_actions;
+            summary.review_policy_actions += packet.action_summary.review_policy_actions;
+            summary.provide_primitive_actions += packet.action_summary.provide_primitive_actions;
+            summary.grant_capability_actions += packet.action_summary.grant_capability_actions;
+            summary.enable_dependency_actions += packet.action_summary.enable_dependency_actions;
+
+            summary.total_constraints += packet.constraint_summary.total_constraints;
+            summary.blocking_constraints += packet.constraint_summary.blocking_constraints;
+            summary.review_constraints += packet.constraint_summary.review_constraints;
+
+            summary.total_risks += packet.risk_summary.total_risks;
+            summary.policy_tier_risks += packet.risk_summary.policy_tier_risks;
+            summary.policy_surface_risks += packet.risk_summary.policy_surface_risks;
+
+            summary.total_dependency_edges += packet.dependency_graph.summary.total_edges;
+            summary.blocking_dependency_edges += packet.dependency_graph.summary.blocking_edges;
+
+            match packet.required_tier() {
+                PrivilegeTier::ReadOnly => summary.read_only_packets += 1,
+                PrivilegeTier::LowRisk => summary.low_risk_packets += 1,
+                PrivilegeTier::HumanApproval => summary.human_approval_packets += 1,
+                PrivilegeTier::HighRisk => summary.high_risk_packets += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(packet.required_tier());
+        }
+
+        summary.unique_policy_surfaces = policy_surfaces.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_packets == 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.approval_ready_packets > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_packets > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.total_packets > 0
     }
 }
 
@@ -4954,6 +5180,43 @@ pub fn activation_reviews_at_or_before_priority(
     activation_reviews_from_candidates(catalog, candidates.iter())
 }
 
+pub fn activation_approval_packets_from_candidates<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationApprovalPacket> {
+    let mut packets = candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            IntegrationActivationApprovalPacket::from_candidate(
+                catalog,
+                candidate,
+                enabled_integrations,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    packets.sort_by(compare_activation_approval_packets);
+    packets
+}
+
+pub fn activation_approval_packets_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationApprovalPacket> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_approval_packets_from_candidates(catalog, candidates.iter(), enabled_integrations)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -6164,6 +6427,20 @@ fn compare_activation_reviews(
         })
 }
 
+fn compare_activation_approval_packets(
+    left: &IntegrationActivationApprovalPacket,
+    right: &IntegrationActivationApprovalPacket,
+) -> Ordering {
+    left.priority()
+        .cmp(&right.priority())
+        .then_with(|| right.required_tier().cmp(&left.required_tier()))
+        .then_with(|| left.display_name().cmp(right.display_name()))
+        .then_with(|| {
+            left.requested_integration_id()
+                .cmp(right.requested_integration_id())
+        })
+}
+
 fn compare_activation_dependency_nodes(
     left: &IntegrationActivationDependencyNode,
     right: &IntegrationActivationDependencyNode,
@@ -7219,6 +7496,119 @@ mod tests {
         assert!(catalog_reviews
             .iter()
             .any(IntegrationActivationReviewItem::has_policy_surfaces));
+    }
+
+    #[test]
+    fn activation_approval_packets_bundle_review_work_for_human_decisions() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+
+        let packets = activation_approval_packets_from_candidates(&[], candidates.iter(), &[]);
+
+        assert_eq!(packets.len(), 2);
+        let approval_ready = packets
+            .iter()
+            .find(|packet| packet.requested_integration_id().as_str() == "review_ready_bridge")
+            .unwrap();
+        assert!(approval_ready.approval_ready());
+        assert!(!approval_ready.has_blockers());
+        assert!(approval_ready.requires_attention());
+        assert!(approval_ready.action_summary.review_policy_actions >= 1);
+        assert!(approval_ready.constraint_summary.review_constraints >= 1);
+
+        let blocked = packets
+            .iter()
+            .find(|packet| packet.requested_integration_id().as_str() == "blocked_review_camera")
+            .unwrap();
+        assert!(!blocked.approval_ready());
+        assert!(blocked.has_blockers());
+        assert_eq!(blocked.required_tier(), PrivilegeTier::HighRisk);
+        assert!(blocked.action_summary.provide_primitive_actions >= 1);
+        assert!(blocked.constraint_summary.blocking_constraints >= 1);
+        assert!(blocked.risk_summary.total_risks >= 1);
+        assert!(blocked.dependency_graph.summary.total_edges >= 1);
+        assert!(blocked.dependency_graph.summary.blocking_edges >= 1);
+
+        let summary = IntegrationActivationApprovalSummary::from_packets(packets.iter());
+        assert_eq!(summary.total_packets, 2);
+        assert_eq!(summary.approval_ready_packets, 1);
+        assert_eq!(summary.blocked_packets, 1);
+        assert!(summary.total_actions > 0);
+        assert!(summary.review_policy_actions > 0);
+        assert!(summary.blocking_constraints > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.total_dependency_edges > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(summary.human_approval_packets, 1);
+        assert_eq!(summary.high_risk_packets, 1);
+        assert_eq!(summary.first_approval_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(2));
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_packets = activation_approval_packets_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_packets
+            .iter()
+            .any(IntegrationActivationApprovalPacket::has_policy_surfaces));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog activation approval packets that bundle human-review rows with actions, constraints, risk, and dependency blockers
- expose read-only smart_home activation approval descriptors in smart-home-core
- add Chief handlers, JSON output, schemas, docs, and end-to-end coverage for approval packet list/summary tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools