### PR TITLE
feat(adj-lang): typed value literals — engine reads magnitude of quantity/money/percentage (ADJ expansion step 2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -90,6 +90,25 @@ fn predicate_gated_contribution_emits_cited_comparison_step() {
 }
 
 #[test]
+fn predicate_fires_over_typed_value_literal() {
+    // Step 2: a unit-bearing typed value. The engine reads the leading
+    // magnitude (18000) from `quantity(18000, usd)` for the comparison.
+    let (ok, s) = run(
+        "adjcli_typed.adj",
+        "prior 0.10 for required_to_file\n  source \"IRS Pub 501\" trust authoritative\n\
+         contributes 1000000 from gross_income >= 14600 to required_to_file\n  source \"IRS Pub 501 (2024)\" trust authoritative\n\
+         observe gross_income(quantity(18000, usd))\n? required_to_file\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"kind\":\"predicate\""), "{s}");
+    assert!(s.contains("\"observed\":18000"), "{s}");
+    assert!(
+        s.contains("\"posterior\":0.99") || s.contains("\"posterior\":1"),
+        "{s}"
+    );
+}
+
+#[test]
 fn predicate_below_threshold_does_not_fire() {
     // Income under the threshold: the predicate step never appears, and the
     // posterior stays at the prior.

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -488,6 +488,29 @@ mod tests {
     }
 
     #[test]
+    fn predicate_fires_over_typed_value_literal_end_to_end() {
+        // Step 2: typed value literals. `quantity(18000, usd)` already
+        // parses as a nested compound under the predicate grammar; the
+        // engine reads its leading magnitude (18000) for the predicate
+        // while the `usd` unit travels with the fact. No grammar change.
+        let src = r#"
+            prior 0.10 for required_to_file
+            contributes 1000000 from gross_income >= 14600 to required_to_file
+              source "IRS Pub 501 (2024)" trust authoritative
+            observe gross_income(quantity(18000, usd))
+            ? required_to_file
+        "#;
+        let lowered = compile(src).unwrap();
+        let query = &lowered.queries[0];
+        match search(query, &lowered.kb, SearchMode::LRAggregate) {
+            SearchResult::LRAggregateResult { posterior, .. } => {
+                assert!(posterior > 0.9999, "should saturate, got {posterior}");
+            }
+            other => panic!("expected LRAggregateResult, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn predicate_below_threshold_stays_at_prior() {
         let src = r#"
             prior 0.10 for required_to_file

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-06-10 — typed-value magnitudes (ADJ language expansion, step 2)
+
+### Added
+
+- **`numeric_magnitude(&Term) -> Option<f64>`** — extract the numeric
+  magnitude of a typed value. The ADJ language expansion models a fact's
+  value as either a bare number or a *typed-value wrapper* carrying the
+  magnitude as its leading argument and the unit afterward:
+  `quantity(18000, usd)`, `money(18000, usd)`, `percentage(40)`,
+  `duration(365, days)`, `count(3)`. The rule is uniform — "the leading
+  numeric argument" — so no closed set of wrapper functors is hard-coded.
+
+### Changed
+
+- **`observed_value(slot)`** now reads through a typed-value wrapper via
+  `numeric_magnitude`, so a predicate (`gross_income >= 14600`) fires over
+  `observe gross_income(quantity(18000, usd))` while the `usd` unit stays
+  attached to the fact for the (forthcoming) faithfulness gate. Bare
+  `slot(Num)` facts behave exactly as before.
+
 ## [0.8.0] - 2026-06-10 — predicate-gated contributions (deterministic = saturating probabilistic)
 
 ### Added

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -464,9 +464,20 @@ impl KnowledgeBase {
     }
 
     /// Read the observed numeric value of a valued slot, if one was
-    /// observed. A valued fact has the shape `slot(V)` where `V` is a
-    /// `Term::Num` — e.g. `observe gross_income(18000)` stores
+    /// observed. A valued fact has the shape `slot(V)` — for example
+    /// `observe gross_income(18000)` stores
     /// `Compound { functor: "gross_income", args: [Num(Int(18000))] }`.
+    ///
+    /// `V` may be either a bare number **or a typed-value wrapper** that
+    /// carries the magnitude first: `quantity(18000, usd)`,
+    /// `money(18000, usd)`, `percentage(40)`, `duration(365, days)`,
+    /// `count(3)`. The magnitude is the wrapper's leading numeric
+    /// argument — this is the unit-bearing typed value the ADJ language
+    /// expansion (step 2) extracts, and it lets a predicate
+    /// `gross_income >= 14600` fire over `quantity(18000, usd)` while the
+    /// `usd` unit travels with the fact for the faithfulness gate. See
+    /// [`numeric_magnitude`].
+    ///
     /// Only `Certain` facts gate predicates (same scope as
     /// [`observed_evidence`](Self::observed_evidence)). Returns the value
     /// of the most-recently-added matching fact, as `f64`.
@@ -477,11 +488,7 @@ impl KnowledgeBase {
             .filter(|f| f.probability == Probability::Certain)
             .filter_map(|f| match &f.term {
                 Term::Compound { functor, args } if functor == slot && args.len() == 1 => {
-                    match &args[0] {
-                        Term::Num(Number::Int(i)) => Some((f.id, *i as f64)),
-                        Term::Num(Number::Float(x)) => Some((f.id, *x)),
-                        _ => None,
-                    }
+                    numeric_magnitude(&args[0]).map(|v| (f.id, v))
                 }
                 _ => None,
             })
@@ -551,6 +558,41 @@ impl KnowledgeBase {
         } else {
             Some(matched)
         }
+    }
+}
+
+/// Extract the numeric **magnitude** of a typed value term, if it has one.
+///
+/// The ADJ language expansion (step 2) models a fact's value as either a
+/// bare number or a *typed-value wrapper* that carries the magnitude as
+/// its leading argument and the unit/currency afterward:
+///
+/// | surface value           | term shape                              | magnitude |
+/// |-------------------------|-----------------------------------------|-----------|
+/// | `18000`                 | `Num(18000)`                            | `18000.0` |
+/// | `quantity(18000, usd)`  | `Compound{quantity, [Num(18000), usd]}` | `18000.0` |
+/// | `money(18000, usd)`     | `Compound{money, [Num(18000), usd]}`    | `18000.0` |
+/// | `percentage(40)`        | `Compound{percentage, [Num(40)]}`       | `40.0`    |
+/// | `duration(365, days)`   | `Compound{duration, [Num(365), days]}`  | `365.0`   |
+/// | `count(3)`              | `Compound{count, [Num(3)]}`             | `3.0`     |
+///
+/// The rule is uniform — "the leading numeric argument" — so we do not
+/// hard-code a closed set of wrapper functors; any compound that puts a
+/// number first exposes that number as its magnitude. A predicate
+/// (`gross_income >= 14600`) compares against this magnitude while the
+/// unit stays attached to the fact for the faithfulness gate. Returns
+/// `None` for symbolic terms with no leading number.
+pub fn numeric_magnitude(value: &Term) -> Option<f64> {
+    match value {
+        Term::Num(Number::Int(i)) => Some(*i as f64),
+        Term::Num(Number::Float(x)) => Some(*x),
+        // Typed wrapper: the magnitude is the leading numeric argument.
+        Term::Compound { args, .. } => match args.first() {
+            Some(Term::Num(Number::Int(i))) => Some(*i as f64),
+            Some(Term::Num(Number::Float(x))) => Some(*x),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/code/packages/rust/logic-engine/src/lr_aggregate.rs
+++ b/code/packages/rust/logic-engine/src/lr_aggregate.rs
@@ -1172,6 +1172,54 @@ mod tests {
     }
 
     #[test]
+    fn predicate_fires_over_typed_quantity_wrapper() {
+        // Step 2: a typed value `quantity(18000, usd)` carries its unit;
+        // the predicate compares against the leading magnitude (18000)
+        // while `usd` stays attached to the fact for the audit gate.
+        let mut kb = KnowledgeBase::new();
+        kb.add_prior(PriorClause::from_probability(
+            atom("required_to_file"),
+            0.10,
+        ))
+        .unwrap();
+        kb.add_predicate_contribution(PredicateContributionClause::from_lr(
+            atom("required_to_file"),
+            "gross_income",
+            CmpOp::Ge,
+            14600.0,
+            1e6,
+        ));
+        kb.add_fact(Fact::certain(compound(
+            "gross_income",
+            vec![compound("quantity", vec![int(18000), atom("usd")])],
+        )));
+
+        let result = lr_aggregate(&atom("required_to_file"), &kb);
+        assert!(result.posterior > 0.9999, "got {}", result.posterior);
+    }
+
+    #[test]
+    fn numeric_magnitude_reads_bare_and_wrapped_values() {
+        use crate::numeric_magnitude;
+        assert_eq!(numeric_magnitude(&int(42)), Some(42.0));
+        assert_eq!(numeric_magnitude(&logic_core::float(3.5)), Some(3.5));
+        assert_eq!(
+            numeric_magnitude(&compound("quantity", vec![int(18000), atom("usd")])),
+            Some(18000.0)
+        );
+        assert_eq!(
+            numeric_magnitude(&compound("percentage", vec![int(40)])),
+            Some(40.0)
+        );
+        // No leading number → no magnitude.
+        assert_eq!(numeric_magnitude(&atom("usd")), None);
+        assert_eq!(
+            numeric_magnitude(&compound("pair", vec![atom("a"), int(1)])),
+            None
+        );
+    }
+
+    #[test]
     fn predicate_uses_latest_observation_of_slot() {
         // A later `observe` of the same slot supersedes the earlier value.
         let mut kb = KnowledgeBase::new();

--- a/code/specs/data/adj-language-expansion/DESIGN.md
+++ b/code/specs/data/adj-language-expansion/DESIGN.md
@@ -79,12 +79,18 @@ missing dispositive value → insufficient-evidence/kickback). No new verdict lo
 
 ## 5. The build loop (small PRs, each green + babysat)
 
-1. **Predicate-gated contributions** — `contributes <LR> from <slot> <op> <value> to <verdict>` over a
-   valued fact `observe slot(value)`. Tokens `>= <= == > <`, `evidence = predicate | term`, AST
-   `Evidence` enum, adapter, lower, `PredicateContributionClause` in logic-engine, CLI. (One coupled PR
-   — see `../adj-deterministic/PLAN.md`; the grammar-regen tool already landed.)
-2. **Typed value literals** — `quantity(value, unit)`, `money`, `date`, `duration`, `percentage` as
-   first-class observed values; the engine reads the numeric arg for predicates.
+1. **Predicate-gated contributions** ✅ **DONE (PR #5340)** — `contributes <LR> from <slot> <op> <value>
+   to <verdict>` over a valued fact `observe slot(value)`. Tokens `>= <= == > <`,
+   `evidence = predicate | term`, AST `Evidence` enum, adapter, lower, `PredicateContributionClause` in
+   logic-engine, CLI. (One coupled PR — see `../adj-deterministic/PLAN.md`; the grammar-regen tool
+   already landed.)
+2. **Typed value literals** ✅ **DONE (stacked PR)** — `quantity(value, unit)`, `money`, `percentage`,
+   `duration`, `count` as first-class observed values. No grammar change was needed: a typed wrapper
+   already parses as a nested compound (`gross_income(quantity(18000, usd))`) under step 1's grammar.
+   The engine's `numeric_magnitude`/`observed_value` read the **leading numeric argument** as the
+   magnitude (uniform rule, no hard-coded functor set), so predicates fire over typed values while the
+   unit stays attached to the fact for the faithfulness gate. `date(y,m,d)` magnitude is deferred to the
+   date/duration slice (step 5), where it needs day-ordinal semantics rather than a leading scalar.
 3. **`let` + arithmetic** — `let name = <expr>` over slots/literals via the symbolic-vm adjudication
    backend; the **derivation tree** + `FromComputation` proof origin; the **faithfulness** +
    **no-magic-numbers** gates.


### PR DESCRIPTION
## What

**Step 2** of the [adj-language-expansion](code/specs/data/adj-language-expansion/DESIGN.md) loop, stacked on #5340. A fact's value can now be a **typed wrapper** carrying its magnitude first and its unit after:

```
observe gross_income(quantity(18000, usd))
contributes 1000000 from gross_income >= 14600 to required_to_file
? required_to_file        % fires — engine reads magnitude 18000, usd stays on the fact
```

**No grammar change was needed** — such a wrapper already parses as a nested compound under #5340's grammar. The engine just learned to read the *numeric magnitude* of a typed value.

> ⚠️ **Stacked on #5340** (base branch `adj-lang-predicate-feature`). Merge #5340 first; this will then retarget to `main`. The diff below shows only step 2's commit.

## Changes (logic-engine 0.8.0 → 0.9.0)

- **`numeric_magnitude(&Term) -> Option<f64>`** — the leading numeric argument is the magnitude. Uniform rule (`quantity(18000, usd)`, `money(18000, usd)`, `percentage(40)`, `duration(365, days)`, `count(3)`) — no hard-coded functor set.
- **`observed_value(slot)`** reads through the wrapper via `numeric_magnitude`, so predicates fire over typed values while the unit stays attached to the fact for the forthcoming faithfulness gate. Bare `slot(Num)` is unchanged.

`date(y,m,d)` magnitude is deferred to the date/duration slice (step 5), where it needs day-ordinal semantics rather than a leading scalar.

## Tests

`cargo test -p logic-engine -p adj-lang -p adj-lang-cli` green — engine `numeric_magnitude` (bare / wrapped / no-leading-number), predicate-over-`quantity`, adj-lang end-to-end, CLI golden. `cargo fmt -p` applied; unrelated fmt churn reverted. `/security-review`: PASSED (pure `Option`-returning helper, no panics/unsafe/I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)