### PR TITLE
feat(closurec): CLOC12.61 — close gap-052 (trailing `;` after `}` at EOF for Other)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.65.0] - 2026-06-09
+
+### Changed
+- **CLOSES gap-052** — trailing `;` after `}` at EOF for
+  `BlockKind::Other` (control-flow body, labeled block,
+  bare block). `if(x){a;b;}` at EOF → `if(x){a;b};` matches
+  upstream Closure.
+
+One-line fix in the gap-030 `}`-handler decision machine:
+`BlockKind::Other => false` becomes `BlockKind::Other =>
+next_val.is_none()` — EOF-only.
+
+### Fixed
+
+5 pre-existing tests had pinned the OLD (incorrect) behavior:
+gap032_multi_stmt_body_does_not_flatten,
+gap032_nested_if_does_not_flatten,
+gap032_nested_brace_does_not_flatten,
+gap032_top_level_block_does_not_flatten,
+gap036_switch_as_property_does_not_arm. All updated to
+match upstream (with trailing `;`).
+
 ## [0.64.0] - 2026-06-09
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -797,7 +797,16 @@ pub fn whitespace_only_minify(
                     // `catch` / `finally`.
                     !next_is_chain_continuation
                 }
-                BlockKind::Other => false,
+                // gap-052: extend trailing-`;` to Other-blocks
+                // at EOF. Upstream Closure emits `;` after ANY
+                // top-level `}` at EOF (`if(x){...};`,
+                // `foo:{...};`, `for(;;){...};`, bare
+                // `{a;b;};`). Mid-stream Other-`}` blocks
+                // still don't get a `;` — that would change
+                // statement boundaries inside expressions or
+                // produce stray `;` inside multi-statement
+                // sequences.
+                BlockKind::Other => next_val.is_none(),
             };
             // gap-041: when a synthetic `;` is owed at this
             // `}` AND the very next non-trivia token is
@@ -1992,7 +2001,7 @@ mod tests {
     fn gap032_multi_stmt_body_does_not_flatten() {
         assert_eq!(
             minify("if(x){a();b();}"),
-            "if(x){a();b()}"
+            "if(x){a();b()};"
         );
     }
 
@@ -2026,7 +2035,7 @@ mod tests {
         // which would be a separate future gap.
         assert_eq!(
             minify("if(x){if(y){a();}}"),
-            "if(x){if(y)a()}"
+            "if(x){if(y)a()};"
         );
     }
 
@@ -2036,7 +2045,7 @@ mod tests {
     fn gap032_nested_brace_does_not_flatten() {
         assert_eq!(
             minify("if(x){{a();}}"),
-            "if(x){{a()}}"
+            "if(x){{a()}};"
         );
     }
 
@@ -2097,7 +2106,7 @@ mod tests {
     /// a statement in its own right.
     #[test]
     fn gap032_top_level_block_does_not_flatten() {
-        assert_eq!(minify("{a;}"), "{a}");
+        assert_eq!(minify("{a;}"), "{a};");
     }
 
     /// Function-decl body MUST NOT flatten — not in body
@@ -2236,7 +2245,7 @@ mod tests {
     fn gap036_switch_as_property_does_not_arm() {
         assert_eq!(
             minify("var o={switch:1};while(x){a;b;}"),
-            "var o={switch:1};while(x){a;b}"
+            "var o={switch:1};while(x){a;b};"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.64.0
+Version: 0.65.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -95,10 +95,9 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // inner-call form `(fn(){...}())` normalizes to
     // outer-call form `(fn(){...})()`. `minify_fn_expr_iife`
     // flipped IGNORED → PASS.
-    // gap-052: trailing `;` after `}` at EOF for control-
-    // flow body / label block bodies. Discovered by CLOC14.18.
-    ("labeled_block", "gap-052: trailing `;` after `}` at EOF for label-block"),
-    ("double_break_continue", "gap-052: trailing `;` after `}` at EOF for for-body"),
+    // gap-052 was RESOLVED in CLOC12.61 — `BlockKind::Other`
+    // at EOF now wants `;`. `minify_labeled_block` and
+    // `minify_double_break_continue` flipped IGNORED → PASS.
     // gap-050 was RESOLVED in CLOC12.57 — token-level
     // peephole drops the empty `()` after `new IDENT`
     // when the follower is safe. `minify_new_expr`

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -414,9 +414,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-052 — trailing `;` after `}` at EOF for control-flow / label-block bodies
 
-- **Status:** OPEN — newly discovered by CLOC14.18.
-- **Upstream byte-identity tests:** `minify_labeled_block`, `minify_double_break_continue` seed fixtures.
+- **Status:** **RESOLVED** in CLOC12.61 (PR pending). `minify_labeled_block` and `minify_double_break_continue` flip IGNORED → PASS.
 - **Input:** `for(;;){if(x)break;if(y)continue;use();}` and `foo:{a();break foo;b();}`
 - **Upstream:** Same with trailing `;`.
-- **Why it fails:** gap-030's trailing-`;` rule only fires for function-decl `}`, class `}`, switch `}`, and try-chain endings. Upstream also emits `;` after for-body `}`, while-body `}`, label-block `}`, etc.
-- **What it needs:** Extend gap-030's `kind_wants_semi` decision: `BlockKind::Other` at EOF (and not at_stmt_keyword via gap-047) should also want a `;`. Currently `Other` returns false unconditionally; needs an EOF-context check.
+- **Fix:** Change `BlockKind::Other => false` in `kind_wants_semi` to `BlockKind::Other => next_val.is_none()`. EOF-only — mid-stream Other-blocks still emit no `;`.


### PR DESCRIPTION
## Summary

**Closes gap-052.** Stacks on #5278 (CLOC14.18 fixtures).

One-line fix: change `BlockKind::Other => false` to `BlockKind::Other => next_val.is_none()` in `kind_wants_semi`. Other-blocks at EOF now emit `;` matching upstream.

## Pre-push security review

PASS — verified 6 cases through the decision machine (mid-stream Other, EOF, nested, gap-041 deferred, gap-047 keyword, expression follower).

## Tests

5 pre-existing tests had pinned the old (incorrect) behavior — updated to match upstream. Full suite: **406 passed**.

## Version

0.64.0 → 0.65.0.

## Stacking

After #5278 lands: harness **134/136**. Only gap-044 (lexer-level template substitution) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)