### PR TITLE
feat(adj-lang-cli): PR2 — CPU-bound reasoner CLI (byte-cited proof DAG → JSON)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "adj-lang",
+    "adj-lang-cli",
     "aarch64-backend",
     "aarch64-encoder",
     "x86_64-encoder",

--- a/code/packages/rust/adj-lang-cli/BUILD
+++ b/code/packages/rust/adj-lang-cli/BUILD
@@ -1,0 +1,1 @@
+cargo test -p adj-lang-cli

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.1.0] - 2026-06-10 — initial CLI driver
+
+### Added
+
+- `adj-lang-cli PROGRAM.adj` — the CPU-bound reasoner entry point for the adj-lang
+  DSL. Reads a `.adj` program (rulebook clauses + `observe`/`?` lines), compiles it
+  via `adj_lang::compile`, runs `adj_lang::decide` (the `logic_engine` differential),
+  and emits JSON: the ranked hypotheses with per-step proof DAGs, and the decision
+  (`determinate` / `kickback` / `empty`). **Zero model calls.**
+- Each proof step is joined back to its firing clause and emits the cited
+  `source` / `locator` / `trust` tier — the byte-cited audit trail, reconstructable
+  without the model. Non-finite numbers serialize as JSON `null`.
+- Declarative argument parsing via `cli-builder` (embedded JSON spec). Exit codes:
+  0 ok, 1 compile error (`{"error": ...}`), 2 bad args / unreadable file.
+- 3 golden tests (`tests/cli_golden.rs`): single-hypothesis cited proof DAG,
+  two-hypothesis differential ranking + decision, compile-error-as-JSON.

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "adj-lang-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
+
+[[bin]]
+name = "adj-lang-cli"
+path = "src/main.rs"
+
+[dependencies]
+adj-lang = { path = "../adj-lang" }
+logic-engine = { path = "../logic-engine" }
+logic-core = { path = "../logic-core" }
+cli-builder = { path = "../cli-builder" }

--- a/code/packages/rust/adj-lang-cli/README.md
+++ b/code/packages/rust/adj-lang-cli/README.md
@@ -1,0 +1,69 @@
+# adj-lang-cli (Rust)
+
+Command-line driver for the [`adj-lang`](../adj-lang) adjudication DSL. It is the
+**CPU-bound reasoner** that pipelines (notably the MYCIN-2026 prototype) shell out
+to: read a `.adj` program, compile it, run the `logic-engine` differential, and emit
+the decision **plus a byte-cited proof DAG** as JSON — with **zero model calls**.
+
+## What it does
+
+```
+.adj program (rulebook clauses + observe/query)
+   │ adj_lang::compile        (lex → parse → adapt → lower)
+   ▼ LoweredProgram { kb, queries }
+   │ adj_lang::decide         (logic_engine::differential over the queries)
+   ▼ Differential { ranked, decision }
+   │ serialize
+   ▼ JSON on stdout
+```
+
+## Usage
+
+```sh
+adj-lang-cli PROGRAM.adj
+```
+
+`PROGRAM.adj` is typically the CAS rulebook clauses concatenated with a case's
+`observe`/`?` lines. Output (pretty-printed here):
+
+```json
+{
+  "queries": ["acs"],
+  "ranked": [
+    { "hypothesis": "acs", "posterior": 0.369, "posterior_logit": -0.536,
+      "normalized_share": 1.0,
+      "proof": [
+        { "kind": "prior", "logit": -2.197,
+          "source": "Pope JH et al., NEJM 1995", "locator": null, "trust": "authoritative" },
+        { "kind": "contribution", "evidence": "symptom_quality(pressure_like)", "logit": 0.916,
+          "source": "Panju AA et al., JAMA 1998", "locator": null, "trust": "authoritative" }
+      ] }
+  ],
+  "decision": { "type": "determinate", "leader": "acs", "posterior": 0.369,
+                "margin_posterior": ..., "margin_logit": ... }
+}
+```
+
+Every proof step carries the cited `source`/`locator`/`trust` of the clause it fired,
+so the audit trail is reconstructable without re-running the model. The `decision` is
+`determinate` (a robust leader), `kickback` (an open uncertainty could flip the
+ranking — `reason` + `runner_up` given), or `empty` (no queries). Non-finite numbers
+(e.g. a single-hypothesis infinite margin) serialize as JSON `null`.
+
+## Where it fits
+
+```
+adj-lang-cli  ──depends on──►  adj-lang (compile/decide)
+                               logic-engine (differential, proof DAG, provenance)
+                               logic-core (terms)
+                               cli-builder (declarative arg parsing)
+```
+
+Argument parsing is declarative via `cli-builder` (a JSON spec embedded in
+`src/main.rs`). Exit codes: `0` success, `1` compile error (emitted as
+`{"error": ...}`), `2` bad arguments / unreadable file.
+
+## Test
+
+`cargo test -p adj-lang-cli` — golden tests run the built binary on small `.adj`
+programs and assert the posteriors, the cited proof steps, and the decision.

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -1,0 +1,245 @@
+//! `adj-lang-cli` — compile a `.adj` program and emit the decision + a
+//! byte-cited proof DAG as JSON.
+//!
+//! This is the **CPU-bound reasoner** the MYCIN-2026 prototype shells out to.
+//! It reads a `.adj` program (a rulebook's `prior`/`contributes`/`interacts`
+//! clauses concatenated with a case's `observe`/`?` lines), compiles it through
+//! the adj-lang frontend, runs `logic_engine::differential` over the program's
+//! queries, and prints JSON:
+//!
+//! ```json
+//! { "queries": [...],
+//!   "ranked": [ { "hypothesis", "posterior", "posterior_logit", "normalized_share",
+//!                 "proof": [ { "kind":"prior|contribution|interaction", "logit",
+//!                              "evidence?", "source", "locator", "trust" } ] } ],
+//!   "decision": { "type":"determinate|kickback|empty", ... } }
+//! ```
+//!
+//! Every proof step carries the cited `source`/`locator`/`trust` of the clause it
+//! fired, so the audit trail is reconstructable without re-running the model.
+//! Argument parsing is declarative via `cli-builder`.
+
+use std::fs;
+use std::process::ExitCode;
+
+use cli_builder::types::ParserOutput;
+use cli_builder::{load_spec_from_str, Parser};
+
+use adj_lang::{compile, decide};
+use logic_core::Term;
+use logic_engine::{
+    DerivationOrigin, DifferentialDecision, KnowledgeBase, LRAggregateResult, Provenance, TrustTier,
+};
+
+const SPEC: &str = r#"{
+  "cli_builder_spec_version": "1.0",
+  "name": "adj-lang-cli",
+  "description": "Compile a .adj program and emit decision + byte-cited proof DAG as JSON.",
+  "version": "0.1.0",
+  "arguments": [
+    {"id": "program", "name": "PROGRAM", "description": "Path to a .adj program (rulebook + case)", "type": "string", "required": true}
+  ]
+}"#;
+
+/// JSON-escape a string body.
+fn esc(s: &str) -> String {
+    let mut o = String::with_capacity(s.len() + 2);
+    for c in s.chars() {
+        match c {
+            '"' => o.push_str("\\\""),
+            '\\' => o.push_str("\\\\"),
+            '\n' => o.push_str("\\n"),
+            '\r' => o.push_str("\\r"),
+            '\t' => o.push_str("\\t"),
+            c if (c as u32) < 0x20 => o.push_str(&format!("\\u{:04x}", c as u32)),
+            c => o.push(c),
+        }
+    }
+    o
+}
+
+/// Emit an f64 as a JSON number, or `null` for non-finite (e.g. an infinite
+/// single-hypothesis margin) — JSON has no Infinity.
+fn jnum(x: f64) -> String {
+    if x.is_finite() {
+        format!("{}", x)
+    } else {
+        "null".to_string()
+    }
+}
+
+fn trust(t: &TrustTier) -> &'static str {
+    match t {
+        TrustTier::Consensus => "consensus",
+        TrustTier::Authoritative => "authoritative",
+        TrustTier::Empirical => "empirical",
+        TrustTier::Inferred => "inferred",
+        TrustTier::Unattributed => "unattributed",
+    }
+}
+
+/// The `"source"/"locator"/"trust"` fields of a clause's provenance.
+fn prov(p: &Provenance) -> String {
+    let loc = match &p.locator {
+        Some(l) => format!("\"{}\"", esc(l)),
+        None => "null".to_string(),
+    };
+    format!(
+        "\"source\":\"{}\",\"locator\":{},\"trust\":\"{}\"",
+        esc(&p.source),
+        loc,
+        trust(&p.trust_tier)
+    )
+}
+
+/// Serialize the proof DAG for one hypothesis: walk each step and join its
+/// `clause_id` back to the firing clause's evidence term + cited provenance.
+fn proof_json(hyp: &Term, kb: &KnowledgeBase, result: &LRAggregateResult) -> String {
+    let prior = kb.prior_for(hyp);
+    let contribs = kb.contributions_for(hyp);
+    let joints = kb.joint_contributions_for(hyp);
+    let mut steps: Vec<String> = Vec::new();
+    if let Some(proof) = result.dag.proofs.first() {
+        for st in &proof.steps {
+            match &st.origin {
+                DerivationOrigin::FromPrior { prior_logit, .. } => {
+                    let pj = prior.map(|p| prov(&p.provenance)).unwrap_or_else(|| {
+                        "\"source\":\"\",\"locator\":null,\"trust\":\"unattributed\"".to_string()
+                    });
+                    steps.push(format!(
+                        "{{\"kind\":\"prior\",\"logit\":{},{}}}",
+                        jnum(*prior_logit),
+                        pj
+                    ));
+                }
+                DerivationOrigin::FromContribution {
+                    clause_id,
+                    logit_delta,
+                    ..
+                } => {
+                    if let Some(c) = contribs.iter().find(|c| c.id == *clause_id) {
+                        steps.push(format!(
+                            "{{\"kind\":\"contribution\",\"evidence\":\"{}\",\"logit\":{},{}}}",
+                            esc(&format!("{}", c.evidence_term)),
+                            jnum(*logit_delta),
+                            prov(&c.provenance)
+                        ));
+                    }
+                }
+                DerivationOrigin::FromJointContribution {
+                    clause_id,
+                    joint_logit_delta,
+                    ..
+                } => {
+                    if let Some(j) = joints.iter().find(|j| j.id == *clause_id) {
+                        let ev: Vec<String> = j
+                            .evidence_set
+                            .iter()
+                            .map(|t| format!("\"{}\"", esc(&format!("{}", t))))
+                            .collect();
+                        steps.push(format!(
+                            "{{\"kind\":\"interaction\",\"evidence\":[{}],\"logit\":{},{}}}",
+                            ev.join(","),
+                            jnum(*joint_logit_delta),
+                            prov(&j.provenance)
+                        ));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    format!("[{}]", steps.join(","))
+}
+
+fn main() -> ExitCode {
+    let spec = load_spec_from_str(SPEC).expect("internal: invalid CLI spec");
+    let parser = Parser::new(spec);
+    let argv: Vec<String> = std::env::args().collect();
+    let result = match parser.parse(&argv) {
+        Ok(ParserOutput::Help(h)) => {
+            print!("{}", h.text);
+            return ExitCode::SUCCESS;
+        }
+        Ok(ParserOutput::Version(v)) => {
+            println!("{}", v.version);
+            return ExitCode::SUCCESS;
+        }
+        Ok(ParserOutput::Parse(r)) => r,
+        Err(e) => {
+            eprintln!("{}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let path = result
+        .arguments
+        .get("program")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let src = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("adj-lang-cli: cannot read {}: {}", path, e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let lowered = match compile(&src) {
+        Ok(l) => l,
+        Err(e) => {
+            println!("{{\"error\":\"{}\"}}", esc(&format!("{:?}", e)));
+            return ExitCode::from(1);
+        }
+    };
+    let diff = decide(&lowered);
+
+    let mut ranked: Vec<String> = Vec::new();
+    for r in &diff.ranked {
+        let proof = proof_json(&r.hypothesis, &lowered.kb, &r.result);
+        ranked.push(format!(
+            "{{\"hypothesis\":\"{}\",\"posterior\":{},\"posterior_logit\":{},\"normalized_share\":{},\"proof\":{}}}",
+            esc(&format!("{}", r.hypothesis)),
+            jnum(r.posterior),
+            jnum(r.posterior_logit),
+            jnum(r.normalized_share),
+            proof
+        ));
+    }
+
+    let decision = match &diff.decision {
+        DifferentialDecision::Empty => "{\"type\":\"empty\"}".to_string(),
+        DifferentialDecision::Determinate { leader, posterior, margin_posterior, margin_logit } => {
+            format!(
+                "{{\"type\":\"determinate\",\"leader\":\"{}\",\"posterior\":{},\"margin_posterior\":{},\"margin_logit\":{}}}",
+                esc(&format!("{}", leader)),
+                jnum(*posterior),
+                jnum(*margin_posterior),
+                jnum(*margin_logit)
+            )
+        }
+        DifferentialDecision::Kickback {
+            leader, runner_up, margin_posterior, margin_logit, reason, ..
+        } => format!(
+            "{{\"type\":\"kickback\",\"leader\":\"{}\",\"runner_up\":\"{}\",\"margin_posterior\":{},\"margin_logit\":{},\"reason\":\"{}\"}}",
+            esc(&format!("{}", leader)),
+            esc(&format!("{}", runner_up)),
+            jnum(*margin_posterior),
+            jnum(*margin_logit),
+            esc(reason)
+        ),
+    };
+
+    let queries: Vec<String> = lowered
+        .queries
+        .iter()
+        .map(|q| format!("\"{}\"", esc(&format!("{}", q))))
+        .collect();
+    println!(
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}}}",
+        queries.join(","),
+        ranked.join(","),
+        decision
+    );
+    ExitCode::SUCCESS
+}

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -1,0 +1,72 @@
+//! Golden tests for `adj-lang-cli` — run the built binary on a small `.adj`
+//! program and assert the JSON decision + proof DAG.
+
+use std::process::Command;
+
+/// Write `src` to a temp `.adj` file, run the CLI on it, return (success, stdout).
+fn run(name: &str, src: &str) -> (bool, String) {
+    let path = std::env::temp_dir().join(name);
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&path)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn single_hypothesis_emits_cited_proof_dag() {
+    // prior 0.10 + LR 2.5 observed → posterior ≈ 0.2174 (logit(0.1)+ln(2.5)).
+    let (ok, s) = run(
+        "adjcli_single.adj",
+        "prior 0.10 for acs\n  source \"Pope 1995\" trust authoritative\n\
+         contributes 2.5 from symptom(pressure) to acs\n  source \"Panju 1998\" trust authoritative\n\
+         observe symptom(pressure)\n? acs\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"hypothesis\":\"acs\""), "{s}");
+    assert!(s.contains("\"kind\":\"prior\""), "{s}");
+    assert!(s.contains("\"kind\":\"contribution\""), "{s}");
+    assert!(s.contains("\"evidence\":\"symptom(pressure)\""), "{s}");
+    assert!(s.contains("\"source\":\"Panju 1998\""), "{s}");
+    assert!(s.contains("\"trust\":\"authoritative\""), "{s}");
+    // posterior ≈ 0.2174
+    assert!(
+        s.contains("\"posterior\":0.217"),
+        "expected ~0.217 posterior: {s}"
+    );
+    // single hypothesis ⇒ determinate, infinite margin → null
+    assert!(s.contains("\"type\":\"determinate\""), "{s}");
+    assert!(s.contains("\"margin_logit\":null"), "{s}");
+}
+
+#[test]
+fn two_hypothesis_differential_ranks_and_decides() {
+    // bacterial gets a strong observed LR, viral does not → bacterial leads.
+    let (ok, s) = run(
+        "adjcli_diff.adj",
+        "prior 0.30 for bacterial\n  source \"x\" trust empirical\n\
+         prior 0.30 for viral\n  source \"x\" trust empirical\n\
+         contributes 15 from csf(neutrophilic) to bacterial\n  source \"Straus 2006\" trust authoritative\n\
+         contributes 1.2 from csf(neutrophilic) to viral\n  source \"y\" trust inferred\n\
+         observe csf(neutrophilic)\n? bacterial\n? viral\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    // both hypotheses ranked
+    assert!(s.contains("\"hypothesis\":\"bacterial\""), "{s}");
+    assert!(s.contains("\"hypothesis\":\"viral\""), "{s}");
+    // a decision was produced (determinate leader bacterial, or kickback naming it)
+    assert!(
+        s.contains("\"leader\":\"bacterial\""),
+        "expected bacterial leader: {s}"
+    );
+    // the proof cites the bacterial contribution's source
+    assert!(s.contains("\"source\":\"Straus 2006\""), "{s}");
+}
+
+#[test]
+fn compile_error_is_reported_as_json() {
+    let (ok, s) = run("adjcli_bad.adj", "this is not adj-lang at all !!!\n");
+    assert!(!ok, "expected non-zero exit on bad input");
+    assert!(s.contains("\"error\""), "expected error JSON: {s}");
+}


### PR DESCRIPTION
**MYCIN-2026 prototype, PR2.** The prototype must run the *real* adj-lang/logic-engine from a pipeline — but the lib has no CLI. This adds one.

## New crate `adj-lang-cli`
- Reads a `.adj` program (rulebook `prior`/`contributes`/`interacts` clauses concatenated with a case's `observe`/`?` lines), runs `adj_lang::compile` + `decide` (the `logic_engine` differential), and emits JSON: **ranked hypotheses each with a proof DAG**, plus the **decision** (`determinate` / `kickback` / `empty`). **Zero answer-time model calls** — this is the CPU-bound reasoner.
- **Every proof step is joined back to its firing clause** and carries the cited `source` / `locator` / `trust` tier — the byte-cited audit trail, reconstructable without the model. Manual JSON (RFC-8259 escaper); non-finite floats (e.g. an infinite single-hypothesis margin) → `null`.
- Declarative argument parsing via **`cli-builder`** (embedded JSON spec), per repo convention.
- Kept as a **separate crate** (not a bin inside `adj-lang`) so the adj-lang lib stays free of the cli-builder dependency chain. Added to the rust workspace members.

## Verified
On the real `adj48/rulebook.adj` ACS rulebook + `01-jane-doe.adj` vignette: **P(acs) = 0.369**, matching the documented ADJ48 result, with a complete cited proof DAG (prior + each contribution → source + trust). `cargo test -p adj-lang-cli` (3 golden tests) green; `cargo build -p adj-lang-cli` clean.

> Note: the workspace-wide `cargo build` fails only on the pre-existing platform-only **`uefi`** crate (a `no_std` crate that can't build for the host) — confirmed identical with this change stashed, so not a regression (per lessons.md).

Security review: **PASSED** (escaper RFC-8259-correct, no `unsafe`, no panic on untrusted input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)