### PR TITLE
feat(mccarthy-lisp): W13b — McCarthy lambda on LLVM (F7) — LLVM COMPLETE (F1-F7)

### DIFF
--- a/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
+++ b/code/packages/rust/iir-builtin-lowering/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this crate are documented here.
 
 ---
 
+## [0.16.0] — 2026-06-10 — lambda value-model: arg boxing + polymorphic result coercion (LANG77 / McCarthy W13b)
+
+Closes the two tagged-word value-model gaps a `LAMBDA` exposes in `lower_lisp_repr`
+(F7), reusing the managed pass's lisp-function partition (`lisp_functions`, now
+`pub(crate)`):
+
+- **Argument boxing** — `lisp_arg_regs` now includes the arguments of a `call` to a
+  **lisp function** (not just lisp builtins), so an integer atom passed to a lambda
+  is boxed (`n << 3`). Without it a raw `5` reads as tag `0b101` (`#t`) and `7` as
+  `0b111` (a heap pair) inside the body.
+- **Polymorphic result coercion** — a lambda result is a `call` typed `any` of
+  unknown runtime tag, so the entry-exit coercion wraps it with the new
+  `lispy_to_exit_code` (a RUNTIME tag switch) instead of the static
+  `unbox_int`/`truthy`/verbatim that the int/bool/symbol cases use.
+- **Language gate** — both behaviours fire only for a lisp module (`language ==
+  "mccarthy-lisp"`). Twig shares this pass and also types untyped params `any`, so
+  the gate keeps the pass a faithful no-op for Twig (regression-tested:
+  `non_lisp_call_is_left_untouched`).
+
+New unit tests `lambda_call_boxes_int_arg_and_coerces_result` +
+`non_lisp_call_is_left_untouched`.
+
 ## [0.15.0] — 2026-06-10 — symbol program-result handling (LANG77 / McCarthy W13a)
 
 Extends the type-directed program-exit coercion in `lower_lisp_repr` (the bool case

--- a/code/packages/rust/iir-builtin-lowering/Cargo.toml
+++ b/code/packages/rust/iir-builtin-lowering/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-builtin-lowering"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "IIR builtin lowering pass — converts call_builtin instructions into typed IIR arithmetic/comparison ops"
 

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr.rs
@@ -108,6 +108,34 @@ const UNBOX_BUILTIN: &str = "lispy_unbox_int";
 /// on a `COND` predicate that produced a tagged boolean.
 const TRUTHY_BUILTIN: &str = "lispy_truthy";
 
+/// The universal exit-coercion helper (`__twig_lispy_to_exit_code`): a tagged
+/// `LispyValue` of *statically unknown* runtime tag → a raw `i64` exit code,
+/// dispatching on the tag at RUN time (int → `>> 3`; `#t`/`#f`/nil → `1`/`0`;
+/// symbol/pair → the tagged word verbatim). Used for a **lambda** result (F7):
+/// the program-exit boundary sees a `call` whose return type is `any`, so the
+/// right coercion can't be picked at compile time the way `unbox_int` (int) /
+/// `truthy` (bool) / verbatim (symbol) are — this single runtime switch handles
+/// every case.
+const EXIT_CODE_BUILTIN: &str = "lispy_to_exit_code";
+
+/// True when a module's source language uses the tagged-word lisp value model
+/// (today: McCarthy 1960 Lisp). Gates the lambda-aware `call` handling so a Twig
+/// module — which shares this pass and also types untyped params `any` — is left
+/// completely untouched.
+fn is_lisp_language(language: &str) -> bool {
+    language == "mccarthy-lisp"
+}
+
+/// True when `instr` is a `call` to a **lisp function** (a `LAMBDA`/`LABEL`,
+/// identified by `lisp_funcs`). Its parameters and result use the tagged-word
+/// value model, so an integer atom argument must be boxed and the result is a
+/// `LispyValue` of unknown runtime tag. A *non-lisp* `call` (e.g. a Twig `fib`
+/// recursion) is excluded, so this pass stays a no-op for non-lisp modules.
+fn is_lisp_function_call(instr: &IIRInstr, lisp_funcs: &HashSet<String>) -> bool {
+    instr.op == "call"
+        && matches!(instr.srcs.first(), Some(Operand::Var(c)) if lisp_funcs.contains(c))
+}
+
 /// If `instr` is `call_builtin "<lisp builtin>"`, return that name.
 fn lisp_builtin_name(instr: &IIRInstr) -> Option<&str> {
     if instr.op != "call_builtin" {
@@ -160,13 +188,30 @@ fn rename_lisp_not(func: &mut IIRFunction) {
 /// Twig/Nib/Brainfuck program) has nothing to box and is left unchanged.
 pub fn lower_lisp_repr(module: &mut IIRModule) {
     let entry = module.entry_point.clone();
+    // The set of **lisp functions** (uniform value model at their boundary):
+    // those that use the heap / lisp predicates or take a lisp (`any`) param,
+    // closed under *calling*. This is exactly how the managed structural pass
+    // partitions a module — reusing it keeps the tagged-word and managed passes
+    // in agreement on what a "lisp call" is. Only a `call` whose callee is a
+    // lisp function boxes its atom arguments / coerces its result.
+    //
+    // CRUCIAL: gate on the source language. Twig also types untyped params
+    // `any` and shares this pass (twig-aot runs it on every module), so the
+    // `any`-param heuristic alone would mis-flag a Twig `(define (fib n) …)` as
+    // lisp and corrupt it. The empty set for a non-lisp module makes every new
+    // `call`-handling branch inert — the pass stays a faithful no-op for Twig.
+    let lisp_funcs = if is_lisp_language(&module.language) {
+        crate::lisp_repr_structural::lisp_functions(module)
+    } else {
+        HashSet::new()
+    };
     for func in &mut module.functions {
         let is_entry = entry.as_deref() == Some(func.name.as_str());
-        lower_lisp_repr_function(func, is_entry);
+        lower_lisp_repr_function(func, is_entry, &lisp_funcs);
     }
 }
 
-fn lower_lisp_repr_function(func: &mut IIRFunction, is_entry: bool) {
+fn lower_lisp_repr_function(func: &mut IIRFunction, is_entry: bool, lisp_funcs: &HashSet<String>) {
     // ── 0. Type-directed `not` → `lispy_not`. ──
     //
     // `not` is ambiguous: a *numeric* builtin (Twig's machine boolean-not) and
@@ -178,11 +223,21 @@ fn lower_lisp_repr_function(func: &mut IIRFunction, is_entry: bool) {
     // result, not a `lispy_*` value) is left for the numeric lowering.
     rename_lisp_not(func);
 
-    // ── 1. Registers that feed a lisp builtin (their integer atoms box). ──
+    // ── 1. Registers that feed a lisp call (their integer atoms box). ──
+    //
+    // Two callers put a value into a lisp context, so an integer *atom* passed
+    // to either must be boxed (`n << 3`) to become a tagged `LispyValue`:
+    //   • a lisp **builtin** (`call_builtin "lispy_*"`) — `cons`/`car`/`equal`/…;
+    //   • a user **lambda / function** (`call` returning the polymorphic `any`),
+    //     whose parameters are themselves lisp values (F7). Without this, an int
+    //     argument arrives raw — e.g. `5` has tag bits `0b101` (= `#t`) and `7`
+    //     has `0b111` (= a heap pair), so the body misreads it.
+    // In both, `srcs[0]` is the callee/name and `srcs[1..]` are the arguments.
     let mut lisp_arg_regs: HashSet<String> = HashSet::new();
     for instr in &func.instructions {
-        if lisp_builtin_name(instr).is_some() {
-            // srcs[0] is the builtin name; srcs[1..] are the value arguments.
+        let is_lisp_call =
+            lisp_builtin_name(instr).is_some() || is_lisp_function_call(instr, lisp_funcs);
+        if is_lisp_call {
             for src in instr.srcs.iter().skip(1) {
                 if let Operand::Var(v) = src {
                     lisp_arg_regs.insert(v.clone());
@@ -283,7 +338,7 @@ fn lower_lisp_repr_function(func: &mut IIRFunction, is_entry: bool) {
 
     // ── 5. Unbox at the program-exit boundary (entry function only). ──
     if is_entry {
-        insert_unbox_before_lisp_rets(func, &boxed_regs);
+        insert_unbox_before_lisp_rets(func, &boxed_regs, lisp_funcs);
     }
 }
 
@@ -343,11 +398,31 @@ fn wrap_tagged_conditions(func: &mut IIRFunction, boxed_regs: &HashSet<String>) 
 /// In the entry function, rewrite each `ret %x` whose `%x` holds a boxed
 /// `LispyValue` into `%u = lispy_unbox_int(%x); ret %u`, so the process exit
 /// code is the raw integer value rather than the tagged word.
-fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<String>) {
-    // Nothing returns a boxed value → no work (avoids the Vec rebuild).
+fn insert_unbox_before_lisp_rets(
+    func: &mut IIRFunction,
+    boxed_regs: &HashSet<String>,
+    lisp_funcs: &HashSet<String>,
+) {
+    // McCarthy lambda-result handling (F7): a user function / lambda result is a
+    // `call` whose return type is the polymorphic `any` (or a lisp `ref<Lispy…>`).
+    // Its runtime tag (int / bool / symbol / pair) is unknown at compile time, so
+    // none of the static coercions (`unbox_int` / `truthy` / verbatim) is right on
+    // its own. Returning such a value runs it through `lispy_to_exit_code`, a
+    // runtime tag switch. (Lisp *builtin* results — `car`/`cons`/… — are already
+    // in `boxed_regs` and keep their existing handling; only plain `call`s join
+    // this set.)
+    let call_result_regs: HashSet<String> = func
+        .instructions
+        .iter()
+        .filter(|i| is_lisp_function_call(i, lisp_funcs))
+        .filter_map(|i| i.dest.clone())
+        .collect();
+
+    // Nothing returns a coercible lisp value → no work (avoids the Vec rebuild).
     let needs_unbox = func.instructions.iter().any(|i| {
         i.op == "ret"
-            && matches!(i.srcs.first(), Some(Operand::Var(v)) if boxed_regs.contains(v))
+            && matches!(i.srcs.first(), Some(Operand::Var(v))
+                if boxed_regs.contains(v) || call_result_regs.contains(v))
     });
     if !needs_unbox {
         return;
@@ -384,40 +459,44 @@ fn insert_unbox_before_lisp_rets(func: &mut IIRFunction, boxed_regs: &HashSet<St
     let mut unbox_counter = 0usize;
 
     for instr in old {
-        let ret_boxed_reg = if instr.op == "ret" {
+        // The register a `ret` returns, if it holds a coercible lisp value.
+        let ret_reg = if instr.op == "ret" {
             match instr.srcs.first() {
-                Some(Operand::Var(v)) if boxed_regs.contains(v) => Some(v.clone()),
+                Some(Operand::Var(v)) if boxed_regs.contains(v) || call_result_regs.contains(v) => {
+                    Some(v.clone())
+                }
                 _ => None,
             }
         } else {
             None
         };
 
-        match ret_boxed_reg {
-            Some(boxed) if symbol_regs.contains(&boxed) => {
+        match ret_reg {
+            Some(reg) if symbol_regs.contains(&reg) => {
                 // A symbol result is returned as its tagged word (no coercion).
-                new_instrs.push(IIRInstr::new(
-                    "ret",
-                    None,
-                    vec![Operand::Var(boxed)],
-                    "i64",
-                ));
+                new_instrs.push(IIRInstr::new("ret", None, vec![Operand::Var(reg)], "i64"));
             }
-            Some(boxed) => {
-                // A boolean result → `lispy_truthy` (→ 0/1); an integer result →
-                // `lispy_unbox_int` (→ `>> 3`). Both yield a raw `i64`.
-                let coerce = if bool_regs.contains(&boxed) {
+            Some(reg) => {
+                // Pick the exit coercion by what we statically know about `reg`:
+                //   • a lambda / user-`call` result (tag unknown) → `lispy_to_exit_code`
+                //     (a RUNTIME tag switch — int/bool/symbol/pair all handled);
+                //   • a boolean (predicate) result → `lispy_truthy` (→ 0/1);
+                //   • otherwise a boxed integer → `lispy_unbox_int` (→ `>> 3`).
+                // All three yield a raw `i64`.
+                let coerce = if call_result_regs.contains(&reg) {
+                    EXIT_CODE_BUILTIN
+                } else if bool_regs.contains(&reg) {
                     TRUTHY_BUILTIN
                 } else {
                     UNBOX_BUILTIN
                 };
-                // %u = call_builtin "<coerce>", %boxed  : i64
+                // %u = call_builtin "<coerce>", %reg  : i64
                 let u_reg = format!("__unbox_{unbox_counter}");
                 unbox_counter += 1;
                 new_instrs.push(IIRInstr::new(
                     "call_builtin",
                     Some(u_reg.clone()),
-                    vec![Operand::Var(coerce.to_string()), Operand::Var(boxed)],
+                    vec![Operand::Var(coerce.to_string()), Operand::Var(reg)],
                     "i64",
                 ));
                 // ret %u
@@ -716,6 +795,61 @@ mod tests {
         // The final instruction is a bare `ret` of the symbol register.
         let last = m.functions[0].instructions.last().unwrap();
         assert_eq!(last.op, "ret", "ends with a bare ret of the tagged symbol word");
+    }
+
+    /// Build a module with `main` (entry, `functions[0]`) plus extra functions.
+    fn multi_fn_module(main: Vec<IIRInstr>, extra: Vec<IIRFunction>, language: &str) -> IIRModule {
+        let mut functions = vec![IIRFunction::new("main", vec![], "any", main)];
+        functions.extend(extra);
+        IIRModule {
+            name: "test".into(),
+            functions,
+            entry_point: Some("main".into()),
+            language: language.into(),
+            exports: vec![],
+            imports: vec![],
+        }
+    }
+
+    /// `main { a = 5; r = <callee>(a); ret r }` plus an identity `<callee>(X){ ret X }`.
+    fn apply_identity_module(callee: &str, language: &str) -> IIRModule {
+        let id = IIRFunction::new(callee, vec![("X".into(), "any".into())], "any", vec![ret("X")]);
+        let main = vec![
+            konst("a", 5, "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var(callee.into()), Operand::Var("a".into())],
+                "any",
+            ),
+            ret("r"),
+        ];
+        multi_fn_module(main, vec![id], language)
+    }
+
+    /// McCarthy W13b (F7): a `call` to a lisp function boxes its integer atom
+    /// argument (`5 << 3 = 40`) and coerces its polymorphic result at the program
+    /// exit with the runtime tag switch `lispy_to_exit_code`.
+    #[test]
+    fn lambda_call_boxes_int_arg_and_coerces_result() {
+        let mut m = apply_identity_module("lambda_0", "mccarthy-lisp");
+        lower_lisp_repr(&mut m);
+        assert_eq!(find_const(&m, "a"), 40, "int atom arg must box before the lambda");
+        assert_eq!(count_builtin(&m, "lispy_to_exit_code"), 1, "lambda result → to_exit_code");
+        assert_eq!(count_builtin(&m, "lispy_unbox_int"), 0, "polymorphic result is NOT unboxed");
+    }
+
+    /// The same IIR shape in a **Twig** module is left completely untouched: an
+    /// untyped Twig param is also `any`, but the source language is not lisp, so
+    /// the int arg stays raw and the result is returned verbatim. (Guards the
+    /// regression where `(define (fib n) …)` was mis-boxed.)
+    #[test]
+    fn non_lisp_call_is_left_untouched() {
+        let mut m = apply_identity_module("fib", "twig");
+        lower_lisp_repr(&mut m);
+        assert_eq!(find_const(&m, "a"), 5, "a Twig int arg stays a raw machine word");
+        assert_eq!(count_builtin(&m, "lispy_to_exit_code"), 0, "a Twig call is never coerced");
+        assert_eq!(count_builtin(&m, "lispy_box_int"), 0, "a Twig arg is never boxed");
     }
 
     /// A raw machine condition (e.g. a Twig `cmp` result, not in boxed_regs)

--- a/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
+++ b/code/packages/rust/iir-builtin-lowering/src/lisp_repr_structural.rs
@@ -157,7 +157,7 @@ fn has_lisp_param(func: &IIRFunction) -> bool {
 /// function that `call`s a lisp function is itself lisp (its call site must box
 /// the args and treat the result as a reference). For a McCarthy module every
 /// function ends up lisp; a Twig module's pure-scalar functions never enter.
-fn lisp_functions(module: &IIRModule) -> HashSet<String> {
+pub(crate) fn lisp_functions(module: &IIRModule) -> HashSet<String> {
     let mut lisp: HashSet<String> = module
         .functions
         .iter()

--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.8.0] — 2026-06-10 (McCarthy W13b — lisp lambda (F7) — LLVM COMPLETE)
+
+Registers the universal exit-coercion runtime helper so the LLVM backend can
+declare + call it: `LISPY_BUILTINS` gains `("lispy_to_exit_code",
+"__twig_lispy_to_exit_code", 1)`. A lambda result is a `call` typed `any` whose
+runtime tag is unknown at compile time; the shared `lower_lisp_repr` now emits
+`lispy_to_exit_code` for it, and this entry lets the backend lower that to a
+`call i64 @__twig_lispy_to_exit_code(i64)`. With it, **LLVM is McCarthy-complete
+(F1–F7)** — verified by RUNNING in `lang-aot` (`lang-aot/tests/llvm_lambda.rs`).
+
 ## [0.7.0] — 2026-06-10 (McCarthy W13a — lisp symbols (F6))
 
 `llvm_type_for("symbol")` now maps to `i64` — an interned McCarthy symbol is a

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-llvm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -86,7 +86,8 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.5.0  | Tagged-word lisp `cons`/`car`/`cdr` → `call @__twig_lispy_*` (McCarthy W12b-1). |
 | v0.6.0  | `COND` via stack-slot (`alloca`) SSA-merge + `jmp_if` void-cond + empty-block `br` (McCarthy W12b-3). |
 | v0.7.0  | Lisp symbols — `symbol` type → `i64` tagged immediate (McCarthy W13a). |
-| (later) | Lisp lambda result coercion (W13b), GC, debug info via `!dbg`. |
+| v0.8.0  | Lisp lambda (F7) — declare `lispy_to_exit_code` runtime switch; **LLVM McCarthy-complete F1–F7** (McCarthy W13b). |
+| (later) | GC, debug info via `!dbg`. |
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -284,6 +284,7 @@ const LISPY_BUILTINS: &[(&str, &str, usize)] = &[
     ("lispy_truthy", "__twig_lispy_truthy", 1),
     ("lispy_box_int", "__twig_lispy_box_int", 1),
     ("lispy_unbox_int", "__twig_lispy_unbox_int", 1),
+    ("lispy_to_exit_code", "__twig_lispy_to_exit_code", 1),
     ("lispy_nil", "__twig_lispy_nil", 0),
 ];
 

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `lang-aot`
 
+## 0.39.0 — 2026-06-10 — McCarthy → **LLVM lambda** (F7) on a clang-built executable — **LLVM COMPLETE F1–F7** (LANG77 / W13b)
+
+No `lang-aot` source change — the work is in `iir-builtin-lowering` 0.16.0 (lambda
+arg boxing + polymorphic result coercion), `twig-aot`'s `lispy_runtime.c` 0.14.0
+(the `__twig_lispy_to_exit_code` runtime switch) and `iir-to-llvm` 0.8.0 (declaring
+it), all of which `compile_source_to_llvm` already drives. New verify-by-running
+test `tests/llvm_lambda.rs` (link `lispy_runtime.c` with clang, run):
+`((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
+`((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, `((LAMBDA (X) (ATOM X)) 7)`→1,
+lambda-with-`COND`-body→100/200. **LLVM is now McCarthy-complete (F1–F7)** — the
+sixth backend to finish, after VM/WASM/JVM/CLR/BEAM.
+
 ## 0.38.0 — 2026-06-10 — McCarthy → **LLVM symbols** (F6) on a clang-built executable (LANG77 / W13a)
 
 No `lang-aot` source change — the work is in `iir-to-llvm` 0.7.0 (`symbol`→`i64`) and

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -77,8 +77,13 @@ across blocks is promoted to a stack slot (`alloca`/`store`/`load`, a cross-bloc
 merge) — `(COND ((ATOM 7) 11) ((ATOM 8) 22))` → 11, nested `COND` → 44.
 **Symbols** run too (W13a, F6): an interned symbol is a tagged `i64` immediate, and a
 bare symbol result is returned verbatim (not unboxed) — `(EQ (QUOTE A) (QUOTE A))` →
-1, `(EQ (QUOTE A) (QUOTE B))` → 0, `(ATOM (QUOTE A))` → 1. **LLVM is now F1–F6**; only
-lambda (F7, W13b) remains.
+1, `(EQ (QUOTE A) (QUOTE B))` → 0, `(ATOM (QUOTE A))` → 1.
+**Lambda** runs too (W13b, F7): an integer atom argument is boxed before crossing
+into the lambda, and the polymorphic result is coerced at the program exit by
+`__twig_lispy_to_exit_code` (a runtime tag switch) — `((LAMBDA (X) X) 5)` → 5,
+`((LAMBDA (X) (CAR X)) (CONS 7 9))` → 7, `((LAMBDA (X Y) (EQ X Y)) 3 3)` → 1,
+lambda-with-`COND`-body → 100/200. **LLVM is now McCarthy-complete (F1–F7)** — the
+sixth backend to finish, after VM/WASM/JVM/CLR/BEAM.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/llvm_lambda.rs
+++ b/code/packages/rust/lang-aot/tests/llvm_lambda.rs
@@ -1,0 +1,68 @@
+//! # LLVM lambda — F7 (LANG77 / McCarthy W13b). **Completes the LLVM backend.**
+//!
+//! A McCarthy `(LAMBDA (params…) body)` lowers to an emitted function plus a
+//! `call`; the lambda *mechanism* (params, application, body) was already free
+//! from the shared pipeline. W13b closes the two value-model gaps a lambda exposes:
+//!
+//!   1. **Argument boxing** — a lambda's parameters are lisp values, so an integer
+//!      *atom* argument must be boxed (`n << 3`). Raw `5` has tag bits `0b101`
+//!      (`#t`!) and raw `7` has `0b111` (a heap pair!), so an unboxed arg is
+//!      misread by the body. `lisp_arg_regs` now includes user-`call` arguments.
+//!   2. **Polymorphic result coercion** — the program exit sees a `call` typed
+//!      `any`; its runtime tag (int/bool/symbol/pair) is unknown at compile time,
+//!      so it is coerced by `__twig_lispy_to_exit_code`, a RUNTIME tag switch
+//!      (int → `>> 3`, `#t`/`#f`/nil → `1`/`0`/`0`, symbol/pair → verbatim).
+//!
+//! **Verified by RUNNING**: emit host IR, link `lispy_runtime.c`, run with `clang`.
+
+use lang_aot::{compile_source_to_llvm_with_target, Language};
+
+fn clang_available() -> bool {
+    std::process::Command::new("clang").arg("--version").output()
+        .map(|o| o.status.success()).unwrap_or(false)
+}
+fn host_triple() -> String {
+    let o = std::process::Command::new("clang").arg("-dumpmachine").output().expect("clang -dumpmachine");
+    String::from_utf8_lossy(&o.stdout).trim().to_string()
+}
+fn lispy_runtime_c() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../twig-aot/runtime/lispy_runtime.c")
+}
+fn run(src: &str, module: &str) -> i32 {
+    let ll = compile_source_to_llvm_with_target(Language::McCarthyLisp, src, module, &host_triple())
+        .unwrap_or_else(|e| panic!("compile {src:?}: {e}"));
+    let tmp = std::env::temp_dir().join(format!("mccarthy_w13b_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).expect("temp dir");
+    let ll_path = tmp.join(format!("{module}.ll"));
+    std::fs::write(&ll_path, &ll).expect("write .ll");
+    let exe = tmp.join(module);
+    let build = std::process::Command::new("clang")
+        .arg("-x").arg("ir").arg(&ll_path)
+        .arg("-x").arg("none").arg(lispy_runtime_c())
+        .arg("-o").arg(&exe).output().expect("spawn clang");
+    assert!(build.status.success(), "clang failed: {}", String::from_utf8_lossy(&build.stderr));
+    std::process::Command::new(&exe).output().expect("run").status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_lambda_runs_on_llvm() {
+    if !clang_available() { eprintln!("clang absent — skipping"); return; }
+    // Identity — int arg boxed, result coerced back to the raw int.
+    assert_eq!(run("((LAMBDA (X) X) 5)", "lam_id"), 5);
+    // Body takes the apart the argument structure.
+    assert_eq!(run("((LAMBDA (X) (CAR X)) (CONS 7 9))", "lam_car"), 7);
+    assert_eq!(run("((LAMBDA (X) (CDR X)) (CONS 7 9))", "lam_cdr"), 9);
+    // Two parameters; a predicate body → a boolean result, truthy-coerced (0/1).
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 3)", "lam_eq_t"), 1);
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 4)", "lam_eq_f"), 0);
+    // `ATOM` of a (boxed) integer atom — exercises argument boxing directly.
+    assert_eq!(run("((LAMBDA (X) (ATOM X)) 7)", "lam_atom"), 1);
+}
+
+#[test]
+fn mccarthy_lambda_with_cond_body_runs_on_llvm() {
+    if !clang_available() { return; }
+    // A lambda whose body is a `COND` over its parameter — composes F5 + F7.
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0)", "lam_cond0"), 100);
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 9)", "lam_cond9"), 200);
+}

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `twig-aot`
 
+## 0.14.0 — 2026-06-10 — `lispy_runtime.c`: universal exit coercion (LANG77 / McCarthy W13b)
+
+Adds `__twig_lispy_to_exit_code(uint64_t)` to the shared tagged-word C runtime: it
+coerces ANY `LispyValue` to a raw exit code by dispatching on its runtime tag
+(integer → `>> 3`; `#t`/`#f`/nil → `1`/`0`/`0`; symbol/pair → the tagged word
+verbatim). This is the program-exit boundary for a value whose tag the compiler
+cannot know statically — a **lambda** result (F7), typed `any`. It is a safe
+superset of the static `unbox_int`/`truthy` helpers (they agree on every tag they
+each cover). Reusable by every tagged-word backend that links this runtime (LLVM
+today; native AOT W14 and JIT W15 inherit it). No Rust source change; this is a
+runtime-asset addition compiled into the AOT executable.
+
 ## 0.13.0 — 2026-06-04 — native symbols (LANG77 / McCarthy L3b-2c-3)
 
 `prepare_module_for_aot` now runs `iir_builtin_lowering::intern_symbols`

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source."
 

--- a/code/packages/rust/twig-aot/runtime/lispy_runtime.c
+++ b/code/packages/rust/twig-aot/runtime/lispy_runtime.c
@@ -164,6 +164,36 @@ int64_t __twig_lispy_truthy(uint64_t v) {
     return (v == LISPY_FALSE || v == LISPY_NIL) ? 0 : 1;
 }
 
+/* __twig_lispy_to_exit_code — coerce ANY tagged LispyValue to a raw exit code,
+ * dispatching on its RUNTIME tag.  This is the program-exit boundary for a
+ * value whose tag the compiler cannot know statically — a lambda result (F7),
+ * which the frontend types as the polymorphic `any`.  The static coercions each
+ * cover one tag; this switch covers them all at once:
+ *
+ *   tag (v & 0b111)  value           exit code
+ *   ───────────────  ──────────────  ──────────────────────────────────────
+ *   0b000  INT       boxed integer   arithmetic  v >> 3   (sign-extended)
+ *   0b101  TRUE      #t              1
+ *   0b011  FALSE     #f              0
+ *   0b001  NIL       ()              0   (nil is falsy, like #f)
+ *   0b010  SYMBOL    interned atom   the tagged word verbatim (stable id+tag)
+ *   0b111  HEAP      cons pair       the tagged word verbatim (stable pointer)
+ *
+ * Agreement with the static helpers (so this is a safe superset):
+ *   to_exit_code(box_int n) == unbox_int(box_int n) == n
+ *   to_exit_code(#t/#f/nil) == truthy(#t/#f/nil)    == 1/0/0
+ *   to_exit_code(symbol)    == (symbol returned verbatim)
+ */
+int64_t __twig_lispy_to_exit_code(uint64_t v) {
+    switch (v & LISPY_TAG_BITS) {
+        case LISPY_TAG_INT:   return ((int64_t)v) >> 3;  /* integer atom    */
+        case LISPY_TAG_TRUE:  return 1;                  /* #t              */
+        case LISPY_TAG_FALSE: return 0;                  /* #f              */
+        case LISPY_TAG_NIL:   return 0;                  /* () is falsy     */
+        default:              return (int64_t)v;         /* symbol / pair   */
+    }
+}
+
 /* `equal?` — structural deep equality, returning a tagged boolean.
  *
  *   - Two atoms (neither is a pair) are equal iff their bits are equal.

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -63,7 +63,7 @@ representation + per-builtin backend lowering.
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
-| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
+| **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged-word |
 | **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
@@ -264,7 +264,8 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     `br`. Verified by RUNNING (clang + `lispy_runtime.c`):
     `(COND ((ATOM 7) 11) …)`→11, second-clause→22, **nested `COND`**→44
     (`lang-aot/tests/llvm_cond.rs`). **LLVM core F1–F5 complete.**
-- ◑ **W13 — LLVM symbols + lambda (F6–F7).** *In progress.* **Completes LLVM.**
+- ✅ **W13 — LLVM symbols + lambda (F6–F7). DONE — LLVM COMPLETE (F1–F7).** Sixth
+  backend to finish all seven features (after VM/WASM/JVM/CLR/BEAM).
   - ✅ **W13a — LLVM symbols (F6).** `intern_symbols` already runs in the LLVM
     pipeline; two fixes finish it: `llvm_type_for("symbol") = i64` (a tagged
     immediate), and the shared `lower_lisp_repr` returns a **symbol** result verbatim
@@ -273,12 +274,21 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     (clang + `lispy_runtime.c`): `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0,
     `(ATOM (QUOTE A))`→1, symbol-in-`COND`→11, `(QUOTE A)`→its tagged word
     (`lang-aot/tests/llvm_symbols.rs`).
-  - ☐ **W13b — LLVM lambda (F7). Completes LLVM.** The lambda *mechanism* already
-    works (`(LAMBDA …)` → an emitted function + a `call`; `((LAMBDA (X) X) 5)`→5).
-    The open work is the **entry coercion of a polymorphic `call` result**: a lambda
-    returning a tagged int/bool/cons isn't unboxed/truthy'd at the program exit
-    (`((LAMBDA (X) (CAR X)) (CONS 7 9))`→56 = boxed 7, not 7). Needs the lambda's
-    return type threaded to the entry ret, or a runtime-tag-dispatched coercion.
+  - ✅ **W13b — LLVM lambda (F7). COMPLETES LLVM.** The lambda *mechanism* was
+    already free from the shared pipeline; W13b closed the two value-model gaps:
+    (1) **argument boxing** — a lambda's params are lisp values, so an integer atom
+    argument is boxed (`lisp_arg_regs` now includes user-`call` args; without it a
+    raw `5` reads as tag `0b101` = `#t`, `7` as `0b111` = a pair); (2) **polymorphic
+    result coercion** — the entry sees a `call` typed `any` (runtime tag unknown), so
+    a new shared runtime helper `__twig_lispy_to_exit_code` dispatches on the tag at
+    RUN time (int → `>> 3`, `#t`/`#f`/nil → `1`/`0`/`0`, symbol/pair → verbatim). Both
+    gated on the source language so the pass stays a faithful no-op for Twig (which
+    also types untyped params `any`). The helper lives in `lispy_runtime.c`, so the
+    native AOT (W14) and JIT (W15) tagged-word backends inherit it. Verified by
+    RUNNING (clang + `lispy_runtime.c`): `((LAMBDA (X) X) 5)`→5,
+    `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1,
+    `((LAMBDA (X) (ATOM X)) 7)`→1, lambda-with-`COND`-body→100/200
+    (`lang-aot/tests/llvm_lambda.rs`).
 
 ### Phase F — native AOT + JIT completion
 


### PR DESCRIPTION
## McCarthy lambda runs as native machine code — **the LLVM backend is complete (F1–F7)**

The sixth backend to finish all seven features, after VM/WASM/JVM/CLR/BEAM. The lambda *mechanism* (an emitted function + a `call`) was already free from the shared pipeline; W13b closes the two tagged-word value-model gaps a lambda exposes.

## Change

**`iir-builtin-lowering` 0.16.0** (shared `lower_lisp_repr`)
- **Argument boxing** — `lisp_arg_regs` now includes the arguments of a `call` to a **lisp function** (not just lisp builtins), so an integer atom passed to a lambda is boxed (`n << 3`). Without it a raw `5` reads as tag `0b101` (`#t`) and `7` as `0b111` (a heap pair) inside the body.
- **Polymorphic result coercion** — a lambda result is a `call` typed `any` of unknown runtime tag, so the program-exit coercion wraps it with `lispy_to_exit_code` (a **runtime** tag switch) instead of the static `unbox_int`/`truthy`/verbatim used for int/bool/symbol.
- Reuses the managed pass's lisp-function partition (`lisp_functions`, now `pub(crate)`). Both behaviours **gate on the source language** (`== "mccarthy-lisp"`) — Twig shares this pass and also types untyped params `any`, so the gate keeps the pass a faithful no-op for Twig.

**`twig-aot` 0.14.0** (`lispy_runtime.c`) — adds `__twig_lispy_to_exit_code(v)`: dispatch on the runtime tag (int → `>> 3`; `#t`/`#f`/nil → `1`/`0`/`0`; symbol/pair → tagged word verbatim). A safe superset of `unbox_int`/`truthy`. **Reusable by every tagged-word backend** — native AOT (W14) + JIT (W15) inherit it.

**`iir-to-llvm` 0.8.0** — `LISPY_BUILTINS` gains `lispy_to_exit_code` so the backend declares + lowers `call i64 @__twig_lispy_to_exit_code(i64)`.

## Verified by RUNNING (`tests/llvm_lambda.rs`, clang + `lispy_runtime.c`)

| program | result |
|---|---|
| `((LAMBDA (X) X) 5)` | 5 (arg boxed, result coerced back) |
| `((LAMBDA (X) (CAR X)) (CONS 7 9))` | 7 |
| `((LAMBDA (X) (CDR X)) (CONS 7 9))` | 9 |
| `((LAMBDA (X Y) (EQ X Y)) 3 3)` / `3 4` | 1 / 0 (bool result truthy'd) |
| `((LAMBDA (X) (ATOM X)) 7)` | 1 (boxed-atom arg) |
| `((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0` / `9)` | 100 / 200 (**F5 + F7**) |

## Test plan

`iir-builtin-lowering` **111** (+2: lambda coercion + Twig no-op guard), `iir-to-llvm` **51**, `lang-aot` `llvm_lambda` 2 + symbols/cond/predicates/cons/scalar (no regression), **`twig-aot` 25+5 green** — the language gate fixes a regression where `(define (fib n) …)` was briefly mis-boxed (caught before push). clippy clean (warnings all in pre-existing files). `lispy_runtime.c` is a C asset, not the `twig-vm`/`lispy-runtime` Rust crates → no Miri.

## Security & safety

Security review **PASSED**: the C helper is pure arithmetic + a switch on the low 3 tag bits (no memory access/deref/alloc/recursion; the pair case returns the tagged word **without** dereferencing it); the Rust pass adds only bounded iter-passes (no panic/unwrap/OOB/overflow/recursion; `lisp_functions`' fixpoint is monotone over a function-count-bounded set); the language gate compares for equality only (no injection) and only ever *reduces* coercion for non-lisp.

## Matrix

LLVM **F7 → ✅**. W13/W13b **DONE**. **LLVM COMPLETE (F1–F7)** — sixth backend finished. Remaining: native AOT lambda (W14, F7), JIT (W15), cross-backend conformance (W16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)