### PR TITLE
feat(mccarthy-lisp): W6a — McCarthy → CLR (CIL) run-foundation (scalar) (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `lang-aot`
 
+## 0.26.0 — 2026-06-09 — McCarthy → **CLR (CIL)** run-foundation (scalar) (LANG77 / W6a)
+
+Adds `compile_source_to_cil_artifact` — the **third** managed `--emit` target
+(after WASM and JVM). Source → IIR → `concretize_scalar_any_for_cil` (scalar
+`any`/`i64` → CLR `i32`) → `iir-to-cil-bytecode`. **Scalar McCarthy programs emit
+CIL that RUNS** — verified by running the entry method's IL on the in-repo
+`clr-simulator` (zero external `dotnet`, mirroring how the JVM path uses
+`jvm-simulator`): `42`→42, `0`→0, `7`→7; Twig `42` too. Adds
+`LangAotError::ClrBackendError`. The cons/symbol/lambda uniform-`object` value
+model (the CLR replication of the shared structural passes, reusing the JVM
+strict-backend fixes) is W6b+.
+
 ## 0.25.0 — 2026-06-09 — McCarthy **`LAMBDA`/`LABEL`/recursion** on the JVM — **JVM complete** (LANG77 / W5b, F7)
 
 `compile_source_to_jvm` now runs McCarthy functions on a real `java`:

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
@@ -18,6 +18,7 @@ cli-builder           = { path = "../cli-builder" }
 iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-wasm           = { path = "../iir-to-wasm" }
 iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
+iir-to-cil-bytecode   = { path = "../iir-to-cil-bytecode" }
 iir-builtin-lowering  = { path = "../iir-builtin-lowering" }
 riscv-backend         = { path = "../riscv-backend" }
 riscv-encoder         = { path = "../riscv-encoder" }
@@ -48,3 +49,6 @@ wasm-runtime = { path = "../wasm-runtime" }
 # zero-external-dep (no `java` needed for the scalar path).
 jvm-class-file = { path = "../jvm-class-file" }
 jvm-simulator = { path = "../jvm-simulator" }
+# In-repo CLR (CIL) bytecode simulator — used to RUN the emitted CIL in tests and
+# assert the computed result (LANG77 / McCarthy W6a), mirroring jvm-simulator.
+clr-simulator = { path = "../clr-simulator" }

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -27,6 +27,11 @@ the JVM `ldc` constant-pool path. And `LAMBDA`/`LABEL`/recursion (W5b):
 `((LAMBDA (X) X) 5)` → 5, a recursive `LABEL` → 99. **The JVM backend is now
 McCarthy-complete (F1–F7)** — the second managed backend after WASM.
 
+`compile_source_to_cil_artifact` is the third managed target (W6a): scalar
+McCarthy emits CIL that **runs** — verified on the in-repo `clr-simulator`
+(`42` → 42), no external `dotnet`. The CLR cons/symbol/lambda value model
+(uniform-`object`, reusing the JVM strict-backend fixes) is W6b+.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -189,6 +189,12 @@ pub enum LangAotError {
     /// the modern *managed* targets, replicating the WASM uniform-reference value
     /// model with `Object`/`Integer` boxing (LANG77 / McCarthy W3).
     JvmBackendError(String),
+    /// The CLR (.NET CIL) backend rejected the IIR.
+    ///
+    /// Carries the string from `iir-to-cil-bytecode`.  The CLR is the third of
+    /// the modern *managed* targets, replicating the WASM/JVM uniform-reference
+    /// value model with `object`/boxing (LANG77 / McCarthy W6).
+    ClrBackendError(String),
 }
 
 impl fmt::Display for LangAotError {
@@ -203,6 +209,7 @@ impl fmt::Display for LangAotError {
             LangAotError::LlvmBackendError(m) => write!(f, "llvm: {m}"),
             LangAotError::WasmBackendError(m) => write!(f, "wasm: {m}"),
             LangAotError::JvmBackendError(m) => write!(f, "jvm: {m}"),
+            LangAotError::ClrBackendError(m) => write!(f, "clr: {m}"),
             LangAotError::RiscvBackendError(m) => write!(f, "riscv32: {m}"),
             LangAotError::Intel8008BackendError(m) => write!(f, "intel8008: {m}"),
             LangAotError::Armv7BackendError(m) => write!(f, "armv7: {m}"),
@@ -521,6 +528,70 @@ pub fn compile_source_to_jvm_class(
     let config = iir_to_jvm_class_file::IIRJvmConfig::new(class_name);
     iir_to_jvm_class_file::lower_iir_to_jvm(&module, &config)
         .map_err(|e| LangAotError::JvmBackendError(format!("{e:?}")))
+}
+
+/// Retype a **scalar** module's `any`/`polymorphic`/`i64` values to CLR `i32`,
+/// for the CLR run-foundation (LANG77 / McCarthy W6a). The CLR twin of
+/// `concretize_scalar_any_for_jvm`: the in-repo `clr-simulator` (used to verify)
+/// is a 32-bit integer machine and `iir-to-cil-bytecode`'s entry returns
+/// `int32`, so a scalar program's result is an `int`. Heap/reference functions
+/// (cons/symbols/lambda — W6b+) are left for the uniform-`object` value model.
+fn concretize_scalar_any_for_cil(module: &mut IIRModule) {
+    const HEAP_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
+    const LISP_BUILTINS: &[&str] = &[
+        "cons", "car", "cdr", "pair?", "not", "equal?", "make_symbol", "make_nil", "null?",
+    ];
+    for func in &mut module.functions {
+        let uses_lisp = func.params.iter().any(|(_, t)| t == "any" || t == "symbol")
+            || func.instructions.iter().any(|i| {
+                HEAP_OPS.contains(&i.op.as_str())
+                    || (i.op == "call_builtin"
+                        && matches!(i.srcs.first(),
+                            Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
+                    || i.type_hint.starts_with("ref<")
+            });
+        if uses_lisp {
+            continue; // uniform-object value model — CLR W6b+.
+        }
+        let to_i32 = |t: &str| t == "any" || t == "polymorphic" || t == "i64";
+        if to_i32(&func.return_type) {
+            func.return_type = "i32".to_string();
+        }
+        for instr in &mut func.instructions {
+            if to_i32(&instr.type_hint) {
+                instr.type_hint = "i32".to_string();
+            }
+        }
+    }
+}
+
+/// Cross-platform: source → IIR → a **CLR CIL artifact** (LANG77 / McCarthy W6).
+///
+/// The third of the modern *managed* `--emit` targets. The CLR has its own
+/// uniform-reference value model (`object` references, value-type boxing) — the
+/// analogue of the WASM `anyref` / JVM `Object` models. **W6a (this slice)** wires
+/// the pipeline and runs **scalar** programs: source → IIR →
+/// `concretize_scalar_any_for_cil` → `iir-to-cil-bytecode`. The cons/symbol/lambda
+/// value model (the uniform-`object` replication of the shared structural passes)
+/// lands in W6b+.
+///
+/// Verified end-to-end by *running* the emitted entry method's CIL on the in-repo
+/// `clr-simulator` (see the `cil_emit` tests) — no external `dotnet`.
+///
+/// # Errors
+/// * `FrontendError` — the frontend rejected the source.
+/// * `ClrBackendError` — `iir-to-cil-bytecode` rejected the (lowered) IIR.
+pub fn compile_source_to_cil_artifact(
+    language: Language,
+    source: &str,
+    name: &str,
+) -> Result<iir_to_cil_bytecode::CILProgramArtifact, LangAotError> {
+    let mut module = compile_source_to_iir(language, source, name)?;
+    concretize_scalar_any_for_cil(&mut module);
+
+    let config = iir_to_cil_bytecode::IIRClrConfig::new(name);
+    iir_to_cil_bytecode::lower_iir_to_cil(&module, &config)
+        .map_err(|e| LangAotError::ClrBackendError(format!("{e:?}")))
 }
 
 /// Cross-platform: source file → IIR → JVM class file (`.class`) on disk.

--- a/code/packages/rust/lang-aot/tests/cil_emit.rs
+++ b/code/packages/rust/lang-aot/tests/cil_emit.rs
@@ -1,0 +1,43 @@
+//! # CLR (CIL) emit + run tests (LANG77 / McCarthy W6a).
+//!
+//! The third *managed* `--emit` target. These RUN the emitted entry method's CIL
+//! on the in-repo `clr-simulator` and assert the result (zero-external-dep, like
+//! `jvm_emit.rs` uses `jvm-simulator`). W6a scope: **scalar** McCarthy programs;
+//! the cons/symbol/lambda uniform-`object` value model is W6b+.
+
+use clr_simulator::CLRSimulator;
+use lang_aot::{compile_source_to_cil_artifact, Language};
+
+/// Compile a scalar program to CIL, run its `main` method on the in-repo
+/// simulator, and return the `int` result left on the stack by `ret`.
+fn compile_and_run(language: Language, source: &str) -> i32 {
+    let artifact = compile_source_to_cil_artifact(language, source, "Main")
+        .unwrap_or_else(|e| panic!("compile {source:?} to CIL: {e}"));
+    let main = artifact
+        .methods
+        .iter()
+        .find(|m| m.name == "main")
+        .expect("a `main` method");
+
+    let mut sim = CLRSimulator::new();
+    sim.load(&main.body, main.local_types.len());
+    sim.run(10_000);
+    // CIL `ret` leaves the return value on top of the evaluation stack.
+    sim.stack
+        .last()
+        .and_then(|v| *v)
+        .unwrap_or_else(|| panic!("`{source}` left no value on the stack"))
+}
+
+#[test]
+fn mccarthy_scalar_emits_and_runs_on_clr() {
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "42"), 42, "McCarthy 42");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "0"), 0, "McCarthy 0");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "7"), 7, "McCarthy 7");
+}
+
+#[test]
+fn twig_scalar_emits_and_runs_on_clr() {
+    // Reusability: Twig flows through the identical CLR scalar path.
+    assert_eq!(compile_and_run(Language::Twig, "42"), 42, "Twig 42");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -147,7 +147,19 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase C — CLR (replicate as `object`)
 
-- ☐ **W6 — CLR cons (F2).** `$LispyPair` type, `newobj`/`ldfld`; boxed ints.
+- ✅ **W6a — CLR run-foundation (F1, scalar).** `lang-aot::compile_source_to_cil_artifact`
+  + `concretize_scalar_any_for_cil` (scalar `any`/`i64` → CLR `i32`) →
+  `iir-to-cil-bytecode`. **Verified by RUNNING** — the entry method's CIL on the
+  in-repo **`clr-simulator`** (zero external `dotnet`, mirroring `jvm-simulator`):
+  `42`→42, `0`→0, `7`→7, Twig `42`→42. Establishes the CLR pipeline + run-verify
+  harness that W6b+ build on.
+- ☐ **W6b — CLR cons (F2).** cons cells are `object[]` (the CLR backend already
+  lowers `alloc`/`field_*` for `ref<LispyPair>` → `newarr`/`stelem`/`ldelem`);
+  add the atom boxing (`box [mscorlib]System.Int32` / `unbox.any`), remove
+  `box`/`unbox` from its `UNSUPPORTED_OPS`, and run the shared structural passes
+  (incl. the JVM strict-backend fixes). NOTE: `clr-simulator` is a 32-bit integer
+  machine (no object/heap execution), so W6b's run-verify needs the real `dotnet`
+  (9.0.313, available via mise) — mirror the JVM W3b real-`java` harness.
 - ☐ **W7 — CLR `ATOM`/`EQ`/`COND` (F3–F5).** `isinst`; equality; truthiness.
 - ☐ **W8 — CLR symbols + lambda (F6–F7).** **Completes CLR.**
 


### PR DESCRIPTION
## What & why — the CLR (.NET) backend begins

Eighth worklist item, opening the **third managed backend** (after WASM and JVM). Wire the McCarthy→CIL pipeline and **run** scalar programs on the in-repo `clr-simulator` (zero external `dotnet`) — the CLR analog of the JVM W3a foundation.

**Survey:** `iir-to-cil-bytecode` is well-built (already lowers cons as `object[]` via `alloc`/`field` for `ref<LispyPair>`, like the JVM backend), `clr-simulator` is a 32-bit integer CIL machine, and `dotnet` 9.0.313 is available via mise — but **nothing wired McCarthy/lang → CIL, and there was no run-verify path**. This slice establishes both, scoped to scalar (F1).

## Change (`lang-aot` 0.26.0)

- **`compile_source_to_cil_artifact`** — source → IIR → `concretize_scalar_any_for_cil` → `iir-to-cil-bytecode::lower_iir_to_cil`.
- **`concretize_scalar_any_for_cil`** — the CLR twin of `concretize_scalar_any_for_jvm`: scalar `any`/`polymorphic`/`i64` → CLR `i32` (the entry returns `int32`, which the 32-bit `clr-simulator` runs), skipping lisp/heap functions.
- `LangAotError::ClrBackendError`.

## Verified by RUNNING (`tests/cil_emit.rs`)

compile → run the entry method's CIL on **`clr-simulator`** → assert the value left on the stack by `ret`. **`42`→42, `0`→0, `7`→7; Twig `42`→42**. No external `dotnet`.

## Test plan

2 new e2e tests; full lang-aot suite green (`cil_emit` 2, `jvm_*` + `wasm_emit` unchanged, lib green); clippy clean; no regressions.

## Security & safety

Security review **PASSED**: the new code is a pure O(N) in-place IIR retype + an error-propagating compile entry — no `unwrap`/`expect`/indexing/overflow on adversarial IIR; the `clr-simulator` `run` is step-capped (no hang). No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Establishes **CLR F1** + the run-verify harness (W6a ✅). **Next: W6b** — CLR cons (the `object[]`/box value model). Its run-verify will use the real `dotnet` (9.0.313, available via mise), mirroring the JVM W3b real-`java` harness, and reuse the shared structural passes + JVM strict-backend fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)