### PR TITLE
feat(mccarthy-lisp): W3a — McCarthy → JVM run-foundation (scalar) (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.21.0 — 2026-06-09 — McCarthy → **JVM** run-foundation (scalar) (LANG77 / W3a)
+
+Adds `compile_source_to_jvm` / `compile_file_to_jvm` — the second *managed*
+`--emit` target. Source → IIR → `concretize_scalar_any_for_jvm` (scalar `any`/
+`i64` → JVM `i32`) → `iir-to-jvm-class-file` → a serialized `.class`. **Scalar
+McCarthy programs emit a class that RUNS** — verified end-to-end by parsing the
+emitted bytes and running the entry method on the in-repo `jvm-simulator` (zero
+external `java`, mirroring how the wasm path uses `wasm-runtime`): `42` → 42,
+`0` → 0, `7` → 7; Twig `42` too. The cons/symbol/lambda uniform-`Object` value
+model (the JVM replication of the WASM structural passes) is W3b+.
+
 ## 0.20.0 — 2026-06-09 — McCarthy → WebAssembly, **`LAMBDA`/`LABEL`/recursion** (LANG77 / W2)
 
 `compile_source_to_wasm` now runs McCarthy functions: `LAMBDA` application,

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
@@ -17,6 +17,7 @@ interpreter-ir        = { path = "../interpreter-ir" }
 cli-builder           = { path = "../cli-builder" }
 iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-wasm           = { path = "../iir-to-wasm" }
+iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
 iir-builtin-lowering  = { path = "../iir-builtin-lowering" }
 riscv-backend         = { path = "../riscv-backend" }
 riscv-encoder         = { path = "../riscv-encoder" }
@@ -41,3 +42,9 @@ tempfile = "3"
 # the computed result (LANG77 / McCarthy L3b-3a-2). Keeps wasm verification
 # zero-external-dep.
 wasm-runtime = { path = "../wasm-runtime" }
+# In-repo JVM class-file parser + bytecode simulator — used to RUN the emitted
+# JVM class in tests and assert the computed result (LANG77 / McCarthy W3a),
+# mirroring how wasm-runtime verifies the wasm path. Keeps JVM verification
+# zero-external-dep (no `java` needed for the scalar path).
+jvm-class-file = { path = "../jvm-class-file" }
+jvm-simulator = { path = "../jvm-simulator" }

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -15,6 +15,11 @@ predicates, `COND`, and symbols: `pair?`/`ATOM` (`(ATOM 5)` → 1; L3b-3a-4b),
 McCarthy core** — cons, `ATOM`, `EQ`, `COND`, symbols, and lambda/label/recursion
 (F1–F7) — now runs on the wasm backend.
 
+`compile_source_to_jvm` is the second managed target (W3a): scalar McCarthy emits
+a JVM `.class` that **runs** — verified by running the entry method on the in-repo
+`jvm-simulator` (`42` → 42), no external `java`. The JVM cons/symbol/lambda value
+model (uniform-`Object`, replicating the wasm passes) is W3b+.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -182,6 +182,13 @@ pub enum LangAotError {
     /// the modern *managed* targets the worked example reaches (LANG77 /
     /// McCarthy L3b-3).
     WasmBackendError(String),
+    /// The JVM (Java class-file) backend rejected the IIR.
+    ///
+    /// Carries the string from `iir-to-jvm-class-file` (a validation failure, or
+    /// an op/type its lowering does not yet handle).  The JVM is the second of
+    /// the modern *managed* targets, replicating the WASM uniform-reference value
+    /// model with `Object`/`Integer` boxing (LANG77 / McCarthy W3).
+    JvmBackendError(String),
 }
 
 impl fmt::Display for LangAotError {
@@ -195,6 +202,7 @@ impl fmt::Display for LangAotError {
             LangAotError::Io(e) => write!(f, "io: {e}"),
             LangAotError::LlvmBackendError(m) => write!(f, "llvm: {m}"),
             LangAotError::WasmBackendError(m) => write!(f, "wasm: {m}"),
+            LangAotError::JvmBackendError(m) => write!(f, "jvm: {m}"),
             LangAotError::RiscvBackendError(m) => write!(f, "riscv32: {m}"),
             LangAotError::Intel8008BackendError(m) => write!(f, "intel8008: {m}"),
             LangAotError::Armv7BackendError(m) => write!(f, "armv7: {m}"),
@@ -424,6 +432,86 @@ pub fn compile_source_to_wasm(
         .map_err(|e| LangAotError::WasmBackendError(format!("{e:?}")))?;
     iir_to_wasm::encode_module(&wasm)
         .map_err(|e| LangAotError::WasmBackendError(format!("{e:?}")))
+}
+
+/// Retype a **scalar** module's `any`/`polymorphic`/`i64` values to JVM `i32`,
+/// for the JVM run-foundation (LANG77 / McCarthy W3a). Like
+/// `concretize_scalar_any_for_wasm`, but the managed target here is the JVM, and
+/// the in-repo `jvm-simulator` (used to verify) is a 32-bit integer machine — so
+/// a scalar program's entry returns `int` (`ireturn`), not `long`. We leave
+/// heap/reference functions alone (cons/symbols/lambda are W3b+, where the
+/// uniform-`Object` value model lands).
+fn concretize_scalar_any_for_jvm(module: &mut IIRModule) {
+    const HEAP_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
+    const LISP_BUILTINS: &[&str] = &[
+        "cons", "car", "cdr", "pair?", "not", "equal?", "make_symbol", "make_nil", "null?",
+    ];
+    for func in &mut module.functions {
+        let uses_lisp = func.params.iter().any(|(_, t)| t == "any" || t == "symbol")
+            || func.instructions.iter().any(|i| {
+                HEAP_OPS.contains(&i.op.as_str())
+                    || (i.op == "call_builtin"
+                        && matches!(i.srcs.first(),
+                            Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
+                    || i.type_hint.starts_with("ref<")
+            });
+        if uses_lisp {
+            continue; // uniform-Object value model — JVM W3b+.
+        }
+        let to_i32 = |t: &str| t == "any" || t == "polymorphic" || t == "i64";
+        if to_i32(&func.return_type) {
+            func.return_type = "i32".to_string();
+        }
+        for instr in &mut func.instructions {
+            if to_i32(&instr.type_hint) {
+                instr.type_hint = "i32".to_string();
+            }
+        }
+    }
+}
+
+/// Cross-platform: source → IIR → **JVM class file** bytes (LANG77 / McCarthy W3).
+///
+/// The second of the modern *managed* `--emit` targets. The JVM has its own
+/// uniform-reference value model (`Object` references, `Integer` boxing) — the
+/// analogue of the WASM `anyref`/`i31ref` model. **W3a (this slice)** wires the
+/// pipeline and runs **scalar** programs: source → IIR → `concretize_scalar_any_for_jvm`
+/// → `iir-to-jvm-class-file` → a serialized `.class`. The cons/symbol/lambda value
+/// model (the uniform-`Object` replication of the WASM passes) lands in W3b+.
+///
+/// Verified end-to-end by *running* the emitted class's entry method on the
+/// in-repo `jvm-simulator` (see the `jvm_emit` tests) — no external `java`.
+///
+/// # Errors
+/// * `FrontendError` — the frontend rejected the source.
+/// * `JvmBackendError` — `iir-to-jvm-class-file` rejected the (lowered) IIR.
+pub fn compile_source_to_jvm(
+    language: Language,
+    source: &str,
+    class_name: &str,
+) -> Result<Vec<u8>, LangAotError> {
+    let mut module = compile_source_to_iir(language, source, class_name)?;
+    concretize_scalar_any_for_jvm(&mut module);
+
+    let config = iir_to_jvm_class_file::IIRJvmConfig::new(class_name);
+    let class = iir_to_jvm_class_file::lower_iir_to_jvm(&module, &config)
+        .map_err(|e| LangAotError::JvmBackendError(format!("{e:?}")))?;
+    Ok(iir_to_jvm_class_file::serialize_jvm_class_file(&class))
+}
+
+/// Cross-platform: source file → IIR → JVM class file (`.class`) on disk.
+///
+/// Thin wrapper over [`compile_source_to_jvm`]. Pair with `--emit=jvm`.
+pub fn compile_file_to_jvm(
+    src: &Path,
+    out: &Path,
+    language: Language,
+) -> Result<(), LangAotError> {
+    let source = std::fs::read_to_string(src)?;
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("Main");
+    let bytes = compile_source_to_jvm(language, &source, stem)?;
+    std::fs::write(out, bytes)?;
+    Ok(())
 }
 
 /// Cross-platform: source file → IIR → WebAssembly binary (`.wasm`) on disk.

--- a/code/packages/rust/lang-aot/tests/jvm_emit.rs
+++ b/code/packages/rust/lang-aot/tests/jvm_emit.rs
@@ -1,0 +1,51 @@
+//! # JVM emit + run tests (LANG77 / McCarthy W3a).
+//!
+//! The second *managed* `--emit` target. These don't just check the bytes —
+//! they **run** the emitted class's entry method on the in-repo `jvm-simulator`
+//! and assert the computed result (zero-external-dep verification, mirroring how
+//! `wasm_emit.rs` uses `wasm-runtime`). W3a scope: **scalar** McCarthy programs;
+//! the cons/symbol/lambda uniform-`Object` value model is W3b+.
+
+use jvm_class_file::parse_class_file;
+use jvm_simulator::JVMSimulator;
+use lang_aot::{compile_source_to_jvm, Language};
+
+/// Compile a scalar program to a JVM class, then run its `main` method on the
+/// in-repo simulator and return the `int` result.
+fn compile_and_run(language: Language, source: &str) -> i32 {
+    let bytes = compile_source_to_jvm(language, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?} to JVM: {e}"));
+
+    // A well-formed class file: magic 0xCAFEBABE.
+    assert_eq!(&bytes[..4], &[0xCA, 0xFE, 0xBA, 0xBE], "JVM class-file magic");
+
+    // Parse the emitted bytes back and locate the entry method `main`.
+    let class = parse_class_file(&bytes).expect("emitted class must parse");
+    let main = class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .expect("class has a `main` method");
+    let code = main.code_attribute().expect("main has a Code attribute");
+
+    // Run its bytecode on the simulator (no constant pool ints needed for the
+    // small literals here; bipush/iconst cover them).
+    let mut sim = JVMSimulator::new();
+    sim.load(&code.code, &[], code.max_locals as usize);
+    sim.run(10_000);
+    sim.return_value
+        .unwrap_or_else(|| panic!("`{source}` did not ireturn a value"))
+}
+
+#[test]
+fn mccarthy_scalar_emits_and_runs_on_jvm() {
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "42"), 42, "McCarthy 42");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "0"), 0, "McCarthy 0");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "7"), 7, "McCarthy 7");
+}
+
+#[test]
+fn twig_scalar_emits_and_runs_on_jvm() {
+    // Reusability: Twig flows through the identical JVM scalar path.
+    assert_eq!(compile_and_run(Language::Twig, "42"), 42, "Twig 42");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -100,11 +100,20 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase B — JVM (replicate the uniform-ref model as `Object`)
 
-- ☐ **W3 — JVM cons (F2).** A `$LispyPair` class (two `Object` fields);
+- ✅ **W3a — JVM run-foundation (F1, scalar).** `lang-aot::compile_source_to_jvm` /
+  `compile_file_to_jvm` + `concretize_scalar_any_for_jvm` (scalar `any`/`i64` →
+  JVM `i32`) → `iir-to-jvm-class-file` → a serialized `.class`. **Verified by
+  RUNNING** — parse the emitted bytes (`jvm-class-file::parse_class_file`) and run
+  the entry method on the in-repo **`jvm-simulator`** (zero external `java`,
+  mirroring `wasm-runtime`): `42`→42, `0`→0, `7`→7, Twig `42`→42. Establishes the
+  JVM pipeline + run-verify harness that W3b+ build on.
+- ☐ **W3b — JVM cons (F2).** A `$LispyPair` class (two `Object` fields);
   `cons`/`car`/`cdr` → `new`/`getfield`/… ; integers boxed as `java.lang.Integer`
   (or a small `LispyInt`); `lower_lisp_repr_structural` adapted to JVM boxing.
-  `(CAR (CONS 7 9))` → 7, run on a JVM (or the in-repo class-file
-  verifier/interpreter, mirroring how wasm used `wasm-runtime`).
+  `(CAR (CONS 7 9))` → 7. NOTE: `jvm-simulator` is a 32-bit integer machine (no
+  object/heap execution), so W3b's run-verify needs either an extended simulator
+  or the real `java` (Temurin 21, available via mise + used in CI) — decide when
+  W3b starts.
 - ☐ **W4 — JVM `ATOM`/`EQ`/`COND` (F3–F5).** `instanceof $LispyPair` for `pair?`;
   `Integer.equals`/identity for `EQ`; truthiness for `COND`.
 - ☐ **W5 — JVM symbols + lambda (F6–F7).** Interned symbol objects; lambda →


### PR DESCRIPTION
## What & why — the JVM backend begins

Third worklist item, opening the **managed-backend replication** on the JVM. Wire the McCarthy→JVM pipeline and **run** scalar programs end-to-end on the in-repo `jvm-simulator` (zero external `java`) — the JVM analog of wasm's L3b-3a-2 scalar foundation.

**Survey finding:** `iir-to-jvm-class-file` is well-built (already lowers cons via `LispyPair` alloc/field ops), and `jvm-simulator` is a 32-bit integer bytecode machine that can run a scalar method and return the int — but **nothing wired McCarthy/lang → JVM, and there was no run-verify harness**. This slice establishes both, scoped to scalar (F1).

## Change (`lang-aot` 0.21.0)

- **`compile_source_to_jvm` / `compile_file_to_jvm`** — source → IIR → `concretize_scalar_any_for_jvm` → `iir-to-jvm-class-file::lower_iir_to_jvm` → `serialize_jvm_class_file` (the `.class`).
- **`concretize_scalar_any_for_jvm`** — the JVM twin of `concretize_scalar_any_for_wasm`: scalar `any`/`polymorphic`/`i64` → JVM `i32` (so the entry returns `int` via `ireturn`, which the 32-bit `jvm-simulator` runs), skipping lisp/heap functions.
- `LangAotError::JvmBackendError`.

## Verified by RUNNING

`tests/jvm_emit.rs`: compile → `jvm-class-file::parse_class_file` the emitted bytes → run the entry method's bytecode on **`jvm-simulator`** → assert. **`42`→42, `0`→0, `7`→7; Twig `42`→42**. No external `java`.

## Test plan

2 new e2e tests; full lang-aot suite green (`wasm_emit` 18, `jvm_emit` 2, lib green); clippy clean; no regressions.

## Security & safety

Security review **PASSED**: the new code is a pure O(N) in-place IIR retype + an error-propagating compile entry — no `unwrap`/`expect`/indexing/overflow on adversarial IIR; `compile_file_to_jvm` uses the safe `unwrap_or` fallback; the `jvm-simulator` `run` is step-capped (no hang). No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Establishes **JVM F1** + the run-verify harness (W3a ✅). **Next: W3b** — JVM cons (the `LispyPair`/`Object` value model). Its run-verify will need either an extended `jvm-simulator` (no object execution today) or the real `java` (Temurin 21, available via mise + used in CI) — a decision noted in the matrix for W3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)