### PR TITLE
feat(symbolic-vm): Weierstrass symbolic-coefficient port (Track G2)

### DIFF
--- a/code/packages/rust/cas-simplify/CHANGELOG.md
+++ b/code/packages/rust/cas-simplify/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog — cas-simplify (Rust)
 
+## [0.2.0] — 2026-05-29
+
+**Track G2 — compound-relation assumption store (Rust port).**
+
+Extends `AssumptionContext` so `assume_relation(...)` and
+`is_true_relation(...)` accept arbitrary relational shapes, not just
+plain-symbol-vs-zero.  Previously `assume(a^2 > b^2)` was silently
+dropped; under Track G2 it is canonicalised into a
+`(IRNode, &'static str, IRNode)` triple and stored in a new
+`HashSet`.  Subsequent `is(a^2 > b^2)` / `is(b^2 < a^2)` queries
+return `Some(true)` via structural lookup with commutativity-aware
+rewriting.  The legacy plain-symbol path is unchanged; the new path
+fires only when the plain-symbol path returns `None`.
+
+Mirrors Python `cas-simplify` 0.4.0 (Track G1) and TypeScript
+`@coding-adventures/cas-simplify` 0.2.0.  The symbolic-coefficient
+Weierstrass integrator that consumes this store ships in
+`symbolic-vm` 0.19.0.
+
+### Added
+
+- Private `general_relations` field on `AssumptionContext`, a
+  `HashSet<(IRNode, &'static str, IRNode)>` of canonical compound
+  relations.
+- Private helpers `parse_relation`, `canon_relation`, `node_key`, and
+  the centralised `head_to_op` map.
+- `assume_relation`, `forget_relation`, and `is_true_relation` now
+  have a compound-relation fallback when the plain-symbol path
+  doesn't apply.  `forget_all` clears both stores.
+
+### Semantics
+
+- No negative-knowledge inference: `assume(a^2 > b^2)` does NOT make
+  `is(a^2 < b^2)` return `Some(false)` — it returns `None`.
+- Commutativity is honoured: `is(b^2 < a^2)` ≡ `is(a^2 > b^2)`,
+  `is(b^2 = a^2)` ≡ `is(a^2 = b^2)`, and similarly for `<=` / `>=` and `!=`.
+
 ## Unreleased
 
 ### Added

--- a/code/packages/rust/cas-simplify/Cargo.toml
+++ b/code/packages/rust/cas-simplify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-simplify"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Algebraic simplification of symbolic IR trees: canonical form, constant folding, identity rules"
 license = "MIT"

--- a/code/packages/rust/cas-simplify/src/assumptions.rs
+++ b/code/packages/rust/cas-simplify/src/assumptions.rs
@@ -4,6 +4,32 @@ use std::collections::{HashMap, HashSet};
 
 use symbolic_ir::{IRNode, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, NOT_EQUAL};
 
+// Short operator strings used to canonicalise compound relations.
+// Mirrors the Python ``_RELATION_HEAD_TO_OP`` map and gives us a
+// stable, hashable middle component for the ``(lhs, op, rhs)`` triple
+// stored in ``general_relations``.  ``&'static str`` keeps the triple
+// type cheap to clone.
+const OP_GT: &str = ">";
+const OP_LT: &str = "<";
+const OP_GE: &str = ">=";
+const OP_LE: &str = "<=";
+const OP_EQ: &str = "=";
+const OP_NE: &str = "!=";
+
+/// Map a relational head name to the canonical operator string, or
+/// `None` when the head isn't one of the six relational operators.
+fn head_to_op(head: &str) -> Option<&'static str> {
+    match head {
+        GREATER => Some(OP_GT),
+        LESS => Some(OP_LT),
+        GREATER_EQUAL => Some(OP_GE),
+        LESS_EQUAL => Some(OP_LE),
+        EQUAL => Some(OP_EQ),
+        NOT_EQUAL => Some(OP_NE),
+        _ => None,
+    }
+}
+
 const POSITIVE: &str = "positive";
 const NEGATIVE: &str = "negative";
 const ZERO: &str = "zero";
@@ -15,6 +41,13 @@ const INTEGER: &str = "integer";
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AssumptionContext {
     facts: HashMap<String, HashSet<&'static str>>,
+    /// Track G2 — compound relations as canonicalised `(lhs, op, rhs)`
+    /// triples.  `op` is one of the six static strings declared above.
+    /// `IRNode` implements `Hash + Eq` so the set deduplicates
+    /// structurally.  See [`Self::assume_relation`] for the canonical
+    /// form rules — `<` is always rewritten to `>`, `<=` to `>=`,
+    /// `=`/`!=` ordered by display key.
+    general_relations: HashSet<(IRNode, &'static str, IRNode)>,
 }
 
 impl AssumptionContext {
@@ -23,17 +56,27 @@ impl AssumptionContext {
     }
 
     pub fn assume_relation(&mut self, expr: &IRNode) {
-        if let Some((sym_name, head)) = relation_against_zero(expr) {
-            match head {
-                GREATER => self.add(sym_name, POSITIVE),
-                LESS => self.add(sym_name, NEGATIVE),
-                GREATER_EQUAL => self.add(sym_name, NONNEG),
-                LESS_EQUAL => self.add(sym_name, NONPOS),
-                EQUAL => self.add(sym_name, ZERO),
-                NOT_EQUAL => self.add(sym_name, NONZERO),
+        let Some((lhs, op, rhs)) = parse_relation(expr) else {
+            return;
+        };
+        // Plain-symbol-vs-zero path: fold into the per-symbol fact
+        // table (Phase 21 behaviour).
+        if let (Some(name), true) = (sym_name(lhs), rhs == &IRNode::Integer(0)) {
+            match op {
+                OP_GT => self.add(name, POSITIVE),
+                OP_LT => self.add(name, NEGATIVE),
+                OP_GE => self.add(name, NONNEG),
+                OP_LE => self.add(name, NONPOS),
+                OP_EQ => self.add(name, ZERO),
+                OP_NE => self.add(name, NONZERO),
                 _ => {}
             }
+            return;
         }
+        // Track G2 — compound-relation path.  Canonicalise so commuted
+        // and dual surface forms collapse to the same triple.
+        let triple = canon_relation(lhs.clone(), op, rhs.clone());
+        self.general_relations.insert(triple);
     }
 
     pub fn assume_property(&mut self, sym: &IRNode, prop: &IRNode) {
@@ -57,21 +100,28 @@ impl AssumptionContext {
     }
 
     pub fn forget_relation(&mut self, expr: &IRNode) {
-        if let Some((sym_name, head)) = relation_against_zero(expr) {
-            match head {
-                GREATER => self.remove(sym_name, POSITIVE),
-                LESS => self.remove(sym_name, NEGATIVE),
-                GREATER_EQUAL => self.remove(sym_name, NONNEG),
-                LESS_EQUAL => self.remove(sym_name, NONPOS),
-                EQUAL => self.remove(sym_name, ZERO),
-                NOT_EQUAL => self.remove(sym_name, NONZERO),
+        let Some((lhs, op, rhs)) = parse_relation(expr) else {
+            return;
+        };
+        if let (Some(name), true) = (sym_name(lhs), rhs == &IRNode::Integer(0)) {
+            match op {
+                OP_GT => self.remove(name, POSITIVE),
+                OP_LT => self.remove(name, NEGATIVE),
+                OP_GE => self.remove(name, NONNEG),
+                OP_LE => self.remove(name, NONPOS),
+                OP_EQ => self.remove(name, ZERO),
+                OP_NE => self.remove(name, NONZERO),
                 _ => {}
             }
+            return;
         }
+        let triple = canon_relation(lhs.clone(), op, rhs.clone());
+        self.general_relations.remove(&triple);
     }
 
     pub fn forget_all(&mut self) {
         self.facts.clear();
+        self.general_relations.clear();
     }
 
     pub fn is_positive(&self, sym_name: &str) -> Option<bool> {
@@ -125,12 +175,38 @@ impl AssumptionContext {
     }
 
     pub fn is_true_relation(&self, expr: &IRNode) -> Option<bool> {
-        let (sym_name, head) = relation_against_zero(expr)?;
+        let (lhs, op, rhs) = parse_relation(expr)?;
+
+        // Path 1 — plain-symbol-vs-zero (Phase 21 behaviour).
+        if let (Some(name), true) = (sym_name(lhs), rhs == &IRNode::Integer(0)) {
+            if let Some(answer) = self.is_true_plain(name, op) {
+                return Some(answer);
+            }
+            // Fall through to the compound path so an explicit
+            // verbatim assertion with a symbol-vs-zero shape can still
+            // match (mirrors the Python helper).
+        }
+
+        // Path 2 — Track G2 compound-relation lookup.  Canonicalise the
+        // query and probe the structural set.
+        let triple = canon_relation(lhs.clone(), op, rhs.clone());
+        if self.general_relations.contains(&triple) {
+            Some(true)
+        } else {
+            None
+        }
+    }
+
+    /// Plain-symbol-vs-zero branch of [`Self::is_true_relation`].
+    /// Returns `None` when nothing in the fact table speaks to the
+    /// query, letting the caller fall through to the compound-relation
+    /// lookup.
+    fn is_true_plain(&self, sym_name: &str, op: &str) -> Option<bool> {
         let facts = self.fact_set(sym_name);
-        match head {
-            GREATER => self.is_positive(sym_name),
-            LESS => self.is_negative(sym_name),
-            GREATER_EQUAL => {
+        match op {
+            OP_GT => self.is_positive(sym_name),
+            OP_LT => self.is_negative(sym_name),
+            OP_GE => {
                 if facts.contains(POSITIVE) || facts.contains(ZERO) || facts.contains(NONNEG) {
                     Some(true)
                 } else if facts.contains(NEGATIVE) {
@@ -139,7 +215,7 @@ impl AssumptionContext {
                     None
                 }
             }
-            LESS_EQUAL => {
+            OP_LE => {
                 if facts.contains(NEGATIVE) || facts.contains(ZERO) || facts.contains(NONPOS) {
                     Some(true)
                 } else if facts.contains(POSITIVE) {
@@ -148,7 +224,7 @@ impl AssumptionContext {
                     None
                 }
             }
-            EQUAL => {
+            OP_EQ => {
                 if facts.contains(ZERO) {
                     Some(true)
                 } else if facts.contains(POSITIVE)
@@ -160,7 +236,7 @@ impl AssumptionContext {
                     None
                 }
             }
-            NOT_EQUAL => {
+            OP_NE => {
                 if facts.contains(NONZERO) || facts.contains(POSITIVE) || facts.contains(NEGATIVE) {
                     Some(true)
                 } else if facts.contains(ZERO) {
@@ -221,18 +297,53 @@ impl AssumptionContext {
     }
 }
 
-fn relation_against_zero(expr: &IRNode) -> Option<(&str, &str)> {
+/// Parse a relational `Apply(head, [lhs, rhs])` and return
+/// `(lhs, op, rhs)` with `op` mapped to the canonical operator string.
+/// Returns `None` for non-relational nodes (head not in the six
+/// recognised relational operators, wrong arity, etc.).
+fn parse_relation(expr: &IRNode) -> Option<(&IRNode, &'static str, &IRNode)> {
     let IRNode::Apply(apply) = expr else {
         return None;
     };
-    if apply.args.len() != 2 || apply.args[1] != IRNode::Integer(0) {
+    if apply.args.len() != 2 {
         return None;
     }
-    let sym_name = sym_name(&apply.args[0])?;
     let IRNode::Symbol(head) = &apply.head else {
         return None;
     };
-    Some((sym_name, head.as_str()))
+    let op = head_to_op(head.as_str())?;
+    Some((&apply.args[0], op, &apply.args[1]))
+}
+
+/// Canonicalise a `(lhs, op, rhs)` relation triple.  Rules mirror the
+/// Python `_canon_relation`:
+///
+/// - `a < b` is rewritten to `(b, ">", a)` — every strict inequality
+///   becomes `>`.
+/// - `a <= b` becomes `(b, ">=", a)`.
+/// - `a = b` / `a != b` are commutative — ordered by display-string key
+///   so duplicates from either operand order collapse.
+/// - `a > b` and `a >= b` pass through verbatim.
+fn canon_relation(lhs: IRNode, op: &'static str, rhs: IRNode) -> (IRNode, &'static str, IRNode) {
+    match op {
+        OP_LT => (rhs, OP_GT, lhs),
+        OP_LE => (rhs, OP_GE, lhs),
+        OP_EQ | OP_NE => {
+            if node_key(&lhs) <= node_key(&rhs) {
+                (lhs, op, rhs)
+            } else {
+                (rhs, op, lhs)
+            }
+        }
+        _ => (lhs, op, rhs),
+    }
+}
+
+/// Deterministic ordering key for the commutativity tiebreak in
+/// [`canon_relation`].  Uses `Display` since every IR node has a
+/// structural `Display` impl.
+fn node_key(node: &IRNode) -> String {
+    format!("{node}")
 }
 
 fn sym_name(node: &IRNode) -> Option<&str> {

--- a/code/packages/rust/cas-simplify/tests/tests.rs
+++ b/code/packages/rust/cas-simplify/tests/tests.rs
@@ -730,3 +730,178 @@ fn demoivre_splits_pure_and_mixed_complex_exponentials() {
     let real_only = apply(sym(EXP), vec![x()]);
     assert_eq!(demoivre(real_only.clone()), real_only);
 }
+
+// ---------------------------------------------------------------------------
+// Track G2 — compound-relation assumption store.
+//
+// Mirrors the Python tests in
+// `code/packages/python/cas-simplify/tests/test_assumptions_compound.py`.
+// Until G2 the Rust `AssumptionContext` only understood
+// plain-symbol-vs-zero relations (`assume(x > 0)`).  Compound relations
+// such as `assume(a^2 > b^2)` were silently dropped, which prevented
+// the symbolic-coefficient Weierstrass integrator from learning the
+// discriminant sign at integration time.
+// ---------------------------------------------------------------------------
+
+fn a_sq() -> IRNode {
+    apply(sym(POW), vec![a(), int(2)])
+}
+
+fn b_sq() -> IRNode {
+    apply(sym(POW), vec![b(), int(2)])
+}
+
+fn gt(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(GREATER), vec![lhs, rhs])
+}
+
+fn lt(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(LESS), vec![lhs, rhs])
+}
+
+fn ge(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(GREATER_EQUAL), vec![lhs, rhs])
+}
+
+fn le(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym("LessEqual"), vec![lhs, rhs])
+}
+
+fn eq_rel(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(EQUAL), vec![lhs, rhs])
+}
+
+fn ne_rel(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(NOT_EQUAL), vec![lhs, rhs])
+}
+
+#[test]
+fn compound_assume_greater_direct() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&gt(a_sq(), b_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_equal_direct() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&eq_rel(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&eq_rel(a_sq(), b_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_less_direct() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&lt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&lt(a_sq(), b_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_greater_equal_direct() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&ge(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&ge(a_sq(), b_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_not_equal_direct() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&ne_rel(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&ne_rel(a_sq(), b_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_greater_commutes_to_less() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&lt(b_sq(), a_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_less_commutes_to_greater() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&lt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&gt(b_sq(), a_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_ge_commutes_to_le() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&ge(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&le(b_sq(), a_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_equal_is_commutative() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&eq_rel(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&eq_rel(b_sq(), a_sq())), Some(true));
+}
+
+#[test]
+fn compound_assume_not_equal_is_commutative() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&ne_rel(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&ne_rel(b_sq(), a_sq())), Some(true));
+}
+
+#[test]
+fn compound_unknown_returns_none() {
+    let ctx = AssumptionContext::new();
+    let c_sq = apply(sym(POW), vec![c(), int(2)]);
+    let d_sq = apply(sym(POW), vec![sym("d"), int(2)]);
+    assert_eq!(ctx.is_true_relation(&gt(c_sq, d_sq)), None);
+}
+
+#[test]
+fn compound_assume_greater_does_not_imply_less_false() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    // No negative-knowledge inference — asserting `a^2 > b^2` says
+    // nothing about `a^2 < b^2` until the user explicitly asserts it.
+    assert_eq!(ctx.is_true_relation(&lt(a_sq(), b_sq())), None);
+}
+
+#[test]
+fn compound_forget_relation() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&gt(a_sq(), b_sq())), Some(true));
+    ctx.forget_relation(&gt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&gt(a_sq(), b_sq())), None);
+}
+
+#[test]
+fn compound_forget_all_clears_compound_relations() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    ctx.assume_relation(&greater_zero(x()));
+    ctx.forget_all();
+    assert_eq!(ctx.is_true_relation(&gt(a_sq(), b_sq())), None);
+    assert_eq!(ctx.is_positive("x"), None);
+}
+
+#[test]
+fn compound_plain_symbol_path_still_works() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&greater_zero(x()));
+    assert_eq!(ctx.is_positive("x"), Some(true));
+    assert_eq!(ctx.is_true_relation(&greater_zero(x())), Some(true));
+    assert_eq!(
+        ctx.is_true_relation(&apply(sym(LESS), vec![x(), int(0)])),
+        Some(false)
+    );
+}
+
+#[test]
+fn compound_assume_dedupes() {
+    let mut ctx = AssumptionContext::new();
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    ctx.assume_relation(&gt(a_sq(), b_sq()));
+    // Re-assert via the commuted form — canonicalisation should fold.
+    ctx.assume_relation(&lt(b_sq(), a_sq()));
+    // A single forget should zero out the fact regardless of which
+    // surface form was used.
+    ctx.forget_relation(&gt(a_sq(), b_sq()));
+    assert_eq!(ctx.is_true_relation(&gt(a_sq(), b_sq())), None);
+}

--- a/code/packages/rust/symbolic-vm/BUILD
+++ b/code/packages/rust/symbolic-vm/BUILD
@@ -4,6 +4,6 @@ _targets = [
     rust_library(
         name = "symbolic-vm",
         srcs = ["src/**/*.rs", "tests/**/*.rs"],
-        deps = ["symbolic-ir"],
+        deps = ["symbolic-ir", "cas-simplify"],
     ),
 ]

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.19.0] — 2026-05-29
+
+**Track G2 — symbolic-coefficient Weierstrass lift (Rust port).**
+
+Generalises the Phase-34/35/36/37 Weierstrass substitution
+`∫ c / (a + b·trig(α·x + β)) dx` from concrete rational `a, b` to
+symbolic ones.  When the numeric pattern returns `None` because
+either coefficient is a free IR expression, the new helper consults
+`vm.assumptions` for the sign of the discriminant `a² − b²` and,
+upon finding a declared inequality / equality, emits the matching
+arctan / log / degenerate closed form with symbolic
+`Sqrt(a² − b²)` (or `Sqrt(b² − a²)`) in the result.  When no
+assumption pins down the sign, the integral is left unevaluated.
+
+This depends on the compound-relation extension to
+`cas_simplify::AssumptionContext` shipped in cas-simplify 0.2.0
+(same PR, Track G2).  Mirrors Python `symbolic-vm` 0.74.0 and
+TypeScript `@coding-adventures/symbolic-vm` 0.19.0.
+
+### Added
+
+- New `assumptions: AssumptionContext` field on `VM` — populated via
+  the `Assume(...)` / `Forget(...)` / `ForgetAll()` handlers and
+  consulted by `try_weierstrass_symbolic_coefficients` via a
+  thread-local snapshot.
+- `Assume`, `Forget`, and `ForgetAll` handlers registered on the
+  symbolic backend.  Both relational heads are added to the
+  hold-evaluate set so the relation argument reaches the handler
+  intact.
+- `try_weierstrass_symbolic_coefficients` — symbolic dispatcher,
+  invoked after the numeric helper returns `None`.
+- `weierstrass_parse_a_plus_b_sincos_symbolic` — symbolic sibling of
+  the numeric parser.
+- Branch emitters `try_weierstrass_{arctan,log,degenerate}_symbolic`.
+- New `cas-simplify` crate dependency.
+
+### Regression
+
+The numeric Weierstrass path is tried first and unchanged; the
+symbolic path explicitly bails out when both `a` and `b` are
+rational, so concrete-coefficient integrals continue to use the
+arithmetic-folded numeric closed forms.  All 225 existing tests still
+pass; 8 new tests cover the symbolic branches.
+
 ## [0.18.0] - 2026-06-06
 
 ### Added

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "symbolic-vm"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"
 
 [dependencies]
 cas-factor = { path = "../cas-factor" }
+cas-simplify = { path = "../cas-simplify" }
 symbolic-ir = { path = "../symbolic-ir" }

--- a/code/packages/rust/symbolic-vm/src/backend.rs
+++ b/code/packages/rust/symbolic-vm/src/backend.rs
@@ -164,7 +164,12 @@ impl BaseBackend {
         env.insert("True".to_string(), IRNode::Symbol("True".to_string()));
         env.insert("False".to_string(), IRNode::Symbol("False".to_string()));
 
-        let held = ["Assign", "Define", "If"]
+        // Track G2: `Assume(rel)` and `Forget(rel)` must NOT pre-evaluate
+        // their relational argument — `Greater(a^2, b^2)` would otherwise
+        // be reduced (or echoed by the symbolic backend) before reaching
+        // the handler, which would then have no symbolic relation to
+        // record.
+        let held = ["Assign", "Define", "If", "Assume", "Forget"]
             .iter()
             .map(|s| s.to_string())
             .collect();

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -26,6 +26,7 @@ use std::collections::{HashMap, HashSet};
 use cas_factor::{
     factor_integer_polynomial, try_bivariate_hensel, BiPoly as HenselBiPoly, Rat as HenselRat,
 };
+use cas_simplify::AssumptionContext;
 use symbolic_ir::{
     IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ASSIGN, ATAN, ATANH, COS, COSH, COTH,
     CSCH, D, DEFINE, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, INV, LESS, LESS_EQUAL,
@@ -1975,6 +1976,398 @@ fn try_weierstrass_one_over_linear_trig(
     Some(apply_node(MUL, vec![coef_ir, apply_node(ATAN, vec![atan_arg])]))
 }
 
+// ---------------------------------------------------------------------------
+// Track G2 — symbolic-coefficient Weierstrass lift (Rust port).
+//
+// The numeric helpers above parse `a, b` as `RatC` and bail out when
+// either is not a rational literal.  Track G2 generalises them: when
+// the numeric path returns `None` because `a` and/or `b` is a free IR
+// symbol (or any non-numeric IR expression), we re-parse the
+// integrand keeping `a, b` as IR nodes (`α, β, c` stay rational), then
+// consult `vm.assumptions` for the sign of the discriminant
+// `a² − b²` to decide which closed form to emit:
+//
+//   disc > 0 → arctan form with Sqrt(a²−b²)
+//   disc < 0 → log form with Sqrt(b²−a²)
+//   disc = 0 → degenerate rational-in-tan(arg/2) form
+//   no fact  → return None (integrator leaves it unevaluated)
+//
+// Linear-argument lifting `α·x + β` composes unchanged because the
+// inner substitution `u = tan(arg/2)` depends only on `α, β` (which
+// stay rational).
+//
+// `integrate` is a pure function with no `&VM` argument, and
+// threading one through ~30 call sites would be invasive.  Instead
+// we publish the live assumption store via a `thread_local!` mirror
+// of Python's `_CURRENT_VM` ContextVar.  `integrate_handler` clones
+// the `AssumptionContext` into the thread-local for the duration of
+// one evaluation; an RAII guard restores the previous value on Drop
+// so nested integrals (and panics) cannot strand it.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    /// Live assumption store published by `integrate_handler` for the
+    /// duration of one `Integrate(...)` evaluation.
+    static CURRENT_ASSUMPTIONS: std::cell::RefCell<Option<AssumptionContext>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII guard that restores the previous current-assumptions value on
+/// Drop.  Mirrors Python's `_CURRENT_VM.reset(_vm_token)` in the
+/// `finally` clause.
+struct AssumptionGuard {
+    previous: Option<AssumptionContext>,
+}
+
+impl AssumptionGuard {
+    fn install(new: AssumptionContext) -> Self {
+        let previous = CURRENT_ASSUMPTIONS.with(|slot| slot.borrow_mut().replace(new));
+        Self { previous }
+    }
+}
+
+impl Drop for AssumptionGuard {
+    fn drop(&mut self) {
+        CURRENT_ASSUMPTIONS.with(|slot| {
+            *slot.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+/// Match `c·sin(α·x+β)` / `c·cos(α·x+β)` returning `c` as an IR node
+/// (instead of a `RatC`).  Only the outer scalar `c` is allowed to be
+/// symbolic; `α, β` stay rational because that's what makes the
+/// Weierstrass substitution composable in closed form.
+fn weierstrass_parse_const_times_trig_linear_symbolic(
+    node: &IRNode,
+    x: &str,
+) -> Option<(IRNode, &'static str, RatC, RatC)> {
+    if let IRNode::Apply(apply) = node {
+        if apply.args.len() == 1 {
+            let head_str = if apply.head == IRNode::Symbol(SIN.to_string()) {
+                Some(SIN)
+            } else if apply.head == IRNode::Symbol(COS.to_string()) {
+                Some(COS)
+            } else {
+                None
+            };
+            if let Some(head) = head_str {
+                if let Some((alpha, beta)) = weierstrass_parse_linear_in_x(&apply.args[0], x) {
+                    return Some((IRNode::Integer(1), head, alpha, beta));
+                }
+            }
+        }
+        if apply.head == IRNode::Symbol(MUL.to_string()) && apply.args.len() == 2 {
+            let (a, b) = (&apply.args[0], &apply.args[1]);
+            for (const_side, trig_side) in [(a, b), (b, a)] {
+                if depends_on(const_side, x) {
+                    continue;
+                }
+                let IRNode::Apply(trig) = trig_side else {
+                    continue;
+                };
+                if trig.args.len() != 1 {
+                    continue;
+                }
+                let head_str = if trig.head == IRNode::Symbol(SIN.to_string()) {
+                    Some(SIN)
+                } else if trig.head == IRNode::Symbol(COS.to_string()) {
+                    Some(COS)
+                } else {
+                    None
+                };
+                let Some(head) = head_str else { continue };
+                if let Some((alpha, beta)) = weierstrass_parse_linear_in_x(&trig.args[0], x) {
+                    return Some((const_side.clone(), head, alpha, beta));
+                }
+            }
+        }
+        if apply.head == IRNode::Symbol(NEG.to_string()) && apply.args.len() == 1 {
+            if let Some((c, head, alpha, beta)) =
+                weierstrass_parse_const_times_trig_linear_symbolic(&apply.args[0], x)
+            {
+                return Some((apply_node(NEG, vec![c]), head, alpha, beta));
+            }
+        }
+    }
+    None
+}
+
+/// Symbolic-coefficient sibling of [`weierstrass_parse_a_plus_b_sincos`].
+/// Parses `a + b·sin(α·x+β)` / `a + b·cos(α·x+β)` (any operand order,
+/// ADD or SUB) into `(a, b, head_str, α, β)` where `a` and `b` are IR
+/// nodes free of `x` and `α, β` are rational with `α ≠ 0`.
+fn weierstrass_parse_a_plus_b_sincos_symbolic(
+    node: &IRNode,
+    x: &str,
+) -> Option<(IRNode, IRNode, &'static str, RatC, RatC)> {
+    if let Some((b, head, alpha, beta)) =
+        weierstrass_parse_const_times_trig_linear_symbolic(node, x)
+    {
+        return Some((IRNode::Integer(0), b, head, alpha, beta));
+    }
+    let IRNode::Apply(apply) = node else {
+        return None;
+    };
+    if apply.args.len() != 2 {
+        return None;
+    }
+    let (left, right) = (&apply.args[0], &apply.args[1]);
+    if apply.head == IRNode::Symbol(ADD.to_string()) {
+        for (const_side, trig_side) in [(left, right), (right, left)] {
+            if depends_on(const_side, x) {
+                continue;
+            }
+            if let Some((b_node, head, alpha, beta)) =
+                weierstrass_parse_const_times_trig_linear_symbolic(trig_side, x)
+            {
+                return Some((const_side.clone(), b_node, head, alpha, beta));
+            }
+        }
+        return None;
+    }
+    if apply.head == IRNode::Symbol(SUB.to_string()) {
+        // `a − b·trig(...)` → `(a, −b, head, α, β)`.
+        if !depends_on(left, x) {
+            if let Some((b_node, head, alpha, beta)) =
+                weierstrass_parse_const_times_trig_linear_symbolic(right, x)
+            {
+                return Some((
+                    left.clone(),
+                    apply_node(NEG, vec![b_node]),
+                    head,
+                    alpha,
+                    beta,
+                ));
+            }
+        }
+        // `b·trig(...) − a` → `(−a, b, head, α, β)`.
+        if !depends_on(right, x) {
+            if let Some((b_node, head, alpha, beta)) =
+                weierstrass_parse_const_times_trig_linear_symbolic(left, x)
+            {
+                return Some((
+                    apply_node(NEG, vec![right.clone()]),
+                    b_node,
+                    head,
+                    alpha,
+                    beta,
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Build `Pow(node, 2)`.
+fn ir_square(node: &IRNode) -> IRNode {
+    apply_node(POW, vec![node.clone(), IRNode::Integer(2)])
+}
+
+/// Symbolic-coefficient arctan branch (a² > b²).
+fn try_weierstrass_arctan_symbolic(
+    c_scaled: IRNode,
+    a: &IRNode,
+    b: &IRNode,
+    trig_head: &'static str,
+    arg_node: &IRNode,
+) -> IRNode {
+    let disc = apply_node(SUB, vec![ir_square(a), ir_square(b)]);
+    let sqrt_disc = apply_node(SQRT, vec![disc]);
+    let tan_half = apply_node(
+        TAN,
+        vec![apply_node(DIV, vec![arg_node.clone(), IRNode::Integer(2)])],
+    );
+    let atan_arg_top = if trig_head == SIN {
+        // (a·tan(arg/2) + b)
+        apply_node(
+            ADD,
+            vec![apply_node(MUL, vec![a.clone(), tan_half]), b.clone()],
+        )
+    } else {
+        // (a − b)·tan(arg/2)
+        apply_node(
+            MUL,
+            vec![apply_node(SUB, vec![a.clone(), b.clone()]), tan_half],
+        )
+    };
+    let atan_arg = apply_node(DIV, vec![atan_arg_top, sqrt_disc.clone()]);
+    let coef = apply_node(
+        DIV,
+        vec![apply_node(MUL, vec![IRNode::Integer(2), c_scaled]), sqrt_disc],
+    );
+    apply_node(MUL, vec![coef, apply_node(ATAN, vec![atan_arg])])
+}
+
+/// Symbolic-coefficient log branch (a² < b²).
+fn try_weierstrass_log_symbolic(
+    c_scaled: IRNode,
+    a: &IRNode,
+    b: &IRNode,
+    trig_head: &'static str,
+    arg_node: &IRNode,
+) -> IRNode {
+    let neg_disc = apply_node(SUB, vec![ir_square(b), ir_square(a)]);
+    let sqrt_neg_disc = apply_node(SQRT, vec![neg_disc]);
+    let tan_half = apply_node(
+        TAN,
+        vec![apply_node(DIV, vec![arg_node.clone(), IRNode::Integer(2)])],
+    );
+    let (numer, denom) = if trig_head == SIN {
+        let a_tan = apply_node(MUL, vec![a.clone(), tan_half]);
+        let a_tan_plus_b = apply_node(ADD, vec![a_tan, b.clone()]);
+        let numer = apply_node(SUB, vec![a_tan_plus_b.clone(), sqrt_neg_disc.clone()]);
+        let denom = apply_node(ADD, vec![a_tan_plus_b, sqrt_neg_disc.clone()]);
+        (numer, denom)
+    } else {
+        let bma = apply_node(SUB, vec![b.clone(), a.clone()]);
+        let bma_tan = apply_node(MUL, vec![bma, tan_half]);
+        let numer = apply_node(ADD, vec![sqrt_neg_disc.clone(), bma_tan.clone()]);
+        let denom = apply_node(SUB, vec![sqrt_neg_disc.clone(), bma_tan]);
+        (numer, denom)
+    };
+    let log_arg = apply_node("Abs", vec![apply_node(DIV, vec![numer, denom])]);
+    let coef = apply_node(DIV, vec![c_scaled, sqrt_neg_disc]);
+    apply_node(MUL, vec![coef, apply_node(LOG, vec![log_arg])])
+}
+
+/// Symbolic-coefficient degenerate branch (a² = b²).
+fn try_weierstrass_degenerate_symbolic(
+    c_scaled: IRNode,
+    a: &IRNode,
+    b: &IRNode,
+    trig_head: &'static str,
+    arg_node: &IRNode,
+) -> IRNode {
+    let tan_half = apply_node(
+        TAN,
+        vec![apply_node(DIV, vec![arg_node.clone(), IRNode::Integer(2)])],
+    );
+    let a_plus_b = apply_node(ADD, vec![a.clone(), b.clone()]);
+    let a_minus_b = apply_node(SUB, vec![a.clone(), b.clone()]);
+    if trig_head == SIN {
+        // −2·c / ( (a+b)·tan(arg/2) + (a−b) )
+        let numer = apply_node(MUL, vec![IRNode::Integer(-2), c_scaled]);
+        let denom = apply_node(
+            ADD,
+            vec![apply_node(MUL, vec![a_plus_b, tan_half]), a_minus_b],
+        );
+        apply_node(DIV, vec![numer, denom])
+    } else {
+        // 2·c·tan(arg/2) / ( (a−b)·tan²(arg/2) + (a+b) )
+        let tan_sq = apply_node(POW, vec![tan_half.clone(), IRNode::Integer(2)]);
+        let numer = apply_node(
+            MUL,
+            vec![apply_node(MUL, vec![IRNode::Integer(2), c_scaled]), tan_half],
+        );
+        let denom = apply_node(
+            ADD,
+            vec![apply_node(MUL, vec![a_minus_b, tan_sq]), a_plus_b],
+        );
+        apply_node(DIV, vec![numer, denom])
+    }
+}
+
+/// Did the user pin down `a² > b²` (disc > 0)?  Probes both the
+/// natural `a² > b²` and the canonical-against-zero `a² − b² > 0`
+/// surface forms.
+fn assumption_says_disc_positive(
+    assumptions: &AssumptionContext,
+    a: &IRNode,
+    b: &IRNode,
+) -> bool {
+    let a_sq = ir_square(a);
+    let b_sq = ir_square(b);
+    let disc = apply_node(SUB, vec![a_sq.clone(), b_sq.clone()]);
+    assumptions.is_true_relation(&apply_node(GREATER, vec![a_sq, b_sq])) == Some(true)
+        || assumptions.is_true_relation(&apply_node(GREATER, vec![disc, IRNode::Integer(0)]))
+            == Some(true)
+}
+
+fn assumption_says_disc_negative(
+    assumptions: &AssumptionContext,
+    a: &IRNode,
+    b: &IRNode,
+) -> bool {
+    let a_sq = ir_square(a);
+    let b_sq = ir_square(b);
+    let disc = apply_node(SUB, vec![a_sq.clone(), b_sq.clone()]);
+    assumptions.is_true_relation(&apply_node(LESS, vec![a_sq, b_sq])) == Some(true)
+        || assumptions.is_true_relation(&apply_node(LESS, vec![disc, IRNode::Integer(0)]))
+            == Some(true)
+}
+
+fn assumption_says_disc_zero(
+    assumptions: &AssumptionContext,
+    a: &IRNode,
+    b: &IRNode,
+) -> bool {
+    let a_sq = ir_square(a);
+    let b_sq = ir_square(b);
+    let disc = apply_node(SUB, vec![a_sq.clone(), b_sq.clone()]);
+    assumptions.is_true_relation(&apply_node(EQUAL, vec![a_sq, b_sq])) == Some(true)
+        || assumptions.is_true_relation(&apply_node(EQUAL, vec![disc, IRNode::Integer(0)]))
+            == Some(true)
+}
+
+/// Track G2 entry point.  Mirrors the numeric
+/// [`try_weierstrass_one_over_linear_trig`] but accepts non-numeric
+/// `a, b`.  Returns `None` when the shape doesn't match, the
+/// numerator depends on `x`, no assumption store is available
+/// (called outside `integrate_handler`), or no assumption pins down
+/// the discriminant sign.
+fn try_weierstrass_symbolic_coefficients(f: &IRNode, x: &str) -> Option<IRNode> {
+    let IRNode::Apply(apply) = f else {
+        return None;
+    };
+    if apply.head != IRNode::Symbol(DIV.to_string()) || apply.args.len() != 2 {
+        return None;
+    }
+    let (num, den) = (&apply.args[0], &apply.args[1]);
+    if depends_on(num, x) {
+        return None;
+    }
+    let (a, b, trig_head, alpha, beta) = weierstrass_parse_a_plus_b_sincos_symbolic(den, x)?;
+    if alpha.0 == 0 {
+        return None;
+    }
+    // Numeric path would already have closed the integral when both
+    // `a` and `b` are rational; bail out so we don't emit a second
+    // (potentially uglier) result.
+    if node_to_rc(&a).is_some() && node_to_rc(&b).is_some() {
+        return None;
+    }
+    // u = α·x + β; numerator scales by 1/α.
+    let one_over_alpha = rc(alpha.1, alpha.0)?;
+    let c_scaled = if rc_is_one(one_over_alpha) {
+        num.clone()
+    } else {
+        apply_node(MUL, vec![rc_to_ir(one_over_alpha)?, num.clone()])
+    };
+    let arg_node = weierstrass_build_linear_arg_ir(alpha, beta, x)?;
+    // Snapshot the current-assumptions thread-local.  We only need a
+    // read-only view, but the slot stores an owned
+    // `AssumptionContext`; we clone — cheap because each `Integrate`
+    // call only does this once.
+    let assumptions = CURRENT_ASSUMPTIONS.with(|slot| slot.borrow().clone())?;
+    if assumption_says_disc_positive(&assumptions, &a, &b) {
+        return Some(try_weierstrass_arctan_symbolic(
+            c_scaled, &a, &b, trig_head, &arg_node,
+        ));
+    }
+    if assumption_says_disc_negative(&assumptions, &a, &b) {
+        return Some(try_weierstrass_log_symbolic(
+            c_scaled, &a, &b, trig_head, &arg_node,
+        ));
+    }
+    if assumption_says_disc_zero(&assumptions, &a, &b) {
+        return Some(try_weierstrass_degenerate_symbolic(
+            c_scaled, &a, &b, trig_head, &arg_node,
+        ));
+    }
+    None
+}
+
 fn integrate_handler() -> Handler {
     std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
         if expr.args.len() != 2 && expr.args.len() != 4 {
@@ -1989,6 +2382,13 @@ fn integrate_handler() -> Handler {
             IRNode::Symbol(s) => s.clone(),
             _ => return IRNode::Apply(Box::new(expr)),
         };
+
+        // Track G2: publish a snapshot of the VM's assumption store
+        // for helpers that consult it (currently:
+        // `try_weierstrass_symbolic_coefficients`).  The guard
+        // restores the previous value on Drop so nested calls and
+        // panics can't strand the thread-local.
+        let _assumption_guard = AssumptionGuard::install(vm.assumptions.clone());
 
         if expr.args.len() == 4 {
             if let Some(result) = complete_elliptic_first_kind(&f, &x, &expr.args[2], &expr.args[3]) {
@@ -2070,8 +2470,13 @@ fn integrate(f: &IRNode, x: &str) -> IRNode {
         }
         // Phase 34: Weierstrass substitution for c / (a + b·sin/cos(x))
         // when c, a, b are rational and a² > b² (and a > 0 for the cos case).
+        // Track G2: symbolic-coefficient Weierstrass — fires only when
+        // the numeric path returns None and `vm.assumptions` records a
+        // sign for `a² − b²`.  Mirrors the Python helper at
+        // `symbolic_vm/integrate.py`.
         (DIV, [c, denom]) if !depends_on(c, x) => {
             try_weierstrass_one_over_linear_trig(c, denom, x)
+                .or_else(|| try_weierstrass_symbolic_coefficients(f, x))
                 .unwrap_or_else(|| apply_node(INTEGRATE, vec![f.clone(), IRNode::Symbol(x.to_string())]))
         }
         (POW, [base, exponent]) if base == &IRNode::Symbol(x.to_string()) => {
@@ -6799,8 +7204,44 @@ pub fn build_handler_table(simplify: bool) -> HashMap<String, Handler> {
         m.insert(FACTOR.to_string(), handler_fn(factor_handler));
         // Track B1 — Apart simple-roots partial-fraction decomposition.
         m.insert(APART.to_string(), handler_fn(apart_handler));
+        // Track G2 — assumption store mutators.  `Assume(rel)` records a
+        // sign / equality fact on `vm.assumptions`; `Forget(rel)`
+        // removes one; `ForgetAll()` clears the whole table.  The
+        // relation argument is held (see `BaseBackend::new`) so it
+        // reaches the handler intact.  Returning the original expr
+        // mirrors the Python handler and lets MACSYMA chains like
+        // `Assume(x > 0); Sqrt(x^2)` thread the assertion through
+        // without producing extraneous result expressions.
+        m.insert("Assume".to_string(), assume_handler());
+        m.insert("Forget".to_string(), forget_handler());
+        m.insert("ForgetAll".to_string(), forget_all_handler());
     }
     m
+}
+
+fn assume_handler() -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() == 1 {
+            vm.assumptions.assume_relation(&expr.args[0]);
+        }
+        IRNode::Apply(Box::new(expr))
+    })
+}
+
+fn forget_handler() -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        if expr.args.len() == 1 {
+            vm.assumptions.forget_relation(&expr.args[0]);
+        }
+        IRNode::Apply(Box::new(expr))
+    })
+}
+
+fn forget_all_handler() -> Handler {
+    std::sync::Arc::new(move |vm: &mut VM, expr: IRApply| -> IRNode {
+        vm.assumptions.forget_all();
+        IRNode::Apply(Box::new(expr))
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/symbolic-vm/src/vm.rs
+++ b/code/packages/rust/symbolic-vm/src/vm.rs
@@ -24,6 +24,7 @@
 //! The "self-loop guard" in symbol evaluation prevents `x := x` from
 //! recursing forever.
 
+use cas_simplify::AssumptionContext;
 use symbolic_ir::{IRApply, IRNode, DEFINE, LIST};
 
 use crate::backend::Backend;
@@ -35,12 +36,21 @@ use crate::backend::Backend;
 pub struct VM {
     /// The evaluation policy — language-specific behaviour lives here.
     pub backend: Box<dyn Backend>,
+    /// Track G2 — per-VM assumption store consulted by the
+    /// symbolic-coefficient Weierstrass integrator (and any future
+    /// sign-aware helper).  Mutated via the `Assume(...)` /
+    /// `Forget(...)` / `ForgetAll()` handlers; tests and embedders may
+    /// also read or write it directly.
+    pub assumptions: AssumptionContext,
 }
 
 impl VM {
     /// Create a new VM backed by `backend`.
     pub fn new(backend: Box<dyn Backend>) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            assumptions: AssumptionContext::new(),
+        }
     }
 
     // ------------------------------------------------------------------

--- a/code/packages/rust/symbolic-vm/tests/weierstrass_symbolic_coefficients.rs
+++ b/code/packages/rust/symbolic-vm/tests/weierstrass_symbolic_coefficients.rs
@@ -1,0 +1,238 @@
+//! Track G2 (Rust port) — symbolic-coefficient Weierstrass lift.
+//!
+//! Mirrors
+//! `code/packages/python/symbolic-vm/tests/test_weierstrass_symbolic_coefficients.py`
+//! shipped with Python G1 / PR #5361, and the TypeScript port in
+//! `code/packages/typescript/symbolic-vm/tests/weierstrass-symbolic-coefficients.test.ts`.
+//!
+//! The numeric Phase-34 Weierstrass helper only fires when `a` and
+//! `b` in `∫ c / (a + b·sin(α·x+β)) dx` are concrete rationals.
+//! Track G2 generalises it: when the user has declared the sign of
+//! the discriminant `a² − b²` via `Assume(...)`, the integrator emits
+//! the corresponding closed form with symbolic `a, b`.
+//!
+//! The branch selection is driven by `vm.assumptions` lookups against
+//! the compound-relation store added in the Rust cas-simplify Track
+//! G2 first half.  These tests cover all four branches (`> 0`,
+//! `< 0`, `= 0`, no assumption → unevaluated) plus the
+//! linear-argument lifting that must still compose.
+//!
+//! Structural assertions rather than numeric ones — the result is a
+//! tree in symbolic `a, b` that no numeric evaluation can collapse
+//! cheaply.  We assert the kind of the outer head (`Atan`, `Log`,
+//! `Integrate`) and that the recorded discriminant radicand appears
+//! literally somewhere in the tree.
+
+use symbolic_ir::{
+    apply, int, sym, IRNode, ADD, ATAN, COS, DIV, EQUAL, GREATER, INTEGRATE, LESS, LOG, MUL, POW,
+    SIN, SQRT, SUB,
+};
+use symbolic_vm::{SymbolicBackend, VM};
+
+fn make_vm() -> VM {
+    VM::new(Box::new(SymbolicBackend::new()))
+}
+
+fn x_sym() -> IRNode {
+    sym("x")
+}
+fn a_sym() -> IRNode {
+    sym("a")
+}
+fn b_sym() -> IRNode {
+    sym("b")
+}
+
+fn sq(node: IRNode) -> IRNode {
+    apply(sym(POW), vec![node, int(2)])
+}
+
+fn gt(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(GREATER), vec![lhs, rhs])
+}
+fn lt(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(LESS), vec![lhs, rhs])
+}
+fn eq(lhs: IRNode, rhs: IRNode) -> IRNode {
+    apply(sym(EQUAL), vec![lhs, rhs])
+}
+
+fn assume(vm: &mut VM, rel: IRNode) {
+    vm.eval(apply(sym("Assume"), vec![rel]));
+}
+
+fn integrate_expr(f: IRNode) -> IRNode {
+    apply(sym(INTEGRATE), vec![f, x_sym()])
+}
+
+fn is_integrate(node: &IRNode) -> bool {
+    matches!(node, IRNode::Apply(a) if a.head == sym(INTEGRATE))
+}
+
+fn contains_head(node: &IRNode, head: &IRNode) -> bool {
+    match node {
+        IRNode::Apply(a) => &a.head == head || a.args.iter().any(|arg| contains_head(arg, head)),
+        _ => false,
+    }
+}
+
+fn contains_subtree(node: &IRNode, target: &IRNode) -> bool {
+    if node == target {
+        return true;
+    }
+    match node {
+        IRNode::Apply(a) => a.args.iter().any(|arg| contains_subtree(arg, target)),
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// disc > 0  →  arctan branch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbolic_sin_arctan_branch() {
+    let mut vm = make_vm();
+    assume(&mut vm, gt(sq(a_sym()), sq(b_sym())));
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(SIN), vec![x_sym()])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result), "got {result}");
+    assert!(contains_head(&result, &sym(ATAN)));
+    let expected_sqrt = apply(sym(SQRT), vec![apply(sym(SUB), vec![sq(a_sym()), sq(b_sym())])]);
+    assert!(contains_subtree(&result, &expected_sqrt), "result = {result}");
+}
+
+#[test]
+fn symbolic_cos_arctan_branch() {
+    let mut vm = make_vm();
+    assume(&mut vm, gt(sq(a_sym()), sq(b_sym())));
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(COS), vec![x_sym()])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result), "got {result}");
+    assert!(contains_head(&result, &sym(ATAN)));
+    let expected_sqrt = apply(sym(SQRT), vec![apply(sym(SUB), vec![sq(a_sym()), sq(b_sym())])]);
+    assert!(contains_subtree(&result, &expected_sqrt), "result = {result}");
+}
+
+// ---------------------------------------------------------------------------
+// disc < 0  →  log branch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbolic_sin_log_branch() {
+    let mut vm = make_vm();
+    assume(&mut vm, lt(sq(a_sym()), sq(b_sym())));
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(SIN), vec![x_sym()])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result), "got {result}");
+    assert!(contains_head(&result, &sym(LOG)));
+    let expected_sqrt = apply(sym(SQRT), vec![apply(sym(SUB), vec![sq(b_sym()), sq(a_sym())])]);
+    assert!(contains_subtree(&result, &expected_sqrt), "result = {result}");
+}
+
+// ---------------------------------------------------------------------------
+// disc = 0  →  degenerate branch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbolic_sin_degenerate_branch() {
+    let mut vm = make_vm();
+    assume(&mut vm, eq(sq(a_sym()), sq(b_sym())));
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(SIN), vec![x_sym()])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result), "got {result}");
+    // No outer arctan, no outer log — only `tan(...)` below an
+    // arithmetic tree.
+    assert!(!contains_head(&result, &sym(ATAN)));
+    assert!(!contains_head(&result, &sym(LOG)));
+}
+
+// ---------------------------------------------------------------------------
+// No assumption  →  unevaluated
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_assumption_returns_unevaluated() {
+    let mut vm = make_vm();
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(SIN), vec![x_sym()])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(is_integrate(&result));
+}
+
+// ---------------------------------------------------------------------------
+// Linear-argument lifting composes (Phase 38 + Track G2).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn symbolic_linear_argument_arctan() {
+    let mut vm = make_vm();
+    assume(&mut vm, gt(sq(a_sym()), sq(b_sym())));
+    let inner = apply(sym(ADD), vec![apply(sym(MUL), vec![int(2), x_sym()]), int(1)]);
+    let denom = apply(
+        sym(ADD),
+        vec![
+            a_sym(),
+            apply(sym(MUL), vec![b_sym(), apply(sym(SIN), vec![inner])]),
+        ],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result));
+    assert!(contains_head(&result, &sym(ATAN)));
+    let expected_sqrt = apply(sym(SQRT), vec![apply(sym(SUB), vec![sq(a_sym()), sq(b_sym())])]);
+    assert!(contains_subtree(&result, &expected_sqrt));
+}
+
+// ---------------------------------------------------------------------------
+// Numeric regression — the symbolic helper must not steal numeric cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn numeric_regression_arctan_still_works() {
+    let mut vm = make_vm();
+    let denom = apply(sym(ADD), vec![int(2), apply(sym(SIN), vec![x_sym()])]);
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result));
+    assert!(contains_head(&result, &sym(ATAN)));
+}
+
+#[test]
+fn numeric_regression_log_still_works() {
+    let mut vm = make_vm();
+    let denom = apply(
+        sym(ADD),
+        vec![int(1), apply(sym(MUL), vec![int(2), apply(sym(SIN), vec![x_sym()])])],
+    );
+    let result = vm.eval(integrate_expr(apply(sym(DIV), vec![int(1), denom])));
+    assert!(!is_integrate(&result));
+    assert!(contains_head(&result, &sym(LOG)));
+}

--- a/code/packages/typescript/cas-simplify/CHANGELOG.md
+++ b/code/packages/typescript/cas-simplify/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [0.2.0] — 2026-05-29
+
+**Track G2 — compound-relation assumption store (TypeScript port).**
+
+Extends `AssumptionContext` so `assumeRelation(...)` and
+`isTrueRelation(...)` accept arbitrary relational shapes, not just
+plain-symbol-vs-zero.  Previously `assume(a^2 > b^2)` was silently
+dropped; under Track G2 it is canonicalised into a `(lhs, op, rhs)`
+triple and stored in a new structural-key set.  Subsequent
+`is(a^2 > b^2)` / `is(b^2 < a^2)` queries return `true` via lookup
+with commutativity-aware rewriting.  The legacy plain-symbol path is
+unchanged; the new path fires only when the plain-symbol path
+returns `undefined`.
+
+Mirrors Python `cas-simplify` 0.4.0 (Track G1).  The
+symbolic-coefficient Weierstrass integrator that consumes this
+compound-relation store ships in `symbolic-vm` 0.19.0.
+
+### Added
+
+- Private `generalRelations` set of canonical-key strings for
+  compound relations.
+- `assumeRelation`, `forgetRelation`, and `isTrueRelation` now have
+  a compound-relation fallback when the plain-symbol path doesn't
+  apply.  `forgetAll` clears both stores.
+
+### Semantics
+
+- No negative-knowledge inference: `assume(a^2 > b^2)` does NOT make
+  `is(a^2 < b^2)` return `false` — it returns `undefined`.
+- Commutativity is honoured:
+    - `is(b^2 < a^2)` ≡ `is(a^2 > b^2)`,
+    - `is(b^2 = a^2)` ≡ `is(a^2 = b^2)`,
+    - and the same for `<=`/`>=`, `!=`.
+
 ## Unreleased
 
 - Add deterministic `AssumptionContext.factsFor(...)` and

--- a/code/packages/typescript/cas-simplify/package-lock.json
+++ b/code/packages/typescript/cas-simplify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/cas-simplify",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-simplify",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",

--- a/code/packages/typescript/cas-simplify/package.json
+++ b/code/packages/typescript/cas-simplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-simplify",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Canonicalization and simplification for symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-simplify/src/assumptions.ts
+++ b/code/packages/typescript/cas-simplify/src/assumptions.ts
@@ -9,6 +9,7 @@ import {
   equals,
   headName,
   int,
+  structuralKey,
 } from "@coding-adventures/symbolic-ir";
 
 const POSITIVE = "positive";
@@ -36,19 +37,48 @@ const PROPERTY_MAP = new Map<string, string>([
 
 const ZERO_IR = int(0);
 
+// Short operator strings used to canonicalise compound relations.  The
+// six legal values mirror the Python ``_RELATION_HEAD_TO_OP`` map and
+// give us a stable, hashable middle component for the
+// ``(lhs, op, rhs)`` triple stored in ``_generalRelations``.
+type RelationOp = ">" | "<" | ">=" | "<=" | "=" | "!=";
+
+const RELATION_HEAD_TO_OP: ReadonlyMap<string, RelationOp> = new Map([
+  [GREATER.name, ">"],
+  [LESS.name, "<"],
+  [GREATER_EQUAL.name, ">="],
+  [LESS_EQUAL.name, "<="],
+  [EQUAL.name, "="],
+  [NOT_EQUAL.name, "!="],
+]);
+
 export class AssumptionContext {
   private readonly facts = new Map<string, Set<string>>();
 
+  // Track G1 (TS port) — store compound relations as canonicalised
+  // ``(lhs, op, rhs)`` triples keyed by a structural string.  IR nodes
+  // are not natively hashable in JavaScript, but ``structuralKey``
+  // produces a deterministic string that respects structural equality
+  // (the same key Add / Mul canonicalisation already relies on).
+  private readonly generalRelations = new Set<string>();
+
   assumeRelation(expr: IRNode): void {
-    const parsed = relationAgainstZero(expr);
+    const parsed = parseRelation(expr);
     if (parsed === undefined) return;
-    const [symbolName, relation] = parsed;
-    if (relation === GREATER.name) this.add(symbolName, POSITIVE);
-    else if (relation === LESS.name) this.add(symbolName, NEGATIVE);
-    else if (relation === GREATER_EQUAL.name) this.add(symbolName, NONNEG);
-    else if (relation === LESS_EQUAL.name) this.add(symbolName, NONPOS);
-    else if (relation === EQUAL.name) this.add(symbolName, ZERO);
-    else if (relation === NOT_EQUAL.name) this.add(symbolName, NONZERO);
+    const { lhs, op, rhs } = parsed;
+    const sym = symbolNameOf(lhs);
+    // Plain-symbol-vs-zero path: fold into the per-symbol fact table.
+    if (sym !== undefined && equals(rhs, ZERO_IR)) {
+      if (op === ">") this.add(sym, POSITIVE);
+      else if (op === "<") this.add(sym, NEGATIVE);
+      else if (op === ">=") this.add(sym, NONNEG);
+      else if (op === "<=") this.add(sym, NONPOS);
+      else if (op === "=") this.add(sym, ZERO);
+      else if (op === "!=") this.add(sym, NONZERO);
+      return;
+    }
+    // Compound-relation path: canonicalise and stash.
+    this.generalRelations.add(canonKey(lhs, op, rhs));
   }
 
   assumeProperty(symbol: IRNode, property: IRNode): void {
@@ -60,19 +90,25 @@ export class AssumptionContext {
   }
 
   forgetRelation(expr: IRNode): void {
-    const parsed = relationAgainstZero(expr);
+    const parsed = parseRelation(expr);
     if (parsed === undefined) return;
-    const [symbolName, relation] = parsed;
-    if (relation === GREATER.name) this.remove(symbolName, POSITIVE);
-    else if (relation === LESS.name) this.remove(symbolName, NEGATIVE);
-    else if (relation === GREATER_EQUAL.name) this.remove(symbolName, NONNEG);
-    else if (relation === LESS_EQUAL.name) this.remove(symbolName, NONPOS);
-    else if (relation === EQUAL.name) this.remove(symbolName, ZERO);
-    else if (relation === NOT_EQUAL.name) this.remove(symbolName, NONZERO);
+    const { lhs, op, rhs } = parsed;
+    const sym = symbolNameOf(lhs);
+    if (sym !== undefined && equals(rhs, ZERO_IR)) {
+      if (op === ">") this.remove(sym, POSITIVE);
+      else if (op === "<") this.remove(sym, NEGATIVE);
+      else if (op === ">=") this.remove(sym, NONNEG);
+      else if (op === "<=") this.remove(sym, NONPOS);
+      else if (op === "=") this.remove(sym, ZERO);
+      else if (op === "!=") this.remove(sym, NONZERO);
+      return;
+    }
+    this.generalRelations.delete(canonKey(lhs, op, rhs));
   }
 
   forgetAll(): void {
     this.facts.clear();
+    this.generalRelations.clear();
   }
 
   isPositive(symbolName: string): boolean | undefined {
@@ -108,30 +144,59 @@ export class AssumptionContext {
     return undefined;
   }
 
+  /**
+   * Evaluate a relational IR node to ``true`` / ``false`` / ``undefined``.
+   *
+   * Two paths, tried in order:
+   *
+   *   1. Plain-symbol-vs-zero — folds against the per-symbol fact
+   *      table (Phase 21 behaviour).  May return ``true`` or ``false``
+   *      depending on what the user asserted; falls through on
+   *      ``undefined`` so a verbatim compound assertion may still
+   *      match.
+   *   2. Compound-relation lookup — Track G1.  Structurally looks up
+   *      ``_generalRelations`` for the canonicalised query.  Returns
+   *      ``true`` on hit, otherwise ``undefined``.  No
+   *      negative-knowledge inference: asserting ``a^2 > b^2`` does
+   *      NOT make ``a^2 < b^2`` return ``false``.
+   */
   isTrueRelation(expr: IRNode): boolean | undefined {
-    const parsed = relationAgainstZero(expr);
+    const parsed = parseRelation(expr);
     if (parsed === undefined) return undefined;
-    const [symbolName, relation] = parsed;
-    const facts = this.facts.get(symbolName);
+    const { lhs, op, rhs } = parsed;
+    const sym = symbolNameOf(lhs);
 
-    if (relation === GREATER.name) return this.isPositive(symbolName);
-    if (relation === LESS.name) return this.isNegative(symbolName);
-    if (relation === GREATER_EQUAL.name) {
+    if (sym !== undefined && equals(rhs, ZERO_IR)) {
+      const plain = this.isTruePlain(sym, op);
+      if (plain !== undefined) return plain;
+      // Fall through to compound-relation lookup just in case the user
+      // asserted the comparison verbatim with a non-symbol LHS that
+      // canonicalises to the same triple.
+    }
+
+    return this.generalRelations.has(canonKey(lhs, op, rhs)) ? true : undefined;
+  }
+
+  private isTruePlain(symbolName: string, op: RelationOp): boolean | undefined {
+    const facts = this.facts.get(symbolName);
+    if (op === ">") return this.isPositive(symbolName);
+    if (op === "<") return this.isNegative(symbolName);
+    if (op === ">=") {
       if (facts?.has(POSITIVE) || facts?.has(ZERO) || facts?.has(NONNEG)) return true;
       if (facts?.has(NEGATIVE)) return false;
       return undefined;
     }
-    if (relation === LESS_EQUAL.name) {
+    if (op === "<=") {
       if (facts?.has(NEGATIVE) || facts?.has(ZERO) || facts?.has(NONPOS)) return true;
       if (facts?.has(POSITIVE)) return false;
       return undefined;
     }
-    if (relation === EQUAL.name) {
+    if (op === "=") {
       if (facts?.has(ZERO)) return true;
       if (facts?.has(POSITIVE) || facts?.has(NEGATIVE) || facts?.has(NONZERO)) return false;
       return undefined;
     }
-    if (relation === NOT_EQUAL.name) {
+    if (op === "!=") {
       if (facts?.has(NONZERO) || facts?.has(POSITIVE) || facts?.has(NEGATIVE)) return true;
       if (facts?.has(ZERO)) return false;
       return undefined;
@@ -171,13 +236,42 @@ export class AssumptionContext {
   }
 }
 
-function relationAgainstZero(expr: IRNode): readonly [string, string] | undefined {
-  if (expr.kind !== "apply" || expr.args.length !== 2 || !equals(expr.args[1], ZERO_IR)) {
-    return undefined;
+interface ParsedRelation {
+  readonly lhs: IRNode;
+  readonly op: RelationOp;
+  readonly rhs: IRNode;
+}
+
+function parseRelation(expr: IRNode): ParsedRelation | undefined {
+  if (expr.kind !== "apply" || expr.args.length !== 2) return undefined;
+  const op = RELATION_HEAD_TO_OP.get(headName(expr.head));
+  if (op === undefined) return undefined;
+  return { lhs: expr.args[0], op, rhs: expr.args[1] };
+}
+
+/**
+ * Canonicalise a ``(lhs, op, rhs)`` relation and return a string key
+ * suitable for set membership.  Rules mirror the Python ``_canon_relation``:
+ *
+ *   - ``a < b`` is stored as ``(b, >, a)`` — every strict inequality
+ *     becomes ``>``.
+ *   - ``a <= b`` becomes ``(b, >=, a)``.
+ *   - ``a = b`` / ``a != b`` are commutative — order by structural key.
+ *   - ``a > b`` and ``a >= b`` pass through verbatim.
+ */
+function canonKey(lhs: IRNode, op: RelationOp, rhs: IRNode): string {
+  if (op === "<") return tripleKey(rhs, ">", lhs);
+  if (op === "<=") return tripleKey(rhs, ">=", lhs);
+  if (op === "=" || op === "!=") {
+    const a = structuralKey(lhs);
+    const b = structuralKey(rhs);
+    return a <= b ? `${a}|${op}|${b}` : `${b}|${op}|${a}`;
   }
-  const symbolName = symbolNameOf(expr.args[0]);
-  if (symbolName === undefined) return undefined;
-  return [symbolName, headName(expr.head)];
+  return tripleKey(lhs, op, rhs);
+}
+
+function tripleKey(lhs: IRNode, op: RelationOp, rhs: IRNode): string {
+  return `${structuralKey(lhs)}|${op}|${structuralKey(rhs)}`;
 }
 
 function symbolNameOf(node: IRNode): string | undefined {

--- a/code/packages/typescript/cas-simplify/tests/assumptions-compound.test.ts
+++ b/code/packages/typescript/cas-simplify/tests/assumptions-compound.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for compound-relation support in {@link AssumptionContext}
+ * (Track G2 TypeScript port of Python G1, macsyma-truly-finish-plan).
+ *
+ * Until Track G2 the assumption store only understood
+ * plain-symbol-vs-zero relations (``assume(x > 0)``).  Compound
+ * relations such as ``assume(a^2 > b^2)`` were silently dropped, which
+ * prevented the symbolic-coefficient Weierstrass integrator from
+ * learning the discriminant sign at integration time.
+ *
+ * These tests exercise the new compound-relation path end-to-end at
+ * the {@link AssumptionContext} API level — they neither require nor
+ * exercise the VM.  The integrator-side behaviour is tested in
+ * ``symbolic-vm/tests/weierstrass-symbolic-coefficients.test.ts``.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  EQUAL,
+  GREATER,
+  GREATER_EQUAL,
+  IRNode,
+  LESS,
+  LESS_EQUAL,
+  NOT_EQUAL,
+  POW,
+  app,
+  int,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { AssumptionContext } from "../src/assumptions.js";
+
+// ``a^2`` / ``b^2`` as IR.  Built once at module scope because IR nodes
+// are structural — the same node identity flows through every test.
+const A = sym("a");
+const B = sym("b");
+const TWO = int(2);
+const A_SQ = app(POW, [A, TWO]);
+const B_SQ = app(POW, [B, TWO]);
+
+const gt = (lhs: IRNode, rhs: IRNode): IRNode => app(GREATER, [lhs, rhs]);
+const lt = (lhs: IRNode, rhs: IRNode): IRNode => app(LESS, [lhs, rhs]);
+const ge = (lhs: IRNode, rhs: IRNode): IRNode => app(GREATER_EQUAL, [lhs, rhs]);
+const le = (lhs: IRNode, rhs: IRNode): IRNode => app(LESS_EQUAL, [lhs, rhs]);
+const eq = (lhs: IRNode, rhs: IRNode): IRNode => app(EQUAL, [lhs, rhs]);
+const ne = (lhs: IRNode, rhs: IRNode): IRNode => app(NOT_EQUAL, [lhs, rhs]);
+
+describe("AssumptionContext compound relations — direct lookups", () => {
+  it("assume(a^2 > b^2) then is(a^2 > b^2) returns true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(gt(A_SQ, B_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 = b^2) then is(a^2 = b^2) returns true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(eq(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(eq(A_SQ, B_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 < b^2) then is(a^2 < b^2) returns true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(lt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(lt(A_SQ, B_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 >= b^2) then is(a^2 >= b^2) returns true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(ge(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(ge(A_SQ, B_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 != b^2) then is(a^2 != b^2) returns true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(ne(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(ne(A_SQ, B_SQ))).toBe(true);
+  });
+});
+
+describe("AssumptionContext compound relations — commutative rewrites", () => {
+  it("assume(a^2 > b^2) implies is(b^2 < a^2) is true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(lt(B_SQ, A_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 < b^2) implies is(b^2 > a^2) is true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(lt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(gt(B_SQ, A_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 >= b^2) implies is(b^2 <= a^2) is true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(ge(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(le(B_SQ, A_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 = b^2) implies is(b^2 = a^2) is true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(eq(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(eq(B_SQ, A_SQ))).toBe(true);
+  });
+
+  it("assume(a^2 != b^2) implies is(b^2 != a^2) is true", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(ne(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(ne(B_SQ, A_SQ))).toBe(true);
+  });
+});
+
+describe("AssumptionContext compound relations — unknown / no-negative inference", () => {
+  it("no assertion → query returns undefined (not false)", () => {
+    const ctx = new AssumptionContext();
+    const c = sym("c");
+    const d = sym("d");
+    const cSq = app(POW, [c, TWO]);
+    const dSq = app(POW, [d, TWO]);
+    expect(ctx.isTrueRelation(gt(cSq, dSq))).toBeUndefined();
+  });
+
+  it("assume(a^2 > b^2) does NOT imply is(a^2 < b^2) is false", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(lt(A_SQ, B_SQ))).toBeUndefined();
+  });
+});
+
+describe("AssumptionContext compound relations — forget path", () => {
+  it("forgetRelation removes the stored compound fact", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(gt(A_SQ, B_SQ))).toBe(true);
+    ctx.forgetRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(gt(A_SQ, B_SQ))).toBeUndefined();
+  });
+
+  it("forgetAll clears both plain-symbol facts AND compound relations", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    const x = sym("x");
+    ctx.assumeRelation(gt(x, int(0)));
+    ctx.forgetAll();
+    expect(ctx.isTrueRelation(gt(A_SQ, B_SQ))).toBeUndefined();
+    expect(ctx.isPositive("x")).toBeUndefined();
+  });
+
+  it("re-asserting the same compound fact (or its commuted form) dedupes", () => {
+    const ctx = new AssumptionContext();
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    ctx.assumeRelation(gt(A_SQ, B_SQ));
+    // Re-assert via the commuted form — canonicalisation should fold.
+    ctx.assumeRelation(lt(B_SQ, A_SQ));
+    // A single forget should zero out the fact regardless of which
+    // surface form we used.
+    ctx.forgetRelation(gt(A_SQ, B_SQ));
+    expect(ctx.isTrueRelation(gt(A_SQ, B_SQ))).toBeUndefined();
+  });
+});
+
+describe("AssumptionContext compound relations — plain-symbol path unchanged", () => {
+  it("assume(x > 0) still threads through the per-symbol fact table", () => {
+    const ctx = new AssumptionContext();
+    const x = sym("x");
+    ctx.assumeRelation(gt(x, int(0)));
+    expect(ctx.isPositive("x")).toBe(true);
+    expect(ctx.isTrueRelation(gt(x, int(0)))).toBe(true);
+    expect(ctx.isTrueRelation(lt(x, int(0)))).toBe(false);
+  });
+});

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [0.19.0] — 2026-05-29
+
+**Track G2 — symbolic-coefficient Weierstrass lift (TypeScript port).**
+
+Generalises the Phase-34/35/36/37 Weierstrass substitution
+``∫ c / (a + b·trig(α·x + β)) dx`` from concrete rational ``a, b`` to
+symbolic ones.  When the numeric pattern returns `undefined` because
+either coefficient is a free IR expression, the new helper consults
+`vm.assumptions` for the sign of the discriminant ``a² − b²`` and,
+upon finding a declared inequality / equality, emits the matching
+arctan / log / degenerate closed form with symbolic
+``Sqrt(a² − b²)`` (or ``Sqrt(b² − a²)``) in the result.  When no
+assumption pins down the sign, the integral is left unevaluated.
+
+This depends on the compound-relation extension to
+`cas-simplify.AssumptionContext` shipped in cas-simplify 0.2.0 (same
+PR, Track G2).  Mirrors Python `symbolic-vm` 0.74.0.
+
+### Added
+
+- New `assumptions: AssumptionContext` field on `VM` — published to
+  Weierstrass helpers via a module-level current-assumptions mirror
+  of Python's `_CURRENT_VM` ContextVar.
+- Handlers `Assume(rel)` / `Forget(rel)` / `ForgetAll()` registered
+  on the symbolic backend, threading user-declared facts through to
+  `vm.assumptions`.  Both relational heads are added to the
+  hold-evaluate set so the relation argument reaches the handler
+  intact.
+- `tryWeierstrassSymbolicCoefficients` — symbolic dispatcher,
+  invoked after the numeric helper returns `undefined`.
+- `weierstrassParseAPlusBSincosSymbolic` — symbolic sibling of the
+  numeric parser.
+- Branch emitters `tryWeierstrass{Arctan,Log,Degenerate}Symbolic`.
+- New dependency on `@coding-adventures/cas-simplify`.
+
+### Regression
+
+The numeric Weierstrass path is tried first and unchanged; the
+symbolic path explicitly bails out when both ``a`` and ``b`` are
+numeric, so concrete-coefficient integrals continue to use the
+arithmetic-folded numeric closed forms.  All 38 existing
+Phase 34 / 35 / 36 / 37 tests still pass; 218 / 218 in the broader
+TS symbolic-vm suite.
+
 ## [0.18.0] - 2026-06-06
 
 ### Added

--- a/code/packages/typescript/symbolic-vm/package-lock.json
+++ b/code/packages/typescript/symbolic-vm/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/symbolic-vm",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",
+        "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
@@ -24,6 +25,20 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.19.18",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../cas-simplify": {
+      "name": "@coding-adventures/cas-simplify",
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
         "typescript": "^5.0.0",
         "vitest": "^4.1.0"
@@ -44,6 +59,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -53,6 +69,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -62,6 +79,7 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
       },
@@ -77,6 +95,7 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7"
@@ -99,6 +118,10 @@
       "resolved": "../cas-factor",
       "link": true
     },
+    "node_modules/@coding-adventures/cas-simplify": {
+      "resolved": "../cas-simplify",
+      "link": true
+    },
     "node_modules/@coding-adventures/symbolic-ir": {
       "resolved": "../symbolic-ir",
       "link": true
@@ -108,6 +131,7 @@
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
@@ -119,6 +143,7 @@
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -129,6 +154,7 @@
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -139,6 +165,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -147,26 +174,29 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -182,6 +212,7 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
       "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -194,6 +225,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -210,6 +242,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -226,6 +259,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -242,6 +276,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -258,6 +293,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -274,6 +310,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -290,6 +330,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -306,6 +350,10 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -322,6 +370,10 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -338,6 +390,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -354,6 +410,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -370,6 +430,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -386,6 +447,7 @@
         "wasm32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
@@ -404,6 +466,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -420,6 +483,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -432,19 +496,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -455,6 +522,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -464,19 +532,22 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
       "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.8",
@@ -507,6 +578,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
       "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
@@ -524,6 +596,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
       "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
@@ -550,6 +623,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
       "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -562,6 +636,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
       "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
@@ -575,6 +650,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
       "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.8",
         "@vitest/utils": "4.1.8",
@@ -590,6 +666,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
       "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -599,6 +676,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
       "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
@@ -613,15 +691,17 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
-      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
@@ -633,6 +713,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -641,13 +722,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -656,13 +739,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -672,6 +757,7 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -681,6 +767,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -699,6 +786,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -767,13 +855,15 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -806,6 +896,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
@@ -826,6 +917,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -846,6 +938,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -866,6 +959,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -886,6 +980,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -906,6 +1001,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -926,6 +1025,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -946,6 +1049,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -966,6 +1073,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -986,6 +1097,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1006,6 +1118,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1023,6 +1136,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -1032,6 +1146,7 @@
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
@@ -1065,6 +1180,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1073,32 +1189,39 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
-      ]
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1125,6 +1248,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -1139,6 +1263,7 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -1168,9 +1293,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1184,13 +1309,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1199,13 +1326,15 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -1224,13 +1353,15 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -1240,6 +1371,7 @@
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -1256,6 +1388,7 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1265,6 +1398,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
+      "license": "0BSD",
       "optional": true
     },
     "node_modules/typescript": {
@@ -1286,6 +1420,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1363,6 +1498,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -1452,6 +1588,7 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@coding-adventures/cas-factor": "file:../cas-factor",
+    "@coding-adventures/cas-simplify": "file:../cas-simplify",
     "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
   },
   "devDependencies": {

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -57,6 +57,7 @@ import {
 } from "@coding-adventures/symbolic-ir";
 import { BiRational, factorIntegerPolynomial, tryBivariateHensel } from "@coding-adventures/cas-factor";
 import type { BiPoly } from "@coding-adventures/cas-factor";
+import { AssumptionContext } from "@coding-adventures/cas-simplify";
 
 export type Handler = (vm: VM, expr: IRApply) => IRNode;
 export type RulePredicate = (expr: IRApply) => boolean;
@@ -87,6 +88,12 @@ class BaseBackend {
     ASSIGN.name,
     DEFINE.name,
     IF.name,
+    // Track G2: `Assume(rel)` and `Forget(rel)` must NOT pre-evaluate
+    // their relational argument — `Greater(a^2, b^2)` would otherwise be
+    // reduced (or echoed by the symbolic backend) before reaching the
+    // handler, which would then have no symbolic relation to record.
+    "Assume",
+    "Forget",
   ]);
 
   lookup(name: string): IRNode | undefined {
@@ -147,6 +154,15 @@ export class SymbolicBackend extends BaseBackend implements Backend {
 }
 
 export class VM {
+  /**
+   * Track G2 (TypeScript port): per-VM assumption store consulted by
+   * the symbolic-coefficient Weierstrass integrator (and any future
+   * sign-aware helper).  Mutated only via the `Assume(...)` /
+   * `Forget(...)` / `ForgetAll()` handlers — direct field access is
+   * supported for tests and embedders.
+   */
+  readonly assumptions: AssumptionContext = new AssumptionContext();
+
   constructor(public readonly backend: Backend) {}
 
   eval(node: IRNode): IRNode {
@@ -950,6 +966,28 @@ function buildHandlerTable(simplify: boolean): ReadonlyMap<string, Handler> {
   if (simplify) {
     table.set(D.name, differentiate());
     table.set(INTEGRATE.name, integrate());
+    // Track G2 (TS port): `Assume(rel)` records a sign / equality fact
+    // on the VM's `assumptions` store; `Forget(rel)` removes one;
+    // `ForgetAll()` clears the whole table.  Returning the relation
+    // verbatim mirrors the Python handler's behaviour and lets MACSYMA
+    // chains like `Assume(x > 0); Sqrt(x^2)` thread the assertion
+    // through without producing an extraneous result expression.
+    table.set("Assume", (vm, expr) => {
+      if (expr.args.length === 1) {
+        vm.assumptions.assumeRelation(expr.args[0]);
+      }
+      return expr;
+    });
+    table.set("Forget", (vm, expr) => {
+      if (expr.args.length === 1) {
+        vm.assumptions.forgetRelation(expr.args[0]);
+      }
+      return expr;
+    });
+    table.set("ForgetAll", (vm, expr) => {
+      vm.assumptions.forgetAll();
+      return expr;
+    });
   }
 
   return table;
@@ -2520,6 +2558,25 @@ function apartHandler(_vm: VM, expr: IRApply): IRNode {
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// Track G2 — current-VM assumption store, mirror of the Python
+// ``_CURRENT_VM`` ContextVar.
+//
+// Most integrator helpers operate on pure IR and don't need the VM.
+// The symbolic-coefficient Weierstrass helper (added in Track G2)
+// needs to query ``vm.assumptions`` for the discriminant sign.
+// Threading ``vm`` through every helper signature would touch ~30
+// call sites; we instead publish the live store via a module-level
+// reference that the top-level ``Integrate`` handler sets for the
+// duration of one evaluation.  JavaScript is single-threaded so a
+// plain ``let`` is the natural mirror of Python's ``ContextVar``.
+// ---------------------------------------------------------------------------
+let CURRENT_ASSUMPTIONS: AssumptionContext | undefined;
+
+function currentAssumptions(): AssumptionContext | undefined {
+  return CURRENT_ASSUMPTIONS;
+}
+
 function integrate(): Handler {
   return (vm, expr) => {
     if (expr.args.length !== 2 && expr.args.length !== 4) {
@@ -2529,33 +2586,44 @@ function integrate(): Handler {
     if (x.kind !== "symbol") {
       return expr;
     }
-    if (expr.args.length === 4) {
-      const resultK = completeEllipticFirstKind(f, x, expr.args[2], expr.args[3]);
-      if (resultK !== undefined) return vm.eval(resultK);
-      const resultE = completeEllipticSecondKind(f, x, expr.args[2], expr.args[3]);
-      if (resultE !== undefined) return vm.eval(resultE);
-      const resultPi = completeEllipticThirdKind(f, x, expr.args[2], expr.args[3]);
-      if (resultPi !== undefined) return vm.eval(resultPi);
-      return expr;
-    }
-    const result = integrateIndefinite(f, x);
-    if (result === undefined) {
-      // Track E2: generic tabular IBP fallback.  Fires after every
-      // shape-specific handler in integrateIndefinite returned undefined.
-      // Mirrors the Python ``try_ibp_tabular`` hook in ``integrate.py``.
-      const ibpResult = tryIbpTabular(
-        f,
-        x,
-        (g) => integrateIndefinite(g, x),
-        (g) => diff(g, x),
-        (n) => vm.eval(n),
-      );
-      if (ibpResult !== undefined) {
-        return vm.eval(ibpResult);
+    // Track G2: publish the live assumption store for helpers that
+    // consult it (currently: symbolic-coefficient Weierstrass).  The
+    // previous value is restored in `finally` so nested calls and
+    // exceptions can't strand the module-level mirror in an
+    // inconsistent state.
+    const previousAssumptions = CURRENT_ASSUMPTIONS;
+    CURRENT_ASSUMPTIONS = vm.assumptions;
+    try {
+      if (expr.args.length === 4) {
+        const resultK = completeEllipticFirstKind(f, x, expr.args[2], expr.args[3]);
+        if (resultK !== undefined) return vm.eval(resultK);
+        const resultE = completeEllipticSecondKind(f, x, expr.args[2], expr.args[3]);
+        if (resultE !== undefined) return vm.eval(resultE);
+        const resultPi = completeEllipticThirdKind(f, x, expr.args[2], expr.args[3]);
+        if (resultPi !== undefined) return vm.eval(resultPi);
+        return expr;
       }
-      return expr;
+      const result = integrateIndefinite(f, x);
+      if (result === undefined) {
+        // Track E2: generic tabular IBP fallback.  Fires after every
+        // shape-specific handler in integrateIndefinite returned undefined.
+        // Mirrors the Python ``try_ibp_tabular`` hook in ``integrate.py``.
+        const ibpResult = tryIbpTabular(
+          f,
+          x,
+          (g) => integrateIndefinite(g, x),
+          (g) => diff(g, x),
+          (n) => vm.eval(n),
+        );
+        if (ibpResult !== undefined) {
+          return vm.eval(ibpResult);
+        }
+        return expr;
+      }
+      return isDeferredIntegral(result, f, x) ? result : vm.eval(result);
+    } finally {
+      CURRENT_ASSUMPTIONS = previousAssumptions;
     }
-    return isDeferredIntegral(result, f, x) ? result : vm.eval(result);
   };
 }
 
@@ -3055,6 +3123,314 @@ function tryWeierstrassLogForm(
   return app(MUL, [coefIR, app(LOG, [logArg])]);
 }
 
+// ---------------------------------------------------------------------------
+// Track G2 — symbolic-coefficient Weierstrass lift (TypeScript port).
+//
+// The numeric helpers above parse ``a, b`` as ``Numeric`` and bail out
+// when either is not a literal Int/Rat.  Track G2 generalises them:
+// when the numeric path can't fire because ``a`` and/or ``b`` is a
+// free IR symbol or any non-numeric IR expression, we re-parse the
+// integrand keeping ``a, b`` as IR nodes (``α, β, c`` stay rational —
+// only the outer trig coefficient pair is allowed to be symbolic),
+// then query ``vm.assumptions`` for the sign of the discriminant
+// ``a² − b²`` to decide which closed form to emit:
+//
+//   disc > 0 → arctan form with Sqrt(a²−b²)
+//   disc < 0 → log form with Sqrt(b²−a²)
+//   disc = 0 → degenerate rational-in-tan(arg/2) form
+//   no fact  → return undefined (integrator leaves it unevaluated)
+//
+// Linear-argument lifting ``α·x + β`` composes unchanged — the inner
+// substitution ``u = tan((α·x+β)/2)`` does not depend on the values
+// of the outer coefficients ``a, b``, so we still fold ``1/α`` into
+// the numerator scaling exactly as the numeric path does.  Mirrors
+// the Python helper at ``symbolic_vm/integrate.py``.
+// ---------------------------------------------------------------------------
+
+/** Match ``c·sin(α·x+β)`` / ``c·cos(α·x+β)`` returning ``c`` as an IR
+ *  node (instead of a Numeric).  ``α, β`` stay rational because the
+ *  inner linear-form is what makes the Weierstrass substitution
+ *  composable; only the outer scalar ``c`` is allowed to be symbolic,
+ *  since that's what flows into ``a, b`` for the dispatcher below. */
+function weierstrassParseConstTimesTrigLinearSymbolic(
+  node: IRNode,
+  x: IRNode,
+):
+  | { readonly c: IRNode; readonly head: IRNode; readonly alpha: Numeric; readonly beta: Numeric }
+  | undefined {
+  if (
+    node.kind === "apply" &&
+    (equals(node.head, SIN) || equals(node.head, COS)) &&
+    node.args.length === 1
+  ) {
+    const lin = weierstrassParseLinearInX(node.args[0], x);
+    if (lin !== undefined) {
+      return { c: int(1), head: node.head, alpha: lin.alpha, beta: lin.beta };
+    }
+  }
+  if (node.kind === "apply" && equals(node.head, MUL) && node.args.length === 2) {
+    const [left, right] = node.args;
+    for (const [constSide, trigSide] of [
+      [left, right],
+      [right, left],
+    ] as const) {
+      if (dependsOn(constSide, x)) continue;
+      if (
+        trigSide.kind === "apply" &&
+        (equals(trigSide.head, SIN) || equals(trigSide.head, COS)) &&
+        trigSide.args.length === 1
+      ) {
+        const lin = weierstrassParseLinearInX(trigSide.args[0], x);
+        if (lin !== undefined) {
+          return { c: constSide, head: trigSide.head, alpha: lin.alpha, beta: lin.beta };
+        }
+      }
+    }
+  }
+  if (node.kind === "apply" && equals(node.head, NEG) && node.args.length === 1) {
+    const inner = weierstrassParseConstTimesTrigLinearSymbolic(node.args[0], x);
+    if (inner !== undefined) {
+      return { c: app(NEG, [inner.c]), head: inner.head, alpha: inner.alpha, beta: inner.beta };
+    }
+  }
+  return undefined;
+}
+
+/** Symbolic-coefficient sibling of {@link weierstrassParseAPlusBSincos}.
+ *  Parses ``a + b·sin(α·x+β)`` / ``a + b·cos(α·x+β)`` (any operand
+ *  order, ADD or SUB) into ``(a, b, head, α, β)`` where ``a`` and
+ *  ``b`` are IR nodes free of ``x`` and ``α, β`` are rational with
+ *  ``α ≠ 0``.  Returns undefined when the shape doesn't fit. */
+function weierstrassParseAPlusBSincosSymbolic(
+  node: IRNode,
+  x: IRNode,
+):
+  | {
+      readonly a: IRNode;
+      readonly b: IRNode;
+      readonly trigHead: IRNode;
+      readonly alpha: Numeric;
+      readonly beta: Numeric;
+    }
+  | undefined {
+  const bareTrig = weierstrassParseConstTimesTrigLinearSymbolic(node, x);
+  if (bareTrig !== undefined) {
+    return { a: int(0), b: bareTrig.c, trigHead: bareTrig.head, alpha: bareTrig.alpha, beta: bareTrig.beta };
+  }
+  if (node.kind !== "apply" || node.args.length !== 2) return undefined;
+  if (equals(node.head, ADD)) {
+    const [left, right] = node.args;
+    for (const [constSide, trigSide] of [
+      [left, right],
+      [right, left],
+    ] as const) {
+      if (dependsOn(constSide, x)) continue;
+      const trigParse = weierstrassParseConstTimesTrigLinearSymbolic(trigSide, x);
+      if (trigParse === undefined) continue;
+      return {
+        a: constSide,
+        b: trigParse.c,
+        trigHead: trigParse.head,
+        alpha: trigParse.alpha,
+        beta: trigParse.beta,
+      };
+    }
+    return undefined;
+  }
+  if (equals(node.head, SUB)) {
+    const [left, right] = node.args;
+    // ``a − b·trig(...)`` → ``(a, −b, head, α, β)``.
+    if (!dependsOn(left, x)) {
+      const trigParse = weierstrassParseConstTimesTrigLinearSymbolic(right, x);
+      if (trigParse !== undefined) {
+        return {
+          a: left,
+          b: app(NEG, [trigParse.c]),
+          trigHead: trigParse.head,
+          alpha: trigParse.alpha,
+          beta: trigParse.beta,
+        };
+      }
+    }
+    // ``b·trig(...) − a`` → ``(−a, b, head, α, β)``.
+    if (!dependsOn(right, x)) {
+      const trigParse = weierstrassParseConstTimesTrigLinearSymbolic(left, x);
+      if (trigParse !== undefined) {
+        return {
+          a: app(NEG, [right]),
+          b: trigParse.c,
+          trigHead: trigParse.head,
+          alpha: trigParse.alpha,
+          beta: trigParse.beta,
+        };
+      }
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/** Construct the discriminant ``a² − b²`` as IR.  Used as both the
+ *  query operand for ``vm.assumptions`` and the radicand of the
+ *  closed-form ``Sqrt(...)`` term. */
+function weierstrassDiscExpr(a: IRNode, b: IRNode): IRNode {
+  return app(SUB, [app(POW, [a, int(2)]), app(POW, [b, int(2)])]);
+}
+
+/** ``b² − a²`` — radicand of the log-branch ``Sqrt(b²−a²)`` for the
+ *  ``disc < 0`` case. */
+function weierstrassNegDiscExpr(a: IRNode, b: IRNode): IRNode {
+  return app(SUB, [app(POW, [b, int(2)]), app(POW, [a, int(2)])]);
+}
+
+/** Symbolic-coefficient arctan branch: emitted when the assumption
+ *  store says ``a² > b²``.  ``c_scaled`` already absorbs ``1/α`` from
+ *  the linear-arg lift; we just need to emit the closed form with
+ *  symbolic ``Sqrt(a²−b²)``. */
+function tryWeierstrassArctanSymbolic(
+  cScaled: IRNode,
+  a: IRNode,
+  b: IRNode,
+  trigHead: IRNode,
+  argNode: IRNode,
+): IRNode {
+  const sqrtDisc = app(SQRT, [weierstrassDiscExpr(a, b)]);
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
+  let atanArgTop: IRNode;
+  if (equals(trigHead, SIN)) {
+    // (a·tan(arg/2) + b) / √(a²−b²)
+    atanArgTop = app(ADD, [app(MUL, [a, tanHalf]), b]);
+  } else {
+    // cos branch — same sign-clean form as the Python port:
+    // (a−b)·tan(arg/2) / √(a²−b²).  See the inline derivation in
+    // the Python helper for why this is correct on the whole disc>0
+    // region.
+    atanArgTop = app(MUL, [app(SUB, [a, b]), tanHalf]);
+  }
+  const atanArg = app(DIV, [atanArgTop, sqrtDisc]);
+  const coef = app(DIV, [app(MUL, [int(2), cScaled]), sqrtDisc]);
+  return app(MUL, [coef, app(ATAN, [atanArg])]);
+}
+
+/** Symbolic-coefficient log branch: emitted when the assumption store
+ *  says ``a² < b²``.  Mirrors the numeric :func:`tryWeierstrassLogForm`. */
+function tryWeierstrassLogSymbolic(
+  cScaled: IRNode,
+  a: IRNode,
+  b: IRNode,
+  trigHead: IRNode,
+  argNode: IRNode,
+): IRNode {
+  const sqrtNegDisc = app(SQRT, [weierstrassNegDiscExpr(a, b)]);
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
+  const absHead = sym("Abs");
+  let numer: IRNode;
+  let denom: IRNode;
+  if (equals(trigHead, SIN)) {
+    const aTan = app(MUL, [a, tanHalf]);
+    const aTanPlusB = app(ADD, [aTan, b]);
+    numer = app(SUB, [aTanPlusB, sqrtNegDisc]);
+    denom = app(ADD, [aTanPlusB, sqrtNegDisc]);
+  } else {
+    const bma = app(SUB, [b, a]);
+    const bmaTan = app(MUL, [bma, tanHalf]);
+    numer = app(ADD, [sqrtNegDisc, bmaTan]);
+    denom = app(SUB, [sqrtNegDisc, bmaTan]);
+  }
+  const logArg = app(absHead, [app(DIV, [numer, denom])]);
+  const coef = app(DIV, [cScaled, sqrtNegDisc]);
+  return app(MUL, [coef, app(LOG, [logArg])]);
+}
+
+/** Symbolic-coefficient degenerate branch: ``a² = b²``.  See the
+ *  Python helper for the derivation; both forms reduce to the numeric
+ *  Phase-35 results when ``a, b`` happen to be concrete. */
+function tryWeierstrassDegenerateSymbolic(
+  cScaled: IRNode,
+  a: IRNode,
+  b: IRNode,
+  trigHead: IRNode,
+  argNode: IRNode,
+): IRNode {
+  const tanHalf = app(TAN, [app(DIV, [argNode, int(2)])]);
+  const aPlusB = app(ADD, [a, b]);
+  const aMinusB = app(SUB, [a, b]);
+  if (equals(trigHead, SIN)) {
+    // −2·c / ( (a+b)·tan(arg/2) + (a−b) )
+    const numer = app(MUL, [int(-2), cScaled]);
+    const denom = app(ADD, [app(MUL, [aPlusB, tanHalf]), aMinusB]);
+    return app(DIV, [numer, denom]);
+  }
+  // cos: 2·c·tan(arg/2) / ( (a−b)·tan²(arg/2) + (a+b) )
+  const tanSq = app(POW, [tanHalf, int(2)]);
+  const numer = app(MUL, [app(MUL, [int(2), cScaled]), tanHalf]);
+  const denom = app(ADD, [app(MUL, [aMinusB, tanSq]), aPlusB]);
+  return app(DIV, [numer, denom]);
+}
+
+/** Track G2 entry point.  Mirrors the numeric
+ *  {@link tryWeierstrassOneOverLinearTrig} but accepts non-numeric
+ *  ``a, b`` (IR nodes free of ``x``).  Returns undefined when:
+ *   - the integrand doesn't match the shape,
+ *   - the numerator ``c`` depends on ``x``,
+ *   - ``α, β`` aren't rational,
+ *   - no assumption context is available (called outside the handler),
+ *   - or no assumption pins down the sign of ``a² − b²``.
+ *
+ *  The numeric path is left untouched: the dispatcher tries it first
+ *  and only falls through to here if it returned undefined. */
+function tryWeierstrassSymbolicCoefficients(
+  integrand: IRNode,
+  x: IRNode,
+): IRNode | undefined {
+  if (integrand.kind !== "apply" || !equals(integrand.head, DIV)) return undefined;
+  if (integrand.args.length !== 2) return undefined;
+  const [num, den] = integrand.args;
+  if (dependsOn(num, x)) return undefined;
+  const parsed = weierstrassParseAPlusBSincosSymbolic(den, x);
+  if (parsed === undefined) return undefined;
+  const { a, b, trigHead, alpha, beta } = parsed;
+  if (isZeroNumeric(alpha)) return undefined;
+  // Numeric path is tried first; if both ``a`` and ``b`` are
+  // numeric, that path would have closed the integral already.  Bail
+  // out gracefully to avoid emitting a second (potentially uglier)
+  // result.
+  if (toNumeric(a) !== undefined && toNumeric(b) !== undefined) return undefined;
+  const assumptions = currentAssumptions();
+  if (assumptions === undefined) return undefined;
+  // Apply ``u = α·x + β`` change of variable: scale numerator by 1/α.
+  const oneOverAlpha = divNumeric({ kind: "int", value: 1n }, alpha);
+  const cScaled = isOne(fromNumeric(oneOverAlpha))
+    ? num
+    : app(MUL, [fromNumeric(oneOverAlpha), num]);
+  const argNode = weierstrassBuildLinearArgIR(alpha, beta, x);
+  // Probe both surface forms of the discriminant sign — the natural
+  // ``a² > b²`` written by the user and the canonical-against-zero
+  // form ``a² − b² > 0`` someone might write programmatically.
+  const aSq = app(POW, [a, int(2)]);
+  const bSq = app(POW, [b, int(2)]);
+  const disc = app(SUB, [aSq, bSq]);
+  if (
+    assumptions.isTrueRelation(app(GREATER, [aSq, bSq])) === true ||
+    assumptions.isTrueRelation(app(GREATER, [disc, int(0)])) === true
+  ) {
+    return tryWeierstrassArctanSymbolic(cScaled, a, b, trigHead, argNode);
+  }
+  if (
+    assumptions.isTrueRelation(app(LESS, [aSq, bSq])) === true ||
+    assumptions.isTrueRelation(app(LESS, [disc, int(0)])) === true
+  ) {
+    return tryWeierstrassLogSymbolic(cScaled, a, b, trigHead, argNode);
+  }
+  if (
+    assumptions.isTrueRelation(app(EQUAL, [aSq, bSq])) === true ||
+    assumptions.isTrueRelation(app(EQUAL, [disc, int(0)])) === true
+  ) {
+    return tryWeierstrassDegenerateSymbolic(cScaled, a, b, trigHead, argNode);
+  }
+  return undefined;
+}
+
 function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
   if (!dependsOn(f, x)) {
     return app(MUL, [f, x]);
@@ -3137,6 +3513,12 @@ function integrateIndefinite(f: IRNode, x: IRNode): IRNode | undefined {
     // c / (a + b·cos(x)) when a, b numeric and a² > b² (a > 0 for cos).
     const weier = tryWeierstrassOneOverLinearTrig(f, x);
     if (weier !== undefined) return weier;
+    // Track G2: symbolic-coefficient Weierstrass.  Fires only when the
+    // numeric path returns undefined and ``vm.assumptions`` records a
+    // sign for ``a² − b²``.  See
+    // {@link tryWeierstrassSymbolicCoefficients}.
+    const weierSym = tryWeierstrassSymbolicCoefficients(f, x);
+    if (weierSym !== undefined) return weierSym;
     return undefined;
   }
   if (equals(f.head, POW)) {

--- a/code/packages/typescript/symbolic-vm/tests/weierstrass-symbolic-coefficients.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/weierstrass-symbolic-coefficients.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for Track G2 (TypeScript port): symbolic-coefficient
+ * Weierstrass lift.  Mirrors
+ * ``python/symbolic-vm/tests/test_weierstrass_symbolic_coefficients.py``
+ * shipped with Python G1 / PR #5361.
+ *
+ * The numeric Phase-34 Weierstrass helper only fires when ``a`` and
+ * ``b`` in ``∫ c / (a + b·sin(α·x+β)) dx`` are concrete rationals.
+ * Track G2 generalises it: when the user has declared the sign of the
+ * discriminant ``a² − b²`` via ``Assume(...)``, the integrator emits
+ * the corresponding closed form with symbolic ``a, b``.
+ *
+ * The branch selection is driven by ``vm.assumptions`` lookups
+ * against the compound-relation store added in the cas-simplify Track
+ * G2 first half.  These tests cover all four branches
+ * (``> 0``, ``< 0``, ``= 0``, no assumption → unevaluated) plus the
+ * linear-argument lifting that must still compose.
+ *
+ * Structural assertions rather than numeric ones — the result is a
+ * tree in symbolic ``a, b`` that no numeric evaluation can collapse
+ * cheaply.  We assert the kind of the outer head (``Atan``, ``Log``,
+ * ``Integrate``) and that the recorded discriminant radicand appears
+ * literally somewhere in the tree.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  ATAN,
+  COS,
+  DIV,
+  EQUAL,
+  GREATER,
+  INTEGRATE,
+  IRNode,
+  LESS,
+  LOG,
+  MUL,
+  POW,
+  SIN,
+  SQRT,
+  SUB,
+  app,
+  equals,
+  int,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { SymbolicBackend, VM } from "../src/index.js";
+
+const X = sym("x");
+const A = sym("a");
+const B = sym("b");
+const TWO = int(2);
+
+function makeVM(): VM {
+  return new VM(new SymbolicBackend());
+}
+
+function assume(vm: VM, rel: IRNode): void {
+  vm.eval(app(sym("Assume"), [rel]));
+}
+
+const gt = (lhs: IRNode, rhs: IRNode): IRNode => app(GREATER, [lhs, rhs]);
+const lt = (lhs: IRNode, rhs: IRNode): IRNode => app(LESS, [lhs, rhs]);
+const eq = (lhs: IRNode, rhs: IRNode): IRNode => app(EQUAL, [lhs, rhs]);
+const sq = (node: IRNode): IRNode => app(POW, [node, TWO]);
+
+function integrate(f: IRNode): IRNode {
+  return app(INTEGRATE, [f, X]);
+}
+
+function containsHead(node: IRNode, head: IRNode): boolean {
+  if (node.kind !== "apply") return false;
+  if (equals(node.head, head)) return true;
+  return node.args.some((a) => containsHead(a, head));
+}
+
+function containsSubtree(node: IRNode, target: IRNode): boolean {
+  if (equals(node, target)) return true;
+  if (node.kind !== "apply") return false;
+  return node.args.some((a) => containsSubtree(a, target));
+}
+
+describe("symbolic-coefficient Weierstrass — disc > 0 arctan branch", () => {
+  it("∫ 1/(a + b·sin(x)) with assume(a² > b²) returns arctan form with Sqrt(a² − b²)", () => {
+    const vm = makeVM();
+    assume(vm, gt(sq(A), sq(B)));
+    const denom = app(ADD, [A, app(MUL, [B, app(SIN, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(true);
+    const expectedSqrt = app(SQRT, [app(SUB, [sq(A), sq(B)])]);
+    expect(containsSubtree(result, expectedSqrt)).toBe(true);
+  });
+
+  it("∫ 1/(a + b·cos(x)) with assume(a² > b²) returns arctan form with Sqrt(a² − b²)", () => {
+    const vm = makeVM();
+    assume(vm, gt(sq(A), sq(B)));
+    const denom = app(ADD, [A, app(MUL, [B, app(COS, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(true);
+    const expectedSqrt = app(SQRT, [app(SUB, [sq(A), sq(B)])]);
+    expect(containsSubtree(result, expectedSqrt)).toBe(true);
+  });
+});
+
+describe("symbolic-coefficient Weierstrass — disc < 0 log branch", () => {
+  it("∫ 1/(a + b·sin(x)) with assume(a² < b²) returns log form with Sqrt(b² − a²)", () => {
+    const vm = makeVM();
+    assume(vm, lt(sq(A), sq(B)));
+    const denom = app(ADD, [A, app(MUL, [B, app(SIN, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, LOG)).toBe(true);
+    const expectedSqrt = app(SQRT, [app(SUB, [sq(B), sq(A)])]);
+    expect(containsSubtree(result, expectedSqrt)).toBe(true);
+  });
+});
+
+describe("symbolic-coefficient Weierstrass — disc = 0 degenerate branch", () => {
+  it("∫ 1/(a + b·sin(x)) with assume(a² = b²) returns rational-in-tan(x/2), no outer Atan or Log", () => {
+    const vm = makeVM();
+    assume(vm, eq(sq(A), sq(B)));
+    const denom = app(ADD, [A, app(MUL, [B, app(SIN, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(false);
+    expect(containsHead(result, LOG)).toBe(false);
+  });
+});
+
+describe("symbolic-coefficient Weierstrass — no assumption", () => {
+  it("Without an Assume(...), the integral is left unevaluated", () => {
+    const vm = makeVM();
+    const denom = app(ADD, [A, app(MUL, [B, app(SIN, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(true);
+  });
+});
+
+describe("symbolic-coefficient Weierstrass — linear-argument lifting", () => {
+  it("∫ 1/(a + b·sin(2x + 1)) with assume(a² > b²) lifts to arctan form with same radicand", () => {
+    const vm = makeVM();
+    assume(vm, gt(sq(A), sq(B)));
+    const inner = app(ADD, [app(MUL, [TWO, X]), int(1)]);
+    const denom = app(ADD, [A, app(MUL, [B, app(SIN, [inner])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(true);
+    const expectedSqrt = app(SQRT, [app(SUB, [sq(A), sq(B)])]);
+    expect(containsSubtree(result, expectedSqrt)).toBe(true);
+  });
+});
+
+describe("symbolic-coefficient Weierstrass — numeric regression", () => {
+  it("∫ 1/(2 + sin(x)) still closes to the numeric arctan form", () => {
+    const vm = makeVM();
+    const denom = app(ADD, [int(2), app(SIN, [X])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, ATAN)).toBe(true);
+  });
+
+  it("∫ 1/(1 + 2·sin(x)) still closes to the numeric log form", () => {
+    const vm = makeVM();
+    const denom = app(ADD, [int(1), app(MUL, [int(2), app(SIN, [X])])]);
+    const result = vm.eval(integrate(app(DIV, [int(1), denom])));
+    expect(result.kind === "apply" && equals(result.head, INTEGRATE)).toBe(false);
+    expect(containsHead(result, LOG)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Track G1 work that landed in PR #5361 to TypeScript and Rust.  See Track G2 of `code/specs/macsyma-truly-finish-plan.md`.

### Part A — `cas-simplify` compound-relation `AssumptionContext`

- `code/packages/typescript/cas-simplify` bumped 0.1.0 → 0.2.0
- `code/packages/rust/cas-simplify` bumped 0.1.0 → 0.2.0

Extends `AssumptionContext` so `assume(...)` and `is(...)` accept arbitrary relational shapes (`a^2 > b^2`, `f(x) = g(x)`, …), not just plain-symbol-vs-zero.  Compound relations are stored as canonicalised `(lhs, op, rhs)` triples; `is(...)` looks them up structurally with commutativity-aware rewriting (`b^2 < a^2` matches a stored `a^2 > b^2`).  No negative-knowledge inference — `assume(a^2 > b^2)` does NOT make `is(a^2 < b^2)` return `false`/`Some(false)`, it returns `undefined`/`None`.

The legacy plain-symbol path is untouched; the new branch only fires when the plain-symbol path returns `None`/`undefined`.

### Part B — `symbolic-vm` symbolic-coefficient Weierstrass lift

- `code/packages/typescript/symbolic-vm` bumped 0.18.0 → 0.19.0 (new `@coding-adventures/cas-simplify` dep)
- `code/packages/rust/symbolic-vm` bumped 0.18.0 → 0.19.0 (new `cas-simplify` dep)

Adds an `assumptions: AssumptionContext` field on `VM` plus three handlers — `Assume(rel)` / `Forget(rel)` / `ForgetAll()` — registered on the symbolic backend.  Both `Assume` and `Forget` are added to the hold-evaluate set so the relation argument reaches the handler intact.

When the numeric Phase-34 Weierstrass helper returns `None`/`undefined` because `a` and/or `b` is non-numeric, the new `tryWeierstrassSymbolicCoefficients` / `try_weierstrass_symbolic_coefficients` helper reparses the integrand keeping `a, b` as IR nodes (with `α, β, c` still rational) and queries the live `vm.assumptions` for the discriminant sign:

| Assumption                | Emits                                                         |
| ------------------------- | ------------------------------------------------------------- |
| `a² > b²` or `a² − b² > 0` | arctan form with `Sqrt(a² − b²)`                              |
| `a² < b²` or `a² − b² < 0` | log form with `Sqrt(b² − a²)`                                 |
| `a² = b²` or `a² − b² = 0` | degenerate rational-in-`tan(arg/2)` form                      |
| no fact                   | `None`/`undefined` — integrator leaves the integral unevaluated |

Linear-argument lifting `α·x + β` composes unchanged because the inner substitution depends only on `α, β` (which stay rational).  The numeric path is unchanged and is tried first; the symbolic helper explicitly bails out when both `a` and `b` are rational so concrete-coefficient integrals continue to use the arithmetic-folded fast path.

VM threading mirrors Python's `ContextVar`: TypeScript uses a module-level `let CURRENT_ASSUMPTIONS` updated in a `try / finally`, Rust uses a `thread_local!<RefCell<Option<AssumptionContext>>>` slot wrapped in an RAII guard so nested integrals and panics cannot strand the publish.

## Test plan

- [x] `cd code/packages/typescript/cas-simplify && npx vitest run` — 37 / 37 pass (includes 17 new compound-relation tests)
- [x] `cd code/packages/typescript/symbolic-vm && npx vitest run` — 218 / 218 pass (includes 8 new symbolic-Weierstrass tests; all 38 existing Phase-34/35/36/37 numeric tests still pass)
- [x] `cd code/packages/rust/cas-simplify && cargo test` — 67 / 67 pass (includes 16 new compound-relation tests)
- [x] `cd code/packages/rust/symbolic-vm && cargo test` — 225 / 225 + 8 / 8 new symbolic-Weierstrass tests pass

## Notes

- No spec doc changes — Track N will close the spec.
- No Python changes — already shipped in PR #5361.
- New tests assert structural shape (outer head is `Atan` / `Log` / `Integrate` and the discriminant `Sqrt(...)` appears as a subtree) rather than numeric values, since the result tree contains symbolic `a, b`.

Reference:
- Track G2 of `code/specs/macsyma-truly-finish-plan.md`
- Python reference PR #5361 (cas-simplify 0.4.0 + symbolic-vm 0.74.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)