### PR TITLE
feat(mccarthy-lisp): W11 — McCarthy symbols + lambda on the BEAM (F6–F7) — COMPLETES THE BEAM BACKEND (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — `lang-aot`
 
+## 0.34.0 — 2026-06-10 — McCarthy → **BEAM symbols + lambda** — BEAM backend COMPLETE (LANG77 / W11, F6–F7)
+
+Symbols (F6) and lambda (F7) run on the BEAM — **completing the entire BEAM
+backend (F1–F7)**, the FIFTH backend to reach full McCarthy support (after VM,
+WASM, JVM, CLR). One-line pipeline addition: `compile_source_to_beam` now runs
+`intern_symbols_structural`, so each symbol interns to a stable `i32` id
+(`SYMBOL_ID_BASE = 1<<29`) — the SAME id the wasm/JVM/CLR backends assign — which
+the BEAM carries as a native Erlang integer (`EQ` → `is_eq_exact`). **Lambda
+needed nothing extra** — a `(LAMBDA …)` application is a method `call`, which
+`iir-to-beam` already lowers natively (a BEAM fun). Verified by RUNNING on a real
+`erl`: `(QUOTE A)`→536870912, `(EQ (QUOTE A) (QUOTE A))`→1,
+`((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, `((LAMBDA (X) (EQ X (QUOTE A))) (QUOTE A))`→1.
+New `tests/beam_symbols_lambda.rs`.
+
 ## 0.33.0 — 2026-06-10 — McCarthy → **BEAM ATOM/EQ/COND** on a real `erl` (LANG77 / W10, F3–F5)
 
 McCarthy's predicates run on the BEAM (`iir-to-beam` 0.5.0 lowers `pair?`→

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -52,8 +52,12 @@ native list cell `[H|T]`, `car`/`cdr` are `hd`/`tl`, integers are native.
 `lower_heap_builtins` produces `alloc`/`field_*` that `iir-to-beam` maps to
 `put_list`/`get_hd`/`get_tl`. Its **predicates** run too (W10, F3–F5):
 `(ATOM 7)`→1, `(EQ 7 7)`→1, `(COND …)` — `pair?`→`is_nonempty_list`,
-`equal?`→`is_eq_exact` (`=:=`), `not`→`x==0`. The remaining BEAM symbols + lambda
-(F6–F7) are W11.
+`equal?`→`is_eq_exact` (`=:=`), `not`→`x==0`. **Symbols + lambda** (W11, F6–F7)
+**complete the BEAM backend (F1–F7):** `(QUOTE A)`→536870912 (the shared
+`intern_symbols_structural` id, same as the other backends), and
+`((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 — lambda needed no BEAM-specific work (a
+`(LAMBDA …)` application is a method `call`, already lowered as a BEAM fun). The
+BEAM is the fifth backend to reach full McCarthy support after VM, WASM, JVM, CLR.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -669,6 +669,14 @@ pub fn compile_source_to_beam(
     // `get_hd`/`get_tl` (`hd`/`tl`). Integers stay native Erlang integers; there
     // is NO boxing (unlike wasm/JVM/CLR). A no-op for a scalar-only module.
     iir_builtin_lowering::lower_heap_builtins(&mut module);
+    // McCarthy symbols (F6): intern each distinct symbol to a stable `i32` id
+    // (`SYMBOL_ID_BASE = 1<<29`). The BEAM carries it as a native Erlang integer,
+    // and `EQ` on symbols becomes integer equality (`is_eq_exact`). We use the
+    // SAME structural interning the wasm/JVM/CLR backends use, so a given symbol
+    // gets the SAME id on every "intern-to-integer" backend (it matters for the
+    // cross-backend conformance suite). Lambda (F7) needs nothing extra — it is
+    // already a method `call`, which `iir-to-beam` lowers natively (a BEAM fun).
+    iir_builtin_lowering::intern_symbols_structural(&mut module);
     concretize_scalar_any_for_beam(&mut module);
 
     let config = iir_to_beam::IIRBeamConfig::new(module_name);

--- a/code/packages/rust/lang-aot/tests/beam_symbols_lambda.rs
+++ b/code/packages/rust/lang-aot/tests/beam_symbols_lambda.rs
@@ -1,0 +1,51 @@
+//! # BEAM symbols + lambda — F6/F7, COMPLETES the BEAM backend (LANG77 / W11).
+//!
+//! - **Symbols (F6):** the shared `intern_symbols_structural` pass interns each
+//!   distinct symbol to a stable `i32` id (`SYMBOL_ID_BASE = 1<<29`) — the SAME
+//!   id the wasm/JVM/CLR backends assign — which the BEAM carries as a native
+//!   Erlang integer; `EQ` on symbols becomes `is_eq_exact`.
+//! - **Lambda (F7):** needs NO BEAM-specific work — a `(LAMBDA …)` application is
+//!   a method `call`, which `iir-to-beam` already lowers natively (a BEAM fun).
+//! **Verified by RUNNING** the emitted `.beam` on a real `erl` (skipped if absent).
+
+use lang_aot::{compile_source_to_beam, Language};
+
+fn erl_available() -> bool {
+    std::process::Command::new("erl").arg("-version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+
+fn run(src: &str, module: &str) -> String {
+    let bytes = compile_source_to_beam(Language::McCarthyLisp, src, module)
+        .unwrap_or_else(|e| panic!("compile {src:?} to BEAM: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w11_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    std::fs::write(tmp.join(format!("{module}.beam")), &bytes).expect("write .beam");
+    let out = std::process::Command::new("erl")
+        .arg("-noshell").arg("-pa").arg(&tmp)
+        .arg("-eval").arg(format!("io:format(\"~w~n\",[{module}:main()]),halt(0)."))
+        .output().expect("spawn erl");
+    assert!(out.status.success(), "erl non-zero; stderr: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+const SYMBOL_ID_BASE: i64 = 1 << 29;
+
+#[test]
+fn mccarthy_symbols_run_on_beam() {
+    if !erl_available() { eprintln!("erl absent — skipping"); return; }
+    // The first distinct symbol gets the base id — identical to the CLR/JVM/wasm id.
+    assert_eq!(run("(QUOTE A)", "bs_q"), SYMBOL_ID_BASE.to_string(), "interned symbol id");
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE A))", "bs_e1"), "1", "a symbol equals itself");
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE B))", "bs_e2"), "0", "distinct symbols differ");
+    assert_eq!(run("(ATOM (QUOTE A))", "bs_a"), "1", "a symbol is an atom");
+}
+
+#[test]
+fn mccarthy_lambda_runs_on_beam() {
+    if !erl_available() { eprintln!("erl absent — skipping"); return; }
+    assert_eq!(run("((LAMBDA (X) X) 5)", "bl_id"), "5", "identity lambda");
+    assert_eq!(run("((LAMBDA (X) (CAR X)) (CONS 7 9))", "bl_car"), "7", "lambda over a cons arg");
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 3)", "bl_eq"), "1", "2-arg lambda");
+    assert_eq!(run("((LAMBDA (X) (EQ X (QUOTE A))) (QUOTE A))", "bl_sym"), "1", "lambda over a symbol arg");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -62,7 +62,7 @@ representation + per-builtin backend lowering.
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
-| **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | Erlang terms |
+| **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
@@ -215,9 +215,16 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
   dispatches the predicate set + rejects others). **Verified by RUNNING** on a real
   `erl`: `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(COND …)`→100/200
   (`lang-aot/tests/beam_predicates.rs`).
-- ☐ **W11 — BEAM symbols + lambda (F6–F7).** Symbols = Erlang atoms; lambda = fun.
-  **Completes BEAM.** (Mind the OTP-27 AtU8 atom-format constraint from
-  `ir-to-beam`.)
+- ✅ **W11 — BEAM symbols + lambda (F6–F7). 🎉 COMPLETES BEAM (F1–F7).**
+  **Symbols (F6):** one-line pipeline addition — `compile_source_to_beam` runs the
+  shared `intern_symbols_structural`, interning each symbol to a stable `i32` id
+  (`SYMBOL_ID_BASE = 1<<29`, the SAME id as wasm/JVM/CLR), carried as a native
+  Erlang integer; `EQ` → `is_eq_exact`. **Lambda (F7) needed NOTHING extra** — a
+  `(LAMBDA …)` application is a method `call`, already lowered natively (a BEAM
+  fun). **Verified by RUNNING** on a real `erl`: `(QUOTE A)`→536870912,
+  `(EQ (QUOTE A) (QUOTE A))`→1, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
+  `((LAMBDA (X) (EQ X (QUOTE A))) (QUOTE A))`→1
+  (`lang-aot/tests/beam_symbols_lambda.rs`). **BEAM is the FIFTH backend at F1–F7.**
 
 ### Phase E — LLVM (tagged-word, like native)
 


### PR DESCRIPTION
## 🎉 Symbols + lambda complete the BEAM backend — F1–F7

Symbols (F6) and lambda (F7) run on the BEAM, **completing the entire BEAM backend** — the **fifth** backend to reach full McCarthy support after VM, WASM, JVM, and CLR.

## Change (`lang-aot` 0.34.0; `iir-to-beam` UNCHANGED)

**Symbols (F6) — one added line:** `compile_source_to_beam` now runs the shared `intern_symbols_structural` pass, interning each distinct symbol to a stable `i32` id (`SYMBOL_ID_BASE = 1<<29`) — the **same** id the wasm/JVM/CLR backends assign (it matters for the W16 conformance suite) — carried as a native Erlang integer; `EQ` → `is_eq_exact`.

**Lambda (F7) — nothing extra:** a `(LAMBDA …)` application is a method `call`, which `iir-to-beam` already lowers natively (a BEAM fun). It was free the moment the cons/predicate pipeline was in place.

## Verified by RUNNING (`tests/beam_symbols_lambda.rs`, real `erl`)

| program | result |
|---|---|
| `(QUOTE A)` | `536870912` (= 2²⁹, the shared id — identical to CLR) |
| `(EQ (QUOTE A) (QUOTE A))` / `(QUOTE B)` | `1` / `0` |
| `(ATOM (QUOTE A))` | `1` |
| `((LAMBDA (X) (CAR X)) (CONS 7 9))` | `7` |
| `((LAMBDA (X Y) (EQ X Y)) 3 3)` | `1` |
| `((LAMBDA (X) (EQ X (QUOTE A))) (QUOTE A))` | `1` (lambda over a symbol arg) |

## Test plan

Full BEAM suite green, no regression — `beam_symbols_lambda` 2, `beam_predicates` 2, `beam_cons` 1, `beam_emit` 2. `lang-aot` clippy-clean. No `twig-vm` → no Miri. (`erl` test self-skips if absent.)

## Security & safety

Security review **PASSED**: the added pass is the same bounded, already-reviewed in-memory rewrite three other backends run (no recursion/IO/unwrap/overflow); the test spawns `erl` with fixed literals only (no injection), gated on `erl` availability.

## Matrix

**🎉 COMPLETES BEAM (F1–F7).** W11 ✅, BEAM row all ✅. **FIVE backends complete: VM, WASM, JVM, CLR, BEAM.** Remaining: LLVM (W12–13), native-AOT lambda (W14), JIT (W15), cross-backend conformance (W16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)