### PR TITLE
feat(mccarthy-lisp): W15b — McCarthy lambda/LABEL on the universal JIT (F7) — JIT COMPLETE; all eight backends done

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — `lang-aot`
 
+## 0.43.0 — 2026-06-10 — McCarthy **JIT lambda/LABEL** (F7) — **JIT COMPLETE; all eight backends done** (LANG77 / W15b)
+
+`jit_lisp` registers `lispy_to_exit_code` (the polymorphic lambda-result exit
+coercion — a runtime tag dispatch derived from `LispyValue`'s predicates, the only
+builtin lambda needs beyond W15a's set). Together with the `vm-core` 0.3.0
+register-sizing fix, McCarthy `LAMBDA`/`LABEL`/recursion now run on the universal
+JIT. Verified by RUNNING (`tests/jit_mccarthy.rs`): `((LAMBDA (X) X) 5)`→5,
+`((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1,
+lambda-with-`COND`-body→100/200, recursive `LABEL`→7. **The JIT is the eighth and
+final backend — McCarthy 1960 LISP now runs on every LANG VM backend (F1–F7).**
+
 ## 0.42.0 — 2026-06-10 — McCarthy on the **universal JIT** (F1–F6) (LANG77 / W15a)
 
 Adds `run_mccarthy_on_jit(source)` + the `jit_lisp` module: McCarthy now runs on

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -89,11 +89,13 @@ the leading-`_` C decoration), and lambda runs via one `lispy_to_exit_code` row 
 each native backend's `V1_BUILTINS` (W14b) — the seventh backend.
 
 `run_mccarthy_on_jit(source)` runs McCarthy on the **universal JIT** —
-`jit-core::GenericCirJit`, the eighth and last backend (W15a, F1–F6). The JIT
+`jit-core::GenericCirJit`, the **eighth and final backend** (W15, **F1–F7**). The JIT
 dispatches `call_builtin "lispy_*"` to Rust callbacks backed by the shared
 `lispy-runtime` crate (the C runtime's Rust twin), with a `LispyValue` riding inside
 the VM's `Value::Int` as its bit pattern — `(CAR (CONS 7 9))` → 7, `(ATOM 7)` → 1,
-nested `COND` → 44, `(EQ (QUOTE A) (QUOTE A))` → 1. Lambda (F7) is W15b.
+nested `COND` → 44, `(EQ (QUOTE A) (QUOTE A))` → 1, `((LAMBDA (X) X) 5)` → 5, and a
+recursive `LABEL` → 7. **With the JIT, McCarthy 1960 LISP now runs on every LANG VM
+backend (F1–F7): VM, native AOT, JIT, WASM, JVM, CLR, BEAM, LLVM.**
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/jit_lisp.rs
+++ b/code/packages/rust/lang-aot/src/jit_lisp.rs
@@ -103,6 +103,29 @@ fn b_truthy(a: &[Value]) -> Value {
 fn b_unbox_int(a: &[Value]) -> Value {
     Value::Int(a.first().and_then(|x| to_lv(x).as_int()).unwrap_or(0))
 }
+/// `lispy_to_exit_code` — the program-exit coercion for a **polymorphic** result
+/// (a `LAMBDA` whose return type is `any`): dispatch on the runtime tag, exactly as
+/// `__twig_lispy_to_exit_code` does in `lispy_runtime.c`. Integer → its raw value;
+/// `#t`/`#f`/nil → `1`/`0`/`0`; a symbol or pair → its tagged word verbatim. Built
+/// from `LispyValue`'s existing predicates — not duplicated.
+fn b_to_exit_code(a: &[Value]) -> Value {
+    Value::Int(
+        a.first()
+            .map(|x| {
+                let lv = to_lv(x);
+                if let Some(n) = lv.as_int() {
+                    n
+                } else if lv.is_true() {
+                    1
+                } else if lv.is_false() || lv.is_nil() {
+                    0
+                } else {
+                    lv.bits() as i64 // symbol / pair: the tagged word, verbatim
+                }
+            })
+            .unwrap_or(0),
+    )
+}
 
 /// Register every McCarthy `lispy_*` builtin on a VM + JIT pair, backed by the
 /// shared `lispy_runtime` crate. Each is registered on both the VM (the
@@ -118,6 +141,7 @@ fn register_lispy_builtins(vm: &mut VMCore, backend: &GenericCirJit) {
         ("lispy_equal", b_equal),
         ("lispy_truthy", b_truthy),
         ("lispy_unbox_int", b_unbox_int),
+        ("lispy_to_exit_code", b_to_exit_code),
     ] {
         vm.builtins_mut().register(name, move |args: &[Value]| Ok(f(args)));
         backend.register_builtin(name, move |args: &[Value]| f(args));
@@ -133,8 +157,8 @@ fn register_lispy_builtins(vm: &mut VMCore, backend: &GenericCirJit) {
 /// module is driven through [`JITCore::execute_with_jit`].
 ///
 /// Returns `Ok(None)` if the entry point returns no value (a `void` program).
-/// Covers McCarthy F1–F6 (scalar / cons / ATOM / EQ / COND / symbols). `LAMBDA`
-/// (F7) is W15b — the VM's user-`call` path needs work first.
+/// Covers all of McCarthy F1–F7 (scalar / cons / ATOM / EQ / COND / symbols /
+/// `LAMBDA` / `LABEL` / recursion) — the JIT is the eighth and final backend.
 pub fn run_mccarthy_on_jit(source: &str) -> Result<Option<i64>, LangAotError> {
     let mut module = compile_source_to_iir(Language::McCarthyLisp, source, "jit")?;
     iir_builtin_lowering::lower_heap_builtins_runtime(&mut module);

--- a/code/packages/rust/lang-aot/tests/jit_mccarthy.rs
+++ b/code/packages/rust/lang-aot/tests/jit_mccarthy.rs
@@ -7,8 +7,8 @@
 //! computed integer result, exactly as the wasm/jvm/clr suites do with their
 //! in-repo simulators.
 //!
-//! `LAMBDA` (F7) is NOT covered here: the VM's user-`call` path panics on a lambda
-//! frame today, which is the separate W15b slice.
+//! `LAMBDA`/`LABEL` (F7) is covered by `lambda_and_label_f7` (W15b) — the JIT is now
+//! McCarthy-complete (F1–F7), the eighth and final backend.
 
 use lang_aot::run_mccarthy_on_jit;
 
@@ -53,4 +53,23 @@ fn symbols_f6() {
     assert_eq!(run("(EQ (QUOTE A) (QUOTE B))"), 0);
     assert_eq!(run("(ATOM (QUOTE A))"), 1);
     assert_eq!(run("(COND ((EQ (QUOTE A) (QUOTE A)) 11) ((EQ 1 1) 22))"), 11);
+}
+
+#[test]
+fn lambda_and_label_f7() {
+    // Direct application: the argument is boxed across the call and the
+    // polymorphic result coerced at the program exit by `lispy_to_exit_code`.
+    assert_eq!(run("((LAMBDA (X) X) 5)"), 5);
+    assert_eq!(run("((LAMBDA (X) (CAR X)) (CONS 7 9))"), 7);
+    assert_eq!(run("((LAMBDA (X) (CDR X)) (CONS 7 9))"), 9);
+    // A predicate body → boolean result, truthy-coerced to 0/1.
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 3)"), 1);
+    assert_eq!(run("((LAMBDA (X Y) (EQ X Y)) 3 4)"), 0);
+    assert_eq!(run("((LAMBDA (X) (ATOM X)) 7)"), 1);
+    // Lambda body is a COND over the parameter (composes F5 + F7).
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0)"), 100);
+    assert_eq!(run("((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 9)"), 200);
+    // LABEL: a recursive closure. `FF` descends the car-spine to the leftmost atom.
+    assert_eq!(run("((LABEL FF (LAMBDA (X) (COND ((ATOM X) X) ((QUOTE T) (FF (CAR X)))))) (CONS (CONS 7 8) 9))"), 7);
+    assert_eq!(run("((LABEL FF (LAMBDA (X) (COND ((ATOM X) X) ((QUOTE T) (FF (CAR X)))))) 42)"), 42);
 }

--- a/code/packages/rust/vm-core/CHANGELOG.md
+++ b/code/packages/rust/vm-core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — vm-core
 
+## [0.3.0] — 2026-06-10 (McCarthy W15b — lambda-frame register sizing)
+
+### Fixed
+
+- `VMFrame::for_function` now sizes the register file to
+  `max(register_count, params.len())`. A frontend may under-report
+  `register_count` for a function whose only registers are its parameters — a
+  hoisted McCarthy `LAMBDA` body like `(LAMBDA (X) X)` reports `register_count = 0` —
+  and the dispatcher writes the call arguments directly at indices `0..params.len()`.
+  Previously the register file was sized to `register_count` alone, so a lambda call
+  indexed past the end of `registers` and **panicked**. This mirrors how `assign`
+  already grows the file for under-reported *locals*. Unblocks McCarthy `LAMBDA`/
+  `LABEL` on the universal JIT (the eighth and final backend). New unit test
+  `for_function_sizes_registers_to_cover_params_when_count_underreports`.
+
 ## [0.2.1] — 2026-05-22
 
 ### Added (LANG74 follow-up — universal `mov` dispatch)

--- a/code/packages/rust/vm-core/Cargo.toml
+++ b/code/packages/rust/vm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-core"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Generic register interpreter for InterpreterIR — the vm-core of the LANG pipeline"
 

--- a/code/packages/rust/vm-core/README.md
+++ b/code/packages/rust/vm-core/README.md
@@ -62,7 +62,10 @@ integer classification (`0–255 → "u8"`, `0–65535 → "u16"`, etc.).
 
 One frame per active function call.  Holds a flat `registers: Vec<Value>` and a
 `name_to_reg: HashMap<String, usize>` that maps variable names to register
-indices.  `assign()` grows the register file on demand.
+indices.  `assign()` grows the register file on demand, and `for_function()`
+sizes it to at least the parameter count (`max(register_count, params.len())`) so
+the dispatcher can place call arguments at indices `0..params.len()` even when a
+frontend under-reports `register_count` (e.g. a hoisted McCarthy `LAMBDA` body).
 
 ### `VMCore` — the execution API
 

--- a/code/packages/rust/vm-core/src/frame.rs
+++ b/code/packages/rust/vm-core/src/frame.rs
@@ -83,7 +83,14 @@ impl VMFrame {
         register_count: usize,
         return_dest: Option<usize>,
     ) -> Self {
-        let mut frame = VMFrame::new(fn_name, register_count, return_dest);
+        // A function always needs at least one register slot per parameter: the
+        // dispatcher places the call arguments directly at indices `0..params.len()`.
+        // A frontend may under-report `register_count` (e.g. a hoisted `LAMBDA` body
+        // whose only register is its parameter reports `0`), so size the register
+        // file to cover the parameters regardless — mirroring how `assign` grows the
+        // file for under-reported *locals*. Without this a lambda call indexes past
+        // the end of `registers` and panics.
+        let mut frame = VMFrame::new(fn_name, register_count.max(params.len()), return_dest);
         for (idx, (param_name, _)) in params.iter().enumerate() {
             frame.name_to_reg.insert(param_name.clone(), idx);
         }
@@ -156,6 +163,24 @@ mod tests {
         frame.registers[1] = Value::Int(20);
         assert_eq!(frame.resolve("a"), Some(&Value::Int(10)));
         assert_eq!(frame.resolve("b"), Some(&Value::Int(20)));
+    }
+
+    /// A frontend may under-report `register_count` for a function whose only
+    /// registers are its parameters — a hoisted McCarthy `LAMBDA` body like
+    /// `(LAMBDA (X) X)` reports `register_count = 0`. The register file must still
+    /// be sized to hold the parameters, or the dispatcher's direct
+    /// `registers[i] = arg` writes index past the end and panics (McCarthy W15b).
+    #[test]
+    fn for_function_sizes_registers_to_cover_params_when_count_underreports() {
+        let params = vec![("x".to_string(), "any".to_string())];
+        let mut frame = VMFrame::for_function("lambda_0", &params, 0, None);
+        assert!(
+            frame.registers.len() >= params.len(),
+            "register file must cover the parameters even when register_count under-reports",
+        );
+        // The dispatcher writes the argument directly by index — must not panic.
+        frame.registers[0] = Value::Int(5);
+        assert_eq!(frame.resolve("x"), Some(&Value::Int(5)));
     }
 
     #[test]

--- a/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
+++ b/code/specs/MCCARTHY-LISP-PLATFORM-MATRIX.md
@@ -64,7 +64,7 @@ representation + per-builtin backend lowering.
 | **CLR** | `iir-to-cil-bytecode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | uniform-object |
 | **BEAM** | `iir-to-beam` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Erlang terms |
 | **LLVM** | `iir-to-llvm` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged-word |
-| **JIT** | `jit-core` + `lispy-runtime` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ☐ | tagged-word |
+| **JIT** | `jit-core` + `lispy-runtime` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | tagged-word |
 
 (F-cell `✅` = verified end-to-end; `☐` = not yet. The VM and native AOT are the
 furthest along; the managed backends are the frontier.)
@@ -314,8 +314,9 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     macOS arm64: `((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
     `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, `((LAMBDA (X) (ATOM X)) 7)`→1,
     lambda-with-`COND`-body→100/200 (`lang-aot/tests/macos_native_lisp.rs`).
-- ◑ **W15 — JIT McCarthy core (F1–F7).** *In progress.* Drive McCarthy through the
-  universal JIT (`jit-core::GenericCirJit`) — the eighth and last backend.
+- ✅ **W15 — JIT McCarthy core (F1–F7). DONE — JIT COMPLETE.** The **eighth and final
+  backend** finishes all seven features. **McCarthy 1960 LISP now runs on every LANG
+  VM backend (F1–F7): VM, native AOT, JIT, WASM, JVM, CLR, BEAM, LLVM.**
   - ✅ **W15a — JIT F1–F6 (scalar / cons / ATOM / EQ / COND / symbols).** The JIT
     dispatches `call_builtin "lispy_*"` to **Rust callbacks** (not native `__twig_lispy_*`
     calls), so the lisp ops are registered against the shared **`lispy-runtime`** crate
@@ -325,10 +326,18 @@ F-cell(s) in the matrix above and add a row to the relevant CHANGELOG(s).
     (existing primitives — not duplicated). New reusable entry `lang_aot::run_mccarthy_on_jit`.
     Verified by RUNNING (`lang-aot/tests/jit_mccarthy.rs`): `(CAR (CONS 7 9))`→7,
     `(ATOM 7)`→1, `(EQ 7 7)`→1, nested `COND`→44, `(EQ (QUOTE A) (QUOTE A))`→1.
-  - ☐ **W15b — JIT `LAMBDA` (F7). Completes the JIT — and McCarthy across all eight
-    backends.** The VM's user-`call` path (`vm-core::dispatch`) panics on a lambda
-    frame today; that must be fixed (or the JIT taught to call user functions) before
-    a lambda runs. The lowered IIR + `lispy_to_exit_code` coercion already exist.
+  - ✅ **W15b — JIT `LAMBDA`/`LABEL` (F7). COMPLETES THE JIT — and McCarthy across all
+    eight backends.** Two small fixes: (1) `vm-core::VMFrame::for_function` now sizes
+    the register file to `max(register_count, params.len())` — a hoisted `LAMBDA` body
+    reports `register_count = 0`, so the dispatcher's direct `registers[i] = arg` write
+    indexed past the end and panicked; (2) `jit_lisp` registers `lispy_to_exit_code`
+    (the polymorphic-result coercion — a tag dispatch derived from `LispyValue`'s
+    predicates, the only builtin lambda needs beyond W15a's set). Verified by RUNNING
+    (`lang-aot/tests/jit_mccarthy.rs`): `((LAMBDA (X) X) 5)`→5,
+    `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1,
+    lambda-with-`COND`-body→100/200, and a recursive `LABEL` (`FF` descending the
+    car-spine to the leftmost atom)→7. Recursion depth is bounded by the JIT's fuel
+    step-cap.
 
 ### Phase G — conformance
 


### PR DESCRIPTION
## 🎉 McCarthy lambda/LABEL run on the JIT — the eighth and final backend is complete

McCarthy `LAMBDA`/`LABEL`/recursion now run on `jit-core`'s `GenericCirJit`. **McCarthy 1960 LISP is now complete (F1–F7) on EVERY LANG VM backend: VM, native AOT, JIT, WASM, JVM, CLR, BEAM, LLVM.**

## Two small fixes

**`vm-core` 0.3.0** — `VMFrame::for_function` now sizes the register file to `max(register_count, params.len())`. A hoisted `LAMBDA` body like `(LAMBDA (X) X)` reports `register_count = 0`, but the dispatcher places call arguments directly at indices `0..params.len()` (`registers[i] = arg`), so the file was indexed past its end and **panicked**. This mirrors how `assign` already grows the file for under-reported *locals*. The fix converts a panic (DoS) into correct behavior; for `register_count >= params.len()` it's a no-op.

**`lang-aot` 0.43.0** — `jit_lisp` registers `lispy_to_exit_code`, the polymorphic lambda-result exit coercion: a runtime tag dispatch (int → raw; `#t`/`#f`/nil → `1`/`0`/`0`; symbol/pair → tagged word verbatim) **derived from `LispyValue`'s existing predicates** (`as_int`/`is_true`/`is_false`/`is_nil`/`bits`) — pure tag classification, never derefs a heap pointer. It's the only builtin lambda needs beyond W15a's set.

## Verified by RUNNING (`tests/jit_mccarthy.rs`)

| program | result |
|---|---|
| `((LAMBDA (X) X) 5)` | 5 |
| `((LAMBDA (X) (CAR X)) (CONS 7 9))` / `(CDR …)` | 7 / 9 |
| `((LAMBDA (X Y) (EQ X Y)) 3 3)` / `3 4` | 1 / 0 |
| `((LAMBDA (X) (ATOM X)) 7)` | 1 |
| `((LAMBDA (N) (COND ((EQ N 0) 100) ((EQ 1 1) 200))) 0` / `9)` | 100 / 200 |
| recursive `LABEL` `FF` descending the car-spine | 7 |

F1–F6 still run (no regression). Recursion depth is bounded by the JIT's fuel step-cap.

## Security & safety

Security review **PASSED**: the register-sizing fix introduces no unbounded allocation (`params.len()` is bounded by IIR size, ≤ the unconstrained `register_count` path that already allocated), no `MAX_FRAME_REGISTERS` interaction, and is a no-op in the normal case — it converts an OOB **panic into correct behavior**. `b_to_exit_code` has no panic/OOB/overflow and **never follows a heap pointer** (tag classification only), preserving the W15a safety contract.

## Test plan

`vm-core` **40** (+1), `lang-aot` `jit_mccarthy` **6** (+1 `lambda_and_label_f7`). clippy clean. `vm-core` is **not** a `twig-vm` dep and has no `unsafe`; `lispy-runtime` is used, not modified → no Miri.

## Matrix

JIT **F7 → ✅**. W15/W15b **DONE**. **JIT COMPLETE.** **McCarthy 1960 LISP now runs on all eight LANG VM backends (F1–F7).** Only **W16** (cross-backend conformance suite) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)