### PR TITLE
feat(mccarthy-lisp): W15a — McCarthy on the universal JIT (F1-F6) — eighth backend begins

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — `lang-aot`
 
+## 0.42.0 — 2026-06-10 — McCarthy on the **universal JIT** (F1–F6) (LANG77 / W15a)
+
+Adds `run_mccarthy_on_jit(source)` + the `jit_lisp` module: McCarthy now runs on
+`jit-core`'s `GenericCirJit` — the eighth and final backend. The JIT dispatches
+`call_builtin "lispy_*"` to Rust callbacks (not native `__twig_lispy_*` calls like
+the AOT/LLVM path), so the lisp ops are registered against the shared `lispy-runtime`
+crate (the C runtime's Rust twin — identical `u64` tagged-word model). A `LispyValue`
+rides inside `Value::Int` as its bit pattern; `unbox_int`/`truthy` are derived from
+`LispyValue::as_int`/`is_truthy` (existing primitives, not duplicated). New deps:
+`vm-core`, `lispy-runtime`. New error variant `LangAotError::JitBackendError`.
+Verified by RUNNING (`tests/jit_mccarthy.rs`): `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1,
+`(EQ 7 7)`→1, nested `COND`→44, `(EQ (QUOTE A) (QUOTE A))`→1. Lambda (F7) is W15b —
+the VM's user-`call` path needs work first.
+
 ## 0.41.0 — 2026-06-10 — McCarthy **native AOT lambda** (F7) — **NATIVE AOT COMPLETE F1–F7** (LANG77 / W14b)
 
 No `lang-aot` source change — the fix is in `aarch64-backend` 0.9.0 + `x86_64-backend`

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
@@ -33,6 +33,11 @@ ge225-backend         = { path = "../ge225-backend" }
 ge225-encoder         = { path = "../ge225-encoder" }
 aot-core              = { path = "../aot-core" }
 jit-core              = { path = "../jit-core" }
+# JIT McCarthy path (W15): the universal bytecode JIT (`jit-core`) executes
+# McCarthy by dispatching its `lispy_*` builtins to the shared tagged-word value
+# runtime (`lispy-runtime`), bridged through the VM's `Value`.
+vm-core               = { path = "../vm-core" }
+lispy-runtime         = { path = "../lispy-runtime" }
 
 [[bin]]
 name = "lang-aot"

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -83,7 +83,17 @@ into the lambda, and the polymorphic result is coerced at the program exit by
 `__twig_lispy_to_exit_code` (a runtime tag switch) — `((LAMBDA (X) X) 5)` → 5,
 `((LAMBDA (X) (CAR X)) (CONS 7 9))` → 7, `((LAMBDA (X Y) (EQ X Y)) 3 3)` → 1,
 lambda-with-`COND`-body → 100/200. **LLVM is now McCarthy-complete (F1–F7)** — the
-sixth backend to finish, after VM/WASM/JVM/CLR/BEAM.
+sixth backend to finish, after VM/WASM/JVM/CLR/BEAM. **Native AOT** completed too
+(W14): the macOS Mach-O runtime-link gap closed (W14a — external symbols now carry
+the leading-`_` C decoration), and lambda runs via one `lispy_to_exit_code` row in
+each native backend's `V1_BUILTINS` (W14b) — the seventh backend.
+
+`run_mccarthy_on_jit(source)` runs McCarthy on the **universal JIT** —
+`jit-core::GenericCirJit`, the eighth and last backend (W15a, F1–F6). The JIT
+dispatches `call_builtin "lispy_*"` to Rust callbacks backed by the shared
+`lispy-runtime` crate (the C runtime's Rust twin), with a `LispyValue` riding inside
+the VM's `Value::Int` as its bit pattern — `(CAR (CONS 7 9))` → 7, `(ATOM 7)` → 1,
+nested `COND` → 44, `(EQ (QUOTE A) (QUOTE A))` → 1. Lambda (F7) is W15b.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/jit_lisp.rs
+++ b/code/packages/rust/lang-aot/src/jit_lisp.rs
@@ -1,0 +1,158 @@
+//! # McCarthy Lisp on the universal JIT (LANG77 / McCarthy W15)
+//!
+//! The eighth and final backend. `jit-core`'s [`GenericCirJit`] is a *universal
+//! bytecode JIT*: any typed-IIR language plugs in by registering its builtins as
+//! Rust callbacks. Unlike the AOT/LLVM tagged-word backends — which lower a
+//! `call_builtin "lispy_*"` to a native `call __twig_lispy_*` into the C runtime
+//! (`lispy_runtime.c`) — the JIT dispatches the *same* `lispy_*` names to Rust
+//! closures backed by the **shared [`lispy_runtime`] crate** (the C runtime's Rust
+//! twin: an identical `u64` tagged-word model). So the JIT inherits the whole lisp
+//! value model for free; this module is only the thin glue.
+//!
+//! ## Value bridging
+//!
+//! The JIT carries every value as a [`vm_core::value::Value`]. A `LispyValue` is a
+//! single `u64`, so it rides inside a `Value::Int(i64)` as the bit pattern — the
+//! JIT moves it opaquely (it never does arithmetic on a lisp word; the lowered IIR
+//! boxes integer atoms as `TAG_INT` and routes all lisp ops through `call_builtin`).
+//! [`to_lv`] / [`from_lv`] convert at the builtin boundary.
+//!
+//! ## Coercions (`unbox_int` / `truthy`)
+//!
+//! These program-boundary coercions live in `lispy_runtime.c` (C) but not as named
+//! functions in the Rust crate — they're trivial and derived here from the crate's
+//! existing public primitives (`LispyValue::as_int` / `is_truthy`), NOT duplicated.
+//!
+//! ## Safety
+//!
+//! [`to_lv`] uses [`LispyValue::from_raw_bits`] (`unsafe`): the contract is that the
+//! bits are a valid `LispyValue`. They always are here — every lisp word the JIT
+//! holds either came from [`from_lv`] (a real `LispyValue`) or from a lowered
+//! constant the McCarthy frontend emitted (`TAG_INT`/`TAG_NIL`/`TAG_SYMBOL`
+//! immediates). The frontend never fabricates a heap pointer (it performs no
+//! arithmetic on lisp values), so `car`/`cdr` only ever see a real cons cell or a
+//! non-heap value — for which `lispy_runtime::builtins::{car,cdr}` return `Err`,
+//! which we map to `nil` rather than panicking. The input is McCarthy *source*, run
+//! through the trusted frontend, so untrusted bytes cannot reach `from_raw_bits`
+//! with a forged heap tag. The JIT's default step-cap (fuel) bounds execution — and
+//! hence the number of `cons` allocations — so an adversarial loop cannot exhaust
+//! the heap.
+
+use crate::{compile_source_to_iir, Language, LangAotError};
+use jit_core::core::JITCore;
+use jit_core::GenericCirJit;
+use lispy_runtime::builtins;
+use lispy_runtime::value::LispyValue;
+use vm_core::core::VMCore;
+use vm_core::value::Value;
+
+/// Reinterpret a JIT `Value` as a tagged `LispyValue`.
+///
+/// SAFETY: see the module-level "Safety" note — the bits are always a valid
+/// `LispyValue` produced by [`from_lv`] or the McCarthy frontend's lowered
+/// constants; the frontend never forges a heap pointer.
+fn to_lv(v: &Value) -> LispyValue {
+    unsafe { LispyValue::from_raw_bits(v.as_i64().unwrap_or(0) as u64) }
+}
+
+/// Carry a tagged `LispyValue` back into the JIT as an opaque `Value::Int`.
+fn from_lv(lv: LispyValue) -> Value {
+    Value::Int(lv.bits() as i64)
+}
+
+/// `nil` as a JIT value — the graceful result when a lisp builtin traps (e.g.
+/// `car` of a non-pair) so a malformed program yields a value rather than a panic.
+fn nil() -> Value {
+    from_lv(LispyValue::NIL)
+}
+
+// ── The lisp builtins, as JIT callbacks (each `fn` is a `Copy` pointer so it can
+//    be registered on both the VM interpreter and the compiled JIT path). ──
+
+fn b_cons(a: &[Value]) -> Value {
+    match (a.first(), a.get(1)) {
+        (Some(x), Some(y)) => builtins::cons(&[to_lv(x), to_lv(y)]).map(from_lv).unwrap_or_else(|_| nil()),
+        _ => nil(),
+    }
+}
+fn b_car(a: &[Value]) -> Value {
+    a.first().map(|x| builtins::car(&[to_lv(x)]).map(from_lv).unwrap_or_else(|_| nil())).unwrap_or_else(nil)
+}
+fn b_cdr(a: &[Value]) -> Value {
+    a.first().map(|x| builtins::cdr(&[to_lv(x)]).map(from_lv).unwrap_or_else(|_| nil())).unwrap_or_else(nil)
+}
+fn b_pair_p(a: &[Value]) -> Value {
+    a.first().map(|x| builtins::pair_p(&[to_lv(x)]).map(from_lv).unwrap_or_else(|_| nil())).unwrap_or_else(nil)
+}
+fn b_not(a: &[Value]) -> Value {
+    a.first().map(|x| builtins::not(&[to_lv(x)]).map(from_lv).unwrap_or_else(|_| nil())).unwrap_or_else(nil)
+}
+fn b_equal(a: &[Value]) -> Value {
+    match (a.first(), a.get(1)) {
+        (Some(x), Some(y)) => builtins::equal_p(&[to_lv(x), to_lv(y)]).map(from_lv).unwrap_or_else(|_| nil()),
+        _ => nil(),
+    }
+}
+/// `lispy_truthy` — a tagged value → a raw machine `0`/`1` (false iff `#f`/nil),
+/// for the backend's `jmp_if_false` in a `COND`. Derived from `LispyValue::is_truthy`.
+fn b_truthy(a: &[Value]) -> Value {
+    Value::Int(a.first().map(|x| to_lv(x).is_truthy() as i64).unwrap_or(0))
+}
+/// `lispy_unbox_int` — a tagged integer → its raw machine value, the program-exit
+/// coercion for an integer result. Derived from `LispyValue::as_int` (`>> 3`).
+fn b_unbox_int(a: &[Value]) -> Value {
+    Value::Int(a.first().and_then(|x| to_lv(x).as_int()).unwrap_or(0))
+}
+
+/// Register every McCarthy `lispy_*` builtin on a VM + JIT pair, backed by the
+/// shared `lispy_runtime` crate. Each is registered on both the VM (the
+/// interpreter fallback for cold/untyped frames) and the `GenericCirJit` (the
+/// compiled path) so the two agree.
+fn register_lispy_builtins(vm: &mut VMCore, backend: &GenericCirJit) {
+    for (name, f) in [
+        ("lispy_cons", b_cons as fn(&[Value]) -> Value),
+        ("lispy_car", b_car),
+        ("lispy_cdr", b_cdr),
+        ("lispy_pair_p", b_pair_p),
+        ("lispy_not", b_not),
+        ("lispy_equal", b_equal),
+        ("lispy_truthy", b_truthy),
+        ("lispy_unbox_int", b_unbox_int),
+    ] {
+        vm.builtins_mut().register(name, move |args: &[Value]| Ok(f(args)));
+        backend.register_builtin(name, move |args: &[Value]| f(args));
+    }
+}
+
+/// Compile McCarthy `source` and **run it on the universal JIT**, returning the
+/// program's integer result (the entry point's return value).
+///
+/// The full tagged-word pipeline (`lower_heap_builtins_runtime` → `intern_symbols`
+/// → `lower_lisp_repr`) is applied — the same lowering the native AOT / LLVM
+/// backends use — then the `lispy_*` builtins are wired to `lispy_runtime` and the
+/// module is driven through [`JITCore::execute_with_jit`].
+///
+/// Returns `Ok(None)` if the entry point returns no value (a `void` program).
+/// Covers McCarthy F1–F6 (scalar / cons / ATOM / EQ / COND / symbols). `LAMBDA`
+/// (F7) is W15b — the VM's user-`call` path needs work first.
+pub fn run_mccarthy_on_jit(source: &str) -> Result<Option<i64>, LangAotError> {
+    let mut module = compile_source_to_iir(Language::McCarthyLisp, source, "jit")?;
+    iir_builtin_lowering::lower_heap_builtins_runtime(&mut module);
+    iir_builtin_lowering::intern_symbols(&mut module);
+    iir_builtin_lowering::lower_lisp_repr(&mut module);
+
+    let mut vm = VMCore::new();
+    let backend = GenericCirJit::new(); // default step-cap (fuel) bounds execution
+    register_lispy_builtins(&mut vm, &backend);
+    let error_handle = backend.error_handle();
+
+    let mut jit = JITCore::new(&mut vm, Box::new(backend));
+    let result = jit
+        .execute_with_jit(&mut vm, &mut module, "main", &[])
+        .map_err(|e| LangAotError::JitBackendError(format!("{e:?}")))?;
+
+    if let Some(msg) = error_handle.lock().unwrap_or_else(|e| e.into_inner()).clone() {
+        return Err(LangAotError::JitBackendError(msg));
+    }
+    Ok(result.and_then(|v| v.as_i64()))
+}

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -47,6 +47,10 @@ use std::path::Path;
 
 use interpreter_ir::module::IIRModule;
 
+/// McCarthy Lisp on the universal JIT backend (W15).
+pub mod jit_lisp;
+pub use jit_lisp::run_mccarthy_on_jit;
+
 /// Source language a `lang-aot` invocation is compiling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Language {
@@ -144,6 +148,9 @@ pub enum LangAotError {
     /// Carries the human-readable string from `iir-to-llvm` (which already
     /// includes the failing function name and the unsupported op/type).
     LlvmBackendError(String),
+    /// The universal JIT (`jit-core`) rejected or trapped while running the IIR
+    /// (McCarthy W15). Carries the JIT/VM error string.
+    JitBackendError(String),
     /// The RV32I backend rejected the IIR.
     ///
     /// Carries the human-readable string from `iir-to-riscv` (which
@@ -213,6 +220,7 @@ impl fmt::Display for LangAotError {
             LangAotError::AotError(e) => write!(f, "{e}"),
             LangAotError::Io(e) => write!(f, "io: {e}"),
             LangAotError::LlvmBackendError(m) => write!(f, "llvm: {m}"),
+            LangAotError::JitBackendError(m) => write!(f, "jit: {m}"),
             LangAotError::WasmBackendError(m) => write!(f, "wasm: {m}"),
             LangAotError::JvmBackendError(m) => write!(f, "jvm: {m}"),
             LangAotError::ClrBackendError(m) => write!(f, "clr: {m}"),

--- a/code/packages/rust/lang-aot/tests/jit_mccarthy.rs
+++ b/code/packages/rust/lang-aot/tests/jit_mccarthy.rs
@@ -1,0 +1,56 @@
+//! # McCarthy Lisp on the universal JIT — F1–F6 (LANG77 / McCarthy W15a).
+//!
+//! Drives McCarthy source through `jit-core`'s `GenericCirJit` (the eighth and
+//! final backend) via `lang_aot::run_mccarthy_on_jit`, which registers the
+//! `lispy_*` builtins against the shared `lispy-runtime` value model and runs the
+//! module with `JITCore::execute_with_jit`. VERIFY BY RUNNING — assert the
+//! computed integer result, exactly as the wasm/jvm/clr suites do with their
+//! in-repo simulators.
+//!
+//! `LAMBDA` (F7) is NOT covered here: the VM's user-`call` path panics on a lambda
+//! frame today, which is the separate W15b slice.
+
+use lang_aot::run_mccarthy_on_jit;
+
+fn run(src: &str) -> i64 {
+    run_mccarthy_on_jit(src)
+        .unwrap_or_else(|e| panic!("JIT run of {src:?} failed: {e}"))
+        .unwrap_or_else(|| panic!("JIT run of {src:?} returned no value"))
+}
+
+#[test]
+fn scalar_f1() {
+    assert_eq!(run("42"), 42);
+    assert_eq!(run("(COND ((EQ 1 1) 7))"), 7);
+}
+
+#[test]
+fn cons_car_cdr_f2() {
+    assert_eq!(run("(CAR (CONS 7 9))"), 7);
+    assert_eq!(run("(CDR (CONS 7 9))"), 9);
+    assert_eq!(run("(CAR (CDR (CONS 1 (CONS 2 3))))"), 2);
+}
+
+#[test]
+fn atom_eq_predicates_f3_f4() {
+    assert_eq!(run("(ATOM 7)"), 1);
+    assert_eq!(run("(ATOM (CONS 1 2))"), 0);
+    assert_eq!(run("(EQ 7 7)"), 1);
+    assert_eq!(run("(EQ 7 8)"), 0);
+}
+
+#[test]
+fn cond_f5() {
+    assert_eq!(run("(COND ((ATOM 7) 11) ((ATOM 8) 22))"), 11);
+    assert_eq!(run("(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))"), 22);
+    // nested COND
+    assert_eq!(run("(COND ((EQ 1 1) (COND ((EQ 2 3) 11) ((EQ 4 4) 44))))"), 44);
+}
+
+#[test]
+fn symbols_f6() {
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE A))"), 1);
+    assert_eq!(run("(EQ (QUOTE A) (QUOTE B))"), 0);
+    assert_eq!(run("(ATOM (QUOTE A))"), 1);
+    assert_eq!(run("(COND ((EQ (QUOTE A) (QUOTE A)) 11) ((EQ 1 1) 22))"), 11);
+}

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -64,7 +64,7 @@ representation + per-builtin backend lowering.
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged-word |
-| **JIT** | (lang JIT path) | ✅ | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ | tagged-word |
+| **JIT** | `jit-core` + `lispy-runtime` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
 furthest along; the managed backends are the frontier.)
@@ -314,7 +314,21 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     macOS arm64: `((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
     `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, `((LAMBDA (X) (ATOM X)) 7)`→1,
     lambda-with-`COND`-body→100/200 (`lang-aot/tests/macos_native_lisp.rs`).
-- ☐ **W15 — JIT McCarthy core (F1–F7).** Drive McCarthy through the JIT path.
+- ◑ **W15 — JIT McCarthy core (F1–F7).** *In progress.* Drive McCarthy through the
+  universal JIT (`jit-core::GenericCirJit`) — the eighth and last backend.
+  - ✅ **W15a — JIT F1–F6 (scalar / cons / ATOM / EQ / COND / symbols).** The JIT
+    dispatches `call_builtin "lispy_*"` to **Rust callbacks** (not native `__twig_lispy_*`
+    calls), so the lisp ops are registered against the shared **`lispy-runtime`** crate
+    (the C runtime's Rust twin — identical `u64` tagged-word model). A `LispyValue`
+    rides inside `Value::Int` as its bit pattern; the JIT moves it opaquely. The
+    `unbox_int`/`truthy` exit coercions are derived from `LispyValue::as_int`/`is_truthy`
+    (existing primitives — not duplicated). New reusable entry `lang_aot::run_mccarthy_on_jit`.
+    Verified by RUNNING (`lang-aot/tests/jit_mccarthy.rs`): `(CAR (CONS 7 9))`→7,
+    `(ATOM 7)`→1, `(EQ 7 7)`→1, nested `COND`→44, `(EQ (QUOTE A) (QUOTE A))`→1.
+  - ☐ **W15b — JIT `LAMBDA` (F7). Completes the JIT — and McCarthy across all eight
+    backends.** The VM's user-`call` path (`vm-core::dispatch`) panics on a lambda
+    frame today; that must be fixed (or the JIT taught to call user functions) before
+    a lambda runs. The lowered IIR + `lispy_to_exit_code` coercion already exist.
 
 ### Phase G — conformance
 


### PR DESCRIPTION
## McCarthy runs on the universal JIT — the eighth and final backend begins

`jit-core`'s `GenericCirJit` now runs McCarthy F1–F6 (scalar / cons / ATOM / EQ / COND / symbols). Lambda (F7) is **W15b**.

## The shape of it

Unlike the AOT/LLVM tagged-word backends — which lower `call_builtin "lispy_*"` to a native `call __twig_lispy_*` into the C runtime — the universal JIT dispatches the **same** `lispy_*` names to **Rust callbacks**. So McCarthy's lisp ops are registered against the shared **`lispy-runtime`** crate (the C runtime's Rust twin: an identical `u64` tagged-word model). The JIT inherits the whole value model; this slice is the thin glue.

## Change

**`lang-aot` 0.42.0** — new `jit_lisp` module + `run_mccarthy_on_jit(source)`:
- compile McCarthy → the **same** tagged-word lowering the AOT/LLVM paths use (`lower_heap_builtins_runtime` + `intern_symbols` + `lower_lisp_repr`) → register `lispy_cons`/`car`/`cdr`/`pair_p`/`not`/`equal`/`truthy`/`unbox_int` on both the VM (interpreter fallback) and the `GenericCirJit` (compiled path), backed by `lispy-runtime` → `JITCore::execute_with_jit`.
- **Value bridging:** a `LispyValue` is a `u64`, so it rides inside `Value::Int` as the bit pattern; the JIT moves it opaquely. `unbox_int`/`truthy` are **derived** from `LispyValue::as_int`/`is_truthy` (existing primitives) — not duplicated, so the Miri-gated `lispy-runtime` crate is untouched.
- New deps `vm-core` + `lispy-runtime`; new error variant `LangAotError::JitBackendError`.

## Verified by RUNNING (`tests/jit_mccarthy.rs`)

| program | result |
|---|---|
| `(CAR (CONS 7 9))` / `(CDR (CONS 7 9))` | 7 / 9 |
| `(ATOM 7)` / `(ATOM (CONS 1 2))` | 1 / 0 |
| `(EQ 7 7)` / `(EQ 7 8)` | 1 / 0 |
| `(COND ((ATOM 7) 11) ((ATOM 8) 22))` / nested `COND` | 11 / 44 |
| `(EQ (QUOTE A) (QUOTE A))` / `(QUOTE B)` / `(ATOM (QUOTE A))` | 1 / 0 / 1 |

## Security & safety

Security review **PASSED** (rigorous memory-safety analysis): the one `unsafe` (`to_lv` → `from_raw_bits`) is sound for frontend-produced IIR — the McCarthy frontend emits **no arithmetic opcode**, atoms box as `TAG_INT` (`0b000`, can never alias `TAG_HEAP` `0b111`), and the only heap values come from real `lispy_cons` allocations, so `car`/`cdr` (tag-checked, return `Err`→`nil` on non-pair) never deref a forged pointer. Input is McCarthy *source* through the trusted frontend; the residual hand-crafted-IIR risk is documented in the module's Safety note and unreachable via the source-in API. No panics (graceful `.unwrap_or_else`/`.first()`/`.get()`; poison-safe lock). DoS bounded by the JIT's default 100M-step fuel cap (bounds cons-allocation count on the non-GC heap).

## Test plan

`lang-aot` `jit_mccarthy` 5 tests (F1–F6). clippy clean. `lispy-runtime` is **used, not modified** → no Miri; no `twig-vm`.

## Matrix

JIT **F2–F6 → ✅** (F1 already ✅). **W15a ✅**; **W15b (lambda) ☐** — the VM's user-`call` path (`vm-core::dispatch`) panics on a lambda frame and must be fixed first. Seven backends complete (VM/WASM/JVM/CLR/BEAM/LLVM/native AOT); JIT at F1–F6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)