### PR TITLE
feat(mccarthy-lisp): W9a — McCarthy → BEAM (Erlang VM) run-foundation (scalar) (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `lang-aot`
 
+## 0.27.0 — 2026-06-10 — McCarthy → **BEAM (Erlang VM)** run-foundation (scalar) (LANG77 / W9a)
+
+Adds `compile_source_to_beam` — the **fourth** managed `--emit` target and the
+first on the **Erlang VM**. Source → IIR → `concretize_scalar_any_for_beam`
+(scalar `any` → `i64`; the BEAM has native arbitrary-precision integers) →
+`iir-to-beam` → `encode_beam` (a `.beam` module exporting `main/0`). **Scalar
+McCarthy programs emit a `.beam` that RUNS** — verified by running it on a real
+`erl` (OTP 28): `42`→42, `0`→0, `7`→7; Twig `42` too. Adds
+`LangAotError::BeamBackendError`. BEAM uses the native **Erlang-terms** value
+model (integers/atoms/list cells), not the structural uniform-reference model of
+WASM/JVM/CLR — so its cons/symbol/lambda lowering (W9+) is its own.
+
 ## 0.26.0 — 2026-06-09 — McCarthy → **CLR (CIL)** run-foundation (scalar) (LANG77 / W6a)
 
 Adds `compile_source_to_cil_artifact` — the **third** managed `--emit` target

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
@@ -19,6 +19,7 @@ iir-to-llvm           = { path = "../iir-to-llvm" }
 iir-to-wasm           = { path = "../iir-to-wasm" }
 iir-to-jvm-class-file = { path = "../iir-to-jvm-class-file" }
 iir-to-cil-bytecode   = { path = "../iir-to-cil-bytecode" }
+iir-to-beam           = { path = "../iir-to-beam" }
 iir-builtin-lowering  = { path = "../iir-builtin-lowering" }
 riscv-backend         = { path = "../riscv-backend" }
 riscv-encoder         = { path = "../riscv-encoder" }

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -32,6 +32,11 @@ McCarthy emits CIL that **runs** — verified on the in-repo `clr-simulator`
 (`42` → 42), no external `dotnet`. The CLR cons/symbol/lambda value model
 (uniform-`object`, reusing the JVM strict-backend fixes) is W6b+.
 
+`compile_source_to_beam` is the fourth managed target and the first on the
+**Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real
+`erl` (OTP), `42` → 42. BEAM uses the native Erlang-terms value model
+(integers/atoms/list cells), so its cons/symbol/lambda lowering (W9+) is its own.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -195,6 +195,12 @@ pub enum LangAotError {
     /// the modern *managed* targets, replicating the WASM/JVM uniform-reference
     /// value model with `object`/boxing (LANG77 / McCarthy W6).
     ClrBackendError(String),
+    /// The BEAM (Erlang VM) backend rejected the IIR.
+    ///
+    /// Carries the string from `iir-to-beam`.  BEAM uses the native **Erlang
+    /// terms** value model (integers, atoms, list cells) rather than the
+    /// structural uniform-reference model of WASM/JVM/CLR (LANG77 / McCarthy W9).
+    BeamBackendError(String),
 }
 
 impl fmt::Display for LangAotError {
@@ -210,6 +216,7 @@ impl fmt::Display for LangAotError {
             LangAotError::WasmBackendError(m) => write!(f, "wasm: {m}"),
             LangAotError::JvmBackendError(m) => write!(f, "jvm: {m}"),
             LangAotError::ClrBackendError(m) => write!(f, "clr: {m}"),
+            LangAotError::BeamBackendError(m) => write!(f, "beam: {m}"),
             LangAotError::RiscvBackendError(m) => write!(f, "riscv32: {m}"),
             LangAotError::Intel8008BackendError(m) => write!(f, "intel8008: {m}"),
             LangAotError::Armv7BackendError(m) => write!(f, "armv7: {m}"),
@@ -592,6 +599,72 @@ pub fn compile_source_to_cil_artifact(
     let config = iir_to_cil_bytecode::IIRClrConfig::new(name);
     iir_to_cil_bytecode::lower_iir_to_cil(&module, &config)
         .map_err(|e| LangAotError::ClrBackendError(format!("{e:?}")))
+}
+
+/// Concretise a **scalar** module's `any`/`polymorphic` values to `i64` for the
+/// BEAM run-foundation (LANG77 / McCarthy W9a). Unlike the WASM/JVM/CLR
+/// simulators (32-bit), the BEAM has **native arbitrary-precision integers**, so
+/// the natural concrete type is `i64` (the `iir-to-beam` backend's integer
+/// width). The `iir-to-beam` validator rejects `any`/`polymorphic`, so a scalar
+/// program must be concretised before lowering. Heap/reference functions
+/// (cons/symbols/lambda — W9+, the native Erlang-terms model) are left alone.
+fn concretize_scalar_any_for_beam(module: &mut IIRModule) {
+    const HEAP_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
+    const LISP_BUILTINS: &[&str] = &[
+        "cons", "car", "cdr", "pair?", "not", "equal?", "make_symbol", "make_nil", "null?",
+    ];
+    for func in &mut module.functions {
+        let uses_lisp = func.params.iter().any(|(_, t)| t == "any" || t == "symbol")
+            || func.instructions.iter().any(|i| {
+                HEAP_OPS.contains(&i.op.as_str())
+                    || (i.op == "call_builtin"
+                        && matches!(i.srcs.first(),
+                            Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
+                    || i.type_hint.starts_with("ref<")
+            });
+        if uses_lisp {
+            continue; // native Erlang-terms value model — BEAM W9+.
+        }
+        let to_i64 = |t: &str| t == "any" || t == "polymorphic";
+        if to_i64(&func.return_type) {
+            func.return_type = "i64".to_string();
+        }
+        for instr in &mut func.instructions {
+            if to_i64(&instr.type_hint) {
+                instr.type_hint = "i64".to_string();
+            }
+        }
+    }
+}
+
+/// Cross-platform: source → IIR → a **BEAM module** (`.beam` bytes) (LANG77 / W9).
+///
+/// The fourth managed `--emit` target — and the first on the **Erlang VM**, whose
+/// native value model (integers, atoms, list cells) replaces the structural
+/// uniform-reference model of WASM/JVM/CLR. **W9a (this slice)** wires the
+/// pipeline and runs **scalar** programs: source → IIR →
+/// `concretize_scalar_any_for_beam` → `iir-to-beam` → `encode_beam`. The cons/
+/// symbol/lambda Erlang-terms lowering lands in W9+.
+///
+/// `module_name` must be a valid Erlang atom (lowercase, `[a-z][a-z0-9_]*`); the
+/// emitted module exports `main/0`, so a runner loads it and calls
+/// `<module_name>:main()`. Verified end-to-end by running on a real `erl` (OTP).
+///
+/// # Errors
+/// * `FrontendError` — the frontend rejected the source.
+/// * `BeamBackendError` — `iir-to-beam` rejected the (lowered) IIR.
+pub fn compile_source_to_beam(
+    language: Language,
+    source: &str,
+    module_name: &str,
+) -> Result<Vec<u8>, LangAotError> {
+    let mut module = compile_source_to_iir(language, source, module_name)?;
+    concretize_scalar_any_for_beam(&mut module);
+
+    let config = iir_to_beam::IIRBeamConfig::new(module_name);
+    let beam = iir_to_beam::lower_iir_to_beam(&module, &config)
+        .map_err(|e| LangAotError::BeamBackendError(format!("{e:?}")))?;
+    Ok(iir_to_beam::encode_beam(&beam))
 }
 
 /// Cross-platform: source file → IIR → JVM class file (`.class`) on disk.

--- a/code/packages/rust/lang-aot/tests/beam_emit.rs
+++ b/code/packages/rust/lang-aot/tests/beam_emit.rs
@@ -1,0 +1,57 @@
+//! # BEAM emit + run tests (LANG77 / McCarthy W9a).
+//!
+//! The fourth *managed* `--emit` target, and the first on the Erlang VM. These
+//! RUN the emitted `.beam` on a real `erl` (OTP) and assert the result — the
+//! same verify-by-running discipline as the wasm/jvm/clr paths. W9a scope:
+//! **scalar** McCarthy programs; the cons/symbol/lambda Erlang-terms model is W9+.
+
+use lang_aot::{compile_source_to_beam, Language};
+
+fn erl_available() -> bool {
+    std::process::Command::new("erl")
+        .args(["-noshell", "-eval", "halt(0)."])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Compile a scalar program to a `.beam`, load it on a real `erl`, call
+/// `module:main()`, and return its printed result (or None if `erl` is absent).
+fn compile_and_run(language: Language, source: &str, module: &str) -> Option<String> {
+    if !erl_available() {
+        return None;
+    }
+    let bytes = compile_source_to_beam(language, source, module)
+        .unwrap_or_else(|e| panic!("compile {source:?} to BEAM: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w9_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join(format!("{module}.beam")), &bytes).expect("write .beam");
+    let out = std::process::Command::new("erl")
+        .arg("-noshell")
+        .arg("-pa").arg(&tmp)
+        .arg("-eval")
+        .arg(format!("io:format(\"~w~n\",[{module}:main()]),halt(0)."))
+        .output()
+        .expect("spawn erl");
+    assert!(out.status.success(), "erl non-zero; stderr: {}", String::from_utf8_lossy(&out.stderr));
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[test]
+fn mccarthy_scalar_emits_and_runs_on_beam() {
+    let Some(_) = compile_and_run(Language::McCarthyLisp, "42", "mc_probe") else {
+        eprintln!("erl absent — skipped");
+        return;
+    };
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "42", "mc_a").unwrap(), "42", "McCarthy 42");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "0", "mc_b").unwrap(), "0", "McCarthy 0");
+    assert_eq!(compile_and_run(Language::McCarthyLisp, "7", "mc_c").unwrap(), "7", "McCarthy 7");
+}
+
+#[test]
+fn twig_scalar_emits_and_runs_on_beam() {
+    if !erl_available() {
+        return;
+    }
+    assert_eq!(compile_and_run(Language::Twig, "42", "tw_a").unwrap(), "42", "Twig 42");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -165,8 +165,17 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase D — BEAM (Erlang terms)
 
-- ☐ **W9 — BEAM cons (F2).** Cons as a 2-tuple (or proper list cell); `car`/`cdr`
-  = element access; integers are native Erlang integers; nil = `[]`/`nil` atom.
+- ◑ **W9 — BEAM cons (F2).** *In progress.* Cons as a list cell `[a|b]`;
+  `car`/`cdr` = `hd`/`tl`; integers are native Erlang integers; nil = `[]`.
+  - ✅ **W9a — BEAM run-foundation (F1, scalar).** `lang-aot::compile_source_to_beam`
+    + `concretize_scalar_any_for_beam` (scalar `any` → `i64`) → `iir-to-beam` →
+    `encode_beam`. **Verified by RUNNING** the emitted `.beam` on a real `erl`
+    (OTP 28): `42`→42, `0`→0, `7`→7, Twig `42`→42. Started as a parallel stream
+    (independent of the held CLR W6b PR); reuses the backend's established
+    real-`erl` round-trip harness. Establishes the BEAM pipeline.
+  - ☐ **W9b — BEAM cons.** Lower `cons`/`car`/`cdr` to BEAM list ops
+    (`put_list`/`get_hd`/`get_tl`) — the native Erlang-terms model (NOT the
+    structural uniform-ref pass). `(CAR (CONS 7 9))`→7 on a real `erl`.
 - ☐ **W10 — BEAM `ATOM`/`EQ`/`COND` (F3–F5).** `is_tuple`/guards; `=:=`; truthiness.
 - ☐ **W11 — BEAM symbols + lambda (F6–F7).** Symbols = Erlang atoms; lambda = fun.
   **Completes BEAM.** (Mind the OTP-27 AtU8 atom-format constraint from


### PR DESCRIPTION
## What & why — the BEAM (Erlang VM) backend begins (parallel stream)

Opens the **fourth managed backend** (after WASM, JVM, CLR) — and the first on the **Erlang VM**. Started as a **parallel stream**, independent of the held CLR W6b PR (#5296), per the "never idle waiting for CI" workflow. Wire the McCarthy→BEAM pipeline and **run** scalar programs on a real `erl`.

**Survey:** `iir-to-beam` is mature (already handles closures via `erlang:apply/3`, has an established **real-`erl` round-trip harness**), emits real `.beam` modules, and `erl` (OTP 28) is available via mise — but nothing wired McCarthy/lang → BEAM. This slice establishes the pipeline, scoped to scalar (F1). BEAM uses the native **Erlang-terms** value model (integers/atoms/list cells), **not** the structural uniform-reference model of WASM/JVM/CLR — so its cons/symbol/lambda lowering (W9+) is its own.

## Change (`lang-aot` 0.27.0)

- **`compile_source_to_beam`** — source → IIR → `concretize_scalar_any_for_beam` → `iir-to-beam::lower_iir_to_beam` → `encode_beam` (a `.beam` exporting `main/0`).
- **`concretize_scalar_any_for_beam`** — scalar `any`/`polymorphic` → `i64` (the BEAM has native arbitrary-precision integers; the `iir-to-beam` validator rejects `any`). Skips lisp/heap functions.
- `LangAotError::BeamBackendError`.

## Verified by RUNNING (`tests/beam_emit.rs`)

compile → write `<module>.beam` → `erl -noshell -pa <tmp> -eval 'io:format("~w~n",[<module>:main()]),halt(0).'` → assert. **`42`→42, `0`→0, `7`→7; Twig `42`→42**. Gated on `erl_available()` (skips gracefully where OTP is absent).

## Test plan

2 new e2e tests; full lang-aot suite green (`beam_emit` 2, `cil_emit`/`jvm_*`/`wasm_emit` unchanged, lib); my lang-aot code clippy-clean. **NOTE:** `cargo clippy -p iir-to-beam` flags a **pre-existing** lint (`iir-to-beam/src/lower.rs:2019` `next_reg: u8 >= 255`, from PR #3898) — unrelated to this diff and only on a newer local toolchain; CI's pinned toolchain is unaffected.

## Security & safety

Security review **PASSED**: the new code is a pure O(N) in-place IIR retype + an error-propagating compile entry (no `unwrap`/`expect`/indexing/overflow on adversarial IIR); the test spawns `erl` with `Vec` args (no shell/injection; the `-eval` module name is a hardcoded test literal) + a pid-scoped temp dir. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Establishes **BEAM F1** + reuses the real-`erl` harness (W9a ✅, W9 now ◑). **Next: W9b** — BEAM cons (the native list-cell lowering `put_list`/`get_hd`/`get_tl`), and **W6b-2** (CLR cons) once #5296 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)