### PR TITLE
feat(mycin-proto): PR1 — standard dictionary + enforcement linter (MYCIN-2026 foundation)

### DIFF
--- a/code/specs/data/mycin-prototype/SPEC.md
+++ b/code/specs/data/mycin-prototype/SPEC.md
@@ -1,0 +1,94 @@
+# MYCIN-2026 prototype — specification (full pipeline, no shortcuts)
+
+> Resurrects MYCIN on the byte-provenance substrate, on its own domain (bacterial vs viral
+> meningitis), to prove **five claims end-to-end**. Plan of record: the approved build plan.
+> Companion paper specs: [`PAPER2-MYCIN-build-spec.md`](../../papers/PAPER2-MYCIN-build-spec.md),
+> [`PAPER2-MYCIN-derive-once-proof.md`](../../papers/PAPER2-MYCIN-derive-once-proof.md).
+
+## 1. The five claims this prototype proves
+
+1. **Golden rulebook** — a rulebook is derived **once** (with the model + an adversarial gate) and
+   reused on many held-out cases at **zero answer-time model calls**.
+2. **Cost-to-correct is small** — a wrong rule **localizes to one clause** in the audit trail, and a
+   **single CAS edit** fixes it and **propagates** to every dependent case (0 model calls).
+3. **The audit trail is easy to follow** — every decision is a proof DAG: prior → each contribution
+   (with its cited source bytes) → posterior.
+4. **Errors are localizable** — a wrong verdict traces to exactly one clause/fact.
+5. **Inference is CPU-bound** — the decision is computed by the deterministic adj-lang/logic engine,
+   not the model.
+
+## 2. The hard constraint — the model only decomposes
+
+The LLM is used at exactly **two** points, and **never reasons toward the answer**:
+- **Cold (once):** translate byte-grounded literature into candidate adj-lang clauses, then submit
+  each to the adversarial CAS-write gate.
+- **Warm (per case):** **decompose** a messy clinical vignette into typed IR (findings as dictionary
+  terms, with byte spans, type, polarity, a discard list, and inference justifications). It does **not**
+  diagnose.
+
+Everything downstream — IR→adj-lang emission, compilation, the differential, the proof DAG — is
+**deterministic / CPU**. The diagnosis is the engine's, not the model's.
+
+## 3. The standard dictionary (the linchpin) — [`dictionary.json`](dictionary.json)
+
+A controlled vocabulary **shared** by the decomposer and the rulebook/case programs. Each canonical
+term is `functor(value)` (findings) or a bare atom (hypotheses), with a definition, the surface forms
+the decomposer maps prose from, and a value domain. It (a) **constrains the decomposer** (its prompt
+lists the legal terms), (b) is **enforced** by [`dict_lint.py`](dict_lint.py) — which rejects any
+rulebook/case `.adj` that uses an unregistered finding or hypothesis — and (c) makes "finding absent"
+(a value, observed) distinguishable from "finding not yet observed" (term legal, no `observe` line),
+because the finding set is **closed**. Without it, a case's `observe csf_glucose(low)` could silently
+miss a rulebook clause written `csf_glu(low)` — the golden-rulebook problem in miniature.
+
+## 4. Pipeline (data flow)
+
+```
+COLD (once):  grounded LRs (adj52 byte_quotes) → rulebook/meningitis.adj
+              → CAS-write gate (N adversarial readers: byte_quote ⊨ LR? × byte-stability
+                × blind-judge × completeness/discard) → ACCEPT(trust tier) | KICKBACK
+              → cas/objects/<hash>.json  (the content-addressed ADJ LIBRARY)
+
+WARM (per case):  vignette prose
+              → decompose (LLM, dictionary-constrained, decompose-only)
+              → typed IR: findings(term, span, stated|inferred, polarity)
+                          + DISCARD list (unmapped spans + reason)
+                          + inference justifications (ENTAILED/LEAP basis)
+              → adversarial_read: inference read + DISCARD read × N-reader vote × decision-sensitivity
+              → ir_to_adj.py (DETERMINISTIC, dict-validated) → case .adj  (observe… ? bacterial ? viral)
+              → decide.py: concat(CAS rulebook, case) → adj-lang CLI → differential + proof DAG
+              answer-time model calls = 0
+```
+
+## 5. Components (build order; one PR each)
+
+| PR | component | reuses |
+|---|---|---|
+| 1 | **this SPEC**, `dictionary.json`, `dict_lint.py` (+ tests) | — |
+| 2 | **adj-lang CLI** (`code/packages/rust/adj-lang/src/bin/`) → JSON differential + proof DAG | adj-lang `compile`/`decide`, logic-engine `differential`/`proof_dag` |
+| 3 | `rulebook/meningitis.adj` (bacterial + grounded viral arm) + **CAS-write gate** | `adj52/corpus` byte_quotes; `run100b/adversarial_entail`, `decision_sensitivity_gate`, `cas_exercise` |
+| 4 | **case pipeline**: `decompose` + `adversarial_read` (incl. **discard read**) + `ir_to_adj.py` + `decide.py` | `run100/extract100` IR shape; `FORWARD-DESIGN` discard design |
+| 5 | **the five proofs** + `FINDINGS.md` | `adj52/cas/overrides/meningitis-csf-correlation.json` (the cost-to-correct bug+fix) |
+
+## 6. The cost-to-correct demonstration (claim 2, concrete)
+
+Ship a **naive** rulebook that treats the four correlated CSF findings (neutrophilic pleocytosis,
+low glucose, elevated protein, elevated lactate) as **independent** `contributes` clauses. On the
+pre-culture case this **over-saturates** to P ≈ 0.9999 before any culture — the documented ADJ56
+failure. The **proof DAG localizes** the error to those four stacked contributions. A **single CAS
+override** — keep one representative `contributes` + add an explaining-away `interacts` (joint LR < 1),
+the fix in [`adj52/cas/overrides/meningitis-csf-correlation.json`](../adj52/cas/overrides/meningitis-csf-correlation.json)
+— re-derives to a calibrated P ≈ 0.77 and **propagates** to every case citing those clauses, at **0
+answer-time model calls**. The metric: **1 edit, 1 localized locus, propagates**.
+
+## 7. Verification
+
+`python3 test_dict_lint.py`; `python3 dict_lint.py rulebook/meningitis.adj cases/*.adj`;
+`cargo test -p adj-lang` (CLI golden tests); `proofs/golden_rulebook.py` (0 calls);
+`proofs/cost_to_correct.py` (naive→localize→1 edit→calibrated→propagate). Posteriors spot-checked
+against [`adj52/corpus/eval.py`](../adj52/corpus/eval.py).
+
+## 8. Non-goals (so "small" stays small)
+
+Treatment arm; population stratification; full-text PDF caching / automated citation retrieval;
+native adj-lang term-validation (pipeline-level enforcement only this round); LR confidence-interval
+propagation. Each is a clean follow-up.

--- a/code/specs/data/mycin-prototype/dict_lint.py
+++ b/code/specs/data/mycin-prototype/dict_lint.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""dict_lint — enforce the standard dictionary on an adj-lang program.
+
+The dictionary (dictionary.json) is the controlled vocabulary SHARED by the input
+decomposer and the rulebook/case programs. This linter is the *enforcement*: it
+rejects any .adj file that uses a finding term or a hypothesis the dictionary does
+not register. That is what guarantees the model's IR and the compiled program
+share one vocabulary — a case's `observe csf_glucose(low)` can never silently miss
+a rulebook clause because of a naming drift, because both must validate here first.
+
+It validates two things:
+  * every compound finding term `functor(value)` — the functor must be a registered
+    finding and the value must be in that finding's value_domain; and
+  * every hypothesis atom used as a conclusion (after `for`, after `to`, or in a
+    `? query`) — it must be a registered hypothesis.
+
+Usage:  python3 dict_lint.py <file.adj> [<file2.adj> ...]
+Exit code 0 = all terms known; 1 = at least one unknown term (violations printed).
+"""
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# adj-lang keywords + trust tiers + annotation heads — bare atoms that are NOT
+# hypotheses and must be ignored when we scan for conclusion atoms.
+KEYWORDS = {
+    "prior", "for", "contributes", "from", "to", "interacts", "when", "and",
+    "uncertain", "observe", "source", "locator", "trust",
+    "consensus", "authoritative", "empirical", "inferred", "unattributed",
+}
+
+
+def load_dictionary(path=None):
+    path = path or os.path.join(HERE, "dictionary.json")
+    d = json.load(open(path))
+    findings = {f["functor"]: set(f["value_domain"]) for f in d["findings"]}
+    hypotheses = {h["term"] for h in d["hypotheses"]}
+    return findings, hypotheses
+
+
+def _strip(text):
+    """Remove `% ...` comments and `"..."` string literals so their contents
+    (citations, prose) never trip the term scanner."""
+    text = re.sub(r'"(?:[^"\\]|\\.)*"', " ", text)        # string literals
+    text = re.sub(r"(?m)%.*$", " ", text)                 # line comments
+    return text
+
+
+_COMPOUND = re.compile(r"\b([a-z_][a-z0-9_]*)\s*\(\s*([a-z_][a-z0-9_]*)\s*\)")
+# a conclusion atom follows `for`/`to`, or opens a `?` query; it is a bare atom
+# (no opening paren after it).
+_CONCLUSION = re.compile(r"(?:\bfor\b|\bto\b|^\s*\?)\s+([a-z_][a-z0-9_]*)\b(?!\s*\()", re.M)
+
+
+def lint(text, findings, hypotheses):
+    """Return a list of violation strings (empty == clean)."""
+    t = _strip(text)
+    violations = []
+
+    for functor, value in _COMPOUND.findall(t):
+        if functor not in findings:
+            violations.append(f"unknown finding functor: {functor}({value})")
+        elif value not in findings[functor]:
+            violations.append(
+                f"value '{value}' not in domain of {functor} "
+                f"(allowed: {sorted(findings[functor])})"
+            )
+
+    for atom in _CONCLUSION.findall(t):
+        if atom in KEYWORDS:
+            continue
+        if atom not in hypotheses:
+            violations.append(f"unknown hypothesis: {atom}")
+
+    # de-dup, preserve order
+    seen, out = set(), []
+    for v in violations:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+
+
+def main(argv):
+    findings, hypotheses = load_dictionary()
+    bad = 0
+    for path in argv:
+        text = open(path).read()
+        viol = lint(text, findings, hypotheses)
+        if viol:
+            bad += 1
+            print(f"FAIL {path}")
+            for v in viol:
+                print(f"  - {v}")
+        else:
+            print(f"ok   {path}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: python3 dict_lint.py <file.adj> ...", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-prototype/dictionary.json
+++ b/code/specs/data/mycin-prototype/dictionary.json
@@ -1,0 +1,98 @@
+{
+  "_doc": "MYCIN-2026 standard dictionary — the controlled vocabulary SHARED by the input decomposer (LLM) and the adj-lang rulebook/case programs. This is the linchpin: it guarantees the IR the model emits and the program it is compiled into use the SAME terms, so a finding never silently misses the rulebook because of a naming mismatch. Every canonical term is `functor(value)`. The decomposer is constrained to these terms (prompted with the surface_forms); dict_lint.py rejects any rulebook or case .adj that uses a term not registered here. Because the finding set is CLOSED, the framework can distinguish 'finding absent' (a value in the domain, observed) from 'finding not yet observed' (term legal but no observe line).",
+  "domain": "meningitis_differential",
+  "hypotheses": [
+    {
+      "term": "bacterial_meningitis",
+      "definition": "Acute bacterial meningitis (e.g. S. pneumoniae, N. meningitidis).",
+      "surface_forms": ["bacterial meningitis", "pyogenic meningitis", "acute bacterial meningitis"]
+    },
+    {
+      "term": "viral_meningitis",
+      "definition": "Aseptic / viral meningitis (overwhelmingly enteroviral; also HSV).",
+      "surface_forms": ["viral meningitis", "aseptic meningitis", "enteroviral meningitis"]
+    }
+  ],
+  "findings": [
+    {
+      "functor": "csf_gram_stain",
+      "value_domain": ["positive", "negative"],
+      "definition": "Result of microscopic Gram stain of cerebrospinal fluid.",
+      "surface_forms": ["Gram stain positive", "organisms seen on Gram stain", "gram-positive diplococci on CSF", "CSF Gram stain showed", "no organisms on Gram stain"],
+      "supports": {"positive": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f1 (LR+ 85; WHO/Straus 2006)"
+    },
+    {
+      "functor": "csf_neutrophilic_pleocytosis",
+      "value_domain": ["high", "normal"],
+      "definition": "Elevated CSF white-cell count with neutrophil (PMN) predominance.",
+      "surface_forms": ["neutrophil-predominant pleocytosis", "PMN predominance", "CSF WBC elevated with neutrophils", "CSF 1200 cells 90% polys", "neutrophilic pleocytosis"],
+      "supports": {"high": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f2 (LR+ 15; Straus 2006 JAMA, CSF WBC >=500/uL)"
+    },
+    {
+      "functor": "csf_lymphocytic_pleocytosis",
+      "value_domain": ["high", "normal"],
+      "definition": "Elevated CSF white-cell count with lymphocyte predominance.",
+      "surface_forms": ["lymphocyte-predominant pleocytosis", "lymphocytic pleocytosis", "CSF WBC elevated with lymphocytes", "CSF 200 cells 85% lymphocytes", "mononuclear predominance"],
+      "supports": {"high": "viral_meningitis"},
+      "provenance": "viral arm; ground in rulebook/SOURCES (Negrini 2000 / Straus 2006 aseptic profile)"
+    },
+    {
+      "functor": "csf_glucose",
+      "value_domain": ["low", "normal"],
+      "definition": "CSF glucose, typically as CSF:blood glucose ratio. Low (<=0.4) favours bacterial; normal favours viral.",
+      "surface_forms": ["low CSF glucose", "CSF:serum glucose ratio 0.2", "hypoglycorrhachia", "normal CSF glucose", "CSF glucose ratio 0.6"],
+      "supports": {"low": "bacterial_meningitis", "normal": "viral_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f3 (LR+ 18 for low; Straus 2006)"
+    },
+    {
+      "functor": "csf_protein",
+      "value_domain": ["elevated", "normal"],
+      "definition": "CSF total protein concentration.",
+      "surface_forms": ["elevated CSF protein", "CSF protein 2.1 g/L", "high CSF protein", "normal CSF protein"],
+      "supports": {"elevated": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f4 (LR+ 9.33 for elevated; Viallon via PMC4886299)"
+    },
+    {
+      "functor": "csf_lactate",
+      "value_domain": ["elevated", "normal"],
+      "definition": "CSF lactate concentration (>=3.5 mmol/L = elevated).",
+      "surface_forms": ["elevated CSF lactate", "CSF lactate 6 mmol/L", "high CSF lactate", "normal CSF lactate"],
+      "supports": {"elevated": "bacterial_meningitis", "normal": "viral_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f5 (LR+ 22.9 for elevated; Sakushima 2011)"
+    },
+    {
+      "functor": "serum_procalcitonin",
+      "value_domain": ["elevated", "normal"],
+      "definition": "Serum procalcitonin (PCT) level.",
+      "surface_forms": ["elevated procalcitonin", "PCT 5 ng/mL", "high serum procalcitonin", "normal procalcitonin"],
+      "supports": {"elevated": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f6 (LR+ 27.3 for elevated; Vikse 2015)"
+    },
+    {
+      "functor": "seizure",
+      "value_domain": ["present", "absent"],
+      "definition": "Seizure at or before presentation.",
+      "surface_forms": ["had a seizure", "convulsion on presentation", "seized in the ED", "no seizure"],
+      "supports": {"present": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f7 (LR+ 5.84 for present; Nigrovic 2002)"
+    },
+    {
+      "functor": "csf_culture",
+      "value_domain": ["positive", "negative", "pending"],
+      "definition": "CSF bacterial culture result (the reference standard). 'pending' means not yet resulted.",
+      "surface_forms": ["culture positive", "CSF grew S. pneumoniae", "cultures pending", "culture negative", "awaiting culture"],
+      "supports": {"positive": "bacterial_meningitis"},
+      "provenance": "adj52/corpus/bacterial_meningitis/corpus.json#f8 (LR+ 271 for positive; Wu 2013)"
+    },
+    {
+      "functor": "enteroviral_pcr",
+      "value_domain": ["positive", "negative"],
+      "definition": "CSF enterovirus PCR result. A positive enteroviral PCR strongly favours viral meningitis.",
+      "surface_forms": ["enterovirus PCR positive", "CSF enteroviral PCR detected", "EV PCR positive", "enterovirus PCR negative"],
+      "supports": {"positive": "viral_meningitis"},
+      "provenance": "viral arm; ground in rulebook/SOURCES (enterovirus PCR meta-analysis)"
+    }
+  ]
+}

--- a/code/specs/data/mycin-prototype/test_dict_lint.py
+++ b/code/specs/data/mycin-prototype/test_dict_lint.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Tests for dict_lint — the dictionary enforcement linter.
+
+Run: python3 test_dict_lint.py   (exits non-zero on failure)
+"""
+import dict_lint
+
+FIND, HYP = dict_lint.load_dictionary()
+
+
+def check(name, text, expect_clean, expect_substr=None):
+    viol = dict_lint.lint(text, FIND, HYP)
+    clean = not viol
+    assert clean == expect_clean, f"{name}: expected clean={expect_clean}, got {viol}"
+    if expect_substr is not None:
+        assert any(expect_substr in v for v in viol), f"{name}: {expect_substr!r} not in {viol}"
+    print(f"ok   {name}")
+
+
+# a valid rulebook-style snippet (findings + hypotheses + citations + comments)
+check("valid_rulebook", '''
+% bacterial arm
+prior 0.037 for bacterial_meningitis
+  source "Nigrovic 2007 JAMA" trust authoritative
+contributes 85 from csf_gram_stain(positive) to bacterial_meningitis
+  source "WHO 2025" trust consensus
+interacts 0.3 when csf_glucose(low) and csf_lactate(elevated) for bacterial_meningitis
+? bacterial_meningitis
+? viral_meningitis
+''', expect_clean=True)
+
+# a valid case-style snippet (observe + query)
+check("valid_case", '''
+observe csf_neutrophilic_pleocytosis(high)
+observe csf_glucose(low)
+observe enteroviral_pcr(positive)
+? bacterial_meningitis
+''', expect_clean=True)
+
+# unknown finding functor
+check("unknown_functor",
+      "observe csf_color(yellow)\n? bacterial_meningitis",
+      expect_clean=False, expect_substr="unknown finding functor: csf_color")
+
+# value outside the functor's domain
+check("bad_value",
+      "observe csf_glucose(sky_high)\n? bacterial_meningitis",
+      expect_clean=False, expect_substr="not in domain of csf_glucose")
+
+# unknown hypothesis
+check("unknown_hypothesis",
+      "contributes 2.0 from seizure(present) to fungal_meningitis\n? fungal_meningitis",
+      expect_clean=False, expect_substr="unknown hypothesis: fungal_meningitis")
+
+# comments and citation strings must not trip the scanner (csf_color only inside a string)
+check("string_and_comment_ignored",
+      'observe csf_glucose(low)  % note: not csf_color(yellow)\n'
+      '  source "mentions csf_color(yellow) in prose"\n? bacterial_meningitis',
+      expect_clean=True)
+
+print("\nall dict_lint tests passed")


### PR DESCRIPTION
First slice of the **MYCIN-2026 prototype** — resurrecting MYCIN on the byte-provenance substrate (bacterial vs viral meningitis) to prove five claims end-to-end, no shortcuts: **golden rulebook, cost-to-correct, audit-trail legibility, error localization, CPU-bound inference.** The model only *decomposes*; IR compiles deterministically into adj-lang programs (frontend) and CAS libraries (backend). Approved plan; staged PRs.

## This PR — the linchpin: the standard dictionary

The confirmed gap: adj-lang does free-text term matching, so a case's `observe csf_glucose(low)` silently misses the rulebook if the rulebook wrote the term differently. The **standard dictionary** is the controlled vocabulary shared by the decomposer and the rulebook/case programs — the thing that makes "IR and program share one vocabulary" true.

- **`dictionary.json`** — 10 canonical meningitis findings (`functor` + `value_domain` + `surface_forms` the decomposer maps prose from + `provenance` to the grounded corpus) + 2 hypotheses (bacterial / viral). The finding set is **closed**, so "finding absent" (a value, observed) is distinguishable from "finding not yet observed".
- **`dict_lint.py`** — the **enforcement**: rejects any rulebook/case `.adj` that uses an unregistered finding functor, an out-of-domain value, or an unknown hypothesis. Strips comments + citation strings, validates compound terms + conclusion atoms. **6 tests pass** (`test_dict_lint.py`).
- **`SPEC.md`** — the full pipeline, the five claims, and the concrete cost-to-correct demo (the documented CSF over-saturation bug → one CAS edit → propagates).

## Next PRs
PR2 adj-lang CLI (real CPU reasoner → JSON proof DAG) · PR3 rulebook + CAS-write gate · PR4 case pipeline (decompose + discard read + ir_to_adj + decide) · PR5 the five proofs + FINDINGS.

Security review: PASSED (linear regexes, no subprocess/network/eval). Docs + Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)