### PR TITLE
feat(mccarthy-lisp): W12b-1 — McCarthy cons on LLVM via lispy_runtime.c (F2, LANG77)

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.5.0] — 2026-06-10 (McCarthy W12b-1 — tagged-word lisp `cons`/`car`/`cdr` → `__twig_lispy_*`)
+
+Lowers the **tagged-word lisp** builtins to `call`s into the shared C runtime
+(`twig-aot/runtime/lispy_runtime.c`) — the SAME runtime the native AOT path links,
+so any lisp-family frontend inherits it.
+
+- `LISPY_BUILTINS` table maps the `lispy_*` IIR names (from
+  `iir_builtin_lowering::lower_heap_builtins_runtime`/`lower_lisp_repr`) to the
+  runtime's `__twig_lispy_*` symbols: `cons`/`car`/`cdr`/`pair_p`/`equal`/`not`/
+  `truthy`/`box_int`/`unbox_int`/`nil`. Each is `i64 (i64 × arity)` — a lisp value
+  is a tagged 64-bit word.
+- `call_builtin "lispy_*"` lowers to `%d = call i64 @__twig_lispy_*(i64 …)`; one
+  `declare` per used builtin is emitted in the module header (first-seen order, deduped).
+- `llvm_type_for`: `any` and a lisp reference (`ref<Lispy…>`) map to `i64` (the
+  tagged word). A NON-lisp `ref<Foo>` stays `UnsupportedType`.
+- **Verified by RUNNING** end-to-end in `lang-aot` (clang links `lispy_runtime.c`):
+  `(CAR (CONS 7 9))`→7, `(CDR …)`→9, nested→2. Predicates (pair?/equal?/not, COND)
+  are emitted but their tagged-boolean result handling is W12b-2.
+
 ## [0.4.0] — 2026-06-01 (LLVM04 — `call` + `call_builtin print_i64` + `lang-aot --emit=llvm-ir`)
 
 ### Added — user-defined `call`

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-llvm"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -83,7 +83,8 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.2.0  | Function signatures + `ret`/`ret_void`/`const`/`mov`.       |
 | v0.3.0  | Typed arithmetic (`add`/`sub`/`mul`/...) + cmp + branches.  |
 | v0.4.0  | `call` + `call_builtin print_i64` extern declarations.      |
-| (later) | Memory ops, GC, debug info via `!dbg` metadata.             |
+| v0.5.0  | Tagged-word lisp `cons`/`car`/`cdr` → `call @__twig_lispy_*` (McCarthy W12b-1). |
+| (later) | Lisp predicates (tagged-bool result), GC, debug info via `!dbg`. |
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -194,6 +194,14 @@ fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlv
         "i64" | "u64" => Ok("i64"),
         "f32" => Ok("float"),
         "f64" => Ok("double"),
+        // McCarthy W12b (tagged-word lisp): a lisp value is a tagged 64-bit word
+        // (the C runtime's `LispyValue`), and the polymorphic `any` flows as the
+        // same word. A lisp heap reference (`ref<LispyPair>`, and any future
+        // `ref<Lispy…>`) is likewise carried as a tagged `i64` — the runtime owns
+        // the cell layout, the backend only moves words and calls `__twig_lispy_*`.
+        // NON-lisp references (`ref<Foo>`) remain unsupported (no value model).
+        "any" => Ok("i64"),
+        t if t.starts_with("ref<Lispy") => Ok("i64"),
         other => Err(IIRLlvmError::UnsupportedType {
             function: function.to_string(),
             type_hint: other.to_string(),
@@ -244,6 +252,43 @@ const SUPPORTED_OPS: &[&str] = &[
 /// global names commonly use `__` for runtime / launcher symbols, and the
 /// downstream linker resolves the host implementation.
 const SUPPORTED_BUILTINS: &[&str] = &["print_i64"];
+
+/// McCarthy W12b — the **tagged-word lisp** builtins the LLVM backend lowers to
+/// `call`s into the shared C runtime (`twig-aot/runtime/lispy_runtime.c`), the
+/// same runtime the native AOT backend links. Each entry is
+/// `(iir_name, runtime_symbol, arity)`; every lisp value is a tagged 64-bit word
+/// so the signature is always `i64 (i64 × arity)`. The `lispy_*` IIR names are
+/// produced by `iir_builtin_lowering::lower_heap_builtins_runtime` /
+/// `lower_lisp_repr`; they map to the runtime's `__twig_lispy_*` symbols.
+///
+/// | iir name         | runtime symbol            | McCarthy primitive            |
+/// |------------------|---------------------------|-------------------------------|
+/// | `lispy_cons`     | `__twig_lispy_cons`       | `CONS` — build a pair `[a|b]`  |
+/// | `lispy_car`/`cdr`| `__twig_lispy_car`/`cdr`  | `CAR`/`CDR`                    |
+/// | `lispy_pair_p`   | `__twig_lispy_pair_p`     | `pair?` (→ `ATOM`)            |
+/// | `lispy_equal`    | `__twig_lispy_equal`      | `EQ`                          |
+/// | `lispy_not`      | `__twig_lispy_not`        | logical `not`                 |
+/// | `lispy_truthy`   | `__twig_lispy_truthy`     | `COND` clause test            |
+/// | `lispy_box_int`  | `__twig_lispy_box_int`    | int → tagged word             |
+/// | `lispy_unbox_int`| `__twig_lispy_unbox_int`  | tagged word → int (result)    |
+/// | `lispy_nil`      | `__twig_lispy_nil`        | `()` / nil                    |
+const LISPY_BUILTINS: &[(&str, &str, usize)] = &[
+    ("lispy_cons", "__twig_lispy_cons", 2),
+    ("lispy_car", "__twig_lispy_car", 1),
+    ("lispy_cdr", "__twig_lispy_cdr", 1),
+    ("lispy_pair_p", "__twig_lispy_pair_p", 1),
+    ("lispy_equal", "__twig_lispy_equal", 2),
+    ("lispy_not", "__twig_lispy_not", 1),
+    ("lispy_truthy", "__twig_lispy_truthy", 1),
+    ("lispy_box_int", "__twig_lispy_box_int", 1),
+    ("lispy_unbox_int", "__twig_lispy_unbox_int", 1),
+    ("lispy_nil", "__twig_lispy_nil", 0),
+];
+
+/// Look up a `lispy_*` builtin by its IIR name.
+fn lispy_builtin(name: &str) -> Option<&'static (&'static str, &'static str, usize)> {
+    LISPY_BUILTINS.iter().find(|(n, _, _)| *n == name)
+}
 
 /// Pre-flight validation for IIR → LLVM lowering.
 ///
@@ -363,12 +408,19 @@ pub fn lower_iir_to_llvm(
     // Currently the only supported builtin is `print_i64` (LLVM convention
     // chosen for BASIC's PRINT — see `SUPPORTED_BUILTINS` doc above).
     let mut used_print_i64 = false;
+    // McCarthy W12b: collect the tagged-word lisp builtins actually used, in
+    // first-seen order, so each gets exactly one `declare i64 @__twig_lispy_*`.
+    let mut used_lispy: Vec<&'static (&'static str, &'static str, usize)> = Vec::new();
     for f in &module.functions {
         for i in &f.instructions {
             if i.op == "call_builtin" {
                 if let Some(Operand::Var(name)) = i.srcs.first() {
                     if name == "print_i64" {
                         used_print_i64 = true;
+                    } else if let Some(b) = lispy_builtin(name) {
+                        if !used_lispy.iter().any(|(n, _, _)| n == &b.0) {
+                            used_lispy.push(b);
+                        }
                     }
                 }
             }
@@ -377,6 +429,13 @@ pub fn lower_iir_to_llvm(
     if used_print_i64 {
         out.push('\n');
         out.push_str("declare void @__print_i64(i64)\n");
+    }
+    if !used_lispy.is_empty() {
+        out.push('\n');
+        for (_iir_name, symbol, arity) in &used_lispy {
+            let params = vec!["i64"; *arity].join(", ");
+            out.push_str(&format!("declare i64 @{symbol}({params})\n"));
+        }
     }
 
     // ── Function bodies ───────────────────────────────────────────────────
@@ -1004,6 +1063,21 @@ fn lower_call_builtin(
             detail: "call_builtin requires srcs[0] = Operand::Var(builtin_name)".into(),
         }),
     };
+    // McCarthy W12b: a tagged-word lisp builtin lowers to a `call` into the C
+    // runtime. Every arg + the result is an `i64` (tagged word); the dest gets a
+    // fresh SSA name registered in the env so later instructions can use it.
+    if let Some((_iir_name, symbol, arity)) = lispy_builtin(&name) {
+        let dest = require_dest(instr, &name, state.fn_name)?.to_string();
+        let mut args = Vec::with_capacity(*arity);
+        for k in 0..*arity {
+            // srcs[0] is the builtin name; the operands start at srcs[1].
+            let a = resolve_operand(instr.srcs.get(1 + k), &state.env, "i64", state.fn_name)?;
+            args.push(format!("i64 {a}"));
+        }
+        out.push_str(&format!("  %{dest} = call i64 @{symbol}({})\n", args.join(", ")));
+        state.env.insert(dest.clone(), format!("%{dest}"));
+        return Ok(());
+    }
     if !SUPPORTED_BUILTINS.contains(&name.as_str()) {
         return Err(IIRLlvmError::UnsupportedOp {
             function: state.fn_name.into(),

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -888,3 +888,67 @@ fn errors_display_without_panic() {
     let _ = format!("{}", IIRLlvmError::InvalidOperand { function: "f".into(), detail: "bad".into() });
     let _ = format!("{}", IIRLlvmError::UndefinedVariable { function: "f".into(), name: "nope".into() });
 }
+
+/// McCarthy W12b: a tagged-word lisp builtin (`call_builtin "lispy_cons"`) lowers
+/// to a `call i64 @__twig_lispy_cons(i64, i64)` and emits exactly one matching
+/// `declare`. A lisp heap reference type (`ref<LispyPair>`) is accepted (carried
+/// as a tagged `i64`); a non-lisp `ref<Foo>` is still rejected (see
+/// `validate_rejects_unsupported_type`).
+#[test]
+fn lispy_cons_lowers_to_runtime_call() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(56)], "i64"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(72)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("p".into()),
+                vec![
+                    Operand::Var("lispy_cons".into()),
+                    Operand::Var("a".into()),
+                    Operand::Var("b".into()),
+                ],
+                "ref<LispyPair>",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("h".into()),
+                vec![Operand::Var("lispy_car".into()), Operand::Var("p".into())],
+                "any",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("h".into())], "any"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("declare i64 @__twig_lispy_cons(i64, i64)"), "cons declare; got:\n{ll}");
+    assert!(ll.contains("declare i64 @__twig_lispy_car(i64)"), "car declare; got:\n{ll}");
+    assert!(ll.contains("= call i64 @__twig_lispy_cons(i64 "), "cons call site; got:\n{ll}");
+    assert!(ll.contains("= call i64 @__twig_lispy_car(i64 "), "car call site; got:\n{ll}");
+    // Exactly one declare per used builtin (no duplicates from two call sites).
+    assert_eq!(ll.matches("declare i64 @__twig_lispy_cons").count(), 1, "one cons declare");
+}
+
+/// An unknown `lispy_*`-shaped builtin that is NOT in `LISPY_BUILTINS` is rejected.
+#[test]
+fn unknown_builtin_still_rejected() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("x".into()),
+                vec![Operand::Var("lispy_bogus".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i64"),
+        ],
+    );
+    let err = lower_iir_to_llvm(&module_with(f), &IIRLlvmConfig::default())
+        .expect_err("unknown builtin must be rejected");
+    assert!(matches!(err, IIRLlvmError::UnsupportedOp { .. }), "got: {err:?}");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — `lang-aot`
 
+## 0.36.0 — 2026-06-10 — McCarthy → **LLVM cons** (F2) on a clang-built executable (LANG77 / W12b-1)
+
+`compile_source_to_llvm` now runs the **native tagged-word lisp pipeline** — the
+SAME passes the native AOT path runs, NOT the managed structural pass:
+`lower_heap_builtins_runtime` (cons/car/cdr → `call_builtin "lispy_*"`) →
+`intern_symbols` → `lower_lisp_repr` (boxes int literals to tagged words, inserts the
+final `lispy_unbox_int` so the result is a plain `i64`). `iir-to-llvm` (0.5.0) lowers
+each `lispy_*` to `call @__twig_lispy_*`. A pure-scalar program never enters those
+passes (then `concretize_scalar_any_for_llvm` handles `any`→`i64` as before).
+
+**Verified by RUNNING** (`tests/llvm_cons.rs`): emit host-triple IR, **link
+`twig-aot/runtime/lispy_runtime.c`** with `clang` (`-x ir <ours> -x none <runtime.c>`),
+run the native executable — exit code = result: `(CAR (CONS 7 9))`→7,
+`(CDR (CONS 7 9))`→9, `(CAR (CDR (CONS 1 (CONS 2 3))))`→2, scalar `42`→42 (no
+regression). Predicates (pair?/equal?/not, COND — F3–F5) are W12b-2 (their
+tagged-boolean result needs its own handling).
+
 ## 0.35.0 — 2026-06-10 — McCarthy → **LLVM** scalar run-foundation via `clang` (LANG77 / W12a)
 
 Establishes the LLVM **verify-by-running** substrate — the first **tagged-word**

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -65,7 +65,11 @@ emits LLVM IR that **runs**: the test emits host-triple IR (`clang -dumpmachine`
 builds it with `clang -x ir`, and runs the native executable — its exit code is
 the result, `42` → 42 (W12a). It uses the `clang` already on the box (no
 `lli`/`qemu`), the LLVM analogue of `wasm-runtime`/the `clr-simulator`/real `erl`.
-The cons/predicate/symbol/lambda lowering (`call __twig_lispy_*`) is W12b+.
+**Cons** runs too (W12b-1, F2): the native lisp pipeline
+(`lower_heap_builtins_runtime`→`intern_symbols`→`lower_lisp_repr`) lowers cons/car/cdr
+to `call @__twig_lispy_*`, and the test **links `lispy_runtime.c`** into the
+clang-built executable — `(CAR (CONS 7 9))` → 7, `(CDR (CONS 7 9))` → 9. The
+predicate/symbol/lambda steps (F3–F7) are W12b-2+.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -414,6 +414,18 @@ pub fn compile_source_to_llvm_with_target(
     target_triple: &str,
 ) -> Result<String, LangAotError> {
     let mut module = compile_source_to_iir(language, source, module_name)?;
+    // The TAGGED-WORD lisp pipeline (McCarthy W12b) — the SAME passes the native
+    // AOT path runs, NOT the managed structural pass. `lower_heap_builtins_runtime`
+    // turns cons/car/cdr/pair?/equal?/not into `call_builtin "lispy_*"`;
+    // `intern_symbols` assigns each symbol a tagged immediate; `lower_lisp_repr`
+    // boxes integer literals to tagged words and inserts the final `lispy_unbox_int`
+    // so the result is a plain `i64`. `iir-to-llvm` then lowers each `lispy_*` to a
+    // `call @__twig_lispy_*` into `lispy_runtime.c`. A no-op for a scalar program.
+    iir_builtin_lowering::lower_heap_builtins_runtime(&mut module);
+    iir_builtin_lowering::intern_symbols(&mut module);
+    iir_builtin_lowering::lower_lisp_repr(&mut module);
+    // Concretise any residual scalar `any` (a pure-integer program never enters
+    // the lisp passes above) to `i64`.
     concretize_scalar_any_for_llvm(&mut module);
     let cfg = iir_to_llvm::IIRLlvmConfig::new(module_name).with_target(target_triple);
     iir_to_llvm::lower_iir_to_llvm(&module, &cfg)

--- a/code/packages/rust/lang-aot/tests/llvm_cons.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_cons.rs
@@ -1,0 +1,56 @@
+//! # LLVM cons — F2 (LANG77 / McCarthy W12b-1).
+//!
+//! The first **tagged-word** cons backend: a McCarthy cons is a tagged 64-bit
+//! word managed by the shared C runtime `lispy_runtime.c` (the SAME runtime the
+//! native AOT path links). `compile_source_to_llvm` runs the native lisp pipeline
+//! (`lower_heap_builtins_runtime` → `intern_symbols` → `lower_lisp_repr`), so
+//! cons/car/cdr become `call_builtin "lispy_*"` over pre-boxed tagged words with a
+//! final `lispy_unbox_int`; `iir-to-llvm` lowers each to `call @__twig_lispy_*`.
+//! **Verified by RUNNING**: emit host-triple IR, link `lispy_runtime.c` with
+//! `clang`, run the native executable — its exit code is the result. (Predicates
+//! F3–F5, whose tagged-boolean result needs its own handling, are W12b-2.)
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+fn host_triple() -> String {
+    let o = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+/// Path to the shared C runtime (relative to this crate).
+fn lispy_runtime_c() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../twig-aot/runtime/lispy_runtime.c")
+}
+
+/// Compile to host LLVM IR, link `lispy_runtime.c` with `clang`, run, return exit code.
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?} to LLVM: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w12b_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        // `-x ir <our IR>` then `-x none <C runtime>` (reset so clang treats the .c by extension).
+        .arg("-x").arg("ir").arg(&ll_path)
+        .arg("-x").arg("none").arg(lispy_runtime_c())
+        .arg("-o").arg(&exe)
+        .output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    let out = std::process::Command::new(&exe).output().expect("run exe");
+    out.status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_cons_car_cdr_run_on_llvm() {
+    if !clang_available() { eprintln!("clang absent — skipping"); return; }
+    assert_eq!(run("(CAR (CONS 7 9))", "lc_car"), 7, "car of a cons");
+    assert_eq!(run("(CDR (CONS 7 9))", "lc_cdr"), 9, "cdr of a cons");
+    assert_eq!(run("(CAR (CDR (CONS 1 (CONS 2 3))))", "lc_nest"), 2, "car of cdr of nested cons");
+    assert_eq!(run("42", "lc_scalar"), 42, "scalar still runs (backward compat)");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -63,7 +63,7 @@ representation + per-builtin backend lowering.
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
-| **LLVM** | `iir-to-llvm` | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
+| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
@@ -238,9 +238,18 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     native executable — exit code = result: `42`→42, `7`→7, `0`→0, `100`→100, Twig
     `42`→42. Uses the `clang` already on the box (no `lli`/`qemu` needed; self-skips if
     absent). The LLVM analogue of `wasm-runtime`/`clr-simulator`/real `erl`.
-  - ☐ **W12b — LLVM cons + predicates (F2–F5).** Lower cons/car/cdr/pair?/equal?/not →
-    `call __twig_lispy_*`, link `lispy_runtime.c` in the clang harness, COND via
-    `lispy_truthy`. `(CAR (CONS 7 9))`→7 on the clang-built executable.
+  - ✅ **W12b-1 — LLVM cons (F2).** Lower cons/car/cdr → `call @__twig_lispy_*`
+    (the `LISPY_BUILTINS` table maps `lispy_*`→runtime symbols; `ref<LispyPair>`/`any`
+    carried as a tagged `i64`). `compile_source_to_llvm` runs the native lisp pipeline
+    (`lower_heap_builtins_runtime`→`intern_symbols`→`lower_lisp_repr`). Verified by
+    RUNNING on a clang-built executable **linked against `lispy_runtime.c`**:
+    `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, `(CAR (CDR (CONS 1 (CONS 2 3))))`→2,
+    scalar `42`→42 (`lang-aot/tests/llvm_cons.rs`).
+  - ☐ **W12b-2 — LLVM predicates (F3–F5).** pair?/equal?/not lowering is already
+    emitted (`lispy_pair_p`/`lispy_equal`/`lispy_not` in `LISPY_BUILTINS`); needs the
+    **tagged-boolean result** handling (a predicate returns `__twig_lispy_tag_true/false`,
+    not 0/1) + the `COND` `trunc void` fix (`lispy_truthy` clause test).
+    `(ATOM 7)`→1, `(EQ 7 7)`→1, `(COND …)`.
 - ☐ **W13 — LLVM symbols + lambda (F6–F7).** **Completes LLVM.**
 
 ### Phase F — native AOT + JIT completion


### PR DESCRIPTION
## McCarthy cons runs on a real LLVM-compiled native executable

Lowers tagged-word lisp `cons`/`car`/`cdr` to `call @__twig_lispy_*` into the **shared** C runtime (`twig-aot/runtime/lispy_runtime.c`) — the same runtime the native AOT path links — and runs it on a real `clang`-built executable. **LLVM reaches F2.**

## Change

**`iir-to-llvm` 0.5.0**
- `LISPY_BUILTINS` table maps the `lispy_*` IIR names (from `lower_heap_builtins_runtime`/`lower_lisp_repr`) to the runtime `__twig_lispy_*` symbols (cons/car/cdr/pair_p/equal/not/truthy/box_int/unbox_int/nil); each is `i64 (i64 × arity)` — a lisp value is a tagged 64-bit word.
- `call_builtin "lispy_*"` → `%d = call i64 @__twig_lispy_*(i64 …)`; one deduped `declare` per used builtin in the header.
- `llvm_type_for`: `any` and a lisp ref (`ref<Lispy…>`) → `i64`; a **non**-lisp `ref<Foo>` stays `UnsupportedType`.

**`lang-aot` 0.36.0**
- `compile_source_to_llvm` runs the **native** tagged-word lisp pipeline (the same passes the native AOT path runs, NOT the managed structural pass): `lower_heap_builtins_runtime` → `intern_symbols` → `lower_lisp_repr` (boxes int literals to tagged words, inserts the final `lispy_unbox_int` so the result is a plain `i64`), then `concretize_scalar_any_for_llvm` for residual scalars.

## Verified by RUNNING (`tests/llvm_cons.rs`)

Emit host IR, **link `lispy_runtime.c`** with clang (`-x ir <ours> -x none <runtime.c>`), run — exit code = result:

| program | result |
|---|---|
| `(CAR (CONS 7 9))` | 7 |
| `(CDR (CONS 7 9))` | 9 |
| `(CAR (CDR (CONS 1 (CONS 2 3))))` | 2 |
| `42` | 42 (scalar, no regression) |

## Test plan

`iir-to-llvm` **48** (+2 lispy lowering unit tests), `lang-aot` `llvm_cons` 1 + `llvm_scalar` 1 (no regression). clippy clean. No `twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: new lowering is bounded (arity from a hardcoded ≤2 table), missing operand/dest return `Err` (no panic/OOB/overflow), declares/calls interpolate only hardcoded symbols (no IR injection), `any`/`ref<Lispy…>`→`i64` is ABI-consistent with the runtime's 64-bit `LispyValue`; `lang-aot` just composes already-reviewed passes.

## Matrix

W12 sliced: **W12a** (scalar foundation) ✅, **W12b-1 (cons, F2)** ✅ this, **W12b-2 (predicates, F3–F5)** ☐ — pair?/equal?/not lowering is already emitted but their **tagged-boolean result** (returns `__twig_lispy_tag_true/false`, not 0/1) + the `COND` `trunc void` fix are the next slice. LLVM row: F1 ✅ F2 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)