### PR TITLE
Add smart-home activation decision tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -50,6 +50,7 @@ Chief of Staff job/session/agent
   -> activation-constraint list and summary reads for grouped blockers/reviews
   -> activation-review list and summary reads for human-review queue planning
   -> activation-approval list and summary reads for bundled approval packets
+  -> activation-decision list and summary reads for approve/block queue planning
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -97,6 +98,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_review_summary`
 - `smart_home.list_integration_activation_approvals`
 - `smart_home.get_integration_activation_approval_summary`
+- `smart_home.list_integration_activation_decisions`
+- `smart_home.get_integration_activation_decision_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -35,25 +35,27 @@ use smart_home_discovery::{
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_candidates_at_or_before_priority,
-    activation_constraints_from_candidates, activation_dependency_graph_from_reports,
-    activation_health_from_candidates, activation_maintenance_from_candidates,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    activation_constraints_from_candidates, activation_decisions_from_candidates,
+    activation_dependency_graph_from_reports, activation_health_from_candidates,
+    activation_maintenance_from_candidates, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
+    IntegrationActivationApprovalSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationDecisionItem,
+    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
     IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
     IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
     IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
@@ -207,6 +209,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_APPROVALS_TOOL_ID: &str =
     "smart_home.list_integration_activation_approvals";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_approval_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_decisions";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_decision_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -415,6 +421,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID => {
                     let query = integration_activation_approval_query(&arguments)?;
                     Ok(get_integration_activation_approval_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID => {
+                    let query = integration_activation_decision_query(&arguments)?;
+                    Ok(list_integration_activation_decisions_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_decision_query(&arguments)?;
+                    Ok(get_integration_activation_decision_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1448,6 +1464,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation approval summary",
             "Return compact D23A activation approval packet counts for approval-ready and blocked human decision work.",
             integration_activation_approval_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID,
+            "List smart-home integration activation decisions",
+            "List D23A activation decision rows derived from human-approval packets, grouped into ready-to-approve and blocked prerequisite work.",
+            integration_activation_decision_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_decisions", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_decisions",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation decision summary",
+            "Return compact D23A activation decision counts for approval-ready and prerequisite-blocked human decisions.",
+            integration_activation_decision_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4044,6 +4094,18 @@ struct IntegrationActivationApprovalQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationDecisionQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    decision_status: Option<IntegrationActivationDecisionStatus>,
+    required_tier: Option<PrivilegeTier>,
+    policy_surface: Option<IntegrationPolicySurface>,
+    approval_ready: Option<bool>,
+    blocked_only: Option<bool>,
+    requires_attention: Option<bool>,
+    decision_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4185,6 +4247,32 @@ fn integration_activation_approval_query(
         blocked_only: optional_bool(arguments, "blocked_only")?,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         approval_limit: optional_u64(arguments, "approval_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_decision_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationDecisionQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let decision_status = optional_string(arguments, "decision_status")?
+        .map(|label| parse_activation_decision_status(&label))
+        .transpose()?;
+    let required_tier = optional_string(arguments, "required_tier")?
+        .map(|tier| parse_privilege_tier(&tier))
+        .transpose()?;
+    let policy_surface = optional_string(arguments, "policy_surface")?
+        .map(|surface| parse_policy_surface(&surface))
+        .transpose()?;
+
+    Ok(IntegrationActivationDecisionQuery {
+        candidates,
+        decision_status,
+        required_tier,
+        policy_surface,
+        approval_ready: optional_bool(arguments, "approval_ready")?,
+        blocked_only: optional_bool(arguments, "blocked_only")?,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        decision_limit: optional_u64(arguments, "decision_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4541,6 +4629,49 @@ fn integration_activation_approvals_for_query(
     }
 
     (packets, catalog_count)
+}
+
+fn integration_activation_decisions_for_query(
+    query: &IntegrationActivationDecisionQuery,
+) -> (Vec<IntegrationActivationDecisionItem>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut decisions = activation_decisions_from_candidates(
+        &catalog,
+        candidates.iter(),
+        &query.candidates.readiness.enabled_integrations,
+    );
+
+    if let Some(decision_status) = query.decision_status {
+        decisions.retain(|decision| decision.decision_status == decision_status);
+    }
+    if let Some(required_tier) = query.required_tier {
+        decisions.retain(|decision| decision.required_tier() == required_tier);
+    }
+    if let Some(policy_surface) = query.policy_surface {
+        decisions.retain(|decision| {
+            decision
+                .packet
+                .review
+                .policy_surfaces
+                .contains(&policy_surface)
+        });
+    }
+    if let Some(approval_ready) = query.approval_ready {
+        decisions.retain(|decision| decision.approval_ready() == approval_ready);
+    }
+    if let Some(blocked_only) = query.blocked_only {
+        decisions.retain(|decision| decision.has_blockers() == blocked_only);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        decisions.retain(|decision| decision.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.decision_limit {
+        decisions.truncate(limit);
+    }
+
+    (decisions, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -5566,6 +5697,72 @@ fn get_integration_activation_approval_summary_output_handler_output(
                 integer(summary.approval_ready_packets as i64),
             ),
             ("blocked_packets", integer(summary.blocked_packets as i64)),
+        ]),
+    )
+}
+
+fn list_integration_activation_decisions_output_handler_output(
+    query: IntegrationActivationDecisionQuery,
+) -> ToolHandlerOutput {
+    let (decisions, catalog_count) = integration_activation_decisions_for_query(&query);
+    let summary = IntegrationActivationDecisionSummary::from_decisions(decisions.iter());
+    let count = decisions.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_decisions",
+            JsonValue::Array(decisions.iter().map(activation_decision_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_decision_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_decisions")),
+            ("activation_decisions", integer(count as i64)),
+            (
+                "ready_to_approve_decisions",
+                integer(summary.ready_to_approve_decisions as i64),
+            ),
+            (
+                "blocked_decisions",
+                integer(summary.blocked_decisions as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_decision_summary_output_handler_output(
+    query: IntegrationActivationDecisionQuery,
+) -> ToolHandlerOutput {
+    let (decisions, _) = integration_activation_decisions_for_query(&query);
+    let summary = IntegrationActivationDecisionSummary::from_decisions(decisions.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_decision_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_decision_summary"),
+            ),
+            ("total_decisions", integer(summary.total_decisions as i64)),
+            (
+                "ready_to_approve_decisions",
+                integer(summary.ready_to_approve_decisions as i64),
+            ),
+            (
+                "blocked_decisions",
+                integer(summary.blocked_decisions as i64),
+            ),
         ]),
     )
 }
@@ -9742,6 +9939,215 @@ fn integration_activation_approval_summary_json(
     ])
 }
 
+fn activation_decision_json(decision: &IntegrationActivationDecisionItem) -> JsonValue {
+    object([
+        (
+            "integration_id",
+            string(decision.requested_integration_id().as_str()),
+        ),
+        (
+            "requested_integration_id",
+            string(decision.requested_integration_id().as_str()),
+        ),
+        ("display_name", string(decision.display_name())),
+        ("priority", integer(decision.priority() as i64)),
+        ("decision_status", string(decision.decision_status.as_str())),
+        (
+            "recommended_decision",
+            string(match decision.decision_status {
+                IntegrationActivationDecisionStatus::ReadyToApprove => "approve",
+                IntegrationActivationDecisionStatus::BlockedOnPrerequisites => {
+                    "block_until_prerequisites_ready"
+                }
+            }),
+        ),
+        (
+            "activation_target",
+            activation_target_json(&decision.packet.review.activation_target),
+        ),
+        (
+            "recommendation",
+            string(activation_candidate_recommendation_label(
+                decision.packet.review.recommendation,
+            )),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(decision.required_tier())),
+        ),
+        (
+            "policy_surfaces",
+            JsonValue::Array(
+                decision
+                    .packet
+                    .review
+                    .policy_surfaces
+                    .iter()
+                    .map(|surface| string(surface.as_str()))
+                    .collect(),
+            ),
+        ),
+        ("approval_ready", JsonValue::Bool(decision.approval_ready())),
+        ("has_blockers", JsonValue::Bool(decision.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(decision.requires_attention()),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(&decision.packet.action_summary),
+        ),
+        (
+            "constraint_summary",
+            integration_activation_constraint_summary_json(&decision.packet.constraint_summary),
+        ),
+        (
+            "risk_summary",
+            integration_activation_risk_summary_json(&decision.packet.risk_summary),
+        ),
+        (
+            "dependency_summary",
+            integration_activation_dependency_summary_json(
+                &decision.packet.dependency_graph.summary,
+            ),
+        ),
+        (
+            "approval_packet",
+            activation_approval_packet_json(&decision.packet),
+        ),
+    ])
+}
+
+fn integration_activation_decision_summary_json(
+    summary: &IntegrationActivationDecisionSummary,
+) -> JsonValue {
+    object([
+        ("total_decisions", integer(summary.total_decisions as i64)),
+        (
+            "ready_to_approve_decisions",
+            integer(summary.ready_to_approve_decisions as i64),
+        ),
+        (
+            "blocked_decisions",
+            integer(summary.blocked_decisions as i64),
+        ),
+        (
+            "local_only_decisions",
+            integer(summary.local_only_decisions as i64),
+        ),
+        (
+            "cloud_required_decisions",
+            integer(summary.cloud_required_decisions as i64),
+        ),
+        (
+            "decisions_with_policy_surfaces",
+            integer(summary.decisions_with_policy_surfaces as i64),
+        ),
+        (
+            "decisions_without_policy_surfaces",
+            integer(summary.decisions_without_policy_surfaces as i64),
+        ),
+        (
+            "unique_policy_surfaces",
+            integer(summary.unique_policy_surfaces as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "activate_integration_actions",
+            integer(summary.activate_integration_actions as i64),
+        ),
+        (
+            "review_policy_actions",
+            integer(summary.review_policy_actions as i64),
+        ),
+        (
+            "provide_primitive_actions",
+            integer(summary.provide_primitive_actions as i64),
+        ),
+        (
+            "grant_capability_actions",
+            integer(summary.grant_capability_actions as i64),
+        ),
+        (
+            "enable_dependency_actions",
+            integer(summary.enable_dependency_actions as i64),
+        ),
+        (
+            "total_constraints",
+            integer(summary.total_constraints as i64),
+        ),
+        (
+            "blocking_constraints",
+            integer(summary.blocking_constraints as i64),
+        ),
+        (
+            "review_constraints",
+            integer(summary.review_constraints as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "policy_tier_risks",
+            integer(summary.policy_tier_risks as i64),
+        ),
+        (
+            "policy_surface_risks",
+            integer(summary.policy_surface_risks as i64),
+        ),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "read_only_decisions",
+            integer(summary.read_only_decisions as i64),
+        ),
+        (
+            "low_risk_decisions",
+            integer(summary.low_risk_decisions as i64),
+        ),
+        (
+            "human_approval_decisions",
+            integer(summary.human_approval_decisions as i64),
+        ),
+        (
+            "high_risk_decisions",
+            integer(summary.high_risk_decisions as i64),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -12209,6 +12615,22 @@ fn parse_activation_health_status(
     }
 }
 
+fn parse_activation_decision_status(
+    label: &str,
+) -> Result<IntegrationActivationDecisionStatus, ToolCallError> {
+    match label {
+        "ready_to_approve" | "ready" | "approve" | "approval_ready" => {
+            Ok(IntegrationActivationDecisionStatus::ReadyToApprove)
+        }
+        "blocked_on_prerequisites" | "blocked" | "prerequisites" => {
+            Ok(IntegrationActivationDecisionStatus::BlockedOnPrerequisites)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation decision status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_constraint_kind(
     label: &str,
 ) -> Result<IntegrationActivationConstraintKind, ToolCallError> {
@@ -13116,6 +13538,33 @@ fn integration_activation_approval_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_decision_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "decision_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("decision_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("required_tier", JsonSchema::String));
+        properties.push(SchemaProperty::new("policy_surface", JsonSchema::String));
+        properties.push(SchemaProperty::new("approval_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -13260,7 +13709,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 79);
+        assert_eq!(definitions.len(), 81);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -13465,9 +13914,15 @@ mod tests {
             .tool_ids()
             .contains(&SMART_HOME_DESCRIBE_CAPABILITIES_TOOL_ID));
         assert!(export.tool_ids().contains(&SMART_HOME_GET_HEALTH_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            71
+            73
         );
         assert_eq!(
             export
@@ -13857,11 +14312,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(79))
+            Some(&integer(81))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(71))
+            Some(&integer(73))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -15259,6 +15714,129 @@ mod tests {
         );
         assert_eq!(
             field(activation_approval_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_decisions_request = request(
+            "call-list-integration-activation-decisions",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("decision_limit", integer(3)),
+            ]),
+            5_013,
+        );
+        let list_activation_decisions_trace =
+            tool_runtime.invoke_with_events(&list_activation_decisions_request);
+        assert!(list_activation_decisions_trace.result.ok);
+        assert_eq!(
+            list_activation_decisions_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_decisions_output = list_activation_decisions_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_decision_count =
+            integer_value(field(list_activation_decisions_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_decision_count));
+        let activation_decision_summary =
+            field(list_activation_decisions_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_decision_summary, "total_decisions").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_decision_summary, "review_policy_actions").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_decision_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_decision = array_item(
+            field(list_activation_decisions_output, "activation_decisions").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(matches!(
+            field(activation_decision, "decision_status"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(field(activation_decision, "approval_packet").is_some());
+        assert!(field(activation_decision, "action_summary").is_some());
+        assert!(field(activation_decision, "constraint_summary").is_some());
+        assert!(field(activation_decision, "risk_summary").is_some());
+        assert!(field(activation_decision, "dependency_summary").is_some());
+
+        let activation_decision_summary_request = request(
+            "call-integration-activation-decision-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("decision_status", string("blocked")),
+            ]),
+            5_014,
+        );
+        let activation_decision_summary_trace =
+            tool_runtime.invoke_with_events(&activation_decision_summary_request);
+        assert!(activation_decision_summary_trace.result.ok);
+        assert_eq!(
+            activation_decision_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_decision_summary_output = activation_decision_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_decision_rollup =
+            field(activation_decision_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_decision_rollup, "blocked_decisions").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_decision_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
         );
 
@@ -16953,6 +17531,14 @@ mod tests {
             activation_approval_summary_request,
             activation_approval_summary_trace,
         );
+        journal.record_trace(
+            list_activation_decisions_request,
+            list_activation_decisions_trace,
+        );
+        journal.record_trace(
+            activation_decision_summary_request,
+            activation_decision_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -17026,9 +17612,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 79);
-        assert_eq!(journal_summary.completed_count, 79);
-        assert_eq!(journal.audit_records().len(), 79);
+        assert_eq!(journal_summary.invocation_count, 81);
+        assert_eq!(journal_summary.completed_count, 81);
+        assert_eq!(journal.audit_records().len(), 81);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -54,6 +54,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_approval_summary` tool descriptors
   for read-only human-decision packet planning across review rows, actions,
   constraints, risk, and dependency blockers.
+- `smart_home.list_integration_activation_decisions` and
+  `smart_home.get_integration_activation_decision_summary` tool descriptors
+  for read-only approve/block queue planning derived from activation approval
+  packets.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -73,6 +73,8 @@ Current scope:
 - D18D integration activation-approval descriptors for bundled human-decision
   packets that combine review rows with actions, constraints, risk, and
   dependency blockers
+- D18D integration activation-decision descriptors for read-only approve/block
+  queue planning derived from approval packets
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1477,6 +1477,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationReviewSummary,
     ListIntegrationActivationApprovals,
     GetIntegrationActivationApprovalSummary,
+    ListIntegrationActivationDecisions,
+    GetIntegrationActivationDecisionSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1614,6 +1616,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationApprovalSummary => {
                 read_tool("smart_home.get_integration_activation_approval_summary")
+            }
+            Self::ListIntegrationActivationDecisions => {
+                read_tool("smart_home.list_integration_activation_decisions")
+            }
+            Self::GetIntegrationActivationDecisionSummary => {
+                read_tool("smart_home.get_integration_activation_decision_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2274,6 +2282,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationReviewSummary,
         SmartHomeTool::ListIntegrationActivationApprovals,
         SmartHomeTool::GetIntegrationActivationApprovalSummary,
+        SmartHomeTool::ListIntegrationActivationDecisions,
+        SmartHomeTool::GetIntegrationActivationDecisionSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3116,7 +3126,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 79);
+        assert_eq!(catalog.len(), 81);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3256,6 +3266,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_approval_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_decisions"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_decision_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3446,15 +3464,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 79);
-        assert_eq!(summary.read_tools, 71);
+        assert_eq!(summary.total_tools, 81);
+        assert_eq!(summary.read_tools, 73);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 71);
+        assert_eq!(summary.read_only_tier_tools, 73);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 79);
+        assert_eq!(summary.total_required_capabilities, 81);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -56,6 +56,8 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation approval packets that bundle each human-review row with its
   concrete actions, grouped constraints, policy risk, and dependency blockers
   for approval preparation
+- activation decision rows that project approval packets into ready-to-approve
+  and prerequisite-blocked queues for Chief planning
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1025,6 +1025,25 @@ impl IntegrationActivationHealthStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationDecisionStatus {
+    ReadyToApprove,
+    BlockedOnPrerequisites,
+}
+
+impl IntegrationActivationDecisionStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadyToApprove => "ready_to_approve",
+            Self::BlockedOnPrerequisites => "blocked_on_prerequisites",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationActionKind {
     ActivateIntegration,
     ReviewPolicy,
@@ -1255,6 +1274,45 @@ pub struct IntegrationActivationApprovalSummary {
     pub low_risk_packets: usize,
     pub human_approval_packets: usize,
     pub high_risk_packets: usize,
+    pub first_approval_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDecisionItem {
+    pub packet: IntegrationActivationApprovalPacket,
+    pub decision_status: IntegrationActivationDecisionStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDecisionSummary {
+    pub total_decisions: usize,
+    pub ready_to_approve_decisions: usize,
+    pub blocked_decisions: usize,
+    pub local_only_decisions: usize,
+    pub cloud_required_decisions: usize,
+    pub decisions_with_policy_surfaces: usize,
+    pub decisions_without_policy_surfaces: usize,
+    pub unique_policy_surfaces: usize,
+    pub total_actions: usize,
+    pub activate_integration_actions: usize,
+    pub review_policy_actions: usize,
+    pub provide_primitive_actions: usize,
+    pub grant_capability_actions: usize,
+    pub enable_dependency_actions: usize,
+    pub total_constraints: usize,
+    pub blocking_constraints: usize,
+    pub review_constraints: usize,
+    pub total_risks: usize,
+    pub policy_tier_risks: usize,
+    pub policy_surface_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub read_only_decisions: usize,
+    pub low_risk_decisions: usize,
+    pub human_approval_decisions: usize,
+    pub high_risk_decisions: usize,
     pub first_approval_priority: Option<u8>,
     pub first_blocked_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
@@ -2799,6 +2857,177 @@ impl IntegrationActivationApprovalSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.total_packets > 0
+    }
+}
+
+impl IntegrationActivationDecisionItem {
+    fn from_packet(packet: IntegrationActivationApprovalPacket) -> Self {
+        let decision_status = if packet.approval_ready() && !packet.has_blockers() {
+            IntegrationActivationDecisionStatus::ReadyToApprove
+        } else {
+            IntegrationActivationDecisionStatus::BlockedOnPrerequisites
+        };
+
+        Self {
+            packet,
+            decision_status,
+        }
+    }
+
+    pub fn requested_integration_id(&self) -> &IntegrationId {
+        self.packet.requested_integration_id()
+    }
+
+    pub fn display_name(&self) -> &str {
+        self.packet.display_name()
+    }
+
+    pub fn priority(&self) -> u8 {
+        self.packet.priority()
+    }
+
+    pub fn required_tier(&self) -> PrivilegeTier {
+        self.packet.required_tier()
+    }
+
+    pub fn approval_ready(&self) -> bool {
+        self.packet.approval_ready()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.packet.has_blockers()
+    }
+
+    pub fn has_policy_surfaces(&self) -> bool {
+        self.packet.has_policy_surfaces()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.decision_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationDecisionSummary {
+    pub fn from_decisions<'a>(
+        decisions: impl IntoIterator<Item = &'a IntegrationActivationDecisionItem>,
+    ) -> Self {
+        let mut policy_surfaces = BTreeSet::new();
+        let mut summary = Self {
+            total_decisions: 0,
+            ready_to_approve_decisions: 0,
+            blocked_decisions: 0,
+            local_only_decisions: 0,
+            cloud_required_decisions: 0,
+            decisions_with_policy_surfaces: 0,
+            decisions_without_policy_surfaces: 0,
+            unique_policy_surfaces: 0,
+            total_actions: 0,
+            activate_integration_actions: 0,
+            review_policy_actions: 0,
+            provide_primitive_actions: 0,
+            grant_capability_actions: 0,
+            enable_dependency_actions: 0,
+            total_constraints: 0,
+            blocking_constraints: 0,
+            review_constraints: 0,
+            total_risks: 0,
+            policy_tier_risks: 0,
+            policy_surface_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            read_only_decisions: 0,
+            low_risk_decisions: 0,
+            human_approval_decisions: 0,
+            high_risk_decisions: 0,
+            first_approval_priority: None,
+            first_blocked_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for decision in decisions {
+            summary.total_decisions += 1;
+            match decision.decision_status {
+                IntegrationActivationDecisionStatus::ReadyToApprove => {
+                    summary.ready_to_approve_decisions += 1;
+                    summary.first_approval_priority = min_optional_priority(
+                        summary.first_approval_priority,
+                        Some(decision.priority()),
+                    );
+                }
+                IntegrationActivationDecisionStatus::BlockedOnPrerequisites => {
+                    summary.blocked_decisions += 1;
+                    summary.first_blocked_priority = min_optional_priority(
+                        summary.first_blocked_priority,
+                        Some(decision.priority()),
+                    );
+                }
+            }
+
+            if decision.packet.review.local_only {
+                summary.local_only_decisions += 1;
+            }
+            if decision.packet.review.cloud_required {
+                summary.cloud_required_decisions += 1;
+            }
+            if decision.has_policy_surfaces() {
+                summary.decisions_with_policy_surfaces += 1;
+            } else {
+                summary.decisions_without_policy_surfaces += 1;
+            }
+            for surface in &decision.packet.review.policy_surfaces {
+                policy_surfaces.insert(*surface);
+            }
+
+            summary.total_actions += decision.packet.action_summary.total_actions;
+            summary.activate_integration_actions +=
+                decision.packet.action_summary.activate_integration_actions;
+            summary.review_policy_actions += decision.packet.action_summary.review_policy_actions;
+            summary.provide_primitive_actions +=
+                decision.packet.action_summary.provide_primitive_actions;
+            summary.grant_capability_actions +=
+                decision.packet.action_summary.grant_capability_actions;
+            summary.enable_dependency_actions +=
+                decision.packet.action_summary.enable_dependency_actions;
+
+            summary.total_constraints += decision.packet.constraint_summary.total_constraints;
+            summary.blocking_constraints += decision.packet.constraint_summary.blocking_constraints;
+            summary.review_constraints += decision.packet.constraint_summary.review_constraints;
+
+            summary.total_risks += decision.packet.risk_summary.total_risks;
+            summary.policy_tier_risks += decision.packet.risk_summary.policy_tier_risks;
+            summary.policy_surface_risks += decision.packet.risk_summary.policy_surface_risks;
+
+            summary.total_dependency_edges += decision.packet.dependency_graph.summary.total_edges;
+            summary.blocking_dependency_edges +=
+                decision.packet.dependency_graph.summary.blocking_edges;
+
+            match decision.required_tier() {
+                PrivilegeTier::ReadOnly => summary.read_only_decisions += 1,
+                PrivilegeTier::LowRisk => summary.low_risk_decisions += 1,
+                PrivilegeTier::HumanApproval => summary.human_approval_decisions += 1,
+                PrivilegeTier::HighRisk => summary.high_risk_decisions += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(decision.required_tier());
+        }
+
+        summary.unique_policy_surfaces = policy_surfaces.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_decisions == 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.ready_to_approve_decisions > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_decisions > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.total_decisions > 0
     }
 }
 
@@ -5217,6 +5446,38 @@ pub fn activation_approval_packets_at_or_before_priority(
     activation_approval_packets_from_candidates(catalog, candidates.iter(), enabled_integrations)
 }
 
+pub fn activation_decisions_from_candidates<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDecisionItem> {
+    let mut decisions =
+        activation_approval_packets_from_candidates(catalog, candidates, enabled_integrations)
+            .into_iter()
+            .map(IntegrationActivationDecisionItem::from_packet)
+            .collect::<Vec<_>>();
+
+    decisions.sort_by(compare_activation_decisions);
+    decisions
+}
+
+pub fn activation_decisions_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDecisionItem> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_decisions_from_candidates(catalog, candidates.iter(), enabled_integrations)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -6441,6 +6702,21 @@ fn compare_activation_approval_packets(
         })
 }
 
+fn compare_activation_decisions(
+    left: &IntegrationActivationDecisionItem,
+    right: &IntegrationActivationDecisionItem,
+) -> Ordering {
+    left.priority()
+        .cmp(&right.priority())
+        .then_with(|| left.decision_status.cmp(&right.decision_status))
+        .then_with(|| right.required_tier().cmp(&left.required_tier()))
+        .then_with(|| left.display_name().cmp(right.display_name()))
+        .then_with(|| {
+            left.requested_integration_id()
+                .cmp(right.requested_integration_id())
+        })
+}
+
 fn compare_activation_dependency_nodes(
     left: &IntegrationActivationDependencyNode,
     right: &IntegrationActivationDependencyNode,
@@ -7609,6 +7885,122 @@ mod tests {
         assert!(catalog_packets
             .iter()
             .any(IntegrationActivationApprovalPacket::has_policy_surfaces));
+    }
+
+    #[test]
+    fn activation_decisions_project_approval_packets_into_decision_queue() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+
+        let decisions = activation_decisions_from_candidates(&[], candidates.iter(), &[]);
+
+        assert_eq!(decisions.len(), 2);
+        let ready_to_approve = decisions
+            .iter()
+            .find(|decision| decision.requested_integration_id().as_str() == "review_ready_bridge")
+            .unwrap();
+        assert_eq!(
+            ready_to_approve.decision_status,
+            IntegrationActivationDecisionStatus::ReadyToApprove
+        );
+        assert!(ready_to_approve.approval_ready());
+        assert!(!ready_to_approve.has_blockers());
+        assert!(ready_to_approve.requires_attention());
+
+        let blocked = decisions
+            .iter()
+            .find(|decision| {
+                decision.requested_integration_id().as_str() == "blocked_review_camera"
+            })
+            .unwrap();
+        assert_eq!(
+            blocked.decision_status,
+            IntegrationActivationDecisionStatus::BlockedOnPrerequisites
+        );
+        assert!(!blocked.approval_ready());
+        assert!(blocked.has_blockers());
+        assert_eq!(blocked.required_tier(), PrivilegeTier::HighRisk);
+
+        let summary = IntegrationActivationDecisionSummary::from_decisions(decisions.iter());
+        assert_eq!(summary.total_decisions, 2);
+        assert_eq!(summary.ready_to_approve_decisions, 1);
+        assert_eq!(summary.blocked_decisions, 1);
+        assert!(summary.total_actions > 0);
+        assert!(summary.review_policy_actions > 0);
+        assert!(summary.blocking_constraints > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.total_dependency_edges > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(summary.human_approval_decisions, 1);
+        assert_eq!(summary.high_risk_decisions, 1);
+        assert_eq!(summary.first_approval_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(2));
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_decisions = activation_decisions_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_decisions
+            .iter()
+            .any(IntegrationActivationDecisionItem::has_policy_surfaces));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-level activation decision rows and summaries derived from approval packets
- expose read-only Chief tools for listing/summarizing activation decisions with status, tier, policy-surface, blocker, and attention filters
- register core D18D descriptors and update docs/changelog for the decision queue surface

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
- git diff --check