### PR TITLE
feat(mccarthy-lisp): W5a — JVM symbols (F6) via the large-int ldc fix (LANG77)

### DIFF
--- a/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
+++ b/code/packages/rust/iir-to-jvm-class-file/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.10.0] — 2026-06-09 — large-`int` constants via the constant pool (McCarthy W5a / F6)
+
+### Fixed
+
+- **`int` literals beyond ±32767 now lower correctly.** `emit_iconst`'s
+  out-of-`sipush`-range path emitted `ldc 0` — a reference to the *reserved*
+  constant-pool slot 0 — which crashed real JVMs at class load
+  (`constantTag.cpp ShouldNotReachHere`). Added `emit_iconst_cp`, which appends a
+  `CONSTANT_Integer` entry (`ConstantPoolBuilder::add_integer`) and emits
+  `ldc`/`ldc_w` (the `LDC_W` 0x13 opcode for a CP index > 255). Every
+  *user-constant* call site (a `const`, a `mov`/`ret` immediate, a `call`
+  argument) now routes through it; the old invalid path is `debug_assert`-guarded.
+  Structural indices (field numbers, slot/arg counts) stay on `emit_iconst` — they
+  are always small.
+
+### Enabled
+
+- **McCarthy symbols (F6) on the JVM.** A symbol interns to an id in a high
+  reserved range (`SYMBOL_ID_BASE = 2²⁹`), exactly the large-`int` const this
+  fixes — so `(EQ 'X 'X)` → T, `(EQ 'X 'Y)` → nil, `(QUOTE X)` → its id now run on
+  a real JVM.
+
 ## [0.9.0] — 2026-06-09 — lisp predicates `pair?`/`not`/`equal?` (McCarthy W4)
 
 ### Added

--- a/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
+++ b/code/packages/rust/iir-to-jvm-class-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-jvm-class-file"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "IIR → JVM class file backend — lowers IIRModule to JvmClassFile.  v0.7.0 (G3): whitelist call_builtin print_i64 and lower it to invokestatic env/BasicRuntime.println(J)V, mirroring iir-to-wasm v0.8.0's env.__print_i64 host import.  Together they let BASIC's PRINT reach real JVM and wasm bytecode."
 

--- a/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/src/lower.rs
@@ -110,6 +110,7 @@ const DCONST_1: u8 = 0x0F;  // push double 1.0
 const BIPUSH: u8 = 0x10;    // push byte (sign-extended to int)
 const SIPUSH: u8 = 0x11;    // push short (sign-extended to int)
 const LDC: u8 = 0x12;       // push constant from CP (1-byte index)
+const LDC_W: u8 = 0x13;     // push int/float constant from CP (2-byte index)
 const LDC2_W: u8 = 0x14;    // push long/double constant from CP (2-byte index)
 
 // ── Local variable loads ───────────────────────────────────────────────────
@@ -878,11 +879,42 @@ fn emit_iconst(code: &mut Vec<u8>, value: i32) {
             code.extend_from_slice(&(v as i16).to_be_bytes());
         }
         _ => {
-            // Out of sipush range.  In v1 we emit ldc with a placeholder index.
-            // Tests that use large constants would need a proper CP builder.
-            code.push(LDC);
-            code.push(0); // placeholder CP index
+            // Out of sipush range: this path requires a constant-pool entry, so
+            // callers with an `int` literal beyond ±32767 MUST use
+            // `emit_iconst_cp` instead. Reaching here would emit an invalid `ldc`
+            // (placeholder index 0 → a JVM `constantTag` crash), so we refuse:
+            // a 0-byte no-op leaves the stack short, which the verifier/test
+            // catches loudly rather than corrupting a class. (McCarthy W5a fixed
+            // every user-constant call site to route large values through the CP.)
+            debug_assert!(
+                false,
+                "emit_iconst called with out-of-sipush-range value {value}; \
+                 use emit_iconst_cp (constant-pool ldc) instead"
+            );
         }
+    }
+}
+
+/// Push an `int` constant, using the **constant pool** (`ldc`/`ldc_w`) for values
+/// outside the `bipush`/`sipush` range. The constant-pool-aware companion of
+/// [`emit_iconst`]: every call site that emits a *user-controlled* integer
+/// literal (a `const`, a `mov`/`ret` immediate, a `call` argument) must use this,
+/// since an interned symbol id or any literal ≥ 2¹⁵ would otherwise hit the
+/// (now-`debug_assert`-guarded) invalid-`ldc` path. Structural indices (field
+/// numbers, slot counts, arg counts) stay on [`emit_iconst`] — they are always
+/// small (McCarthy W5a).
+fn emit_iconst_cp(code: &mut Vec<u8>, cp: &mut ConstantPoolBuilder, value: i32) {
+    if (-32768..=32767).contains(&value) {
+        emit_iconst(code, value);
+        return;
+    }
+    let idx = cp.add_integer(value);
+    if idx <= 0xFF {
+        code.push(LDC);
+        code.push(idx as u8);
+    } else {
+        code.push(LDC_W);
+        code.extend_from_slice(&idx.to_be_bytes());
     }
 }
 
@@ -1297,6 +1329,14 @@ impl ConstantPoolBuilder {
         self.add_entry(key, JvmConstantPoolEntry::Utf8(s.to_string()))
     }
 
+    /// Add a `CONSTANT_Integer` entry (deduplicated) and return its 1-based
+    /// index, for an `int` literal too large for `bipush`/`sipush` and so loaded
+    /// with `ldc`/`ldc_w` (McCarthy W5a — e.g. an interned symbol id ≥ 2²⁹).
+    fn add_integer(&mut self, value: i32) -> u16 {
+        let key = format!("Integer:{}", value);
+        self.add_entry(key, JvmConstantPoolEntry::Integer(value))
+    }
+
     /// Add a Class entry referencing a UTF8 name.
     fn add_class(&mut self, class_name: &str) -> u16 {
         let name_idx = self.add_utf8(class_name);
@@ -1601,7 +1641,7 @@ fn lower_function(
                             JvmType::Long => emit_lconst(&mut code, *v),
                             JvmType::Float => emit_fconst(&mut code, *v as f32),
                             JvmType::Double => emit_dconst(&mut code, *v as f64),
-                            _ => emit_iconst(&mut code, *v as i32),
+                            _ => emit_iconst_cp(&mut code, cp, *v as i32),
                         }
                     }
                     Operand::Bool(b) => {
@@ -1615,7 +1655,7 @@ fn lower_function(
                             _ => {
                                 // Integer destination with float source — unusual
                                 // but not necessarily wrong (e.g. casting).
-                                emit_iconst(&mut code, *f as i32);
+                                emit_iconst_cp(&mut code, cp, *f as i32);
                             }
                         }
                     }
@@ -1882,7 +1922,7 @@ fn lower_function(
                     }
                     Some(Operand::Int(v)) => {
                         // Constant mov — unusual but valid; emit iconst.
-                        emit_iconst(&mut code, *v as i32);
+                        emit_iconst_cp(&mut code, cp, *v as i32);
                         emit_istore(&mut code, dest_slot);
                     }
                     Some(Operand::Bool(b)) => {
@@ -1982,7 +2022,7 @@ fn lower_function(
                                 code.push(LRETURN);
                             }
                             _ => {
-                                emit_iconst(&mut code, *v as i32);
+                                emit_iconst_cp(&mut code, cp, *v as i32);
                                 code.push(IRETURN);
                             }
                         }
@@ -2003,7 +2043,7 @@ fn lower_function(
                                 code.push(DRETURN);
                             }
                             _ => {
-                                emit_iconst(&mut code, *f as i32);
+                                emit_iconst_cp(&mut code, cp, *f as i32);
                                 code.push(IRETURN);
                             }
                         }
@@ -2305,7 +2345,7 @@ fn lower_function(
                             let (slot, jtype) = lookup_var(n)?;
                             emit_typed_load(&mut code, slot, jtype);
                         }
-                        Operand::Int(v) => emit_iconst(&mut code, *v as i32),
+                        Operand::Int(v) => emit_iconst_cp(&mut code, cp, *v as i32),
                         Operand::Bool(b) => emit_iconst(&mut code, if *b { 1 } else { 0 }),
                         Operand::Float(f) => emit_fconst(&mut code, *f as f32),
                         // LANG32: Str is a compile-time string literal — not

--- a/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-jvm-class-file/tests/test_backend.rs
@@ -2418,3 +2418,34 @@ fn mccarthy_w4_predicates_lower() {
     assert!(code.contains(&0x82u8), "not → ixor");
     assert!(code.contains(&0xA0u8), "equal? → if_icmpne (compare-to-bool)");
 }
+
+/// McCarthy W5a: a large `int` const (beyond ±32767 — e.g. an interned symbol id
+/// ≥ 2²⁹) lowers via `ldc`/`ldc_w` + a `CONSTANT_Integer` pool entry, NOT the old
+/// invalid `ldc 0` placeholder (which crashed real JVMs at `constantTag`).
+#[test]
+fn mccarthy_w5a_large_int_const_uses_constant_pool() {
+    let big = 536_870_912i64; // 2^29 — a symbol id; needs ldc.
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i32",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(big)], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i32"),
+        ],
+    );
+    let class = lower(&module_with(f));
+    // A CONSTANT_Integer(2^29) entry must exist in the pool.
+    assert!(
+        class.constant_pool.iter().any(|e| matches!(
+            e,
+            Some(jvm_class_file::JvmConstantPoolEntry::Integer(v)) if *v == big as i32
+        )),
+        "large const must add a CONSTANT_Integer pool entry"
+    );
+    let code = &class.methods.iter().find(|m| m.name == "main").unwrap()
+        .code_attribute().unwrap().code;
+    // ldc (0x12) or ldc_w (0x13) — and never a bare `ldc 0` (index 0 reserved).
+    let ldc_pos = code.iter().position(|&b| b == 0x12 || b == 0x13).expect("ldc/ldc_w emitted");
+    assert_ne!(code[ldc_pos + 1], 0, "ldc index must not be the reserved slot 0");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.24.0 — 2026-06-09 — McCarthy **symbols** on the JVM (LANG77 / W5a, F6)
+
+`compile_source_to_jvm` now produces working classes for McCarthy **symbols**:
+`(EQ 'X 'X)` → 1, `(EQ 'X 'Y)` → 0, `(QUOTE X)` → its interned id, all run on a
+real `java`. No lang-aot code change — the win is in `iir-to-jvm-class-file`
+0.10.0, which fixed the large-`int` constant `ldc` path (a symbol id lives in the
+`2²⁹` reserved range, too big for `bipush`/`sipush`; the old backend emitted an
+invalid `ldc 0` that crashed the JVM). New `tests/jvm_symbols.rs` round-trips it
+on a real JVM.
+
 ## 0.23.0 — 2026-06-09 — McCarthy → **JVM `ATOM`/`EQ`/`COND`** on a real JVM (LANG77 / W4)
 
 The JVM backend now lowers the lisp predicates (`pair?`/`not`/`equal?`), so

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -22,7 +22,8 @@ in-repo `jvm-simulator` (`42` → 42; W3a), **cons** runs on a real JVM —
 passes as the wasm path; the JVM backend lowers the backend-agnostic
 `box`/`unbox`/`alloc`/`field_*` + `pair?`/`not`/`equal?` to `Integer`/`Object[]` +
 `instanceof`/`ixor`/`if_icmpeq` (where wasm uses `i31ref`/`$LispyPair`/`ref.test`).
-The remaining JVM symbols + lambda (F6–F7) are W5.
+**Symbols** run too (W5a): `(EQ 'X 'X)` → 1 — their interned ids (`2²⁹`) load via
+the JVM `ldc` constant-pool path. The remaining JVM lambda (F7) is W5b.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/jvm_symbols.rs
+++ b/code/packages/rust/lang-aot/tests/jvm_symbols.rs
@@ -1,0 +1,115 @@
+//! # JVM symbols on a real JVM (LANG77 / McCarthy W5a, F6).
+//!
+//! Symbols are interned to distinct integers in a high reserved range
+//! (`SYMBOL_ID_BASE = 2²⁹`) — too large for `bipush`/`sipush`, so they exercise
+//! the JVM backend's `ldc` + `CONSTANT_Integer` constant-pool path (W5a fixed an
+//! invalid `ldc 0` placeholder that crashed real JVMs). With that, `EQ` on
+//! symbols works: `(EQ 'X 'X)` → T, `(EQ 'X 'Y)` → nil.
+//!
+//! Verified on a real `java` via the same descriptor-aware launcher as the W4
+//! predicate tests.
+
+use iir_to_jvm_class_file::serialize_jvm_class_file;
+use jvm_class_file::{
+    JvmCodeAttribute, JvmConstantPoolEntry, JvmMethodAttribute, JvmMethodInfo, ACC_PUBLIC,
+    ACC_STATIC,
+};
+use lang_aot::{compile_source_to_jvm_class, Language};
+
+fn java_available() -> bool {
+    std::process::Command::new("java")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn cp_append(cp: &mut Vec<Option<JvmConstantPoolEntry>>, e: JvmConstantPoolEntry) -> u16 {
+    cp.push(Some(e));
+    (cp.len() - 1) as u16
+}
+
+fn run_on_java(source: &str, tag: &str) -> Option<String> {
+    if !java_available() {
+        return None;
+    }
+    let mut class = compile_source_to_jvm_class(Language::McCarthyLisp, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?}: {e}"));
+    let entry_desc = class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .expect("entry `main`")
+        .descriptor
+        .clone();
+    let is_long = entry_desc == "()J";
+    let (entry_d, pln_d) = if is_long { ("()J", "(J)V") } else { ("()I", "(I)V") };
+
+    let (out_fieldref, println_ref, entry_ref) = {
+        let cp = &mut class.constant_pool;
+        let su = cp_append(cp, JvmConstantPoolEntry::Utf8("java/lang/System".into()));
+        let sc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: su });
+        let ou = cp_append(cp, JvmConstantPoolEntry::Utf8("out".into()));
+        let pd = cp_append(cp, JvmConstantPoolEntry::Utf8("Ljava/io/PrintStream;".into()));
+        let on = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: ou, descriptor_index: pd });
+        let of = cp_append(cp, JvmConstantPoolEntry::Fieldref { class_index: sc, name_and_type_index: on });
+        let pu = cp_append(cp, JvmConstantPoolEntry::Utf8("java/io/PrintStream".into()));
+        let pc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: pu });
+        let lu = cp_append(cp, JvmConstantPoolEntry::Utf8("println".into()));
+        let ld = cp_append(cp, JvmConstantPoolEntry::Utf8(pln_d.into()));
+        let ln = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: lu, descriptor_index: ld });
+        let pr = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: pc, name_and_type_index: ln });
+        let mu = cp_append(cp, JvmConstantPoolEntry::Utf8("Main".into()));
+        let mc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: mu });
+        let nu = cp_append(cp, JvmConstantPoolEntry::Utf8("main".into()));
+        let du = cp_append(cp, JvmConstantPoolEntry::Utf8(entry_d.into()));
+        let nn = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: nu, descriptor_index: du });
+        let er = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: mc, name_and_type_index: nn });
+        let _ = cp_append(cp, JvmConstantPoolEntry::Utf8("([Ljava/lang/String;)V".into()));
+        (of, pr, er)
+    };
+
+    let [oh, ol] = out_fieldref.to_be_bytes();
+    let [eh, el] = entry_ref.to_be_bytes();
+    let [ph, pl] = println_ref.to_be_bytes();
+    let max_stack = if is_long { 3 } else { 2 };
+    class.methods.push(JvmMethodInfo {
+        access_flags: ACC_PUBLIC | ACC_STATIC,
+        name: "main".into(),
+        descriptor: "([Ljava/lang/String;)V".into(),
+        attributes: vec![JvmMethodAttribute::Code(JvmCodeAttribute {
+            name: "Code".into(),
+            max_stack,
+            max_locals: 1,
+            code: vec![0xB2, oh, ol, 0xB8, eh, el, 0xB6, ph, pl, 0xB1],
+            nested_attributes: vec![],
+        })],
+    });
+
+    let bytes = serialize_jvm_class_file(&class);
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w5a_{tag}"));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join("Main.class"), &bytes).expect("write Main.class");
+    let out = std::process::Command::new("java")
+        .arg("-Xverify:none").arg("-cp").arg(&tmp).arg("Main")
+        .output().expect("run java");
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[test]
+fn mccarthy_symbols_run_on_real_jvm() {
+    let Some(_) = run_on_java("(QUOTE X)", "probe") else {
+        eprintln!("java absent — skipped");
+        return;
+    };
+    // A bare symbol is its interned id — a large int via the `ldc` path (the W5a
+    // fix; this used to crash the JVM at `constantTag`).
+    assert_eq!(run_on_java("(QUOTE X)", "q").unwrap(), "536870912", "interned id of 'X");
+    // EQ distinguishes symbols.
+    assert_eq!(run_on_java("(EQ (QUOTE X) (QUOTE X))", "a").unwrap(), "1", "'X = 'X");
+    assert_eq!(run_on_java("(EQ (QUOTE X) (QUOTE Y))", "b").unwrap(), "0", "'X ≠ 'Y");
+    // A symbol is an atom (not a cons).
+    assert_eq!(run_on_java("(ATOM (QUOTE X))", "c").unwrap(), "1", "'X is an atom");
+    // Symbols are disjoint from integer atoms.
+    assert_eq!(run_on_java("(EQ (QUOTE X) 5)", "d").unwrap(), "0", "a symbol ≠ an integer");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -60,7 +60,7 @@ representation + per-builtin backend lowering.
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
-| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | uniform-Object |
+| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -125,13 +125,18 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   **descriptor-aware** launcher: predicate→`()I`, COND-over-int→`()J`):
   `(ATOM 5)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 5 5)`→1, `(EQ 5 6)`→0,
   `(COND ((EQ 1 1) 7) (5 9))`→7, fall-through→9.
-- ☐ **W5 — JVM symbols + lambda (F6–F7).** Interned symbol objects; lambda →
-  method (the uniform-anyref boundary, mirroring wasm W2). **NOTE:** symbol ids
-  use the high reserved range (`SYMBOL_ID_BASE = 2²⁹`), an `i32` const too large
-  for `bipush`/`sipush` — it must lower via `ldc` + a CONSTANT_Integer pool entry.
-  A first attempt crashed the JVM (`constantTag.cpp ShouldNotReachHere`), so W5
-  must fix/verify the JVM backend's large-`i32`-const (`ldc`) path first.
-  **Completes JVM.**
+- ✅ **W5a — JVM symbols (F6) + the large-`int` `ldc` fix.** The JVM `const`
+  lowering emitted `ldc 0` (the *reserved* CP slot) for any `int` beyond ±32767 —
+  which crashed real JVMs (`constantTag.cpp ShouldNotReachHere`). Added
+  `emit_iconst_cp` (a `CONSTANT_Integer` entry + `ldc`/`ldc_w`) and routed every
+  user-constant site through it. A symbol id (`SYMBOL_ID_BASE = 2²⁹`) is exactly
+  that large const, so symbols now run: `(EQ 'X 'X)`→1, `(EQ 'X 'Y)`→0,
+  `(QUOTE X)`→its id, `(ATOM 'X)`→1, on a real `java` (`tests/jvm_symbols.rs`).
+  The shared `intern_symbols_structural` pass (same as wasm W1) needed no change.
+- ☐ **W5b — JVM lambda/`LABEL`/recursion (F7).** The uniform-anyref function
+  boundary on the JVM, mirroring wasm W2: lisp params → `Object`, call args boxed,
+  a lambda → a `static` method returning `Object`, recursion via `invokestatic`.
+  `((LAMBDA (X) X) 5)`→5 and a recursive `LABEL`, on a real `java`. **Completes JVM.**
 
 ### Phase C — CLR (replicate as `object`)
 


### PR DESCRIPTION
## What & why

Sixth worklist item. McCarthy **symbols** now run on the JVM: `(EQ 'X 'X)`→1, `(EQ 'X 'Y)`→0, `(QUOTE X)`→its interned id, on a real `java`. The shared `intern_symbols_structural` pass (same as wasm W1) needed **no change** — the work was fixing a JVM backend bug that symbols exposed.

**Root cause** (flagged during W4): a symbol interns to an id in a high reserved range (`SYMBOL_ID_BASE = 2²⁹`), an `i32` const too large for `bipush`/`sipush`. The JVM `const` lowering's out-of-range path emitted **`ldc 0`** — a reference to the *reserved* constant-pool slot 0 — which **crashed real JVMs** at class load (`constantTag.cpp ShouldNotReachHere`).

## Change (`iir-to-jvm-class-file` 0.10.0)

- **`emit_iconst_cp(code, cp, value)`** — for a value outside ±32767, append a `CONSTANT_Integer` entry (`ConstantPoolBuilder::add_integer`) and emit `ldc` (1-byte index) or `ldc_w` (`LDC_W` 0x13, for CP index > 255).
- Routed **every user-constant call site** through it: a `const`, a `mov`/`ret` immediate, a `call` arg, **and the two float→int const sites** (the latter fixed after a security-review MEDIUM — a release build would otherwise emit a silent no-op for a large float-cast const).
- The old invalid `ldc 0` path is now a `debug_assert` guard (unreachable for user constants). Structural indices (field/slot/arg counts) stay on `emit_iconst` — always small.

## Verified by RUNNING on a real JVM (`lang-aot/tests/jvm_symbols.rs`)

`(QUOTE X)`→536870912 (no crash), `(EQ 'X 'X)`→1, `(EQ 'X 'Y)`→0, `(ATOM 'X)`→1, `(EQ 'X 5)`→0 (symbols disjoint from integers).

## Test plan

1 backend unit test (large const → `CONSTANT_Integer` + `ldc`, never `ldc 0`) + a real-`java` symbol e2e (5 programs). Suites green — `iir-to-jvm-class-file` **94**, lang-aot (`jvm_symbols` 1, `jvm_predicates` 1, `jvm_cons` 1, `jvm_emit` 2, `wasm_emit` 18, lib green); clippy clean.

## Security & safety

Security review **PASSED (2 rounds)**: round 1 flagged two user-controlled float→int const sites still on the no-op `emit_iconst`; fixed by routing them through `emit_iconst_cp`. Index encoding (`ldc` ≤255 / `ldc_w` >255), `CONSTANT_Integer` serialization, and the ±32767 boundary all verified correct; CP growth bounded by program size + the existing 65535 overflow assert; no panics on adversarial (i64-cast / float-cast) input. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **JVM F6 (symbols)** + fixes a general large-`int`-const bug affecting **any** backend user. **Next: W5b** (JVM lambda/`LABEL`/recursion, F7) — the uniform-anyref function boundary on the JVM, mirroring wasm W2 — **completes the JVM backend**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)