### PR TITLE
feat(closurec): CLOC12.67 — close gap-058 (numeric separator in float literals)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.71.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-058** — the ES2021 `_` numeric separator is now
+  stripped from FLOAT and scientific literals, not just integers:
+  - `1_000.5` → `1000.5`
+  - `1_0e3`   → `10e3`
+
+  `normalize_number_value`'s float/scientific branch previously
+  returned the literal verbatim (separators intact). It now
+  returns `cleaned` — the value with every `_` already removed —
+  so separators are stripped while the float/scientific *shape*
+  is otherwise untouched. Full float shortest-form (`0.5` → `.5`,
+  `1000e3` → `1E6`) remains a separate deferred gap. The
+  separator is purely lexical sugar, so its removal needs no
+  numeric reasoning and is always safe.
+
 ## [0.70.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.70.0"
+version = "0.71.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1540,10 +1540,18 @@ fn normalize_number_value(value: &str) -> String {
         cleaned.parse::<u128>().ok()
     } else {
         // Has a `.` or `e`/`E` or other non-integer
-        // character — leave alone. Decimal floating-point
-        // shortest-form (e.g. `0.5` → `.5`) is a separate
-        // future gap.
-        return value.to_string();
+        // character. We do NOT attempt full shortest-form
+        // normalization here (e.g. `0.5` → `.5`, `1000e3` →
+        // `1E6`) — that's a separate deferred gap. BUT the
+        // ES2021 `_` numeric separator is PURELY LEXICAL
+        // sugar, so it must still be stripped even for
+        // floats and scientific forms (gap-058):
+        //   `1_000.5` → `1000.5`   (separator removed)
+        //   `1_0e3`   → `10e3`     (separator removed)
+        // `cleaned` is `value` with every `_` already
+        // removed, so returning it strips separators while
+        // leaving the float/sci shape otherwise untouched.
+        return cleaned;
     };
 
     let Some(n) = parsed else {
@@ -2861,6 +2869,33 @@ mod tests {
     #[test]
     fn gap040_zero_unchanged() {
         assert_eq!(minify("var x=0;"), "var x=0;");
+    }
+
+    // ---- gap-058: numeric separator in float literals ----
+
+    /// gap-058: a `_` separator in a FLOAT literal is purely
+    /// lexical sugar and must be stripped, even though full
+    /// float shortest-form (`0.5` → `.5`) stays deferred.
+    /// `1_000.5` → `1000.5` (matches upstream).
+    #[test]
+    fn gap058_float_separator_stripped() {
+        assert_eq!(minify("var x=1_000.5;"), "var x=1000.5;");
+    }
+
+    /// gap-058: separator in the mantissa of a scientific
+    /// literal is likewise stripped (`1_0e3` → `10e3`). The
+    /// `e`-exponent shape is otherwise left untouched (sci
+    /// shortest-form is a separate deferred gap).
+    #[test]
+    fn gap058_scientific_mantissa_separator_stripped() {
+        assert_eq!(minify("var x=1_0e3;"), "var x=10e3;");
+    }
+
+    /// gap-058 non-regression: a float with NO separator is
+    /// returned verbatim (no spurious shortest-form rewrite).
+    #[test]
+    fn gap058_plain_float_unchanged() {
+        assert_eq!(minify("var x=3.14;"), "var x=3.14;");
     }
 
     /// **Non-regression**: decimal source without trailing

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.70.0
+Version: 0.71.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,10 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-058 (CLOC14.29): numeric separator inside a FLOAT
-    // literal is not stripped — `1_000.5` → `1000.5` upstream.
-    // gap-040 covered integer/scientific forms only.
-    ("numeric_underscore_float", "gap-058: numeric separator in float literal"),
     // gap-059 (CLOC14.29): member access on a `new` expression.
     // Upstream drops the empty call parens AND re-wraps to keep
     // precedence: `new A().b` → `(new A).b`.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -453,9 +453,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-058 — numeric separator in float literals
 
-- **Status:** OPEN — discovered by CLOC14.29. `minify_numeric_underscore_float` ignored.
+- **Status:** **RESOLVED** in CLOC12.67. `minify_numeric_underscore_float` flips IGNORED → PASS.
 - **Input:** `var x=1_000.5;` → **Upstream:** `var x=1000.5;`
-- **What it needs:** Extend the gap-040 numeric-separator stripping (which handled integer + scientific forms) to cover the fractional part of a float literal — strip `_` from `1_000.5` too. Likely the separator strip is keyed on a token shape that doesn't match a NUMBER with a `.`-fraction.
+- **Fix:** `normalize_number_value`'s float/scientific branch returned the value verbatim (leaving `_` in). It now returns `cleaned` (the value with every `_` already stripped) instead — separators removed for floats/scientific too. Full float shortest-form (`0.5` → `.5`, `1000e3` → `1E6`) remains a separate deferred gap; only the purely-lexical separator stripping is added here.
 
 ### gap-059 — member access on a `new` expression
 


### PR DESCRIPTION
## What

Closes **gap-058** (found in CLOC14.29). The ES2021 `_` numeric separator was stripped from integer literals but left intact in **float** and scientific forms:

```
1_000.5  →  1000.5   (was: 1_000.5)
1_0e3    →  10e3
```

`minify_numeric_underscore_float` flips IGNORED → PASS.

## How

One-line fix in `normalize_number_value`: the float/scientific else-branch returned the literal verbatim (`return value.to_string()`); it now returns `cleaned` — the value with every `_` already stripped earlier in the same function. The separator is purely lexical sugar, so its removal needs no numeric reasoning and is always safe. Full float shortest-form (`0.5`→`.5`, `1000e3`→`1E6`) remains a separate deferred gap.

## Tests

- 3 new unit tests: float separator, scientific-mantissa separator, plain-float non-regression.
- 414 unit tests + byte-identity harness green (23 suites).
- Security-reviewed (read-only subagent): **PASS** — confirmed `replace('_','')` touches only `_`, no value/shape change, no panic path, and only number tokens reach the function (string/regex/template are guarded out).

Version 0.70→0.71; help-markdown fixture regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)