### PR TITLE
data(adj101/B3): provenance-gated program executor + tests

### DIFF
--- a/code/specs/data/adj101-defensibility-100crossdomain/provenance_program.py
+++ b/code/specs/data/adj101-defensibility-100crossdomain/provenance_program.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""ADJ101 — provenance-gated program executor (the deterministic core of the program-emission track).
+
+The framework arm, on a computational item, does NOT compute in the model's forward pass. It emits:
+
+  emission = {
+    "facts":   { name: {"magnitude": <num>, "unit": <str>, "polarity": "affirmed"|"denied",
+                        "type": "stated"|"inferred", "span": <verbatim source bytes>,
+                        "basis_span": <str>, "entailment": "ENTAILED"|"LEAP"} , ... },
+    "discarded": [ {"span": <source bytes>, "reason": <why this quantity is irrelevant>} , ... ],
+    "program": "<python that computes RESULT using ONLY facts[...] values + tool libraries>"
+  }
+
+This module enforces byte-provenance on the program's inputs and runs it deterministically:
+
+  1. JUSTIFICATION gate — every fact is stated(span) or inferred(basis_span + ENTAILED). A fact with
+     no provenance is a fabrication. (No fact inferred/used without justification.)
+  2. COVERAGE gate — every quantity-bearing span in the SOURCE is either represented by a fact (its
+     span) or listed in `discarded(reason)`. A source quantity that is neither is a silent drop.
+     (No fact dropped without justification.)
+  3. NO-MAGIC-NUMBERS — the emitted program may not hard-code numeric quantities; every numeric input
+     must arrive via facts[...]. Small structural constants (0,1,2,10,100, etc.) are allowed; any other
+     literal is an un-provenanced input. (Closes the "launder a number as a code literal" hole.)
+  4. EXECUTE — run the program in a subprocess with a timeout, `facts` injected, capture RESULT.
+
+NOTE on sandboxing: the program is model-emitted code. We run it in a separate process with a wall
+timeout. In this benchmark the emitter is our own model-under-test on math/chem problems (not an
+adversary), so process isolation + timeout is the appropriate guard; a hostile setting would need a
+seccomp/container sandbox. We do not pass network creds or args to the child.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# Structural constants a program may use without provenance (exponents, bases, rounding, etc.).
+ALLOWED_LITERALS = {0, 1, 2, 3, 4, 5, 10, 100, 1000, 60, 360, 3600, 24, 12, 0.5, 2.0}
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "")).strip().lower()
+
+
+def check_justification(facts: dict) -> list:
+    """Return the list of fact names whose provenance is missing (fabrications)."""
+    bad = []
+    for name, f in facts.items():
+        typ = f.get("type")
+        if typ == "stated" and f.get("span"):
+            continue
+        if typ == "inferred" and f.get("basis_span") and f.get("entailment") == "ENTAILED":
+            continue
+        bad.append(name)
+    return bad
+
+
+# A quantity in the source = a number (optionally with a unit/word). Coarse but effective for coverage.
+_QTY = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+
+
+def source_quantities(source: str) -> list:
+    """Distinct numeric tokens appearing in the source text (the things that must be accounted for)."""
+    return sorted({m.group(0).replace(",", "") for m in _QTY.finditer(source or "")})
+
+
+def check_coverage(quantity_spans: list, facts: dict, discarded: list) -> list:
+    """Declared source quantity PHRASES neither represented by a fact nor explicitly discarded.
+
+    Span/phrase-based (not bare-number): the item declares the quantity-bearing phrases the solver
+    must account for; each must be matched by a fact's span/basis (used) or a discarded span. This is
+    robust to unit-exponent noise (the '2' in 'm/s^2' is not a quantity) and makes the benchmark's
+    coverage expectation explicit and auditable.
+    """
+    used = [_norm(f.get("span") or f.get("basis_span") or "") for f in facts.values()]
+    dropped = [_norm(d.get("span") or "") for d in (discarded or [])]
+    accounted = [s for s in used + dropped if s]
+    missing = []
+    for span in (quantity_spans or []):
+        s = _norm(span)
+        if not any(s in a or a in s for a in accounted):
+            missing.append(span)
+    return missing
+
+
+def magic_numbers(program: str) -> list:
+    """Numeric literals in the program that are not allowed structural constants -> un-provenanced inputs."""
+    out = []
+    try:
+        tree = ast.parse(program)
+    except SyntaxError:
+        return ["<syntax-error>"]
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
+            if node.value not in ALLOWED_LITERALS:
+                out.append(node.value)
+    return out
+
+
+def execute(program: str, facts: dict, timeout: float = 8.0) -> dict:
+    """Run the emitted program in a subprocess with `facts` injected; capture RESULT."""
+    harness = (
+        "import json, sys, math\n"
+        "facts = json.loads(sys.argv[1])\n"
+        "RESULT = None\n"
+        + program + "\n"
+        "print(json.dumps({'RESULT': RESULT}))\n"
+    )
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+        fh.write(harness)
+        path = fh.name
+    try:
+        proc = subprocess.run(
+            [sys.executable, path, json.dumps(facts)],
+            capture_output=True, text=True, timeout=timeout,
+            env={"PATH": os.environ.get("PATH", "")},  # no inherited creds/tokens
+        )
+        if proc.returncode != 0:
+            return {"exec_ok": False, "result": None, "stderr": proc.stderr.strip()[:500]}
+        last = [ln for ln in proc.stdout.splitlines() if ln.strip()][-1]
+        return {"exec_ok": True, "result": json.loads(last)["RESULT"], "stderr": ""}
+    except subprocess.TimeoutExpired:
+        return {"exec_ok": False, "result": None, "stderr": "timeout"}
+    except Exception as e:  # noqa: BLE001 — surface any harness failure as a typed result
+        return {"exec_ok": False, "result": None, "stderr": f"{type(e).__name__}: {e}"[:500]}
+    finally:
+        os.unlink(path)
+
+
+def adjudicate_program(quantity_spans: list, emission: dict, gold=None, tolerance: float = 0.0) -> dict:
+    """Full gate + execute. Returns the auditable verdict for one computational item.
+
+    quantity_spans: the item's declared quantity-bearing phrases (used or discarded must cover them).
+    """
+    facts = emission.get("facts", {})
+    fabrications = check_justification(facts)
+    missing_coverage = check_coverage(quantity_spans, facts, emission.get("discarded", []))
+    magic = magic_numbers(emission.get("program", ""))
+    run = execute(emission.get("program", ""), facts)
+    result = run["result"]
+    correct = None
+    if gold is not None and isinstance(result, (int, float)):
+        correct = abs(result - gold) <= max(tolerance, 1e-9)
+    return {
+        "result": result,
+        "exec_ok": run["exec_ok"],
+        "stderr": run["stderr"],
+        "fabrications": fabrications,            # facts lacking provenance
+        "missing_coverage": missing_coverage,    # source quantities silently dropped
+        "magic_numbers": magic,                  # un-provenanced numeric literals in the program
+        "provenance_clean": not fabrications and not missing_coverage and not magic,
+        "correct": correct,
+    }
+
+
+if __name__ == "__main__":
+    # Smoke: PHYS1 done right — distractor discarded, no magic numbers, correct answer.
+    src = ("A projectile is launched from ground level at a speed of 20 m/s at an angle of 30 degrees "
+           "above the horizontal. Take g = 9.8 m/s^2. The launch pad is 2 meters wide.")
+    emission = {
+        "facts": {
+            "v0": {"magnitude": 20, "unit": "m/s", "polarity": "affirmed", "type": "stated", "span": "20 m/s"},
+            "angle_deg": {"magnitude": 30, "unit": "degree", "polarity": "affirmed", "type": "stated", "span": "30 degrees"},
+            "g": {"magnitude": 9.8, "unit": "m/s^2", "polarity": "affirmed", "type": "stated", "span": "9.8 m/s^2"},
+        },
+        "discarded": [{"span": "2 meters wide", "reason": "pad width does not affect vertical max height"}],
+        "program": (
+            "import sympy as sp\n"
+            "v0 = facts['v0']['magnitude']\n"
+            "ang = sp.rad(facts['angle_deg']['magnitude'])\n"
+            "g = facts['g']['magnitude']\n"
+            "RESULT = float((v0*sp.sin(ang))**2/(2*g))\n"
+        ),
+    }
+    spans = ["20 m/s", "30 degrees", "9.8 m/s^2", "2 meters wide"]
+    out = adjudicate_program(spans, emission, gold=5.102, tolerance=0.02)
+    print(json.dumps(out, indent=1))

--- a/code/specs/data/adj101-defensibility-100crossdomain/provenance_program.py
+++ b/code/specs/data/adj101-defensibility-100crossdomain/provenance_program.py
@@ -87,6 +87,50 @@ def check_coverage(quantity_spans: list, facts: dict, discarded: list) -> list:
     return missing
 
 
+def check_faithfulness(facts: dict) -> list:
+    """Stated facts whose magnitude does NOT appear in their own cited span — a localized
+    mis-extraction. This is the workhorse of localizability: most wrong answers come from a fact
+    whose VALUE contradicts the BYTES it claims to come from, and the audit catches it at that exact
+    fact. (Distinct from a fabrication, which has no span at all.)"""
+    bad = []
+    for name, f in facts.items():
+        if f.get("type") != "stated":
+            continue
+        mag = f.get("magnitude")
+        span = f.get("span")
+        if mag is None or not span:
+            continue
+        span_vals = _numeric_values(span)
+        try:
+            if not any(abs(float(mag) - v) < 1e-9 for v in span_vals):
+                bad.append(name)
+        except (TypeError, ValueError):
+            bad.append(name)
+    return bad
+
+
+def _numeric_values(text: str) -> set:
+    out = set()
+    for m in _QTY.finditer(text or ""):
+        try:
+            out.add(float(m.group(0).replace(",", "")))
+        except ValueError:
+            pass
+    return out
+
+
+def override_facts(emission: dict, overrides: dict) -> dict:
+    """Return a corrected emission with named facts' magnitudes overridden — the 'fix the fact, not
+    the weight' move. Re-running adjudicate_program on the result re-derives with ZERO model calls."""
+    facts = json.loads(json.dumps(emission.get("facts", {})))  # deep copy
+    for name, new_mag in overrides.items():
+        if name in facts:
+            facts[name]["magnitude"] = new_mag
+            facts[name].setdefault("_override", {})["from"] = emission["facts"][name].get("magnitude")
+            facts[name]["_override"]["to"] = new_mag
+    return {**emission, "facts": facts}
+
+
 def magic_numbers(program: str) -> list:
     """Numeric literals in the program that are not allowed structural constants -> un-provenanced inputs."""
     out = []
@@ -137,22 +181,41 @@ def adjudicate_program(quantity_spans: list, emission: dict, gold=None, toleranc
     quantity_spans: the item's declared quantity-bearing phrases (used or discarded must cover them).
     """
     facts = emission.get("facts", {})
-    fabrications = check_justification(facts)
+    fabrications = check_justification(facts)        # facts with no provenance at all
+    unfaithful = check_faithfulness(facts)           # facts whose value contradicts their cited span
     missing_coverage = check_coverage(quantity_spans, facts, emission.get("discarded", []))
     magic = magic_numbers(emission.get("program", ""))
     run = execute(emission.get("program", ""), facts)
     result = run["result"]
+
+    # Correctness is INFORMATIONAL in the rescored paradigm, not the target. The target is whether the
+    # trail is auditable and the error, when present, is localized + correctable.
     correct = None
     if gold is not None and isinstance(result, (int, float)):
         correct = abs(result - gold) <= max(tolerance, 1e-9)
+
+    # The error locus: where an auditor should look. Mis-extracted facts (value != cited bytes) are the
+    # usual culprit and are named explicitly; assumptions/LEAP inferences are the next place to look.
+    assumptions = [n for n, f in facts.items()
+                   if f.get("type") == "inferred" and f.get("entailment") != "ENTAILED"]
+    error_locus = {
+        "unfaithful_facts": unfaithful,      # value contradicts its own span -> fix here first
+        "assumptions": assumptions,          # inferred-but-not-entailed -> verify/override
+        "fabrications": fabrications,        # no provenance -> reject or ground
+        "exec_error": run["stderr"] or None,
+    }
     return {
         "result": result,
         "exec_ok": run["exec_ok"],
         "stderr": run["stderr"],
-        "fabrications": fabrications,            # facts lacking provenance
-        "missing_coverage": missing_coverage,    # source quantities silently dropped
-        "magic_numbers": magic,                  # un-provenanced numeric literals in the program
-        "provenance_clean": not fabrications and not missing_coverage and not magic,
+        # provenance / auditability signals (the PRIMARY axis)
+        "fabrications": fabrications,
+        "unfaithful_facts": unfaithful,
+        "missing_coverage": missing_coverage,
+        "magic_numbers": magic,
+        "auditable": not fabrications and not missing_coverage and not magic,
+        "error_locus": error_locus,          # when wrong, this names where to look + override
+        # correctness is reported but SECONDARY
         "correct": correct,
     }
 

--- a/code/specs/data/adj101-defensibility-100crossdomain/test_provenance_program.py
+++ b/code/specs/data/adj101-defensibility-100crossdomain/test_provenance_program.py
@@ -17,14 +17,14 @@ DISCARD = [{"span": "2 meters wide", "reason": "pad width irrelevant to vertical
 
 def test_clean_passes():
     out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": DISCARD, "program": PROG_OK}, 5.102, 0.02)
-    assert out["provenance_clean"] and out["correct"], out
+    assert out["auditable"] and out["correct"], out
 
 
 def test_dropped_distractor_flagged():
     # distractor "2 meters wide" neither used nor discarded -> coverage gate must flag the phrase
     out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": [], "program": PROG_OK}, 5.102, 0.02)
     assert "2 meters wide" in out["missing_coverage"], out["missing_coverage"]
-    assert not out["provenance_clean"], out
+    assert not out["auditable"], out
 
 
 def test_magic_number_flagged():
@@ -33,7 +33,7 @@ def test_magic_number_flagged():
                   "RESULT = float((facts['v0']['magnitude']*sp.sin(sp.rad(facts['angle_deg']['magnitude'])))**2/(2*9.8))\n")
     out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": DISCARD, "program": prog_magic}, 5.102, 0.02)
     assert 9.8 in out["magic_numbers"], out["magic_numbers"]
-    assert not out["provenance_clean"], out
+    assert not out["auditable"], out
 
 
 def test_fabricated_fact_flagged():
@@ -41,13 +41,39 @@ def test_fabricated_fact_flagged():
     facts_bad = {**FACTS, "made_up": {"magnitude": 7, "unit": "m", "type": "inferred"}}
     out = P.adjudicate_program(SPANS, {"facts": facts_bad, "discarded": DISCARD, "program": PROG_OK}, 5.102, 0.02)
     assert "made_up" in out["fabrications"], out["fabrications"]
-    assert not out["provenance_clean"], out
+    assert not out["auditable"], out
 
 
 def test_inferred_with_entailment_passes_justification():
     facts_inf = {**FACTS, "half_g": {"magnitude": 4.9, "type": "inferred",
                                      "basis_span": "9.8 m/s^2", "entailment": "ENTAILED"}}
     assert P.check_justification(facts_inf) == []  # entailed + basis -> justified
+
+
+# --- the rescored paradigm for programs: WRONG is fine if it's localized + correctable -------------
+
+# A mis-extraction: v0 read as 25 but its cited span still says "20 m/s" (value contradicts the bytes).
+WRONG = {
+    "facts": {**FACTS, "v0": {"magnitude": 25, "unit": "m/s", "type": "stated", "span": "20 m/s"}},
+    "discarded": DISCARD, "program": PROG_OK,
+}
+
+
+def test_wrong_answer_is_localized_to_the_exact_fact():
+    out = P.adjudicate_program(SPANS, WRONG, 5.102, 0.02)
+    assert out["correct"] is False, out["result"]          # it got the wrong answer ...
+    assert out["unfaithful_facts"] == ["v0"], out          # ... and the audit points EXACTLY at v0
+    assert out["error_locus"]["unfaithful_facts"] == ["v0"]
+    # correctness is not the target; localization is. The trail names the one thing to fix.
+
+
+def test_override_the_fact_re_derives_correctly_with_no_model_call():
+    out_wrong = P.adjudicate_program(SPANS, WRONG, 5.102, 0.02)
+    assert out_wrong["correct"] is False
+    fixed = P.override_facts(WRONG, {"v0": 20})             # fix the fact, not the weight
+    out_fixed = P.adjudicate_program(SPANS, fixed, 5.102, 0.02)
+    assert out_fixed["correct"] is True and out_fixed["auditable"], out_fixed
+    assert fixed["facts"]["v0"]["_override"] == {"from": 25, "to": 20}  # the correction is itself audited
 
 
 if __name__ == "__main__":

--- a/code/specs/data/adj101-defensibility-100crossdomain/test_provenance_program.py
+++ b/code/specs/data/adj101-defensibility-100crossdomain/test_provenance_program.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""ADJ101 — tests for the provenance-gated executor. The gates must BITE on violations."""
+import provenance_program as P
+
+SPANS = ["20 m/s", "30 degrees", "9.8 m/s^2", "2 meters wide"]
+
+FACTS = {
+    "v0": {"magnitude": 20, "unit": "m/s", "type": "stated", "span": "20 m/s"},
+    "angle_deg": {"magnitude": 30, "unit": "degree", "type": "stated", "span": "30 degrees"},
+    "g": {"magnitude": 9.8, "unit": "m/s^2", "type": "stated", "span": "9.8 m/s^2"},
+}
+PROG_OK = ("import sympy as sp\n"
+           "RESULT = float((facts['v0']['magnitude']*sp.sin(sp.rad(facts['angle_deg']['magnitude'])))**2"
+           "/(2*facts['g']['magnitude']))\n")
+DISCARD = [{"span": "2 meters wide", "reason": "pad width irrelevant to vertical max height"}]
+
+
+def test_clean_passes():
+    out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": DISCARD, "program": PROG_OK}, 5.102, 0.02)
+    assert out["provenance_clean"] and out["correct"], out
+
+
+def test_dropped_distractor_flagged():
+    # distractor "2 meters wide" neither used nor discarded -> coverage gate must flag the phrase
+    out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": [], "program": PROG_OK}, 5.102, 0.02)
+    assert "2 meters wide" in out["missing_coverage"], out["missing_coverage"]
+    assert not out["provenance_clean"], out
+
+
+def test_magic_number_flagged():
+    # program hard-codes 9.8 instead of facts['g'] -> magic-number gate must flag 9.8
+    prog_magic = ("import sympy as sp\n"
+                  "RESULT = float((facts['v0']['magnitude']*sp.sin(sp.rad(facts['angle_deg']['magnitude'])))**2/(2*9.8))\n")
+    out = P.adjudicate_program(SPANS, {"facts": FACTS, "discarded": DISCARD, "program": prog_magic}, 5.102, 0.02)
+    assert 9.8 in out["magic_numbers"], out["magic_numbers"]
+    assert not out["provenance_clean"], out
+
+
+def test_fabricated_fact_flagged():
+    # a fact with no provenance (no span, no basis) -> justification gate must flag it
+    facts_bad = {**FACTS, "made_up": {"magnitude": 7, "unit": "m", "type": "inferred"}}
+    out = P.adjudicate_program(SPANS, {"facts": facts_bad, "discarded": DISCARD, "program": PROG_OK}, 5.102, 0.02)
+    assert "made_up" in out["fabrications"], out["fabrications"]
+    assert not out["provenance_clean"], out
+
+
+def test_inferred_with_entailment_passes_justification():
+    facts_inf = {**FACTS, "half_g": {"magnitude": 4.9, "type": "inferred",
+                                     "basis_span": "9.8 m/s^2", "entailment": "ENTAILED"}}
+    assert P.check_justification(facts_inf) == []  # entailed + basis -> justified
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print("PASS", fn.__name__)
+    print(f"\nall {len(fns)} tests passed")


### PR DESCRIPTION
**B3 (part 1) — the novel deterministic core of the program-emission track**, built and tested before any LLM wiring (de-risks the run).

The framework arm, on a computational item, emits `{facts (typed + provenanced), discarded(reason), program}` and this module enforces byte-provenance on the program's **inputs**, then executes it:

- **Justification gate** — every fact is `stated(span)` or `inferred(basis + ENTAILED)`; an unprovenanced fact is a fabrication.
- **Coverage gate** (span-based) — every declared source quantity phrase is *used* (a fact span) or explicitly *discarded(reason)*; a silent drop is flagged. Robust to unit-exponent noise (the "2" in `m/s^2` is not a quantity).
- **No-magic-numbers** — AST scan flags numeric literals that didn't arrive via `facts[...]` (closes the launder-a-number-as-a-code-literal hole).
- **Execute** — model-emitted program runs in a subprocess with a timeout, `facts` injected, `RESULT` captured, no inherited creds.

**5 tests prove the gates bite:** clean PHYS1 → 5.102 correct & provenance-clean; dropped distractor flagged; hard-coded `9.8` flagged; fabricated fact flagged; entailed inference accepted.

⚠️ **Security note:** this executes model-emitted Python. The emitter here is our own model-under-test on math/chem problems (not adversarial), so subprocess isolation + timeout + no-inherited-creds is the appropriate guard; a hostile setting would need seccomp/container. Flagging for review given the arbitrary-exec surface.

Next in B3: add `quantity_spans` to the compute corpus, wire the LLM extraction→emit-program / adjudication arms + bare arm + corrected dual-judge, run the pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)