### PR TITLE
data(adj101): prereg + pilot corpus + program-emission/typed-IR design

### DIFF
--- a/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
+++ b/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
@@ -109,6 +109,74 @@ question — the shape the engine adjudicates, generalised across domains.
 3. **Full run: N = 100**, one orchestrated pre-registered workflow, batched (≤10 concurrent per the
    rate-limit lesson), results + CIs + per-domain table.
 
+## Addendum A — the IR is TYPED (extraction schema; non-negotiable)
+
+Both arms' extraction emits a **typed** IR. Nothing untyped reaches the reasoner (engine or emitted
+program) — an untyped fact cannot be computed over correctly, and an unpolarized fact silently flips
+verdicts. Every fact/slot carries:
+
+```jsonc
+{
+  "value": "...",                       // the typed value
+  "type": "stated" | "inferred",
+  "span": "verbatim source bytes",      // stated: provenance
+  "basis_span": "...", "entailment": "ENTAILED" | "LEAP",   // inferred: justification (ADJ61 gate)
+  "polarity": "affirmed" | "denied" | "inherit",            // ADJ03 — "not liable", "no allergy", "excluded"
+  "quantity": { "magnitude": 1200, "unit": "USD" },          // ADJ21/22 — typed unit, NOT a bare number
+  "modality": "categorical" | "conditional" | "uncertain",   // ADJ01
+  "uncertainty": null | "..."
+}
+```
+
+- **Polarity (ADJ03)** is mandatory: a denied condition (`not liable`, `no known drug allergy`, `coverage
+  excluded`) is represented as `polarity:denied`, never dropped or affirmed. The polarity/modality
+  consistency check runs over the IR before the engine fires.
+- **Units (ADJ21/22)** are mandatory on every quantity: `{magnitude, unit}`. The program/engine does the
+  unit algebra (km→m, h→s, °→rad, %→fraction); UNIT1 and PHYS1 are wrong without it. A coverage check
+  ensures **every quantity in the source is typed-and-represented or explicitly discarded-with-reason**
+  (ADJ02/ADJ22) — no number silently dropped.
+- **Type + provenance**: `stated(span)` or `inferred(basis_span + entailment)` — no fact inferred
+  without a justification (the ADJ61 entailment gate).
+
+## Addendum B — program-emission track (the LLM translates; a PROGRAM reasons)
+
+For **computational** items (`stratum: program-required` — math, physics, chemistry, units, finance;
+`items_pilot_compute.json`), the model must **not** compute in its forward pass (LLMs are weak at
+math/multi-step derivation — the ADJ99 "self-contained derivation drifted" failure). Instead:
+
+1. **Translate** the messy source → the typed IR above (quantities with units + polarity + provenance).
+2. **Emit a program** in a tool that does the actual work — **SymPy** (algebra/calculus/ODEs),
+   **RDKit** (chemistry), NumPy/SciPy, or the repo's own `arithmetic`/`symbol-core`/`cas-matrix`/`stats`
+   packages — that computes the answer **from the typed IR facts** (not from re-stated numbers).
+3. **Execute** the program in a sandbox; the captured output is the answer.
+
+**Byte-provenance is enforced on the program's inputs**, the same discipline as everywhere else:
+- **Coverage** — every source quantity is either consumed by the program (traced to its `span`) or
+  carries an explicit `discarded(reason)` (the PHYS1 "2 m wide" / FIN1 "branch 4021" distractors test
+  this — a silently-dropped distractor is a coverage failure, *and* a distractor used as input is a
+  fabrication-class error).
+- **Justification** — every program input is `stated(span)` or `inferred(basis+ENTAILED)`; no input
+  invented. The program literally cannot reference a value that isn't a typed, provenanced IR fact.
+
+This is the **general form of the adjudication engine**: rules are the fixed program; SymPy/RDKit are
+emitted programs; both consume the same typed, provenanced IR and own the answer. It is also the direct
+mechanism behind paper-2 MYCIN (CPU-bound reasoning over derived rules).
+
+### Metrics added for the program track
+- **Accuracy** = executed program output within `tolerance` of `gold_answer` (gold itself
+  tool-computed; see `compute_gold.py`).
+- **Program-input provenance**: coverage-complete (every source quantity represented/discarded) +
+  fabrication count (inputs not traceable to a span/basis). *Predicted 0 fabrication, full coverage.*
+- **Defensibility (corrected, dual-judge)**: the emitted program + typed-IR fact table *is* the
+  auditable derivation — a reviewer checks the program and the input provenance, not the model's prose.
+
+### Hypotheses added
+- **H5 (program ≫ in-head):** on `program-required` items, FRAMEWORK (emit-program) beats BARE
+  (reason-in-head) on **both accuracy and defensibility** — the gap is largest exactly where ADJ99
+  showed in-head derivation drifts.
+- **H6 (program provenance clean):** FRAMEWORK program-input fabrication = 0 and coverage complete
+  (distractors discarded-with-reason, never silently dropped or used).
+
 ## Resolved decisions (ADJ86's open list)
 - ✅ **Both models** {Haiku, Opus} (the defensibility-parity axis is core, not optional).
 - ✅ **Corrected metric** (locus-exposure + format-normalized + dual-judge), not the format-confounded

--- a/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
+++ b/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
@@ -162,20 +162,37 @@ This is the **general form of the adjudication engine**: rules are the fixed pro
 emitted programs; both consume the same typed, provenanced IR and own the answer. It is also the direct
 mechanism behind paper-2 MYCIN (CPU-bound reasoning over derived rules).
 
-### Metrics added for the program track
-- **Accuracy** = executed program output within `tolerance` of `gold_answer` (gold itself
-  tool-computed; see `compute_gold.py`).
-- **Program-input provenance**: coverage-complete (every source quantity represented/discarded) +
-  fabrication count (inputs not traceable to a span/basis). *Predicted 0 fabrication, full coverage.*
-- **Defensibility (corrected, dual-judge)**: the emitted program + typed-IR fact table *is* the
-  auditable derivation — a reviewer checks the program and the input provenance, not the model's prose.
+### Metrics added for the program track — correctness is INFORMATIONAL, not the target
 
-### Hypotheses added
-- **H5 (program ≫ in-head):** on `program-required` items, FRAMEWORK (emit-program) beats BARE
-  (reason-in-head) on **both accuracy and defensibility** — the gap is largest exactly where ADJ99
-  showed in-head derivation drifts.
-- **H6 (program provenance clean):** FRAMEWORK program-input fabrication = 0 and coverage complete
-  (distractors discarded-with-reason, never silently dropped or used).
+Where ADJ86 went wrong was scoring these on **getting the right answer**. In the rescored paradigm a
+wrong program is *fine* if its audit trail leads to **exactly** where it went wrong and the error is
+**correctable in one move**. So the program track is scored on the same axis as everything else —
+auditability + localizability + correctability — and accuracy is reported only as context.
+
+- **PRIMARY — auditability**: every program input is a typed, provenanced IR fact
+  (`stated(span)` / `inferred(basis+ENTAILED)`); every source quantity is used or `discarded(reason)`;
+  no magic numbers in the program. (`provenance_program.py` → `auditable`.)
+- **PRIMARY — localizability**: when the answer is wrong, the trail names the **exact** culprit. The
+  workhorse is the **value-vs-span faithfulness** check — a fact whose magnitude contradicts its own
+  cited bytes (e.g. `25` claimed from span `"20 m/s"`) is flagged at that fact. `error_locus` orders
+  the places to look: unfaithful facts → un-entailed assumptions → fabrications → exec errors.
+- **PRIMARY — correctability**: a single **override** of the located fact re-derives the answer with
+  **zero model calls** (`override_facts`; the override is itself audited). This is the program-track
+  instance of E2 (localize→fix→persist) and MYCIN's *fix-the-fact-not-the-weight*.
+- **SECONDARY / informational — accuracy**: executed output within `tolerance` of the tool-computed
+  `gold_answer` (`compute_gold.py`). Reported, never the headline. A **defensible-but-wrong** program
+  (auditable, error localized, one-move correctable) is a SUCCESS for the thesis; a
+  **confidently-right black box** is not the goal.
+
+### Hypotheses added (on the correctability axis)
+- **H5 (auditable + correctable ≫ in-head):** on `program-required` items, FRAMEWORK (emit-program)
+  beats BARE (reason-in-head) on **defensibility, localizability, and correctability** — largest exactly
+  where ADJ99 showed in-head derivation drifts. When FRAMEWORK is *wrong*, the error localizes to a
+  named fact/assumption and a single override fixes it; when BARE is wrong, it is a confident,
+  un-localizable prose error.
+- **H6 (program provenance clean):** FRAMEWORK program-input fabrication = 0, coverage complete
+  (distractors `discarded(reason)`, never silently dropped or used), and **every wrong answer traces to
+  a specific, overridable fact/assumption** — never "the model just miscalculated."
 
 ## Resolved decisions (ADJ86's open list)
 - ✅ **Both models** {Haiku, Opus} (the defensibility-parity axis is core, not optional).

--- a/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
+++ b/code/specs/data/adj101-defensibility-100crossdomain/PREREGISTRATION.md
@@ -1,0 +1,124 @@
+# ADJ101 — 100-item cross-domain defensibility benchmark: pre-registration
+
+**Status: DRAFT — design locked before data, per ADJ73/84/86 discipline.** This is the full-scale
+execution of the ADJ86 design (which only ran as a 12-item pilot), upgraded with the **corrected
+defensibility metric** validated by the ADJ99 rescore (PR #5261) and its W5 Sonnet cross-judge
+replication. It is the paper-1 **E3 breadth proof** and the on-ramp to paper-2 MYCIN (auto-derived
+rulebooks). Specs: [`PAPER1-E3-domain-expansion.md`](../../papers/PAPER1-E3-domain-expansion.md),
+[`MEASUREMENT-VALIDITY-AUDIT.md`](../../papers/MEASUREMENT-VALIDITY-AUDIT.md),
+[`PAPER1-methods-protocol.md`](../../papers/PAPER1-methods-protocol.md).
+
+## Claim under test
+
+> *Byte-provenance makes adjudicative work **defensible** — and defensibility is a property of the
+> verification discipline, not of the domain or of getting the answer right.* Across **100 items in
+> 10 domains**, the framework arm exposes the **locus of contingency** (every load-bearing premise
+> surfaced and flagged fallible; the verdict owned by a deterministic engine over byte-anchored
+> facts), while the bare arm produces confident-but-un-auditable assertions. We do **not** claim
+> correctness parity (FrugalGPT's lane); we claim a **defensibility** improvement that holds **across
+> domains and across model scale**, with the honest boundary that any accuracy gap is absorbed by
+> **abstention, not fabrication**.
+
+## What changed vs the ADJ86 prereg (and why)
+
+The ADJ86 pilot's blind judge was **format-confounded** (the same failure ADJ99 proved): the framework
+arm carried structural tells (`GROUNDED/ENTAILED/ASSUMED`, `INDETERMINATE` verdict) the judge could
+read the arm off, and the old rubric scored citation/traceability, not locus-exposure. Worse, the
+ADJ86 judge **penalized the framework's `ASSUMED` flags as "manufactured doubt"** — which under the
+corrected rubric is exactly the fallibility-flagging we reward. So this run replaces ADJ86's scoring
+with the **corrected, format-normalized, dual-judge** metric. Everything else (the real pipeline, the
+strata, the machine-checked byte-accounting) is retained.
+
+## Design
+
+Each item is an **adjudication problem**: `scenario` (facts) + `policy` (rules) + a determination
+question — the shape the engine adjudicates, generalised across domains.
+
+- **N = 100**, stratified two ways: **10 domains × 10 items**, AND across **4 difficulty strata**
+  (2.5 items/stratum/domain): `clean-determinate`, `underdetermined-baited` (dispositive fact
+  withheld; bare is tempted to fabricate it), `override-precedence` (an exception rule must dominate),
+  `exception-encoding` (an "except…" suppressing an override).
+- **Domains (10):** medicine (clinical-coverage), statutory liability, tax/duty, benefits eligibility,
+  insurance claims, building-code compliance, employment/labor rules, immigration eligibility,
+  contract/SLA terms, academic/grant eligibility. (Spans rule-dense↔precedent-dense and
+  quantitative↔qualitative per the [E3 axes](../../papers/PAPER1-E3-domain-expansion.md).)
+- **Model scale (RESOLVED — both):** run **{Haiku, Opus}** for both arms (the ADJ84/ADJ86
+  defensibility-parity axis). 2× cost, but it tests the central "lifts the *weak* model to the strong
+  model's defensibility" claim, which a single model cannot.
+
+### Arms (within-item, paired)
+- **BARE** — one-shot: model reads scenario+policy, states the determination in prose.
+- **FRAMEWORK = the real pipeline** — the model does ONLY two extraction stages:
+  **Stage A** policy → **auto-derived** rulebook-IR (`rules[]` with `when/then/source_span`),
+  **Stage B** scenario → input-IR (typed `slots`, each `stated|inferred` with a verbatim byte span +
+  a `basis_span` + entailment label, + uncertainties). Then the **deterministic `engine.py`** verifies
+  every stated span is verbatim (byte-accounting), evaluates rules, and **owns the verdict**
+  (`DETERMINATE` / `INDETERMINATE`-structural / `CONFLICT`). Stage A is the **automatic rulebook
+  derivation** — the same mechanism MYCIN-2026 needs for its CAS rules.
+
+## Metrics (per item, per arm, per model)
+
+1. **PRIMARY — corrected defensibility (0–5 locus-exposure), format-normalized, dual-judge.**
+   Both arms rendered into one style-neutral `REASONING/CONCLUSION` envelope (strip
+   GROUNDED/ENTAILED/ASSUMED labels, verdict scaffolding, citation chrome) so the judge **cannot read
+   the arm off format**. Scored by the ADJ99 rubric (is the load-bearing premise surfaced + flagged
+   fallible + would-flip stated?). **Two judges (Opus + Sonnet)**; report inter-judge agreement; a
+   second judge is decisive on close calls (W5 policy).
+2. **Machine-checked byte-accounting** (framework only): citation-fabrication count. *Pre-registered
+   prediction: 0 by construction* (deterministic byte-anchor); > 0 expected in BARE.
+3. **Accuracy** vs held-aside gold verdict/answer (deterministic / style-invariant match; LLM accuracy
+   judge only as flagged approximation, per the ADJ95 lesson).
+4. **Abstention / underdetermination rate** (framework emits structural INDETERMINATE with the named
+   missing slot).
+
+## Pre-registered hypotheses
+
+- **H1 (primary):** mean corrected-defensibility FRAMEWORK > BARE (paired), under **both** judges and
+  at **both** model scales. The fw−bare gap survives format normalization (the ADJ99/W5 result
+  predicts it *grows*, because the rubric now rewards the framework's fallibility flags).
+- **H2:** citation-fabrication = 0 in FRAMEWORK; > 0 in BARE.
+- **H3 (defensibility-parity):** FRAMEWORK closes the **Haiku↔Opus defensibility gap** toward ~0
+  (the weak model, run through the engine, is as defensible as the strong one), while the
+  **accuracy/coverage gap persists** and is absorbed by honest abstention — not fabrication.
+- **H4 (domain-independence):** the defensibility improvement holds in **all 10** domains, not 1–2.
+- **Honest nulls we must be able to report:** if format normalization erases the fw gap (it didn't for
+  ADJ99), H1 fails; if FRAMEWORK fabricates a slot, H2 fails; if the weak-model lift doesn't
+  materialize, H3 fails. The headline is the **conjunction** (defensibility ↑, fabrication = 0,
+  accuracy honest), never defensibility alone.
+
+## Analysis (pre-registered)
+- Mean corrected-defensibility per arm × model, overall + **per domain**, with **bootstrap 95% CIs**.
+- Paired Wilcoxon signed-rank on the fw−bare defensibility delta.
+- Inter-judge agreement (exact / within-1 / r), per the W5 template.
+- Per-domain table; H4 holds iff FRAMEWORK > BARE in every domain.
+- Accuracy + abstention reported alongside (H3); the framework−bare defensibility **distribution
+  across domains**, broken out by the E3 axes, is the headline figure.
+
+## Corpus construction (contamination + leakage control)
+- Items authored to have a **determinable or explicitly-contested** answer with a citable basis; the
+  underdetermined-baited stratum **withholds the dispositive fact** (quality-gated: verify bare is
+  actually tempted to fabricate it — the ADJ73 calibration lesson).
+- Gold verdict/answer + sources held in a file the arms never see; the judge is blind to arm and gold.
+- **Auditor/judge validation:** dual-judge agreement *is* the validation (W5); plus a ≥10% human/
+  third-model spot-check, reporting agreement (LLM-judge caveat, not ground truth).
+
+## Staging + cost control (pre-registered)
+1. **Pilot slice: N = 20 (all 10 domains × 2, spanning strata)** — validate harness, the corrected
+   dual-judge, format normalization, and **measure actual per-item token cost**.
+2. **Report pilot + extrapolated full-100 cost**; proceed.
+3. **Full run: N = 100**, one orchestrated pre-registered workflow, batched (≤10 concurrent per the
+   rate-limit lesson), results + CIs + per-domain table.
+
+## Resolved decisions (ADJ86's open list)
+- ✅ **Both models** {Haiku, Opus} (the defensibility-parity axis is core, not optional).
+- ✅ **Corrected metric** (locus-exposure + format-normalized + dual-judge), not the format-confounded
+  blind judge.
+- ✅ **Pilot N=20 first**, then full 100.
+- ✅ **Auto-derived rulebook** (Stage A) retained and foregrounded — it is the MYCIN bridge.
+
+## Artifact layout
+`code/specs/data/adj101-defensibility-100crossdomain/`: `items_100.json` (corpus, gold held separate
+in the same file but never shown to arms), `pipeline.workflow.js` (the run), `engine.py` /
+`provenance_engine.py` / `render_judge.py` (reused from ADJ86), `judge_*.workflow.js` (corrected
+dual-judge), raw per-cell outputs, `aggregate.py`, `FINDINGS.md`. Every quoted number traces to an
+artifact (byte-provenance applied to the paper itself).

--- a/code/specs/data/adj101-defensibility-100crossdomain/compute_gold.py
+++ b/code/specs/data/adj101-defensibility-100crossdomain/compute_gold.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""ADJ101 — derive the program-required items' gold answers FROM THE TOOLS.
+
+Byte-provenance applied to the benchmark's own answers: every computational gold value is
+computed here by SymPy / RDKit (the same tools the framework arm must emit), not hand-typed.
+Run to verify the gold in items_pilot_compute.json is reproducible.
+
+Run:  python3 compute_gold.py
+"""
+import json
+import os
+
+import sympy as sp
+from rdkit import Chem
+from rdkit.Chem import Descriptors, rdMolDescriptors
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def gold():
+    x = sp.symbols("x")
+    asp = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")
+    caf = Chem.MolFromSmiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+    return {
+        # projectile max height: (v0 * sin(theta))^2 / (2 g)
+        "PHYS1": round(float((20 * sp.sin(sp.rad(30))) ** 2 / (2 * sp.Rational(98, 10))), 3),
+        # real root of the depressed cubic
+        "MATH1": round(float([s for s in sp.solve(x**3 - 2 * x - 5, x) if s.is_real][0]), 3),
+        # 150 km / 1.5 h -> m/s
+        "UNIT1": round(150000 / (1.5 * 3600), 3),
+        # molecular weight of aspirin
+        "CHEM1": round(Descriptors.MolWt(asp), 2),
+        # H-bond donors of caffeine
+        "CHEM2": rdMolDescriptors.CalcNumHBD(caf),
+        # compound interest 5000 * 1.04^3
+        "FIN1": round(5000 * (1.04) ** 3, 2),
+    }
+
+
+def main():
+    g = gold()
+    items = json.load(open(os.path.join(HERE, "items_pilot_compute.json")))["items"]
+    ok = True
+    for it in items:
+        want = it["gold_answer"]
+        got = g[it["id"]]
+        tol = it.get("tolerance", 0) or 0
+        match = abs(got - want) <= max(tol, 1e-9)
+        print(f"{it['id']:7} corpus={want!s:>9}  tool={got!s:>9}  {'OK' if match else 'MISMATCH'}")
+        ok = ok and match
+    print("\nall gold reproduced from tools:" , ok)
+    raise SystemExit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/adj101-defensibility-100crossdomain/items_pilot20.json
+++ b/code/specs/data/adj101-defensibility-100crossdomain/items_pilot20.json
@@ -1,0 +1,215 @@
+{
+  "_meta": {
+    "benchmark": "ADJ101 cross-domain defensibility",
+    "stage": "pilot (N=20: 10 domains x 2, 4 strata x 5)",
+    "format": "each item is an adjudication problem (policy + scenario + question); gold_* held aside, never shown to the solver arms",
+    "strata": {
+      "clean-determinate": "policy+scenario fully determine the answer; engine -> DETERMINATE",
+      "underdetermined-baited": "the dispositive fact is WITHHELD; engine -> INDETERMINATE; bare is tempted to assume it",
+      "override-precedence": "a general rule and an exception/override both fire; the override must dominate",
+      "exception-encoding": "an 'except ...' clause suppresses the outcome that would otherwise apply"
+    }
+  },
+  "items": [
+    {
+      "id": "MED1",
+      "domain": "medicine",
+      "stratum": "clean-determinate",
+      "policy": "The HealthFirst plan reimburses in-network specialist visits at 70% after the annual deductible is met, and out-of-network specialist visits at 40%.",
+      "scenario": "A member whose annual deductible is fully met saw an in-network endocrinologist (a specialist) for a consultation.",
+      "question": "At what rate is this visit reimbursed?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "70%"
+    },
+    {
+      "id": "MED2",
+      "domain": "medicine",
+      "stratum": "underdetermined-baited",
+      "policy": "The HealthFirst plan reimburses in-network specialist visits at 70% after the annual deductible is met, and at 0% before the deductible is met.",
+      "scenario": "A member saw an in-network rheumatologist (a specialist) for a consultation this week.",
+      "question": "At what rate is this visit reimbursed?",
+      "gold_verdict": "INDETERMINATE",
+      "gold_answer_substring": "deductible status not stated"
+    },
+    {
+      "id": "LAW1",
+      "domain": "statutory-liability",
+      "stratum": "override-precedence",
+      "policy": "A vehicle owner is liable for parking fines incurred by the vehicle. Exception: if the vehicle was reported stolen before the time of the violation, the owner is not liable.",
+      "scenario": "A car received a parking fine at 3:00pm. Its owner had filed a police stolen-vehicle report for that car at 9:00am the same day.",
+      "question": "Is the owner liable for the fine?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "not liable"
+    },
+    {
+      "id": "LAW2",
+      "domain": "statutory-liability",
+      "stratum": "exception-encoding",
+      "policy": "A landlord must return a tenant's security deposit within 21 days of move-out, except where the lease was terminated by the tenant for cause, in which case no deadline applies.",
+      "scenario": "A tenant moved out 30 days ago after the landlord ended the lease for non-payment. The deposit has not been returned.",
+      "question": "Has the landlord violated the 21-day return deadline?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "no violation"
+    },
+    {
+      "id": "TAX1",
+      "domain": "tax-duty",
+      "stratum": "clean-determinate",
+      "policy": "Imported goods with a declared customs value of $800 or less are exempt from import duty. Goods valued above $800 are dutiable at 5% of the declared value.",
+      "scenario": "A traveler imported a watch with a declared customs value of $1,200.",
+      "question": "What duty is owed?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "$60"
+    },
+    {
+      "id": "TAX2",
+      "domain": "tax-duty",
+      "stratum": "underdetermined-baited",
+      "policy": "A resident is taxed on worldwide income; a non-resident is taxed only on domestic-source income. Residency is determined by presence of 183 days or more in the tax year.",
+      "scenario": "An individual earned $50,000 of foreign-source income this tax year.",
+      "question": "Is the foreign-source income taxable?",
+      "gold_verdict": "INDETERMINATE",
+      "gold_answer_substring": "days of presence not stated"
+    },
+    {
+      "id": "BEN1",
+      "domain": "benefits-eligibility",
+      "stratum": "override-precedence",
+      "policy": "A household qualifies for the energy subsidy if monthly income is at or below $2,000. Override: households with a member on continuous home oxygen qualify regardless of income.",
+      "scenario": "A household has monthly income of $2,600 and one member who uses continuous home oxygen.",
+      "question": "Does the household qualify for the subsidy?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "qualifies"
+    },
+    {
+      "id": "BEN2",
+      "domain": "benefits-eligibility",
+      "stratum": "exception-encoding",
+      "policy": "Applicants are eligible for tuition assistance if enrolled at least half-time, except applicants in default on a prior education loan, who are ineligible regardless of enrollment.",
+      "scenario": "An applicant is enrolled full-time and is currently in default on a federal student loan from a prior program.",
+      "question": "Is the applicant eligible for tuition assistance?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "ineligible"
+    },
+    {
+      "id": "INS1",
+      "domain": "insurance-claims",
+      "stratum": "clean-determinate",
+      "policy": "The auto policy covers windshield repair in full with no deductible. All other glass damage is subject to a $250 deductible.",
+      "scenario": "A policyholder filed a claim for a chipped windshield repaired at a cost of $90.",
+      "question": "How much does the insurer pay?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "$90"
+    },
+    {
+      "id": "INS2",
+      "domain": "insurance-claims",
+      "stratum": "underdetermined-baited",
+      "policy": "Water damage is covered if sudden and accidental (e.g., a burst pipe), and excluded if due to gradual seepage or long-term maintenance neglect.",
+      "scenario": "A policyholder filed a claim for water damage to a kitchen floor discovered last week.",
+      "question": "Is the damage covered?",
+      "gold_verdict": "INDETERMINATE",
+      "gold_answer_substring": "cause of water damage not stated"
+    },
+    {
+      "id": "BLD1",
+      "domain": "building-code",
+      "stratum": "override-precedence",
+      "policy": "Guardrails are required on any walking surface more than 30 inches above the floor below. Override: guardrails are not required on the loading-dock side of a dock used exclusively for vehicle loading.",
+      "scenario": "A walking surface is 42 inches above the floor below; it is the loading-dock side of a dock used exclusively for vehicle loading.",
+      "question": "Is a guardrail required here?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "not required"
+    },
+    {
+      "id": "BLD2",
+      "domain": "building-code",
+      "stratum": "exception-encoding",
+      "policy": "A means of egress door must swing in the direction of travel, except for doors serving a room with an occupant load of 49 or fewer, which may swing either way.",
+      "scenario": "An egress door serves a conference room with a posted occupant load of 35 and swings against the direction of travel.",
+      "question": "Does the door comply?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "complies"
+    },
+    {
+      "id": "EMP1",
+      "domain": "employment-rules",
+      "stratum": "clean-determinate",
+      "policy": "Non-exempt employees must be paid overtime at 1.5x the regular rate for hours worked beyond 40 in a workweek.",
+      "scenario": "A non-exempt employee with a regular rate of $20/hour worked 46 hours in one workweek.",
+      "question": "What is the overtime pay owed for that week?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "$180"
+    },
+    {
+      "id": "EMP2",
+      "domain": "employment-rules",
+      "stratum": "underdetermined-baited",
+      "policy": "An employee is entitled to protected family leave only if employed by the company for at least 12 months.",
+      "scenario": "An employee requested protected family leave to care for a newborn.",
+      "question": "Is the employee entitled to protected family leave?",
+      "gold_verdict": "INDETERMINATE",
+      "gold_answer_substring": "length of employment not stated"
+    },
+    {
+      "id": "IMM1",
+      "domain": "immigration-eligibility",
+      "stratum": "override-precedence",
+      "policy": "An applicant must have 5 years of continuous residence to naturalize. Override: an applicant married to and living with a citizen spouse for the required period qualifies with 3 years of continuous residence.",
+      "scenario": "An applicant has 3 years and 2 months of continuous residence and has been married to and living with a U.S.-citizen spouse for that entire period.",
+      "question": "Does the applicant meet the continuous-residence requirement?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "meets"
+    },
+    {
+      "id": "IMM2",
+      "domain": "immigration-eligibility",
+      "stratum": "exception-encoding",
+      "policy": "An applicant satisfies the physical-presence requirement with 30 months of presence in the U.S. during the statutory period, except that any single absence of 12 months or more breaks continuity and disqualifies the period regardless of total months.",
+      "scenario": "An applicant accumulated 33 months of physical presence but took one continuous trip abroad lasting 13 months during the period.",
+      "question": "Does the applicant satisfy the physical-presence requirement?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "does not satisfy"
+    },
+    {
+      "id": "CON1",
+      "domain": "contract-sla",
+      "stratum": "clean-determinate",
+      "policy": "The SLA credits the customer 10% of the monthly fee for each full hour of unplanned downtime, capped at 50% of the monthly fee.",
+      "scenario": "A service had 3 full hours of unplanned downtime in a month with a $1,000 monthly fee.",
+      "question": "What service credit is owed?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "$300"
+    },
+    {
+      "id": "CON2",
+      "domain": "contract-sla",
+      "stratum": "underdetermined-baited",
+      "policy": "Unplanned downtime is creditable under the SLA; planned-maintenance downtime announced at least 48 hours in advance is not creditable.",
+      "scenario": "A service was down for 2 hours during a maintenance window last month.",
+      "question": "Is the customer owed a service credit for this downtime?",
+      "gold_verdict": "INDETERMINATE",
+      "gold_answer_substring": "advance notice not stated"
+    },
+    {
+      "id": "ACA1",
+      "domain": "academic-grant",
+      "stratum": "override-precedence",
+      "policy": "A grant requires the applicant to hold a doctoral degree. Override: applicants with 10 or more years of documented professional research experience may apply without a doctoral degree.",
+      "scenario": "An applicant has a master's degree and 12 years of documented professional research experience.",
+      "question": "Is the applicant eligible to apply?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "eligible"
+    },
+    {
+      "id": "ACA2",
+      "domain": "academic-grant",
+      "stratum": "exception-encoding",
+      "policy": "An applicant may hold at most one active grant from the foundation at a time, except for travel grants, which do not count toward the limit.",
+      "scenario": "An applicant currently holds one active travel grant from the foundation and is applying for a research grant.",
+      "question": "Is the applicant barred by the one-active-grant limit?",
+      "gold_verdict": "DETERMINATE",
+      "gold_answer_substring": "not barred"
+    }
+  ]
+}

--- a/code/specs/data/adj101-defensibility-100crossdomain/items_pilot_compute.json
+++ b/code/specs/data/adj101-defensibility-100crossdomain/items_pilot_compute.json
@@ -1,0 +1,76 @@
+{
+  "_meta": {
+    "benchmark": "ADJ101 — program-emission track (computational items)",
+    "principle": "The LLM does NOT compute. It translates the messy source into provenance-tagged facts (each stated-span or inferred-basis), then emits a PROGRAM (SymPy/RDKit/repo tools) that does the actual work; a sandbox executes it. Byte-provenance is enforced on the program's inputs: COVERAGE (every source quantity is used OR explicitly discarded-with-reason) and JUSTIFICATION (no input invented without a span or a basis).",
+    "schema": "source (messy problem with embedded quantities) + question; gold_answer + tolerance + gold_tool held aside; some items embed a DISTRACTOR quantity to test the coverage gate (it must be discarded-with-reason, not silently dropped)",
+    "gold_provenance": "every gold_answer was computed by the tool itself (see compute_gold.py), not by hand — byte-provenance applied to the benchmark's own answers"
+  },
+  "items": [
+    {
+      "id": "PHYS1",
+      "domain": "physics",
+      "stratum": "program-required",
+      "source": "A projectile is launched from ground level at a speed of 20 m/s at an angle of 30 degrees above the horizontal. Take g = 9.8 m/s^2. The launch pad is 2 meters wide.",
+      "question": "What is the maximum height (in meters) the projectile reaches?",
+      "distractor": "launch pad is 2 meters wide",
+      "gold_answer": 5.102,
+      "tolerance": 0.02,
+      "gold_tool": "sympy: (20*sin(rad(30)))**2/(2*9.8)"
+    },
+    {
+      "id": "MATH1",
+      "domain": "mathematics",
+      "stratum": "program-required",
+      "source": "Consider the cubic equation x^3 - 2x - 5 = 0.",
+      "question": "What is its real root (to 3 decimal places)?",
+      "distractor": null,
+      "gold_answer": 2.095,
+      "tolerance": 0.005,
+      "gold_tool": "sympy.solve(x**3 - 2*x - 5, x) -> real root"
+    },
+    {
+      "id": "UNIT1",
+      "domain": "units-physics",
+      "stratum": "program-required",
+      "source": "A car covers a distance of 150 kilometers in a time of 1.5 hours.",
+      "question": "What is its average speed expressed in meters per second?",
+      "distractor": null,
+      "gold_answer": 27.778,
+      "tolerance": 0.05,
+      "gold_tool": "150000 m / (1.5*3600 s)"
+    },
+    {
+      "id": "CHEM1",
+      "domain": "chemistry",
+      "stratum": "program-required",
+      "source": "Aspirin is the molecule with SMILES string CC(=O)Oc1ccccc1C(=O)O.",
+      "question": "What is its molecular weight in g/mol (to 2 decimals)?",
+      "distractor": null,
+      "gold_answer": 180.16,
+      "tolerance": 0.05,
+      "gold_tool": "rdkit Descriptors.MolWt(MolFromSmiles(...))"
+    },
+    {
+      "id": "CHEM2",
+      "domain": "chemistry",
+      "stratum": "program-required",
+      "source": "Caffeine has the SMILES string CN1C=NC2=C1C(=O)N(C(=O)N2C)C and a molar mass of about 194 g/mol.",
+      "question": "How many hydrogen-bond donors does caffeine have?",
+      "distractor": "molar mass of about 194 g/mol",
+      "gold_answer": 0,
+      "tolerance": 0,
+      "gold_tool": "rdkit rdMolDescriptors.CalcNumHBD(MolFromSmiles(...))"
+    },
+    {
+      "id": "FIN1",
+      "domain": "finance-math",
+      "stratum": "program-required",
+      "source": "An account starts with a principal of $5,000 and earns 4% interest compounded annually. The account's branch number is 4021.",
+      "question": "What is the account balance after 3 years (to 2 decimals)?",
+      "distractor": "branch number is 4021",
+      "gold_answer": 5624.32,
+      "tolerance": 0.05,
+      "gold_tool": "5000*(1.04)**3"
+    }
+  ]
+}


### PR DESCRIPTION
**Getting started on the 100 benchmark** — the design lock (B1) + the pilot corpus (B2-pilot).

### Pre-registration (`PREREGISTRATION.md`)
Full-scale execution of the ADJ86 design (only ran as a 12-item pilot), upgraded with the **corrected defensibility metric** the ADJ99 rescore + W5 Sonnet cross-judge validated. The paper-1 **E3 breadth proof** and the **MYCIN on-ramp** — the framework arm's Stage A *auto-derives the rulebook from the policy bytes*, the CAS-rule derivation MYCIN-2026 needs.

- **N=100** (10 domains × 10, 4 strata) × **{Haiku, Opus}** × {bare, framework}.
- **Primary metric:** corrected locus-exposure defensibility (0–5), **format-normalized**, **dual-judge** (Opus+Sonnet) — plus machine-checked byte-accounting (fabrication=0 predicted), accuracy vs held-aside gold, abstention.
- **H1–H4** incl. defensibility-parity (closes the Haiku↔Opus gap while the accuracy gap persists via honest abstention) and domain-independence. Staged: pilot N=20 → full 100.
- Key upgrade over ADJ86: its old judge *penalized* the framework's `ASSUMED` flags as "manufactured doubt"; the corrected rubric *rewards* that fallibility-flagging, so the pessimistic ADJ86 verdict is expected to flip.

### Pilot corpus (`items_pilot20.json`)
The N=20 stage-1 set: 10 domains × 2, 4 strata × 5, self-contained policy+scenario+question with held-aside gold. Validated (unique ids, baited items genuinely withhold the dispositive fact, gold arithmetic checked).

Next: B3 — extend the ADJ86 harness with the corrected dual-judge + format normalization, run the pilot, then scale the corpus + run to 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)