### PR TITLE
feat(adj-lang): grammar regen tooling + plan for deterministic-via-probabilistic predicates

### DIFF
--- a/code/packages/rust/adj-lang/src/bin/regen_grammars.rs
+++ b/code/packages/rust/adj-lang/src/bin/regen_grammars.rs
@@ -1,0 +1,39 @@
+//! `regen_grammars` — regenerate the adj-lang lexer/parser grammar Rust files
+//! from the source `.tokens` / `.grammar` in `code/grammars/`.
+//!
+//! The generated `src/_lexer_grammar.rs` / `src/_parser_grammar.rs` are
+//! AUTO-GENERATED — do not edit them by hand. After editing `adj_lang.tokens`
+//! or `adj_lang.grammar`, run:
+//!
+//! ```sh
+//! cargo run -p adj-lang --bin regen_grammars
+//! ```
+//!
+//! This is the codegen entry point the crate previously lacked (the files had
+//! been produced by an ad-hoc invocation). It is idempotent on an unchanged
+//! grammar.
+
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::{compile_parser_grammar, compile_token_grammar};
+use grammar_tools::parser_grammar::parse_parser_grammar;
+use grammar_tools::token_grammar::parse_token_grammar;
+
+fn main() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let grammars = manifest.join("../../../grammars");
+    let src = manifest.join("src");
+
+    let toks = fs::read_to_string(grammars.join("adj_lang.tokens")).expect("read adj_lang.tokens");
+    let tg = parse_token_grammar(&toks).expect("parse adj_lang.tokens");
+    fs::write(src.join("_lexer_grammar.rs"), compile_token_grammar(&tg, "adj_lang.tokens"))
+        .expect("write _lexer_grammar.rs");
+
+    let gram = fs::read_to_string(grammars.join("adj_lang.grammar")).expect("read adj_lang.grammar");
+    let pg = parse_parser_grammar(&gram).expect("parse adj_lang.grammar");
+    fs::write(src.join("_parser_grammar.rs"), compile_parser_grammar(&pg, "adj_lang.grammar"))
+        .expect("write _parser_grammar.rs");
+
+    println!("regenerated src/_lexer_grammar.rs and src/_parser_grammar.rs");
+}

--- a/code/specs/data/adj-deterministic/PLAN.md
+++ b/code/specs/data/adj-deterministic/PLAN.md
@@ -1,0 +1,54 @@
+# ADJ deterministic-via-probabilistic — build plan (resumable)
+
+## Principle (locked)
+Deterministic decision-making is a **special case of probabilistic** — ONE engine. A verdict is a
+HYPOTHESIS; a hard rule "when C then V" is `contributes <saturating LR> from C to V`;
+DETERMINATE/INDETERMINATE/CONFLICT **fall out of the existing `differential`** (leader / kickback /
+insufficient-evidence). Do NOT build a second engine. See memory
+`feedback_deterministic_is_probabilistic_special_case`.
+
+## The only real gap: predicates (first-class operator syntax, user's choice)
+Express `contributes 1e6 from gross_income >= 14600 to required_to_file` over a valued fact
+`observe gross_income(18000)`. The engine evaluates the predicate against the observed numeric value
+on CPU. "Deterministic" = a saturating LR.
+
+## Build slices (PRs)
+
+### Slice 0 — regen tooling (LANDED)
+`adj-lang/src/bin/regen_grammars.rs` — reads `code/grammars/adj_lang.tokens` + `.grammar`, calls
+`grammar_tools::compiler::compile_token_grammar` / `compile_parser_grammar` (after
+`parse_token_grammar` / `parse_parser_grammar`), writes `src/_lexer_grammar.rs` /
+`src/_parser_grammar.rs`. The codegen entry point the crate previously lacked. **Verified idempotent**
+on the unchanged grammar (reproduces the committed files exactly). Run:
+`cargo run -p adj-lang --bin regen_grammars`.
+
+### Slice 1 — predicate feature (ONE coupled PR — NOT splittable)
+**Finding (verified):** the adapter navigates the parse tree by rule/position
+(`adapter.rs` looks for the "conclusion term" child of `contributes_decl`). Inserting an `evidence`
+non-terminal changes the tree shape and breaks the adapter — so the grammar, AST, adapter, lower, and
+engine MUST change together in one PR (a grammar-only change leaves 8 adj-lang tests red). Steps:
+- **Tokens:** add `GE = ">="  LE = "<="  EQEQ = "=="  GT = ">"  LT = "<"` (multi-char before single).
+  NUMBER already supports `1e6`.
+- **Grammar:** `contributes_decl = "contributes" NUMBER "from" evidence "to" term { annotation }` ;
+  `evidence = predicate | term` ; `predicate = IDENT (GE|LE|GT|LT|EQEQ) NUMBER`. Regenerate.
+- **ast.rs:** `Statement::Contributes` evidence → `Evidence::Term(Term) | Evidence::Predicate{slot,op,value}`.
+- **adapter.rs:** handle the `evidence` node (unwrap to term, or build a predicate); update the
+  `contributes_decl` child navigation so existing term contributions still adapt.
+- **lower.rs:** lower a predicate-gated contribution to a new logic_engine clause `(slot, op, value, logit)`.
+- **logic-engine (`lr_aggregate`):** `PredicateContributionClause`; when aggregating a conclusion,
+  find the observed valued fact `slot(V)` (V = `Term::Num`), evaluate the predicate, add `logit_delta`
+  if true; `DerivationOrigin::FromPredicateContribution` cites the clause + observed value. Valued fact
+  `observe gross_income(18000)` already lowers to `Compound{"gross_income",[Num(18000)]}`.
+- **adj-lang-cli:** render the predicate step in the proof DAG JSON.
+- Tests at adapter / lower / engine / CLI layers; `cargo build --workspace` (ignore pre-existing
+  `uefi`); revert `cargo fmt` churn outside touched files.
+
+### Slice 2 — the Haiku run (separate PR, after the language lands)
+Haiku decomposes each run100/run100b case (policy → saturating predicate rules, scenario → valued
+facts), emit unified `.adj`, `adj-lang-cli` executes on CPU (0 answer-time calls), score vs gold
+(DETERMINATE/INDETERMINATE via the differential). Proves dumb-model + CPU-bound + auditable at scale.
+
+## Verification
+`cargo run -p adj-lang --bin regen_grammars` (regenerates, idempotent), `cargo test -p adj-lang`,
+`cargo test -p logic-engine`, a golden `adj-lang-cli` run on a predicate program, `cargo build --workspace`
+(ignore the pre-existing `uefi` failure). Revert `cargo fmt` churn outside touched files.


### PR DESCRIPTION
Foundation for unifying **deterministic adjudication under adj-lang's probabilistic engine** — per the principle that *deterministic decision-making is a special case of probabilistic*: a verdict is a hypothesis, a hard rule is a saturating `contributes`, and DETERMINATE / INDETERMINATE / CONFLICT fall out of the existing `differential` (leader / kickback / insufficient-evidence). **No second engine.**

## This PR (safe foundation)
- **`adj-lang/src/bin/regen_grammars.rs`** — the grammar codegen entry point the crate lacked. The generated `_lexer_grammar.rs` / `_parser_grammar.rs` had been produced by an ad-hoc invocation; this makes regeneration reproducible: `cargo run -p adj-lang --bin regen_grammars`. **Verified idempotent** — on the unchanged grammar it reproduces the committed files byte-for-byte (so it's safe to use for the real grammar change).
- **`code/specs/data/adj-deterministic/PLAN.md`** — the design + the remaining work as **one coupled PR** (predicate-gated contributions). 

## Key finding (verified, in the plan)
The predicate feature can't be split into independently-green slices: the **adapter navigates the parse tree by position**, so inserting an `evidence` non-terminal into `contributes_decl` changes the tree shape and reds 8 adj-lang tests. The grammar, AST, adapter, lowering, and engine must change **together**. The plan specs each step (tokens `>= <= == > <`; `evidence = predicate | term`; an `Evidence` AST enum; a `PredicateContributionClause` in logic-engine that evaluates the predicate against an observed valued fact `gross_income(18000)`; CLI rendering).

## Next
1. The predicate feature (one PR, per the plan) — then `contributes 1e6 from gross_income >= 14600 to required_to_file` expresses a deterministic rule.
2. The **Haiku run**: Haiku decomposes each run100/run100b case → unified `.adj` → `adj-lang-cli` executes on CPU at 0 answer-time calls → score vs gold across 20 domains.

adj-lang green (14 tests). Security review: PASSED (codegen reads compile-time constants, fixed write paths, no untrusted input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)