### PR TITLE
fix(closurec): CLOC12.72 — close gap-063 (same-sign +/- adjacency CORRECTNESS bug)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.76.0] - 2026-06-11
+
+### Fixed
+- **CLOSES gap-063 (CORRECTNESS)** — same-sign `+`/`-` token
+  adjacency. The WHITESPACE_ONLY re-stitcher joined two adjacent
+  operator tokens that both begin with `+` (or both `-`) into a
+  spurious compound operator, CORRUPTING semantics: `- -a`
+  (double negation) became `--a` (pre-decrement); likewise
+  `+ +a`→`++a`, `a- -b`→`a--b`, `- --a`→`---a`. Discovered by
+  the CLOC14.31 byte-identity harness (`minify_neg_neg`).
+
+### Added — gap-063 same-sign space rule
+
+`needs_separator()` now inserts a single space when the previous
+token's last char and the next token's first char are both `+`,
+or both `-`. Different signs (`a+ -b` → `a+-b`) stay joined —
+`+-` is unambiguous. CRITICAL GUARD: the rule gates on
+`is_punct(a) && is_punct(b)`, so a string/regex/template literal
+whose `.value` ends/starts with a sign char (e.g. `"a-"`, whose
+stored value is `a-`) can never trigger a spurious space — the
+emitted char there is the delimiter, not the sign. Verified
+`"a-"-1` and `"a-"- -b` against the upstream JAR. `minify_neg_neg`
+flips IGNORED → PASS. 6 new gap063_* unit tests.
+
 ## [0.75.0] - 2026-06-10
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.75.0"
+version = "0.76.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -2050,6 +2050,35 @@ fn needs_separator(a: &lexer::token::Token, b: &lexer::token::Token) -> bool {
     {
         return true;
     }
+    // gap-063: same-sign `+`/`-` adjacency (CORRECTNESS). If the
+    // previous operator token ENDS with `+`/`-` and the next
+    // operator token STARTS with the SAME sign character, gluing
+    // them together would form a spurious compound operator:
+    //
+    //   `-` `-a`  →  `--a`   (decrement, NOT double negation!)
+    //   `+` `+a`  →  `++a`   (increment)
+    //   `--` `-a` →  `---a`,  `a` `+` `++b` → `a+++b`, …
+    //
+    // Insert a space to keep the operators distinct. Different
+    // signs (`+` then `-`) are unambiguous (`+-`) and need none.
+    //
+    // CRITICAL GUARD: both sides must be real PUNCTUATOR tokens
+    // (`is_punct`), never string/regex/template literals. A
+    // one-char string `"-"` stores `.value == "-"` (delimiters
+    // stripped), so without this gate `"a-"` followed by a `-`
+    // operator — emitted as `"a-"-…` where the char before `-`
+    // is the closing quote, not `-` — would wrongly get a space.
+    // `is_punct` excludes literals, so only genuine operators
+    // whose emitted text equals `.value` are considered.
+    if is_punct(a) && is_punct(b) {
+        let a_last = a.value.chars().last();
+        let b_first = b.value.chars().next();
+        if (a_last == Some('+') && b_first == Some('+'))
+            || (a_last == Some('-') && b_first == Some('-'))
+        {
+            return true;
+        }
+    }
     false
 }
 
@@ -2194,6 +2223,54 @@ mod tests {
         let out = minify(src);
         assert!(out.contains("return typeof"), "got: {out:?}");
         assert!(out.contains("typeof x"), "got: {out:?}");
+    }
+
+    // ---- gap-063: same-sign `+`/`-` adjacency (CORRECTNESS) ----
+
+    /// gap-063: `- -a` (double negation) must NOT collapse to
+    /// `--a` (pre-decrement) — a different program.
+    #[test]
+    fn gap063_double_minus_keeps_space() {
+        assert_eq!(minify("var x=- -a;"), "var x=- -a;");
+    }
+
+    /// gap-063: `+ +a` must NOT collapse to `++a`.
+    #[test]
+    fn gap063_double_plus_keeps_space() {
+        assert_eq!(minify("var x=+ +a;"), "var x=+ +a;");
+    }
+
+    /// gap-063: binary minus then unary minus — `a- -b` must stay
+    /// `a- -b`, not become `a--b`.
+    #[test]
+    fn gap063_binary_then_unary_minus() {
+        assert_eq!(minify("var x=a- -b;"), "var x=a- -b;");
+    }
+
+    /// gap-063: `- --a` (negate a pre-decrement) keeps the space
+    /// between the `-` and `--` operators.
+    #[test]
+    fn gap063_minus_then_predecrement() {
+        assert_eq!(minify("var x=- --a;"), "var x=- --a;");
+    }
+
+    /// gap-063: DIFFERENT signs are unambiguous — `a+ -b` joins
+    /// to `a+-b` (no spurious operator possible).
+    #[test]
+    fn gap063_different_signs_join() {
+        assert_eq!(minify("var x=a+ -b;"), "var x=a+-b;");
+    }
+
+    /// gap-063 GUARD: a string literal whose content ends in `-`
+    /// must NOT trigger the rule against a following `-` operator
+    /// — the emitted char before the operator is the closing
+    /// quote, not `-`. `"a-"-1` stays `"a-"-1` (no spurious
+    /// space). This is why the rule gates on `is_punct`.
+    #[test]
+    fn gap063_string_ending_in_sign_not_spaced() {
+        assert_eq!(minify("var x=\"a-\"-1;"), "var x=\"a-\"-1;");
+        // ...but the two REAL `-` operators after it still space:
+        assert_eq!(minify("var y=\"a-\"- -b;"), "var y=\"a-\"- -b;");
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.75.0
+Version: 0.76.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,13 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-063 (CLOC14.31): the re-stitcher joins two adjacent
-    // tokens that BOTH start with `+` (or both `-`), forming a
-    // spurious `++`/`--`/`+++`/`---` operator. `- -a` must stay
-    // `- -a` (double negation), not become `--a` (decrement) —
-    // a SEMANTIC change. Needs a same-sign space rule in the
-    // emit adjacency logic.
-    ("neg_neg", "gap-063: `- -a` must not collapse to `--a` (decrement)"),
     // gap-055/056/057 all RESOLVED (CLOC12.64/65/66) — ternary
     // arms, return/throw/=> prefixes, and member-object parens
     // (`(a).b` → `a.b`) now pass and are no longer ignored.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -485,11 +485,11 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-063 — same-sign `+`/`-` token adjacency (CORRECTNESS)
 
-- **Status:** OPEN — discovered by CLOC14.31. `minify_neg_neg` ignored.
-- **Input:** `var x=- -a;` → **Upstream:** `var x=- -a;` → **closurec (WRONG):** `var x=--a;`
+- **Status:** **RESOLVED** in CLOC12.72. `minify_neg_neg` flips IGNORED → PASS.
+- **Input:** `var x=- -a;` → **Upstream:** `var x=- -a;` → **closurec (was WRONG):** `var x=--a;`
 - **Severity:** This is a **semantic-corruption** bug, not a formatting nicety. The re-stitcher joins two adjacent tokens that both begin with `+` (or both with `-`), forming a spurious compound operator: `- -a` (negate the negation of `a`) becomes `--a` (pre-decrement of `a`) — a different program. Characterized cases (all currently WRONG in closurec):
   - `- -a` → `--a`, `+ +a` → `++a`
   - `a- -b` → `a--b`, `a+ +b` → `a++b`
   - `- --a` → `---a`, `+ ++a` → `+++a`, `a- --b` → `a---b`
   - Correct (already OK): `a+ -b` → `a+-b` (different signs — `+-` is unambiguous).
-- **What it needs:** The emit adjacency rule (whitespace_only re-stitcher) must insert a single space between two emitted tokens when the previous token's LAST char and the next token's FIRST char are both `+`, or both `-`. This mirrors the classic minifier rule that prevents `+`/`++`/`-`/`--` boundary merges. Fix lands in CLOC12.72.
+- **Fix (CLOC12.72):** `needs_separator()` gains a same-sign rule — insert a space when the previous token's LAST char and the next token's FIRST char are both `+`, or both `-`. **CRITICAL GUARD:** both sides must be real punctuator tokens (`is_punct`), never string/regex/template literals. A one-char string `"-"` stores `.value == "-"` (delimiters stripped), so without the `is_punct` gate a string ending in `-` (`"a-"`) followed by a `-` operator — emitted as `"a-"-…` where the char before the operator is the closing quote — would wrongly get a space. Verified: `"a-"-1` stays `"a-"-1` and `"a-"- -b` spaces only between the two real `-` operators. 6 unit tests added.


### PR DESCRIPTION
## What

Closes **gap-063**, a **semantic-corruption** bug surfaced by the CLOC14.31 byte-identity harness. The WHITESPACE_ONLY re-stitcher glued two adjacent operator tokens that both begin with `+` (or both `-`) into a spurious compound operator, **changing the program**:

```
- -a   (double negation)   →   --a   (pre-decrement!)
+ +a → ++a,  a- -b → a--b,  - --a → ---a
```

## How

`needs_separator()` gains a same-sign rule: insert a space when the previous token's last char and the next token's first char are both `+`, or both `-`. Different signs (`a+ -b` → `a+-b`) stay joined — `+-` is unambiguous.

**Critical guard:** the rule gates on `is_punct(a) && is_punct(b)`, so a string/regex/template literal whose `.value` ends/starts with a sign char can never trigger a spurious space. A one-char string `"-"` stores `.value == "-"` (delimiters stripped), so without the gate `"a-"` followed by a `-` operator — emitted `"a-"-…`, where the char before the operator is the closing quote — would wrongly get a space. Verified `"a-"-1` → `"a-"-1` and `"a-"- -b` → `"a-"- -b` against the upstream JAR.

## Tests

- 6 new `gap063_*` unit tests (the four corruption cases, the different-sign join, and the string-literal guard).
- All suites green; byte-identity harness with `minify_neg_neg` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified the fix prevents corruption, the `is_punct` guard is necessary & sufficient, different-signs not over-matched, no regression to `++`/`--`/`+=` operators, and **13 spot-cases byte-identical to the JAR** (incl. `a+++b`, `a---b`, `a+= -b`).

Version 0.75→0.76; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)