### PR TITLE
feat(mccarthy-lisp): W5b — McCarthy LAMBDA/LABEL/recursion on the JVM (F7) — JVM complete (LANG77)

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.13.0] — 2026-06-09 — reference funnels + lisp-call result type (LANG77 / McCarthy W5b)
+
+### Fixed
+
+- `lower_lisp_repr_structural` now produces IIR a **strict** backend (JVM/CLR/
+  BEAM) can type, where the loose wasm model previously got away with ambiguity:
+  - **Lisp `call` results are retyped `ref<any>`.** The frontend hints a call
+    `i64`; a lisp function returns the uniform-anyref value, so the call result is
+    a reference. (The JVM stored an `Object` result into a `long` slot otherwise —
+    a recursive `LABEL` returned garbage.)
+  - **Reference funnels.** A `COND` `mov`s each clause's value into one result
+    register. If any clause yields a reference (a cons, `nil`, or a lisp call
+    result — e.g. a recursive `LABEL`), the funnel must be a reference in *every*
+    clause. `ref`-ness is now propagated through `mov` chains to a fixpoint, and
+    the rebuild **boxes each atom clause into the funnel** (`mov %fun, %atom` →
+    `box %fun, %atom`) and retypes the reference clauses — instead of boxing the
+    whole funnel once at `ret`, which mis-boxed a clause that already held a
+    reference.
+
+These make McCarthy `LAMBDA`/`LABEL`/recursion and mixed atom/cons `COND` run on
+the JVM. wasm is unaffected (regression-tested). 1 new test.
+
 ## [0.12.0] — 2026-06-09 — uniform-anyref function boundary (LANG77 / McCarthy W2)
 
 ### Changed

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
@@ -269,14 +269,46 @@ fn lower_structural_function(
             ref_regs.insert(name.clone());
         }
     }
-    for instr in &func.instructions {
-        if !call_lisp_arg_indices(instr, lisp_funcs).is_empty()
-            || (instr.op == "call"
-                && matches!(instr.srcs.first(), Some(Operand::Var(c)) if lisp_funcs.contains(c)))
-        {
+    for instr in &mut func.instructions {
+        let is_lisp_call = instr.op == "call"
+            && matches!(instr.srcs.first(), Some(Operand::Var(c)) if lisp_funcs.contains(c));
+        if is_lisp_call || !call_lisp_arg_indices(instr, lisp_funcs).is_empty() {
             if let Some(dest) = &instr.dest {
                 ref_regs.insert(dest.clone()); // a lisp call returns an anyref.
             }
+        }
+        // A lisp `call` returns `ref<any>` (the callee's uniform-anyref result).
+        // The frontend hints the call `i64`; retype it so a **strict** backend
+        // (JVM/CLR/BEAM) stores the result as a reference, not a machine int.
+        // (The loose wasm model tolerated the stale hint; the JVM does not.)
+        if is_lisp_call {
+            instr.type_hint = REF_ANY.to_string();
+        }
+    }
+
+    // ── Reference funnels. A `COND` lowers each clause to `mov %funnel, value`
+    //    into one result register. If *any* clause yields a reference — a cons,
+    //    `nil`, or a lisp `call` result (e.g. a recursive `LABEL`) — the funnel
+    //    must be a reference in *every* clause, else a strict backend can't give
+    //    the register one type. Propagate `ref`-ness through `mov` chains to a
+    //    fixpoint; the rebuild then **boxes** each atom-valued `mov` into the
+    //    funnel (instead of boxing the whole funnel once at `ret`, which is wrong
+    //    when a clause already put a reference there). ──
+    loop {
+        let mut changed = false;
+        for instr in &func.instructions {
+            if instr.op != "mov" {
+                continue;
+            }
+            if let (Some(dest), Some(Operand::Var(src))) = (&instr.dest, instr.srcs.first()) {
+                if ref_regs.contains(src) && !ref_regs.contains(dest) {
+                    ref_regs.insert(dest.clone());
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
         }
     }
     let lisp_conds = lisp_conditions(func);
@@ -312,6 +344,17 @@ fn lower_structural_function(
             && matches!(producer_hint(func, cond), Some("i64") | Some("i32"))
         {
             needs_box.insert(cond.clone());
+        }
+    }
+    // An **atom** moved into a reference funnel is boxed *into* the funnel (the
+    // `mov` becomes a `box`). Mark its source so any feeding `const` narrows to i32.
+    for instr in &func.instructions {
+        if instr.op == "mov" {
+            if let (Some(dest), Some(Operand::Var(src))) = (&instr.dest, instr.srcs.first()) {
+                if ref_regs.contains(dest) && !ref_regs.contains(src) {
+                    needs_box.insert(src.clone());
+                }
+            }
         }
     }
 
@@ -388,6 +431,33 @@ fn lower_structural_function(
                     j.srcs[0] = Operand::Var(t);
                     new_instrs.push(j);
                     continue;
+                }
+            }
+        }
+
+        // A `mov` into a **reference funnel** (a `COND` result that some clause
+        // fills with a reference): make every clause's value a reference. A
+        // reference source becomes a `ref<any>` move; an atom source is boxed
+        // *into* the funnel (`box %funnel = %atom`), so the funnel needs no
+        // boxing at `ret`.
+        if instr.op == "mov" {
+            if let Some(dest) = instr.dest.clone() {
+                if ref_regs.contains(&dest) {
+                    if let Some(Operand::Var(src)) = instr.srcs.first().cloned() {
+                        if ref_regs.contains(&src) {
+                            let mut m = instr.clone();
+                            m.type_hint = REF_ANY.to_string();
+                            new_instrs.push(m);
+                        } else {
+                            new_instrs.push(IIRInstr::new(
+                                "box",
+                                Some(dest),
+                                vec![Operand::Var(src)],
+                                REF_ANY,
+                            ));
+                        }
+                        continue;
+                    }
                 }
             }
         }
@@ -788,6 +858,56 @@ mod tests {
         // main unboxes the call result at the entry/return boundary → i32.
         assert_eq!(main.instructions.iter().filter(|i| i.op == "unbox").count(), 1);
         assert_eq!(main.return_type, "i32");
+    }
+
+    #[test]
+    fn reference_funnel_boxes_atom_branches() {
+        // A `COND`-style funnel: one clause yields a reference (a cons), another
+        // an atom. The funnel must become a uniform reference — the atom `mov` is
+        // boxed *into* it, the ref `mov` is retyped, and `ret` returns `ref<any>`
+        // WITHOUT a final whole-funnel box (which would mis-box the cons clause).
+        // This is the case a recursive `LABEL` hits (the recursive call result is
+        // the reference clause); it must work on a strict backend like the JVM.
+        let f = IIRFunction::new(
+            "label_0",
+            vec![("L".to_string(), "any".to_string())],
+            "any",
+            vec![
+                // clause A: funnel <- a cons (reference)
+                IIRInstr::new("alloc", Some("p".into()), vec![], REF_PAIR),
+                IIRInstr::new("mov", Some("fun".into()), vec![Operand::Var("p".into())], "i64"),
+                // clause B: funnel <- an atom (needs boxing into the funnel)
+                IIRInstr::new("const", Some("a".into()), vec![Operand::Int(99)], "i64"),
+                IIRInstr::new("mov", Some("fun".into()), vec![Operand::Var("a".into())], "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("fun".into())], "any"),
+            ],
+        );
+        let mut m = IIRModule::new("rec", "mccarthy-lisp");
+        m.entry_point = Some("main".to_string()); // label_0 is non-entry
+        m.functions = vec![f];
+        lower_lisp_repr_structural(&mut m);
+        let f = &m.functions[0];
+
+        // The atom branch `mov fun = a` became `box fun = a`.
+        assert!(
+            f.instructions
+                .iter()
+                .any(|i| i.op == "box" && i.dest.as_deref() == Some("fun")),
+            "atom branch is boxed into the funnel"
+        );
+        // The reference branch stays a (ref<any>) move, never boxed.
+        assert!(
+            f.instructions.iter().any(|i| i.op == "mov"
+                && i.dest.as_deref() == Some("fun")
+                && i.type_hint == REF_ANY),
+            "reference branch is a ref<any> move"
+        );
+        // The funnel is returned as a reference WITHOUT a trailing whole-funnel box.
+        assert!(
+            !f.instructions.iter().any(|i| i.dest.as_deref() == Some("fun.retbox")),
+            "no whole-funnel retbox (each clause already produced a reference)"
+        );
+        assert_eq!(f.return_type, REF_ANY, "non-entry funnel function returns ref<any>");
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.25.0 — 2026-06-09 — McCarthy **`LAMBDA`/`LABEL`/recursion** on the JVM — **JVM complete** (LANG77 / W5b, F7)
+
+`compile_source_to_jvm` now runs McCarthy functions on a real `java`:
+`((LAMBDA (X) X) 5)`→5, multi-arg lambdas, `(CAR ((LAMBDA (X) (CONS X X)) 7))`→7,
+and a **recursive `LABEL`** walking a list to its atom→99. The win is in
+`iir-builtin-lowering` 0.13.0 (lisp-`call` results typed `ref<any>` + reference
+funnels) — the JVM backend already lowered `Object`-param/return methods +
+`invokestatic`. **With this the JVM backend is McCarthy-complete (F1–F7)** — the
+second managed backend done after WASM. New `tests/jvm_lambda.rs`.
+
 ## 0.24.0 — 2026-06-09 — McCarthy **symbols** on the JVM (LANG77 / W5a, F6)
 
 `compile_source_to_jvm` now produces working classes for McCarthy **symbols**:

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -23,7 +23,9 @@ passes as the wasm path; the JVM backend lowers the backend-agnostic
 `box`/`unbox`/`alloc`/`field_*` + `pair?`/`not`/`equal?` to `Integer`/`Object[]` +
 `instanceof`/`ixor`/`if_icmpeq` (where wasm uses `i31ref`/`$LispyPair`/`ref.test`).
 **Symbols** run too (W5a): `(EQ 'X 'X)` → 1 — their interned ids (`2²⁹`) load via
-the JVM `ldc` constant-pool path. The remaining JVM lambda (F7) is W5b.
+the JVM `ldc` constant-pool path. And `LAMBDA`/`LABEL`/recursion (W5b):
+`((LAMBDA (X) X) 5)` → 5, a recursive `LABEL` → 99. **The JVM backend is now
+McCarthy-complete (F1–F7)** — the second managed backend after WASM.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/jvm_lambda.rs
+++ b/code/packages/rust/lang-aot/tests/jvm_lambda.rs
@@ -1,0 +1,118 @@
+//! # JVM `LAMBDA`/`LABEL`/recursion on a real JVM (LANG77 / McCarthy W5b, F7).
+//!
+//! Completes the JVM backend. The frontend lifts each `LAMBDA`/`LABEL` to its
+//! own method; the structural pass makes the call boundary uniform-anyref →
+//! `Object` params/returns, with `invokestatic` for calls and recursion. The
+//! pass also makes a `COND` **funnel** that can hold a reference (a cons, nil, or
+//! a recursive call result) uniform — boxing its atom clauses — so a strict
+//! backend like the JVM can give the result one type. Verified on a real `java`.
+
+use iir_to_jvm_class_file::serialize_jvm_class_file;
+use jvm_class_file::{
+    JvmCodeAttribute, JvmConstantPoolEntry, JvmMethodAttribute, JvmMethodInfo, ACC_PUBLIC,
+    ACC_STATIC,
+};
+use lang_aot::{compile_source_to_jvm_class, Language};
+
+fn java_available() -> bool {
+    std::process::Command::new("java")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn cp_append(cp: &mut Vec<Option<JvmConstantPoolEntry>>, e: JvmConstantPoolEntry) -> u16 {
+    cp.push(Some(e));
+    (cp.len() - 1) as u16
+}
+
+fn run_on_java(source: &str, tag: &str) -> Option<String> {
+    if !java_available() {
+        return None;
+    }
+    let mut class = compile_source_to_jvm_class(Language::McCarthyLisp, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?}: {e}"));
+    let entry_desc = class
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .expect("entry `main`")
+        .descriptor
+        .clone();
+    let is_long = entry_desc == "()J";
+    let (entry_d, pln_d) = if is_long { ("()J", "(J)V") } else { ("()I", "(I)V") };
+
+    let (out_fieldref, println_ref, entry_ref) = {
+        let cp = &mut class.constant_pool;
+        let su = cp_append(cp, JvmConstantPoolEntry::Utf8("java/lang/System".into()));
+        let sc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: su });
+        let ou = cp_append(cp, JvmConstantPoolEntry::Utf8("out".into()));
+        let pd = cp_append(cp, JvmConstantPoolEntry::Utf8("Ljava/io/PrintStream;".into()));
+        let on = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: ou, descriptor_index: pd });
+        let of = cp_append(cp, JvmConstantPoolEntry::Fieldref { class_index: sc, name_and_type_index: on });
+        let pu = cp_append(cp, JvmConstantPoolEntry::Utf8("java/io/PrintStream".into()));
+        let pc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: pu });
+        let lu = cp_append(cp, JvmConstantPoolEntry::Utf8("println".into()));
+        let ld = cp_append(cp, JvmConstantPoolEntry::Utf8(pln_d.into()));
+        let ln = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: lu, descriptor_index: ld });
+        let pr = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: pc, name_and_type_index: ln });
+        let mu = cp_append(cp, JvmConstantPoolEntry::Utf8("Main".into()));
+        let mc = cp_append(cp, JvmConstantPoolEntry::Class { name_index: mu });
+        let nu = cp_append(cp, JvmConstantPoolEntry::Utf8("main".into()));
+        let du = cp_append(cp, JvmConstantPoolEntry::Utf8(entry_d.into()));
+        let nn = cp_append(cp, JvmConstantPoolEntry::NameAndType { name_index: nu, descriptor_index: du });
+        let er = cp_append(cp, JvmConstantPoolEntry::Methodref { class_index: mc, name_and_type_index: nn });
+        let _ = cp_append(cp, JvmConstantPoolEntry::Utf8("([Ljava/lang/String;)V".into()));
+        (of, pr, er)
+    };
+
+    let [oh, ol] = out_fieldref.to_be_bytes();
+    let [eh, el] = entry_ref.to_be_bytes();
+    let [ph, pl] = println_ref.to_be_bytes();
+    let max_stack = if is_long { 3 } else { 2 };
+    class.methods.push(JvmMethodInfo {
+        access_flags: ACC_PUBLIC | ACC_STATIC,
+        name: "main".into(),
+        descriptor: "([Ljava/lang/String;)V".into(),
+        attributes: vec![JvmMethodAttribute::Code(JvmCodeAttribute {
+            name: "Code".into(),
+            max_stack,
+            max_locals: 1,
+            code: vec![0xB2, oh, ol, 0xB8, eh, el, 0xB6, ph, pl, 0xB1],
+            nested_attributes: vec![],
+        })],
+    });
+
+    let bytes = serialize_jvm_class_file(&class);
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w5b_{tag}"));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join("Main.class"), &bytes).expect("write Main.class");
+    let out = std::process::Command::new("java")
+        .arg("-Xverify:none").arg("-cp").arg(&tmp).arg("Main")
+        .output().expect("run java");
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[test]
+fn mccarthy_lambda_and_recursion_run_on_real_jvm() {
+    let Some(_) = run_on_java("((LAMBDA (X) X) 5)", "probe") else {
+        eprintln!("java absent — skipped");
+        return;
+    };
+    // Lambda application, multi-arg, a predicate and a cons inside a lambda.
+    assert_eq!(run_on_java("((LAMBDA (X) X) 5)", "a").unwrap(), "5", "id lambda");
+    assert_eq!(run_on_java("(CAR ((LAMBDA (X) (CONS X X)) 7))", "b").unwrap(), "7", "cons in a lambda");
+    assert_eq!(run_on_java("(CDR ((LAMBDA (X Y) (CONS X Y)) 3 4))", "c").unwrap(), "4", "two-arg lambda");
+    assert_eq!(run_on_java("((LAMBDA (X) (EQ X X)) 5)", "d").unwrap(), "1", "EQ inside a lambda");
+    // A recursive LABEL walking a list to its atom tail.
+    let rec = "((LABEL F (LAMBDA (L) (COND ((ATOM L) 99) ((EQ 1 1) (F (CDR L)))))) (CONS 1 (CONS 2 3)))";
+    assert_eq!(run_on_java(rec, "e").unwrap(), "99", "recursive LABEL");
+    // A COND funnel mixing an atom clause and a cons clause (the funnel-uniformity
+    // case): the atom clause is taken here.
+    assert_eq!(
+        run_on_java("(COND ((ATOM 5) 7) ((EQ 1 1) (CONS 1 2)))", "f").unwrap(),
+        "7",
+        "mixed atom/cons COND funnel"
+    );
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -60,7 +60,7 @@ representation + per-builtin backend lowering.
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
-| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-Object |
+| **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -133,10 +133,17 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   that large const, so symbols now run: `(EQ 'X 'X)`→1, `(EQ 'X 'Y)`→0,
   `(QUOTE X)`→its id, `(ATOM 'X)`→1, on a real `java` (`tests/jvm_symbols.rs`).
   The shared `intern_symbols_structural` pass (same as wasm W1) needed no change.
-- ☐ **W5b — JVM lambda/`LABEL`/recursion (F7).** The uniform-anyref function
-  boundary on the JVM, mirroring wasm W2: lisp params → `Object`, call args boxed,
-  a lambda → a `static` method returning `Object`, recursion via `invokestatic`.
-  `((LAMBDA (X) X) 5)`→5 and a recursive `LABEL`, on a real `java`. **Completes JVM.**
+- ✅ **W5b — JVM lambda/`LABEL`/recursion (F7).** The JVM backend already lowered
+  the uniform-anyref boundary (`Object`-param/return methods + `invokestatic`); the
+  gap was in the *shared* structural pass, where the loose wasm model had hidden
+  two strict-backend bugs: a lisp `call` result was hinted `i64` (the JVM stored an
+  `Object` into a `long` slot), and a `COND` **funnel** mixing atom and reference
+  clauses was boxed wholesale at `ret`. Fixed both in `lower_lisp_repr_structural`
+  (call results → `ref<any>`; reference funnels box each atom clause *into* the
+  funnel via a `mov`-chain fixpoint). `((LAMBDA (X) X) 5)`→5, multi-arg,
+  `(CAR ((LAMBDA (X) (CONS X X)) 7))`→7, a recursive `LABEL`→99, and a mixed
+  atom/cons `COND`→7, on a real `java` (`tests/jvm_lambda.rs`). wasm unaffected.
+  **JVM is now McCarthy-complete (F1–F7).**
 
 ### Phase C — CLR (replicate as `object`)
 


### PR DESCRIPTION
## What & why — the JVM backend is now McCarthy-complete (F1–F7)

Seventh worklist item. McCarthy **functions** run on a real `java`: `((LAMBDA (X) X) 5)`→5, multi-arg lambdas, `(CAR ((LAMBDA (X) (CONS X X)) 7))`→7, and a **recursive `LABEL`** walking a list→99.

The JVM backend already lowered the uniform-anyref boundary (`Object`-param/return methods + `invokestatic`) — lambda/multi-arg/EQ-in-lambda already ran. The gap was in the **shared structural pass**, where the loose wasm model had hidden two bugs only a **strict** backend (JVM) exposes.

## Change (`iir-builtin-lowering` 0.13.0)

- **Lisp `call` results retyped `ref<any>`.** The frontend hints a call `i64`, but a lisp function returns the uniform-anyref value — a reference. The JVM was storing an `Object` result into a `long` slot, so a recursive `LABEL` returned garbage (0 instead of 99).
- **Reference funnels.** A `COND` `mov`s each clause's value into one result register; if any clause yields a reference (a cons, `nil`, or a lisp call result), the funnel must be a reference in *every* clause. `ref`-ness is propagated through `mov` chains to a fixpoint, and the rebuild **boxes each atom clause into the funnel** + retypes the reference clauses — instead of boxing the whole funnel once at `ret` (which mis-boxed a clause that already held a reference).

These are reusable improvements benefiting all strict managed backends (JVM now, CLR/BEAM next). **wasm (loose model) is unaffected — regression-tested.**

## Verified by RUNNING on a real JVM (`lang-aot/tests/jvm_lambda.rs`)

id lambda→5, cons-in-lambda→7, two-arg→4, EQ-in-lambda→1, **recursive `LABEL`→99**, mixed atom/cons COND→7.

## Test plan

1 new unit test (a reference funnel boxes its atom branch, retypes its ref branch, no whole-funnel retbox) + a real-`java` lambda/recursion e2e (6 programs). Suites green — `iir-builtin-lowering` **107**, lang-aot (`jvm_lambda` 1, `jvm_symbols` 1, `jvm_predicates` 1, `jvm_cons` 1, `jvm_emit` 2, `wasm_emit` 18, lib green), `iir-to-wasm` 4; clippy clean.

## Security & safety

Security review **PASSED**: the `mov`-chain fixpoint terminates (`ref_regs` is a name-keyed HashSet that only grows, bounded by the register count; breaks on no insertion — even an `a=b;b=a` cycle terminates); no panics on malformed IIR (every dest/src access Option/Var-guarded); polynomial O(I²); the emitted `box`/`mov` ops are well-formed. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **JVM F7** — **the JVM is now McCarthy-complete (F1–F7)**, the second managed backend after WASM. **Next: W6** (CLR cons) begins the .NET backend, reusing the same structural pass + these strict-backend fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)