### PR TITLE
feat(mccarthy-lisp): W9b — McCarthy cons on the BEAM (F2) — native Erlang list cells (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — `lang-aot`
 
+## 0.32.0 — 2026-06-10 — McCarthy → **BEAM cons** on a real `erl` (LANG77 / W9b, F2)
+
+McCarthy cons runs on the BEAM (Erlang VM) — using the **native Erlang-terms**
+model, NOT the boxing structural pass the managed backends use. A cons cell is a
+native list cell `[H|T]`; `car`/`cdr` are `hd`/`tl`; integers are native. Two
+pipeline changes in `compile_source_to_beam`:
+- Run `lower_heap_builtins` so `cons`/`car`/`cdr` become `alloc ref<LispyPair>` +
+  `field_store`/`field_load`, which `iir-to-beam` already maps to `put_list` /
+  `get_hd` / `get_tl`.
+- Generalize `concretize_scalar_any_for_beam` to concretize `any`→`i64`
+  **per-instruction in every function** (BEAM is dynamically typed; `i64` is the
+  universal native-term placeholder), leaving `ref<LispyPair>` cons cells for the
+  list lowering — previously it skipped any heap-using function wholesale.
+
+Verified by RUNNING on a real `erl`: `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9,
+nested→2, and `(CONS 7 9)`→`[7|9]` (a genuine Erlang list cell). New
+`tests/beam_cons.rs`. (`iir-to-beam` is unchanged — it already had the list ops.)
+
 ## 0.31.0 — 2026-06-10 — McCarthy → **CLR lambda** — CLR backend COMPLETE (LANG77 / W8b, F7)
 
 Lambda (F7) runs on the CLR — **completing the entire CLR backend (F1–F7)**, the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -44,10 +44,14 @@ its own method, applied via `call <MethodDef>`, and run on `clr-simulator` 0.4.0
 inter-method call-frame model. The CLR is the third managed backend to reach full
 McCarthy support after WASM and JVM.
 
-`compile_source_to_beam` is the fourth managed target and the first on the
-**Erlang VM** (W9a): scalar McCarthy emits a `.beam` that **runs** on a real
-`erl` (OTP), `42` → 42. BEAM uses the native Erlang-terms value model
-(integers/atoms/list cells), so its cons/symbol/lambda lowering (W9+) is its own.
+`compile_source_to_beam` targets the **Erlang VM**: scalar McCarthy emits a
+`.beam` that **runs** on a real `erl` (OTP), `42` → 42 (W9a), and **cons** too —
+`(CAR (CONS 7 9))` → 7, `(CONS 7 9)` → `[7|9]` (W9b). BEAM uses the **native
+Erlang-terms** value model, NOT the boxing structural pass: a cons cell is a
+native list cell `[H|T]`, `car`/`cdr` are `hd`/`tl`, integers are native.
+`lower_heap_builtins` produces `alloc`/`field_*` that `iir-to-beam` maps to
+`put_list`/`get_hd`/`get_tl`. The remaining BEAM predicates/symbols/lambda
+(F3–F7) are W10–W11.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -617,23 +617,18 @@ pub fn compile_source_to_cil_artifact(
 /// program must be concretised before lowering. Heap/reference functions
 /// (cons/symbols/lambda — W9+, the native Erlang-terms model) are left alone.
 fn concretize_scalar_any_for_beam(module: &mut IIRModule) {
-    const HEAP_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
-    const LISP_BUILTINS: &[&str] = &[
-        "cons", "car", "cdr", "pair?", "not", "equal?", "make_symbol", "make_nil", "null?",
-    ];
+    // The BEAM is **dynamically typed** — every value is an Erlang *term* — so the
+    // natural concrete type for an `any`/`polymorphic` lisp value is `i64` (a
+    // native Erlang integer; the term carries its real runtime shape regardless).
+    // We concretize **per instruction**, not per function (W9b): a cons program's
+    // scalar results — e.g. the `car`/`cdr` of a cell, or the final `ret` of an
+    // integer — become `i64`, while the cons cells themselves keep their
+    // `ref<LispyPair>` type for `iir-to-beam`'s `put_list`/`get_hd`/`get_tl`
+    // lowering. We never rewrite a `ref<…>` type: those ARE the native list cells.
+    // (`get_hd` returning a sub-list is still sound — the `i64` hint is a lowering
+    // placeholder, never an unboxing op; BEAM resolves the real term at runtime.)
+    let to_i64 = |t: &str| t == "any" || t == "polymorphic";
     for func in &mut module.functions {
-        let uses_lisp = func.params.iter().any(|(_, t)| t == "any" || t == "symbol")
-            || func.instructions.iter().any(|i| {
-                HEAP_OPS.contains(&i.op.as_str())
-                    || (i.op == "call_builtin"
-                        && matches!(i.srcs.first(),
-                            Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
-                    || i.type_hint.starts_with("ref<")
-            });
-        if uses_lisp {
-            continue; // native Erlang-terms value model — BEAM W9+.
-        }
-        let to_i64 = |t: &str| t == "any" || t == "polymorphic";
         if to_i64(&func.return_type) {
             func.return_type = "i64".to_string();
         }
@@ -667,6 +662,13 @@ pub fn compile_source_to_beam(
     module_name: &str,
 ) -> Result<Vec<u8>, LangAotError> {
     let mut module = compile_source_to_iir(language, source, module_name)?;
+    // BEAM uses the NATIVE Erlang-terms value model, not the managed structural
+    // pass: `lower_heap_builtins` turns McCarthy `cons`/`car`/`cdr` into
+    // `alloc ref<LispyPair>` + `field_store`/`field_load`, which `iir-to-beam`
+    // maps directly to BEAM list ops — `put_list` (a cons cell `[H|T]`) and
+    // `get_hd`/`get_tl` (`hd`/`tl`). Integers stay native Erlang integers; there
+    // is NO boxing (unlike wasm/JVM/CLR). A no-op for a scalar-only module.
+    iir_builtin_lowering::lower_heap_builtins(&mut module);
     concretize_scalar_any_for_beam(&mut module);
 
     let config = iir_to_beam::IIRBeamConfig::new(module_name);

--- a/code/packages/rust/lang-aot/tests/beam_cons.rs
+++ b/code/packages/rust/lang-aot/tests/beam_cons.rs
@@ -1,0 +1,46 @@
+//! # BEAM cons — F2 (LANG77 / McCarthy W9b).
+//!
+//! Unlike the managed backends (wasm/JVM/CLR), BEAM uses the **native
+//! Erlang-terms** value model — NOT the boxing structural pass. A McCarthy cons
+//! cell is a native Erlang list cell `[H|T]`; `car`/`cdr` are `hd`/`tl`;
+//! integers are native Erlang integers; nil is `[]`. `lang-aot`'s
+//! `compile_source_to_beam` runs `lower_heap_builtins` (cons/car/cdr →
+//! `alloc ref<LispyPair>` + `field_store`/`field_load`), and `iir-to-beam` maps
+//! those to `put_list` / `get_hd` / `get_tl`. **Verified by RUNNING** the emitted
+//! `.beam` on a real `erl` (skipped if `erl` is absent).
+
+use lang_aot::{compile_source_to_beam, Language};
+
+fn erl_available() -> bool {
+    std::process::Command::new("erl").arg("-version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Compile to `.beam`, run `module:main()` on a real `erl`, return its printout.
+fn run(src: &str, module: &str) -> String {
+    let bytes = compile_source_to_beam(Language::McCarthyLisp, src, module)
+        .unwrap_or_else(|e| panic!("compile {src:?} to BEAM: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w9b_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join(format!("{module}.beam")), &bytes).expect("write .beam");
+    let out = std::process::Command::new("erl")
+        .arg("-noshell").arg("-pa").arg(&tmp)
+        .arg("-eval").arg(format!("io:format(\"~w~n\",[{module}:main()]),halt(0)."))
+        .output().expect("spawn erl");
+    assert!(out.status.success(), "erl non-zero; stderr: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn mccarthy_cons_car_cdr_run_on_beam() {
+    if !erl_available() {
+        eprintln!("erl absent — skipping BEAM cons test");
+        return;
+    }
+    assert_eq!(run("(CAR (CONS 7 9))", "bc_car"), "7", "car of a cons");
+    assert_eq!(run("(CDR (CONS 7 9))", "bc_cdr"), "9", "cdr of a cons");
+    assert_eq!(run("(CAR (CDR (CONS 1 (CONS 2 3))))", "bc_nest"), "2", "car of cdr of nested cons");
+    // A McCarthy dotted pair is a *native Erlang* improper list cell `[H|T]`.
+    assert_eq!(run("(CONS 7 9)", "bc_cell"), "[7|9]", "a cons IS an Erlang list cell");
+    assert_eq!(run("42", "bc_scalar"), "42", "scalar still runs (backward compat)");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -62,7 +62,7 @@ representation + per-builtin backend lowering.
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
-| **BEAM** | `iir-to-beam` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
+| **BEAM** | `iir-to-beam` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
@@ -192,7 +192,7 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase D — BEAM (Erlang terms)
 
-- ◑ **W9 — BEAM cons (F2).** *In progress.* Cons as a list cell `[a|b]`;
+- ✅ **W9 — BEAM cons (F2).** Cons as a list cell `[a|b]`;
   `car`/`cdr` = `hd`/`tl`; integers are native Erlang integers; nil = `[]`.
   - ✅ **W9a — BEAM run-foundation (F1, scalar).** `lang-aot::compile_source_to_beam`
     + `concretize_scalar_any_for_beam` (scalar `any` → `i64`) → `iir-to-beam` →
@@ -200,9 +200,14 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     (OTP 28): `42`→42, `0`→0, `7`→7, Twig `42`→42. Started as a parallel stream
     (independent of the held CLR W6b PR); reuses the backend's established
     real-`erl` round-trip harness. Establishes the BEAM pipeline.
-  - ☐ **W9b — BEAM cons.** Lower `cons`/`car`/`cdr` to BEAM list ops
+  - ✅ **W9b — BEAM cons.** `cons`/`car`/`cdr` → BEAM list ops
     (`put_list`/`get_hd`/`get_tl`) — the native Erlang-terms model (NOT the
-    structural uniform-ref pass). `(CAR (CONS 7 9))`→7 on a real `erl`.
+    structural uniform-ref pass). `compile_source_to_beam` now runs
+    `lower_heap_builtins` (cons → `alloc`/`field_*`, which `iir-to-beam` already
+    lowers) and concretizes `any`→`i64` per-instruction (leaving `ref<LispyPair>`
+    cells). **Verified by RUNNING** on a real `erl`: `(CAR (CONS 7 9))`→7,
+    `(CDR (CONS 7 9))`→9, nested→2, `(CONS 7 9)`→`[7|9]` (a native list cell)
+    (`lang-aot/tests/beam_cons.rs`).
 - ☐ **W10 — BEAM `ATOM`/`EQ`/`COND` (F3–F5).** `is_tuple`/guards; `=:=`; truthiness.
 - ☐ **W11 — BEAM symbols + lambda (F6–F7).** Symbols = Erlang atoms; lambda = fun.
   **Completes BEAM.** (Mind the OTP-27 AtU8 atom-format constraint from


### PR DESCRIPTION
## What & why — McCarthy cons runs on the Erlang VM, as native list cells

McCarthy cons runs on the **BEAM**, **verified by RUNNING on a real `erl`**: `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, nested→2, and `(CONS 7 9)`→`[7|9]` — a genuine native Erlang list cell.

Unlike the managed backends (wasm/JVM/CLR, which box into a uniform reference), the BEAM uses the **native Erlang-terms** value model: a cons cell **is** an Erlang list cell `[H|T]`, `car`/`cdr` are `hd`/`tl`, integers are native, nil is `[]`. `iir-to-beam` already had the list ops (`put_list`/`get_hd`/`get_tl` + the `alloc`→`put_list` fusion) — the only gap was the `lang-aot` pipeline.

## Change (`lang-aot` 0.32.0; `iir-to-beam` UNCHANGED)

Two changes in `compile_source_to_beam`:
- Run `lower_heap_builtins` so `cons`/`car`/`cdr` become `alloc ref<LispyPair>` + `field_store`/`field_load` — the IIR `iir-to-beam` already lowers. (The **same** heap-lowering pass the CIL/JVM paths use; only the per-backend lowering differs — managed boxes, BEAM uses native lists.)
- Generalize `concretize_scalar_any_for_beam`: concretize `any`/`polymorphic`→`i64` **per-instruction in every function** (BEAM is dynamically typed; `i64` is the universal native-term placeholder), leaving `ref<LispyPair>` cells for the list lowering. Previously it skipped any heap-using function wholesale, so a cons program's integer results kept type `any` and failed the `iir-to-beam` "concrete types" validator.

## Verified by RUNNING (`tests/beam_cons.rs`, real `erl`)

| program | result |
|---|---|
| `(CAR (CONS 7 9))` | `7` |
| `(CDR (CONS 7 9))` | `9` |
| `(CAR (CDR (CONS 1 (CONS 2 3))))` | `2` |
| `(CONS 7 9)` | `[7|9]` (native Erlang list cell) |
| `42` | `42` (backward compat) |

## Test plan

Suites green — `iir-to-beam` **65** (unchanged), `lang-aot` `beam_cons` 1 (real-erl), `beam_emit` 2 (W9a scalar still runs). `lang-aot` clippy-clean. No `twig-vm` → no Miri. (`erl` test self-skips if absent.)

## Security & safety

Security review **PASSED**: the concretize rewrite is a bounded in-memory iteration over the compiled IIR doing String field assignment (no unwrap/index/recursion/unbounded work); the `i64` placeholder is a lowering hint, not a type-directed unboxing op — BEAM resolves the real term at runtime, so a mismatch is at worst a correctness bug, never memory unsafety on the memory-safe Erlang VM.

## Matrix

Advances **BEAM to F1–F2** (cons). W9/W9a/W9b ✅. **Next: W10** (BEAM `ATOM`/`EQ`/`COND`, F3–F5 — `is_tuple`/`=:=`/guards), then **W11** (symbols=atoms + lambda=fun) **completes BEAM**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)