### PR TITLE
feat(mccarthy-lisp): W12a — LLVM scalar run-foundation via clang (LANG77)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — `lang-aot`
 
+## 0.35.0 — 2026-06-10 — McCarthy → **LLVM** scalar run-foundation via `clang` (LANG77 / W12a)
+
+Establishes the LLVM **verify-by-running** substrate — the first **tagged-word**
+target (the LLVM/AOT/JIT family that links the shared `lispy_runtime.c`). New
+`compile_source_to_llvm` / `compile_source_to_llvm_with_target`: concretize scalar
+`any`→`i64`, lower to LLVM IR text. The new `tests/llvm_scalar.rs` emits **host**-
+triple IR (`clang -dumpmachine`), builds it with `clang -x ir`, and **runs** the
+native executable — its process exit code carries the McCarthy result: `42`→42,
+`7`→7, `0`→0, `100`→100 (+ Twig `42`→42). Uses the `clang` already on the box (no
+extra toolchain; self-skips if absent) — the LLVM analogue of `wasm-runtime` /
+`clr-simulator` / real `erl`. The cons/predicate/symbol/lambda lowering
+(`call __twig_lispy_*`) is W12b+.
+
 ## 0.34.0 — 2026-06-10 — McCarthy → **BEAM symbols + lambda** — BEAM backend COMPLETE (LANG77 / W11, F6–F7)
 
 Symbols (F6) and lambda (F7) run on the BEAM — **completing the entire BEAM

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -59,6 +59,14 @@ native list cell `[H|T]`, `car`/`cdr` are `hd`/`tl`, integers are native.
 `(LAMBDA …)` application is a method `call`, already lowered as a BEAM fun). The
 BEAM is the fifth backend to reach full McCarthy support after VM, WASM, JVM, CLR.
 
+`compile_source_to_llvm` targets **LLVM IR** — the first **tagged-word** backend
+(the LLVM/AOT/JIT family that links the shared `lispy_runtime.c`). Scalar McCarthy
+emits LLVM IR that **runs**: the test emits host-triple IR (`clang -dumpmachine`),
+builds it with `clang -x ir`, and runs the native executable — its exit code is
+the result, `42` → 42 (W12a). It uses the `clang` already on the box (no
+`lli`/`qemu`), the LLVM analogue of `wasm-runtime`/the `clr-simulator`/real `erl`.
+The cons/predicate/symbol/lambda lowering (`call __twig_lispy_*`) is W12b+.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -351,6 +351,75 @@ pub fn compile_file_to_llvm_ir(
     Ok(())
 }
 
+/// Concretise a **scalar** module's `any`/`polymorphic` values to `i64` for the
+/// LLVM backend (LANG77 / McCarthy W12a). The LLVM backend is a typed SSA IR, so
+/// — like wasm/JVM/CLR/BEAM — a polymorphic scalar value must be given a concrete
+/// type before lowering; for a pure-integer McCarthy program that type is `i64`.
+/// Heap/reference functions (cons/symbols/lambda — the tagged-word value model
+/// routed through `lispy_runtime.c`, W12b+) are left alone.
+fn concretize_scalar_any_for_llvm(module: &mut IIRModule) {
+    const HEAP_OPS: &[&str] = &["alloc", "field_load", "field_store", "is_null"];
+    const LISP_BUILTINS: &[&str] = &[
+        "cons", "car", "cdr", "pair?", "not", "equal?", "make_symbol", "make_nil", "null?",
+    ];
+    for func in &mut module.functions {
+        let uses_lisp = func.params.iter().any(|(_, t)| {
+            t == "any" || t == "symbol" || t.starts_with("ref<")
+        }) || func.instructions.iter().any(|i| {
+            HEAP_OPS.contains(&i.op.as_str())
+                || (i.op == "call_builtin"
+                    && matches!(i.srcs.first(),
+                        Some(interpreter_ir::Operand::Var(n)) if LISP_BUILTINS.contains(&n.as_str())))
+                || i.type_hint.starts_with("ref<")
+        });
+        if uses_lisp {
+            continue; // tagged-word C-runtime value model — W12b+.
+        }
+        if func.return_type == "any" || func.return_type == "polymorphic" {
+            func.return_type = "i64".to_string();
+        }
+        for instr in &mut func.instructions {
+            if instr.type_hint == "any" || instr.type_hint == "polymorphic" {
+                instr.type_hint = "i64".to_string();
+            }
+        }
+    }
+}
+
+/// Cross-platform: source → IIR → **LLVM IR text** (`.ll`) for the default,
+/// reproducible target (`x86_64-unknown-linux-gnu`) — McCarthy W12a.
+///
+/// The fifth `--emit` value model and the first **tagged-word** target (the
+/// LLVM/AOT/JIT family that links the shared `lispy_runtime.c`, as opposed to the
+/// managed object models of wasm/JVM/CLR or BEAM's native terms). This scalar
+/// run-foundation concretises `any`→`i64` and lowers to LLVM IR; the cons /
+/// predicate / symbol / lambda lowering (`call __twig_lispy_*`) is W12b+.
+pub fn compile_source_to_llvm(
+    language: Language,
+    source: &str,
+    module_name: &str,
+) -> Result<String, LangAotError> {
+    compile_source_to_llvm_with_target(language, source, module_name, "x86_64-unknown-linux-gnu")
+}
+
+/// As [`compile_source_to_llvm`], but with a caller-chosen target triple. The
+/// **verify-by-running** harness passes the *host* triple (`clang -dumpmachine`)
+/// so `clang -x ir <out>.ll` produces a native executable that runs on the test
+/// machine — the LLVM analogue of `wasm-runtime` / the `clr-simulator` / real
+/// `erl`, but using the real `clang` already on the box.
+pub fn compile_source_to_llvm_with_target(
+    language: Language,
+    source: &str,
+    module_name: &str,
+    target_triple: &str,
+) -> Result<String, LangAotError> {
+    let mut module = compile_source_to_iir(language, source, module_name)?;
+    concretize_scalar_any_for_llvm(&mut module);
+    let cfg = iir_to_llvm::IIRLlvmConfig::new(module_name).with_target(target_triple);
+    iir_to_llvm::lower_iir_to_llvm(&module, &cfg)
+        .map_err(|e| LangAotError::LlvmBackendError(format!("{e}")))
+}
+
 /// Concretise the polymorphic `"any"`/`"polymorphic"` type hints of a **purely
 /// scalar** function to `"i64"`, so it can flow through the typed WASM backend
 /// (LANG77 / McCarthy L3b-3a-2).

--- a/code/packages/rust/lang-aot/tests/llvm_scalar.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_scalar.rs
@@ -1,0 +1,57 @@
+//! # LLVM scalar run-foundation — F1 (LANG77 / McCarthy W12a).
+//!
+//! The LLVM backend is the first **tagged-word** target (the LLVM/AOT/JIT family
+//! that links the shared `lispy_runtime.c`). This slice establishes the
+//! **verify-by-running** substrate: `lang-aot::compile_source_to_llvm_with_target`
+//! emits host-target LLVM IR, which `clang -x ir` compiles to a native executable
+//! whose process **exit code** carries the McCarthy result. `clang` is already on
+//! the box, so no extra toolchain is needed (skipped if `clang` is absent).
+//! The cons/predicate/symbol/lambda lowering (`call __twig_lispy_*`) is W12b+.
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+
+fn host_triple() -> String {
+    let out = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Compile a scalar program to host-target LLVM IR, build it with `clang -x ir`,
+/// run it, and return the process exit code (the McCarthy integer result).
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?} to LLVM: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w12a_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        .arg("-x").arg("ir").arg(&ll_path).arg("-o").arg(&exe)
+        .output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    let out = std::process::Command::new(&exe).output().expect("run exe");
+    out.status.code().expect("process exit code")
+}
+
+#[test]
+fn mccarthy_scalar_runs_on_llvm_via_clang() {
+    if !clang_available() {
+        eprintln!("clang absent — skipping LLVM scalar run test");
+        return;
+    }
+    assert_eq!(run("42", "ml_a"), 42, "McCarthy 42");
+    assert_eq!(run("7", "ml_b"), 7, "McCarthy 7");
+    assert_eq!(run("0", "ml_c"), 0, "McCarthy 0");
+    assert_eq!(run("100", "ml_d"), 100, "McCarthy 100");
+}
+
+#[test]
+fn twig_scalar_runs_on_llvm_via_clang() {
+    if !clang_available() { return; }
+    assert_eq!(run("42", "tl_a"), 42, "Twig 42");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -228,9 +228,19 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase E — LLVM (tagged-word, like native)
 
-- ☐ **W12 — LLVM cons + predicates (F2–F5).** Reuse the tagged-word C runtime
-  (`lispy_runtime.c`) the native AOT path links; lower cons/car/cdr/pair?/eq via
-  `call` to `__twig_lispy_*`; COND truthiness via `lispy_truthy`.
+- ◑ **W12 — LLVM cons + predicates (F2–F5).** *In progress.* Reuse the tagged-word
+  C runtime (`lispy_runtime.c`) the native AOT path links; lower cons/car/cdr/pair?/eq
+  via `call` to `__twig_lispy_*`; COND truthiness via `lispy_truthy`.
+  - ✅ **W12a — LLVM scalar run-foundation (F1, verify-by-running).** Established the
+    LLVM execution substrate: `compile_source_to_llvm[_with_target]` (concretize
+    `any`→`i64`, lower to LLVM IR). `lang-aot/tests/llvm_scalar.rs` emits **host**-
+    triple IR (`clang -dumpmachine`), compiles it with `clang -x ir`, and **runs** the
+    native executable — exit code = result: `42`→42, `7`→7, `0`→0, `100`→100, Twig
+    `42`→42. Uses the `clang` already on the box (no `lli`/`qemu` needed; self-skips if
+    absent). The LLVM analogue of `wasm-runtime`/`clr-simulator`/real `erl`.
+  - ☐ **W12b — LLVM cons + predicates (F2–F5).** Lower cons/car/cdr/pair?/equal?/not →
+    `call __twig_lispy_*`, link `lispy_runtime.c` in the clang harness, COND via
+    `lispy_truthy`. `(CAR (CONS 7 9))`→7 on the clang-built executable.
 - ☐ **W13 — LLVM symbols + lambda (F6–F7).** **Completes LLVM.**
 
 ### Phase F — native AOT + JIT completion


### PR DESCRIPTION
## What & why — the LLVM verify-by-running substrate

Establishes the LLVM **verify-by-running** path — the first **tagged-word** target (the LLVM/AOT/JIT family that links the shared `lispy_runtime.c`, distinct from the managed object models of wasm/JVM/CLR and BEAM's native terms). This is the LLVM analogue of BEAM W9a: a run-foundation before the cons/predicate lowering.

**The challenge:** unlike the other backends (in-repo runners — `wasm-runtime`, `clr-simulator`/`jvm-simulator`, real `erl`), the LLVM backend emits IR text and the box has no `lli`/`qemu` to execute it. But **`clang` IS present**, and `iir-to-llvm`'s target triple is configurable. So the harness emits **host**-triple IR (`clang -dumpmachine`), builds it with `clang -x ir`, and runs the native executable — its process **exit code** carries the McCarthy result.

## Change (`lang-aot` 0.35.0)

- `concretize_scalar_any_for_llvm` — `any`/`polymorphic`→`i64` for scalar functions (skipping heap/lisp functions — the tagged-word C-runtime model is W12b+). Mirrors the wasm/JVM/CLR/BEAM scalar concretizers.
- `compile_source_to_llvm` / `compile_source_to_llvm_with_target` — concretize + lower to LLVM IR; the `_with_target` variant lets the run-harness pick the host triple.

## Verified by RUNNING (`tests/llvm_scalar.rs`, `clang`)

`42`→42, `7`→7, `0`→0, `100`→100, Twig `42`→42 — the exit code of the clang-built native executable.

## Test plan

clang run-harness (4 McCarthy + 1 Twig scalar) — new `tests/llvm_scalar.rs` (self-skips if `clang` absent). `iir-to-llvm` **46** unaffected. `lang-aot` clippy-clean. No `twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: the new functions are bounded String rewrites + the existing already-reviewed lowering, errors propagate (no unwrap/panic/overflow on adversarial source); the test compiles+runs **fixed literal** sources with argv-array `clang` spawns (no shell, no untrusted input reaching the compiled program). The triple→IR-text interpolation is a pre-existing `with_target` property; in-repo callers are trusted and the worst case is invalid IR `clang` rejects (no ACE).

## Matrix

W12 sliced into **W12a (✅ this — run-foundation)** + **W12b** (cons/predicates → `call __twig_lispy_*`, link `lispy_runtime.c`). Five backends complete (VM/WASM/JVM/CLR/BEAM); LLVM now has a verified execution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)