### PR TITLE
fix(closurec): CLOC12.73 — close gap-064 (string `)` arg misread as empty-paren close)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.77.0] - 2026-06-11
+
+### Fixed
+- **CLOSES gap-064 (CORRECTNESS)** — string `)` argument misread
+  as empty-paren close. The gap-050 `new X()` → `new X`
+  empty-paren-drop pass checked `kept[idx+1].value == ")"`
+  WITHOUT the `is_structural_punct` guard, so a string argument
+  whose content is `)` (stored `.value == ")"` after the lexer
+  strips delimiters) was mistaken for the empty-arg close paren.
+  `new A(")")` was mangled to `new A);` (invalid JS — dropped the
+  string arg and left a stray `)`); `new A(")").b` to
+  `(new A)).b`. Discovered by the CLOC14.32 byte-identity
+  harness.
+
+### Changed — gap-064 fix
+
+Line 976 now gates the close-paren check on
+`is_structural_punct(t, ")")`, so only a genuine `)` punctuator
+token triggers the empty-paren elision — a string/regex/template
+argument never can. The sibling `next2_blocks_drop` checks were
+left as-is: they only ever BLOCK a drop (fail-safe — at worst a
+missed optimization on malformed input, never wrong output). The
+genuine empty-paren drop (`new A()` → `new A`) and real args
+(`new A(x)`) are preserved. `minify_new_str_paren_arg` +
+`minify_new_str_paren_member` flip IGNORED → PASS. 3 new
+gap064_* unit tests.
+
 ## [0.76.0] - 2026-06-11
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.76.0"
+version = "0.77.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -973,7 +973,22 @@ pub fn whitespace_only_minify(
             && idx >= 2
             && kept[idx - 2].value == "new"
             && is_simple_identifier_token(Some(kept[idx - 1]))
-            && kept.get(idx + 1).map(|t| t.value.as_str()) == Some(")")
+            // gap-064: the close-paren check MUST go through
+            // `is_structural_punct`, not a bare `.value == ")"`.
+            // A string/regex/template literal stores its CONTENT
+            // in `.value` (delimiters stripped), so a one-char
+            // string `")"` has `.value == ")"`. Without this
+            // guard `new A(")")` (a NON-empty arg list whose sole
+            // arg is the string `")"`) was misread as the empty
+            // arg list `new A()`, dropping the `(` and the string
+            // and leaving a stray real `)` — `new A);` (mangled,
+            // invalid JS). `is_structural_punct` matches only a
+            // genuine `)` punctuator token, so a string argument
+            // can never trigger the empty-paren elision.
+            && kept
+                .get(idx + 1)
+                .map(|t| is_structural_punct(t, ")"))
+                .unwrap_or(false)
             && !next2_blocks_drop
         {
             // Skip both `(` and `)`. State machine
@@ -3788,6 +3803,34 @@ mod tests {
     #[test]
     fn gap060_member_callee_standalone_unchanged() {
         assert_eq!(minify("var x=new a.b.C();"), "var x=new a.b.C();");
+    }
+
+    /// gap-064 (CORRECTNESS): a string argument whose content is
+    /// `)` must NOT be mistaken for the empty-arg close paren.
+    /// `new A(")")` keeps its string arg (was mangled to
+    /// `new A);` before the `is_structural_punct` guard).
+    #[test]
+    fn gap064_string_paren_arg_not_dropped() {
+        assert_eq!(minify("var z=new A(\")\");"), "var z=new A(\")\");");
+    }
+
+    /// gap-064: same string-`)` arg under the arg-bearing member
+    /// wrap — `new A(")").b` → `(new A(")")).b`, not `(new A)).b`.
+    #[test]
+    fn gap064_string_paren_arg_member_wrap() {
+        assert_eq!(
+            minify("var z=new A(\")\").b;"),
+            "var z=(new A(\")\")).b;"
+        );
+    }
+
+    /// gap-064 non-regression: the genuine empty-paren drop still
+    /// fires (`new A()` → `new A`), and a real non-empty arg
+    /// (`new A(x)`) is preserved.
+    #[test]
+    fn gap064_genuine_empty_paren_still_drops() {
+        assert_eq!(minify("var z=new A();"), "var z=new A;");
+        assert_eq!(minify("var z=new A(x);"), "var z=new A(x);");
     }
 
     /// gap-059: `new Foo()[0]` → `(new Foo)[0]` (computed

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.76.0
+Version: 0.77.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,15 +90,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-064 (CLOC14.32, CORRECTNESS): the gap-050 `new X()` →
-    // `new X` empty-paren drop checks `kept[idx+1].value == ")"`
-    // WITHOUT `is_structural_punct`, so a string argument whose
-    // content is `)` (stored `.value == ")"`) is mistaken for
-    // the empty-arg close paren. `new A(")")` → `new A);` —
-    // mangled, invalid JS (drops the string arg + leaves a stray
-    // `)`). Fix: gate the check on `is_structural_punct`.
-    ("new_str_paren_arg",    "gap-064: string `)` arg misread as empty-paren close"),
-    ("new_str_paren_member", "gap-064: same bug under arg-bearing member wrap"),
+    // gap-064 RESOLVED in CLOC12.73 — `new A(")")` no longer
+    // misreads the string `)` arg as the empty-paren close
+    // (the gap-050 drop now gates on `is_structural_punct`).
+    // `minify_new_str_paren_arg` + `minify_new_str_paren_member`
+    // are enforced again.
     // gap-055/056/057 all RESOLVED (CLOC12.64/65/66) — ternary
     // arms, return/throw/=> prefixes, and member-object parens
     // (`(a).b` → `a.b`) now pass and are no longer ignored.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -496,7 +496,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-064 — string `)` argument misread as empty-paren close (CORRECTNESS)
 
-- **Status:** OPEN — discovered by CLOC14.32. `minify_new_str_paren_arg` + `minify_new_str_paren_member` ignored.
-- **Input:** `var z=new A(")");` → **Upstream:** `var z=new A(")");` → **closurec (WRONG):** `var z=new A);`
+- **Status:** **RESOLVED** in CLOC12.73. `minify_new_str_paren_arg` + `minify_new_str_paren_member` flip IGNORED → PASS.
+- **Input:** `var z=new A(")");` → **Upstream:** `var z=new A(")");` → **closurec (was WRONG):** `var z=new A);`
 - **Severity:** **Semantic corruption producing invalid JS.** The gap-050 `new X()` → `new X` empty-paren-drop pass checks `kept[idx+1].value == ")"` at `code/programs/rust/closurec/src/whitespace_only.rs:976` **without** the `is_structural_punct` guard. A string argument whose content is `)` stores `.value == ")"` (the lexer strips delimiters), so the pass mistakes the string for the empty-arg close paren — dropping the `(` and the string, leaving a stray real `)`. Second manifestation: `new A(")").b` → `(new A)).b` (broken). Plain calls (`f(")")`) are unaffected — only the `new`-expr empty-paren path has the unguarded check.
 - **What it needs (CLOC12.73):** Change line 976 from `kept.get(idx + 1).map(|t| t.value.as_str()) == Some(")")` to `kept.get(idx + 1).map(|t| is_structural_punct(t, ")")).unwrap_or(false)`. Audit the sibling `.value == "("/")"` checks in the same region (lines ~218/324/968-971, the arrow-elision `kept[idx+2/3].value` checks at ~991-992) for the same latent bug and gate them on `is_structural_punct` too.


### PR DESCRIPTION
## What

Closes **gap-064**, a **correctness bug that produced invalid JS**, surfaced by the CLOC14.32 byte-identity harness. The gap-050 `new X()` → `new X` empty-paren-drop pass checked `kept[idx+1].value == ")"` **without** the `is_structural_punct` guard, so a string argument whose content is `)` (stored `.value == ")"` after the lexer strips delimiters) was mistaken for the empty-arg close paren:

| input | upstream | closurec (was WRONG) |
|---|---|---|
| `var z=new A(")");` | `var z=new A(")");` | `var z=new A);` |
| `var z=new A(")").b;` | `var z=(new A(")")).b;` | `var z=(new A)).b;` |

## How

Line 976 now gates the close-paren check on `is_structural_punct(t, ")")`, so only a genuine `)` punctuator triggers the empty-paren elision — a string/regex/template argument never can.

The sibling `next2_blocks_drop` checks were left as-is: they only ever **block** a drop (fail-safe — at worst a missed optimization on malformed input, never wrong output). I confirmed the arrow/IIFE/destructuring/ternary passes all handle string args correctly by probing them.

## Tests

- 3 new `gap064_*` unit tests (string-`)`-arg preserved, member-wrap variant, genuine-empty-paren-still-drops + real-arg-preserved).
- All suites green; byte-identity harness with both gap-064 fixtures un-ignored.
- Security-reviewed (read-only subagent): **PASS** — fix resolves the bug, genuine drop preserved, `is_structural_punct` semantics verified, `next2_blocks_drop` confirmed fail-safe, **11 spot-cases byte-identical to the JAR** (incl. `new A(/)/)`).

> Follow-up (non-blocking, tracked separately): the arrow-elision `.value` checks (~lines 1006-1007) gate an active rewrite and could in principle mis-fire on a string `)`/`=>` — but only on malformed JS the parser would reject; no failing input found. A hygiene audit will gate those on `is_structural_punct` too.

Version 0.76→0.77; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)