### PR TITLE
feat(mccarthy-lisp): W8b — McCarthy lambda on the CLR (F7) — COMPLETES THE CLR BACKEND (LANG77)

### DIFF
--- a/code/packages/rust/clr-simulator/CHANGELOG.md
+++ b/code/packages/rust/clr-simulator/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.0] — 2026-06-10 — McCarthy lambda: inter-method call frames (W8b, F7)
+
+- A whole-program **method table** + **call-frame** model: `load_program(methods, entry)`
+  registers all methods (indexed by `MethodDef` ordinal); `load` now delegates to it.
+- `call <methodTok>` (0x28): resolve the token to `methods[ordinal-1]`, pop the
+  callee's args off the shared operand stack into a fresh `args` vector, push a
+  caller frame, transfer control. `ret` pops the frame (or halts at the entry).
+- `ldarg.0..3` (0x02–0x05) / `ldarg.s` (0x0E): push method parameter N.
+- DoS guard: `MAX_CALL_DEPTH = 10_000` turns runaway recursion into a controlled
+  panic rather than a host-stack overflow.
+- The operand stack + heap are shared across frames (CIL passes args + the return
+  value on the operand stack); only per-method registers are saved/restored.
+  Single-method programs (scalar/cons/predicates) are unchanged — `load` still works.
+
 ## [0.3.0] — 2026-06-10 — McCarthy predicates: isinst + xor + ref-aware compares (W7)
 
 - `isinst <typeTok>` (0x75): the `pair?` type test — keep a heap `object[]` ref,

--- a/code/packages/rust/clr-simulator/Cargo.toml
+++ b/code/packages/rust/clr-simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clr-simulator"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "CLR bytecode simulator — Microsoft's Common Language Runtime"
 

--- a/code/packages/rust/clr-simulator/README.md
+++ b/code/packages/rust/clr-simulator/README.md
@@ -22,6 +22,13 @@ test — keep a heap ref, else `null`), `xor` (logical `not` = `x^1`), and
 reference against `ldnull`). This release also fixes `ldnull` to its real CIL
 opcode `0x14` (was `0x01`), a latent bug the cons path never exercised.
 
+Since 0.4.0 it runs McCarthy **lambda** (W8b) via an inter-method **call-frame**
+model: `load_program(methods, entry)` registers a method table, `call
+<MethodDef>` pops the callee's args + pushes a frame + transfers control, `ret`
+pops the frame (or halts at the entry), and `ldarg.N` reads a parameter.
+Recursion depth is DoS-capped at `MAX_CALL_DEPTH`. The operand stack + heap are
+shared across frames; single-method programs still use `load` unchanged.
+
 ## Usage
 
 ```rust

--- a/code/packages/rust/clr-simulator/src/lib.rs
+++ b/code/packages/rust/clr-simulator/src/lib.rs
@@ -57,6 +57,16 @@ pub const OP_LDC_I4_8: u8 = 0x1E;
 pub const OP_LDC_I4_S: u8 = 0x1F;
 pub const OP_LDC_I4: u8 = 0x20;
 pub const OP_DUP: u8 = 0x25;
+/// `ldarg.0`..`ldarg.3` (0x02–0x05) — McCarthy W8b (lambda). Push method
+/// parameter N onto the stack (the CLR counterpart of the JVM `aload`/`iload`
+/// of a parameter slot and the wasm `local.get` of a function param).
+pub const OP_LDARG_0: u8 = 0x02;
+pub const OP_LDARG_3: u8 = 0x05;
+/// `ldarg.s <idx>` (0x0E + u8) — McCarthy W8b. Push parameter `idx` (4–255).
+pub const OP_LDARG_S: u8 = 0x0E;
+/// `call <methodTok>` (0x28 + 4-byte token) — McCarthy W8b (lambda). Invoke
+/// another method: pop its arguments, push a call frame, transfer control.
+pub const OP_CALL: u8 = 0x28;
 pub const OP_RET: u8 = 0x2A;
 pub const OP_BR_S: u8 = 0x2B;
 pub const OP_BRFALSE_S: u8 = 0x2C;
@@ -92,6 +102,14 @@ pub const OP_PREFIX_FE: u8 = 0xFE;
 /// adversarial length could request tens of GB and OOM. 1M elements is far above
 /// any real McCarthy program (a cons cell is length 2) yet bounds the allocation.
 pub const MAX_ARRAY_LEN: usize = 1 << 20;
+
+/// DoS guard: the maximum call-frame depth (McCarthy W8b). McCarthy lambda makes
+/// `call` recursion possible; an adversarial or runaway program could recurse
+/// unboundedly and exhaust the host stack. The `run` step budget already bounds
+/// total work, but a depth cap turns deep recursion into a controlled panic
+/// rather than a host-stack overflow. 10_000 frames is far beyond any real
+/// McCarthy evaluation yet safely below the host stack limit.
+pub const MAX_CALL_DEPTH: usize = 10_000;
 
 // Two-byte opcode second bytes (after the 0xFE prefix).
 pub const CEQ_BYTE: u8 = 0x01;
@@ -173,6 +191,28 @@ pub struct CLRTrace {
 // ===========================================================================
 
 /// The CLR simulator -- a type-inferring stack-based virtual machine.
+/// One method in the program's method table (McCarthy W8b). Indexed by its
+/// `MethodDef` ordinal: the `call <0x0600_00NN>` token resolves to
+/// `methods[NN - 1]`.
+#[derive(Clone, Debug)]
+pub struct MethodCode {
+    pub body: Vec<u8>,
+    pub num_locals: usize,
+    pub num_args: usize,
+}
+
+/// A saved caller context, pushed by `call` and restored by `ret` (W8b). The
+/// operand `stack` and `heap` are shared across frames (CIL passes args + the
+/// return value on the shared operand stack); only the per-method registers
+/// (`pc`, `bytecode`, `locals`, `args`, `cur_method`) are saved/restored.
+struct Frame {
+    return_pc: usize,
+    return_method: usize,
+    return_bytecode: Vec<u8>,
+    return_locals: Vec<Option<Value>>,
+    return_args: Vec<Option<Value>>,
+}
+
 pub struct CLRSimulator {
     pub stack: Vec<Option<Value>>,
     pub locals: Vec<Option<Value>>,
@@ -182,6 +222,16 @@ pub struct CLRSimulator {
     pub pc: usize,
     pub bytecode: Vec<u8>,
     pub halted: bool,
+    /// Method parameters of the currently-executing method (W8b). `ldarg.N`
+    /// reads `args[N]`; populated by `call`, restored by `ret`.
+    pub args: Vec<Option<Value>>,
+    /// The whole program's method table, indexed by `MethodDef` ordinal − 1
+    /// (W8b). Empty/single-entry for legacy single-method programs.
+    methods: Vec<MethodCode>,
+    /// The index (into `methods`) of the currently-executing method (W8b).
+    cur_method: usize,
+    /// The call stack of saved caller contexts (W8b).
+    frames: Vec<Frame>,
 }
 
 impl CLRSimulator {
@@ -193,15 +243,36 @@ impl CLRSimulator {
             pc: 0,
             bytecode: Vec::new(),
             halted: false,
+            args: Vec::new(),
+            methods: Vec::new(),
+            cur_method: 0,
+            frames: Vec::new(),
         }
     }
 
-    /// Load bytecode and configure local variable count.
+    /// Load a single method's bytecode and configure local variable count. This
+    /// is the legacy single-method entry point (no `call`s); it registers a
+    /// one-method table so `ret` halts cleanly.
     pub fn load(&mut self, bytecode: &[u8], num_locals: usize) {
-        self.bytecode = bytecode.to_vec();
+        self.load_program(
+            vec![MethodCode { body: bytecode.to_vec(), num_locals, num_args: 0 }],
+            0,
+        );
+    }
+
+    /// Load a whole program (method table) and start executing at `entry`
+    /// (McCarthy W8b — lambda). `call <0x0600_00NN>` dispatches to
+    /// `methods[NN − 1]`; `ret` returns to the caller (or halts at the entry).
+    pub fn load_program(&mut self, methods: Vec<MethodCode>, entry: usize) {
+        assert!(entry < methods.len(), "entry method index out of range");
         self.stack.clear();
-        self.locals = vec![None; num_locals];
         self.heap.clear();
+        self.frames.clear();
+        self.cur_method = entry;
+        self.bytecode = methods[entry].body.clone();
+        self.locals = vec![None; methods[entry].num_locals];
+        self.args = vec![None; methods[entry].num_args];
+        self.methods = methods;
         self.pc = 0;
         self.halted = false;
     }
@@ -235,6 +306,25 @@ impl CLRSimulator {
         if opcode_byte == OP_NOP {
             self.pc += 1;
             return self.trace(pc, "nop", stack_before, "no operation".to_string());
+        }
+
+        // ── McCarthy W8b (lambda): method parameters ──
+        // ldarg.0..3 (0x02–0x05): push the method parameter at that index.
+        if (OP_LDARG_0..=OP_LDARG_3).contains(&opcode_byte) {
+            let idx = (opcode_byte - OP_LDARG_0) as usize;
+            let val = self.args.get(idx).copied().flatten()
+                .expect("ldarg: parameter index out of range or uninitialised");
+            self.stack.push(Some(val));
+            self.pc += 1;
+            return self.trace(pc, &format!("ldarg.{idx}"), stack_before, format!("push arg[{idx}] = {val}"));
+        }
+        if opcode_byte == OP_LDARG_S {
+            let idx = self.bytecode[pc + 1] as usize;
+            let val = self.args.get(idx).copied().flatten()
+                .expect("ldarg.s: parameter index out of range or uninitialised");
+            self.stack.push(Some(val));
+            self.pc += 2;
+            return self.trace(pc, "ldarg.s", stack_before, format!("push arg[{idx}] = {val}"));
         }
 
         if opcode_byte == OP_LDNULL {
@@ -381,10 +471,67 @@ impl CLRSimulator {
             return self.trace(pc, "div", stack_before, format!("pop {b_val} and {a_val}, push {result}"));
         }
 
+        // ── call <methodTok> (0x28) — McCarthy W8b (lambda) ──
+        // The 4-byte token is a MethodDef: 0x0600_00NN → methods[NN − 1]. Pop the
+        // callee's N args off the (shared) operand stack — the LAST pushed is the
+        // LAST arg — into a fresh `args` vector, save the caller's registers, and
+        // transfer control to the callee. The return value comes back on the
+        // shared stack at `ret`.
+        if opcode_byte == OP_CALL {
+            let token = u32::from_le_bytes([
+                self.bytecode[pc + 1], self.bytecode[pc + 2],
+                self.bytecode[pc + 3], self.bytecode[pc + 4],
+            ]);
+            // MethodDef tables are 0x06 in the high byte; ordinal is 1-based.
+            let ordinal = (token & 0x00FF_FFFF) as usize;
+            assert!(ordinal >= 1, "call: invalid MethodDef token 0x{token:08X}");
+            let callee_idx = ordinal - 1;
+            let callee = self.methods.get(callee_idx)
+                .unwrap_or_else(|| panic!("call: no method for token 0x{token:08X}"))
+                .clone();
+            // DoS guard: bound recursion depth (turns runaway recursion into a
+            // controlled panic instead of a host-stack overflow).
+            assert!(
+                self.frames.len() < MAX_CALL_DEPTH,
+                "call depth exceeded the simulator cap {MAX_CALL_DEPTH} (runaway recursion?)"
+            );
+            // Pop args (in order: arg[0] was pushed first, so pop into reverse).
+            let mut callee_args = vec![None; callee.num_args];
+            for slot in callee_args.iter_mut().rev() {
+                *slot = Some(self.pop().expect("call: not enough arguments on the stack"));
+            }
+            // Save the caller's context; `pc + 5` is the return address.
+            self.frames.push(Frame {
+                return_pc: pc + 5,
+                return_method: self.cur_method,
+                return_bytecode: std::mem::take(&mut self.bytecode),
+                return_locals: std::mem::take(&mut self.locals),
+                return_args: std::mem::take(&mut self.args),
+            });
+            // Enter the callee.
+            self.cur_method = callee_idx;
+            self.bytecode = callee.body;
+            self.locals = vec![None; callee.num_locals];
+            self.args = callee_args;
+            self.pc = 0;
+            return self.trace(pc, "call", stack_before, format!("call method #{callee_idx} (token 0x{token:08X})"));
+        }
+
         if opcode_byte == OP_RET {
+            // The return value (if any) is left on the shared operand stack. If
+            // there is a caller frame, restore it and continue; otherwise this is
+            // the entry method returning → halt.
+            if let Some(frame) = self.frames.pop() {
+                self.cur_method = frame.return_method;
+                self.bytecode = frame.return_bytecode;
+                self.locals = frame.return_locals;
+                self.args = frame.return_args;
+                self.pc = frame.return_pc;
+                return self.trace(pc, "ret", stack_before, "return to caller".to_string());
+            }
             self.pc += 1;
             self.halted = true;
-            return self.trace(pc, "ret", stack_before, "return".to_string());
+            return self.trace(pc, "ret", stack_before, "return (halt)".to_string());
         }
 
         if opcode_byte == OP_BR_S {

--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.10.0] — 2026-06-10 — McCarthy lambda: accept `call`/`ref<any>` (W8b, F7)
+
+The validator now accepts the `call` op with a `ref<any>` type — a lisp function
+call returns the callee's uniform-reference result. The `call` lowering already
+computed the `MethodDef` token + pushed args (boxed by the structural pass); this
+one-line allowlist addition lets McCarthy `(LAMBDA …)` applications validate and
+emit. `((LAMBDA (X) (CAR X)) (CONS 7 9))` → 7 on the `clr-simulator`.
+
 ## [0.9.0] — 2026-06-10 — McCarthy predicates: ATOM / EQ / COND (W7, F3–F5)
 
 Lower the structural pass's `pair?`/`not`/`equal?` `call_builtin`s on the CLR:

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/validate.rs
@@ -370,6 +370,9 @@ pub fn validate_iir_for_clr(module: &IIRModule) -> Vec<String> {
                     | "jmp_if_true" | "jmp_if_false" | "mov"
                     // McCarthy W6b: `box` produces a `ref<any>` (boxed int32).
                     | "box" | "unbox"
+                    // McCarthy W8b (lambda): a lisp `call` returns `ref<any>`
+                    // (the callee's uniform-reference result).
+                    | "call"
                 );
                 if !(is_supported_ref && is_heap_op) {
                     errors.push(format!(

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.31.0 — 2026-06-10 — McCarthy → **CLR lambda** — CLR backend COMPLETE (LANG77 / W8b, F7)
+
+Lambda (F7) runs on the CLR — **completing the entire CLR backend (F1–F7)**, the
+third managed backend to reach full McCarthy support after WASM and JVM.
+`(LAMBDA (args…) body)` applied lowers to a CLR method `call`: the structural pass
+hoists the lambda into its own method (params → `ldarg.N`), `iir-to-cil-bytecode`
+0.10.0 validates+emits `call <MethodDef>` (args boxed, result `ref<any>`), and
+`clr-simulator` 0.4.0 executes it via an inter-method **call-frame** model.
+`((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, and
+backward-compat (scalar/cons) verified on the simulator. New `tests/cil_lambda.rs`.
+
 ## 0.30.0 — 2026-06-10 — McCarthy → **CLR symbols** on the simulator (LANG77 / W8a, F6)
 
 Symbols (F6) run on the CLR with **zero new backend code** — pure structural-pass

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -38,8 +38,11 @@ McCarthy's predicates run too (W7, F3–F5): `(ATOM 7)`→1, `(EQ 7 7)`→1,
 **Symbols** (W8a, F6) run with *zero new backend code*: the shared
 `intern_symbols_structural` pass interns each symbol to an `i32` id
 (`SYMBOL_ID_BASE = 1<<29`), so `(QUOTE A)`→536870912 and `(EQ (QUOTE A) (QUOTE A))`
-→1 fall out of W6b boxing + W7 `equal?`. The remaining CLR lambda (F7) is W8b
-(`call` lowering + simulator call frames).
+→1 fall out of W6b boxing + W7 `equal?`. **Lambda** (W8b, F7) **completes the CLR
+backend (F1–F7):** `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 — the lambda is hoisted to
+its own method, applied via `call <MethodDef>`, and run on `clr-simulator` 0.4.0's
+inter-method call-frame model. The CLR is the third managed backend to reach full
+McCarthy support after WASM and JVM.
 
 `compile_source_to_beam` is the fourth managed target and the first on the
 **Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real

--- a/code/packages/rust/lang-aot/tests/cil_lambda.rs
+++ b/code/packages/rust/lang-aot/tests/cil_lambda.rs
@@ -1,0 +1,53 @@
+//! # CLR lambda — F7, completes the CLR backend (LANG77 / McCarthy W8b).
+//!
+//! `(LAMBDA (args…) body)` applied to arguments lowers to a CLR **method call**:
+//! the structural pass hoists the lambda into its own method (params → `ldarg.N`,
+//! body returns `ref<any>`), and `iir-to-cil-bytecode` emits `call <MethodDef>`
+//! at the application site (args boxed by the structural pass, result unboxed).
+//! The `clr-simulator` (0.4.0) gained an inter-method **call frame** model — a
+//! method table + a frame stack (`call` pushes a frame + transfers control,
+//! `ret` pops it) + `ldarg` — the CLR counterpart of the wasm call/`local.get`
+//! and the JVM `invokestatic`/`aload`. Verified by RUNNING on the simulator.
+
+use clr_simulator::{CLRSimulator, MethodCode, Value};
+use lang_aot::{compile_source_to_cil_artifact, Language};
+
+fn run(src: &str) -> i32 {
+    let artifact = compile_source_to_cil_artifact(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    // Build the whole-program method table; the `call` MethodDef token resolves
+    // by ordinal into this table. Entry point is `main`.
+    let methods: Vec<MethodCode> = artifact.methods.iter().map(|m| MethodCode {
+        body: m.body.clone(),
+        num_locals: m.local_types.len(),
+        num_args: m.parameter_types.len(),
+    }).collect();
+    let entry = artifact.methods.iter().position(|m| m.name == "main").expect("a `main` method");
+    let mut sim = CLRSimulator::new();
+    sim.load_program(methods, entry);
+    sim.run(1_000_000);
+    match sim.stack.last() {
+        Some(Some(Value::Int(n))) => *n,
+        other => panic!("`{src}` left {other:?} on the stack"),
+    }
+}
+
+#[test]
+fn mccarthy_lambda_runs_on_clr() {
+    assert_eq!(run("((LAMBDA (X) X) 5)"), 5, "identity lambda");
+    assert_eq!(run("((LAMBDA (X) (CAR X)) (CONS 7 9))"), 7, "lambda applying CAR to a cons arg");
+    assert_eq!(run("((LAMBDA (X) (CDR X)) (CONS 7 9))"), 9, "lambda applying CDR");
+}
+
+#[test]
+fn mccarthy_multi_arg_lambda_runs_on_clr() {
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 3)"), 1, "2-arg lambda, equal args");
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 4)"), 0, "2-arg lambda, unequal args");
+}
+
+#[test]
+fn scalar_and_cons_still_run_after_call_frames() {
+    // The call-frame refactor must not regress single-method programs (no calls).
+    assert_eq!(run("42"), 42, "scalar still runs through load_program");
+    assert_eq!(run("(CAR (CONS 7 9))"), 7, "cons still runs");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -61,7 +61,7 @@ representation + per-builtin backend lowering.
 | **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
-| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | uniform-object |
+| **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
@@ -177,16 +177,18 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   `clr-simulator` 0.3.0 gained `isinst`/`xor` + ref-aware `ceq` (and an `ldnull`
   opcode fix). `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(COND …)`
   verified on the simulator (`lang-aot/tests/cil_predicates.rs`).
-- ◑ **W8 — CLR symbols + lambda (F6–F7).** *In progress.* **Completes CLR when done.**
+- ✅ **W8 — CLR symbols + lambda (F6–F7). 🎉 COMPLETES CLR (F1–F7).**
   - ✅ **W8a — CLR symbols (F6).** **Zero new backend code** — the shared
     `intern_symbols_structural` pass interns symbols to `i32` ids (`SYMBOL_ID_BASE
     = 1<<29`) and W6b boxing + W7 `equal?`/`pair?`/`jmp_if` execute them.
     `(QUOTE A)`→536870912, `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`
     →0, `(ATOM (QUOTE A))`→1, on the simulator (`lang-aot/tests/cil_symbols.rs`).
-  - ☐ **W8b — CLR lambda (F7).** Accept `call`/`ref<any>` in the validator (the
-    `call` arm already computes the MethodDef token + boxes args via the structural
-    pass), and extend `clr-simulator` with **inter-method call frames** (it currently
-    runs only `main`). Verify `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 on the simulator.
+  - ✅ **W8b — CLR lambda (F7).** Validator accepts `call`/`ref<any>` (the `call`
+    arm already computes the MethodDef token + boxes args via the structural pass);
+    `clr-simulator` 0.4.0 gained an inter-method **call-frame** model (method table +
+    frame stack + `ldarg`, DoS-capped at `MAX_CALL_DEPTH`). `((LAMBDA (X) (CAR X))
+    (CONS 7 9))`→7, `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, on the simulator
+    (`lang-aot/tests/cil_lambda.rs`). **CLR is the third backend to reach F1–F7.**
 
 ### Phase D — BEAM (Erlang terms)
 


### PR DESCRIPTION
## 🎉 Lambda completes the CLR backend — F1–F7

Lambda (F7) runs on the CLR, **completing the entire CLR backend** — the **third managed backend** to reach full McCarthy support after WASM and JVM, all three driven by the **same** shared structural pass.

`(LAMBDA (args…) body)` applied lowers to a CLR method `call`: the structural pass hoists the lambda into its own method (params → `ldarg.N`, body returns `ref<any>`); the call site emits `call <MethodDef>` (args boxed, result unboxed). Two small pieces complete the path.

## Change

**`iir-to-cil-bytecode` 0.10.0** — validator accepts `call`/`ref<any>` (one-line allowlist; the `call` arm already computed the MethodDef token + pushed args).

**`clr-simulator` 0.4.0** — inter-method **call frames** (it previously ran only `main`):
- `load_program(methods, entry)`: a whole-program method table indexed by MethodDef ordinal. `load` delegates to it → backward compatible.
- `call` (0x28): resolve token → `methods[ordinal-1]`, pop the callee's args off the shared operand stack into a fresh `args` vec, push a caller `Frame`, transfer control.
- `ret`: pop the frame (return value stays on the shared stack), or halt at the entry.
- `ldarg.0..3` / `ldarg.s`: push parameter N.
- DoS guard: `MAX_CALL_DEPTH = 10_000` — `step()` is iterative, so `call`/`ret` grow the heap `frames` Vec, not the host stack; runaway recursion → controlled panic.

## Verified by RUNNING (`tests/cil_lambda.rs`)

| program | result |
|---|---|
| `((LAMBDA (X) X) 5)` | `5` |
| `((LAMBDA (X) (CAR X)) (CONS 7 9))` | `7` |
| `((LAMBDA (X) (CDR X)) (CONS 7 9))` | `9` |
| `((LAMBDA (X Y) (EQ X Y)) 3 3)` / `3 4` | `1` / `0` |
| `42` ; `(CAR (CONS 7 9))` | `42` ; `7` (single-method backward-compat) |

…on the `clr-simulator`. This is the **same** structural-pass output wasm (`call`/`local.get`) and JVM (`invokestatic`/`aload`) consume — the uniform-reference function boundary, reused for the CLR.

## Test plan

Suites green — `clr-simulator` 7, `nib-clr` 20, `brainfuck-clr` 19 (the call-frame refactor preserves `load`), `iir-to-cil-bytecode`, `lang-aot` `cil_lambda`/`cil_symbols`/`cil_predicates`/`cil_cons`. My crates clippy-clean. No `lispy-runtime`/`twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: every adversarial-bytecode condition is a controlled panic (matching the oracle's baseline); `step()` is iterative so recursion grows the `frames` Vec not the host stack, capped at `MAX_CALL_DEPTH`; memory bounded by depth × method table; `mem::take`/restore is correct under self-recursion. No OOB/overflow introduced.

## Matrix

**🎉 COMPLETES CLR (F1–F7).** W8/W8a/W8b ✅, CLR row all ✅. **Backends complete: VM, WASM, JVM, CLR.** Remaining: BEAM (W9b–W11), LLVM (W12–13), native-AOT lambda (W14), JIT (W15), cross-backend conformance (W16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)