### PR TITLE
feat(mccarthy-lisp): W3b — run McCarthy cons on a real JVM (F2) (LANG77)

### DIFF
--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.0] — 2026-06-09 — `box`/`unbox` + `ref<any>` (McCarthy W3b)
+
+### Added
+
+- **`box` / `unbox` lowering** — the managed uniform-reference value model's
+  atom boxing, the JVM counterpart of the wasm backend's `i31ref`:
+  - `box`  → `iload ; invokestatic java/lang/Integer.valueOf(I)Ljava/lang/Integer; ; astore`
+  - `unbox`→ `aload ; checkcast java/lang/Integer ; invokevirtual Integer.intValue()I ; istore`
+  These are the *same* backend-agnostic IIR ops the wasm path consumes — the
+  structural representation pass emits them, each backend lowers them — so a
+  McCarthy cons program (`(CAR (CONS 7 9))` → 7) now runs on a real JVM. Removed
+  `box`/`unbox` from `UNSUPPORTED_OPS`.
+- **`ref<any>` type** — maps to `JvmType::Ref` (descriptor `Ljava/lang/Object;`):
+  a boxed lisp value is an `Integer` (atom) or `Object[]` (cons cell).
+
+(cons cells were already `Object[]` allocations via `alloc`/`field_*` for
+`ref<LispyPair>`; this release adds the atom boxing that lets integers live in
+those cells and be read back out.)
+
 ## [0.7.0] — 2026-06-01 (G3 — `print_i64` host import → `env/BasicRuntime.println(J)V`)
 
 ### Added — `call_builtin "print_i64"` whitelisted and lowered

--- a/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-jvm-class-file"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile.  v0.7.0 (G3): whitelist call_builtin print_i64 and lower it to invokestatic env/BasicRuntime.println(J)V, mirroring iir-to-wasm v0.8.0's env.__print_i64 host import.  Together they let BASIC's PRINT reach real JVM and wasm bytecode."
 

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -176,6 +176,7 @@ const RETURN: u8 = 0xB1;  // return void
 // ── Method invocation ──────────────────────────────────────────────────────
 const INVOKESTATIC: u8 = 0xB8;   // invoke static method (2-byte CP index)
 const INVOKEVIRTUAL: u8 = 0xB6;  // invoke instance method (2-byte CP index)
+const CHECKCAST: u8 = 0xC0;      // checkcast (2-byte CP class index)
 
 // ── Field access ────────────────────────────────────────────────────────────
 const GETSTATIC: u8 = 0xB2; // get value of static field (2-byte CP index)
@@ -605,6 +606,10 @@ fn iir_type_to_jvm(hint: &str) -> Option<JvmType> {
         // Any variable holding a pair (or nil) gets a Ref slot, which uses
         // aload/astore rather than iload/istore.
         "ref<LispyPair>" => Some(JvmType::Ref),
+        // McCarthy W3b: a boxed lisp value (`ref<any>`) is a `java.lang.Object`
+        // — an `Integer` for an atom, an `Object[]` for a cons cell. Uses
+        // aload/astore like any other reference.
+        "ref<any>" => Some(JvmType::Ref),
         // LANG36: A closure is a `long[]` array reference.
         // Variables holding closures use aload/astore (Ref = reference type).
         "closure" => Some(JvmType::Ref),
@@ -651,6 +656,8 @@ fn type_to_jvm_descriptor(hint: &str) -> &str {
         // The JVM method descriptor for a reference parameter/return is
         // "Ljava/lang/Object;" (the erasure of the actual Object[] type).
         "ref<LispyPair>" => "Ljava/lang/Object;",
+        // McCarthy W3b: a boxed lisp value (`ref<any>`) erases to Object.
+        "ref<any>" => "Ljava/lang/Object;",
         // LANG36: A closure is a `long[]` — descriptor is "[J".
         "closure" => "[J",
         _ => "I", // default for unknown — validator should have caught this
@@ -2785,6 +2792,68 @@ fn lower_function(
             //   `goto`  offset  = (P+8) - (P+4) = 4.           ✓ (lands on istore)
             //
             // This is 8 bytes of code (before istore), analogous to emit_int_compare.
+            // ── box — wrap an i32 atom as a `java.lang.Integer` (McCarthy W3b) ──
+            //
+            // The managed value model is uniform-reference: an atom stored in a
+            // cons cell (`Object[]`) or passed where a lisp value is expected is
+            // boxed. The wasm backend lowers `box` to `ref.i31`; the JVM lowers it
+            // to `Integer.valueOf(I)` — the same shared IIR op, a per-backend
+            // boxing. Bytecode:  iload src ; invokestatic Integer.valueOf ; astore dest.
+            "box" => {
+                let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
+                    function: fname.clone(),
+                    detail: "box has no dest".to_string(),
+                })?;
+                let src_name = match instr.srcs.first() {
+                    Some(Operand::Var(n)) => n.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "box srcs[0] must be a Var".to_string(),
+                    }),
+                };
+                let (dest_slot, _) = lookup_var(dest_name)?;
+                let (src_slot, _) = lookup_var(&src_name)?;
+                emit_iload(&mut code, src_slot);
+                let mref = cp.add_methodref(
+                    "java/lang/Integer",
+                    "valueOf",
+                    "(I)Ljava/lang/Integer;",
+                );
+                code.push(INVOKESTATIC);
+                code.extend_from_slice(&mref.to_be_bytes());
+                emit_astore(&mut code, dest_slot);
+            }
+
+            // ── unbox — unwrap a `java.lang.Integer` reference to its i32 value ──
+            //
+            // The dual of `box`: `checkcast Integer ; Integer.intValue()`. Used at
+            // the entry/return boundary (the wasm backend lowers `unbox` to
+            // `i31.get_s`). Bytecode:  aload src ; checkcast Integer ; invokevirtual
+            // Integer.intValue ; istore dest.
+            "unbox" => {
+                let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
+                    function: fname.clone(),
+                    detail: "unbox has no dest".to_string(),
+                })?;
+                let src_name = match instr.srcs.first() {
+                    Some(Operand::Var(n)) => n.clone(),
+                    _ => return Err(IIRJvmError::InvalidOperand {
+                        function: fname.clone(),
+                        detail: "unbox srcs[0] must be a Var".to_string(),
+                    }),
+                };
+                let (dest_slot, _) = lookup_var(dest_name)?;
+                let (src_slot, _) = lookup_var(&src_name)?;
+                emit_aload(&mut code, src_slot);
+                let cidx = cp.add_class("java/lang/Integer");
+                code.push(CHECKCAST);
+                code.extend_from_slice(&cidx.to_be_bytes());
+                let mref = cp.add_methodref("java/lang/Integer", "intValue", "()I");
+                code.push(INVOKEVIRTUAL);
+                code.extend_from_slice(&mref.to_be_bytes());
+                emit_istore(&mut code, dest_slot);
+            }
+
             "is_null" => {
                 let dest_name = instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
                     function: fname.clone(),

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -60,6 +60,10 @@ use interpreter_ir::{IIRModule, Operand};
 // - `field_load`   — car/cdr via aaload.
 // - `field_store`  — writing pair fields via aastore.
 // - `is_null`      — null check via ifnull.
+//
+// McCarthy W3b additions — now SUPPORTED (removed from the block list):
+// - `box`          — `Integer.valueOf(I)` (wrap an atom for an Object[] cell).
+// - `unbox`        — `checkcast Integer ; Integer.intValue()` (entry boundary).
 
 const UNSUPPORTED_OPS: &[&str] = &[
     // `call_builtin` is *conditionally* unsupported — handled below.
@@ -71,8 +75,6 @@ const UNSUPPORTED_OPS: &[&str] = &[
     "cast",
     // `load_mem` / `store_mem` — Brainfuck: now supported (baload/bastore
     // over a host-provided `env/BFRuntime.__tape : [B` static byte array).
-    "box",
-    "unbox",
     "safepoint",
 ];
 
@@ -495,12 +497,12 @@ mod tests {
         // (baload/bastore over env/BFRuntime.__tape).  `call_builtin` is
         // conditionally accepted via CALL_BUILTIN_SUPPORTED_NAMES — see
         // the call_builtin_*_tests below.
+        // `box`/`unbox` were promoted to supported in McCarthy W3b
+        // (Integer.valueOf / checkcast+intValue) and are NOT in this list.
         for op in &[
             "io_in",
             "io_out",
             "cast",
-            "box",
-            "unbox",
             "safepoint",
         ] {
             let errs = validate_for_jvm(&single_fn_module(vec![

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2342,3 +2342,32 @@ fn g3_print_i64_class_serializes_with_cafebabe_magic() {
         &bytes[0..4]
     );
 }
+
+/// McCarthy W3b: `box` lowers to `Integer.valueOf(I)` (invokestatic 0xB8) and
+/// `unbox` to `checkcast` (0xC0) + `Integer.intValue()` (invokevirtual 0xB6).
+#[test]
+fn mccarthy_w3b_box_unbox_lower_to_integer() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i32",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("box", Some("b".into()), vec![Operand::Var("a".into())], "ref<any>"),
+            IIRInstr::new("unbox", Some("c".into()), vec![Operand::Var("b".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i32"),
+        ],
+    );
+    let class = lower(&module_with(f));
+    let code = &class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .unwrap()
+        .code_attribute()
+        .unwrap()
+        .code;
+    assert!(code.contains(&0xB8u8), "box → invokestatic Integer.valueOf");
+    assert!(code.contains(&0xC0u8), "unbox → checkcast Integer");
+    assert!(code.contains(&0xB6u8), "unbox → invokevirtual intValue");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — `lang-aot`
 
+## 0.22.0 — 2026-06-09 — McCarthy → **JVM cons** on a real JVM (LANG77 / W3b)
+
+`compile_source_to_jvm` now runs the **managed value-model pipeline** (the same
+`lower_heap_builtins` + `intern_symbols_structural` + `lower_lisp_repr_structural`
+the wasm path uses), so McCarthy **cons** runs on the JVM: `(CAR (CONS 7 9))` →
+7, `(CDR (CONS 7 9))` → 9, nested cons too. The structural passes emit
+backend-agnostic `box`/`unbox`/`alloc`/`field_*`; `iir-to-jvm-class-file` lowers
+them to `Integer.valueOf`/`intValue` + `Object[]` cells (where wasm uses
+`i31ref`/`$LispyPair`) — the reusable primitive a future lisp inherits. Adds
+`compile_source_to_jvm_class` (returns the `JvmClassFile` pre-serialization, so a
+caller can inject a `main` launcher). Verified by **running on a real `java`**
+(Temurin 21; the cons cells are `Object[]` the in-repo `jvm-simulator` can't
+execute) — see `tests/jvm_cons.rs`.
+
 ## 0.21.0 — 2026-06-09 — McCarthy → **JVM** run-foundation (scalar) (LANG77 / W3a)
 
 Adds `compile_source_to_jvm` / `compile_file_to_jvm` — the second *managed*

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -15,10 +15,13 @@ predicates, `COND`, and symbols: `pair?`/`ATOM` (`(ATOM 5)` → 1; L3b-3a-4b),
 McCarthy core** — cons, `ATOM`, `EQ`, `COND`, symbols, and lambda/label/recursion
 (F1–F7) — now runs on the wasm backend.
 
-`compile_source_to_jvm` is the second managed target (W3a): scalar McCarthy emits
-a JVM `.class` that **runs** — verified by running the entry method on the in-repo
-`jvm-simulator` (`42` → 42), no external `java`. The JVM cons/symbol/lambda value
-model (uniform-`Object`, replicating the wasm passes) is W3b+.
+`compile_source_to_jvm` is the second managed target: scalar McCarthy runs on the
+in-repo `jvm-simulator` (`42` → 42; W3a), and **cons** runs on a real JVM —
+`(CAR (CONS 7 9))` → 7 (W3b). It runs the *same* structural passes as the wasm
+path; the JVM backend lowers the backend-agnostic `box`/`unbox`/`alloc`/`field_*`
+to `Integer.valueOf`/`intValue` + `Object[]` cells (where wasm uses
+`i31ref`/`$LispyPair`). The remaining JVM predicates/symbols/lambda (F3–F7) are
+W4–W5.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -490,13 +490,37 @@ pub fn compile_source_to_jvm(
     source: &str,
     class_name: &str,
 ) -> Result<Vec<u8>, LangAotError> {
+    let class = compile_source_to_jvm_class(language, source, class_name)?;
+    Ok(iir_to_jvm_class_file::serialize_jvm_class_file(&class))
+}
+
+/// Cross-platform: source → IIR → a **`JvmClassFile`** (the structured class,
+/// pre-serialization).
+///
+/// The shared core of [`compile_source_to_jvm`]; exposed so a caller can inspect
+/// or augment the class before serializing — e.g. a test that injects a
+/// `main([Ljava/lang/String;)V` launcher to run the entry method on a real JVM.
+///
+/// Runs the **managed value-model pipeline**, identical to the wasm path: the
+/// structural passes emit *backend-agnostic* `box`/`unbox`/`alloc`/`field_*`
+/// ops, and the JVM backend lowers them to `Integer.valueOf`/`intValue` +
+/// `Object[]` cons cells (where wasm uses `i31ref`/`$LispyPair`). That shared
+/// representation is exactly the reusable primitive a future lisp-family language
+/// inherits for free.
+pub fn compile_source_to_jvm_class(
+    language: Language,
+    source: &str,
+    class_name: &str,
+) -> Result<iir_to_jvm_class_file::JvmClassFile, LangAotError> {
     let mut module = compile_source_to_iir(language, source, class_name)?;
+    iir_builtin_lowering::lower_heap_builtins(&mut module);
+    iir_builtin_lowering::intern_symbols_structural(&mut module);
+    iir_builtin_lowering::lower_lisp_repr_structural(&mut module);
     concretize_scalar_any_for_jvm(&mut module);
 
     let config = iir_to_jvm_class_file::IIRJvmConfig::new(class_name);
-    let class = iir_to_jvm_class_file::lower_iir_to_jvm(&module, &config)
-        .map_err(|e| LangAotError::JvmBackendError(format!("{e:?}")))?;
-    Ok(iir_to_jvm_class_file::serialize_jvm_class_file(&class))
+    iir_to_jvm_class_file::lower_iir_to_jvm(&module, &config)
+        .map_err(|e| LangAotError::JvmBackendError(format!("{e:?}")))
 }
 
 /// Cross-platform: source file → IIR → JVM class file (`.class`) on disk.

--- a/code/packages/rust/lang-aot/tests/jvm_cons.rs
+++ b/code/packages/rust/lang-aot/tests/jvm_cons.rs
@@ -1,0 +1,133 @@
+//! # JVM cons + run tests on a real JVM (LANG77 / McCarthy W3b).
+//!
+//! Where `jvm_emit.rs` runs *scalar* programs on the in-repo `jvm-simulator`,
+//! cons cells are `Object[]` allocations the simulator cannot execute — so these
+//! tests run the emitted class on a **real `java`** (Temurin via mise; the JVM
+//! CI already uses). We compile a McCarthy program to a `JvmClassFile`, inject a
+//! `main([Ljava/lang/String;)V` launcher that calls the entry method and
+//! `System.out.println`s the `int` result, serialize, write `Main.class`, and
+//! assert stdout.
+//!
+//! This proves the **value-model replication**: the *shared* structural passes
+//! emit backend-agnostic `box`/`unbox`/`alloc`/`field_*`; the JVM backend lowers
+//! them to `Integer.valueOf`/`intValue` + `Object[]` (where wasm uses
+//! `i31ref`/`$LispyPair`).
+
+use iir_to_jvm_class_file::serialize_jvm_class_file;
+use jvm_class_file::{
+    JvmCodeAttribute, JvmConstantPoolEntry, JvmMethodAttribute, JvmMethodInfo, ACC_PUBLIC,
+    ACC_STATIC,
+};
+use lang_aot::{compile_source_to_jvm_class, Language};
+
+/// Is `java` on the PATH?
+fn java_available() -> bool {
+    std::process::Command::new("java")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Append a CP entry, return its 1-based index.
+fn cp_append(cp: &mut Vec<Option<JvmConstantPoolEntry>>, e: JvmConstantPoolEntry) -> u16 {
+    cp.push(Some(e));
+    (cp.len() - 1) as u16
+}
+
+/// Compile a McCarthy program, inject a `main` launcher that prints the entry's
+/// `int` result, run it on a real JVM, and return the trimmed stdout.
+fn compile_and_run_on_java(source: &str, dir_tag: &str) -> Option<String> {
+    if !java_available() {
+        return None; // skip gracefully where no JVM is present
+    }
+    let mut class = compile_source_to_jvm_class(Language::McCarthyLisp, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?}: {e}"));
+
+    // ── Inject the CP machinery for `System.out.println(I)` and a Methodref to
+    //    the entry `Main.main()I`. Duplicate UTF-8/Class entries are legal. ──
+    let (out_fieldref, println_ref, entry_ref) = {
+        let cp = &mut class.constant_pool;
+
+        let sys_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("java/lang/System".into()));
+        let sys_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: sys_utf8 });
+        let out_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("out".into()));
+        let ps_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("Ljava/io/PrintStream;".into()));
+        let out_nat = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: out_utf8, descriptor_index: ps_desc });
+        let out_fieldref = cp_append(cp, JvmConstantPoolEntry::Fieldref { class_index: sys_class, name_and_type_index: out_nat });
+
+        let ps_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("java/io/PrintStream".into()));
+        let ps_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: ps_utf8 });
+        let pln_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("println".into()));
+        let pln_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("(I)V".into()));
+        let pln_nat = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: pln_utf8, descriptor_index: pln_desc });
+        let println_ref = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: ps_class, name_and_type_index: pln_nat });
+
+        // Methodref → Main.main()I (the lowered entry method).
+        let main_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("Main".into()));
+        let main_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: main_utf8 });
+        let ent_name = cp_append(cp, JvmConstantPoolEntry::Utf8("main".into()));
+        let ent_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("()I".into()));
+        let ent_nat = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: ent_name, descriptor_index: ent_desc });
+        let entry_ref = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: main_class, name_and_type_index: ent_nat });
+
+        // The injected launcher's own name + descriptor (serializer looks them up).
+        let _ = cp_append(cp, JvmConstantPoolEntry::Utf8("([Ljava/lang/String;)V".into()));
+        (out_fieldref, println_ref, entry_ref)
+    };
+
+    // ── main([Ljava/lang/String;)V: getstatic out; invokestatic main()I;
+    //    invokevirtual println(I)V; return. ──
+    let [out_hi, out_lo] = out_fieldref.to_be_bytes();
+    let [ent_hi, ent_lo] = entry_ref.to_be_bytes();
+    let [pln_hi, pln_lo] = println_ref.to_be_bytes();
+    let main_code = vec![
+        0xB2, out_hi, out_lo, // getstatic System.out
+        0xB8, ent_hi, ent_lo, // invokestatic Main.main()I  → int
+        0xB6, pln_hi, pln_lo, // invokevirtual println(I)V
+        0xB1,                 // return
+    ];
+    class.methods.push(JvmMethodInfo {
+        access_flags: ACC_PUBLIC | ACC_STATIC,
+        name: "main".into(),
+        descriptor: "([Ljava/lang/String;)V".into(),
+        attributes: vec![JvmMethodAttribute::Code(JvmCodeAttribute {
+            name: "Code".into(),
+            max_stack: 2,  // PrintStream + int
+            max_locals: 1, // slot 0 = args
+            code: main_code,
+            nested_attributes: vec![],
+        })],
+    });
+
+    let bytes = serialize_jvm_class_file(&class);
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w3b_{dir_tag}"));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join("Main.class"), &bytes).expect("write Main.class");
+
+    // `-Xverify:none`: the backend does not emit StackMapTables (Java 21 demands
+    // them unless verification is off) — same flag the LANG36 round-trip uses.
+    let out = std::process::Command::new("java")
+        .arg("-Xverify:none").arg("-cp").arg(&tmp).arg("Main")
+        .output().expect("run java");
+    Some(format!(
+        "{}|stderr:{}",
+        String::from_utf8_lossy(&out.stdout).trim(),
+        String::from_utf8_lossy(&out.stderr).trim()
+    ))
+}
+
+fn run(source: &str, tag: &str) -> Option<String> {
+    compile_and_run_on_java(source, tag).map(|s| s.split('|').next().unwrap().to_string())
+}
+
+#[test]
+fn mccarthy_cons_car_cdr_run_on_real_jvm() {
+    let Some(car) = run("(CAR (CONS 7 9))", "car") else { eprintln!("java absent — skipped"); return; };
+    assert_eq!(car, "7", "(CAR (CONS 7 9)) → 7 on the JVM");
+    assert_eq!(run("(CDR (CONS 7 9))", "cdr").unwrap(), "9", "(CDR (CONS 7 9)) → 9");
+    // Nested: CAR of CDR.
+    assert_eq!(run("(CAR (CDR (CONS 1 (CONS 2 3))))", "nested").unwrap(), "2", "car of cdr");
+    // Scalar still works through the same path.
+    assert_eq!(run("42", "scalar").unwrap(), "42", "scalar 42");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -60,7 +60,7 @@ representation + per-builtin backend lowering.
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
-| **JVM** | `iir-to-jvm-class-file` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-Object |
+| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -107,13 +107,16 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   the entry method on the in-repo **`jvm-simulator`** (zero external `java`,
   mirroring `wasm-runtime`): `42`→42, `0`→0, `7`→7, Twig `42`→42. Establishes the
   JVM pipeline + run-verify harness that W3b+ build on.
-- ☐ **W3b — JVM cons (F2).** A `$LispyPair` class (two `Object` fields);
-  `cons`/`car`/`cdr` → `new`/`getfield`/… ; integers boxed as `java.lang.Integer`
-  (or a small `LispyInt`); `lower_lisp_repr_structural` adapted to JVM boxing.
-  `(CAR (CONS 7 9))` → 7. NOTE: `jvm-simulator` is a 32-bit integer machine (no
-  object/heap execution), so W3b's run-verify needs either an extended simulator
-  or the real `java` (Temurin 21, available via mise + used in CI) — decide when
-  W3b starts.
+- ✅ **W3b — JVM cons (F2).** cons cells are `Object[]` (the JVM backend already
+  lowered `alloc`/`field_*` for `ref<LispyPair>` → `anewarray`/`aastore`/`aaload`);
+  this slice added the missing **atom boxing** — `box` → `Integer.valueOf(I)`,
+  `unbox` → `checkcast Integer` + `intValue()` — plus the `ref<any>`→`Object` type,
+  and wired `lang-aot::compile_source_to_jvm` to run the *same* structural passes
+  as wasm. The pass output is **backend-agnostic** (`box`/`unbox`/`alloc`/`field_*`);
+  wasm lowers to `i31ref`/`$LispyPair`, JVM to `Integer`/`Object[]` — the reusable
+  primitive. **Verified on the real `java`** (Temurin 21; cons cells are `Object[]`
+  the `jvm-simulator` can't run): `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9,
+  nested cons→2, via an injected `main` launcher (`tests/jvm_cons.rs`).
 - ☐ **W4 — JVM `ATOM`/`EQ`/`COND` (F3–F5).** `instanceof $LispyPair` for `pair?`;
   `Integer.equals`/identity for `EQ`; truthiness for `COND`.
 - ☐ **W5 — JVM symbols + lambda (F6–F7).** Interned symbol objects; lambda →


### PR DESCRIPTION
## What & why — McCarthy cons runs on a real JVM

Fourth worklist item. **`(CAR (CONS 7 9))` → 7, verified on a real `java`** (Temurin 21). This replicates the WASM uniform-reference value model on the JVM's uniform-`Object` model — and proves the **structural pass is the reusable primitive**.

The JVM backend already lowered cons cells as **`Object[]`** (`alloc`/`field_*` for `ref<LispyPair>` → `anewarray`/`aastore`/`aaload`). The gap was **atom boxing**: an `Object[]` holds references, so integer atoms must be boxed. The shared structural pass emits backend-agnostic `box`/`unbox` (the wasm backend lowers them to `i31ref`); this slice teaches the JVM backend to lower the *same* ops to `Integer`.

## Change

**`iir-to-jvm-class-file` 0.8.0**
- `box`   → `iload ; invokestatic Integer.valueOf(I)Ljava/lang/Integer; ; astore`
- `unbox` → `aload ; checkcast Integer ; invokevirtual Integer.intValue()I ; istore`
- `ref<any>` → `JvmType::Ref` (`Ljava/lang/Object;`)
- Removed `box`/`unbox` from `UNSUPPORTED_OPS` (+ updated the rejection test).

**`lang-aot` 0.22.0**
- `compile_source_to_jvm` runs the **same** managed value-model pipeline as the wasm path (`lower_heap_builtins` + `intern_symbols_structural` + `lower_lisp_repr_structural`) — the pass output is backend-agnostic; wasm lowers to `i31ref`/`$LispyPair`, JVM to `Integer`/`Object[]`.
- `compile_source_to_jvm_class` returns the `JvmClassFile` pre-serialization (so a caller can inject a `main` launcher).

## Verified by RUNNING on a real JVM (`tests/jvm_cons.rs`)

Compile → `JvmClassFile` → inject a `main([Ljava/lang/String;)V` launcher that calls the entry + `System.out.println`s the int → `java -Xverify:none -cp <tmp> Main` → assert stdout. **`(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, `(CAR (CDR (CONS 1 (CONS 2 3))))`→2, `42`→42**. The `jvm-simulator` can't execute `Object[]` cons cells, so real `java` is the faithful in-repo runner (gated on `java_available()` — skips gracefully where absent). `-Xverify:none` because the backend emits no StackMapTables (the existing LANG36 round-trip uses the same flag).

## Test plan

1 backend unit test (`box`→0xB8, `unbox`→0xC0+0xB6) + a real-`java` cons e2e (4 programs). Suites green — `iir-to-jvm-class-file` **92**, lang-aot (`jvm_cons` 1, `jvm_emit` 2, `wasm_emit` 18, lib green); clippy clean.

## Security & safety

Security review **PASSED**: the `box`/`unbox` arms are Option/match-guarded (no panic on malformed IIR — missing dest/src, undefined var, non-`Var` operand all return errors); emitted bytecode is stack-balanced and well-typed; a bad `unbox` throws `ClassCastException` (JVM memory safety), not memory corruption; the test spawns `java` with fixed literal args + a `PathBuf` (no shell/injection). No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **JVM F2 (cons)**. **Next: W4** — JVM `ATOM`/`EQ`/`COND` (F3–F5), reusing the same structural pass with JVM predicates (`instanceof`, `Integer.equals`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)