### PR TITLE
feat(mccarthy-lisp): W12b-2 — McCarthy predicates ATOM/EQ on LLVM (F3-F4, LANG77)

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.14.0] — 2026-06-10 — boolean program-result coercion (LANG77 / McCarthy W12b-2)
+
+Closes the long-deferred "booleans land in L3b-2c-2" gap in `lower_lisp_repr`'s
+program-exit handling. A value produced by a predicate (`pair?`/`equal?`/`not`) is
+a tagged **boolean** (`LISPY_TRUE = 5` / `LISPY_FALSE = 3`), not a tagged integer —
+so `insert_unbox_before_lisp_rets` is now **type-directed**:
+
+- an INTEGER result is unboxed (`lispy_unbox_int`, `>> 3`) as before;
+- a BOOLEAN result (its producing instruction carries the `bool` type hint) is run
+  through `lispy_truthy` (→ raw `0`/`1`). Unboxing a true (`5 >> 3 = 0`) would have
+  reported *false* — the bug this fixes.
+
+Reusable for every tagged-word backend (LLVM/AOT/JIT) that links `lispy_runtime.c`.
+Verified end-to-end in `lang-aot` on the LLVM/clang path: `(ATOM 7)`→1,
+`(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(EQ 7 8)`→0. Updated the
+`tagged_cond_is_wrapped_with_truthy` unit test (the bool-typed `ret` now also
+truthy-coerces) and added `integer_result_unboxed_boolean_result_truthied`.
+
 ## [0.13.0] — 2026-06-09 — reference funnels + lisp-call result type (LANG77 / McCarthy W5b)
 
 ### Fixed

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
@@ -353,6 +353,20 @@ fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<St
         return;
     }
 
+    // McCarthy boolean-result handling (the L3b-2c-2 gap, closed in W12b-2): a
+    // value produced by a predicate (`pair?`/`equal?`/`not`) is a tagged boolean
+    // (`LISPY_TRUE = 5` / `LISPY_FALSE = 3`), NOT a tagged integer. Unboxing it
+    // (`>> 3`) would give `0` for *true* — wrong. So at the program-exit boundary
+    // a boolean result is coerced with `lispy_truthy` (→ raw `0`/`1`) instead of
+    // `lispy_unbox_int`. A register is "boolean" if the instruction that produced
+    // it carries the `bool` type hint (the predicates do).
+    let bool_regs: HashSet<String> = func
+        .instructions
+        .iter()
+        .filter(|i| i.type_hint == "bool")
+        .filter_map(|i| i.dest.clone())
+        .collect();
+
     let old = std::mem::take(&mut func.instructions);
     let mut new_instrs: Vec<IIRInstr> = Vec::with_capacity(old.len() + 2);
     let mut unbox_counter = 0usize;
@@ -369,13 +383,20 @@ fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<St
 
         match ret_boxed_reg {
             Some(boxed) => {
-                // %u = call_builtin "lispy_unbox_int", %boxed  : i64
+                // A boolean result → `lispy_truthy` (→ 0/1); an integer result →
+                // `lispy_unbox_int` (→ `>> 3`). Both yield a raw `i64`.
+                let coerce = if bool_regs.contains(&boxed) {
+                    TRUTHY_BUILTIN
+                } else {
+                    UNBOX_BUILTIN
+                };
+                // %u = call_builtin "<coerce>", %boxed  : i64
                 let u_reg = format!("__unbox_{unbox_counter}");
                 unbox_counter += 1;
                 new_instrs.push(IIRInstr::new(
                     "call_builtin",
                     Some(u_reg.clone()),
-                    vec![Operand::Var(UNBOX_BUILTIN.to_string()), Operand::Var(boxed)],
+                    vec![Operand::Var(coerce.to_string()), Operand::Var(boxed)],
                     "i64",
                 ));
                 // ret %u
@@ -614,13 +635,48 @@ mod tests {
             ret("a"),
         ]);
         lower_lisp_repr(&mut m);
-        assert_eq!(count_builtin(&m, "lispy_truthy"), 1, "tagged cond must be wrapped");
+        // TWO `lispy_truthy` calls now: (1) the `COND` clause-test wrap, and
+        // (2) the bool-typed `ret a` result coercion (McCarthy W12b-2 — a
+        // boolean program result becomes raw 0/1 via `truthy`, not `unbox_int`).
+        assert_eq!(count_builtin(&m, "lispy_truthy"), 2, "cond test + bool result both wrapped");
+        // The boolean result is coerced with `lispy_truthy`, NOT `lispy_unbox_int`.
+        assert_eq!(count_builtin(&m, "lispy_unbox_int"), 0, "bool result must not be unboxed");
         // The jmp_if_false now tests the truthy result, not the raw tagged bool.
         let jif = m.functions[0].instructions.iter().find(|i| i.op == "jmp_if_false").unwrap();
         assert!(
             matches!(&jif.srcs[0], Operand::Var(v) if v.starts_with("__truthy_")),
             "jmp_if_false must test the truthy result, got {:?}", jif.srcs[0],
         );
+    }
+
+    /// McCarthy W12b-2 — the program-exit coercion is **type-directed**:
+    /// an INTEGER result is unboxed (`>> 3`), a BOOLEAN result (a predicate) is
+    /// run through `lispy_truthy` (→ raw 0/1). Unboxing `LISPY_TRUE` (=5) would
+    /// give `5 >> 3 = 0` — *wrong* for true. So a bool result must never be unboxed.
+    #[test]
+    fn integer_result_unboxed_boolean_result_truthied() {
+        // (CAR (CONS 7 9)) — an integer result → unbox, NOT truthy.
+        let mut int_m = module(vec![
+            konst("a", 56, "i64"),
+            konst("b", 72, "i64"),
+            call_builtin(Some("p"), "lispy_cons", &["a", "b"], "ref<LispyPair>"),
+            call_builtin(Some("h"), "lispy_car", &["p"], "i64"),
+            ret("h"),
+        ]);
+        lower_lisp_repr(&mut int_m);
+        assert_eq!(count_builtin(&int_m, "lispy_unbox_int"), 1, "int result is unboxed");
+        assert_eq!(count_builtin(&int_m, "lispy_truthy"), 0, "int result is not truthied");
+
+        // (ATOM 7) = (not (pair? 7)) — a boolean result → truthy, NOT unbox.
+        let mut bool_m = module(vec![
+            konst("v0", 56, "i64"),
+            call_builtin(Some("p"), "lispy_pair_p", &["v0"], "bool"),
+            call_builtin(Some("a"), "lispy_not", &["p"], "bool"),
+            ret("a"),
+        ]);
+        lower_lisp_repr(&mut bool_m);
+        assert_eq!(count_builtin(&bool_m, "lispy_truthy"), 1, "bool result is truthied");
+        assert_eq!(count_builtin(&bool_m, "lispy_unbox_int"), 0, "bool result is NOT unboxed");
     }
 
     /// A raw machine condition (e.g. a Twig `cmp` result, not in boxed_regs)

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.36.1 — 2026-06-10 — McCarthy → **LLVM predicates** ATOM/EQ (F3–F4) on a clang-built executable (LANG77 / W12b-2)
+
+No `lang-aot` source change — the fix is in the shared `iir-builtin-lowering`
+`lower_lisp_repr` (0.14.0), which `compile_source_to_llvm` already runs: a boolean
+program result (a predicate) is now coerced with `lispy_truthy` (→ raw `0`/`1`)
+instead of `lispy_unbox_int` (which gave `0` for *true*). New verify-by-running
+test `tests/llvm_predicates.rs` (link `lispy_runtime.c` with clang, run):
+`(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(EQ 7 8)`→0. (`COND`, F5,
+needs PHI-node merge of clause values across blocks — W12b-3.)
+
 ## 0.36.0 — 2026-06-10 — McCarthy → **LLVM cons** (F2) on a clang-built executable (LANG77 / W12b-1)
 
 `compile_source_to_llvm` now runs the **native tagged-word lisp pipeline** — the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -68,8 +68,11 @@ the result, `42` → 42 (W12a). It uses the `clang` already on the box (no
 **Cons** runs too (W12b-1, F2): the native lisp pipeline
 (`lower_heap_builtins_runtime`→`intern_symbols`→`lower_lisp_repr`) lowers cons/car/cdr
 to `call @__twig_lispy_*`, and the test **links `lispy_runtime.c`** into the
-clang-built executable — `(CAR (CONS 7 9))` → 7, `(CDR (CONS 7 9))` → 9. The
-predicate/symbol/lambda steps (F3–F7) are W12b-2+.
+clang-built executable — `(CAR (CONS 7 9))` → 7, `(CDR (CONS 7 9))` → 9.
+**Predicates** run too (W12b-2, F3–F4): a predicate returns a *tagged* boolean, so
+the shared `lower_lisp_repr` coerces a boolean program result with `lispy_truthy`
+(→ 0/1) rather than `lispy_unbox_int` — `(ATOM 7)` → 1, `(EQ 7 7)` → 1,
+`(EQ 7 8)` → 0. `COND` (F5, needs PHI nodes) and symbols/lambda (F6–F7) are W12b-3+.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/llvm_predicates.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_predicates.rs
@@ -1,0 +1,55 @@
+//! # LLVM predicates — F3 (ATOM/pair?) + F4 (EQ) (LANG77 / McCarthy W12b-2).
+//!
+//! A McCarthy predicate (`pair?`/`equal?`/`not`) returns a **tagged boolean**
+//! (`LISPY_TRUE = 5` / `LISPY_FALSE = 3`), NOT a tagged integer. The fix lives in
+//! the shared native pass `iir_builtin_lowering::lower_lisp_repr`: at the
+//! program-exit boundary a boolean result is coerced with `lispy_truthy` (→ raw
+//! `0`/`1`) instead of `lispy_unbox_int` (which would compute `5 >> 3 = 0` for
+//! *true*). Reusable for every tagged-word backend (LLVM/AOT/JIT).
+//!
+//! **Verified by RUNNING**: emit host-triple LLVM IR, link `lispy_runtime.c`
+//! with `clang`, run — the process exit code is the `0`/`1` truth value.
+//! (`COND`, F5, needs PHI-node merge of clause values across blocks — W12b-3.)
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+fn host_triple() -> String {
+    let o = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+fn lispy_runtime_c() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../twig-aot/runtime/lispy_runtime.c")
+}
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w12b2_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        .arg("-x").arg("ir").arg(&ll_path)
+        .arg("-x").arg("none").arg(lispy_runtime_c())
+        .arg("-o").arg(&exe).output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    std::process::Command::new(&exe).output().expect("run").status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_atom_pair_predicate_runs_on_llvm() {
+    if !clang_available() { eprintln!("clang absent — skipping"); return; }
+    assert_eq!(run("(ATOM 7)", "lp_atom_t"), 1, "a number is an atom");
+    assert_eq!(run("(ATOM (CONS 1 2))", "lp_atom_f"), 0, "a cons is not an atom");
+}
+
+#[test]
+fn mccarthy_eq_predicate_runs_on_llvm() {
+    if !clang_available() { return; }
+    assert_eq!(run("(EQ 7 7)", "lp_eq_t"), 1, "equal numbers");
+    assert_eq!(run("(EQ 7 8)", "lp_eq_f"), 0, "unequal numbers");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -63,7 +63,7 @@ representation + per-builtin backend lowering.
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
-| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
+| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
@@ -245,11 +245,20 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     RUNNING on a clang-built executable **linked against `lispy_runtime.c`**:
     `(CAR (CONS 7 9))`→7, `(CDR (CONS 7 9))`→9, `(CAR (CDR (CONS 1 (CONS 2 3))))`→2,
     scalar `42`→42 (`lang-aot/tests/llvm_cons.rs`).
-  - ☐ **W12b-2 — LLVM predicates (F3–F5).** pair?/equal?/not lowering is already
-    emitted (`lispy_pair_p`/`lispy_equal`/`lispy_not` in `LISPY_BUILTINS`); needs the
-    **tagged-boolean result** handling (a predicate returns `__twig_lispy_tag_true/false`,
-    not 0/1) + the `COND` `trunc void` fix (`lispy_truthy` clause test).
-    `(ATOM 7)`→1, `(EQ 7 7)`→1, `(COND …)`.
+  - ✅ **W12b-2 — LLVM predicates ATOM/EQ (F3–F4).** Closed the deferred
+    boolean-result gap in the shared `lower_lisp_repr`: a predicate result is a
+    tagged boolean (`LISPY_TRUE=5`/`FALSE=3`), so the program-exit coercion is now
+    type-directed — a **bool** result uses `lispy_truthy` (→ 0/1), an **int** result
+    uses `lispy_unbox_int` (`>>3`). (Unboxing true gave `5>>3=0` — the bug.) Verified
+    by RUNNING (clang + `lispy_runtime.c`): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0,
+    `(EQ 7 7)`→1, `(EQ 7 8)`→0 (`lang-aot/tests/llvm_predicates.rs`). Reusable for all
+    tagged-word backends; `iir-to-llvm` unchanged.
+  - ☐ **W12b-3 — LLVM `COND` (F5).** Needs **PHI nodes**: `COND` assigns the result
+    var in each clause block, but the backend tracks `const`/`mov` as compile-time
+    aliases (only valid in straight-line code), so a var assigned across branches
+    collapses to its last assignment (the emitted `unbox` reads the NIL clause). Needs
+    SSA merge (PHI, or alloca/store/load) + the `jmp_if` void-cond fix + an explicit
+    fallthrough `br` for all-`const`/`mov` (empty) blocks.
 - ☐ **W13 — LLVM symbols + lambda (F6–F7).** **Completes LLVM.**
 
 ### Phase F — native AOT + JIT completion


### PR DESCRIPTION
## McCarthy predicates run on a real LLVM-compiled native executable

A predicate (`pair?`/`equal?`/`not`) returns a **tagged boolean** (`LISPY_TRUE = 5` / `LISPY_FALSE = 3`), not a tagged integer. The shared native pass `lower_lisp_repr` unconditionally unboxed the entry function's result with `lispy_unbox_int` (`>> 3`), so a *true* result (`5 >> 3 = 0`) reported **false** — the long-deferred "booleans land in L3b-2c-2" gap. This closes it.

## Change (`iir-builtin-lowering` 0.14.0 — `iir-to-llvm` UNCHANGED)

`insert_unbox_before_lisp_rets` is now **type-directed**:
- an **integer** result is unboxed (`lispy_unbox_int`, `>> 3`) as before;
- a **boolean** result (its producing instruction carries the `bool` type hint, which the predicates do) is coerced with `lispy_truthy` (→ raw `0`/`1`).

Reusable for **every** tagged-word backend (LLVM/AOT/JIT) that links `lispy_runtime.c`. The W12b-1 lispy lowering already emits the predicate calls, so no backend change was needed.

## Verified by RUNNING (`lang-aot/tests/llvm_predicates.rs`)

Emit host IR, link `lispy_runtime.c` with clang, run — exit code = result:

| program | result |
|---|---|
| `(ATOM 7)` | 1 (a number is an atom) |
| `(ATOM (CONS 1 2))` | 0 (a cons is not) |
| `(EQ 7 7)` | 1 |
| `(EQ 7 8)` | 0 |

## Why COND (F5) is NOT here

`COND` assigns the result var in each clause block, but the backend tracks `const`/`mov` as **compile-time aliases** (only valid in straight-line code), so a var assigned across branches collapses to its last assignment (the emitted `unbox` reads the NIL clause). That needs **PHI nodes** (SSA merge) + the `jmp_if` void-cond fix + an explicit fallthrough `br` for all-`const`/`mov` blocks — scoped as **W12b-3**. Shipping only what's verified end-to-end.

## Test plan

`iir-builtin-lowering` **108** (updated `tagged_cond_is_wrapped_with_truthy` for the 2nd truthy + new `integer_result_unboxed_boolean_result_truthied`), `lang-aot` `llvm_predicates` 2 + `llvm_cons` 1 + `llvm_scalar` 1 (no regression), **`twig-aot` green** (the other consumer of the shared pass). clippy clean (`numeric.rs` lints pre-existing, not mine). No `twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: builds a `HashSet` of bool-typed dests via bounded iteration + a membership check (no panic/unwrap/overflow/recursion/IO); both coercion branches emit the identical `i64` instruction shape (no type confusion); worst case of a wrong `type_hint` is a wrong exit code, not memory unsafety.

## Matrix

LLVM **F3 + F4 → ✅**. W12 sub-slices: W12a ✅, W12b-1 ✅, **W12b-2 ✅**, W12b-3 ☐ (COND/PHI). LLVM row: F1 ✅ F2 ✅ F3 ✅ F4 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)