### PR TITLE
feat(mccarthy-lisp): W6b-2 — run McCarthy cons on the CLR (F2) — CLR cons complete (LANG77)

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.8.0] — 2026-06-10 — McCarthy cons: `box`/`unbox` lowering (W6b)
+
+Lower the shared structural pass's `box`/`unbox` ops: `box` → `ldloc ; box [int32] ; stloc`,
+`unbox` → `ldloc ; unbox.any [int32] ; stloc`. With the already-supported
+`alloc`/`field_*` (`newarr`/`stelem.ref`/`ldelem.ref` over `System.Object[]`),
+McCarthy **cons** runs: `(CAR (CONS 7 9))` → 7 on the in-repo `clr-simulator`.
+Removed `box`/`unbox` from `UNSUPPORTED_OPS`; the validator already accepted
+`ref<any>` and now lists `box`/`unbox` as heap ops.
+
 All notable changes to this crate are documented here.
 
 ## [0.7.0] — 2026-06-01 (G4 — `print_i64` host call → `env.BasicRuntime::PrintI64(int64)`)

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -60,7 +60,7 @@ use std::collections::{BTreeMap, HashMap};
 use interpreter_ir::{IIRModule, Operand};
 use ir_to_cil_bytecode::backend::{CILMethodArtifact, CILProgramArtifact};
 use ir_to_cil_bytecode::builder::{CILBranchKind, CILBytecodeBuilder, CILOpcode};
-use ir_to_cil_bytecode::{OBJECT_ARRAY_TYPE_TOKEN, INT32_ARRAY_TYPE_TOKEN};
+use ir_to_cil_bytecode::{OBJECT_ARRAY_TYPE_TOKEN, INT32_ARRAY_TYPE_TOKEN, INT32_TYPE_TOKEN};
 
 /// Sentinel token for `System.Console.WriteLine(int64)`.
 ///
@@ -1359,6 +1359,41 @@ pub fn lower_iir_to_cil(
                     builder.emit_ldc_i4(field_idx);             // push index
                     emit_load(&mut builder, &value, fn_name)?;  // push value
                     builder.emit_stelem_ref();                   // array[idx] = value
+                }
+
+                // ── box dest src ; unbox.any dest src (McCarthy W6b) ──────────
+                //
+                // The uniform-reference value model's atom boxing — the CLR
+                // counterpart of the wasm `i31ref` and the JVM `Integer`. The
+                // shared structural pass emits these `box`/`unbox` ops; on the CLR
+                // a boxed `int32` lives in an `object[]` cons cell.
+                //   box      → ldloc src ; box [int32] ; stloc dest
+                //   unbox.any→ ldloc src ; unbox.any [int32] ; stloc dest
+                "box" => {
+                    let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                        IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "box instruction must have a dest".into(),
+                        }
+                    })?;
+                    let dest = reg_info!(dest_name).clone();
+                    let src = get_operand_reg(&instr.srcs, 0, &reg_map, fn_name)?;
+                    emit_load(&mut builder, &src, fn_name)?;
+                    builder.emit_box(INT32_TYPE_TOKEN);
+                    emit_store(&mut builder, &dest, fn_name)?;
+                }
+                "unbox" => {
+                    let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                        IIRClrError::InvalidOperand {
+                            function: fn_name.clone(),
+                            detail: "unbox instruction must have a dest".into(),
+                        }
+                    })?;
+                    let dest = reg_info!(dest_name).clone();
+                    let src = get_operand_reg(&instr.srcs, 0, &reg_map, fn_name)?;
+                    emit_load(&mut builder, &src, fn_name)?;
+                    builder.emit_unbox_any(INT32_TYPE_TOKEN);
+                    emit_store(&mut builder, &dest, fn_name)?;
                 }
 
                 // ── is_null dest x ────────────────────────────────────────────

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -97,8 +97,7 @@ const UNSUPPORTED_OPS: &[&str] = &[
     // "load_mem"   — Brainfuck: now supported (ldelem.u1 over env.BFRuntime::__tape).
     // "store_mem"  — Brainfuck: now supported (stelem.i1 over env.BFRuntime::__tape).
     // "alloc"      — promoted in Phase 2 (ref<LispyPair> only)
-    "box",
-    "unbox",
+    // "box" / "unbox" — promoted in McCarthy W6b (box [int32] / unbox.any [int32]).
     // "field_load" — promoted in Phase 2
     // "field_store" — promoted in Phase 2
     // "is_null"    — promoted in Phase 2
@@ -368,6 +367,8 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
                     "alloc" | "field_load" | "field_store" | "is_null"
                     | "const" | "ret" | "load_reg" | "store_reg"
                     | "jmp_if_true" | "jmp_if_false" | "mov"
+                    // McCarthy W6b: `box` produces a `ref<any>` (boxed int32).
+                    | "box" | "unbox"
                 );
                 if !(is_supported_ref && is_heap_op) {
                     errors.push(format!(

--- a/code/packages/rust/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0] — 2026-06-10 — `box`/`unbox.any` opcodes (McCarthy W6b)
+
+Added the `Box` (0x8C) and `UnboxAny` (0xA5) CIL opcodes + `emit_box`/`emit_unbox_any`
+builder methods and an `INT32_TYPE_TOKEN` (the `System.Object[]` cons-cell atom
+boxing). These let the CLR backend box an `int32` McCarthy atom into an `object`
+(the CLR counterpart of the wasm `i31ref` / JVM `Integer`).
+
 ## [0.2.0] — 2026-05-11
 
 ### Added — Bitwise OR, XOR, NOT lowering

--- a/code/packages/rust/ir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/ir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ir-to-cil-bytecode"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/code/packages/rust/ir-to-cil-bytecode/src/builder.rs
+++ b/code/packages/rust/ir-to-cil-bytecode/src/builder.rs
@@ -75,6 +75,13 @@ pub const OBJECT_ARRAY_TYPE_TOKEN: u32 = 0x0100_0001;
 /// and `stelem.i4`.
 pub const INT32_ARRAY_TYPE_TOKEN: u32 = 0x0100_0002;
 
+/// Metadata token for the **`System.Int32` value type** — the operand of
+/// `box`/`unbox.any` when boxing a McCarthy integer atom (row 2 by the same
+/// convention as [`INT32_ARRAY_TYPE_TOKEN`]). The in-repo `clr-simulator`
+/// ignores the operand (box/unbox.any are identity there); a full PE packager
+/// would resolve it to the real `System.Int32` `TypeRef`.
+pub const INT32_TYPE_TOKEN: u32 = 0x0100_0002;
+
 // ---------------------------------------------------------------------------
 // CILBuilderError
 // ---------------------------------------------------------------------------
@@ -209,6 +216,18 @@ pub enum CILOpcode {
     /// `array[index]`.  Used with `dup` to build cons cells in-place without
     /// a separate helper method.
     StElemRef = 0xA4,
+    /// `box <typeTok>` (0x8C) — box a value type into an object reference.
+    ///
+    /// Stack: `..., value → ..., obj`. McCarthy W6b: boxes an `int32` atom so it
+    /// can live in an `object[]` cons cell, the CLR counterpart of the wasm
+    /// `i31ref`. (The in-repo `clr-simulator` treats it as identity in its loose
+    /// model, like the wasm `i31`.)
+    Box       = 0x8C,
+    /// `unbox.any <typeTok>` (0xA5) — the dual of `box`.
+    ///
+    /// Stack: `..., obj → ..., value`. Unwraps a boxed `int32` at the
+    /// entry/return boundary.
+    UnboxAny  = 0xA5,
     PrefixFe  = 0xFE,
 }
 
@@ -530,6 +549,17 @@ impl CILBytecodeBuilder {
     /// Emit `newarr <type_token>`.
     pub fn emit_newarr(&mut self, token: u32) {
         self.emit_token_instruction(CILOpcode::NewArr, token);
+    }
+
+    /// Emit `box <type_token>` (0x8C): box a value type into an object reference
+    /// (McCarthy W6b — wrap an `int32` atom for an `object[]` cons cell).
+    pub fn emit_box(&mut self, token: u32) {
+        self.emit_token_instruction(CILOpcode::Box, token);
+    }
+
+    /// Emit `unbox.any <type_token>` (0xA5): the dual of `box`.
+    pub fn emit_unbox_any(&mut self, token: u32) {
+        self.emit_token_instruction(CILOpcode::UnboxAny, token);
     }
 
     // ── Comparison opcodes (two-byte, 0xFE prefix) ────────────────────────

--- a/code/packages/rust/ir-to-cil-bytecode/src/lib.rs
+++ b/code/packages/rust/ir-to-cil-bytecode/src/lib.rs
@@ -83,6 +83,7 @@ pub use builder::{
     CILOpcode,
     OBJECT_ARRAY_TYPE_TOKEN,
     INT32_ARRAY_TYPE_TOKEN,
+    INT32_TYPE_TOKEN,
     encode_i4,
     encode_ldc_i4,
     encode_ldarg,

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.28.0 — 2026-06-10 — McCarthy → **CLR cons** on the simulator (LANG77 / W6b)
+
+`compile_source_to_cil_artifact` now runs the **managed value-model pipeline**
+(the same `lower_heap_builtins` + `intern_symbols_structural` +
+`lower_lisp_repr_structural` the wasm/JVM paths use), so McCarthy **cons** runs on
+the CLR: `(CAR (CONS 7 9))` → 7, `(CDR (CONS 7 9))` → 9, nested cons too, on the
+object-capable in-repo `clr-simulator` (W6b-1). The structural passes emit
+backend-agnostic `box`/`unbox`/`alloc`/`field_*`; `iir-to-cil-bytecode` 0.8.0
+lowers them to `box [int32]`/`unbox.any` + `object[]` cells (where wasm uses
+`i31ref`/`$LispyPair` and the JVM `Integer`/`Object[]`). New `tests/cil_cons.rs`.
+
 ## 0.27.0 — 2026-06-10 — McCarthy → **BEAM (Erlang VM)** run-foundation (scalar) (LANG77 / W9a)
 
 Adds `compile_source_to_beam` — the **fourth** managed `--emit` target and the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -27,10 +27,13 @@ the JVM `ldc` constant-pool path. And `LAMBDA`/`LABEL`/recursion (W5b):
 `((LAMBDA (X) X) 5)` → 5, a recursive `LABEL` → 99. **The JVM backend is now
 McCarthy-complete (F1–F7)** — the second managed backend after WASM.
 
-`compile_source_to_cil_artifact` is the third managed target (W6a): scalar
-McCarthy emits CIL that **runs** — verified on the in-repo `clr-simulator`
-(`42` → 42), no external `dotnet`. The CLR cons/symbol/lambda value model
-(uniform-`object`, reusing the JVM strict-backend fixes) is W6b+.
+`compile_source_to_cil_artifact` is the third managed target: scalar McCarthy
+emits CIL that **runs** on the in-repo `clr-simulator` (`42` → 42; W6a), and
+**cons** too — `(CAR (CONS 7 9))` → 7 (W6b, after the simulator gained an
+object/reference value model). It runs the *same* structural passes as the
+wasm/JVM paths; the CLR backend lowers the backend-agnostic
+`box`/`unbox`/`alloc`/`field_*` to `box [int32]`/`unbox.any` + `object[]` cells.
+The remaining CLR predicates/symbols/lambda (F3–F7) are W7–W8.
 
 `compile_source_to_beam` is the fourth managed target and the first on the
 **Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -594,6 +594,14 @@ pub fn compile_source_to_cil_artifact(
     name: &str,
 ) -> Result<iir_to_cil_bytecode::CILProgramArtifact, LangAotError> {
     let mut module = compile_source_to_iir(language, source, name)?;
+    // The managed value-model pipeline — the same backend-agnostic structural
+    // passes the wasm/JVM paths use. The CLR backend lowers `box`/`unbox`/
+    // `alloc`/`field_*` to `box [int32]`/`unbox.any` + `object[]` cons cells
+    // (where wasm uses `i31ref`/`$LispyPair` and the JVM `Integer`/`Object[]`).
+    // A no-op for a module without cons/symbols (W6a scalar still flows through).
+    iir_builtin_lowering::lower_heap_builtins(&mut module);
+    iir_builtin_lowering::intern_symbols_structural(&mut module);
+    iir_builtin_lowering::lower_lisp_repr_structural(&mut module);
     concretize_scalar_any_for_cil(&mut module);
 
     let config = iir_to_cil_bytecode::IIRClrConfig::new(name);

--- a/code/packages/rust/lang-aot/tests/cil_cons.rs
+++ b/code/packages/rust/lang-aot/tests/cil_cons.rs
@@ -1,0 +1,33 @@
+//! # CLR cons + run tests (LANG77 / McCarthy W6b).
+//!
+//! McCarthy cons cells (`System.Object[]`) run on the in-repo `clr-simulator`
+//! (which gained an object/reference value model in W6b-1). `compile_source_to_cil_artifact`
+//! runs the *same* shared structural passes as the wasm/JVM paths; the CLR
+//! backend lowers the backend-agnostic `box`/`unbox`/`alloc`/`field_*` to
+//! `box [int32]`/`unbox.any` + `newarr`/`stelem.ref`/`ldelem.ref`.
+
+use clr_simulator::{CLRSimulator, Value};
+use lang_aot::{compile_source_to_cil_artifact, Language};
+
+/// Compile a program to CIL, run its `main` on the simulator, return the int
+/// left on the stack by `ret`.
+fn run(src: &str) -> i32 {
+    let artifact = compile_source_to_cil_artifact(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let main = artifact.methods.iter().find(|m| m.name == "main").expect("a `main` method");
+    let mut sim = CLRSimulator::new();
+    sim.load(&main.body, main.local_types.len());
+    sim.run(10_000);
+    match sim.stack.last() {
+        Some(Some(Value::Int(n))) => *n,
+        other => panic!("`{src}` left {other:?} on the stack"),
+    }
+}
+
+#[test]
+fn mccarthy_cons_car_cdr_run_on_clr() {
+    assert_eq!(run("(CAR (CONS 7 9))"), 7, "car of a cons");
+    assert_eq!(run("(CDR (CONS 7 9))"), 9, "cdr of a cons");
+    assert_eq!(run("(CAR (CDR (CONS 1 (CONS 2 3))))"), 2, "car of cdr of nested cons");
+    assert_eq!(run("42"), 42, "scalar still works through the cons pipeline");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -61,7 +61,7 @@ representation + per-builtin backend lowering.
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
-| **CLR** | `iir-to-cil-bytecode` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
+| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -153,7 +153,7 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   in-repo **`clr-simulator`** (zero external `dotnet`, mirroring `jvm-simulator`):
   `42`→42, `0`→0, `7`→7, Twig `42`→42. Establishes the CLR pipeline + run-verify
   harness that W6b+ build on.
-- ◑ **W6b — CLR cons (F2).** *In progress.*
+- ✅ **W6b — CLR cons (F2).** Completed in two sub-slices.
   - ✅ **W6b-1 — `clr-simulator` object/reference value model.** Real `dotnet`
     turned out non-viable as an in-repo runner (no PE/assembly emitter, no
     `ilasm`), so — per the backend's design intent ("artifact ready for the CLR
@@ -164,12 +164,14 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     (`nib-clr`, `brainfuck-clr`, `iir-to-cil`) green. This is the in-repo
     run-verify substrate for CLR objects (the analog of `wasm-execution`'s
     `GcStruct`).
-  - ☐ **W6b-2 — McCarthy cons on the simulator.** Add the `iir-to-cil` atom
-    boxing (`box [mscorlib]System.Int32` / `unbox.any`), remove `box`/`unbox`
-    from its `UNSUPPORTED_OPS`, retype `ref<any>`→`object`, run the shared
-    structural passes (incl. the JVM strict-backend fixes) in
-    `lang-aot::compile_source_to_cil`, and verify `(CAR (CONS 7 9))`→7 on the
-    extended `clr-simulator`.
+  - ✅ **W6b-2 — McCarthy cons on the simulator.** Added the `iir-to-cil` atom
+    boxing (`box [int32]` / `unbox.any` — new `Box`/`UnboxAny` opcodes +
+    `emit_box`/`emit_unbox_any` + `INT32_TYPE_TOKEN` in `ir-to-cil-bytecode`),
+    removed `box`/`unbox` from `UNSUPPORTED_OPS` (the validator already accepted
+    `ref<any>`), and ran the shared structural passes (incl. the JVM
+    strict-backend fixes) in `lang-aot::compile_source_to_cil_artifact`.
+    `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, nested cons→2, on the
+    object-capable `clr-simulator` (`tests/cil_cons.rs`).
 - ☐ **W7 — CLR `ATOM`/`EQ`/`COND` (F3–F5).** `isinst`; equality; truthiness.
 - ☐ **W8 — CLR symbols + lambda (F6–F7).** **Completes CLR.**
 


### PR DESCRIPTION
## What & why — McCarthy cons runs on the CLR

Completes **W6b (CLR cons)**. `(CAR (CONS 7 9))` → 7, verified on the object-capable in-repo `clr-simulator` (extended in W6b-1). The shared structural pass + the JVM strict-backend fixes did the heavy lifting; this slice only adds the CLR-specific `box`/`unbox` lowering + wires the pipeline.

## Change

**`ir-to-cil-bytecode` 0.3.0** — `Box` (0x8C) / `UnboxAny` (0xA5) `CILOpcode`s + `emit_box`/`emit_unbox_any` + `INT32_TYPE_TOKEN`.

**`iir-to-cil-bytecode` 0.8.0**
- `box`   → `ldloc src ; box [int32] ; stloc dest`
- `unbox` → `ldloc src ; unbox.any [int32] ; stloc dest`
- Removed `box`/`unbox` from `UNSUPPORTED_OPS` + added to the validator's heap-op list (`ref<any>` was already accepted). With the already-supported `alloc`/`field_*` (`newarr`/`stelem.ref`/`ldelem.ref` over `object[]`), cons runs.

**`lang-aot` 0.28.0** — `compile_source_to_cil_artifact` runs the **same** structural passes as the wasm/JVM paths. The pass output is backend-agnostic: wasm→`i31ref`/`$LispyPair`, JVM→`Integer`/`Object[]`, CLR→`box[int32]`/`object[]`.

## Verified by RUNNING (`tests/cil_cons.rs`)

`(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, `(CAR (CDR (CONS 1 (CONS 2 3))))`→2, scalar `42`→42 — on the `clr-simulator`.

## Test plan

Suites green — `iir-to-cil-bytecode` **59**, `ir-to-cil-bytecode` + lang-aot (`cil_cons` 1, `cil_emit` 2); my CLR crates clippy-clean. **NOTE:** `cargo clippy -p iir-to-beam` flags a **pre-existing** lint (`iir-to-beam/src/lower.rs:2019` `next_reg:u8>=255`, PR #3898) pulled in transitively via lang-aot's `iir-to-beam` dep — unrelated to this diff; CI's pinned toolchain is unaffected.

## Security & safety

Security review **PASSED**: the `box`/`unbox` arms are Option/Result-guarded (no panic on malformed IIR); emitted CIL is stack-balanced + the 4-byte token width is correct; O(1) per instruction; `INT32_TYPE_TOKEN` is a documented sentinel the simulator ignores. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Completes **CLR F2 (cons)** — W6b ✅. **Next: W7** (CLR `ATOM`/`EQ`/`COND`), reusing the same structural pass + the object-capable simulator (`isinst` for `pair?`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)