### PR TITLE
feat(closurec): CLOC12.64 — close gap-055 (paren elision around ternary/`:` arms)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.68.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-055** — paren elision around a whole-arm
+  sub-expression following `?` or `:`. Matches upstream on
+  ternary arms (`x?(a=1):(b=2)` → `x?a=1:b=2`), object-literal
+  values (`{a:(b+c)}` → `{a:b+c}`), and label/case bodies
+  (`foo:(x);` → `foo:x;`).
+
+### Added
+
+Token-stream pre-pass: when prev is `?` or `:` and next is
+`(`, scan to the matching `)`. Drop both parens iff:
+- the token after `)` is an arm-terminator (`:`/`;`/`,`/`)`/
+  `]`/`}`/EOF) — so the parens span the COMPLETE arm; and
+- no top-level `,` inside (preserves the comma operator).
+
+Whole-arm guard prevents precedence-shift bugs:
+`x?(a=1)+2:c` stays (next-after-`)` is `+`). `?.` lexes as a
+single OPTIONAL_CHAIN token so optional calls (`a?.(b)`) are
+never matched. 9 edge cases verified against upstream.
+
+(Skipping no versions — 0.68.0 follows 0.67.0.)
+
 ## [0.67.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.67.0"
+version = "0.68.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -327,6 +327,101 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // gap-055: paren elision around a *whole-arm* sub-
+    // expression that follows `?` or `:`. Upstream Closure
+    // strips redundant grouping parens around:
+    //   - ternary then-arm:   `x?(E):y`   → `x?E:y`
+    //   - ternary else-arm:   `x?y:(E)`   → `x?y:E`
+    //   - object-literal val:  `{a:(E)}`  → `{a:E}`
+    //   - label / `case` body: `foo:(E);` → `foo:E;`
+    //
+    // SAFETY — three guards, all necessary:
+    //
+    //   1. WHOLE-ARM: the token AFTER the matching `)` must be
+    //      a delimiter that ends the sub-expression (`:` for a
+    //      then-arm, or one of `, ; ) ] }` / EOF for an else-
+    //      arm / value). Otherwise dropping changes precedence,
+    //      e.g. `x?(a=1)+2:c` must stay (next-after-`)` is `+`).
+    //
+    //   2. NO TOP-LEVEL COMMA: `(a,b)` is a comma operator —
+    //      semantically distinct from `a,b` in these positions.
+    //      Upstream keeps it; so do we.
+    //
+    //   3. STRUCTURAL-ONLY token matching: a string / regex /
+    //      template literal stores its *content* in `.value`
+    //      (delimiters stripped), so a one-char string `")"`
+    //      has `.value == ")"`. We MUST gate every bracket /
+    //      comma / `?` / `:` comparison on `is_structural_punct`
+    //      — else a bracket char inside a literal corrupts the
+    //      depth counter and the wrong token gets removed,
+    //      producing broken output like `x?):y` from
+    //      `x?(")"):y`.
+    //
+    // `?.` lexes as a single OPTIONAL_CHAIN token, so the
+    // `prev == "?"` test never fires on optional chaining
+    // (`a?.(b)` is left untouched).
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 1;
+        while i + 1 < kept.len() {
+            let prev_is_arm_open = is_structural_punct(&kept[i - 1], "?")
+                || is_structural_punct(&kept[i - 1], ":");
+            if prev_is_arm_open && is_structural_punct(&kept[i], "(") {
+                let open_idx = i;
+                let mut depth: i32 = 1;
+                let mut has_top_level_comma = false;
+                let mut close_idx: Option<usize> = None;
+                let mut j = open_idx + 1;
+                while j < kept.len() {
+                    let t = &kept[j];
+                    if is_structural_punct(t, "(")
+                        || is_structural_punct(t, "[")
+                        || is_structural_punct(t, "{")
+                    {
+                        depth += 1;
+                    } else if is_structural_punct(t, ")") {
+                        depth -= 1;
+                        if depth == 0 {
+                            close_idx = Some(j);
+                            break;
+                        }
+                    } else if is_structural_punct(t, "]")
+                        || is_structural_punct(t, "}")
+                    {
+                        depth -= 1;
+                    } else if depth == 1 && is_structural_punct(t, ",") {
+                        has_top_level_comma = true;
+                    }
+                    j += 1;
+                }
+                if let Some(close_idx) = close_idx {
+                    let arm_complete = match kept.get(close_idx + 1) {
+                        None => true,
+                        Some(t) => {
+                            is_structural_punct(t, ":")
+                                || is_structural_punct(t, ";")
+                                || is_structural_punct(t, ",")
+                                || is_structural_punct(t, ")")
+                                || is_structural_punct(t, "]")
+                                || is_structural_punct(t, "}")
+                        }
+                    };
+                    if arm_complete && !has_top_level_comma {
+                        drops.push(open_idx);
+                        drops.push(close_idx);
+                        i = close_idx + 1;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     let kept = kept;
 
     // Re-stitch: insert a single space between two adjacent
@@ -1570,6 +1665,26 @@ fn needs_separator(a: &lexer::token::Token, b: &lexer::token::Token) -> bool {
 ///
 /// String literals are NOT word-like in this sense: `"a""b"`
 /// re-tokenizes correctly as two strings.
+/// True iff `tok` is a *structural punctuator* whose `.value`
+/// equals `val` — i.e. a real operator/bracket token and NOT a
+/// literal that merely happens to CONTAIN that character.
+///
+/// This matters because a string/regex/template literal stores
+/// its *content* in `.value` (the lexer strips the delimiters),
+/// so a one-character string `")"` has `.value == ")"`. Any
+/// token-level peephole that depth-tracks brackets by comparing
+/// `.value` against `"("` / `")"` / `","` MUST gate on this, or
+/// a bracket char inside a literal corrupts the depth count and
+/// the wrong token gets matched/removed.
+///
+/// Word-like tokens (REGEX, TEMPLATE*, BIGINT, NAME, …) and
+/// string literals are the only kinds that can smuggle a bracket
+/// character into `.value`; excluding both leaves exactly the
+/// punctuator tokens.
+fn is_structural_punct(tok: &lexer::token::Token, val: &str) -> bool {
+    tok.value == val && !is_string_literal(tok) && !is_word_like(tok)
+}
+
 fn is_word_like(tok: &lexer::token::Token) -> bool {
     // Prefer the grammar's type_name when present; fall back to
     // the structural TokenType for the basic categories.

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.67.0
+Version: 0.68.0
 
 ## Flags
 

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -435,10 +435,6 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-055 — paren elision around ternary arms (single-expression)
 
-- **Status:** OPEN — newly discovered by CLOC14.25 AFTER 3 consecutive zero rounds. Marathon was NOT converged.
-- **Upstream byte-identity test:** `minify_ternary_assign` seed fixture.
-- **Input:** `var r = x>0?(a=1):(b=2);`
-- **Upstream:** `var r=x>0?a=1:b=2;`
-- **closurec:** `var r=x>0?(a=1):(b=2);`
-- **Why it fails:** closurec passes source parens through. Upstream strips parens around ternary arms when contents are a single assignment — `=` binds tighter than `?:` so parens are redundant.
-- **What it needs:** Token-level peephole: when prev is `?` or `:` (ternary context) and next is `(`, scan to matching `)`. If contents are single expression (no `,` at depth 0, no `?` at depth 0), drop both parens.
+- **Status:** **RESOLVED** in CLOC12.64 (PR pending). Discovered by CLOC14.25 AFTER 3 consecutive zero rounds (marathon was NOT converged). `minify_ternary_assign` flips IGNORED → PASS.
+- **Input:** `var r = x>0?(a=1):(b=2);` → **Upstream:** `var r=x>0?a=1:b=2;`
+- **Fix:** Token-stream pre-pass: when prev is `?` or `:` and next is `(`, scan to matching `)`. Drop both parens iff the token after `)` is an arm-terminator (`:`/`;`/`,`/`)`/`]`/`}`/EOF — parens span the WHOLE arm) and no top-level `,` inside. Whole-arm guard prevents precedence shifts (`x?(a=1)+2:c` stays). `?.` lexes as single OPTIONAL_CHAIN token so optional calls are safe.


### PR DESCRIPTION
## Summary

**Closes gap-055.** Stacks on #5298 (CLOC14.25 fixture).

Token-stream pre-pass strips redundant grouping parens around a whole-arm sub-expression after `?` or `:` — covers ternary arms, object-literal values, and label/case bodies. Matches upstream Closure across all 11 verified edge cases.

## Security review — found + fixed a real corruption bug

First review pass caught a literal-content hazard: a string whose content is `)` (`.value == ")"`) was treated as a bracket, corrupting `x?(")"):y` → `x?):y`. Fixed with a new `is_structural_punct` guard that excludes string + word-like (regex/template/bigint) tokens from all bracket/comma/`?`/`:` comparisons. Re-review confirmed the hole is fully closed.

## Tests

Full suite **406 passed**. 11 edge cases byte-identical vs upstream, including `x?(a=1)+2:c` (kept), `x?(a,b):(c)` (comma kept), `a?.(b)` (optional call kept), `x?(")"):y` → `x?")":y`.

## Stacking

After #5298 lands: only gap-044 (lexer template substitution) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)