### PR TITLE
feat(mccarthy-lisp): W14b — McCarthy lambda on native AOT (F7) — NATIVE AOT COMPLETE (F1-F7)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `aarch64-backend`
 
+## 0.9.0 — 2026-06-10 — McCarthy lambda (F7): `lispy_to_exit_code` builtin (LANG77 / W14b)
+
+Adds `lispy_to_exit_code` to `V1_BUILTINS` (→ `BL __twig_lispy_to_exit_code`), the
+universal program-exit coercion for a polymorphic lambda result (W13b). This was the
+*only* gap for native `LAMBDA` on the tagged-word backend — cross-function `call`
+(Twig `fib`), the `any`/`ref<Lispy…>` value model (cons), and the shared arg-boxing +
+result-coercion passes were already in place. Native lambda now runs (verified
+end-to-end on macOS arm64). New unit test `lispy_to_exit_code_lowers`.
+
 ## 0.8.0 — 2026-06-04 — ATOM/EQ predicate + truthy helpers (LANG77 / McCarthy L3b-2c-2)
 
 Adds four `V1_BUILTINS` rows — `lispy_pair_p` (1), `lispy_not` (1),

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/README.md
+++ b/code/packages/rust/aarch64-backend/README.md
@@ -30,5 +30,10 @@ V1: stack-spill register allocation, integer arithmetic + comparisons +
 control flow + returns.  Enough to compile typed Twig functions like
 `fib`, `fact`, `sum`.  See CHANGELOG for the full opcode list.
 
+McCarthy 1960 Lisp (LANG77) compiles end-to-end through this backend via the
+`__twig_lispy_*` runtime calls in `V1_BUILTINS` — cons/car/cdr, the ATOM/EQ
+predicates, COND truthiness, and (W14b) `LAMBDA`: cross-function `call`s plus
+`lispy_to_exit_code` (the polymorphic program-exit coercion) make native lambda run.
+
 Later passes will add: real register allocation, float operations,
 runtime-call lowering, deopt support for JIT.

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -212,6 +212,10 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "lispy_not",       n_args: 1, returns: true },
     BuiltinSig { name: "lispy_equal",     n_args: 2, returns: true },
     BuiltinSig { name: "lispy_truthy",    n_args: 1, returns: true },
+    // LANG77 W13b — the universal program-exit coercion for a polymorphic
+    // (lambda / `any`) result: dispatch on the runtime tag.
+    // `int64_t __twig_lispy_to_exit_code(uint64_t)`.
+    BuiltinSig { name: "lispy_to_exit_code", n_args: 1, returns: true },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -1463,6 +1467,26 @@ mod tests {
         ] {
             assert!(symbols.contains(&want), "missing {want}: {symbols:?}");
         }
+    }
+
+    /// W14b (F7): the universal exit coercion `lispy_to_exit_code` — the program
+    /// boundary for a polymorphic lambda result — lowers to a BL into the runtime.
+    #[test]
+    fn lispy_to_exit_code_lowers() {
+        assert!(lookup_builtin("lispy_to_exit_code").is_some(), "builtin must be registered");
+        let cir = vec![
+            const_u64("x", 5 << 3),
+            call_builtin(Some("r"), "lispy_to_exit_code", &["x"]),
+            ret_u64("r"),
+        ];
+        let (bytes, ext) = compile_with_relocs(&ctx("exit_coerce", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("to_exit_code must lower: {e}"));
+        assert!(!bytes.is_empty() && bytes.len() % 4 == 0);
+        let symbols: Vec<&str> = ext.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_lispy_to_exit_code"),
+            "missing __twig_lispy_to_exit_code: {symbols:?}",
+        );
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.41.0 — 2026-06-10 — McCarthy **native AOT lambda** (F7) — **NATIVE AOT COMPLETE F1–F7** (LANG77 / W14b)
+
+No `lang-aot` source change — the fix is in `aarch64-backend` 0.9.0 + `x86_64-backend`
+0.11.0 (`lispy_to_exit_code` added to `V1_BUILTINS`), which the native path already
+drives. `tests/macos_native_lisp.rs` gains `mccarthy_lambda_runs_natively_on_macos`:
+`((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
+`((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, `((LAMBDA (X) (ATOM X)) 7)`→1,
+lambda-with-`COND`-body→100/200. **Native AOT is now McCarthy-complete (F1–F7)** — the
+seventh backend, after VM/WASM/JVM/CLR/BEAM/LLVM. Only the JIT (W15) remains.
+
 ## 0.40.0 — 2026-06-10 — McCarthy **native AOT** (F2–F6) now links + runs on macOS arm64 (LANG77 / W14a)
 
 No `lang-aot` source change — the fix is in `code-packager` 0.5.0 (Mach-O external

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/tests/macos_native_lisp.rs
+++ b/code/packages/rust/lang-aot/tests/macos_native_lisp.rs
@@ -55,3 +55,19 @@ fn mccarthy_core_runs_natively_on_macos() {
     assert_eq!(run("(EQ (QUOTE A) (QUOTE A))", "n_sym_t"), 1);
     assert_eq!(run("(EQ (QUOTE A) (QUOTE B))", "n_sym_f"), 0);
 }
+
+#[test]
+fn mccarthy_lambda_runs_natively_on_macos() {
+    if !ld_available() { eprintln!("no system linker — skipping"); return; }
+    // F7 — `LAMBDA`: arg boxed across the call, polymorphic result coerced at exit
+    // by `__twig_lispy_to_exit_code`. Native AOT is the seventh backend to run these.
+    assert_eq!(run("((LAMBDA (X) X) 5)", "n_lam_id"), 5);
+    assert_eq!(run("((LAMBDA (X) (CAR X)) (CONS 7 9))", "n_lam_car"), 7);
+    assert_eq!(run("((LAMBDA (X) (CDR X)) (CONS 7 9))", "n_lam_cdr"), 9);
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 3)", "n_lam_eq_t"), 1);
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 4)", "n_lam_eq_f"), 0);
+    assert_eq!(run("((LAMBDA (X) (ATOM X)) 7)", "n_lam_atom"), 1);
+    // lambda body is itself a COND (composes F5 + F7).
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0)", "n_lam_c0"), 100);
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 9)", "n_lam_c9"), 200);
+}

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — `x86_64-backend`
 
+## 0.11.0 — 2026-06-10 — McCarthy lambda (F7): `lispy_to_exit_code` builtin (LANG77 / W14b)
+
+Adds `lispy_to_exit_code` to `V1_BUILTINS` (→ `call __twig_lispy_to_exit_code`), the
+universal program-exit coercion for a polymorphic lambda result (W13b) — mirroring
+the `aarch64-backend` change so native McCarthy lambda is uniform across both host
+arches. New unit test `lispy_to_exit_code_lowers`.
+
 ## 0.10.0 — 2026-06-04 — ATOM/EQ predicate + truthy helpers (LANG77 / McCarthy L3b-2c-2)
 
 Adds four `V1_BUILTINS` rows — `lispy_pair_p` (1), `lispy_not` (1),

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/README.md
+++ b/code/packages/rust/x86_64-backend/README.md
@@ -60,6 +60,7 @@ Matches the aarch64-backend baseline through LANG38:
 | Returns | `ret_<ty>`, `ret_void` |
 | Moves | `mov_<ty>` |
 | Type guards | `type_assert` (lowered to `UD2` trap — AOT has no deopt) |
+| Lisp runtime (LANG77) | `call_builtin "lispy_*"` → `CALL __twig_lispy_*` — cons/car/cdr, ATOM/EQ predicates, COND truthiness, and `lispy_to_exit_code` (W14b — the polymorphic lambda-result exit coercion) |
 
 
 ## Register allocation

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -309,6 +309,10 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "lispy_not",       n_args: 1, returns: true },
     BuiltinSig { name: "lispy_equal",     n_args: 2, returns: true },
     BuiltinSig { name: "lispy_truthy",    n_args: 1, returns: true },
+    // LANG77 W13b — the universal program-exit coercion for a polymorphic
+    // (lambda / `any`) result: dispatch on the runtime tag.
+    // `int64_t __twig_lispy_to_exit_code(uint64_t)`.
+    BuiltinSig { name: "lispy_to_exit_code", n_args: 1, returns: true },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -1407,6 +1411,26 @@ mod tests {
         ] {
             assert!(symbols.contains(&want), "missing {want}: {symbols:?}");
         }
+    }
+
+    /// W14b (F7): the universal exit coercion `lispy_to_exit_code` — the program
+    /// boundary for a polymorphic lambda result — lowers to a call into the runtime.
+    #[test]
+    fn lispy_to_exit_code_lowers() {
+        let ir = vec![
+            instr("const_u64", Some("x"), vec![Op::Int(5 << 3)]),
+            call_builtin(Some("r"), "lispy_to_exit_code", &["x"]),
+            instr("ret_u64", None, vec![Op::Var("r".into())]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("exit_coerce", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("to_exit_code must lower");
+        assert!(!bytes.is_empty());
+        let symbols: Vec<&str> = relocs.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_lispy_to_exit_code"),
+            "missing __twig_lispy_to_exit_code: {symbols:?}",
+        );
     }
 
     #[test]

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -58,7 +58,7 @@ representation + per-builtin backend lowering.
 | Backend | Crate(s) | F1 | F2 | F3 | F4 | F5 | F6 | F7 | Value model |
 |---------|----------|----|----|----|----|----|----|----|-------------|
 | **VM** | `mccarthy-lisp-vm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged (interpreter over `lispy-runtime`) |
-| **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
+| **AOT native** | `twig-aot` + `aarch64`/`x86_64-backend` + `lispy_runtime.c` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged-word |
 | **WASM** | `iir-to-wasm` + `wasm-*` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-anyref |
 | **JVM** | `iir-to-jvm-class-file` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-Object |
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
@@ -292,9 +292,8 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
 
 ### Phase F — native AOT + JIT completion
 
-- ◑ **W14 — native AOT `LAMBDA`/`LABEL` (F7).** *In progress.* Finish closures/
-  user-calls on the tagged-word native backend (cons/ATOM/EQ/COND/symbols already
-  done in L3b-2).
+- ✅ **W14 — native AOT `LAMBDA`/`LABEL` (F7). DONE — NATIVE AOT COMPLETE (F1–F7).**
+  Seventh backend to finish all seven features (after VM/WASM/JVM/CLR/BEAM/LLVM).
   - ✅ **W14a — close the macOS Mach-O runtime-link gap.** The native object
     referenced the runtime helpers by their raw C name (`__twig_lispy_car`), but the
     `cc`-built archive — Mach-O C ABI — exports them decorated (`___twig_lispy_car`),
@@ -305,11 +304,16 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     Verified by RUNNING natively on macOS arm64: `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1,
     `(EQ 7 7)`→1, `(COND …)`→11, `(EQ (QUOTE A) (QUOTE A))`→1
     (`lang-aot/tests/macos_native_lisp.rs`). **F2–F6 now run natively on macOS too.**
-  - ☐ **W14b — native backend `LAMBDA` (F7).** The native `aarch64-backend` still
-    refuses a lambda program (`untyped or unsupported op`): it needs the lisp
-    tagged-word typing (`any`/`ref<Lispy…>` → `i64`, as the LLVM backend does) and
-    `lispy_to_exit_code` in its `call_builtin` table. The shared IIR machinery
-    (arg boxing, result coercion) and the runtime helper already exist from W13b.
+  - ✅ **W14b — native backend `LAMBDA` (F7).** The reusable-primitives thesis at
+    its sharpest: native lambda was **one builtin-table row** away. All the machinery
+    already existed — cross-function `call` (from Twig `fib`), `any`/`ref<Lispy…>`
+    tagged-word values (from cons), arg boxing + result coercion (shared, W13b). The
+    only gap was `lispy_to_exit_code` missing from the `aarch64`/`x86_64` backends'
+    `V1_BUILTINS` table, so the `call_builtin` to it was refused as an unsupported op.
+    Adding the row to both backends makes native lambda run. Verified by RUNNING on
+    macOS arm64: `((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
+    `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, `((LAMBDA (X) (ATOM X)) 7)`→1,
+    lambda-with-`COND`-body→100/200 (`lang-aot/tests/macos_native_lisp.rs`).
 - ☐ **W15 — JIT McCarthy core (F1–F7).** Drive McCarthy through the JIT path.
 
 ### Phase G — conformance


### PR DESCRIPTION
## McCarthy lambda runs as native machine code — **native AOT is complete (F1–F7)**

The **seventh** backend to finish all seven features, after VM/WASM/JVM/CLR/BEAM/LLVM.

## The reusable-primitives thesis at its sharpest

Native lambda was **one builtin-table row** away. Everything else already existed:
- cross-function `call` (from Twig `fib`'s recursion),
- the `any`/`ref<Lispy…>` tagged-word value model (from cons/car/cdr),
- arg boxing + polymorphic result coercion (the shared `lower_lisp_repr`, W13b),
- the `__twig_lispy_to_exit_code` runtime helper (`lispy_runtime.c`, W13b),
- the macOS Mach-O link path (W14a).

The only gap: `lispy_to_exit_code` was missing from the `aarch64`/`x86_64` backends' `V1_BUILTINS` table, so the `call_builtin` to it was refused as an unsupported op (`backend refused function 'main'`). Adding the row to **both** backends makes the existing generic `call_builtin` path lower it to a `BL`/`CALL __twig_lispy_to_exit_code`.

## Change

**`aarch64-backend` 0.9.0 + `x86_64-backend` 0.11.0** — one `V1_BUILTINS` row each (`lispy_to_exit_code`, `n_args=1`, `returns=true` → `__twig_lispy_to_exit_code`). **No lowering-code change.** New unit test `lispy_to_exit_code_lowers` in each.

## Verified by RUNNING natively on macOS arm64 (`tests/macos_native_lisp.rs`)

| program | result |
|---|---|
| `((LAMBDA (X) X) 5)` | 5 |
| `((LAMBDA (X) (CAR X)) (CONS 7 9))` / `(CDR …)` | 7 / 9 |
| `((LAMBDA (X Y) (EQ X Y)) 3 3)` / `3 4` | 1 / 0 |
| `((LAMBDA (X) (ATOM X)) 7)` | 1 |
| `((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0` / `9)` | 100 / 200 |

F2–F6 (cons/predicates/COND/symbols) still run — no regression.

## Test plan

`aarch64-backend` **48** (+1), `x86_64-backend` **55** (+1), `lang-aot` `macos_native_lisp` 2 (F2–F6 + lambda, gated macos). clippy clean. No `twig-vm` dep → no Miri.

## Security & safety

Security review **PASSED**: the row is identical in shape to existing 1-arg returning lispy builtins (`lispy_car`/`unbox_int`/`truthy`); arity is validated by the unchanged validator (existing wrong-arity tests); single 64-bit in / 64-bit out matches the C ABI on AAPCS64 + SysV + MS x64; the lowering code is byte-for-byte unchanged (only a data row added).

## Matrix

Native AOT **F7 → ✅**. W14/W14b **DONE**. **NATIVE AOT COMPLETE (F1–F7)** — seventh backend. Only the **JIT (W15)** and the cross-backend conformance suite (W16) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)