### PR TITLE
feat(mccarthy-lisp): W7 — run McCarthy ATOM/EQ/COND on the CLR (F3–F5) (LANG77)

### DIFF
--- a/code/packages/rust/clr-simulator/CHANGELOG.md
+++ b/code/packages/rust/clr-simulator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0] — 2026-06-10 — McCarthy predicates: isinst + xor + ref-aware compares (W7)
+
+- `isinst <typeTok>` (0x75): the `pair?` type test — keep a heap `object[]` ref,
+  else push `null` (the CLR twin of JVM `instanceof` / wasm `ref.test`).
+- `xor` (0x61): McCarthy logical `not` lowers to `x ^ 1`.
+- Comparison opcodes (`ceq`/`cgt`/`clt`) are now **reference-aware** via a new
+  `as_cmp_int` (null→0, heap ref→1) so `pair?`/`is_null` can `ceq` a reference
+  against `ldnull` without the strict arithmetic guard firing.
+- **Fix:** `ldnull` is `0x14` (was mis-defined as `0x01` = `break`); a latent bug
+  the cons path never hit but `pair?`/`is_null` do. Existing consumers unaffected.
+
 All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - 2026-06-10 — object/reference value model (LANG77 / McCarthy W6b)

--- a/code/packages/rust/clr-simulator/Cargo.toml
+++ b/code/packages/rust/clr-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clr-simulator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "CLR bytecode simulator — Microsoft's Common Language Runtime"
 

--- a/code/packages/rust/clr-simulator/README.md
+++ b/code/packages/rust/clr-simulator/README.md
@@ -16,6 +16,12 @@ reference opcodes `newarr`, `stelem.ref`, `ldelem.ref`, `dup`, and identity
 `box`/`unbox.any` run — enough to execute the `System.Object[]` cons cells the
 IIR→CIL backend emits for McCarthy Lisp (LANG77 / W6b).
 
+Since 0.3.0 it runs McCarthy's **predicates** (W7): `isinst` (the `pair?` type
+test — keep a heap ref, else `null`), `xor` (logical `not` = `x^1`), and
+**reference-aware** `ceq`/`cgt`/`clt` (so `pair?`/`is_null` can compare a
+reference against `ldnull`). This release also fixes `ldnull` to its real CIL
+opcode `0x14` (was `0x01`), a latent bug the cons path never exercised.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/clr-simulator/src/lib.rs
+++ b/code/packages/rust/clr-simulator/src/lib.rs
@@ -45,7 +45,7 @@ use std::fmt;
 // ===========================================================================
 
 pub const OP_NOP: u8 = 0x00;
-pub const OP_LDNULL: u8 = 0x01;
+pub const OP_LDNULL: u8 = 0x14;
 pub const OP_LDLOC_0: u8 = 0x06;
 pub const OP_LDLOC_3: u8 = 0x09;
 pub const OP_STLOC_0: u8 = 0x0A;
@@ -65,6 +65,8 @@ pub const OP_ADD: u8 = 0x58;
 pub const OP_SUB: u8 = 0x59;
 pub const OP_MUL: u8 = 0x5A;
 pub const OP_DIV: u8 = 0x5B;
+/// `xor` (0x61) — McCarthy W7 logical `not` lowers to `x ^ 1`.
+pub const OP_XOR: u8 = 0x61;
 /// `box <typeTok>` — McCarthy W6b. Boxes a value type into an object reference.
 /// In this loose model the `Int` already roundtrips through `object[]`, so `box`
 /// is identity (skips the 4-byte type token). Mirrors the wasm `i31` box no-op.
@@ -79,6 +81,10 @@ pub const OP_STELEM_REF: u8 = 0xA4;
 /// `unbox.any <typeTok>` — McCarthy W6b. The dual of `box`; identity here (skips
 /// the 4-byte type token).
 pub const OP_UNBOX_ANY: u8 = 0xA5;
+/// `isinst <typeTok>` (0x75) — McCarthy W7 `pair?`. Pops a reference; pushes it
+/// back if it is an `object[]` (a cons cell), else pushes `null`. The CLR
+/// counterpart of the JVM `instanceof` and the wasm `ref.test`.
+pub const OP_ISINST: u8 = 0x75;
 pub const OP_PREFIX_FE: u8 = 0xFE;
 
 /// DoS guard: the maximum `newarr` length the simulator will allocate. A single
@@ -111,6 +117,19 @@ impl Value {
         match self {
             Value::Int(n) => n,
             Value::Ref(_) => panic!("expected an int on the CLR stack, found a reference"),
+        }
+    }
+
+    /// Reference-aware integer projection for **comparison** opcodes only
+    /// (`ceq`/`cgt`/`clt`). Unlike [`as_int`], this does not panic on a
+    /// reference: `null` ranks 0 and any heap reference ranks 1, matching their
+    /// truthiness. This lets `pair?`/`is_null` compare a reference against
+    /// `ldnull` without the strict arithmetic guard firing.
+    fn as_cmp_int(self) -> i32 {
+        match self {
+            Value::Int(n) => n,
+            Value::Ref(None) => 0,
+            Value::Ref(Some(_)) => 1,
         }
     }
 
@@ -323,6 +342,21 @@ impl CLRSimulator {
             self.pc += 5; // opcode + 4-byte type token
             return self.trace(pc, "unbox.any", stack_before, "unbox.any (identity)".to_string());
         }
+        if opcode_byte == OP_ISINST {
+            // isinst <typeTok>: the McCarthy `pair?` type test. A cons cell is a
+            // heap `object[]` (`Ref(Some)`); an atom is a boxed int (`Int`); nil
+            // is `Ref(None)`. So "is this an object[]?" ≡ "is it a heap ref?":
+            // keep `Ref(Some)`, otherwise push `null`. The token is ignored (the
+            // loose model has exactly one reference kind — the cons array).
+            let value = self.pop().expect("isinst operand");
+            let result = match value {
+                Value::Ref(Some(i)) => Value::Ref(Some(i)),
+                _ => Value::Ref(None),
+            };
+            self.stack.push(Some(result));
+            self.pc += 5; // opcode + 4-byte type token
+            return self.trace(pc, "isinst", stack_before, format!("{value} isinst object[] → {result}"));
+        }
 
         // Arithmetic operations.
         if opcode_byte == OP_ADD {
@@ -333,6 +367,9 @@ impl CLRSimulator {
         }
         if opcode_byte == OP_MUL {
             return self.execute_arithmetic(stack_before, "mul", |a, b| a.wrapping_mul(b));
+        }
+        if opcode_byte == OP_XOR {
+            return self.execute_arithmetic(stack_before, "xor", |a, b| a ^ b);
         }
         if opcode_byte == OP_DIV {
             let b_val = self.pop_int();
@@ -415,8 +452,15 @@ impl CLRSimulator {
     fn execute_two_byte_opcode(&mut self, stack_before: Vec<Option<Value>>) -> CLRTrace {
         let pc = self.pc;
         let second_byte = self.bytecode[pc + 1];
-        let b = self.pop_int();
-        let a = self.pop_int();
+        // Comparisons are reference-aware: McCarthy `pair?`/`is_null` compare a
+        // reference against `null` (`isinst …; ldnull; ceq`). Map a reference to
+        // its truthiness rank for the compare — `null` → 0, a cons ref → 1 — so
+        // `ceq` against `ldnull` (0) answers "is it null?" without panicking.
+        // Atoms remain their integer value (this never collides: an atom that
+        // happens to be 0/1 is only ever compared with `equal?`, which unboxes
+        // both sides to genuine ints first).
+        let b = self.pop().expect("Cannot compare null").as_cmp_int();
+        let a = self.pop().expect("Cannot compare null").as_cmp_int();
         let (mnemonic, op_str, result) = match second_byte {
             CEQ_BYTE => ("ceq", "==", if a == b { 1 } else { 0 }),
             CGT_BYTE => ("cgt", ">", if a > b { 1 } else { 0 }),

--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.9.0] — 2026-06-10 — McCarthy predicates: ATOM / EQ / COND (W7, F3–F5)
+
+Lower the structural pass's `pair?`/`not`/`equal?` `call_builtin`s on the CLR:
+`pair?` → `isinst object[]; ldnull; ceq; ldc.i4.0; ceq`; `not` → `x ^ 1`;
+`equal?` → `unbox.any int32; unbox.any int32; ceq`. `COND` reuses the existing
+`jmp_if_true`/`jmp_if_false`. Whitelisted the three names in the validator.
+`(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(COND …)` all run on the
+`clr-simulator`. These are the CLR twins of the JVM `instanceof`/`ixor`/`if_icmpeq`.
+
 ## [0.8.0] — 2026-06-10 — McCarthy cons: `box`/`unbox` lowering (W6b)
 
 Lower the shared structural pass's `box`/`unbox` ops: `box` → `ldloc ; box [int32] ; stloc`,

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lower.rs
@@ -1803,6 +1803,80 @@ pub fn lower_iir_to_cil(
                             emit_load(&mut builder, &val_info, fn_name)?;
                             builder.emit_call(BASIC_PRINT_I64_TOKEN);
                         }
+
+                        // ── McCarthy W7 predicates (F3–F5) ────────────────────
+                        //
+                        // The CLR twins of the JVM `instanceof`/`ixor`/`if_icmpeq`
+                        // and the wasm `ref.test`/`i32.eqz`/`i32.eq`. The shared
+                        // structural pass decomposes `ATOM x` → `not (pair? x)`
+                        // and `EQ a b` → `equal? a b`; `COND` lowers to the
+                        // already-supported `jmp_if_true`/`jmp_if_false`.
+                        //
+                        // | builtin | layout                         | CIL |
+                        // |---------|--------------------------------|-----|
+                        // | `pair?` | [Var("pair?"), Var(x)]; dest   | `ldloc x; isinst object[]; ldnull; ceq; ldc.i4.0; ceq` |
+                        // | `not`   | [Var("not"), Var(x)]; dest     | `ldloc x; ldc.i4.1; xor` |
+                        // | `equal?`| [Var("equal?"), Var(a), Var(b)]; dest | `ldloc a; unbox.any int32; ldloc b; unbox.any int32; ceq` |
+                        "pair?" => {
+                            // Is the (boxed) lisp value a cons cell? A cons is an
+                            // `object[]` (heap ref); an atom is a boxed int; nil is
+                            // null. `isinst` leaves the ref or null; the two `ceq`s
+                            // turn that into a clean 1 (pair) / 0 (not) — the first
+                            // `ceq ldnull` answers "is it null (≠ pair)?", the
+                            // second flips it (`== 0` ⇒ "was a pair").
+                            let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                                IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"pair?\" requires a dest".into(),
+                                }
+                            })?;
+                            let dest = reg_info!(dest_name).clone();
+                            let arg = get_operand_reg(&instr.srcs, 1, &reg_map, fn_name)?;
+                            emit_load(&mut builder, &arg, fn_name)?;
+                            builder.emit_isinst(OBJECT_ARRAY_TYPE_TOKEN);
+                            builder.emit_ldnull();
+                            builder.emit_ceq();        // 1 if null (not a pair)
+                            builder.emit_ldc_i4(0);
+                            builder.emit_ceq();        // flip → 1 if it was a pair
+                            emit_store(&mut builder, &dest, fn_name)?;
+                        }
+                        "not" => {
+                            // Logical not of a 0/1 bool: `x ^ 1`. (Distinct from the
+                            // top-level Twig `not` op, which is bitwise complement.)
+                            let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                                IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"not\" requires a dest".into(),
+                                }
+                            })?;
+                            let dest = reg_info!(dest_name).clone();
+                            let arg = get_operand_reg(&instr.srcs, 1, &reg_map, fn_name)?;
+                            emit_load(&mut builder, &arg, fn_name)?;
+                            builder.emit_ldc_i4(1);
+                            builder.emit_xor();
+                            emit_store(&mut builder, &dest, fn_name)?;
+                        }
+                        "equal?" => {
+                            // `EQ` on atoms: unbox both and compare. The structural
+                            // pass guarantees both args are boxed atoms (symbols
+                            // interned to ints, integers as ints), so identity
+                            // reduces to integer equality.
+                            let dest_name = instr.dest.as_deref().ok_or_else(|| {
+                                IIRClrError::InvalidOperand {
+                                    function: fn_name.clone(),
+                                    detail: "call_builtin \"equal?\" requires a dest".into(),
+                                }
+                            })?;
+                            let dest = reg_info!(dest_name).clone();
+                            let a = get_operand_reg(&instr.srcs, 1, &reg_map, fn_name)?;
+                            let b = get_operand_reg(&instr.srcs, 2, &reg_map, fn_name)?;
+                            emit_load(&mut builder, &a, fn_name)?;
+                            builder.emit_unbox_any(INT32_TYPE_TOKEN);
+                            emit_load(&mut builder, &b, fn_name)?;
+                            builder.emit_unbox_any(INT32_TYPE_TOKEN);
+                            builder.emit_ceq();
+                            emit_store(&mut builder, &dest, fn_name)?;
+                        }
                         _ => {
                             // Validator should have rejected this; defense in depth.
                             return Err(IIRClrError::UnsupportedOp {

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -131,7 +131,8 @@ const UNSUPPORTED_OPS: &[&str] = &[
 /// (distinct from `env.BFRuntime`) because BASIC's I/O model is
 /// line/value oriented while Brainfuck's is byte-stream oriented; a CLR
 /// runtime can stub or provide either independently.
-pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] = &["putchar", "getchar", "print_i64"];
+pub(crate) const CALL_BUILTIN_SUPPORTED_NAMES: &[&str] =
+    &["putchar", "getchar", "print_i64", "pair?", "not", "equal?"];
 
 // ---------------------------------------------------------------------------
 // Heap ops that need special validation (type-restricted)

--- a/code/packages/rust/ir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/ir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.0] — 2026-06-10 — `isinst` opcode (McCarthy W7 `pair?`)
+
+Added the `IsInst` (0x75) `CILOpcode` + `emit_isinst(token)` builder method — the
+CLR type test backing McCarthy `pair?` (is the boxed value an `object[]` cons cell?).
+
 ## [0.3.0] — 2026-06-10 — `box`/`unbox.any` opcodes (McCarthy W6b)
 
 Added the `Box` (0x8C) and `UnboxAny` (0xA5) CIL opcodes + `emit_box`/`emit_unbox_any`

--- a/code/packages/rust/ir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/ir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ir-to-cil-bytecode"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/code/packages/rust/ir-to-cil-bytecode/src/builder.rs
+++ b/code/packages/rust/ir-to-cil-bytecode/src/builder.rs
@@ -228,6 +228,11 @@ pub enum CILOpcode {
     /// Stack: `..., obj → ..., value`. Unwraps a boxed `int32` at the
     /// entry/return boundary.
     UnboxAny  = 0xA5,
+    /// `isinst <typeTok>` (0x75) — McCarthy W7 `pair?`. Stack: `..., obj → ...,
+    /// result`, where `result` is `obj` if it is an instance of the token's type
+    /// (an `object[]` cons cell) else `null`. The CLR counterpart of the JVM
+    /// `instanceof` and the wasm `ref.test`.
+    IsInst    = 0x75,
     PrefixFe  = 0xFE,
 }
 
@@ -560,6 +565,12 @@ impl CILBytecodeBuilder {
     /// Emit `unbox.any <type_token>` (0xA5): the dual of `box`.
     pub fn emit_unbox_any(&mut self, token: u32) {
         self.emit_token_instruction(CILOpcode::UnboxAny, token);
+    }
+
+    /// Emit `isinst <type_token>` (0x75): McCarthy W7 `pair?` — push the operand
+    /// if it is an instance of the token's type (`object[]`), else `null`.
+    pub fn emit_isinst(&mut self, token: u32) {
+        self.emit_token_instruction(CILOpcode::IsInst, token);
     }
 
     // ── Comparison opcodes (two-byte, 0xFE prefix) ────────────────────────

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `lang-aot`
 
+## 0.29.0 — 2026-06-10 — McCarthy → **CLR ATOM/EQ/COND** on the simulator (LANG77 / W7)
+
+The CLR backend now runs McCarthy's primitive predicates (F3–F5). The same
+managed structural pipeline `compile_source_to_cil_artifact` already runs (no
+driver change) emits `pair?`/`not`/`equal?`/`jmp_if`; `iir-to-cil-bytecode` 0.9.0
++ `clr-simulator` 0.3.0 (new `isinst`/`xor` + ref-aware compares) execute them.
+New `tests/cil_predicates.rs`: `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1,
+`(EQ 7 8)`→0, `(COND ((ATOM 7) 100) ((ATOM 8) 200))`→100, and fall-through→200.
+
 ## 0.28.0 — 2026-06-10 — McCarthy → **CLR cons** on the simulator (LANG77 / W6b)
 
 `compile_source_to_cil_artifact` now runs the **managed value-model pipeline**

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -33,7 +33,9 @@ emits CIL that **runs** on the in-repo `clr-simulator` (`42` → 42; W6a), and
 object/reference value model). It runs the *same* structural passes as the
 wasm/JVM paths; the CLR backend lowers the backend-agnostic
 `box`/`unbox`/`alloc`/`field_*` to `box [int32]`/`unbox.any` + `object[]` cells.
-The remaining CLR predicates/symbols/lambda (F3–F7) are W7–W8.
+McCarthy's predicates run too (W7, F3–F5): `(ATOM 7)`→1, `(EQ 7 7)`→1,
+`(COND …)` — `pair?`→`isinst object[]`, `not`→`x^1`, `equal?`→`unbox; unbox; ceq`.
+The remaining CLR symbols + lambda (F6–F7) are W8.
 
 `compile_source_to_beam` is the fourth managed target and the first on the
 **Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real

--- a/code/packages/rust/lang-aot/tests/cil_predicates.rs
+++ b/code/packages/rust/lang-aot/tests/cil_predicates.rs
@@ -1,0 +1,43 @@
+//! # CLR predicates: ATOM / EQ / COND (LANG77 / McCarthy W7, F3–F5).
+//!
+//! The CLR twins of the JVM `instanceof`/`ixor`/`if_icmpeq` and the wasm
+//! `ref.test`/`i32.eqz`/`i32.eq`. The shared structural pass decomposes
+//! `ATOM x` → `not (pair? x)`, `EQ a b` → `equal? a b`, and `COND` → chained
+//! `jmp_if_true`/`jmp_if_false`; `iir-to-cil-bytecode` lowers `pair?` to
+//! `isinst object[]`, `not` to `x ^ 1`, `equal?` to `unbox.any; unbox.any; ceq`.
+//! Verified by RUNNING the emitted CIL on the in-repo `clr-simulator`.
+
+use clr_simulator::{CLRSimulator, Value};
+use lang_aot::{compile_source_to_cil_artifact, Language};
+
+fn run(src: &str) -> i32 {
+    let artifact = compile_source_to_cil_artifact(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let main = artifact.methods.iter().find(|m| m.name == "main").expect("a `main` method");
+    let mut sim = CLRSimulator::new();
+    sim.load(&main.body, main.local_types.len());
+    sim.run(100_000);
+    match sim.stack.last() {
+        Some(Some(Value::Int(n))) => *n,
+        other => panic!("`{src}` left {other:?} on the stack"),
+    }
+}
+
+#[test]
+fn mccarthy_atom_runs_on_clr() {
+    assert_eq!(run("(ATOM 7)"), 1, "an integer atom IS an atom");
+    assert_eq!(run("(ATOM (CONS 1 2))"), 0, "a cons cell is NOT an atom");
+}
+
+#[test]
+fn mccarthy_eq_runs_on_clr() {
+    assert_eq!(run("(EQ 7 7)"), 1, "equal atoms");
+    assert_eq!(run("(EQ 7 8)"), 0, "unequal atoms");
+}
+
+#[test]
+fn mccarthy_cond_runs_on_clr() {
+    assert_eq!(run("(COND ((ATOM 7) 100) ((ATOM 8) 200))"), 100, "first clause true");
+    assert_eq!(run("(COND ((EQ 1 2) 100) ((EQ 3 3) 200))"), 200, "first false, second true");
+    assert_eq!(run("(COND ((ATOM (CONS 1 2)) 100) ((EQ 5 5) 200))"), 200, "cons is not atom → fall through");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -61,7 +61,7 @@ representation + per-builtin backend lowering.
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
-| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | uniform-object |
+| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -172,7 +172,11 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     strict-backend fixes) in `lang-aot::compile_source_to_cil_artifact`.
     `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, nested cons→2, on the
     object-capable `clr-simulator` (`tests/cil_cons.rs`).
-- ☐ **W7 — CLR `ATOM`/`EQ`/`COND` (F3–F5).** `isinst`; equality; truthiness.
+- ✅ **W7 — CLR `ATOM`/`EQ`/`COND` (F3–F5).** `pair?`→`isinst object[]`, `not`→`x^1`,
+  `equal?`→`unbox.any; unbox.any; ceq`; `COND`→`jmp_if_true`/`jmp_if_false`.
+  `clr-simulator` 0.3.0 gained `isinst`/`xor` + ref-aware `ceq` (and an `ldnull`
+  opcode fix). `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(COND …)`
+  verified on the simulator (`lang-aot/tests/cil_predicates.rs`).
 - ☐ **W8 — CLR symbols + lambda (F6–F7).** **Completes CLR.**
 
 ### Phase D — BEAM (Erlang terms)


### PR DESCRIPTION
## What & why — McCarthy predicates run on the CLR

Makes McCarthy's primitive predicates run on the CLR, **verified by RUNNING** on the in-repo `clr-simulator`. The shared structural pass already decomposes `ATOM x`→`not(pair? x)`, `EQ a b`→`equal? a b`, and `COND`→chained `jmp_if`; this slice adds the CLR-specific predicate lowering + the simulator opcodes to execute it.

## Change

**`ir-to-cil-bytecode` 0.4.0** — `IsInst` (0x75) `CILOpcode` + `emit_isinst` (the CLR `pair?` type test — twin of JVM `instanceof` / wasm `ref.test`).

**`iir-to-cil-bytecode` 0.9.0** — three `call_builtin` arms:
- `pair?`  → `ldloc; isinst object[]; ldnull; ceq; ldc.i4.0; ceq` (clean 1/0)
- `not`    → `ldloc; ldc.i4.1; xor` (logical, `x^1`)
- `equal?` → `ldloc a; unbox.any int32; ldloc b; unbox.any int32; ceq`
- `COND` reuses the existing `jmp_if_true`/`jmp_if_false`. Whitelisted the 3 names.

**`clr-simulator` 0.3.0** — `isinst` (0x75: keep a heap `object[]` ref, else null), `xor` (0x61), and **reference-aware** `ceq`/`cgt`/`clt` (new `as_cmp_int`: null→0, heap ref→1) so `pair?`/`is_null` can `ceq` a reference against `ldnull`. Strict `as_int` still gates arithmetic + the `ldelem` index (no OOB). **Fix:** `ldnull` is `0x14` (was mis-defined `0x01`=`break`) — a latent bug the cons path never hit.

**`lang-aot` 0.29.0** — driver unchanged (the managed pipeline already emits these); new `tests/cil_predicates.rs`.

This is the **same** structural-pass output the wasm/JVM paths consume — wasm `ref.test`/`i32.eqz`/`i32.eq`, JVM `instanceof`/`ixor`/`if_icmpeq`, CLR `isinst`/`xor`/`ceq`.

## Verified by RUNNING (`tests/cil_predicates.rs`)

`(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(EQ 7 8)`→0, `(COND ((ATOM 7) 100) ((ATOM 8) 200))`→100, fall-through→200 — on the `clr-simulator`.

## Test plan

Suites green — `clr-simulator` **33**, `ir-to-cil-bytecode` **86**, `iir-to-cil-bytecode` **59**, `nib-clr` **20**, `brainfuck-clr` **19** (the `ldnull` fix didn't break consumers), `lang-aot` `cil_predicates`/`cil_cons`/`cil_emit`. My crates clippy-clean (`builder.rs:357` manual-range-contains is **pre-existing**, not my diff; the `iir-to-beam` `next_reg` lint is a pre-existing transitive-dep lint).

## Security & safety

Security review **PASSED**: the simulator's new `isinst`/`xor`/compare paths add no OOB/overflow/infinite-loop (controlled panics only, matching the existing oracle); the ref-aware compare loosening masks no memory-safety bug (strict `as_int` still guards every index); the lowering arms are Option/Result-guarded; emitted CIL is stack-balanced. No `lispy-runtime`/`twig-vm` touched → no Miri.

## Matrix

Advances **CLR to F1–F5** (cons + predicates) — W7 ✅. **Next: W8** (CLR symbols + lambda, F6–F7) → **completes CLR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)