### PR TITLE
feat(mccarthy-lisp): W8a — McCarthy symbols (F6) run on the CLR — zero new backend code (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.30.0 — 2026-06-10 — McCarthy → **CLR symbols** on the simulator (LANG77 / W8a, F6)
+
+Symbols (F6) run on the CLR with **zero new backend code** — pure structural-pass
+reuse. The shared `intern_symbols_structural` pass interns each distinct symbol to
+a stable `i32` id in a reserved range (`SYMBOL_ID_BASE = 1 << 29`); W6b boxing +
+W7 `equal?`/`pair?`/`jmp_if` then execute `QUOTE`/`EQ`/`ATOM`/`COND` on symbols.
+`(QUOTE A)`→536870912, `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0,
+`(ATOM (QUOTE A))`→1, on the `clr-simulator`. New `tests/cil_symbols.rs`. (The CLR
+backend itself is unchanged — this release adds the regression test + the F6 tick.)
+Remaining for CLR: **W8b lambda (F7)** — `call` lowering + simulator call frames.
+
 ## 0.29.0 — 2026-06-10 — McCarthy → **CLR ATOM/EQ/COND** on the simulator (LANG77 / W7)
 
 The CLR backend now runs McCarthy's primitive predicates (F3–F5). The same

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -35,7 +35,11 @@ wasm/JVM paths; the CLR backend lowers the backend-agnostic
 `box`/`unbox`/`alloc`/`field_*` to `box [int32]`/`unbox.any` + `object[]` cells.
 McCarthy's predicates run too (W7, F3–F5): `(ATOM 7)`→1, `(EQ 7 7)`→1,
 `(COND …)` — `pair?`→`isinst object[]`, `not`→`x^1`, `equal?`→`unbox; unbox; ceq`.
-The remaining CLR symbols + lambda (F6–F7) are W8.
+**Symbols** (W8a, F6) run with *zero new backend code*: the shared
+`intern_symbols_structural` pass interns each symbol to an `i32` id
+(`SYMBOL_ID_BASE = 1<<29`), so `(QUOTE A)`→536870912 and `(EQ (QUOTE A) (QUOTE A))`
+→1 fall out of W6b boxing + W7 `equal?`. The remaining CLR lambda (F7) is W8b
+(`call` lowering + simulator call frames).
 
 `compile_source_to_beam` is the fourth managed target and the first on the
 **Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real

--- a/code/packages/rust/lang-aot/tests/cil_symbols.rs
+++ b/code/packages/rust/lang-aot/tests/cil_symbols.rs
@@ -1,0 +1,51 @@
+//! # CLR symbols: QUOTE / EQ-on-symbols (LANG77 / McCarthy W8a, F6).
+//!
+//! Symbols are the *fifth* McCarthy primitive to run on the CLR — and they
+//! required **zero new backend code**. The shared `intern_symbols_structural`
+//! pass (the managed twin of the native `intern_symbols`) assigns each distinct
+//! symbol a stable integer id in a reserved range (`SYMBOL_ID_BASE = 1 << 29`)
+//! and retypes it to `i32`, so:
+//!   - `(QUOTE A)` is the interned id `536870912` (2^29),
+//!   - `EQ` on two symbols reduces to the W7 `equal?` → `unbox.any; ceq`,
+//!   - `ATOM` on a symbol is the W7 `pair?`/`not` (a symbol is not a cons),
+//!   - `COND` on a symbol predicate is the W3b/W7 `jmp_if`.
+//! Everything below already existed (W6b boxing + W7 predicates); this slice
+//! only *verifies* it. The CLR thus reaches feature parity with wasm/JVM on
+//! symbols via pure structural-pass reuse — the reusable-primitives thesis.
+
+use clr_simulator::{CLRSimulator, Value};
+use lang_aot::{compile_source_to_cil_artifact, Language};
+
+fn run(src: &str) -> i32 {
+    let artifact = compile_source_to_cil_artifact(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let main = artifact.methods.iter().find(|m| m.name == "main").expect("a `main` method");
+    let mut sim = CLRSimulator::new();
+    sim.load(&main.body, main.local_types.len());
+    sim.run(100_000);
+    match sim.stack.last() {
+        Some(Some(Value::Int(n))) => *n,
+        other => panic!("`{src}` left {other:?} on the stack"),
+    }
+}
+
+/// The reserved symbol-id base — `intern_symbols_structural`'s `SYMBOL_ID_BASE`.
+const SYMBOL_ID_BASE: i32 = 1 << 29;
+
+#[test]
+fn mccarthy_quote_interns_a_symbol_on_clr() {
+    // The first distinct symbol gets the base id; ids are stable + distinct.
+    assert_eq!(run("(QUOTE A)"), SYMBOL_ID_BASE, "a quoted symbol is its interned id");
+}
+
+#[test]
+fn mccarthy_eq_on_symbols_runs_on_clr() {
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE A))"), 1, "a symbol equals itself");
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE B))"), 0, "distinct symbols are not equal");
+}
+
+#[test]
+fn mccarthy_atom_and_cond_on_symbols_run_on_clr() {
+    assert_eq!(run("(ATOM (QUOTE A))"), 1, "a symbol is an atom");
+    assert_eq!(run("(COND ((EQ (QUOTE A) (QUOTE A)) 11) ((EQ 1 1) 22))"), 11, "symbol predicate in COND");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -61,7 +61,7 @@ representation + per-builtin backend lowering.
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
-| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | uniform-object |
+| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -177,7 +177,16 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   `clr-simulator` 0.3.0 gained `isinst`/`xor` + ref-aware `ceq` (and an `ldnull`
   opcode fix). `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(COND …)`
   verified on the simulator (`lang-aot/tests/cil_predicates.rs`).
-- ☐ **W8 — CLR symbols + lambda (F6–F7).** **Completes CLR.**
+- ◑ **W8 — CLR symbols + lambda (F6–F7).** *In progress.* **Completes CLR when done.**
+  - ✅ **W8a — CLR symbols (F6).** **Zero new backend code** — the shared
+    `intern_symbols_structural` pass interns symbols to `i32` ids (`SYMBOL_ID_BASE
+    = 1<<29`) and W6b boxing + W7 `equal?`/`pair?`/`jmp_if` execute them.
+    `(QUOTE A)`→536870912, `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`
+    →0, `(ATOM (QUOTE A))`→1, on the simulator (`lang-aot/tests/cil_symbols.rs`).
+  - ☐ **W8b — CLR lambda (F7).** Accept `call`/`ref<any>` in the validator (the
+    `call` arm already computes the MethodDef token + boxes args via the structural
+    pass), and extend `clr-simulator` with **inter-method call frames** (it currently
+    runs only `main`). Verify `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 on the simulator.
 
 ### Phase D — BEAM (Erlang terms)
 


### PR DESCRIPTION
## What & why — symbols run on the CLR with ZERO new backend code

Symbols are the **fifth** McCarthy primitive to run on the CLR, and they needed **no CLR-specific work at all** — the clearest demonstration yet of the reusable-primitives thesis. The shared `intern_symbols_structural` pass interns each distinct symbol to a stable `i32` id in a reserved range (`SYMBOL_ID_BASE = 1<<29`); W6b boxing + W7 `equal?`/`pair?`/`jmp_if` then execute `QUOTE`/`EQ`/`ATOM`/`COND` on symbols.

This is the **same** structural-pass output wasm and JVM consume — symbols are `i32` ids on all three managed backends, `EQ` = integer equality after `unbox`.

## Verified by RUNNING (`tests/cil_symbols.rs`)

| program | result |
|---|---|
| `(QUOTE A)` | `536870912` (= 2²⁹, the interned id) |
| `(EQ (QUOTE A) (QUOTE A))` | `1` |
| `(EQ (QUOTE A) (QUOTE B))` | `0` |
| `(ATOM (QUOTE A))` | `1` |
| `(COND ((EQ (QUOTE A) (QUOTE A)) 11) …)` | `11` |

…on the in-repo `clr-simulator`.

## Change

**Verification-only.** The CLR backend (`iir-to-cil-bytecode`, `ir-to-cil-bytecode`, `clr-simulator`) is **unchanged**. This slice adds the regression test, the **F6 matrix tick**, and docs. `lang-aot` 0.30.0.

## Test plan

3-test symbol suite (QUOTE/EQ/ATOM/COND on symbols) on the simulator — all green. No production code touched → no new clippy surface; no `lispy-runtime`/`twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: verification-only — no production code change; the test is bounded (`sim.run(100_000)`) and deterministic over trusted source literals.

## Matrix

Advances **CLR to F1–F6**. W8 sliced into **W8a (✅ this)** + **W8b** (lambda, F7). **Next: W8b** — accept `call`/`ref<any>` in the validator (the `call` arm already computes the MethodDef token + boxes args) + extend `clr-simulator` with inter-method **call frames** → **completes CLR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)