### PR TITLE
feat(mccarthy-lisp): W14a — close the macOS Mach-O runtime-link gap (native lisp links + runs)

### DIFF
--- a/code/packages/rust/code-packager/CHANGELOG.md
+++ b/code/packages/rust/code-packager/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.5.0] — 2026-06-10 (McCarthy W14a — Mach-O external-symbol C decoration)
+
+Fixes the macOS runtime-link gap: `pack_object_with_globals_and_externals` now
+writes each external (undefined) symbol into the Mach-O string table with the
+leading `_` C decoration — the same one `_main`/`_twig_globals` already carried.
+
+A C function `__twig_lispy_car` is `___twig_lispy_car` in a Mach-O object/archive
+(ABI underscore + the C name's two). The backend hands the packager the raw,
+platform-agnostic C name; the Mach-O packager owns the decoration (the ELF emitter
+deliberately does not). Before this, the object referenced the undecorated
+`__twig_lispy_car` while the `cc`-built runtime archive exported the decorated
+`___twig_lispy_car`, so `ld` reported "Undefined symbols for architecture arm64"
+for every `__twig_*` runtime call on macOS — blocking native McCarthy-lisp (cons /
+ATOM / EQ / COND / symbols) and `io_out` alike. ELF/Linux was unaffected (no
+decoration there), which is why the gap was macOS-only.
+
+New unit test `full_extern_symbol_is_mach_o_decorated`; the size-formula test
+updated for the +1 byte per external symbol. Verified by RUNNING native McCarthy
+end-to-end on macOS arm64 (`lang-aot/tests/macos_native_lisp.rs`).
+
 ## [0.4.0] — 2026-05-14 (LANG45 phase 2 — PE/COFF object emitter)
 
 **New `pe_object` module — Windows x86-64 PE/COFF object-file writer.**

--- a/code/packages/rust/code-packager/Cargo.toml
+++ b/code/packages/rust/code-packager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-packager"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Cross-platform binary packaging for compiled code (LANG10) — Mach-O on Apple Silicon ships ad-hoc code-signed."
 license = "MIT"

--- a/code/packages/rust/code-packager/README.md
+++ b/code/packages/rust/code-packager/README.md
@@ -75,6 +75,13 @@ Minimal Mach-O executable (`MH_EXECUTE`):
 - 32-byte `mach_header_64` + `LC_SEGMENT_64` + `section_64 __TEXT/__text` + `LC_MAIN`
 - Default `load_address = 0x100000000` (arm64/x86_64 standard)
 
+**C symbol decoration.** Mach-O decorates C symbols with a leading underscore
+(`main` → `_main`). The object emitter owns this: defined entry/data symbols
+(`_main`, `_twig_globals`) *and* external/undefined symbols (e.g. a runtime call
+`__twig_lispy_car` → `___twig_lispy_car`) are written into the string table with the
+`_` prefix, so the linker resolves them against the C runtime archive. The ELF
+emitter does **not** decorate — ELF C symbols have no leading underscore.
+
 ### PE32+ (Windows)
 
 Minimal PE32+ console executable:

--- a/code/packages/rust/code-packager/src/macho_object.rs
+++ b/code/packages/rust/code-packager/src/macho_object.rs
@@ -730,6 +730,16 @@ pub fn pack_object_with_globals_and_externals(
     let mut ext_strx: Vec<u32> = Vec::with_capacity(n_ext_syms);
     for sym in &unique_ext_syms {
         ext_strx.push(strtab.len() as u32);
+        // Mach-O C decoration: a C symbol `foo` is `_foo` in the object/archive
+        // (the same legacy underscore `_main`/`_twig_globals` carry above). The
+        // backend hands us the raw C name (e.g. `__twig_lispy_car`, `__twig_print_i64`),
+        // platform-agnostic; the Mach-O packager owns the leading underscore so the
+        // undefined reference matches the symbol the `cc`-built runtime archive
+        // exports (`___twig_lispy_car`). On ELF there is no decoration, so
+        // `elf_object.rs` deliberately leaves the name unchanged. Without this the
+        // system linker reports "Undefined symbols" for every `__twig_*` runtime
+        // call on macOS — the McCarthy-lisp / `io_out` runtime-link gap.
+        strtab.push(b'_');
         strtab.extend_from_slice(sym.as_bytes());
         strtab.push(0u8);
     }
@@ -1212,15 +1222,16 @@ mod tests {
         // total = 312 (header) + N (text) + 0 (no data) + 1×8 (reloc) +
         //         3×16 (syms: _main + _twig_globals + extern) + strtab_len
         //
-        // strtab = "\0_main\0_twig_globals\0__twig_print_i64\0"
+        // strtab = "\0_main\0_twig_globals\0___twig_print_i64\0"
         //   "\0"           = 1 byte  (leading NUL sentinel)
         //   "_main\0"      = 6 bytes
         //   "_twig_globals\0" = 14 bytes
-        //   "__twig_print_i64\0" = 17 bytes  (16 chars + NUL)
+        //   "___twig_print_i64\0" = 18 bytes  (17 chars + NUL — the Mach-O `_`
+        //                          decoration prefixes the raw C name `__twig_print_i64`)
         //                         ─────────
-        //                   total = 38 bytes
+        //                   total = 39 bytes
         let n = 8usize;
-        let strtab_len = 1 + 6 + 14 + 17; // 38
+        let strtab_len = 1 + 6 + 14 + 18; // 39
         let expected = 312 + n + 0 + 1 * 8 + 3 * 16 + strtab_len;
         let ext = vec![ExternBranchReloc {
             byte_offset: 0,
@@ -1228,6 +1239,33 @@ mod tests {
         }];
         let bytes = arm64_full(vec![0x00u8; n], 0, &[], &ext);
         assert_eq!(bytes.len(), expected, "size formula for no-globals + 1 extern");
+    }
+
+    /// W14a: an external symbol is written into the Mach-O string table with the
+    /// leading `_` C decoration, so the undefined reference matches the symbol the
+    /// `cc`-built runtime archive exports. The raw C name `__twig_lispy_car` must
+    /// appear as `___twig_lispy_car` (three underscores) in the strtab bytes.
+    #[test]
+    fn full_extern_symbol_is_mach_o_decorated() {
+        let ext = vec![ExternBranchReloc {
+            byte_offset: 0,
+            symbol: "__twig_lispy_car".to_string(),
+        }];
+        let bytes = arm64_full(vec![0x00u8; 8], 0, &[], &ext);
+        // The decorated name (with NUL terminator) is present...
+        assert!(
+            bytes
+                .windows(b"___twig_lispy_car\0".len())
+                .any(|w| w == b"___twig_lispy_car\0"),
+            "strtab must contain the `_`-decorated `___twig_lispy_car`",
+        );
+        // ...and the raw, *undecorated* name is NOT (it would never resolve).
+        assert!(
+            !bytes
+                .windows(b"\0__twig_lispy_car\0".len())
+                .any(|w| w == b"\0__twig_lispy_car\0"),
+            "the undecorated `__twig_lispy_car` must not appear as a standalone strtab entry",
+        );
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.40.0 — 2026-06-10 — McCarthy **native AOT** (F2–F6) now links + runs on macOS arm64 (LANG77 / W14a)
+
+No `lang-aot` source change — the fix is in `code-packager` 0.5.0 (Mach-O external
+symbols now carry the leading `_` C decoration), which the native macOS path already
+drives. New verify-by-running test `tests/macos_native_lisp.rs` (gated to
+`target_os = "macos"`): compiles McCarthy through the native `aarch64-backend`,
+links the runtime archive with `ld`, and runs — `(CAR (CONS 7 9))`→7, `(CDR …)`→9,
+`(ATOM 7)`→1, `(EQ 7 7)`→1, `(COND …)`→11, `(EQ (QUOTE A) (QUOTE A))`→1. Closes the
+macOS runtime-link gap that previously failed native lisp at link time. Lambda (F7)
+is still backend-refused — the separate W14b slice.
+
 ## 0.39.0 — 2026-06-10 — McCarthy → **LLVM lambda** (F7) on a clang-built executable — **LLVM COMPLETE F1–F7** (LANG77 / W13b)
 
 No `lang-aot` source change — the work is in `iir-builtin-lowering` 0.16.0 (lambda

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/tests/macos_native_lisp.rs
+++ b/code/packages/rust/lang-aot/tests/macos_native_lisp.rs
@@ -1,0 +1,57 @@
+//! # Native McCarthy LISP on macOS arm64 — W14a (the runtime-link gap).
+//!
+//! Compiles McCarthy programs through the **native** AOT tagged-word backend
+//! (`aarch64-backend` → Mach-O object → system `ld`, linking the `cc`-built
+//! runtime archive that bundles `lispy_runtime.c`) and **runs** them, asserting
+//! the exit code.
+//!
+//! Before W14a these failed at link: the Mach-O object referenced the runtime
+//! helpers by their raw C name (`__twig_lispy_car`), but the archive — built with
+//! the Mach-O C ABI — exports them decorated (`___twig_lispy_car`). `ld` saw the
+//! two as different symbols and reported "Undefined symbols for architecture
+//! arm64". `code-packager` now applies the leading-`_` decoration to external
+//! symbols (the same one `_main`/`_twig_globals` already carried), closing the gap
+//! for every `__twig_*` runtime call — McCarthy lisp **and** `io_out`.
+//!
+//! `LAMBDA` (F7) is intentionally NOT covered here: it is still refused by the
+//! native backend (untyped `any` `call` result) and is the separate W14b slice.
+
+#![cfg(target_os = "macos")]
+
+use lang_aot::{compile_file_to_macos_executable, Language};
+
+fn ld_available() -> bool {
+    std::process::Command::new("ld").arg("-v").output()
+        .map(|o| o.status.success() || o.status.code().is_some()).unwrap_or(false)
+}
+
+fn run(src: &str, name: &str) -> i32 {
+    let dir = std::env::temp_dir().join(format!("mccarthy_w14a_{}_{name}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let s = dir.join(format!("{name}.mcl"));
+    std::fs::write(&s, src).expect("write source");
+    let exe = dir.join(name);
+    compile_file_to_macos_executable(&s, &exe, Language::McCarthyLisp)
+        .unwrap_or_else(|e| panic!("native compile+link of {src:?} failed: {e}"));
+    std::process::Command::new(&exe).output().expect("run").status.code().expect("exit code")
+}
+
+#[test]
+fn mccarthy_core_runs_natively_on_macos() {
+    if !ld_available() { eprintln!("no system linker — skipping"); return; }
+    // F1 scalar.
+    assert_eq!(run("42", "n_scalar"), 42);
+    // F2 cons / car / cdr — the case that exposed the link gap.
+    assert_eq!(run("(CAR (CONS 7 9))", "n_car"), 7);
+    assert_eq!(run("(CDR (CONS 7 9))", "n_cdr"), 9);
+    // F3 ATOM, F4 EQ.
+    assert_eq!(run("(ATOM 7)", "n_atom_t"), 1);
+    assert_eq!(run("(ATOM (CONS 1 2))", "n_atom_f"), 0);
+    assert_eq!(run("(EQ 7 7)", "n_eq_t"), 1);
+    assert_eq!(run("(EQ 7 8)", "n_eq_f"), 0);
+    // F5 COND.
+    assert_eq!(run("(COND ((ATOM 7) 11) ((ATOM 8) 22))", "n_cond"), 11);
+    // F6 symbols.
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE A))", "n_sym_t"), 1);
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE B))", "n_sym_f"), 0);
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -292,9 +292,24 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase F — native AOT + JIT completion
 
-- ☐ **W14 — native AOT `LAMBDA`/`LABEL` (F7).** Finish closures/user-calls on the
-  tagged-word native backend (cons/ATOM/EQ/COND/symbols already done in L3b-2).
-  Note the macOS runtime-link gap.
+- ◑ **W14 — native AOT `LAMBDA`/`LABEL` (F7).** *In progress.* Finish closures/
+  user-calls on the tagged-word native backend (cons/ATOM/EQ/COND/symbols already
+  done in L3b-2).
+  - ✅ **W14a — close the macOS Mach-O runtime-link gap.** The native object
+    referenced the runtime helpers by their raw C name (`__twig_lispy_car`), but the
+    `cc`-built archive — Mach-O C ABI — exports them decorated (`___twig_lispy_car`),
+    so `ld` reported "Undefined symbols for architecture arm64" for **every**
+    `__twig_*` call on macOS (lisp **and** `io_out`). `code-packager` now applies the
+    leading-`_` decoration to external symbols (the ELF emitter deliberately does
+    not — that's why the gap was macOS-only and native F2–F6 "passed" on Linux CI).
+    Verified by RUNNING natively on macOS arm64: `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1,
+    `(EQ 7 7)`→1, `(COND …)`→11, `(EQ (QUOTE A) (QUOTE A))`→1
+    (`lang-aot/tests/macos_native_lisp.rs`). **F2–F6 now run natively on macOS too.**
+  - ☐ **W14b — native backend `LAMBDA` (F7).** The native `aarch64-backend` still
+    refuses a lambda program (`untyped or unsupported op`): it needs the lisp
+    tagged-word typing (`any`/`ref<Lispy…>` → `i64`, as the LLVM backend does) and
+    `lispy_to_exit_code` in its `call_builtin` table. The shared IIR machinery
+    (arg boxing, result coercion) and the runtime helper already exist from W13b.
 - ☐ **W15 — JIT McCarthy core (F1–F7).** Drive McCarthy through the JIT path.
 
 ### Phase G — conformance


### PR DESCRIPTION
## Native McCarthy programs now link **and run** on macOS arm64

Before this, the native AOT tagged-word path failed at **link** on macOS — even `(CAR (CONS 7 9))`:
```
Undefined symbols for architecture arm64:
  "__twig_lispy_car", "__twig_lispy_cons", "__twig_lispy_unbox_int"
```

## Root cause (confirmed by `nm`)

Mach-O decorates C symbols with a leading underscore. A C function `__twig_lispy_car` is `___twig_lispy_car` (**3** underscores) in a Mach-O object/archive. The `cc`-built runtime archive (which bundles `lispy_runtime.c`) exports the decorated `___twig_lispy_car` — but `code-packager` wrote the **external/undefined** symbol into the Mach-O string table **verbatim** (`__twig_lispy_car`, 2 underscores), while `_main`/`_twig_globals` were hardcoded *with* the underscore. `ld` saw the two names as different symbols → undefined.

ELF/Linux has no decoration, so native F2–F6 "passed" on Linux CI and the gap was **macOS-only**; `io_out` (`__twig_print_i64`) had the same latent gap.

## Change

**`code-packager` 0.5.0** — `pack_object_with_globals_and_externals` now prepends the leading `_` C decoration to each external symbol's string-table entry. The platform-specific decoration lives in the platform-specific packager (the backend stays agnostic; the ELF emitter deliberately leaves names undecorated). One added byte per symbol; `ext_strx` offsets are captured *before* the write so all symtab `n_strx` / file offsets stay consistent.

## Verified by RUNNING natively on macOS arm64 (`tests/macos_native_lisp.rs`, gated `target_os = "macos"`)

Compile via `aarch64-backend` → Mach-O → `ld` + runtime archive → run:

| program | result |
|---|---|
| `(CAR (CONS 7 9))` / `(CDR (CONS 7 9))` | 7 / 9 |
| `(ATOM 7)` / `(ATOM (CONS 1 2))` | 1 / 0 |
| `(EQ 7 7)` / `(EQ 7 8)` | 1 / 0 |
| `(COND ((ATOM 7) 11) ((ATOM 8) 22))` | 11 |
| `(EQ (QUOTE A) (QUOTE A))` / `(QUOTE B)` | 1 / 0 |

**F2–F6 now run natively on macOS too** (previously verified only on Linux).

## Why this is W14a (not the whole of W14)

W14 (native lambda, F7) is sliced. This is **W14a** — the prerequisite link-gap fix, valuable on its own (it also fixes `io_out` on macOS). **W14b** (lambda) is still pending: the `aarch64-backend` refuses a lambda program (`untyped or unsupported op`) — it needs the lisp tagged-word typing (`any`/`ref<Lispy…>`→`i64`) + `lispy_to_exit_code` in its `call_builtin` table. The shared IIR machinery + runtime helper already exist from W13b.

## Test plan

`code-packager` **35** macho tests (+1 `full_extern_symbol_is_mach_o_decorated`; size-formula test updated `+17`→`+18` = one byte), `lang-aot` `macos_native_lisp` 1 (10 programs, gated macos). clippy clean. `code-packager` is the object packager (not a `twig-vm`/`lispy-runtime` Rust crate) and the change is pure byte assembly → no Miri.

## Security & safety

Security review **PASSED**: offset/size arithmetic stays consistent (`off32!` guards >4 GiB), bounded HashMap-deduped loop (no panic/OOB/overflow), the `_` is a fixed literal (no new injection surface; embedded-NUL behavior is pre-existing and unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)