### PR TITLE
feat(mccarthy-lisp): W4 — run McCarthy ATOM/EQ/COND on a real JVM (F3–F5) (LANG77)

### DIFF
--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.0] — 2026-06-09 — lisp predicates `pair?`/`not`/`equal?` (McCarthy W4)
+
+### Added
+
+- **`call_builtin` lowering for the McCarthy predicates** (F3–F5), the JVM
+  counterparts of the wasm `ref.test`/`i32.eqz`/`i31.get_s`+`i32.eq`:
+  - `pair?`  → `aload ; instanceof [Ljava/lang/Object; ; istore` — a cons is an
+    `Object[]`, an atom an `Integer`, nil `null` (so `instanceof` is 0/1).
+  - `not`    → `iload ; iconst_1 ; ixor ; istore` (logical not of a 0/1 bool).
+  - `equal?` → unbox both `Integer`s (`checkcast` + `intValue`) then
+    `if_icmpne`-synthesised 0/1 — `EQ` on atoms is integer equality.
+  Added `pair?`/`not`/`equal?` to `CALL_BUILTIN_SUPPORTED_NAMES`, the `INSTANCEOF`
+  (0xC1) opcode, and `builtin_dest`/`builtin_arg` operand helpers. With the
+  already-lowered `jmp_if_false`/`is_null`, McCarthy `ATOM`/`EQ`/`COND` now run on
+  a real JVM: `(ATOM 5)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 5 5)`→1, `(COND …)`.
+
 ## [0.8.0] — 2026-06-09 — `box`/`unbox` + `ref<any>` (McCarthy W3b)
 
 ### Added

--- a/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-jvm-class-file"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile.  v0.7.0 (G3): whitelist call_builtin print_i64 and lower it to invokestatic env/BasicRuntime.println(J)V, mirroring iir-to-wasm v0.8.0's env.__print_i64 host import.  Together they let BASIC's PRINT reach real JVM and wasm bytecode."
 

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -177,6 +177,7 @@ const RETURN: u8 = 0xB1;  // return void
 const INVOKESTATIC: u8 = 0xB8;   // invoke static method (2-byte CP index)
 const INVOKEVIRTUAL: u8 = 0xB6;  // invoke instance method (2-byte CP index)
 const CHECKCAST: u8 = 0xC0;      // checkcast (2-byte CP class index)
+const INSTANCEOF: u8 = 0xC1;     // instanceof (2-byte CP class index) → push 0/1
 
 // ── Field access ────────────────────────────────────────────────────────────
 const GETSTATIC: u8 = 0xB2; // get value of static field (2-byte CP index)
@@ -1022,6 +1023,36 @@ fn emit_dconst(code: &mut Vec<u8>, value: f64) {
 ///
 /// Stack state on entry: `[…, int1, int2]`
 /// Stack state on exit:  `[…, 0_or_1]`
+/// Extract a `call_builtin`'s dest register name, or a descriptive error
+/// (McCarthy W4 predicate lowering).
+fn builtin_dest<'a>(
+    instr: &'a interpreter_ir::IIRInstr,
+    fname: &str,
+    name: &str,
+) -> Result<&'a str, IIRJvmError> {
+    instr.dest.as_deref().ok_or_else(|| IIRJvmError::InvalidOperand {
+        function: fname.to_string(),
+        detail: format!("call_builtin {name:?} requires a dest register"),
+    })
+}
+
+/// Extract a `call_builtin`'s `srcs[idx]` as a variable name (the builtin name
+/// is `srcs[0]`, so arguments start at `idx == 1`).
+fn builtin_arg(
+    instr: &interpreter_ir::IIRInstr,
+    fname: &str,
+    name: &str,
+    idx: usize,
+) -> Result<String, IIRJvmError> {
+    match instr.srcs.get(idx) {
+        Some(Operand::Var(s)) => Ok(s.clone()),
+        _ => Err(IIRJvmError::InvalidOperand {
+            function: fname.to_string(),
+            detail: format!("call_builtin {name:?} requires srcs[{idx}] = Operand::Var"),
+        }),
+    }
+}
+
 fn emit_int_compare(code: &mut Vec<u8>, cmp_opcode: u8) {
     // if_icmpXX at current PC, offset to iconst_0 (7 bytes forward)
     code.push(cmp_opcode);
@@ -2173,6 +2204,68 @@ fn lower_function(
                         let mref = cp.add_methodref(BASIC_RUNTIME_CLASS, "println", "(J)V");
                         code.push(INVOKESTATIC);
                         code.extend_from_slice(&mref.to_be_bytes());
+                    }
+                    // ── McCarthy W4: the lisp predicates (F3–F5). ──
+                    //
+                    // The structural pass emits these as the *same* backend-agnostic
+                    // `call_builtin`s the wasm path uses (where they lower to
+                    // `ref.test`/`i32.eqz`/`i31.get_s`+`i32.eq`). On the JVM the
+                    // uniform-`Object` model makes them:
+                    //   pair?   → `instanceof Object[]`   (a cons is an Object[])
+                    //   not     → logical not of a 0/1 bool
+                    //   equal?  → unbox both Integers and `if_icmpeq`
+                    "pair?" => {
+                        // Is the (boxed) lisp value a cons cell? A cons is an
+                        // `Object[]`; an atom is an `Integer`; nil is `null`.
+                        let dest_name = builtin_dest(instr, fname, "pair?")?;
+                        let arg = builtin_arg(instr, fname, "pair?", 1)?;
+                        let (dest_slot, _) = lookup_var(dest_name)?;
+                        let (arg_slot, _) = lookup_var(&arg)?;
+                        emit_aload(&mut code, arg_slot);
+                        let cidx = cp.add_class("[Ljava/lang/Object;");
+                        code.push(INSTANCEOF);
+                        code.extend_from_slice(&cidx.to_be_bytes());
+                        emit_istore(&mut code, dest_slot);
+                    }
+                    "not" => {
+                        // Logical not of a 0/1 machine boolean: `arg ^ 1`.
+                        let dest_name = builtin_dest(instr, fname, "not")?;
+                        let arg = builtin_arg(instr, fname, "not", 1)?;
+                        let (dest_slot, _) = lookup_var(dest_name)?;
+                        let (arg_slot, _) = lookup_var(&arg)?;
+                        emit_iload(&mut code, arg_slot);
+                        code.push(ICONST_1);
+                        code.push(IXOR);
+                        emit_istore(&mut code, dest_slot);
+                    }
+                    "equal?" => {
+                        // `EQ` on atoms: unbox both `Integer`s and compare. The
+                        // structural pass guarantees both args are boxed atoms
+                        // (symbols interned to ints, integers as ints), so the
+                        // identity test reduces to integer equality.
+                        let dest_name = builtin_dest(instr, fname, "equal?")?;
+                        let a = builtin_arg(instr, fname, "equal?", 1)?;
+                        let b = builtin_arg(instr, fname, "equal?", 2)?;
+                        let (dest_slot, _) = lookup_var(dest_name)?;
+                        let (a_slot, _) = lookup_var(&a)?;
+                        let (b_slot, _) = lookup_var(&b)?;
+                        let int_cidx = cp.add_class("java/lang/Integer");
+                        let intval = cp.add_methodref("java/lang/Integer", "intValue", "()I");
+                        // unbox a
+                        emit_aload(&mut code, a_slot);
+                        code.push(CHECKCAST);
+                        code.extend_from_slice(&int_cidx.to_be_bytes());
+                        code.push(INVOKEVIRTUAL);
+                        code.extend_from_slice(&intval.to_be_bytes());
+                        // unbox b
+                        emit_aload(&mut code, b_slot);
+                        code.push(CHECKCAST);
+                        code.extend_from_slice(&int_cidx.to_be_bytes());
+                        code.push(INVOKEVIRTUAL);
+                        code.extend_from_slice(&intval.to_be_bytes());
+                        // a == b ? 1 : 0  (IF_ICMPNE skips the true arm when a≠b)
+                        emit_int_compare(&mut code, IF_ICMPNE);
+                        emit_istore(&mut code, dest_slot);
                     }
                     _ => {
                         // Validator should have rejected this; defense in depth.

--- a/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/validate.rs
@@ -103,7 +103,10 @@ const UNSUPPORTED_OPS: &[&str] = &[
 /// dedicated host class (`env/BasicRuntime`) rather than overloading
 /// `BFRuntime` because BASIC and Brainfuck have different I/O models:
 /// BF is byte-stream oriented, BASIC's PRINT is line/value oriented.
-pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar", "print_i64"];
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] =
+    // McCarthy W4 (F3–F5): the lisp predicates — `pair?` (instanceof Object[]),
+    // `not` (logical not), `equal?` (unbox + if_icmpeq).
+    &["putchar", "getchar", "print_i64", "pair?", "not", "equal?"];
 
 /// Ops that are conditionally supported depending on their `type_hint`.
 ///

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2371,3 +2371,50 @@ fn mccarthy_w3b_box_unbox_lower_to_integer() {
     assert!(code.contains(&0xC0u8), "unbox → checkcast Integer");
     assert!(code.contains(&0xB6u8), "unbox → invokevirtual intValue");
 }
+
+/// McCarthy W4: the lisp predicates lower to JVM bytecode — `pair?` →
+/// `instanceof` (0xC1), `not` → `ixor` (0x82), `equal?` → `checkcast` (0xC0) +
+/// `invokevirtual intValue` (0xB6) + `if_icmpne` (0xA0, via emit_int_compare).
+#[test]
+fn mccarthy_w4_predicates_lower() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i32",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(5)], "i32"),
+            IIRInstr::new("box", Some("ab".into()), vec![Operand::Var("a".into())], "ref<any>"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("p".into()),
+                vec![Operand::Var("pair?".into()), Operand::Var("ab".into())],
+                "bool",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("n".into()),
+                vec![Operand::Var("not".into()), Operand::Var("p".into())],
+                "bool",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("e".into()),
+                vec![Operand::Var("equal?".into()), Operand::Var("ab".into()), Operand::Var("ab".into())],
+                "bool",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("e".into())], "i32"),
+        ],
+    );
+    let class = lower(&module_with(f));
+    let code = &class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .unwrap()
+        .code_attribute()
+        .unwrap()
+        .code;
+    assert!(code.contains(&0xC1u8), "pair? → instanceof");
+    assert!(code.contains(&0x82u8), "not → ixor");
+    assert!(code.contains(&0xA0u8), "equal? → if_icmpne (compare-to-bool)");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `lang-aot`
 
+## 0.23.0 — 2026-06-09 — McCarthy → **JVM `ATOM`/`EQ`/`COND`** on a real JVM (LANG77 / W4)
+
+The JVM backend now lowers the lisp predicates (`pair?`/`not`/`equal?`), so
+McCarthy `ATOM`, `EQ`, and `COND` run on a real `java`: `(ATOM 5)`→1,
+`(ATOM (CONS 1 2))`→0, `(EQ 5 5)`→1, `(EQ 5 6)`→0, `(COND ((EQ 1 1) 7) (5 9))`→7.
+Same shared structural pass as wasm — only the per-builtin JVM lowering is new
+(`instanceof Object[]` / `ixor` / `checkcast`+`intValue`+`if_icmpeq`). The
+real-`java` test harness (`tests/jvm_predicates.rs`) is now **descriptor-aware**:
+a predicate result is `int` (`()I`), a COND selecting an integer atom is `long`
+(`()J`) — it picks the matching `println` overload. (Symbols — F6 — are W5: their
+interned ids land in a high range that needs `ldc`, handled separately.)
+
 ## 0.22.0 — 2026-06-09 — McCarthy → **JVM cons** on a real JVM (LANG77 / W3b)
 
 `compile_source_to_jvm` now runs the **managed value-model pipeline** (the same

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -16,12 +16,13 @@ McCarthy core** — cons, `ATOM`, `EQ`, `COND`, symbols, and lambda/label/recurs
 (F1–F7) — now runs on the wasm backend.
 
 `compile_source_to_jvm` is the second managed target: scalar McCarthy runs on the
-in-repo `jvm-simulator` (`42` → 42; W3a), and **cons** runs on a real JVM —
-`(CAR (CONS 7 9))` → 7 (W3b). It runs the *same* structural passes as the wasm
-path; the JVM backend lowers the backend-agnostic `box`/`unbox`/`alloc`/`field_*`
-to `Integer.valueOf`/`intValue` + `Object[]` cells (where wasm uses
-`i31ref`/`$LispyPair`). The remaining JVM predicates/symbols/lambda (F3–F7) are
-W4–W5.
+in-repo `jvm-simulator` (`42` → 42; W3a), **cons** runs on a real JVM —
+`(CAR (CONS 7 9))` → 7 (W3b) — and now `ATOM`/`EQ`/`COND` too: `(ATOM 5)` → 1,
+`(EQ 5 5)` → 1, `(COND ((EQ 1 1) 7) (5 9))` → 7 (W4). It runs the *same* structural
+passes as the wasm path; the JVM backend lowers the backend-agnostic
+`box`/`unbox`/`alloc`/`field_*` + `pair?`/`not`/`equal?` to `Integer`/`Object[]` +
+`instanceof`/`ixor`/`if_icmpeq` (where wasm uses `i31ref`/`$LispyPair`/`ref.test`).
+The remaining JVM symbols + lambda (F6–F7) are W5.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/jvm_predicates.rs
+++ b/code/packages/rust/lang-aot/tests/jvm_predicates.rs
@@ -1,0 +1,131 @@
+//! # JVM `ATOM`/`EQ`/`COND` on a real JVM (LANG77 / McCarthy W4, F3–F5).
+//!
+//! Builds on the W3b cons harness: compile a McCarthy program to a
+//! `JvmClassFile`, inject a `main([Ljava/lang/String;)V` launcher that calls the
+//! entry and `System.out.println`s the result, then run on a real `java`. The
+//! predicates exercise the JVM lowering of the *shared* structural-pass builtins:
+//! `pair?` → `instanceof Object[]`, `not` → logical not, `equal?` → unbox +
+//! `if_icmpeq`, and the COND control flow (`jmp_if_false`/`is_null`).
+//!
+//! The launcher is **descriptor-aware**: a predicate result is `int` (`()I`), a
+//! COND that selects an integer atom is `long` (`()J`) — we pick the matching
+//! `println` overload so either runs.
+
+use iir_to_jvm_class_file::serialize_jvm_class_file;
+use jvm_class_file::{
+    JvmCodeAttribute, JvmConstantPoolEntry, JvmMethodAttribute, JvmMethodInfo, ACC_PUBLIC,
+    ACC_STATIC,
+};
+use lang_aot::{compile_source_to_jvm_class, Language};
+
+fn java_available() -> bool {
+    std::process::Command::new("java")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn cp_append(cp: &mut Vec<Option<JvmConstantPoolEntry>>, e: JvmConstantPoolEntry) -> u16 {
+    cp.push(Some(e));
+    (cp.len() - 1) as u16
+}
+
+/// Compile `source`, inject a launcher matching the entry's return type, run on
+/// a real JVM, and return trimmed stdout (or `None` if `java` is absent).
+fn run_on_java(source: &str, tag: &str) -> Option<String> {
+    if !java_available() {
+        return None;
+    }
+    let mut class = compile_source_to_jvm_class(Language::McCarthyLisp, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?}: {e}"));
+
+    // The entry's descriptor decides the launcher: `()I` → int / `println(I)V`,
+    // `()J` → long / `println(J)V`.
+    let entry_desc = class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .expect("entry `main`")
+        .descriptor
+        .clone();
+    let is_long = entry_desc == "()J";
+    let (entry_d, pln_d) = if is_long { ("()J", "(J)V") } else { ("()I", "(I)V") };
+
+    let (out_fieldref, println_ref, entry_ref) = {
+        let cp = &mut class.constant_pool;
+        let su = cp_append(cp, JvmConstantPoolEntry::Utf8("java/lang/System".into()));
+        let sc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: su });
+        let ou = cp_append(cp, JvmConstantPoolEntry::Utf8("out".into()));
+        let pd = cp_append(cp, JvmConstantPoolEntry::Utf8("Ljava/io/PrintStream;".into()));
+        let on = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: ou, descriptor_index: pd });
+        let of = cp_append(cp, JvmConstantPoolEntry::Fieldref { class_index: sc, name_and_type_index: on });
+        let pu = cp_append(cp, JvmConstantPoolEntry::Utf8("java/io/PrintStream".into()));
+        let pc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: pu });
+        let lu = cp_append(cp, JvmConstantPoolEntry::Utf8("println".into()));
+        let ld = cp_append(cp, JvmConstantPoolEntry::Utf8(pln_d.into()));
+        let ln = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: lu, descriptor_index: ld });
+        let pr = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: pc, name_and_type_index: ln });
+        let mu = cp_append(cp, JvmConstantPoolEntry::Utf8("Main".into()));
+        let mc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: mu });
+        let nu = cp_append(cp, JvmConstantPoolEntry::Utf8("main".into()));
+        let du = cp_append(cp, JvmConstantPoolEntry::Utf8(entry_d.into()));
+        let nn = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: nu, descriptor_index: du });
+        let er = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: mc, name_and_type_index: nn });
+        let _ = cp_append(cp, JvmConstantPoolEntry::Utf8("([Ljava/lang/String;)V".into()));
+        (of, pr, er)
+    };
+
+    let [oh, ol] = out_fieldref.to_be_bytes();
+    let [eh, el] = entry_ref.to_be_bytes();
+    let [ph, pl] = println_ref.to_be_bytes();
+    let main_code = vec![
+        0xB2, oh, ol, // getstatic System.out
+        0xB8, eh, el, // invokestatic Main.main()I|J
+        0xB6, ph, pl, // invokevirtual println(I|J)V
+        0xB1,         // return
+    ];
+    // long takes two stack slots, so PrintStream + long needs 3.
+    let max_stack = if is_long { 3 } else { 2 };
+    class.methods.push(JvmMethodInfo {
+        access_flags: ACC_PUBLIC | ACC_STATIC,
+        name: "main".into(),
+        descriptor: "([Ljava/lang/String;)V".into(),
+        attributes: vec![JvmMethodAttribute::Code(JvmCodeAttribute {
+            name: "Code".into(),
+            max_stack,
+            max_locals: 1,
+            code: main_code,
+            nested_attributes: vec![],
+        })],
+    });
+
+    let bytes = serialize_jvm_class_file(&class);
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w4_{tag}"));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join("Main.class"), &bytes).expect("write Main.class");
+    let out = std::process::Command::new("java")
+        .arg("-Xverify:none").arg("-cp").arg(&tmp).arg("Main")
+        .output().expect("run java");
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[test]
+fn mccarthy_atom_eq_cond_run_on_real_jvm() {
+    let Some(_) = run_on_java("(ATOM 5)", "probe") else {
+        eprintln!("java absent — skipped");
+        return;
+    };
+    // ATOM (= not pair?): an integer/symbol atom is an atom; a cons is not.
+    assert_eq!(run_on_java("(ATOM 5)", "a").unwrap(), "1", "5 is an atom");
+    assert_eq!(run_on_java("(ATOM (CONS 1 2))", "b").unwrap(), "0", "a cons is not an atom");
+    // EQ on integer atoms. (Symbols — F6 — are W5: their interned ids live in a
+    // high reserved range that needs `ldc`, which the JVM const path handles
+    // separately; out of scope here.)
+    assert_eq!(run_on_java("(EQ 5 5)", "c").unwrap(), "1", "5 = 5");
+    assert_eq!(run_on_java("(EQ 5 6)", "d").unwrap(), "0", "5 ≠ 6");
+    // COND: lisp truthiness + branch selection.
+    assert_eq!(run_on_java("(COND ((EQ 1 1) 7) (5 9))", "g").unwrap(), "7", "first clause true");
+    assert_eq!(run_on_java("(COND ((EQ 1 2) 7) (5 9))", "h").unwrap(), "9", "fall to second clause");
+    assert_eq!(run_on_java("(COND ((ATOM (CONS 1 2)) 7) (5 9))", "i").unwrap(), "9", "pair? guard false");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -60,7 +60,7 @@ representation + per-builtin backend lowering.
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
-| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-Object |
+| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -117,10 +117,21 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   primitive. **Verified on the real `java`** (Temurin 21; cons cells are `Object[]`
   the `jvm-simulator` can't run): `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9,
   nested cons→2, via an injected `main` launcher (`tests/jvm_cons.rs`).
-- ☐ **W4 — JVM `ATOM`/`EQ`/`COND` (F3–F5).** `instanceof $LispyPair` for `pair?`;
-  `Integer.equals`/identity for `EQ`; truthiness for `COND`.
+- ✅ **W4 — JVM `ATOM`/`EQ`/`COND` (F3–F5).** The JVM backend lowers the *shared*
+  structural-pass predicates: `pair?` → `instanceof [Ljava/lang/Object;` (a cons
+  is an `Object[]`), `not` → `ixor 1`, `equal?` → unbox both `Integer`s + a
+  `if_icmpeq`-synthesised 0/1. `jmp_if_false`/`is_null` were already lowered, so
+  `COND` works too. Verified on the real `java` (`tests/jvm_predicates.rs`, a
+  **descriptor-aware** launcher: predicate→`()I`, COND-over-int→`()J`):
+  `(ATOM 5)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 5 5)`→1, `(EQ 5 6)`→0,
+  `(COND ((EQ 1 1) 7) (5 9))`→7, fall-through→9.
 - ☐ **W5 — JVM symbols + lambda (F6–F7).** Interned symbol objects; lambda →
-  method or `invokedynamic`/inner class. **Completes JVM.**
+  method (the uniform-anyref boundary, mirroring wasm W2). **NOTE:** symbol ids
+  use the high reserved range (`SYMBOL_ID_BASE = 2²⁹`), an `i32` const too large
+  for `bipush`/`sipush` — it must lower via `ldc` + a CONSTANT_Integer pool entry.
+  A first attempt crashed the JVM (`constantTag.cpp ShouldNotReachHere`), so W5
+  must fix/verify the JVM backend's large-`i32`-const (`ldc`) path first.
+  **Completes JVM.**
 
 ### Phase C — CLR (replicate as `object`)
 


### PR DESCRIPTION
## What & why

Fifth worklist item. McCarthy `ATOM`, `EQ`, `COND` now run on a real `java`: `(ATOM 5)`→1, `(EQ 5 5)`→1, `(COND ((EQ 1 1) 7) (5 9))`→7. **Same shared structural pass as wasm** — only the per-builtin JVM lowering is new.

The structural pass emits the predicates as backend-agnostic `call_builtin`s (`pair?`/`not`/`equal?`) — the *same* ops the wasm backend lowers to `ref.test`/`i32.eqz`/`i31.get_s`+`i32.eq`. This slice lowers them on the JVM's uniform-`Object` model.

## Change (`iir-to-jvm-class-file` 0.9.0)

- `pair?`  → `aload ; instanceof [Ljava/lang/Object; ; istore` (a cons is an `Object[]`, an atom an `Integer`, nil `null` → 0/1)
- `not`    → `iload ; iconst_1 ; ixor ; istore`
- `equal?` → unbox both `Integer`s (`checkcast` + `intValue`) ; `if_icmpeq`→0/1
- Added `INSTANCEOF` (0xC1), `builtin_dest`/`builtin_arg` helpers, and `pair?`/`not`/`equal?` to `CALL_BUILTIN_SUPPORTED_NAMES`. `jmp_if_false`/`is_null` were already lowered, so **COND works with no extra backend code**.

## Verified by RUNNING on a real JVM (`lang-aot/tests/jvm_predicates.rs`)

The launcher is now **descriptor-aware** — a predicate result is `int` (`()I`), a COND selecting an integer atom is `long` (`()J`) — so it picks the matching `println` overload. `(ATOM 5)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 5 5)`→1, `(EQ 5 6)`→0, `(COND ((EQ 1 1) 7) (5 9))`→7, fall-through→9, pair?-guard-false→9.

## Note: symbols (F6) are W5, not W4

Symbol ids use a high reserved range (`SYMBOL_ID_BASE = 2²⁹`), an `i32` const too large for `bipush`/`sipush` — it must lower via `ldc` + a `CONSTANT_Integer` pool entry, and a first attempt crashed the JVM (`constantTag.cpp ShouldNotReachHere`). **Flagged as a tracked bug + noted in the matrix as W5's prerequisite.** W4 is scoped to integer atoms.

## Test plan

1 backend unit test (`pair?`→0xC1, `not`→0x82, `equal?`→0xA0) + a real-`java` ATOM/EQ/COND e2e (7 programs). Suites green — `iir-to-jvm-class-file` **93**, lang-aot (`jvm_predicates` 1, `jvm_cons` 1, `jvm_emit` 2, `wasm_emit` 18, lib green); clippy clean.

## Security & safety

Security review **PASSED**: the new arms are Option/Result-guarded (no panic on malformed IIR); the three bytecode sequences are stack-balanced and well-typed; CP indices are 2-byte; a bad `equal?` `checkcast` throws `ClassCastException` (JVM memory safety), not corruption; O(1) per instruction. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **JVM F3–F5**. **Next: W5** (JVM symbols + lambda) — fix the large-`i32`-const `ldc` path first, then symbols + the uniform-anyref lambda boundary (mirroring wasm W2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)