### PR TITLE
feat(closurec): CLOC12.71 — close gap-061 (arg-bearing new-expr wrap)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.75.0] - 2026-06-10
+
+### Changed
+- **CLOSES gap-061** — arg-bearing new-expression member wrap:
+  `new A(y).b` → `(new A(y)).b`. Completes the new-expr-member
+  family (gap-059 single-ident, gap-060 member-callee, gap-061
+  arg-bearing).
+
+### Added — gap-061 synthetic-paren pre-pass
+
+Unlike gap-059/060 (which REORDER the empty arg-list parens),
+the arg-bearing wrap has no spare parens, so this pass INSERTS
+synthetic ones. Two grouping tokens — one `(` and one `)` —
+are cloned from the source's own parens and declared before
+`kept` so they outlive it; the pass inserts `&`-references (a
+`(` before `new`, a `)` after the arg-list's depth-balanced
+close). Reuses the gap-060 callee scan, so member-chain callees
+(`new a.b.C(y,z).d`), multiple args, and nested-call args
+(`new A(f(x)).b`) all wrap correctly. Guards: operator `new`
+only; non-empty args; follower ∈ `.`/`[`/`(`; all checks via
+`is_structural_punct`. 5 new gap061_* unit tests; the former
+gap059_arg_bearing_new_deferred test is updated to assert the
+wrapped form.
+
 ## [0.74.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.74.0"
+version = "0.75.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -145,6 +145,24 @@ pub fn whitespace_only_minify(
     // `type_name` string (set by the grammar's named rules);
     // we accept multiple common spellings since different
     // grammars label them differently.
+    // gap-061 needs to INSERT a `(`/`)` pair into the token
+    // stream (the arg-bearing new-expr wrap can't reuse the
+    // empty-args reorder trick). We clone one real `(` and one
+    // real `)` from the source as synthetic grouping parens —
+    // declared BEFORE `kept` so they outlive it, letting `kept`
+    // (a `Vec<&Token>`) hold references to them. Only `.value`
+    // matters for re-stitching, so the cloned line/column are
+    // irrelevant. If the source has no parens, gap-061 can't
+    // fire anyway, so `None` is fine.
+    let synth_open: Option<lexer::token::Token> = tokens
+        .iter()
+        .find(|t| is_structural_punct(t, "("))
+        .cloned();
+    let synth_close: Option<lexer::token::Token> = tokens
+        .iter()
+        .find(|t| is_structural_punct(t, ")"))
+        .cloned();
+
     let mut kept: Vec<_> = tokens
         .iter()
         .filter(|t| !is_trivia(t))
@@ -691,6 +709,105 @@ pub fn whitespace_only_minify(
         drops.sort_unstable();
         for &drop_idx in drops.iter().rev() {
             kept.remove(drop_idx);
+        }
+    }
+
+    // ---- gap-061: arg-bearing new-expression member wrap -----
+    // `new A(y).b` → `(new A(y)).b`. Like gap-059/060, a
+    // NewExpression that is the object/callee of a following
+    // `.`/`[`/`(` must be wrapped in parens. But here the arg
+    // list is NON-EMPTY (`(y)`), so we can't REORDER the empty
+    // parens — there are none spare. Instead we INSERT a
+    // synthetic `(` before `new` and a synthetic `)` after the
+    // arg-list's `)`.
+    //
+    // Match shape: `new <callee> ( <non-empty args> ) FOLLOWER`
+    //   - callee: identifier + zero-or-more `.IDENT` (same scan
+    //     as gap-060),
+    //   - NON-EMPTY args (at least one token between `(` `)` —
+    //     the empty case is gap-059/060's reorder),
+    //   - FOLLOWER ∈ {`.`,`[`,`(`}.
+    //
+    // Guards: operator `new` only (not `.new`/`?.new`); all
+    // bracket/accessor checks via `is_structural_punct`; the
+    // arg-list close is found by a depth-balanced scan so nested
+    // calls (`new A(f(x)).b`) are handled.
+    if let (Some(so), Some(sc)) = (synth_open.as_ref(), synth_close.as_ref()) {
+        let mut i = 0;
+        while i + 1 < kept.len() {
+            let is_operator_new = kept[i].value == "new"
+                && !is_string_literal(kept[i])
+                && (i == 0
+                    || (!is_structural_punct(&kept[i - 1], ".")
+                        && !is_structural_punct(&kept[i - 1], "?.")));
+            if is_operator_new
+                && is_simple_identifier_token(kept.get(i + 1).copied())
+            {
+                // Scan the callee extent (identifier + `.IDENT`).
+                let mut p = i + 2;
+                while p + 1 < kept.len()
+                    && is_structural_punct(&kept[p], ".")
+                    && is_simple_identifier_token(Some(kept[p + 1]))
+                {
+                    p += 2;
+                }
+                // `kept[p]` must be the arg-list `(` and the
+                // first arg token must NOT be `)` (non-empty).
+                if p + 1 < kept.len()
+                    && is_structural_punct(&kept[p], "(")
+                    && !is_structural_punct(&kept[p + 1], ")")
+                {
+                    // Depth-balanced scan for the matching `)`.
+                    let mut depth: i32 = 1;
+                    let mut close: Option<usize> = None;
+                    let mut j = p + 1;
+                    while j < kept.len() {
+                        let t = &kept[j];
+                        if is_structural_punct(t, "(")
+                            || is_structural_punct(t, "[")
+                            || is_structural_punct(t, "{")
+                        {
+                            depth += 1;
+                        } else if is_structural_punct(t, ")") {
+                            depth -= 1;
+                            if depth == 0 {
+                                close = Some(j);
+                                break;
+                            }
+                        } else if is_structural_punct(t, "]")
+                            || is_structural_punct(t, "}")
+                        {
+                            depth -= 1;
+                        }
+                        j += 1;
+                    }
+                    if let Some(q) = close {
+                        let follower_wraps = matches!(
+                            kept.get(q + 1).map(|t| t.value.as_str()),
+                            Some(".") | Some("[") | Some("(")
+                        ) && kept
+                            .get(q + 1)
+                            .map(|t| is_structural_punct(t, ".")
+                                || is_structural_punct(t, "[")
+                                || is_structural_punct(t, "("))
+                            .unwrap_or(false);
+                        if follower_wraps {
+                            // Insert `)` after the arg-list close
+                            // FIRST (higher index, no shift to
+                            // earlier positions), then `(` before
+                            // `new`.
+                            kept.insert(q + 1, sc);
+                            kept.insert(i, so);
+                            // `( new <callee> ( args ) )` now
+                            // spans i..=q+2; the follower sits at
+                            // q+3. Re-scan from there.
+                            i = q + 3;
+                            continue;
+                        }
+                    }
+                }
+            }
+            i += 1;
         }
     }
 
@@ -3626,12 +3743,47 @@ mod tests {
         assert_eq!(minify("var x=a.new().b;"), "var x=a.new().b;");
     }
 
-    /// gap-059 deferred: arg-bearing `new Foo(y).b` is left
-    /// untouched by the minimal slice (upstream wraps it to
-    /// `(new Foo(y)).b` — a follow-up).
+    /// gap-061: arg-bearing new-expr member — `new Foo(y).b` →
+    /// `(new Foo(y)).b`. Synthetic parens are inserted since the
+    /// arg list is non-empty (no spare parens to reorder). The
+    /// old behavior (left unchanged) was deferred; gap-061 makes
+    /// it byte-identical with upstream.
     #[test]
-    fn gap059_arg_bearing_new_deferred() {
-        assert_eq!(minify("var x=new Foo(y).b;"), "var x=new Foo(y).b;");
+    fn gap061_arg_bearing_new_wraps() {
+        assert_eq!(minify("var x=new Foo(y).b;"), "var x=(new Foo(y)).b;");
+    }
+
+    /// gap-061: member callee + multiple args + member follower
+    /// — `new a.b.C(y,z).d` → `(new a.b.C(y,z)).d`.
+    #[test]
+    fn gap061_member_callee_multi_arg_wraps() {
+        assert_eq!(
+            minify("var x=new a.b.C(y,z).d;"),
+            "var x=(new a.b.C(y,z)).d;"
+        );
+    }
+
+    /// gap-061: nested call in the arg list — the depth-balanced
+    /// scan finds the OUTER arg-list close. `new A(f(x)).b` →
+    /// `(new A(f(x))).b`.
+    #[test]
+    fn gap061_nested_call_args_wraps() {
+        assert_eq!(minify("var x=new A(f(x)).b;"), "var x=(new A(f(x))).b;");
+    }
+
+    /// gap-061 non-regression: arg-bearing new with NO following
+    /// member/call is NOT wrapped (`new A(y)` stays — nothing to
+    /// disambiguate).
+    #[test]
+    fn gap061_standalone_arg_new_unchanged() {
+        assert_eq!(minify("var x=new A(y);"), "var x=new A(y);");
+    }
+
+    /// gap-061 guard: property `new` (`a.new(x).b`) is not the
+    /// operator — must NOT wrap.
+    #[test]
+    fn gap061_property_new_not_wrapped() {
+        assert_eq!(minify("var x=a.new(x).b;"), "var x=a.new(x).b;");
     }
 
     // ---- gap-062: redundant double-paren collapse --------

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.74.0
+Version: 0.75.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,10 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-061 (CLOC14.30): arg-bearing new-expr member —
-    // `new A(y).b` → `(new A(y)).b`. gap-059 handled only the
-    // EMPTY arg list; non-empty args need arg-list scanning.
-    ("new_with_args_member", "gap-061: arg-bearing new-expr member `new A(y).b`"),
     // gap-055/056/057 all RESOLVED (CLOC12.64/65/66) — ternary
     // arms, return/throw/=> prefixes, and member-object parens
     // (`(a).b` → `a.b`) now pass and are no longer ignored.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -472,9 +472,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-061 — arg-bearing new-expression member
 
-- **Status:** OPEN — discovered by CLOC14.30. `minify_new_with_args_member` ignored.
+- **Status:** **RESOLVED** in CLOC12.71. `minify_new_with_args_member` flips IGNORED → PASS.
 - **Input:** `var x=new A(y).b;` → **Upstream:** `var x=(new A(y)).b;`
-- **What it needs:** gap-059 only handles the EMPTY arg list `()` (which it reorders). Non-empty args (`(y)`) can't be reordered the same way — the wrap needs a synthetic open-paren before `new` and a synthetic close-paren after the (non-empty) arg-list `)`. Follow-up of gap-059.
+- **Fix:** A new pre-pass that, unlike gap-059/060, INSERTS synthetic parens (the non-empty arg list has no spare parens to reorder). Two synthetic grouping tokens — one `(` and one `)` — are cloned from the source's own parens and declared before `kept` so they outlive it; the pass inserts `&`-references to them (a `(` before `new`, a `)` after the arg-list's depth-balanced close). Reuses the gap-060 callee scan; handles member-chain callees, multiple args, and nested-call args (`new A(f(x)).b`). Guards: operator `new` only; non-empty args (empty is gap-059/060's reorder); follower ∈ `.`/`[`/`(`; all checks via `is_structural_punct`. This completes the new-expression-member family (gap-059/060/061).
 
 ### gap-062 — redundant double-paren collapse
 


### PR DESCRIPTION
## What

Closes **gap-061** (found in CLOC14.30). Wraps an arg-bearing new-expression that is the object/callee of a `.`/`[`/`(`:

```
new A(y).b   →   (new A(y)).b
```

This **completes the new-expression-member wrap family**: gap-059 (single-identifier callee), gap-060 (member-chain callee), gap-061 (arg-bearing). `minify_new_with_args_member` flips IGNORED → PASS.

## How

Unlike gap-059/060 (which **reorder** the empty arg-list parens), the arg-bearing form has no spare parens, so this pass **inserts synthetic ones**. Two grouping tokens (one `(`, one `)`) are cloned from the source's own parens and declared before `kept` so they outlive it; the pass inserts `&`-references — a `(` before `new`, a `)` after the arg-list's depth-balanced close. Reuses the gap-060 callee scan, so member-chain callees (`new a.b.C(y,z).d`), multiple args, and nested-call args (`new A(f(x)).b`) all wrap. Guards: operator-`new` only (`a.new(x).b` untouched); non-empty args (empty is gap-059/060's reorder); follower ∈ `.`/`[`/`(`; all checks via `is_structural_punct`.

## Tests

- 5 new `gap061_*` unit tests; the former `gap059_arg_bearing_new_deferred` test now asserts the wrapped form.
- 23 suites green incl. byte-identity harness with `new_with_args_member` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified synthetic-token lifetime, insertion-shift correctness, empty-args exclusion (composes with gap-059/060, no double-wrap), depth scan, operator-`new`/property guards, follower guard, bounds.

> The reviewer noted a **pre-existing, unrelated** corruption (a string literal whose content is a lone bracket char, e.g. `new A(")")`) that reproduces on `origin/main`; gap-061's `is_structural_punct` guards correctly exclude it, so this PR is not at fault. Flagged separately as a follow-up.

Version 0.74→0.75; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)