### PR TITLE
feat(mycin-proto): PR4 — warm-path case pipeline (decompose-only → CPU decision, 0 model calls)

### DIFF
--- a/code/specs/data/mycin-prototype/CASE_PIPELINE.md
+++ b/code/specs/data/mycin-prototype/CASE_PIPELINE.md
@@ -1,0 +1,49 @@
+# Warm-path case pipeline — findings
+
+The warm path runs **decompose → adversarial read → ir_to_adj → decide**, with the model used at
+**exactly one point** (decompose) and **zero answer-time model calls** at decision time.
+
+```
+vignette (prose)
+  → decompose.workflow.js   (LLM, dictionary-constrained, decompose-only) → ir/<id>.json
+  → adversarial_read.workflow.js (3 readers: inference read + discard read, majority) → advread/<id>.json
+  → ir_to_adj.py            (DETERMINISTIC: gated IR → observe lines, dict-validated)
+  → decide.py              (concat CAS rulebook + case → adj-lang-cli → differential + proof DAG)
+```
+
+## Result: 4/4 defensible decisions, `answer_time_model_calls = 0`
+
+| case | observed findings | engine decision | gold | ✓ |
+|---|---|---|---|---|
+| MEN-1 | Gram+ , neutrophilic, low glucose, ↑protein, ↑lactate, seizure, ↑PCT (7) | **determinate → bacterial** (P=1.0) | bacterial | ✓ |
+| MEN-2 | neutrophilic, low glucose, ↑protein, ↑lactate, seizure; Gram−, culture pending (5 evid.) | **determinate → bacterial** (P=0.9999) | bacterial | ✓ |
+| MEN-3 | lymphocytic, normal glucose, normal lactate, enteroviral PCR+, seizure absent (4) | **determinate → viral** (P=1.0) | viral | ✓ |
+| MEN-4 | only culture-pending + seizure-absent (0 evidence) | **insufficient_evidence → abstain** | indeterminate | ✓ |
+
+## What this exercises (the named mechanisms)
+
+- **Decompose-only / model never reasons.** The decomposer mapped prose → canonical dictionary
+  findings + byte spans + a discard list + inference justifications, and **did not diagnose**. The
+  diagnosis is the CPU engine's. MEN-2's four CSF findings were emitted `inferred` with ENTAILED
+  bases; the decomposer also correctly distinguished "procalcitonin not sent" (a legal term, *not
+  observed*) from a finding — the closed-vocabulary "absent vs not-yet-observed" distinction.
+- **Standard dictionary enforced.** Every emitted term validated against `dictionary.json`
+  (`ir_to_adj` raises on a non-dictionary term); IR and rulebook share one vocabulary by construction.
+- **Adversarial reading, both links.** 3 model-diverse readers ran the **inference read** (no
+  over-reads found — the decompose was faithful) and the **discard read** (no wrongly-dropped
+  findings) — the safety net confirming, here, that nothing was dropped or over-asserted.
+- **Evidence-sufficiency (abstain, don't fabricate).** MEN-4 has no dispositive finding, so the
+  engine would otherwise commit to viral on the **prior alone** (0.963 vs 0.037). A deterministic
+  guard on the proof DAG — *the leader fired zero contributions* — overrides this to
+  `insufficient_evidence`. This is the honest failure mode surfaced and fixed: don't decide on base
+  rates when no evidence was observed.
+- **CPU-bound inference.** `decide.py` invokes only the `adj-lang-cli` binary — no agent, no model.
+  `answer_time_model_calls_total = 0` across all four cases.
+
+## The over-saturation is live (for the cost-to-correct proof)
+
+MEN-2 returns **P=0.9999** — the correct leader (bacterial) but an indefensible certainty *before*
+the Gram stain / culture, because the four correlated CSF findings are multiplied as independent.
+`proofs/cost_to_correct` (PR5) localizes this from the proof DAG and fixes it with one explaining-away
+edit. The linked programs (`cases/<id>.linked.adj`) and full results (`decide_results.json`) are the
+reproducible artifacts.

--- a/code/specs/data/mycin-prototype/adversarial_read.workflow.js
+++ b/code/specs/data/mycin-prototype/adversarial_read.workflow.js
@@ -1,0 +1,82 @@
+export const meta = {
+  name: 'mycin-adversarial-read',
+  description: 'Adversarial reading of a case IR at BOTH link types (FORWARD-DESIGN §1). N model-diverse readers (Opus + Sonnet + Haiku) per case: (1) INFERENCE READ — for each inferred finding, does the basis span ENTAIL it or is it a LEAP (over-read)? (2) DISCARD READ — for each discarded span, try to show it is actually a load-bearing dictionary finding that was WRONGLY dropped (the dangerous direction in medicine). Majority vote (>=2 of 3). The over-reads are dropped; the wrongly-dropped findings are surfaced for recovery. Sequential batches of 10 cases.',
+  phases: [{ title: 'AdversarialRead', detail: '3 readers per case: inference read + discard read' }],
+}
+
+const DIR = '/Users/adhithya/Downloads/coding-adventures/code/specs/data/mycin-prototype'
+const ids = Array.isArray(args) ? args : (typeof args === 'string' ? JSON.parse(args) : args)
+const BATCH = 10
+const READERS = [undefined, 'sonnet', 'haiku']
+
+const SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['inference_leaps', 'discard_load_bearing'],
+  properties: {
+    inference_leaps: {
+      type: 'array', description: 'terms of inferred findings whose basis span does NOT entail them',
+      items: { type: 'string' },
+    },
+    discard_load_bearing: {
+      type: 'array',
+      description: 'discarded spans that are actually a load-bearing dictionary finding wrongly dropped',
+      items: {
+        type: 'object', additionalProperties: false, required: ['span', 'recovered_term'],
+        properties: { span: { type: 'string' }, recovered_term: { type: 'string' } },
+      },
+    },
+  },
+}
+
+function reader(id, model) {
+  const irPath = `${DIR}/ir/${id}.json`
+  const prompt =
+    `You are an ADVERSARIAL reader auditing a clinical case decomposition. Read TWO files with the ` +
+    `Read tool:\n1. the case IR: ${irPath} — { findings (each term/span/type/polarity), discard ` +
+    `(spans not mapped, each with a reason), inference_justifications }.\n2. the dictionary: ` +
+    `${DIR}/dictionary.json — the CLOSED set of canonical finding functors + value domains + ` +
+    `surface_forms.\n\nDo TWO adversarial reads:\n` +
+    `(A) INFERENCE READ — for every finding with type "inferred", decide whether its span genuinely ` +
+    `ENTAILS the claimed term, or whether it is a LEAP (an over-read the bytes do not force). List the ` +
+    `terms you judge LEAP.\n` +
+    `(B) DISCARD READ — for every span in "discard", try to REFUTE the discard: does that span ` +
+    `actually establish a dictionary finding (a functor+value, mappable via surface_forms) that was ` +
+    `WRONGLY dropped? If yes, report the span and the recovered_term. Be strict: only flag a span if it ` +
+    `truly maps to a dictionary finding value (not a symptom/demographic with no functor).\n\n` +
+    `Return inference_leaps (list of terms) and discard_load_bearing (list of {span, recovered_term}).`
+  return agent(prompt, { label: `advread:${id}:${model || 'opus'}`, phase: 'AdversarialRead', schema: SCHEMA, ...(model ? { model } : {}) })
+}
+
+function caseRead(id) {
+  return parallel(READERS.map((m) => () => reader(id, m))).then((vs) => {
+    const reads = vs.filter(Boolean)
+    // majority (>=2 of the readers that returned)
+    const need = Math.max(2, Math.ceil(reads.length / 2))
+    const leapCount = {}
+    const dbCount = {}
+    const dbTerm = {}
+    for (const r of reads) {
+      for (const t of r.inference_leaps || []) leapCount[t] = (leapCount[t] || 0) + 1
+      for (const d of r.discard_load_bearing || []) {
+        dbCount[d.span] = (dbCount[d.span] || 0) + 1
+        dbTerm[d.span] = d.recovered_term
+      }
+    }
+    const inference_leaps = Object.keys(leapCount).filter((t) => leapCount[t] >= need)
+    const discard_load_bearing = Object.keys(dbCount)
+      .filter((s) => dbCount[s] >= need)
+      .map((s) => ({ span: s, recovered_term: dbTerm[s] }))
+    return { case_id: id, n_readers: reads.length, inference_leaps, discard_load_bearing }
+  })
+}
+
+phase('AdversarialRead')
+const all = []
+for (let i = 0; i < ids.length; i += BATCH) {
+  const batch = ids.slice(i, i + BATCH)
+  log(`Batch ${i / BATCH + 1}: adversarial-reading ${batch.join(', ')} (${all.length} done).`)
+  const res = await parallel(batch.map((id) => () => caseRead(id)))
+  all.push(...res.filter(Boolean))
+}
+log(`Collected ${all.length}/${ids.length} adversarial reads.`)
+return all

--- a/code/specs/data/mycin-prototype/advread/MEN-1.json
+++ b/code/specs/data/mycin-prototype/advread/MEN-1.json
@@ -1,0 +1,6 @@
+{
+ "case_id": "MEN-1",
+ "n_readers": 3,
+ "inference_leaps": [],
+ "discard_load_bearing": []
+}

--- a/code/specs/data/mycin-prototype/advread/MEN-2.json
+++ b/code/specs/data/mycin-prototype/advread/MEN-2.json
@@ -1,0 +1,6 @@
+{
+ "case_id": "MEN-2",
+ "n_readers": 3,
+ "inference_leaps": [],
+ "discard_load_bearing": []
+}

--- a/code/specs/data/mycin-prototype/advread/MEN-3.json
+++ b/code/specs/data/mycin-prototype/advread/MEN-3.json
@@ -1,0 +1,6 @@
+{
+ "case_id": "MEN-3",
+ "n_readers": 3,
+ "inference_leaps": [],
+ "discard_load_bearing": []
+}

--- a/code/specs/data/mycin-prototype/advread/MEN-4.json
+++ b/code/specs/data/mycin-prototype/advread/MEN-4.json
@@ -1,0 +1,6 @@
+{
+ "case_id": "MEN-4",
+ "n_readers": 3,
+ "inference_leaps": [],
+ "discard_load_bearing": []
+}

--- a/code/specs/data/mycin-prototype/cases/MEN-1.linked.adj
+++ b/code/specs/data/mycin-prototype/cases/MEN-1.linked.adj
@@ -1,0 +1,71 @@
+% MYCIN-2026 — bacterial vs viral meningitis differential rulebook (adj-lang).
+%
+% Derived ONCE from byte-grounded literature (the grounded corpus at
+% ../../adj52/corpus/bacterial_meningitis/corpus.json). Each clause's `source` is
+% the short citation shown in the proof DAG; the verbatim byte_quote + the LR
+% computation the CAS-write gate verifies live in rulebook/provenance.json keyed
+% by (hypothesis, evidence). Trust tiers: consensus > authoritative > empirical >
+% inferred > unattributed.
+%
+% NOTE — this is the NAIVE first-pass derivation: the four correlated CSF-chemistry
+% findings (neutrophilic pleocytosis, low glucose, elevated protein, elevated
+% lactate) are encoded as INDEPENDENT `contributes`. They are manifestations of one
+% process, so multiplying their LRs over-counts and over-saturates the posterior
+% (the documented ADJ56 failure). That latent bug is intentional: proofs/cost_to_correct
+% localizes it from the proof DAG and fixes it with one explaining-away `interacts`.
+
+% ============================ BACTERIAL arm ============================
+prior 0.037 for bacterial_meningitis
+  source "Nigrovic 2007 JAMA (PMID 17200475), n=3295" trust authoritative
+
+contributes 85 from csf_gram_stain(positive) to bacterial_meningitis
+  source "WHO 2025 guideline NBK614844 (pooled Straus 2006); sens 85% spec 99%" trust consensus
+
+contributes 15 from csf_neutrophilic_pleocytosis(high) to bacterial_meningitis
+  source "Straus 2006 JAMA (PMID 17062865); CSF WBC >=500/uL LR 15" trust authoritative
+
+contributes 18 from csf_glucose(low) to bacterial_meningitis
+  source "Straus 2006 JAMA; CSF:blood glucose ratio <=0.4 LR 18" trust authoritative
+
+contributes 9.33 from csf_protein(elevated) to bacterial_meningitis
+  source "Viallon via PMC4886299; >=1.88 g/L sens 84% spec 91%" trust empirical
+
+contributes 22.9 from csf_lactate(elevated) to bacterial_meningitis
+  source "Sakushima 2011 J Infect (PMID 21382412), 33 studies; LR+ 22.9" trust authoritative
+
+contributes 27.3 from serum_procalcitonin(elevated) to bacterial_meningitis
+  source "Vikse 2015 Int J Infect Dis (PMID 26188130), 9 studies; LR+ 27.3" trust authoritative
+
+contributes 5.84 from seizure(present) to bacterial_meningitis
+  source "Nigrovic 2002 Pediatrics; seizure 22% bacterial vs 4% aseptic, LR+ 5.84" trust empirical
+
+contributes 271 from csf_culture(positive) to bacterial_meningitis
+  source "Wu 2013 BMC Infect Dis (PMC3558362) latent-class; sens 81.3% spec 99.7%" trust authoritative
+
+% ============================ VIRAL arm ============================
+prior 0.963 for viral_meningitis
+  source "Nigrovic 2007 JAMA complement; aseptic 3174/3295 = 96.3%" trust authoritative
+
+contributes 4.9 from csf_glucose(normal) to viral_meningitis
+  source "Straus 2006 JAMA, derived: normal glucose LR for aseptic = spec/(1-sens) = 0.98/0.20" trust authoritative
+
+contributes 13.7 from csf_lactate(normal) to viral_meningitis
+  source "Sakushima 2011, derived: normal lactate LR for aseptic = spec/(1-sens) = 0.96/0.07" trust authoritative
+
+contributes 5.0 from csf_lymphocytic_pleocytosis(high) to viral_meningitis
+  source "[inferred] lymphocyte predominance is characteristic of aseptic meningitis; LR not yet byte-grounded" trust inferred
+
+contributes 50 from enteroviral_pcr(positive) to viral_meningitis
+  source "[inferred] CSF enterovirus RT-PCR is near-diagnostic for enteroviral meningitis; LR not yet byte-grounded" trust inferred
+
+? bacterial_meningitis
+? viral_meningitis
+
+% case MEN-1 — observations only; the rulebook supplies the queries
+observe csf_neutrophilic_pleocytosis(high)
+observe csf_glucose(low)
+observe csf_protein(elevated)
+observe csf_lactate(elevated)
+observe csf_gram_stain(positive)
+observe seizure(present)
+observe serum_procalcitonin(elevated)

--- a/code/specs/data/mycin-prototype/cases/MEN-2.linked.adj
+++ b/code/specs/data/mycin-prototype/cases/MEN-2.linked.adj
@@ -1,0 +1,71 @@
+% MYCIN-2026 — bacterial vs viral meningitis differential rulebook (adj-lang).
+%
+% Derived ONCE from byte-grounded literature (the grounded corpus at
+% ../../adj52/corpus/bacterial_meningitis/corpus.json). Each clause's `source` is
+% the short citation shown in the proof DAG; the verbatim byte_quote + the LR
+% computation the CAS-write gate verifies live in rulebook/provenance.json keyed
+% by (hypothesis, evidence). Trust tiers: consensus > authoritative > empirical >
+% inferred > unattributed.
+%
+% NOTE — this is the NAIVE first-pass derivation: the four correlated CSF-chemistry
+% findings (neutrophilic pleocytosis, low glucose, elevated protein, elevated
+% lactate) are encoded as INDEPENDENT `contributes`. They are manifestations of one
+% process, so multiplying their LRs over-counts and over-saturates the posterior
+% (the documented ADJ56 failure). That latent bug is intentional: proofs/cost_to_correct
+% localizes it from the proof DAG and fixes it with one explaining-away `interacts`.
+
+% ============================ BACTERIAL arm ============================
+prior 0.037 for bacterial_meningitis
+  source "Nigrovic 2007 JAMA (PMID 17200475), n=3295" trust authoritative
+
+contributes 85 from csf_gram_stain(positive) to bacterial_meningitis
+  source "WHO 2025 guideline NBK614844 (pooled Straus 2006); sens 85% spec 99%" trust consensus
+
+contributes 15 from csf_neutrophilic_pleocytosis(high) to bacterial_meningitis
+  source "Straus 2006 JAMA (PMID 17062865); CSF WBC >=500/uL LR 15" trust authoritative
+
+contributes 18 from csf_glucose(low) to bacterial_meningitis
+  source "Straus 2006 JAMA; CSF:blood glucose ratio <=0.4 LR 18" trust authoritative
+
+contributes 9.33 from csf_protein(elevated) to bacterial_meningitis
+  source "Viallon via PMC4886299; >=1.88 g/L sens 84% spec 91%" trust empirical
+
+contributes 22.9 from csf_lactate(elevated) to bacterial_meningitis
+  source "Sakushima 2011 J Infect (PMID 21382412), 33 studies; LR+ 22.9" trust authoritative
+
+contributes 27.3 from serum_procalcitonin(elevated) to bacterial_meningitis
+  source "Vikse 2015 Int J Infect Dis (PMID 26188130), 9 studies; LR+ 27.3" trust authoritative
+
+contributes 5.84 from seizure(present) to bacterial_meningitis
+  source "Nigrovic 2002 Pediatrics; seizure 22% bacterial vs 4% aseptic, LR+ 5.84" trust empirical
+
+contributes 271 from csf_culture(positive) to bacterial_meningitis
+  source "Wu 2013 BMC Infect Dis (PMC3558362) latent-class; sens 81.3% spec 99.7%" trust authoritative
+
+% ============================ VIRAL arm ============================
+prior 0.963 for viral_meningitis
+  source "Nigrovic 2007 JAMA complement; aseptic 3174/3295 = 96.3%" trust authoritative
+
+contributes 4.9 from csf_glucose(normal) to viral_meningitis
+  source "Straus 2006 JAMA, derived: normal glucose LR for aseptic = spec/(1-sens) = 0.98/0.20" trust authoritative
+
+contributes 13.7 from csf_lactate(normal) to viral_meningitis
+  source "Sakushima 2011, derived: normal lactate LR for aseptic = spec/(1-sens) = 0.96/0.07" trust authoritative
+
+contributes 5.0 from csf_lymphocytic_pleocytosis(high) to viral_meningitis
+  source "[inferred] lymphocyte predominance is characteristic of aseptic meningitis; LR not yet byte-grounded" trust inferred
+
+contributes 50 from enteroviral_pcr(positive) to viral_meningitis
+  source "[inferred] CSF enterovirus RT-PCR is near-diagnostic for enteroviral meningitis; LR not yet byte-grounded" trust inferred
+
+? bacterial_meningitis
+? viral_meningitis
+
+% case MEN-2 — observations only; the rulebook supplies the queries
+observe csf_neutrophilic_pleocytosis(high)
+observe csf_glucose(low)
+observe csf_protein(elevated)
+observe csf_lactate(elevated)
+observe seizure(present)
+observe csf_gram_stain(negative)
+observe csf_culture(pending)

--- a/code/specs/data/mycin-prototype/cases/MEN-3.linked.adj
+++ b/code/specs/data/mycin-prototype/cases/MEN-3.linked.adj
@@ -1,0 +1,70 @@
+% MYCIN-2026 — bacterial vs viral meningitis differential rulebook (adj-lang).
+%
+% Derived ONCE from byte-grounded literature (the grounded corpus at
+% ../../adj52/corpus/bacterial_meningitis/corpus.json). Each clause's `source` is
+% the short citation shown in the proof DAG; the verbatim byte_quote + the LR
+% computation the CAS-write gate verifies live in rulebook/provenance.json keyed
+% by (hypothesis, evidence). Trust tiers: consensus > authoritative > empirical >
+% inferred > unattributed.
+%
+% NOTE — this is the NAIVE first-pass derivation: the four correlated CSF-chemistry
+% findings (neutrophilic pleocytosis, low glucose, elevated protein, elevated
+% lactate) are encoded as INDEPENDENT `contributes`. They are manifestations of one
+% process, so multiplying their LRs over-counts and over-saturates the posterior
+% (the documented ADJ56 failure). That latent bug is intentional: proofs/cost_to_correct
+% localizes it from the proof DAG and fixes it with one explaining-away `interacts`.
+
+% ============================ BACTERIAL arm ============================
+prior 0.037 for bacterial_meningitis
+  source "Nigrovic 2007 JAMA (PMID 17200475), n=3295" trust authoritative
+
+contributes 85 from csf_gram_stain(positive) to bacterial_meningitis
+  source "WHO 2025 guideline NBK614844 (pooled Straus 2006); sens 85% spec 99%" trust consensus
+
+contributes 15 from csf_neutrophilic_pleocytosis(high) to bacterial_meningitis
+  source "Straus 2006 JAMA (PMID 17062865); CSF WBC >=500/uL LR 15" trust authoritative
+
+contributes 18 from csf_glucose(low) to bacterial_meningitis
+  source "Straus 2006 JAMA; CSF:blood glucose ratio <=0.4 LR 18" trust authoritative
+
+contributes 9.33 from csf_protein(elevated) to bacterial_meningitis
+  source "Viallon via PMC4886299; >=1.88 g/L sens 84% spec 91%" trust empirical
+
+contributes 22.9 from csf_lactate(elevated) to bacterial_meningitis
+  source "Sakushima 2011 J Infect (PMID 21382412), 33 studies; LR+ 22.9" trust authoritative
+
+contributes 27.3 from serum_procalcitonin(elevated) to bacterial_meningitis
+  source "Vikse 2015 Int J Infect Dis (PMID 26188130), 9 studies; LR+ 27.3" trust authoritative
+
+contributes 5.84 from seizure(present) to bacterial_meningitis
+  source "Nigrovic 2002 Pediatrics; seizure 22% bacterial vs 4% aseptic, LR+ 5.84" trust empirical
+
+contributes 271 from csf_culture(positive) to bacterial_meningitis
+  source "Wu 2013 BMC Infect Dis (PMC3558362) latent-class; sens 81.3% spec 99.7%" trust authoritative
+
+% ============================ VIRAL arm ============================
+prior 0.963 for viral_meningitis
+  source "Nigrovic 2007 JAMA complement; aseptic 3174/3295 = 96.3%" trust authoritative
+
+contributes 4.9 from csf_glucose(normal) to viral_meningitis
+  source "Straus 2006 JAMA, derived: normal glucose LR for aseptic = spec/(1-sens) = 0.98/0.20" trust authoritative
+
+contributes 13.7 from csf_lactate(normal) to viral_meningitis
+  source "Sakushima 2011, derived: normal lactate LR for aseptic = spec/(1-sens) = 0.96/0.07" trust authoritative
+
+contributes 5.0 from csf_lymphocytic_pleocytosis(high) to viral_meningitis
+  source "[inferred] lymphocyte predominance is characteristic of aseptic meningitis; LR not yet byte-grounded" trust inferred
+
+contributes 50 from enteroviral_pcr(positive) to viral_meningitis
+  source "[inferred] CSF enterovirus RT-PCR is near-diagnostic for enteroviral meningitis; LR not yet byte-grounded" trust inferred
+
+? bacterial_meningitis
+? viral_meningitis
+
+% case MEN-3 — observations only; the rulebook supplies the queries
+observe csf_lymphocytic_pleocytosis(high)
+observe csf_glucose(normal)
+observe csf_lactate(normal)
+observe csf_protein(elevated)
+observe enteroviral_pcr(positive)
+observe seizure(absent)

--- a/code/specs/data/mycin-prototype/cases/MEN-4.linked.adj
+++ b/code/specs/data/mycin-prototype/cases/MEN-4.linked.adj
@@ -1,0 +1,66 @@
+% MYCIN-2026 — bacterial vs viral meningitis differential rulebook (adj-lang).
+%
+% Derived ONCE from byte-grounded literature (the grounded corpus at
+% ../../adj52/corpus/bacterial_meningitis/corpus.json). Each clause's `source` is
+% the short citation shown in the proof DAG; the verbatim byte_quote + the LR
+% computation the CAS-write gate verifies live in rulebook/provenance.json keyed
+% by (hypothesis, evidence). Trust tiers: consensus > authoritative > empirical >
+% inferred > unattributed.
+%
+% NOTE — this is the NAIVE first-pass derivation: the four correlated CSF-chemistry
+% findings (neutrophilic pleocytosis, low glucose, elevated protein, elevated
+% lactate) are encoded as INDEPENDENT `contributes`. They are manifestations of one
+% process, so multiplying their LRs over-counts and over-saturates the posterior
+% (the documented ADJ56 failure). That latent bug is intentional: proofs/cost_to_correct
+% localizes it from the proof DAG and fixes it with one explaining-away `interacts`.
+
+% ============================ BACTERIAL arm ============================
+prior 0.037 for bacterial_meningitis
+  source "Nigrovic 2007 JAMA (PMID 17200475), n=3295" trust authoritative
+
+contributes 85 from csf_gram_stain(positive) to bacterial_meningitis
+  source "WHO 2025 guideline NBK614844 (pooled Straus 2006); sens 85% spec 99%" trust consensus
+
+contributes 15 from csf_neutrophilic_pleocytosis(high) to bacterial_meningitis
+  source "Straus 2006 JAMA (PMID 17062865); CSF WBC >=500/uL LR 15" trust authoritative
+
+contributes 18 from csf_glucose(low) to bacterial_meningitis
+  source "Straus 2006 JAMA; CSF:blood glucose ratio <=0.4 LR 18" trust authoritative
+
+contributes 9.33 from csf_protein(elevated) to bacterial_meningitis
+  source "Viallon via PMC4886299; >=1.88 g/L sens 84% spec 91%" trust empirical
+
+contributes 22.9 from csf_lactate(elevated) to bacterial_meningitis
+  source "Sakushima 2011 J Infect (PMID 21382412), 33 studies; LR+ 22.9" trust authoritative
+
+contributes 27.3 from serum_procalcitonin(elevated) to bacterial_meningitis
+  source "Vikse 2015 Int J Infect Dis (PMID 26188130), 9 studies; LR+ 27.3" trust authoritative
+
+contributes 5.84 from seizure(present) to bacterial_meningitis
+  source "Nigrovic 2002 Pediatrics; seizure 22% bacterial vs 4% aseptic, LR+ 5.84" trust empirical
+
+contributes 271 from csf_culture(positive) to bacterial_meningitis
+  source "Wu 2013 BMC Infect Dis (PMC3558362) latent-class; sens 81.3% spec 99.7%" trust authoritative
+
+% ============================ VIRAL arm ============================
+prior 0.963 for viral_meningitis
+  source "Nigrovic 2007 JAMA complement; aseptic 3174/3295 = 96.3%" trust authoritative
+
+contributes 4.9 from csf_glucose(normal) to viral_meningitis
+  source "Straus 2006 JAMA, derived: normal glucose LR for aseptic = spec/(1-sens) = 0.98/0.20" trust authoritative
+
+contributes 13.7 from csf_lactate(normal) to viral_meningitis
+  source "Sakushima 2011, derived: normal lactate LR for aseptic = spec/(1-sens) = 0.96/0.07" trust authoritative
+
+contributes 5.0 from csf_lymphocytic_pleocytosis(high) to viral_meningitis
+  source "[inferred] lymphocyte predominance is characteristic of aseptic meningitis; LR not yet byte-grounded" trust inferred
+
+contributes 50 from enteroviral_pcr(positive) to viral_meningitis
+  source "[inferred] CSF enterovirus RT-PCR is near-diagnostic for enteroviral meningitis; LR not yet byte-grounded" trust inferred
+
+? bacterial_meningitis
+? viral_meningitis
+
+% case MEN-4 — observations only; the rulebook supplies the queries
+observe csf_culture(pending)
+observe seizure(absent)

--- a/code/specs/data/mycin-prototype/cases/cases.json
+++ b/code/specs/data/mycin-prototype/cases/cases.json
@@ -1,0 +1,29 @@
+{
+  "_doc": "Held-out clinical vignettes (messy prose) for the warm path. The LLM DECOMPOSES each into typed IR (dictionary findings + byte spans + a discard list); it does NOT diagnose. Each vignette deliberately contains distractor details (demographics, unrelated history) so the discard read has real spans to adjudicate. gold = the defensible answer a clinician would give at that decision point.",
+  "cases": [
+    {
+      "id": "MEN-1",
+      "gold": "bacterial_meningitis",
+      "gold_note": "Gram stain positive + neutrophilic CSF + low glucose = bacterial, confirmable.",
+      "vignette": "A 58-year-old man with a history of hypertension and a 20-pack-year smoking history presents with 12 hours of fever, severe headache, and neck stiffness. He takes lisinopril. On exam he is photophobic. Lumbar puncture shows a CSF white-cell count of 2200/uL with 95% neutrophils; CSF:serum glucose ratio is 0.18; CSF protein is 2.4 g/L; CSF lactate is 7.1 mmol/L. The CSF Gram stain shows gram-positive diplococci. He had a brief generalized seizure in the emergency department. Serum procalcitonin is 6.2 ng/mL."
+    },
+    {
+      "id": "MEN-2",
+      "gold": "bacterial_meningitis",
+      "gold_note": "Pre-culture: strong CSF chemistry but Gram stain unrevealing and culture pending — high suspicion, not certainty. The over-saturation case.",
+      "vignette": "A 41-year-old woman, otherwise healthy, develops fever and confusion over 8 hours. Her only medication is an oral contraceptive. CSF analysis: white-cell count 1500/uL, neutrophil-predominant; CSF:serum glucose ratio 0.25; protein 2.0 g/L; lactate 5.8 mmol/L. She had a witnessed convulsion on arrival. The Gram stain was reported as showing no organisms, and cultures are still pending. Procalcitonin was not sent."
+    },
+    {
+      "id": "MEN-3",
+      "gold": "viral_meningitis",
+      "gold_note": "Lymphocytic CSF, normal glucose and lactate, positive enterovirus PCR = viral/aseptic.",
+      "vignette": "A 24-year-old previously well graduate student presents in late summer with 2 days of headache, low-grade fever, and mild neck discomfort after a recent gastrointestinal illness. CSF shows 180 white cells/uL with 88% lymphocytes; CSF:serum glucose ratio is 0.62 (normal); CSF lactate is 1.9 mmol/L (normal); protein is mildly elevated. CSF enterovirus RT-PCR returns positive. He never had a seizure and is fully alert."
+    },
+    {
+      "id": "MEN-4",
+      "gold": "indeterminate",
+      "gold_note": "Early/sparse: mild pleocytosis only, the dispositive chemistries not yet back — expect a kickback (too close to commit).",
+      "vignette": "A 33-year-old man presents with 6 hours of headache and feeling feverish after a camping trip; he mentions a tick bite last week. Initial CSF shows a mildly elevated white-cell count but the differential, glucose, protein, lactate, Gram stain, and cultures are all still pending at the time of this note. He is alert with no seizure."
+    }
+  ]
+}

--- a/code/specs/data/mycin-prototype/decide.py
+++ b/code/specs/data/mycin-prototype/decide.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""decide — the WARM-PATH decision step. DETERMINISTIC, zero answer-time model calls.
+
+For each case: take the typed IR (decompose) + the adversarial read (inference + discard
+verdicts), apply the gate (drop adversarial-LEAP findings; surface wrongly-dropped
+discards), compile the gated IR to a case `.adj` (ir_to_adj), CONCATENATE it with the
+CAS rulebook (the linking), and run the adj-lang-cli — the CPU reasoner — to get the
+differential + proof DAG. The only thing this step invokes is the engine binary: no
+agent, no model. We assert `answer_time_model_calls == 0`.
+
+Run:  python3 decide.py   (after decompose -> ir/, adversarial_read -> advread/)
+Outputs: cases/<id>.linked.adj (rulebook + case), decide_results.json.
+"""
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import ir_to_adj as I
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CAS = os.path.join(HERE, "cas", "objects")
+IR = os.path.join(HERE, "ir")
+ADV = os.path.join(HERE, "advread")
+CASES = os.path.join(HERE, "cases")
+
+
+def find_cli():
+    """Locate the adj-lang-cli binary, building it if necessary."""
+    p = shutil.which("adj-lang-cli")
+    if p:
+        return p
+    for cand in (
+        os.path.join(HERE, "..", "..", "..", "packages", "rust", "target", "debug", "adj-lang-cli"),
+        os.path.join(HERE, "..", "..", "..", "packages", "rust", "target", "release", "adj-lang-cli"),
+    ):
+        cand = os.path.abspath(cand)
+        if os.path.exists(cand):
+            return cand
+    raise SystemExit("adj-lang-cli not found — run `cargo build -p adj-lang-cli` in code/packages/rust")
+
+
+def load_rulebook():
+    """Return (rulebook_text, cas_hash) from the gated CAS library object."""
+    objs = sorted(glob.glob(os.path.join(CAS, "*.json")))
+    if not objs:
+        raise SystemExit("no CAS object — run cas_write_gate.py prep && commit")
+    obj = json.load(open(objs[-1]))
+    rb_path = os.path.join(HERE, obj["rulebook_path"])
+    return open(rb_path).read(), obj["hash"]
+
+
+def gated_ir(ir, adv):
+    """Mark adversarial-LEAP inferred findings as LEAP (so ir_to_adj drops them);
+    return (gated_ir, recovered_discards)."""
+    leaps = set((adv or {}).get("inference_leaps", []))
+    ij = {j["term"]: dict(j) for j in ir.get("inference_justifications", [])}
+    for t in leaps:
+        ij.setdefault(t, {"term": t, "basis_span": "", "verdict": "LEAP"})["verdict"] = "LEAP"
+    g = {**ir, "inference_justifications": list(ij.values())}
+    return g, (adv or {}).get("discard_load_bearing", [])
+
+
+def decide_case(cid, rulebook, findings, cli):
+    ir = json.load(open(os.path.join(IR, f"{cid}.json")))
+    adv_path = os.path.join(ADV, f"{cid}.json")
+    adv = json.load(open(adv_path)) if os.path.exists(adv_path) else {}
+    gir, recovered = gated_ir(ir, adv)
+    case_adj, dropped = I.ir_to_adj(gir, findings)
+    linked = rulebook.rstrip() + "\n\n" + case_adj
+    linked_path = os.path.join(CASES, f"{cid}.linked.adj")
+    open(linked_path, "w").write(linked)
+
+    out = subprocess.run([cli, linked_path], capture_output=True, text=True)
+    result = json.loads(out.stdout) if out.stdout.strip().startswith("{") else {"error": out.stderr}
+    dec = dict(result.get("decision", {}))
+    leader = dec.get("leader")
+
+    # Evidence-sufficiency guard (abstain, don't fabricate): if the leader's proof
+    # fired ONLY a prior — no observed finding contributed — the "decision" rests on
+    # base rates alone, which is not a defensible commitment. Override to abstain.
+    ranked = {r["hypothesis"]: r for r in result.get("ranked", [])}
+    lead_proof = ranked.get(leader, {}).get("proof", [])
+    n_evidence = sum(1 for s in lead_proof if s.get("kind") in ("contribution", "interaction"))
+    if leader is not None and n_evidence == 0:
+        dec = {"type": "insufficient_evidence", "leader": leader,
+               "reason": "no observed finding contributed — decision would rest on the prior alone"}
+
+    return {
+        "case_id": cid,
+        "answer_time_model_calls": 0,           # decide invokes only the engine binary
+        "decision": dec,
+        "leader": leader,
+        "n_evidence_for_leader": n_evidence,
+        "posteriors": {r["hypothesis"]: round(r["posterior"], 4) for r in result.get("ranked", [])},
+        "dropped_leap_findings": dropped,
+        "recovered_discards": recovered,        # discard read: wrongly-dropped findings surfaced
+        "linked_program": f"cases/{cid}.linked.adj",
+    }
+
+
+def main():
+    cli = find_cli()
+    rulebook, cas_hash = load_rulebook()
+    findings = I.load_findings()
+    gold = {c["id"]: c["gold"] for c in json.load(open(os.path.join(CASES, "cases.json")))["cases"]}
+    ids = sorted(os.path.splitext(os.path.basename(p))[0] for p in glob.glob(os.path.join(IR, "*.json")))
+
+    rows = []
+    for cid in ids:
+        r = decide_case(cid, rulebook, findings, cli)
+        g = gold.get(cid)
+        d = r["decision"]
+        # match: determinate leader == gold; abstain (kickback / insufficient_evidence)
+        # is correct iff gold is indeterminate.
+        if d.get("type") in ("kickback", "insufficient_evidence"):
+            r["match"] = (g == "indeterminate")
+        else:
+            r["match"] = (r["leader"] == g)
+        r["gold"] = g
+        rows.append(r)
+
+    summary = {
+        "cas_library": cas_hash,
+        "answer_time_model_calls_total": sum(r["answer_time_model_calls"] for r in rows),
+        "decisions": {r["case_id"]: f"{r['decision'].get('type')} -> {r.get('leader')} "
+                                    f"(P={r['posteriors'].get(r.get('leader'), '-')}) [gold {r['gold']}]"
+                      for r in rows},
+        "recovered_discards": {r["case_id"]: r["recovered_discards"] for r in rows if r["recovered_discards"]},
+    }
+    json.dump({"summary": summary, "rows": rows},
+              open(os.path.join(HERE, "decide_results.json"), "w"), indent=1)
+    print(json.dumps(summary, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/code/specs/data/mycin-prototype/decide_results.json
+++ b/code/specs/data/mycin-prototype/decide_results.json
@@ -1,0 +1,101 @@
+{
+ "summary": {
+  "cas_library": "286c17aaf48ff32d",
+  "answer_time_model_calls_total": 0,
+  "decisions": {
+   "MEN-1": "determinate -> bacterial_meningitis (P=1.0) [gold bacterial_meningitis]",
+   "MEN-2": "determinate -> bacterial_meningitis (P=0.9999) [gold bacterial_meningitis]",
+   "MEN-3": "determinate -> viral_meningitis (P=1.0) [gold viral_meningitis]",
+   "MEN-4": "insufficient_evidence -> viral_meningitis (P=0.963) [gold indeterminate]"
+  },
+  "recovered_discards": {}
+ },
+ "rows": [
+  {
+   "case_id": "MEN-1",
+   "answer_time_model_calls": 0,
+   "decision": {
+    "type": "determinate",
+    "leader": "bacterial_meningitis",
+    "posterior": 0.999999966707283,
+    "margin_posterior": 0.036999966707282894,
+    "margin_logit": 13.958791641631386
+   },
+   "leader": "bacterial_meningitis",
+   "n_evidence_for_leader": 7,
+   "posteriors": {
+    "bacterial_meningitis": 1.0,
+    "viral_meningitis": 0.963
+   },
+   "dropped_leap_findings": [],
+   "recovered_discards": [],
+   "linked_program": "cases/MEN-1.linked.adj",
+   "match": true,
+   "gold": "bacterial_meningitis"
+  },
+  {
+   "case_id": "MEN-2",
+   "answer_time_model_calls": 0,
+   "decision": {
+    "type": "determinate",
+    "leader": "bacterial_meningitis",
+    "posterior": 0.9999227502157347,
+    "margin_posterior": 0.03692275021573466,
+    "margin_logit": 6.209253682950156
+   },
+   "leader": "bacterial_meningitis",
+   "n_evidence_for_leader": 5,
+   "posteriors": {
+    "bacterial_meningitis": 0.9999,
+    "viral_meningitis": 0.963
+   },
+   "dropped_leap_findings": [],
+   "recovered_discards": [],
+   "linked_program": "cases/MEN-2.linked.adj",
+   "match": true,
+   "gold": "bacterial_meningitis"
+  },
+  {
+   "case_id": "MEN-3",
+   "answer_time_model_calls": 0,
+   "decision": {
+    "type": "determinate",
+    "leader": "viral_meningitis",
+    "posterior": 0.999997710620515,
+    "margin_posterior": 0.7361180582711215,
+    "margin_logit": 14.013127939261455
+   },
+   "leader": "viral_meningitis",
+   "n_evidence_for_leader": 4,
+   "posteriors": {
+    "viral_meningitis": 1.0,
+    "bacterial_meningitis": 0.2639
+   },
+   "dropped_leap_findings": [],
+   "recovered_discards": [],
+   "linked_program": "cases/MEN-3.linked.adj",
+   "match": true,
+   "gold": "viral_meningitis"
+  },
+  {
+   "case_id": "MEN-4",
+   "answer_time_model_calls": 0,
+   "decision": {
+    "type": "insufficient_evidence",
+    "leader": "viral_meningitis",
+    "reason": "no observed finding contributed \u2014 decision would rest on the prior alone"
+   },
+   "leader": "viral_meningitis",
+   "n_evidence_for_leader": 0,
+   "posteriors": {
+    "viral_meningitis": 0.963,
+    "bacterial_meningitis": 0.037
+   },
+   "dropped_leap_findings": [],
+   "recovered_discards": [],
+   "linked_program": "cases/MEN-4.linked.adj",
+   "match": true,
+   "gold": "indeterminate"
+  }
+ ]
+}

--- a/code/specs/data/mycin-prototype/decompose.workflow.js
+++ b/code/specs/data/mycin-prototype/decompose.workflow.js
@@ -1,0 +1,78 @@
+export const meta = {
+  name: 'mycin-decompose',
+  description: 'WARM-PATH DECOMPOSE (the one model touchpoint per case). The LLM reads a messy clinical vignette and the standard dictionary, and DECOMPOSES the prose into typed IR: findings as CANONICAL dictionary terms (each with a verbatim byte span, type stated|inferred, polarity), a DISCARD list (spans it did not map to a finding, each with a reason), and inference justifications for any inferred finding. It does NOT diagnose — the diagnosis is the CPU engine\'s. Constrained to the dictionary vocabulary so the IR and the rulebook share one vocabulary. Sequential batches of 10.',
+  phases: [{ title: 'Decompose', detail: 'vignette -> typed IR, dictionary-constrained, no diagnosis' }],
+}
+
+const DIR = '/Users/adhithya/Downloads/coding-adventures/code/specs/data/mycin-prototype'
+const ids = Array.isArray(args) ? args : (typeof args === 'string' ? JSON.parse(args) : args)
+const BATCH = 10
+
+const FINDING = {
+  type: 'object', additionalProperties: false,
+  required: ['term', 'span', 'type'],
+  properties: {
+    term: { type: 'string', description: 'a canonical dictionary term, e.g. csf_glucose(low)' },
+    span: { type: 'string', description: 'verbatim substring of the vignette that establishes it' },
+    type: { type: 'string', enum: ['stated', 'inferred'] },
+    polarity: { type: 'string', enum: ['affirmed', 'denied'] },
+  },
+}
+const SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['case_id', 'findings', 'discard'],
+  properties: {
+    case_id: { type: 'string' },
+    findings: { type: 'array', items: FINDING },
+    discard: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false, required: ['span', 'reason'],
+        properties: { span: { type: 'string' }, reason: { type: 'string', description: '<= 25 words' } },
+      },
+    },
+    inference_justifications: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false, required: ['term', 'basis_span', 'verdict'],
+        properties: {
+          term: { type: 'string' }, basis_span: { type: 'string' },
+          verdict: { type: 'string', enum: ['ENTAILED', 'LEAP'] },
+        },
+      },
+    },
+  },
+}
+
+function decompose(id) {
+  const prompt =
+    `You are the DECOMPOSE stage of a clinical adjudication framework. You do NOT diagnose — a ` +
+    `deterministic engine decides the differential. Read TWO files with the Read tool:\n` +
+    `1. the standard dictionary: ${DIR}/dictionary.json — the CLOSED set of canonical finding terms ` +
+    `(each "functor" + "value_domain" + "surface_forms") and hypotheses.\n` +
+    `2. the cases: ${DIR}/cases/cases.json — find the case with "id" == "${id}" and read its "vignette".\n\n` +
+    `Decompose the vignette's PROSE into typed IR:\n` +
+    `- findings: for every clinical fact that maps to a dictionary term, emit { term: "functor(value)" ` +
+    `(MUST be a dictionary functor with a value in its value_domain — use the surface_forms to map), ` +
+    `span: the verbatim vignette substring that establishes it, type: "stated" if the span directly ` +
+    `says it / "inferred" if you had to interpret, polarity: "affirmed" or "denied" }. Use value ` +
+    `"normal" / "negative" / "absent" for explicitly-normal or absent findings. Do NOT invent a ` +
+    `finding the vignette does not support, and do NOT emit a term outside the dictionary.\n` +
+    `- discard: every clinical or contextual span you did NOT turn into a finding (demographics, ` +
+    `unrelated history, medications, exposures), each with a short reason it is not a dispositive finding.\n` +
+    `- inference_justifications: for each "inferred" finding, give the basis_span and whether the bytes ` +
+    `ENTAIL it or it is a LEAP.\n\nEcho the case_id. Return the structured IR.`
+  return agent(prompt, { label: `decompose:${id}`, phase: 'Decompose', schema: SCHEMA })
+    .then((e) => (e ? { ...e, case_id: id } : null))
+}
+
+phase('Decompose')
+const all = []
+for (let i = 0; i < ids.length; i += BATCH) {
+  const batch = ids.slice(i, i + BATCH)
+  log(`Batch ${i / BATCH + 1}: decomposing ${batch.join(', ')} (${all.length} done).`)
+  const res = await parallel(batch.map((id) => () => decompose(id)))
+  all.push(...res.filter(Boolean))
+}
+log(`Collected ${all.length}/${ids.length} decompositions.`)
+return all

--- a/code/specs/data/mycin-prototype/ir/MEN-1.json
+++ b/code/specs/data/mycin-prototype/ir/MEN-1.json
@@ -1,0 +1,78 @@
+{
+ "case_id": "MEN-1",
+ "findings": [
+  {
+   "term": "csf_neutrophilic_pleocytosis(high)",
+   "span": "CSF white-cell count of 2200/uL with 95% neutrophils",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_glucose(low)",
+   "span": "CSF:serum glucose ratio is 0.18",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_protein(elevated)",
+   "span": "CSF protein is 2.4 g/L",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_lactate(elevated)",
+   "span": "CSF lactate is 7.1 mmol/L",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_gram_stain(positive)",
+   "span": "The CSF Gram stain shows gram-positive diplococci",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "seizure(present)",
+   "span": "He had a brief generalized seizure in the emergency department",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "serum_procalcitonin(elevated)",
+   "span": "Serum procalcitonin is 6.2 ng/mL",
+   "type": "stated",
+   "polarity": "affirmed"
+  }
+ ],
+ "discard": [
+  {
+   "span": "A 58-year-old man",
+   "reason": "Demographics; age/sex not a dictionary finding term."
+  },
+  {
+   "span": "a history of hypertension",
+   "reason": "Unrelated comorbidity; no dictionary term."
+  },
+  {
+   "span": "a 20-pack-year smoking history",
+   "reason": "Risk-factor history; not a dispositive meningitis finding."
+  },
+  {
+   "span": "12 hours of fever, severe headache, and neck stiffness",
+   "reason": "Meningismus symptoms; no dictionary functor for fever/headache/neck stiffness."
+  },
+  {
+   "span": "He takes lisinopril",
+   "reason": "Medication; not a finding in the closed set."
+  },
+  {
+   "span": "On exam he is photophobic",
+   "reason": "Symptom (photophobia); no dictionary functor."
+  },
+  {
+   "span": "Lumbar puncture shows",
+   "reason": "Procedure framing; the values it introduces are captured as findings."
+  }
+ ],
+ "inference_justifications": []
+}

--- a/code/specs/data/mycin-prototype/ir/MEN-2.json
+++ b/code/specs/data/mycin-prototype/ir/MEN-2.json
@@ -1,0 +1,91 @@
+{
+ "case_id": "MEN-2",
+ "findings": [
+  {
+   "term": "csf_neutrophilic_pleocytosis(high)",
+   "span": "white-cell count 1500/uL, neutrophil-predominant",
+   "type": "inferred",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_glucose(low)",
+   "span": "CSF:serum glucose ratio 0.25",
+   "type": "inferred",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_protein(elevated)",
+   "span": "protein 2.0 g/L",
+   "type": "inferred",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_lactate(elevated)",
+   "span": "lactate 5.8 mmol/L",
+   "type": "inferred",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "seizure(present)",
+   "span": "She had a witnessed convulsion on arrival",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_gram_stain(negative)",
+   "span": "The Gram stain was reported as showing no organisms",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_culture(pending)",
+   "span": "cultures are still pending",
+   "type": "stated",
+   "polarity": "affirmed"
+  }
+ ],
+ "discard": [
+  {
+   "span": "A 41-year-old woman",
+   "reason": "Demographics (age/sex); not a dictionary finding."
+  },
+  {
+   "span": "otherwise healthy",
+   "reason": "General health context, no mappable finding term."
+  },
+  {
+   "span": "develops fever and confusion over 8 hours",
+   "reason": "Fever and confusion/timeline are not in the closed finding dictionary."
+  },
+  {
+   "span": "Her only medication is an oral contraceptive",
+   "reason": "Medication history; unrelated to the meningitis differential findings."
+  },
+  {
+   "span": "Procalcitonin was not sent",
+   "reason": "serum_procalcitonin term is legal but not observed — 'not yet observed', not a finding value."
+  }
+ ],
+ "inference_justifications": [
+  {
+   "term": "csf_neutrophilic_pleocytosis(high)",
+   "basis_span": "white-cell count 1500/uL, neutrophil-predominant",
+   "verdict": "ENTAILED"
+  },
+  {
+   "term": "csf_glucose(low)",
+   "basis_span": "CSF:serum glucose ratio 0.25",
+   "verdict": "ENTAILED"
+  },
+  {
+   "term": "csf_protein(elevated)",
+   "basis_span": "protein 2.0 g/L",
+   "verdict": "ENTAILED"
+  },
+  {
+   "term": "csf_lactate(elevated)",
+   "basis_span": "lactate 5.8 mmol/L",
+   "verdict": "ENTAILED"
+  }
+ ]
+}

--- a/code/specs/data/mycin-prototype/ir/MEN-3.json
+++ b/code/specs/data/mycin-prototype/ir/MEN-3.json
@@ -1,0 +1,64 @@
+{
+ "case_id": "MEN-3",
+ "findings": [
+  {
+   "term": "csf_lymphocytic_pleocytosis(high)",
+   "span": "CSF shows 180 white cells/uL with 88% lymphocytes",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_glucose(normal)",
+   "span": "CSF:serum glucose ratio is 0.62 (normal)",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_lactate(normal)",
+   "span": "CSF lactate is 1.9 mmol/L (normal)",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "csf_protein(elevated)",
+   "span": "protein is mildly elevated",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "enteroviral_pcr(positive)",
+   "span": "CSF enterovirus RT-PCR returns positive",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "seizure(absent)",
+   "span": "He never had a seizure",
+   "type": "stated",
+   "polarity": "affirmed"
+  }
+ ],
+ "discard": [
+  {
+   "span": "A 24-year-old previously well graduate student",
+   "reason": "Demographics and baseline health; no dictionary functor."
+  },
+  {
+   "span": "presents in late summer",
+   "reason": "Seasonal/epidemiologic context, not a dictionary finding."
+  },
+  {
+   "span": "2 days of headache, low-grade fever, and mild neck discomfort",
+   "reason": "Nonspecific meningitic symptoms; no functor in the closed dictionary."
+  },
+  {
+   "span": "after a recent gastrointestinal illness",
+   "reason": "Prodrome/exposure history; not a dispositive dictionary finding."
+  },
+  {
+   "span": "is fully alert",
+   "reason": "Mental status observation; no functor (no confusion/alertness term in dictionary)."
+  }
+ ],
+ "inference_justifications": []
+}

--- a/code/specs/data/mycin-prototype/ir/MEN-4.json
+++ b/code/specs/data/mycin-prototype/ir/MEN-4.json
@@ -1,0 +1,48 @@
+{
+ "case_id": "MEN-4",
+ "findings": [
+  {
+   "term": "csf_culture(pending)",
+   "span": "cultures are all still pending at the time of this note",
+   "type": "stated",
+   "polarity": "affirmed"
+  },
+  {
+   "term": "seizure(absent)",
+   "span": "no seizure",
+   "type": "stated",
+   "polarity": "affirmed"
+  }
+ ],
+ "discard": [
+  {
+   "span": "A 33-year-old man",
+   "reason": "Demographics; age/sex not a dispositive dictionary finding."
+  },
+  {
+   "span": "6 hours of headache and feeling feverish",
+   "reason": "Nonspecific meningitis symptoms; no dictionary functor for headache/fever."
+  },
+  {
+   "span": "after a camping trip",
+   "reason": "Contextual exposure history; no dictionary term."
+  },
+  {
+   "span": "he mentions a tick bite last week",
+   "reason": "Exposure/distractor; no dictionary functor for tick bite."
+  },
+  {
+   "span": "Initial CSF shows a mildly elevated white-cell count",
+   "reason": "Pleocytosis present but differential pending; cannot map to neutrophilic vs lymphocytic functor and no undifferentiated-pleocytosis term exists."
+  },
+  {
+   "span": "the differential, glucose, protein, lactate, Gram stain, and cultures are all still pending at the time of this note",
+   "reason": "differential/glucose/protein/lactate/Gram-stain functors have no 'pending' value; unresulted tests cannot be emitted (only csf_culture has 'pending', emitted as a finding)."
+  },
+  {
+   "span": "He is alert",
+   "reason": "Mental status; no dictionary functor for alertness/consciousness."
+  }
+ ],
+ "inference_justifications": []
+}

--- a/code/specs/data/mycin-prototype/ir_to_adj.py
+++ b/code/specs/data/mycin-prototype/ir_to_adj.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""ir_to_adj — DETERMINISTIC compiler: typed IR -> a case adj-lang program.
+
+This is the frontend half of "IR -> ADJ program". It is **model-free**: given the
+(gated) typed IR for a case, it emits one `observe <term>` line per accepted finding,
+having first validated every term against the standard dictionary (the same
+enforcement dict_lint applies to the rulebook). The rulebook supplies the `?` queries,
+so the case program is just the observations — concatenated with the CAS rulebook at
+decide time. No model reasoning happens here; the diagnosis is the engine's.
+
+Which findings become `observe` lines:
+  * type == "stated"  -> always (byte-anchored to the vignette).
+  * type == "inferred" -> only if the adversarial inference read did NOT rule it a
+    majority-LEAP (a surfaced over-read is dropped, not silently asserted).
+Findings whose term is not in the dictionary are rejected (raises) — the shared
+vocabulary is enforced, so a case can never `observe` a term the rulebook can't see.
+
+Usage:  python3 ir_to_adj.py <gated_ir.json>  ->  prints the case .adj to stdout
+        (or imported: ir_to_adj(ir, findings_dict) -> (adj_text, dropped))
+"""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_findings():
+    d = json.load(open(os.path.join(HERE, "dictionary.json")))
+    return {f["functor"]: set(f["value_domain"]) for f in d["findings"]}
+
+
+def _parse_term(term):
+    """'csf_glucose(low)' -> ('csf_glucose', 'low'); bare atom -> (atom, None)."""
+    term = term.strip()
+    if "(" in term and term.endswith(")"):
+        functor, value = term[:-1].split("(", 1)
+        return functor.strip(), value.strip()
+    return term, None
+
+
+def ir_to_adj(ir, findings_dict):
+    """Return (adj_text, dropped). `dropped` lists findings excluded as LEAP."""
+    leap = {j["term"] for j in ir.get("inference_justifications", [])
+            if j.get("verdict") == "LEAP"}
+    lines, dropped = [], []
+    seen = set()
+    for f in ir.get("findings", []):
+        term = f["term"].replace(" ", "")
+        functor, value = _parse_term(term)
+        if functor not in findings_dict or value not in findings_dict[functor]:
+            raise ValueError(f"{ir.get('case_id')}: term '{term}' is not in the dictionary "
+                             f"(enforcement: rulebook and case must share one vocabulary)")
+        if f.get("polarity") == "denied":
+            continue  # negation is carried by the value (normal/absent/negative), not by observe
+        if f.get("type") == "inferred" and term in leap:
+            dropped.append(term)       # surfaced over-read: do not assert it
+            continue
+        if term in seen:
+            continue
+        seen.add(term)
+        lines.append(f"observe {functor}({value})")
+    adj = (f"% case {ir.get('case_id')} — observations only; the rulebook supplies the queries\n"
+           + "\n".join(lines) + "\n")
+    return adj, dropped
+
+
+def main(path):
+    ir = json.load(open(path))
+    adj, dropped = ir_to_adj(ir, load_findings())
+    if dropped:
+        sys.stderr.write(f"dropped LEAP findings: {dropped}\n")
+    sys.stdout.write(adj)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: python3 ir_to_adj.py <gated_ir.json>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])


### PR DESCRIPTION
**MYCIN-2026 prototype, PR4.** The warm path — messy vignette → typed IR → adversarial read → case `.adj` → engine. The model is used at **exactly one point** (decompose) and there are **zero answer-time model calls** at decision time.

## Pipeline
- **`decompose.workflow.js`** — LLM decomposes prose → typed IR (canonical dictionary findings + byte spans + type/polarity + **discard list** + inference justifications), dictionary-constrained, and **does not diagnose**. Quality was high: it distinguished "procalcitonin not sent" (a legal term, *not observed*) from a finding, and refused to force a pleocytosis type when the differential was pending.
- **`adversarial_read.workflow.js`** — 3 model-diverse readers (Opus+Sonnet+Haiku) per case run the **inference read** + the **new discard read** (the dangerous direction: is a dropped span actually a load-bearing finding?), majority-voted. On these faithful decompositions: 0 over-reads, 0 wrongly-dropped findings — the safety net confirming nothing was lost.
- **`ir_to_adj.py`** — deterministic, model-free IR → case `.adj` (`observe` lines); every term validated against the dictionary (raises on drift). The "IR → ADJ program" frontend.
- **`decide.py`** — concat the CAS rulebook + case `.adj` → `adj-lang-cli` → differential + proof DAG. Invokes **only the engine binary**. Plus an **evidence-sufficiency guard**: if the leader fired zero contributions (decision would rest on the prior alone) → **abstain**.

## Result — 4/4 defensible, `answer_time_model_calls_total = 0`
| case | decision | gold | ✓ |
|---|---|---|---|
| MEN-1 | determinate → bacterial (P=1.0) | bacterial | ✓ |
| MEN-2 | determinate → bacterial (**P=0.9999**, over-saturated) | bacterial | ✓ |
| MEN-3 | determinate → viral (P=1.0) | viral | ✓ |
| MEN-4 | **insufficient_evidence → abstain** | indeterminate | ✓ |

MEN-4 surfaced (and the guard fixed) the honest failure mode — *don't decide on base rates when no evidence was observed*. MEN-2's 0.9999 is the over-saturation target for PR5's cost-to-correct proof. Writeup: [`CASE_PIPELINE.md`](code/specs/data/mycin-prototype/CASE_PIPELINE.md).

## Next
PR5 — the five proofs + FINDINGS (golden rulebook reuse, cost-to-correct, audit trail, error localization, CPU-bound).

Security review: PASSED. BATCH=10 on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)