### PR TITLE
feat(mccarthy-lisp): W2 — run McCarthy LAMBDA/LABEL/recursion on wasm (F7) (LANG77)

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.12.0] — 2026-06-09 — uniform-anyref function boundary (LANG77 / McCarthy W2)
+
+### Changed
+
+- `lower_lisp_repr_structural` now makes the **function-call boundary**
+  uniform-anyref, so a `LAMBDA`/`LABEL` can be applied and can recurse:
+  - a new `lisp_functions` module analysis (functions using the heap/predicates
+    or taking lisp params, closed under *calling*) replaces the per-function
+    `function_uses_heap` gate — every lisp function is processed, even a trivial
+    `(LAMBDA (X) X)`;
+  - each **lisp parameter** (`any`/`symbol`) is retyped to `ref<any>` and treated
+    as a reference;
+  - each argument of a `call` to a lisp function is **boxed** (`i31ref`) before
+    crossing the boundary, and the **call result** is a reference;
+  - a **non-entry** function (a lambda) returns `ref<any>` — boxing a scalar /
+    predicate-boolean / atom result — so every value crossing a boundary is an
+    `anyref`; the entry function still unboxes its result to `i32`.
+  - Recursion needs no special handling: a self-`call` is just a lisp call.
+- `lang-aot::concretize_scalar_any_for_wasm` correspondingly skips functions with
+  lisp params, keeping the two passes' partition exact.
+
+1 new test (the `((LAMBDA (X) X) 5)` boundary: param→ref<any>, arg boxed, return
+ref<any>, caller unboxes).
+
 ## [0.11.0] — 2026-06-09 — managed-backend symbol interning (LANG77 / McCarthy W1)
 
 ### Added

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
@@ -142,21 +142,83 @@ fn lisp_value_src_indices(instr: &IIRInstr) -> Vec<usize> {
     }
 }
 
-/// Apply the structural representation pass to every heap-using function.
+/// Whether a function takes **lisp-value parameters** — a `LAMBDA`/`LABEL`
+/// lifted to a function. The frontend types a lisp parameter `"any"` (or
+/// `"symbol"`); a Twig function's params are concrete (`i32`/`i64`). Such a
+/// function participates in the uniform-anyref **function boundary** even if its
+/// body touches no heap op (e.g. `(LAMBDA (X) X)`).
+fn has_lisp_param(func: &IIRFunction) -> bool {
+    func.params.iter().any(|(_, t)| t == "any" || t == "symbol" || t.starts_with("ref<"))
+}
+
+/// Compute the set of **lisp functions** in a module — those that use the
+/// uniform-anyref value model at their boundary. Seeded by functions that use
+/// the heap/predicates or take lisp params, then closed under *calling*: a
+/// function that `call`s a lisp function is itself lisp (its call site must box
+/// the args and treat the result as a reference). For a McCarthy module every
+/// function ends up lisp; a Twig module's pure-scalar functions never enter.
+fn lisp_functions(module: &IIRModule) -> HashSet<String> {
+    let mut lisp: HashSet<String> = module
+        .functions
+        .iter()
+        .filter(|f| function_uses_heap(f) || has_lisp_param(f))
+        .map(|f| f.name.clone())
+        .collect();
+    // Fixpoint: a caller of a lisp function is lisp.
+    loop {
+        let mut changed = false;
+        for f in &module.functions {
+            if lisp.contains(&f.name) {
+                continue;
+            }
+            let calls_lisp = f.instructions.iter().any(|i| {
+                i.op == "call"
+                    && matches!(i.srcs.first(), Some(Operand::Var(callee)) if lisp.contains(callee))
+            });
+            if calls_lisp {
+                lisp.insert(f.name.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    lisp
+}
+
+/// The argument `srcs` indices of a `call` to a **lisp function** (so each atom
+/// argument is boxed as an `i31ref` before crossing the function boundary). The
+/// callee name is `srcs[0]`; the arguments are `srcs[1..]`.
+fn call_lisp_arg_indices(instr: &IIRInstr, lisp_funcs: &HashSet<String>) -> Vec<usize> {
+    if instr.op == "call" {
+        if let Some(Operand::Var(callee)) = instr.srcs.first() {
+            if lisp_funcs.contains(callee) {
+                return (1..instr.srcs.len()).collect();
+            }
+        }
+    }
+    Vec::new()
+}
+
+/// Apply the structural representation pass to every lisp function.
 ///
 /// Run by `lang-aot::compile_source_to_wasm` **after** `lower_heap_builtins`
 /// (so cons/car/cdr are already `alloc`/`field_*`) and alongside
 /// `concretize_scalar_any_for_wasm` (which handles the pure-scalar functions
-/// this pass skips). Safe to run on any module: a function with no heap op is
-/// left untouched.
+/// this pass skips). Safe to run on any module: a non-lisp function is left
+/// untouched. Lisp functions share a **uniform-anyref boundary** — every
+/// parameter, call argument, call result, and (non-entry) return is an
+/// `anyref` — so a `LAMBDA`/`LABEL` can be called and can recurse.
 pub fn lower_lisp_repr_structural(module: &mut IIRModule) {
     let entry = module.entry_point.clone();
+    let lisp_funcs = lisp_functions(module);
     for func in &mut module.functions {
-        if !function_uses_heap(func) {
+        if !lisp_funcs.contains(&func.name) {
             continue; // pure scalar — concretize_scalar_any_for_wasm owns it.
         }
         let is_entry = entry.as_deref() == Some(func.name.as_str());
-        lower_structural_function(func, is_entry);
+        lower_structural_function(func, is_entry, &lisp_funcs);
     }
 }
 
@@ -188,17 +250,53 @@ fn reference_registers(func: &IIRFunction) -> HashSet<String> {
     refs
 }
 
-fn lower_structural_function(func: &mut IIRFunction, is_entry: bool) {
-    let ref_regs = reference_registers(func);
+fn lower_structural_function(
+    func: &mut IIRFunction,
+    is_entry: bool,
+    lisp_funcs: &HashSet<String>,
+) {
+    // ── 0. The function boundary is uniform-anyref. Every lisp parameter is an
+    //       `anyref` (a reference), and so is every result of a `call` to a lisp
+    //       function. Retype the params and seed the reference set with both. ──
+    for (_, ty) in func.params.iter_mut() {
+        if ty == "any" || ty == "symbol" {
+            *ty = REF_ANY.to_string();
+        }
+    }
+    let mut ref_regs = reference_registers(func);
+    for (name, ty) in &func.params {
+        if ty.starts_with("ref<") {
+            ref_regs.insert(name.clone());
+        }
+    }
+    for instr in &func.instructions {
+        if !call_lisp_arg_indices(instr, lisp_funcs).is_empty()
+            || (instr.op == "call"
+                && matches!(instr.srcs.first(), Some(Operand::Var(c)) if lisp_funcs.contains(c)))
+        {
+            if let Some(dest) = &instr.dest {
+                ref_regs.insert(dest.clone()); // a lisp call returns an anyref.
+            }
+        }
+    }
     let lisp_conds = lisp_conditions(func);
+
+    // The lisp-value source indices of an instruction: the structural positions
+    // (`field_store` value, `pair?`/`equal?` args) plus the arguments of a `call`
+    // to a lisp function (boxed before crossing the boundary).
+    let value_idxs_of = |instr: &IIRInstr| -> Vec<usize> {
+        let mut idxs = lisp_value_src_indices(instr);
+        idxs.extend(call_lisp_arg_indices(instr, lisp_funcs));
+        idxs
+    };
 
     // ── 1. Which atoms must be boxed? Any non-reference value that flows into a
     //       lisp-value position — a `field_store`'s value operand, a
-    //       `pair?`/`equal?` argument, or a lisp-value `COND` guard (which is
-    //       boxed so its truthiness can be tested with `is_null`). ──
+    //       `pair?`/`equal?` argument, a lisp `call` argument, or a lisp-value
+    //       `COND` guard (boxed so its truthiness can be tested with `is_null`). ──
     let mut needs_box: HashSet<String> = HashSet::new();
     for instr in &func.instructions {
-        for idx in lisp_value_src_indices(instr) {
+        for idx in value_idxs_of(instr) {
             if let Some(Operand::Var(val)) = instr.srcs.get(idx) {
                 if !ref_regs.contains(val) {
                     needs_box.insert(val.clone());
@@ -294,7 +392,7 @@ fn lower_structural_function(func: &mut IIRFunction, is_entry: bool) {
             }
         }
 
-        let value_idxs = lisp_value_src_indices(&instr);
+        let value_idxs = value_idxs_of(&instr);
         if !value_idxs.is_empty() {
             let mut rewritten = instr.clone();
             for idx in value_idxs {
@@ -326,7 +424,8 @@ fn lower_structural_function(func: &mut IIRFunction, is_entry: bool) {
     }
     func.instructions = new_instrs;
 
-    // ── 3. The machine boundary: unbox the entry function's reference result. ──
+    // ── 3. The machine boundary: unbox the entry function's reference result;
+    //       a non-entry lisp function returns an `anyref` for its caller. ──
     set_return_representation(func, is_entry, &ref_regs);
 
     // ── 4. Defensive sweep: no `any`/`polymorphic` hint may survive (the
@@ -376,15 +475,42 @@ fn set_return_representation(func: &mut IIRFunction, is_entry: bool, ref_regs: &
         if func.return_type == "any" || func.return_type == "polymorphic" || func.return_type == REF_PAIR {
             func.return_type = REF_ANY.to_string();
         }
+    } else if !is_entry {
+        // A non-entry lisp function (a `LAMBDA`/`LABEL`) whose result is a
+        // **scalar** — a predicate boolean or an integer/symbol atom. The
+        // function boundary is uniform-anyref, so box it and return `ref<any>`.
+        // `box` (`ref.i31`) takes an i32, so narrow a boxable integer-atom const
+        // first; a predicate boolean is already i32.
+        if let Some(p) = func
+            .instructions
+            .iter_mut()
+            .find(|i| i.dest.as_deref() == Some(ret_reg.as_str()))
+        {
+            if p.op == "const" {
+                if let Some(Operand::Int(n)) = p.srcs.first() {
+                    if (I31_MIN..=I31_MAX).contains(n) {
+                        p.type_hint = "i32".to_string();
+                    }
+                }
+            }
+        }
+        let boxed_ret = format!("{ret_reg}.retbox");
+        func.instructions.insert(
+            ret_pos,
+            IIRInstr::new("box", Some(boxed_ret.clone()), vec![Operand::Var(ret_reg)], REF_ANY),
+        );
+        let ret = &mut func.instructions[ret_pos + 1];
+        ret.srcs = vec![Operand::Var(boxed_ret)];
+        ret.type_hint = REF_ANY.to_string();
+        func.return_type = REF_ANY.to_string();
     } else if func.return_type == "any"
         || func.return_type == "polymorphic"
         || func.instructions[ret_pos].type_hint == "any"
     {
-        // A non-reference scalar result in a heap function. Concretise the return
-        // type to the value's machine width: a **predicate** result (`pair?` /
-        // `not` / `equal?`, whose hint is `"bool"`) is an `i32`; everything else
-        // defaults to `i64`. Setting the `ret` instruction's hint too keeps the
-        // defensive `any` sweep from re-widening a boolean back to `i64`.
+        // The **entry** function returning a non-reference scalar (e.g. a bare
+        // `(EQ 5 5)` program). Concretise the return type to the value's width: a
+        // predicate result (hint `"bool"`) is i32, everything else i64. Setting
+        // the `ret` hint keeps the defensive `any` sweep from re-widening a bool.
         let width = func
             .instructions
             .iter()
@@ -607,6 +733,61 @@ mod tests {
         // No box/unbox inserted; return type untouched (concretize handles it).
         assert_eq!(m.functions[0].instructions.len(), before);
         assert!(m.functions[0].instructions.iter().all(|i| i.op != "box" && i.op != "unbox"));
+    }
+
+    #[test]
+    fn lambda_boundary_is_uniform_anyref() {
+        // `((LAMBDA (X) X) 5)`: a lambda `lam(X)` returning X, called from main.
+        // The boundary must be uniform anyref: X's param type → ref<any>, the
+        // call arg (5) boxed, the lambda return ref<any>, and main unboxes.
+        let lam = IIRFunction::new(
+            "lam",
+            vec![("X".to_string(), "any".to_string())],
+            "any",
+            vec![IIRInstr::new("ret", None, vec![Operand::Var("X".into())], "any")],
+        );
+        let main = IIRFunction::new(
+            "main",
+            vec![],
+            "any",
+            vec![
+                IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(5)], "i64"),
+                IIRInstr::new(
+                    "call",
+                    Some("v1".into()),
+                    vec![Operand::Var("lam".into()), Operand::Var("v0".into())],
+                    "any",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("v1".into())], "any"),
+            ],
+        );
+        let mut m = IIRModule::new("lam", "mccarthy-lisp");
+        m.entry_point = Some("main".to_string());
+        m.functions = vec![lam, main];
+        lower_lisp_repr_structural(&mut m);
+
+        let lam = &m.functions[0];
+        let main = &m.functions[1];
+
+        // The lambda's parameter is now an anyref reference.
+        assert_eq!(lam.params[0].1, REF_ANY, "lisp param retyped to ref<any>");
+        // The lambda returns an anyref to its caller.
+        assert_eq!(lam.return_type, REF_ANY, "lambda returns ref<any>");
+
+        // main boxes the call argument (5) before the call.
+        assert_eq!(
+            main.instructions.iter().filter(|i| i.op == "box").count(),
+            1,
+            "the call argument is boxed"
+        );
+        let call = main.instructions.iter().find(|i| i.op == "call").unwrap();
+        match &call.srcs[1] {
+            Operand::Var(a) => assert!(a.ends_with(".box"), "call passes the boxed arg"),
+            other => panic!("unexpected call arg {other:?}"),
+        }
+        // main unboxes the call result at the entry/return boundary → i32.
+        assert_eq!(main.instructions.iter().filter(|i| i.op == "unbox").count(), 1);
+        assert_eq!(main.return_type, "i32");
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.20.0 — 2026-06-09 — McCarthy → WebAssembly, **`LAMBDA`/`LABEL`/recursion** (LANG77 / W2)
+
+`compile_source_to_wasm` now runs McCarthy functions: `LAMBDA` application,
+multi-argument lambdas, and recursive `LABEL`. The structural pass makes the
+call boundary uniform-anyref (params anyref, call args boxed, lambda returns
+anyref), so `((LAMBDA (X) X) 5)` → 5, `(CDR ((LAMBDA (X Y) (CONS X Y)) 3 4))` →
+4, and a recursive `LABEL` walks a list to its atom. `concretize_scalar_any_for_wasm`
+skips functions with lisp params. **With this the WASM backend is McCarthy-complete
+(F1–F7): cons, ATOM, EQ, COND, symbols, and lambda/label/recursion.** Twig/scalar
+programs are unaffected (regression-tested).
+
 ## 0.19.0 — 2026-06-09 — McCarthy → WebAssembly, **symbols** (LANG77 / W1)
 
 `compile_source_to_wasm` now runs `intern_symbols_structural` (before the repr

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -10,8 +10,10 @@ atoms boxed as `i31ref`, the cons cell a `$LispyPair` struct) — and the McCart
 predicates, `COND`, and symbols: `pair?`/`ATOM` (`(ATOM 5)` → 1; L3b-3a-4b),
 `EQ` atom equality (`(EQ 5 5)` → 1; L3b-3a-4c), `COND` with lisp-truthiness
 (`(COND (0 7) (5 9))` → 7 — `0` is truthy; L3b-3a-4d), and symbols
-(`(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil; W1). The McCarthy core —
-cons, `ATOM`, `EQ`, `COND`, symbols — now runs on the wasm backend.
+(`(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil; W1), and `LAMBDA`/`LABEL`/recursion
+(`((LAMBDA (X) X) 5)` → 5; a recursive `LABEL` walks a list; W2). The **full
+McCarthy core** — cons, `ATOM`, `EQ`, `COND`, symbols, and lambda/label/recursion
+(F1–F7) — now runs on the wasm backend.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -347,15 +347,21 @@ fn concretize_scalar_any_for_wasm(module: &mut IIRModule) {
     ];
 
     for func in &mut module.functions {
-        // Does this function touch the lisp heap / reference model?
-        let uses_heap = func.instructions.iter().any(|i| {
+        // Does this function touch the lisp heap / reference model? A function
+        // with **lisp parameters** (a `LAMBDA`/`LABEL` — params typed `any` /
+        // `symbol` / `ref<…>`) participates in the uniform-anyref boundary and is
+        // owned by `lower_lisp_repr_structural`, so skip it here too (it has
+        // already retyped them to `ref<…>` by the time this runs).
+        let uses_lisp = func.params.iter().any(|(_, t)| {
+            t == "any" || t == "symbol" || t.starts_with("ref<")
+        }) || func.instructions.iter().any(|i| {
             HEAP_OPS.contains(&i.op.as_str())
                 || (i.op == "call_builtin"
                     && matches!(i.srcs.first(),
                         Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
                 || i.type_hint.starts_with("ref<")
         });
-        if uses_heap {
+        if uses_lisp {
             continue; // boxed-anyref value model — out of scope for the scalar slice.
         }
         // Pure scalar function: every `any`/`polymorphic` value is an i64.

--- a/code/packages/rust/lang-aot/tests/wasm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/wasm_emit.rs
@@ -313,3 +313,32 @@ fn mccarthy_symbols_run_on_wasm() {
     // Symbol ids are disjoint from integer atoms.
     assert_eq!(go("(EQ 'A 5)"), vec![0], "a symbol never equals an integer");
 }
+
+/// `LAMBDA`/`LABEL` + user calls + recursion run on wasm (LANG77 W2 / F7). The
+/// frontend lifts each `LAMBDA`/`LABEL` to its own function; the structural pass
+/// makes the call boundary uniform-anyref (params anyref, args boxed, returns
+/// anyref), so a lambda can be applied and a `LABEL` can recurse.
+#[test]
+fn mccarthy_lambda_and_recursion_run_on_wasm() {
+    let rt = WasmRuntime::new();
+    let go = |src: &str| {
+        let bytes = compile_source_to_wasm(Language::McCarthyLisp, src, "lam").expect("emit lambda");
+        rt.load_and_run(&bytes, "main", &[]).expect("run lambda")
+    };
+
+    // Identity lambda returns its argument.
+    assert_eq!(go("((LAMBDA (X) X) 5)"), vec![5], "id lambda");
+    // A lambda that conses its argument; CAR reads it back.
+    assert_eq!(go("(CAR ((LAMBDA (X) (CONS X X)) 7))"), vec![7], "lambda body builds a cons");
+    // Two parameters, bound positionally.
+    assert_eq!(go("(CDR ((LAMBDA (X Y) (CONS X Y)) 3 4))"), vec![4], "two-arg lambda");
+    // A predicate inside a lambda.
+    assert_eq!(go("((LAMBDA (X) (EQ X X)) 5)"), vec![1], "EQ inside a lambda");
+    // A lambda returning a bare atom.
+    assert_eq!(go("((LAMBDA (X) 9) 5)"), vec![9], "lambda returns an atom");
+
+    // A recursive LABEL: walk down a list to its atom tail (no arithmetic in
+    // McCarthy 1.0). f(L) = if (ATOM L) then 99 else f(CDR L).
+    let rec = "((LABEL F (LAMBDA (L) (COND ((ATOM L) 99) ((EQ 1 1) (F (CDR L)))))) (CONS 1 (CONS 2 3)))";
+    assert_eq!(go(rec), vec![99], "recursive LABEL walks to the atom");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -59,7 +59,7 @@ representation + per-builtin backend lowering.
 |---------|----------|----|----|----|----|----|----|----|-------------|
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
-| **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-anyref |
+| **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
@@ -86,10 +86,17 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   no new value type, no polymorphic `EQ`. `lang-aot::compile_source_to_wasm` runs
   it before the repr pass. `(EQ 'A 'A)` → T, `(EQ 'A 'B)` → nil, `(EQ 'A 5)` → nil
   (disjoint range), symbols through cons + `COND`, end-to-end on `wasm-runtime`.
-- ☐ **W2 — WASM `LAMBDA`/`LABEL`/user calls + recursion (F7).** Per-`LAMBDA`/
-  `LABEL` wasm function; `call`; bound params as anyref locals; closure value if
-  captured (env object). Recursion via the existing `call`. A recursive `LABEL`
-  (e.g. a length/append) runs end-to-end. **Completes WASM.**
+- ✅ **W2 — WASM `LAMBDA`/`LABEL`/user calls + recursion (F7).** The frontend
+  already lifts each `LAMBDA`/`LABEL` to its own function + `call`; the structural
+  pass now makes the **call boundary uniform-anyref** — a new `lisp_functions`
+  module analysis (heap/predicate/lisp-param users, closed under *calling*)
+  replaces the per-function gate; lisp **params** retype to `ref<any>`, **call
+  args** box to `i31ref`, **call results** are references, and a **non-entry**
+  function returns `ref<any>` (boxing a scalar/bool/atom). Recursion is just a
+  self-`call`, so it needs nothing extra. `((LAMBDA (X) X) 5)` → 5,
+  `(CDR ((LAMBDA (X Y) (CONS X Y)) 3 4))` → 4, `((LAMBDA (X) (EQ X X)) 5)` → T,
+  and a recursive `LABEL` walking a list to its atom — all end-to-end on
+  `wasm-runtime`. **WASM is now McCarthy-complete (F1–F7).**
 
 ### Phase B — JVM (replicate the uniform-ref model as `Object`)
 


### PR DESCRIPTION
## What & why — WASM is now McCarthy-complete (F1–F7)

Second worklist item. Make McCarthy **functions** run on wasm: `LAMBDA` application, multi-argument lambdas, and **recursive `LABEL`**.

The frontend already lifts each `LAMBDA`/`LABEL` to its own IIRFunction + a `call`. The gap was the value representation at the **function boundary**: the structural pass processed each function in isolation, so a lambda's args/params/return weren't uniformly typed — `((LAMBDA (X) X) 5)` returned **0** (the arg never reached `X`).

## Change

**`iir-builtin-lowering` 0.12.0** — `lower_lisp_repr_structural` makes the call boundary **uniform-anyref**:
- a new `lisp_functions` module analysis (heap/predicate/lisp-param users, **closed under calling** — a caller of a lisp function is lisp) replaces the per-function gate, so every lisp function is processed (even a trivial `(LAMBDA (X) X)`);
- lisp **params** (`any`/`symbol`) retype to `ref<any>`; **call args** box to `i31ref`; **call results** are references; a **non-entry** function returns `ref<any>` (boxing a scalar/bool/atom). The entry function still unboxes to `i32`.
- **Recursion is just a self-`call`** — needs nothing extra.

**`lang-aot` 0.20.0** — `concretize_scalar_any_for_wasm` skips functions with lisp params, keeping the partition exact.

## Verified end-to-end on `wasm-runtime`

`((LAMBDA (X) X) 5)` → 5 · `(CAR ((LAMBDA (X) (CONS X X)) 7))` → 7 · `(CDR ((LAMBDA (X Y) (CONS X Y)) 3 4))` → 4 · `((LAMBDA (X) (EQ X X)) 5)` → 1 · `((LAMBDA (X) 9) 5)` → 9 · recursive `LABEL` walking a list to its atom → 99.

## Test plan

1 new unit test (the boundary: param→ref<any>, arg boxed, return ref<any>, caller unboxes) + a `wasm_emit` e2e (6 programs incl. multi-arg and recursion). Full suites green — iir-builtin-lowering **106**, `wasm_emit` **18**; cons/ATOM/EQ/COND/symbols/scalar/Twig regression-tested; clippy clean.

## Security & safety

Security review **PASSED**: the `lisp_functions` fixpoint terminates (name-keyed HashSet that only grows, bounded by the function count); no panics on malformed IIR (every index Option-guarded or provably in-bounds — no-arg calls, zero-instruction functions, operand-less `ret` all handled); polynomial complexity; the boundary stays consistent because the lisp set is computed module-wide before any rewrite. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **WASM F7** — the WASM backend now runs the **full McCarthy core (F1–F7)**, the reference design for the managed backends. **Next: W3** (JVM cons) begins the JVM/CLR/BEAM replication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)