### PR TITLE
feat(mccarthy-lisp): W12b-3 — McCarthy COND on LLVM via alloca SSA-merge (F5) — LLVM core F1-F5

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.0] — 2026-06-10 (McCarthy W12b-3 — `COND` via alloca SSA-merge — LLVM core F1–F5)
+
+Lowers McCarthy `COND` (a cross-block value merge) and completes the LLVM core
+(F1–F5).
+
+- **Stack-slot promotion (`collect_slot_vars` + `lower_instr_with_slots`):** a
+  variable assigned in 2+ instructions (a `COND` result written per clause) gets an
+  entry `alloca`; each assignment becomes a `store i64 …, ptr %v.slot`, each read a
+  `load i64, ptr %v.slot`. Single-assignment vars keep the `const`/`mov` side-map
+  (fast path, no slot). This is the naive-frontend / `opt -mem2reg` pattern, so no
+  PHI-predecessor analysis is needed.
+- **Block-terminator hygiene (`FnState::block_open`):** a `label` reached while the
+  current block is still open (its body was all tracked-not-emitted `const`/`mov`)
+  emits an explicit fallthrough `br` first — no two labels back-to-back.
+- **`jmp_if` void-cond:** when the `jmp_if_*` carries no operand type (`void`) — its
+  condition is the `i64` 0/1 from `lispy_truthy` — it lowers to `icmp ne i64 %c, 0`
+  instead of an invalid `trunc void`.
+- Verified by RUNNING in `lang-aot` (clang + `lispy_runtime.c`):
+  `(COND ((ATOM 7) 11) ((ATOM 8) 22))`→11, second-clause→22, nested `COND`→44.
+
 ## [0.5.0] — 2026-06-10 (McCarthy W12b-1 — tagged-word lisp `cons`/`car`/`cdr` → `__twig_lispy_*`)
 
 Lowers the **tagged-word lisp** builtins to `call`s into the shared C runtime

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-llvm"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -84,7 +84,8 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.3.0  | Typed arithmetic (`add`/`sub`/`mul`/...) + cmp + branches.  |
 | v0.4.0  | `call` + `call_builtin print_i64` extern declarations.      |
 | v0.5.0  | Tagged-word lisp `cons`/`car`/`cdr` → `call @__twig_lispy_*` (McCarthy W12b-1). |
-| (later) | Lisp predicates (tagged-bool result), GC, debug info via `!dbg`. |
+| v0.6.0  | `COND` via stack-slot (`alloca`) SSA-merge + `jmp_if` void-cond + empty-block `br` (McCarthy W12b-3). |
+| (later) | Lisp symbols + lambda (W13), GC, debug info via `!dbg`. |
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -480,6 +480,22 @@ struct FnState<'a> {
     /// Module-wide map of every user-defined function's signature.  Built
     /// up-front by `lower_iir_to_llvm` before any function body is lowered.
     callee_sigs: &'a HashMap<String, FnSig>,
+    /// Is the current LLVM basic block still **open** (no terminator yet)?
+    /// LLVM requires every block to end in a terminator (`br`/`ret`/…). IIR
+    /// blocks fall through to the next `label` implicitly, and a block whose
+    /// body is all tracked-not-emitted `const`/`mov` emits nothing — so two
+    /// `label`s can land back-to-back. Before emitting a `label` while a block
+    /// is open we synthesize an explicit `br` fallthrough. `false` after
+    /// `jmp`/`ret`; `true` at entry and after every `label`/`jmp_if_*`.
+    /// (McCarthy W12b-3 — needed once `COND`'s clause blocks appeared.)
+    block_open: bool,
+    /// Variables that are assigned in **more than one place** (e.g. a `COND`
+    /// result var written in each clause block). The `const`/`mov` side-map
+    /// trick only models straight-line SSA, so a cross-block variable collapses
+    /// to its last assignment. We instead give each such variable a stack slot
+    /// (`alloca`): every assignment becomes a `store`, every read a `load`. This
+    /// is the naive-frontend / `opt -mem2reg` pattern (McCarthy W12b-3, F5).
+    slots: std::collections::HashSet<String>,
 }
 
 impl FnState<'_> {
@@ -523,12 +539,22 @@ fn lower_function(
     // This side-map trick (rather than emitting `%dest = add 0, x` no-ops
     // for const/mov) keeps output close to what `opt -mem2reg` would
     // produce — short, idiomatic, easy to eyeball-verify.
+    // McCarthy W12b-3: any variable assigned in 2+ instructions is promoted to a
+    // stack slot (an `alloca` in the entry block). All slots are `i64` — every
+    // tagged-word / scalar lisp value is an i64 in this backend.
+    let slots = collect_slot_vars(func);
+    for slot in &slots {
+        out.push_str(&format!("  %{slot}.slot = alloca i64\n"));
+    }
+
     let mut state = FnState {
         env: HashMap::new(),
         env_i1: HashMap::new(),
         counter: 0,
         fn_name: &func.name,
         callee_sigs,
+        block_open: true, // the entry block is open until its first terminator.
+        slots,
     };
     for (pname, _) in &func.params {
         state.env.insert(pname.clone(), format!("%{pname}"));
@@ -536,10 +562,93 @@ fn lower_function(
 
     // ── Body ──────────────────────────────────────────────────────────────
     for instr in &func.instructions {
-        lower_instr(instr, &mut state, out)?;
+        lower_instr_with_slots(instr, &mut state, out)?;
     }
 
     out.push_str("}\n");
+    Ok(())
+}
+
+/// Collect the variables that are the `dest` of **two or more** instructions in
+/// `func`. Such a variable cannot be modelled by the `const`/`mov` compile-time
+/// side-map (which keeps only the latest binding and so is valid only within a
+/// single straight-line block); it needs a stack slot so each assignment is a
+/// real `store` and each read a real `load` (McCarthy W12b-3, F5 — `COND`).
+fn collect_slot_vars(func: &IIRFunction) -> std::collections::HashSet<String> {
+    use std::collections::HashMap as Map;
+    let mut counts: Map<&str, usize> = Map::new();
+    for instr in &func.instructions {
+        if let Some(dest) = &instr.dest {
+            *counts.entry(dest.as_str()).or_insert(0) += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter(|&(_, n)| n >= 2)
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
+/// Wrap [`lower_instr`] with the slot (`alloca`/`load`/`store`) protocol:
+///
+/// 1. **Pre-load:** for every `Var` source operand that is a slot, emit
+///    `%t = load i64, ptr %v.slot` and temporarily rebind it in `env` so the
+///    instruction reads the loaded value.
+/// 2. Lower the instruction normally.
+/// 3. **Post-store:** if `dest` is a slot, emit `store i64 <value>, ptr %v.slot`
+///    (the value the instruction left in `env[dest]` — a literal for `const`/`mov`
+///    or an SSA name for an emitted op) and then drop `env[dest]` so the variable
+///    is only ever read back through its slot.
+/// 4. Restore the env bindings overridden in step 1.
+///
+/// Redundant loads/stores are fine: `opt -mem2reg` collapses them, and an
+/// un-optimized `clang -O0` build runs them correctly.
+fn lower_instr_with_slots(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    if state.slots.is_empty() {
+        return lower_instr(instr, state, out); // fast path — no promoted vars.
+    }
+
+    // 1. Pre-load slot source operands.
+    let mut saved: Vec<(String, Option<String>)> = Vec::new();
+    for op in &instr.srcs {
+        if let Operand::Var(name) = op {
+            if state.slots.contains(name) {
+                let fresh = state.fresh("ld");
+                out.push_str(&format!("  {fresh} = load i64, ptr %{name}.slot\n"));
+                let old = state.env.insert(name.clone(), fresh);
+                saved.push((name.clone(), old));
+            }
+        }
+    }
+
+    // 2. Lower the instruction.
+    lower_instr(instr, state, out)?;
+
+    // 3. Post-store a slot destination.
+    if let Some(dest) = &instr.dest {
+        if state.slots.contains(dest) {
+            if let Some(val) = state.env.get(dest).cloned() {
+                out.push_str(&format!("  store i64 {val}, ptr %{dest}.slot\n"));
+            }
+            state.env.remove(dest); // future reads go through the slot's load.
+        }
+    }
+
+    // 4. Restore the env bindings we overrode for the pre-loads.
+    for (name, old) in saved {
+        match old {
+            Some(v) => {
+                state.env.insert(name, v);
+            }
+            None => {
+                state.env.remove(&name);
+            }
+        }
+    }
     Ok(())
 }
 
@@ -571,6 +680,7 @@ fn lower_instr(
         // ── ret_void ────────────────────────────────────────────────────
         "ret_void" => {
             out.push_str("  ret void\n");
+            state.block_open = false; // `ret` terminates the block.
             Ok(())
         }
 
@@ -580,6 +690,7 @@ fn lower_instr(
             let operand =
                 resolve_operand(instr.srcs.first(), &state.env, &instr.type_hint, fn_name)?;
             out.push_str(&format!("  ret {ty} {operand}\n"));
+            state.block_open = false; // `ret` terminates the block.
             Ok(())
         }
 
@@ -629,7 +740,15 @@ fn lower_instr(
                     detail: "label requires srcs[0] = Operand::Var(name)".into(),
                 }),
             };
+            // If the current block never got a terminator (its body was all
+            // tracked-not-emitted `const`/`mov`), LLVM would see two labels
+            // back-to-back — an invalid empty block. Synthesize the implicit
+            // fallthrough as an explicit `br` to this label (McCarthy W12b-3).
+            if state.block_open {
+                out.push_str(&format!("  br label %{name}\n"));
+            }
             out.push_str(&format!("{name}:\n"));
+            state.block_open = true;
             Ok(())
         }
 
@@ -643,6 +762,7 @@ fn lower_instr(
                 }),
             };
             out.push_str(&format!("  br label %{target}\n"));
+            state.block_open = false; // unconditional branch terminates the block.
             Ok(())
         }
 
@@ -864,6 +984,14 @@ fn lower_jmp_if(
         let cond_ty = llvm_type_for(&instr.type_hint, state.fn_name)?;
         if cond_ty == "i1" {
             cond_op
+        } else if cond_ty == "void" {
+            // McCarthy W12b-3: a `COND` whose clause test is a tagged-word lisp
+            // predicate carries NO operand type on `jmp_if_*` (type_hint "void");
+            // the condition is the `i64` 0/1 from `lispy_truthy`. Compare it
+            // against zero to get the `i1` — `trunc void …` would be invalid.
+            let i1 = state.fresh("tobool");
+            out.push_str(&format!("  {i1} = icmp ne i64 {cond_op}, 0\n"));
+            i1
         } else {
             let i1 = state.fresh("trunc");
             out.push_str(&format!("  {i1} = trunc {cond_ty} {cond_op} to i1\n"));
@@ -884,6 +1012,9 @@ fn lower_jmp_if(
         "  br i1 {cond_i1}, label %{t_label}, label %{f_label}\n"
     ));
     out.push_str(&format!("{fallthrough}:\n"));
+    // The conditional branch terminated the prior block; we are now in the
+    // freshly-opened fallthrough block (needs its own terminator later).
+    state.block_open = true;
     Ok(())
 }
 

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -952,3 +952,55 @@ fn unknown_builtin_still_rejected() {
         .expect_err("unknown builtin must be rejected");
     assert!(matches!(err, IIRLlvmError::UnsupportedOp { .. }), "got: {err:?}");
 }
+
+/// McCarthy W12b-3: a variable assigned in 2+ instructions (here `m`, written in
+/// two blocks like a `COND` result) is promoted to a stack slot — an entry
+/// `alloca`, a `store` per assignment, and a `load` per read. A clause block with
+/// no emitted instructions still gets an explicit fallthrough `br` (no two labels
+/// back-to-back), and `ret` reads the merged value through a `load`.
+#[test]
+fn multi_assigned_var_is_promoted_to_alloca() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            // if cond goto L_else
+            IIRInstr::new("const", Some("c".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("jmp_if_false", None,
+                vec![Operand::Var("c".into()), Operand::Var("L_else".into())], "void"),
+            IIRInstr::new("const", Some("m".into()), vec![Operand::Int(11)], "i64"),
+            IIRInstr::new("jmp", None, vec![Operand::Var("L_end".into())], "void"),
+            IIRInstr::new("label", None, vec![Operand::Var("L_else".into())], "void"),
+            IIRInstr::new("const", Some("m".into()), vec![Operand::Int(22)], "i64"),
+            IIRInstr::new("label", None, vec![Operand::Var("L_end".into())], "void"),
+            IIRInstr::new("ret", None, vec![Operand::Var("m".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("%m.slot = alloca i64"), "entry alloca for the merge var; got:\n{ll}");
+    assert!(ll.contains("store i64 11, ptr %m.slot"), "store of the then-value; got:\n{ll}");
+    assert!(ll.contains("store i64 22, ptr %m.slot"), "store of the else-value; got:\n{ll}");
+    assert!(ll.contains("= load i64, ptr %m.slot"), "load before ret; got:\n{ll}");
+    // The `c == 0` clause test (i64 truthy) compares against zero, not `trunc void`.
+    assert!(ll.contains("icmp ne i64"), "void-typed jmp_if compares against zero; got:\n{ll}");
+    assert!(!ll.contains("trunc void"), "must never emit `trunc void`; got:\n{ll}");
+}
+
+/// A purely straight-line function (no var assigned twice) takes the fast path:
+/// no `alloca`/`store`/`load` is emitted — the `const`/`mov` side-map still wins.
+#[test]
+fn single_assignment_stays_on_the_side_map() {
+    let f = IIRFunction::new(
+        "answer",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(42)], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(!ll.contains("alloca"), "no slot for a single-assignment var; got:\n{ll}");
+    assert!(ll.contains("ret i64 42"), "const folds straight into ret; got:\n{ll}");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.37.0 — 2026-06-10 — McCarthy → **LLVM `COND`** (F5) on a clang-built executable — LLVM core F1–F5 (LANG77 / W12b-3)
+
+No `lang-aot` source change — the work is in `iir-to-llvm` 0.6.0 (cross-block
+SSA-merge via stack-slot/`alloca` promotion, plus the `jmp_if` void-cond and
+empty-block fallthrough fixes), which `compile_source_to_llvm` already drives. New
+verify-by-running test `tests/llvm_cond.rs` (link `lispy_runtime.c` with clang,
+run): `(COND ((ATOM 7) 11) ((ATOM 8) 22))`→11, second-clause→22, nested `COND`→44;
+cons/predicate/scalar all still pass. **LLVM is now F1–F5 (only symbols+lambda,
+W13, remain).**
+
 ## 0.36.1 — 2026-06-10 — McCarthy → **LLVM predicates** ATOM/EQ (F3–F4) on a clang-built executable (LANG77 / W12b-2)
 
 No `lang-aot` source change — the fix is in the shared `iir-builtin-lowering`

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.36.1"
+version = "0.37.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -72,7 +72,10 @@ clang-built executable — `(CAR (CONS 7 9))` → 7, `(CDR (CONS 7 9))` → 9.
 **Predicates** run too (W12b-2, F3–F4): a predicate returns a *tagged* boolean, so
 the shared `lower_lisp_repr` coerces a boolean program result with `lispy_truthy`
 (→ 0/1) rather than `lispy_unbox_int` — `(ATOM 7)` → 1, `(EQ 7 7)` → 1,
-`(EQ 7 8)` → 0. `COND` (F5, needs PHI nodes) and symbols/lambda (F6–F7) are W12b-3+.
+`(EQ 7 8)` → 0. **`COND`** runs too (W12b-3, F5): a clause-result variable assigned
+across blocks is promoted to a stack slot (`alloca`/`store`/`load`, a cross-block SSA
+merge) — `(COND ((ATOM 7) 11) ((ATOM 8) 22))` → 11, nested `COND` → 44. **LLVM is now
+F1–F5**; only symbols + lambda (F6–F7) remain (W13).
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/llvm_cond.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_cond.rs
@@ -1,0 +1,58 @@
+//! # LLVM `COND` — F5 (LANG77 / McCarthy W12b-3) — COMPLETES the LLVM core (F1–F5).
+//!
+//! `COND` assigns its result variable in each clause block, so the value differs
+//! per predecessor — a real SSA merge. The `iir-to-llvm` backend handles it the
+//! naive-frontend way: a variable written in 2+ places is promoted to a stack
+//! slot (`alloca`), each assignment a `store`, each read a `load` (`opt -mem2reg`
+//! would collapse them). Two supporting fixes: a `jmp_if` whose condition is the
+//! `i64` `lispy_truthy` result compares against zero (not `trunc void`), and a
+//! clause block that emits no instructions still gets an explicit fallthrough `br`.
+//! **Verified by RUNNING**: emit host IR, link `lispy_runtime.c`, run with `clang`.
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+fn host_triple() -> String {
+    let o = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+fn lispy_runtime_c() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../twig-aot/runtime/lispy_runtime.c")
+}
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w12b3_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        .arg("-x").arg("ir").arg(&ll_path)
+        .arg("-x").arg("none").arg(lispy_runtime_c())
+        .arg("-o").arg(&exe).output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    std::process::Command::new(&exe).output().expect("run").status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_cond_runs_on_llvm() {
+    if !clang_available() { eprintln!("clang absent — skipping"); return; }
+    // First clause true (ATOM of a number).
+    assert_eq!(run("(COND ((ATOM 7) 11) ((ATOM 8) 22))", "lcd_first"), 11);
+    // First clause false (ATOM of a cons), second clause true (EQ).
+    assert_eq!(run("(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))", "lcd_second"), 22);
+    // Nested COND in a clause body still merges correctly.
+    assert_eq!(run("(COND ((EQ 1 1) (COND ((EQ 2 3) 11) ((EQ 4 4) 44))) ((EQ 5 5) 22))", "lcd_nest"), 44);
+}
+
+#[test]
+fn cond_does_not_regress_straightline() {
+    if !clang_available() { return; }
+    assert_eq!(run("(CAR (CONS 7 9))", "lcd_cons"), 7, "cons still works");
+    assert_eq!(run("(ATOM 7)", "lcd_atom"), 1, "predicate still works");
+    assert_eq!(run("42", "lcd_scalar"), 42, "scalar still works");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -63,7 +63,7 @@ representation + per-builtin backend lowering.
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
-| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | ☐ | tagged-word |
+| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
@@ -228,9 +228,10 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase E — LLVM (tagged-word, like native)
 
-- ◑ **W12 — LLVM cons + predicates (F2–F5).** *In progress.* Reuse the tagged-word
-  C runtime (`lispy_runtime.c`) the native AOT path links; lower cons/car/cdr/pair?/eq
-  via `call` to `__twig_lispy_*`; COND truthiness via `lispy_truthy`.
+- ✅ **W12 — LLVM cons + predicates (F2–F5). DONE** (via sub-slices W12a/W12b-1/2/3).
+  Reused the tagged-word C runtime (`lispy_runtime.c`) the native AOT path links;
+  lowered cons/car/cdr/pair?/eq via `call` to `__twig_lispy_*`; `COND` truthiness via
+  `lispy_truthy`. **LLVM core F1–F5 complete; only symbols+lambda (W13) remain.**
   - ✅ **W12a — LLVM scalar run-foundation (F1, verify-by-running).** Established the
     LLVM execution substrate: `compile_source_to_llvm[_with_target]` (concretize
     `any`→`i64`, lower to LLVM IR). `lang-aot/tests/llvm_scalar.rs` emits **host**-
@@ -253,12 +254,16 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     by RUNNING (clang + `lispy_runtime.c`): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0,
     `(EQ 7 7)`→1, `(EQ 7 8)`→0 (`lang-aot/tests/llvm_predicates.rs`). Reusable for all
     tagged-word backends; `iir-to-llvm` unchanged.
-  - ☐ **W12b-3 — LLVM `COND` (F5).** Needs **PHI nodes**: `COND` assigns the result
-    var in each clause block, but the backend tracks `const`/`mov` as compile-time
-    aliases (only valid in straight-line code), so a var assigned across branches
-    collapses to its last assignment (the emitted `unbox` reads the NIL clause). Needs
-    SSA merge (PHI, or alloca/store/load) + the `jmp_if` void-cond fix + an explicit
-    fallthrough `br` for all-`const`/`mov` (empty) blocks.
+  - ✅ **W12b-3 — LLVM `COND` (F5).** Solved the cross-block SSA merge the
+    naive-frontend way: a variable assigned in 2+ instructions (a `COND` result
+    written per clause) is promoted to a stack **slot** — an entry `alloca`, a
+    `store` per assignment, a `load` per read (what `opt -mem2reg` would collapse);
+    single-assignment vars keep the `const`/`mov` side-map. Two supporting fixes:
+    `jmp_if` on the `i64` `lispy_truthy` result compares `!= 0` (not `trunc void`),
+    and an all-`const`/`mov` (empty) clause block still gets an explicit fallthrough
+    `br`. Verified by RUNNING (clang + `lispy_runtime.c`):
+    `(COND ((ATOM 7) 11) …)`→11, second-clause→22, **nested `COND`**→44
+    (`lang-aot/tests/llvm_cond.rs`). **LLVM core F1–F5 complete.**
 - ☐ **W13 — LLVM symbols + lambda (F6–F7).** **Completes LLVM.**
 
 ### Phase F — native AOT + JIT completion


### PR DESCRIPTION
## McCarthy `COND` runs on LLVM-compiled native code — completing the LLVM core (F1–F5)

`COND` assigns its result variable in **each clause block**, so the value differs per predecessor — a real SSA merge the `const`/`mov` compile-time side-map cannot model (it kept only the last assignment, so `COND` always returned the final NIL clause). Solved the **naive-frontend way**: stack-slot promotion.

## Change

**`iir-to-llvm` 0.6.0**
- **`collect_slot_vars` + `lower_instr_with_slots`:** a variable assigned in 2+ instructions (a `COND` result, written per clause) is promoted to an entry `alloca`; each assignment → `store i64 …, ptr %v.slot`, each read → `load i64, ptr %v.slot`. Single-assignment vars keep the `const`/`mov` side-map (fast path). This is the naive-frontend / `opt -mem2reg` pattern — **no PHI-predecessor analysis needed.**
- **`FnState::block_open`:** a `label` reached while the block is still open (body was all tracked-not-emitted `const`/`mov`) first emits an explicit fallthrough `br` — no two labels back-to-back.
- **`jmp_if` void-cond:** a `jmp_if_*` carrying no operand type (its cond is the `i64` 0/1 from `lispy_truthy`) lowers to `icmp ne i64 %c, 0` instead of an invalid `trunc void`.

**`lang-aot` 0.37.0** — no source change; `compile_source_to_llvm` already drives the above.

## Verified by RUNNING (`tests/llvm_cond.rs`, clang + `lispy_runtime.c`)

| program | result |
|---|---|
| `(COND ((ATOM 7) 11) ((ATOM 8) 22))` | 11 (first clause) |
| `(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))` | 22 (second clause) |
| `(COND ((EQ 1 1) (COND ((EQ 2 3) 11) ((EQ 4 4) 44))) …)` | 44 (**nested `COND`**) |
| `(CAR (CONS 7 9))` / `(ATOM 7)` / `42` | 7 / 1 / 42 (no regression) |

## Test plan

`iir-to-llvm` **50** (+2 slot-promotion unit tests), `lang-aot` `llvm_cond` 2 + `llvm_predicates` 1 + `llvm_cons` 2 + `llvm_scalar` 2 (no regression). clippy clean. No `twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: bounded passes (no panic/unwrap/overflow/OOB/recursion — the wrapper calls `lower_instr`, never the reverse), slot-name interpolation matches the file's existing `%<name>` trust model, all slots are `i64` (loads/stores type-consistent; an uninitialized-slot load is `undef`, not OOB).

## Matrix

LLVM **F5 → ✅**. **W12 DONE** (W12a/W12b-1/2/3). **LLVM core F1–F5 complete; only symbols+lambda (W13) remain.** Backends: VM/WASM/JVM/CLR/BEAM complete (F1–F7); LLVM F1–F5; native AOT F1–F6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)