### PR TITLE
feat(closurec): CLOC12.70 — close gap-060 (member-callee new-expr wrap)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.74.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-060** — member-callee new-expression wrap:
+  `new a.b.C().d` → `(new a.b.C).d`. Generalizes gap-059 from a
+  single-identifier callee to a member-chain callee.
+
+### Changed — gap-059 pre-pass generalized
+
+The new-expr wrap pre-pass (gap-059) now scans a CALLEE EXTENT
+— the leading identifier plus zero-or-more `.IDENT` accessors —
+before the empty `()`, instead of requiring exactly one
+identifier. The single-identifier case (gap-059) is the
+zero-accessor special case, so both are handled by one unified
+pass that reorders the `(` to before `new` (no synthetic
+tokens). Computed `[...]` callees and arg-bearing forms
+(gap-061) stay deferred. 3 new gap060_* unit tests.
+
 ## [0.73.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.73.0"
+version = "0.74.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -540,45 +540,62 @@ pub fn whitespace_only_minify(
     //   `new A ( ) .`   →   `( new A ) .`
     //   [new,A,(,),.]       [(,new,A,),.]
     //
-    // Minimal safe slice (matches the byte-identity fixture
-    // `minify_new_member_chain`):
-    //   - single plain-identifier callee (`new A`, not
-    //     `new a.b.C` — member-callee deferred),
+    // Safe slice (matches `minify_new_member_chain` (gap-059)
+    // AND `minify_new_member_callee` (gap-060)):
+    //   - the CALLEE is a plain identifier optionally followed
+    //     by `.IDENT` member accessors: `new A` (gap-059) or
+    //     `new a.b.C` (gap-060). Computed `[...]` callees are a
+    //     deferred follow-up.
     //   - EMPTY arg list `()` (arg-bearing `new A(y).b` →
-    //     `(new A(y)).b` is a deferred follow-up),
+    //     `(new A(y)).b` is a deferred follow-up — it can't use
+    //     the reorder trick since the args aren't empty),
     //   - followed by `.`, `[`, or `(`.
     //
     // Guards:
     //   - operator `new`, not the property name `.new`/`?.new`
     //     (a property `new` is preceded by a member accessor),
-    //   - all bracket checks go through `is_structural_punct`
-    //     so a string/regex/template whose value looks like a
-    //     bracket can never trigger the reorder.
+    //   - all bracket / accessor checks go through
+    //     `is_structural_punct` so a string/regex/template whose
+    //     value looks like a bracket can never trigger it.
     {
         let mut i = 0;
-        while i + 4 < kept.len() {
+        while i + 1 < kept.len() {
             let is_operator_new = kept[i].value == "new"
                 && !is_string_literal(kept[i])
                 && (i == 0
                     || (!is_structural_punct(&kept[i - 1], ".")
                         && !is_structural_punct(&kept[i - 1], "?.")));
             if is_operator_new
-                && is_simple_identifier_token(Some(kept[i + 1]))
-                && is_structural_punct(&kept[i + 2], "(")
-                && is_structural_punct(&kept[i + 3], ")")
-                && (is_structural_punct(&kept[i + 4], ".")
-                    || is_structural_punct(&kept[i + 4], "[")
-                    || is_structural_punct(&kept[i + 4], "("))
+                && is_simple_identifier_token(kept.get(i + 1).copied())
             {
-                // Reorder: pull the `(` (empty arg-list open)
-                // out from i+2 and re-insert it before `new`.
-                // The `)` stays put — now closing the wrap.
-                let open = kept.remove(i + 2);
-                kept.insert(i, open);
-                // Past `( new IDENT )`; the member/call token
-                // is now at i+4 and re-scanned next iteration.
-                i += 4;
-                continue;
+                // Scan the callee extent: the leading identifier
+                // (at i+1) plus zero or more `.IDENT` accessors.
+                let mut p = i + 2;
+                while p + 1 < kept.len()
+                    && is_structural_punct(&kept[p], ".")
+                    && is_simple_identifier_token(Some(kept[p + 1]))
+                {
+                    p += 2;
+                }
+                // Expect EMPTY args `( )` at p, p+1 then a
+                // member/call follower at p+2.
+                if p + 2 < kept.len()
+                    && is_structural_punct(&kept[p], "(")
+                    && is_structural_punct(&kept[p + 1], ")")
+                    && (is_structural_punct(&kept[p + 2], ".")
+                        || is_structural_punct(&kept[p + 2], "[")
+                        || is_structural_punct(&kept[p + 2], "("))
+                {
+                    // Reorder: pull the `(` (empty arg-list open)
+                    // out from p and re-insert it before `new`.
+                    // The `)` stays put — now closing the wrap.
+                    let open = kept.remove(p);
+                    kept.insert(i, open);
+                    // Past `( new <callee> )`; the follower is
+                    // now at p+2 and re-scanned next iteration.
+                    i = p + 2;
+                    continue;
+                }
             }
             i += 1;
         }
@@ -3552,6 +3569,31 @@ mod tests {
     #[test]
     fn gap059_new_call_then_member_wraps() {
         assert_eq!(minify("var x=new Foo().bar;"), "var x=(new Foo).bar;");
+    }
+
+    /// gap-060: member-CALLEE new-expr — `new a.b.C().d` →
+    /// `(new a.b.C).d`. The callee scan consumes the `.IDENT`
+    /// accessor chain (`a.b.C`) before the empty `()`.
+    #[test]
+    fn gap060_member_callee_new_wraps() {
+        assert_eq!(minify("var x=new a.b.C().d;"), "var x=(new a.b.C).d;");
+    }
+
+    /// gap-060: member callee + computed-member follower —
+    /// `new a.b().c[0]` → `(new a.b).c[0]` (only the new-expr
+    /// is wrapped; the trailing chain is untouched).
+    #[test]
+    fn gap060_member_callee_then_member_chain() {
+        assert_eq!(minify("var x=new a.b().c;"), "var x=(new a.b).c;");
+    }
+
+    /// gap-060 non-regression: a member-callee new with NO
+    /// following member/call is left to gap-050's domain (and
+    /// gap-050 only handles single-identifier callees, so this
+    /// stays as-is — a separate deferred gap, not gap-060).
+    #[test]
+    fn gap060_member_callee_standalone_unchanged() {
+        assert_eq!(minify("var x=new a.b.C();"), "var x=new a.b.C();");
     }
 
     /// gap-059: `new Foo()[0]` → `(new Foo)[0]` (computed

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.73.0
+Version: 0.74.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-060 (CLOC14.30): member-callee new-expr —
-    // `new a.b.C().d` → `(new a.b.C).d`. gap-059 handled only a
-    // single-identifier callee; the member-chain callee needs
-    // callee-extent scanning. Deferred follow-up of gap-059.
-    ("new_member_callee", "gap-060: new-expr member callee `new a.b.C().d`"),
     // gap-061 (CLOC14.30): arg-bearing new-expr member —
     // `new A(y).b` → `(new A(y)).b`. gap-059 handled only the
     // EMPTY arg list; non-empty args need arg-list scanning.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -466,9 +466,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-060 — member-callee new-expression
 
-- **Status:** OPEN — discovered by CLOC14.30. `minify_new_member_callee` ignored.
+- **Status:** **RESOLVED** in CLOC12.70. `minify_new_member_callee` flips IGNORED → PASS.
 - **Input:** `var x=new a.b.C().d;` → **Upstream:** `var x=(new a.b.C).d;`
-- **What it needs:** Extend gap-059's new-expr wrap to a MEMBER-CHAIN callee (`a.b.C`), not just a single identifier. The pre-pass must scan the callee extent (identifiers + `.`/`[...]` member access) between `new` and the `(`, then wrap. Follow-up of gap-059.
+- **Fix:** Generalized gap-059's new-expr reorder to a member-chain callee. The callee scan now consumes the leading identifier plus zero-or-more `.IDENT` accessors before the empty `()`, then reorders the `(` to before `new` (same no-synthetic-token trick). The single-identifier case (gap-059) is the zero-accessor special case, so the two are unified in one pass. Computed `[...]` callees and arg-bearing forms (gap-061) remain deferred. Standalone member-callee `new a.b.C()` → `new a.b.C` (no member follows) is a SEPARATE gap-050 limitation (gap-050 only handles single-identifier callees), not gap-060.
 
 ### gap-061 — arg-bearing new-expression member
 


### PR DESCRIPTION
## What

Closes **gap-060** (found in CLOC14.30). Generalizes gap-059's new-expression wrap from a single-identifier callee to a member-chain callee:

```
new a.b.C().d   →   (new a.b.C).d
```

`minify_new_member_callee` flips IGNORED → PASS.

## How

The gap-059 pre-pass now scans a **callee extent** — the leading identifier plus zero-or-more `.IDENT` accessors — before the empty `()`, then reorders the `(` to before `new` (same no-synthetic-token trick). The single-identifier case (gap-059) is the zero-accessor special case, so both are unified in one pass. Guards preserved: operator-`new` only (property `.new` untouched), empty-args-only (arg-bearing `new A(y).b` deferred to gap-061), all checks via `is_structural_punct`.

## Tests

- 3 new `gap060_*` unit tests (member callee, member-callee-then-member, standalone non-regression).
- 23 suites green incl. byte-identity harness with `new_member_callee` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified callee scan, operator-new guard, empty-args matching, reorder correctness, gap-059 non-regression, bounds, structural-punct guard (incl. two-consecutive-new-exprs and `new a.b` near-EOF).

Computed `[...]` callees and arg-bearing forms (gap-061) remain deferred. Version 0.73→0.74; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)