### PR TITLE
feat(closurec): CLOC12.69 — close gap-062 (redundant double-paren collapse)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.73.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-062** (minimal slice) — redundant double-paren
+  collapse: `((a+b))*c` → `(a+b)*c`. One directly-nested
+  grouping-paren layer is stripped.
+
+### Added — gap-062 token pre-pass
+
+When a GROUPING `(` is directly followed by another `(` and the
+inner group's matching `)` is directly followed by the outer
+`)` (purely-nested `(( ... ))`), the outer pair is dropped.
+Guards: the outer `(` must be a grouping paren (so a CALL paren
+like `f((a,b))` is never collapsed to `f(a,b)` — a different
+program); no top-level comma inside; all bracket checks via
+`is_structural_punct`.
+
+Upstream eliminates parens more aggressively (`((a))` → `a`,
+`(a)+(b)` → `a+b`, `f((a))` → `f(a)`); this slice strips only
+one directly-nested grouping layer — the broader pass is a
+follow-up. Four guard unit tests added.
+
 ## [0.72.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.72.0"
+version = "0.73.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.72.0",
+  "version": "0.73.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -584,6 +584,99 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-062: redundant double-paren collapse ------------
+    // `((a+b))*c` → `(a+b)*c`. When a GROUPING `(` is directly
+    // followed by another `(`, and the inner group's matching
+    // `)` is directly followed by the outer `)`, the OUTER layer
+    // is a redundant grouping — strip it.
+    //
+    // Minimal safe slice (matches `minify_double_paren_arith`):
+    //   - the outer `(` must be a GROUPING paren, never a call /
+    //     index paren. `f((a))` (outer is f's call) and
+    //     `a[(x)]`-style are left to a follow-up — otherwise we
+    //     could turn `f((a,b))` (one comma-operator arg) into
+    //     `f(a,b)` (two args), changing the program.
+    //   - the two open parens must be ADJACENT (`( (`),
+    //   - the inner group's `)` must be IMMEDIATELY followed by
+    //     the outer `)` (so the parens nest with nothing between
+    //     them — purely redundant),
+    //   - NO top-level comma inside the inner group (extra
+    //     conservatism; comma-operator grouping is deferred).
+    //
+    // Upstream actually eliminates parens more aggressively
+    // (`((a))` → `a`, `(a)+(b)` → `a+b`); this slice only strips
+    // ONE directly-nested grouping layer. All bracket / comma
+    // checks route through `is_structural_punct` so a string /
+    // regex / template whose value looks like a bracket can
+    // never trigger the collapse.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 0;
+        while i + 1 < kept.len() {
+            if is_structural_punct(&kept[i], "(")
+                && is_structural_punct(&kept[i + 1], "(")
+            {
+                let grouping = match i.checked_sub(1).and_then(|k| kept.get(k)) {
+                    None => true,
+                    Some(p) => {
+                        is_punct(p)
+                            && !is_structural_punct(p, ")")
+                            && !is_structural_punct(p, "]")
+                            && !is_structural_punct(p, "?.")
+                    }
+                };
+                if grouping {
+                    // Depth-scan from the inner `(` (at i+1) to
+                    // its matching `)`, tracking a top-level
+                    // comma.
+                    let mut depth: i32 = 1;
+                    let mut inner_close: Option<usize> = None;
+                    let mut has_comma = false;
+                    let mut j = i + 2;
+                    while j < kept.len() {
+                        let t = &kept[j];
+                        if is_structural_punct(t, "(")
+                            || is_structural_punct(t, "[")
+                            || is_structural_punct(t, "{")
+                        {
+                            depth += 1;
+                        } else if is_structural_punct(t, ")") {
+                            depth -= 1;
+                            if depth == 0 {
+                                inner_close = Some(j);
+                                break;
+                            }
+                        } else if is_structural_punct(t, "]")
+                            || is_structural_punct(t, "}")
+                        {
+                            depth -= 1;
+                        } else if depth == 1 && is_structural_punct(t, ",") {
+                            has_comma = true;
+                        }
+                        j += 1;
+                    }
+                    if let Some(jc) = inner_close {
+                        let outer_close_follows = kept
+                            .get(jc + 1)
+                            .map(|t| is_structural_punct(t, ")"))
+                            .unwrap_or(false);
+                        if outer_close_follows && !has_comma {
+                            drops.push(i); // outer `(`
+                            drops.push(jc + 1); // outer `)`
+                            i = jc + 2;
+                            continue;
+                        }
+                    }
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     let kept = kept;
 
     // Re-stitch: insert a single space between two adjacent
@@ -3497,6 +3590,39 @@ mod tests {
     #[test]
     fn gap059_arg_bearing_new_deferred() {
         assert_eq!(minify("var x=new Foo(y).b;"), "var x=new Foo(y).b;");
+    }
+
+    // ---- gap-062: redundant double-paren collapse --------
+
+    /// gap-062: `((a+b))*c` → `(a+b)*c` — one redundant
+    /// directly-nested grouping-paren layer is stripped.
+    #[test]
+    fn gap062_double_paren_collapses_one_layer() {
+        assert_eq!(minify("var x=((a+b))*c;"), "var x=(a+b)*c;");
+    }
+
+    /// gap-062 safety: a CALL paren must never be stripped —
+    /// `f((a,b))` (one comma-operator arg) must NOT become
+    /// `f(a,b)` (two args). The outer `(` follows `f` (a
+    /// callable), so the grouping guard skips it.
+    #[test]
+    fn gap062_call_paren_with_comma_preserved() {
+        assert_eq!(minify("f((a,b));"), "f((a,b));");
+    }
+
+    /// gap-062 safety: a single call-arg grouping where the
+    /// outer is a call paren is left alone by THIS pass
+    /// (`g((a)+(b))` — outer is g's call). Deferred follow-up.
+    #[test]
+    fn gap062_call_arg_grouping_preserved() {
+        assert_eq!(minify("g((a)+(b));"), "g((a)+(b));");
+    }
+
+    /// gap-062 non-regression: a single grouping layer is NOT
+    /// touched (`(a+b)*c` stays — nothing redundant to strip).
+    #[test]
+    fn gap062_single_paren_unchanged() {
+        assert_eq!(minify("var x=(a+b)*c;"), "var x=(a+b)*c;");
     }
 
     /// **Non-regression**: `new Foo() + 1` — `+` binds

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.72.0
+Version: 0.73.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -99,10 +99,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // `new A(y).b` → `(new A(y)).b`. gap-059 handled only the
     // EMPTY arg list; non-empty args need arg-list scanning.
     ("new_with_args_member", "gap-061: arg-bearing new-expr member `new A(y).b`"),
-    // gap-062 (CLOC14.30): redundant double-paren collapse —
-    // `((a+b))*c` → `(a+b)*c`. Upstream strips one redundant
-    // grouping-paren layer when parens directly nest.
-    ("double_paren_arith", "gap-062: redundant double-paren collapse `((x))`"),
     // gap-055/056/057 all RESOLVED (CLOC12.64/65/66) — ternary
     // arms, return/throw/=> prefixes, and member-object parens
     // (`(a).b` → `a.b`) now pass and are no longer ignored.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -478,6 +478,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-062 — redundant double-paren collapse
 
-- **Status:** OPEN — discovered by CLOC14.30. `minify_double_paren_arith` ignored.
+- **Status:** **RESOLVED** in CLOC12.69 (minimal slice). `minify_double_paren_arith` flips IGNORED → PASS.
 - **Input:** `var x=((a+b))*c;` → **Upstream:** `var x=(a+b)*c;`
-- **What it needs:** When a `(` is immediately followed by `(` and the inner group's matching `)` is immediately followed by the outer `)` (i.e. directly-nested grouping parens `(( ... ))`), strip one layer. Must NOT touch call/grouping-distinct shapes — only adjacent redundant grouping parens.
+- **Fix:** Token pre-pass — when a GROUPING `(` is directly followed by another `(` and the inner group's matching `)` is directly followed by the outer `)` (purely-nested `(( ... ))`), drop the outer pair. Guards: the outer `(` must be a grouping paren (prev is punct other than `)`/`]`/`?.`, or start) so a CALL paren like `f((a,b))` is never collapsed to `f(a,b)`; no top-level comma inside; all bracket checks via `is_structural_punct`.
+- **Deferred (follow-up):** upstream eliminates parens far more aggressively — `((a))` → `a`, `(a)+(b)` → `a+b`, `f((a))` → `f(a)`. This slice strips only ONE directly-nested grouping layer; the broader redundant-paren pass is future work. (Note: `((a,b))` standalone is already correctly handled by gap-053's var-init paren elision.)


### PR DESCRIPTION
## What

Closes **gap-062** (minimal slice, found in CLOC14.30). Collapses one layer of redundant directly-nested **grouping** parens:

```
((a+b))*c   →   (a+b)*c
```

`minify_double_paren_arith` flips IGNORED → PASS.

## How

A token pre-pass: when a GROUPING `(` is directly followed by another `(` and the inner group's matching `)` is directly followed by the outer `)` (purely-nested `(( ... ))`), drop the outer pair. Guards:
- the outer `(` must be a **grouping** paren (prev is punctuation other than `)`/`]`/`?.`, or start) — so a CALL paren like `f((a,b))` is never collapsed to `f(a,b)` (one comma-operator arg vs two args);
- no top-level comma inside the inner group;
- all bracket/comma checks via `is_structural_punct` (string/regex/template content can't trigger).

Minimal slice — strips only one layer. Upstream goes further (`((a))`→`a`, `(a)+(b)`→`a+b`, `f((a))`→`f(a)`) — deferred. (`((a,b))` standalone is already correctly handled by gap-053's var-init paren elision.)

## Tests

- 4 guard unit tests (target, call-paren-with-comma, call-arg-grouping, single-paren non-regression).
- 23 suites green incl. byte-identity harness with `double_paren_arith` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified call-paren guards, comma guard, depth scan with nested brackets, string/regex bracket-content safety, the `}`-prefix edge case (semantically correct), and 8-deep nesting (no hang, one layer).

Version 0.72→0.73; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)