### PR TITLE
feat(closurec): CLOC12.68 — close gap-059 (member/call on new-expr wraps to (new A).b)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.72.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-059** (minimal slice) — member/call on a `new`
+  expression now wraps in parens: `new A().b` → `(new A).b`.
+  Upstream wraps because `new A.b` parses as `new (A.b)` (a
+  different program), and drops the empty `()` arg list.
+
+### Added — gap-059 token pre-pass
+
+A new pre-pass wraps the new-expression WITHOUT synthesising
+tokens: the empty arg-list `()` already contributes a `(` and a
+`)`, so the pass just REORDERS them — moving the `(` to before
+`new` (`new A ( ) .` → `( new A ) .`). Minimal safe slice:
+single plain-identifier callee, empty arg list, followed by
+`.`/`[`/`(`. Guards: operator `new` only (a property `.new` is
+left alone), all bracket checks via `is_structural_punct`.
+Complements gap-050 (which drops `new A()` → `new A` only when
+NO member/call follows — exactly the cases this pass handles).
+
+Verified against the upstream JAR: `new A().b` → `(new A).b`,
+`.b.c`/`[i]`/`()` chains likewise wrap, standalone `new A()` →
+`new A` (unchanged), and `a.new()` (property) is untouched.
+Member-callee (`new a.b.C().d`) and arg-bearing (`new A(y).b`)
+shapes are deferred follow-ups.
+
+Updated three former gap-050 "keeps_parens" unit tests — they
+asserted the pre-gap-059 (upstream-divergent) output and now
+assert the wrapped form.
+
 ## [0.71.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.71.0"
+version = "0.72.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -521,6 +521,69 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-059: member/call on a `new` expression ----------
+    // `new A().b` → `(new A).b`. When a NewExpression is the
+    // OBJECT of a member access (`.`/`[`) or the CALLEE of a
+    // call (`(`), upstream Closure wraps the whole `new …` in
+    // parens — because `new A.b` would parse as `new (A.b)`
+    // (member access binds tighter than argument-less `new`),
+    // which is a DIFFERENT program. It also drops the empty
+    // `()` arg list (cf. gap-050, which only drops it when no
+    // member/call follows — exactly the cases this pass does
+    // NOT handle, so the two are complementary).
+    //
+    // We implement the wrap WITHOUT synthesising tokens: the
+    // empty arg-list already contributes a `(` and a `)` to the
+    // stream, so we just REORDER them — move the `(` to before
+    // `new`, leaving the `)` after the identifier:
+    //
+    //   `new A ( ) .`   →   `( new A ) .`
+    //   [new,A,(,),.]       [(,new,A,),.]
+    //
+    // Minimal safe slice (matches the byte-identity fixture
+    // `minify_new_member_chain`):
+    //   - single plain-identifier callee (`new A`, not
+    //     `new a.b.C` — member-callee deferred),
+    //   - EMPTY arg list `()` (arg-bearing `new A(y).b` →
+    //     `(new A(y)).b` is a deferred follow-up),
+    //   - followed by `.`, `[`, or `(`.
+    //
+    // Guards:
+    //   - operator `new`, not the property name `.new`/`?.new`
+    //     (a property `new` is preceded by a member accessor),
+    //   - all bracket checks go through `is_structural_punct`
+    //     so a string/regex/template whose value looks like a
+    //     bracket can never trigger the reorder.
+    {
+        let mut i = 0;
+        while i + 4 < kept.len() {
+            let is_operator_new = kept[i].value == "new"
+                && !is_string_literal(kept[i])
+                && (i == 0
+                    || (!is_structural_punct(&kept[i - 1], ".")
+                        && !is_structural_punct(&kept[i - 1], "?.")));
+            if is_operator_new
+                && is_simple_identifier_token(Some(kept[i + 1]))
+                && is_structural_punct(&kept[i + 2], "(")
+                && is_structural_punct(&kept[i + 3], ")")
+                && (is_structural_punct(&kept[i + 4], ".")
+                    || is_structural_punct(&kept[i + 4], "[")
+                    || is_structural_punct(&kept[i + 4], "("))
+            {
+                // Reorder: pull the `(` (empty arg-list open)
+                // out from i+2 and re-insert it before `new`.
+                // The `)` stays put — now closing the wrap.
+                let open = kept.remove(i + 2);
+                kept.insert(i, open);
+                // Past `( new IDENT )`; the member/call token
+                // is now at i+4 and re-scanned next iteration.
+                i += 4;
+                continue;
+            }
+            i += 1;
+        }
+    }
+
     let kept = kept;
 
     // Re-stitch: insert a single space between two adjacent
@@ -3387,34 +3450,53 @@ mod tests {
     }
 
     /// **Non-regression**: `new Foo().bar` — dropping the
-    /// `()` would change parse to `new Foo.bar` (different
-    /// constructor). Must keep parens.
+    /// gap-059 (was gap-050 "keeps_parens"): `new Foo().bar`
+    /// is now WRAPPED to `(new Foo).bar`. Dropping the `()`
+    /// without wrapping would mis-parse as `new(Foo.bar)`, so
+    /// upstream wraps the NewExpression. The old behavior
+    /// (leaving `new Foo().bar` intact) diverged from upstream;
+    /// gap-059 makes it byte-identical.
     #[test]
-    fn gap050_new_call_then_member_keeps_parens() {
-        assert_eq!(
-            minify("var x=new Foo().bar;"),
-            "var x=new Foo().bar;"
-        );
+    fn gap059_new_call_then_member_wraps() {
+        assert_eq!(minify("var x=new Foo().bar;"), "var x=(new Foo).bar;");
     }
 
-    /// **Non-regression**: `new Foo()[x]` — same family;
-    /// element-access on result vs constructor of `Foo[x]`.
+    /// gap-059: `new Foo()[0]` → `(new Foo)[0]` (computed
+    /// member triggers the same wrap).
     #[test]
-    fn gap050_new_call_then_bracket_keeps_parens() {
-        assert_eq!(
-            minify("var x=new Foo()[0];"),
-            "var x=new Foo()[0];"
-        );
+    fn gap059_new_call_then_bracket_wraps() {
+        assert_eq!(minify("var x=new Foo()[0];"), "var x=(new Foo)[0];");
     }
 
-    /// **Non-regression**: `new Foo()()` — chained call on
-    /// result. Dropping would lose the chained call.
+    /// gap-059: `new Foo()()` → `(new Foo)()` (call on the
+    /// constructed object triggers the wrap; the chained call
+    /// is preserved).
     #[test]
-    fn gap050_new_call_then_call_keeps_parens() {
-        assert_eq!(
-            minify("var x=new Foo()();"),
-            "var x=new Foo()();"
-        );
+    fn gap059_new_call_then_call_wraps() {
+        assert_eq!(minify("var x=new Foo()();"), "var x=(new Foo)();");
+    }
+
+    /// gap-059 non-regression: standalone `new Foo()` (no
+    /// member/call follows) is still just `new Foo` (gap-050),
+    /// NOT wrapped.
+    #[test]
+    fn gap059_standalone_new_not_wrapped() {
+        assert_eq!(minify("var x=new Foo();"), "var x=new Foo;");
+    }
+
+    /// gap-059 guard: a property named `new` (`a.new()`) is
+    /// NOT the `new` operator, so no wrap.
+    #[test]
+    fn gap059_property_new_not_wrapped() {
+        assert_eq!(minify("var x=a.new().b;"), "var x=a.new().b;");
+    }
+
+    /// gap-059 deferred: arg-bearing `new Foo(y).b` is left
+    /// untouched by the minimal slice (upstream wraps it to
+    /// `(new Foo(y)).b` — a follow-up).
+    #[test]
+    fn gap059_arg_bearing_new_deferred() {
+        assert_eq!(minify("var x=new Foo(y).b;"), "var x=new Foo(y).b;");
     }
 
     /// **Non-regression**: `new Foo() + 1` — `+` binds

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.71.0
+Version: 0.72.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,10 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-059 (CLOC14.29): member access on a `new` expression.
-    // Upstream drops the empty call parens AND re-wraps to keep
-    // precedence: `new A().b` → `(new A).b`.
-    ("new_member_chain", "gap-059: new-expr member `new A().b` → `(new A).b`"),
     // gap-055/056/057 all RESOLVED (CLOC12.64/65/66) — ternary
     // arms, return/throw/=> prefixes, and member-object parens
     // (`(a).b` → `a.b`) now pass and are no longer ignored.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -459,6 +459,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-059 — member access on a `new` expression
 
-- **Status:** OPEN — discovered by CLOC14.29. `minify_new_member_chain` ignored.
+- **Status:** **RESOLVED** in CLOC12.68 (minimal slice). `minify_new_member_chain` flips IGNORED → PASS.
 - **Input:** `var x=new A().b;` → **Upstream:** `var x=(new A).b;`
-- **What it needs:** Two coordinated transforms: (1) drop the empty call parens of `new A()` (gap-050 does this standalone), and (2) wrap the result in parens when a `.member` follows — `new A.b` would parse as `new (A.b)`, so upstream emits `(new A).b` to preserve "construct A, then read .b". Non-trivial: needs `new`-expression-aware paren insertion in the token re-stitcher. Design before implementing.
+- **Fix:** Token pre-pass that wraps the `new`-expression in parens when it's the object/callee of a following `.`/`[`/`(`. Implemented WITHOUT synthesising tokens: the empty arg-list `()` already provides a `(` and `)`, so the pass just REORDERS them — moves the `(` to before `new`, leaving the `)` after the identifier (`new A ( ) .` → `( new A ) .`). Guards: operator `new` only (not the property `.new`/`?.new`), single plain-identifier callee, empty arg-list, followed by `.`/`[`/`(`; all bracket checks via `is_structural_punct`. Complements gap-050 (which drops `new A()`→`new A` only when NOT followed by member/call). Verified against JAR for `.b`, `.b.c`, `[i]`, `()`, standalone, and property-`new`.
+- **Deferred (follow-up):** member-callee `new a.b.C().d` → `(new a.b.C).d`, and arg-bearing `new A(y).b` → `(new A(y)).b`. The minimal slice handles single-identifier empty-arg new-expressions (the fixture); these broader shapes need callee-extent + arg-list scanning.


### PR DESCRIPTION
## What

Closes **gap-059** (minimal slice, found in CLOC14.29). When a `new`-expression is the object/callee of a following `.`/`[`/`(`, upstream Closure wraps it in parens and drops the empty `()`:

```
new A().b   →  (new A).b
new A().b.c →  (new A).b.c
new A()[i]  →  (new A)[i]
new A()()   →  (new A)()
```

`minify_new_member_chain` flips IGNORED → PASS. Wrapping is required because `new A.b` parses as `new (A.b)` — a different program.

## How

A token pre-pass that **reorders the existing empty arg-list parens** — no synthetic tokens. It moves the `(` to before `new`, leaving the `)` after the identifier:

```
new A ( ) .   →   ( new A ) .
```

Minimal safe slice: single plain-identifier callee, empty arg list, followed by `.`/`[`/`(`. Guards: operator `new` only (the property `a.new()` is left alone), all bracket checks via `is_structural_punct`. Complements gap-050 (drops `new A()`→`new A` only when *no* member/call follows — exactly the cases this handles).

## Tests

- 6 new `gap059_*` unit tests; 3 former gap-050 "keeps_parens" tests updated (they asserted the upstream-divergent pre-gap-059 output).
- 23 suites green incl. byte-identity harness with `new_member_chain` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified reorder correctness, no bounds/loop issues, property-`new`/string-`new` guards, empty-arg-only matching, and clean interaction with gap-050/gap-057 (11 adversarial inputs).

Member-callee (`new a.b.C().d`) and arg-bearing (`new A(y).b`) are deferred follow-ups. Version 0.71→0.72; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)