### PR TITLE
feat(mccarthy-lisp): W13a — McCarthy symbols on LLVM (F6, LANG77) — LLVM now F1-F6

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.15.0] — 2026-06-10 — symbol program-result handling (LANG77 / McCarthy W13a)
+
+Extends the type-directed program-exit coercion in `lower_lisp_repr` (the bool case
+landed in 0.14.0) to **symbols**: a SYMBOL result is already a finished tagged
+immediate from `intern_symbols` (`(id << shift) | TAG_SYMBOL`), so it must NOT be
+`lispy_unbox_int`'d (`>> 3` would corrupt the id+tag). Such a `ret` is returned
+verbatim (its tagged word). Reusable for every tagged-word backend; verified
+end-to-end on the LLVM/clang path (`(EQ (QUOTE A) (QUOTE A))`→1). New unit test
+`symbol_result_returned_verbatim`.
+
 ## [0.14.0] — 2026-06-10 — boolean program-result coercion (LANG77 / McCarthy W12b-2)
 
 Closes the long-deferred "booleans land in L3b-2c-2" gap in `lower_lisp_repr`'s

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
@@ -367,6 +367,18 @@ fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<St
         .filter_map(|i| i.dest.clone())
         .collect();
 
+    // McCarthy symbol-result handling (F6): a SYMBOL is already a finished tagged
+    // immediate from `intern_symbols` (`(id << shift) | TAG_SYMBOL`), NOT a boxed
+    // integer — `lispy_unbox_int` (`>> 3`) would corrupt the id+tag. The program
+    // result IS the tagged symbol word, so such a `ret` is returned verbatim (just
+    // retyped to `i64`, the tagged-word width).
+    let symbol_regs: HashSet<String> = func
+        .instructions
+        .iter()
+        .filter(|i| i.type_hint == SYMBOL_HINT)
+        .filter_map(|i| i.dest.clone())
+        .collect();
+
     let old = std::mem::take(&mut func.instructions);
     let mut new_instrs: Vec<IIRInstr> = Vec::with_capacity(old.len() + 2);
     let mut unbox_counter = 0usize;
@@ -382,6 +394,15 @@ fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<St
         };
 
         match ret_boxed_reg {
+            Some(boxed) if symbol_regs.contains(&boxed) => {
+                // A symbol result is returned as its tagged word (no coercion).
+                new_instrs.push(IIRInstr::new(
+                    "ret",
+                    None,
+                    vec![Operand::Var(boxed)],
+                    "i64",
+                ));
+            }
             Some(boxed) => {
                 // A boolean result → `lispy_truthy` (→ 0/1); an integer result →
                 // `lispy_unbox_int` (→ `>> 3`). Both yield a raw `i64`.
@@ -677,6 +698,24 @@ mod tests {
         lower_lisp_repr(&mut bool_m);
         assert_eq!(count_builtin(&bool_m, "lispy_truthy"), 1, "bool result is truthied");
         assert_eq!(count_builtin(&bool_m, "lispy_unbox_int"), 0, "bool result is NOT unboxed");
+    }
+
+    /// McCarthy W13 (F6): a SYMBOL program result is returned verbatim (its tagged
+    /// immediate) — NOT `unbox_int`'d (`>> 3` would corrupt the id+tag) and NOT
+    /// `truthy`'d. `(QUOTE A)` lowers to `const … : symbol` then a bare `ret`.
+    #[test]
+    fn symbol_result_returned_verbatim() {
+        let mut m = module(vec![
+            // `(QUOTE A)` after intern: a finished tagged symbol immediate.
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Var("A".into())], SYMBOL_HINT),
+            ret("s"),
+        ]);
+        lower_lisp_repr(&mut m);
+        assert_eq!(count_builtin(&m, "lispy_unbox_int"), 0, "a symbol result is NOT unboxed");
+        assert_eq!(count_builtin(&m, "lispy_truthy"), 0, "a symbol result is NOT truthied");
+        // The final instruction is a bare `ret` of the symbol register.
+        let last = m.functions[0].instructions.last().unwrap();
+        assert_eq!(last.op, "ret", "ends with a bare ret of the tagged symbol word");
     }
 
     /// A raw machine condition (e.g. a Twig `cmp` result, not in boxed_regs)

--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.0] — 2026-06-10 (McCarthy W13a — lisp symbols (F6))
+
+`llvm_type_for("symbol")` now maps to `i64` — an interned McCarthy symbol is a
+tagged 64-bit immediate (from `iir_builtin_lowering::intern_symbols`), so it flows
+as a tagged word like `any`/`ref<Lispy…>`. With this, `(QUOTE A)`, symbol `EQ`, and
+symbols inside `COND` all validate and lower. Verified by RUNNING in `lang-aot`
+(clang + `lispy_runtime.c`): `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0.
+
 ## [0.6.0] — 2026-06-10 (McCarthy W12b-3 — `COND` via alloca SSA-merge — LLVM core F1–F5)
 
 Lowers McCarthy `COND` (a cross-block value merge) and completes the LLVM core

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-llvm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -85,7 +85,8 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.4.0  | `call` + `call_builtin print_i64` extern declarations.      |
 | v0.5.0  | Tagged-word lisp `cons`/`car`/`cdr` → `call @__twig_lispy_*` (McCarthy W12b-1). |
 | v0.6.0  | `COND` via stack-slot (`alloca`) SSA-merge + `jmp_if` void-cond + empty-block `br` (McCarthy W12b-3). |
-| (later) | Lisp symbols + lambda (W13), GC, debug info via `!dbg`. |
+| v0.7.0  | Lisp symbols — `symbol` type → `i64` tagged immediate (McCarthy W13a). |
+| (later) | Lisp lambda result coercion (W13b), GC, debug info via `!dbg`. |
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -202,6 +202,8 @@ fn llvm_type_for(type_hint: &str, function: &str) -> Result<&'static str, IIRLlv
         // NON-lisp references (`ref<Foo>`) remain unsupported (no value model).
         "any" => Ok("i64"),
         t if t.starts_with("ref<Lispy") => Ok("i64"),
+        // McCarthy W13 (F6): an interned symbol is a tagged 64-bit immediate.
+        "symbol" => Ok("i64"),
         other => Err(IIRLlvmError::UnsupportedType {
             function: function.to_string(),
             type_hint: other.to_string(),

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1004,3 +1004,21 @@ fn single_assignment_stays_on_the_side_map() {
     assert!(!ll.contains("alloca"), "no slot for a single-assignment var; got:\n{ll}");
     assert!(ll.contains("ret i64 42"), "const folds straight into ret; got:\n{ll}");
 }
+
+/// McCarthy W13 (F6): a `symbol`-typed value (an interned tagged immediate) maps
+/// to an `i64` and validates — it is a tagged 64-bit word like `any`/`ref<Lispy…>`.
+#[test]
+fn symbol_typed_const_validates_and_lowers() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("s".into()), vec![Operand::Int(2)], "symbol"),
+            IIRInstr::new("ret", None, vec![Operand::Var("s".into())], "i64"),
+        ],
+    );
+    assert!(validate_for_llvm(&module_with(f.clone())).is_empty(), "symbol const must validate");
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("ret i64 2"), "symbol immediate flows as i64; got:\n{ll}");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.38.0 — 2026-06-10 — McCarthy → **LLVM symbols** (F6) on a clang-built executable (LANG77 / W13a)
+
+No `lang-aot` source change — the work is in `iir-to-llvm` 0.7.0 (`symbol`→`i64`) and
+`iir-builtin-lowering` 0.15.0 (symbol-result returned verbatim), which
+`compile_source_to_llvm` already drives. New verify-by-running test
+`tests/llvm_symbols.rs` (link `lispy_runtime.c` with clang, run):
+`(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0, `(ATOM (QUOTE A))`→1,
+symbol-in-`COND`→11, `(QUOTE A)`→its tagged word. LLVM is now F1–F6; only lambda
+(F7, W13b) remains.
+
 ## 0.37.0 — 2026-06-10 — McCarthy → **LLVM `COND`** (F5) on a clang-built executable — LLVM core F1–F5 (LANG77 / W12b-3)
 
 No `lang-aot` source change — the work is in `iir-to-llvm` 0.6.0 (cross-block

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -74,8 +74,11 @@ the shared `lower_lisp_repr` coerces a boolean program result with `lispy_truthy
 (→ 0/1) rather than `lispy_unbox_int` — `(ATOM 7)` → 1, `(EQ 7 7)` → 1,
 `(EQ 7 8)` → 0. **`COND`** runs too (W12b-3, F5): a clause-result variable assigned
 across blocks is promoted to a stack slot (`alloca`/`store`/`load`, a cross-block SSA
-merge) — `(COND ((ATOM 7) 11) ((ATOM 8) 22))` → 11, nested `COND` → 44. **LLVM is now
-F1–F5**; only symbols + lambda (F6–F7) remain (W13).
+merge) — `(COND ((ATOM 7) 11) ((ATOM 8) 22))` → 11, nested `COND` → 44.
+**Symbols** run too (W13a, F6): an interned symbol is a tagged `i64` immediate, and a
+bare symbol result is returned verbatim (not unboxed) — `(EQ (QUOTE A) (QUOTE A))` →
+1, `(EQ (QUOTE A) (QUOTE B))` → 0, `(ATOM (QUOTE A))` → 1. **LLVM is now F1–F6**; only
+lambda (F7, W13b) remains.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/llvm_symbols.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_symbols.rs
@@ -1,0 +1,55 @@
+//! # LLVM symbols — F6 (LANG77 / McCarthy W13a).
+//!
+//! A McCarthy symbol is interned (by the shared `intern_symbols` pass) to a stable
+//! tagged 64-bit immediate — the LLVM backend carries it as an `i64` tagged word
+//! (`llvm_type_for("symbol") = i64`). `EQ` on symbols is `__twig_lispy_equal` over
+//! the words. A *symbol* program result is returned verbatim (its tagged word) —
+//! the shared `lower_lisp_repr` must NOT `unbox_int` it (`>> 3` would corrupt the
+//! id+tag), the same type-directed exit coercion that handles bools (W12b-2).
+//! **Verified by RUNNING**: emit host IR, link `lispy_runtime.c`, run with `clang`.
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+fn host_triple() -> String {
+    let o = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+fn lispy_runtime_c() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../twig-aot/runtime/lispy_runtime.c")
+}
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w13_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        .arg("-x").arg("ir").arg(&ll_path)
+        .arg("-x").arg("none").arg(lispy_runtime_c())
+        .arg("-o").arg(&exe).output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    std::process::Command::new(&exe).output().expect("run").status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_symbol_eq_runs_on_llvm() {
+    if !clang_available() { eprintln!("clang absent — skipping"); return; }
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE A))", "ls_eq_t"), 1, "a symbol equals itself");
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE B))", "ls_eq_f"), 0, "distinct symbols differ");
+    assert_eq!(run("(ATOM (QUOTE A))", "ls_atom"), 1, "a symbol is an atom");
+}
+
+#[test]
+fn mccarthy_symbol_in_cond_runs_on_llvm() {
+    if !clang_available() { return; }
+    // The symbol-equality clause selects branch 11.
+    assert_eq!(run("(COND ((EQ (QUOTE A) (QUOTE A)) 11) ((EQ 1 1) 22))", "ls_cond"), 11);
+    // A bare symbol result is its (stable, nonzero) tagged word — not unboxed to garbage.
+    assert!(run("(QUOTE A)", "ls_bare") > 0, "a bare symbol returns its tagged word");
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -63,7 +63,7 @@ representation + per-builtin backend lowering.
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
-| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | ☐ | tagged-word |
+| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
@@ -264,7 +264,21 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     `br`. Verified by RUNNING (clang + `lispy_runtime.c`):
     `(COND ((ATOM 7) 11) …)`→11, second-clause→22, **nested `COND`**→44
     (`lang-aot/tests/llvm_cond.rs`). **LLVM core F1–F5 complete.**
-- ☐ **W13 — LLVM symbols + lambda (F6–F7).** **Completes LLVM.**
+- ◑ **W13 — LLVM symbols + lambda (F6–F7).** *In progress.* **Completes LLVM.**
+  - ✅ **W13a — LLVM symbols (F6).** `intern_symbols` already runs in the LLVM
+    pipeline; two fixes finish it: `llvm_type_for("symbol") = i64` (a tagged
+    immediate), and the shared `lower_lisp_repr` returns a **symbol** result verbatim
+    (its tagged word) instead of `unbox_int`'ing it (`>> 3` would corrupt id+tag) —
+    the same type-directed exit coercion as bools (W12b-2). Verified by RUNNING
+    (clang + `lispy_runtime.c`): `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0,
+    `(ATOM (QUOTE A))`→1, symbol-in-`COND`→11, `(QUOTE A)`→its tagged word
+    (`lang-aot/tests/llvm_symbols.rs`).
+  - ☐ **W13b — LLVM lambda (F7). Completes LLVM.** The lambda *mechanism* already
+    works (`(LAMBDA …)` → an emitted function + a `call`; `((LAMBDA (X) X) 5)`→5).
+    The open work is the **entry coercion of a polymorphic `call` result**: a lambda
+    returning a tagged int/bool/cons isn't unboxed/truthy'd at the program exit
+    (`((LAMBDA (X) (CAR X)) (CONS 7 9))`→56 = boxed 7, not 7). Needs the lambda's
+    return type threaded to the entry ret, or a runtime-tag-dispatched coercion.
 
 ### Phase F — native AOT + JIT completion
 


### PR DESCRIPTION
## McCarthy symbols run on a clang-built native executable — LLVM reaches F6

The shared `intern_symbols` pass already runs in the LLVM pipeline (since W12b-1); two small fixes finish symbols.

## Change

**`iir-to-llvm` 0.7.0** — `llvm_type_for("symbol")` → `i64`. An interned symbol is a tagged 64-bit immediate, so it flows as a tagged word like `any`/`ref<Lispy…>`. `(QUOTE A)`, symbol `EQ`, and symbols inside `COND` now validate + lower.

**`iir-builtin-lowering` 0.15.0** — `lower_lisp_repr`'s program-exit coercion is now **symbol-aware** (extends the bool case from W12b-2): a symbol result is already a finished tagged immediate (`(id << shift) | TAG_SYMBOL`), so it must **not** be `lispy_unbox_int`'d (`>> 3` would corrupt the id+tag). Such a `ret` is returned verbatim (its tagged word). Reusable for every tagged-word backend.

## Verified by RUNNING (`tests/llvm_symbols.rs`, clang + `lispy_runtime.c`)

| program | result |
|---|---|
| `(EQ (QUOTE A) (QUOTE A))` | 1 |
| `(EQ (QUOTE A) (QUOTE B))` | 0 |
| `(ATOM (QUOTE A))` | 1 |
| `(COND ((EQ (QUOTE A) (QUOTE A)) 11) ((EQ 1 1) 22))` | 11 |
| `(QUOTE A)` | its (nonzero) tagged word |

cons/predicate/scalar all still pass (no regression).

## Why lambda (F7) is NOT here

The lambda *mechanism* already works (`(LAMBDA …)` → an emitted function + a `call`; `((LAMBDA (X) X) 5)`→5). The open work is the **entry coercion of a polymorphic `call` result**: a lambda returning a tagged int/bool/cons isn't unboxed/truthy'd at the program exit (`((LAMBDA (X) (CAR X)) (CONS 7 9))`→56 = boxed 7). That needs the lambda's return type threaded to the entry ret (or runtime-tag-dispatched coercion) — scoped as **W13b**.

## Test plan

`iir-to-llvm` **51** (+1), `iir-builtin-lowering` **109** (+1), `lang-aot` `llvm_symbols` 2 + `llvm_cond`/`predicates`/`cons`/`scalar` (no regression), **`twig-aot` 25+ green** (the other consumer of the shared pass). clippy clean (`numeric.rs` lints pre-existing). No `twig-vm` → no Miri.

## Security & safety

Security review **PASSED**: bounded `HashSet` build + membership check + one pushed IIR instruction (no panic/unwrap/overflow/OOB/recursion); the symbol `ret` is an `i64` ret of an `i64` const immediate (no pointer/type confusion); `symbol`→`i64` stays in the tagged-word ABI lane (symbols are opaque words compared by `__twig_lispy_equal`, never addresses).

## Matrix

LLVM **F6 → ✅**. LLVM now **F1–F6**; only lambda (W13b) remains. Five backends complete (VM/WASM/JVM/CLR/BEAM, F1–F7); native AOT F1–F6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)