### PR TITLE
release(macsyma-runtime): TS + Rust 0.4.0 — assumption-aware abs/sqrt/log

### DIFF
--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.0] — 2026-05-29
 
 - Feed the Rust MACSYMA session assumption context into direct `abs`, `sqrt`,
   and `log` evaluation, matching Python reference behavior for cases such as

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-macsyma-runtime"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "MACSYMA runtime session facade over the Rust symbolic VM"
 license = "MIT"

--- a/code/packages/typescript/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/typescript/macsyma-runtime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.4.0] — 2026-05-29
 
 - Feed the TypeScript MACSYMA session assumption context into direct
   `abs`, `sqrt`, and `log` evaluation, matching Python reference behavior

--- a/code/packages/typescript/macsyma-runtime/package.json
+++ b/code/packages/typescript/macsyma-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/macsyma-runtime",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pure TypeScript MACSYMA runtime session over the symbolic VM",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

**Track F** of [`macsyma-truly-finish-plan.md`](code/specs/macsyma-truly-finish-plan.md).

Ships the existing \`Unreleased\` content of TypeScript and Rust \`macsyma-runtime\`
as a dated 0.4.0 release. Both packages already feed the session assumption
context into direct \`abs\`, \`sqrt\`, and \`log\` evaluation — this PR cuts the
version release. No code changes; tests already covered.

## Changes
- TypeScript \`macsyma-runtime\` 0.3.0 → 0.4.0; CHANGELOG Unreleased → [0.4.0] — 2026-05-29
- Rust \`macsyma-runtime\` 0.3.0 → 0.4.0; CHANGELOG Unreleased → [0.4.0] — 2026-05-29

## Test plan
- [x] No code changes; existing tests cover the wiring
- [ ] CI green