### PR TITLE
feat(cas-summation): Gosper hypergeometric summation port (Track H2)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 2.27.0 — 2026-05-29
+
+### Added — Track H2 (Gosper hypergeometric summation port)
+
+Ports the Python ``cas_summation.gosper`` module (Track H1, PR #5366) to
+Rust ``cas-summation``.  When the summand ``a(k)`` is a hypergeometric
+term — a product of a polynomial in ``k`` with constant-base
+exponentials ``c^(αk+β)`` and ``GammaFunc(k+s)`` factors — and the
+upper bound is finite, ``evaluate_sum`` now attempts Gosper's algorithm
+to find an antidifference ``T(k)`` satisfying ``T(k+1) − T(k) = a(k)``
+and returns the closed form ``T(hi+1) − T(lo)``.
+
+This unlocks closed forms for the classical hypergeometric shapes the
+existing narrow recognisers miss, e.g.:
+
+- ``∑_{k=1}^{N} k·2^k = (N−1)·2^(N+1) + 2``
+- ``∑_{k=0}^{N} k·k! = (N+1)! − 1``
+
+### Changes
+
+- ``src/gosper.rs``: new module — full Gosper pipeline (structural
+  decomposition → ratio computation → Petkovšek shift-coprime
+  normalisation → Gosper degree bound → linear system solve via
+  Gaussian elimination over exact ``i128`` rationals).  Mirrors the
+  Python module 1:1 including the boundary-singularity cancellation
+  step that handles removable factorial denominators at ``k = lo``.
+
+  Coefficients use ``i128`` rationals so the intermediate Petkovšek
+  shift-binomial products for the polynomial degrees Gosper actually
+  sees (typically ≤ 5) stay well inside the 128-bit range — avoiding
+  a runtime dependency on ``num-bigint`` while preserving exact
+  arithmetic on the Python reference test cases.
+
+- ``src/gosper.rs``: defensive ``MAX_POLY_DEGREE = 64`` cap on
+  polynomial exponents during IR-to-poly conversion to prevent
+  adversarial inputs like ``Pow(k, i64::MAX)`` ballooning into a
+  memory-bomb.
+
+- ``src/lib.rs``: wire ``try_gosper_sum`` into the dispatch chain at
+  the same insertion point as Python (step 5b in ``summation.py``) —
+  after all narrow recognisers and before the Apart-retry telescope
+  chain and unevaluated fallthrough.  Guarded by ``if !inf_upper`` to
+  mirror Python: Gosper returns ``T(hi+1) − T(lo)`` which is only
+  meaningful for finite ``hi``; infinite upper bounds belong to the
+  limit-aware paths above.
+
+- ``tests/gosper_tests.rs``: 14 tests — 3 polynomial-helper smoke tests,
+  4 acceptance cases (``k·2^k`` concrete + symbolic, ``k·k!`` symbolic,
+  ``2^k`` regression), 2 fall-through cases (``sin(k)``, ``log(k)``),
+  2 regression cases (Faulhaber, constant), 2 structural pieces, and
+  1 DoS-cap test verifying ``Pow(k, i64::MAX)`` is refused promptly.
+
+- ``Cargo.toml``: minor bump to 2.27.0.
+
 ## 2.26.0 - 2026-06-06
 
 ### Added

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.26.0"
+version = "2.27.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/gosper.rs
+++ b/code/packages/rust/cas-summation/src/gosper.rs
@@ -1,0 +1,870 @@
+//! Gosper's algorithm for indefinite hypergeometric summation.
+//!
+//! Track H2 — Rust port of `code/packages/python/cas-summation/src/cas_summation/gosper.py`
+//! (Track H1, PR #5366).  See the Python source for the full mathematical
+//! background.  The pipeline mirrors Python and the TypeScript port 1:1:
+//!
+//!   1. Structurally decompose the summand into a hypergeometric product
+//!      `poly(k) · ∏ base^exp(k) · ∏ Γ(k+s) / ∏ Γ(k+t)`.
+//!   2. Compute the shift ratio `a(k+1)/a(k)` as two polynomials.
+//!   3. Petkovšek-normalise: `r(k) = A(k)·C(k+1) / (B(k)·C(k))` with
+//!      `gcd(A(k), B(k+h)) = 1` for every integer `h ≥ 0`.
+//!   4. Bound the degree of `x(k)` in the Gosper key equation
+//!      `A(k)·x(k+1) − B(k−1)·x(k) = C(k)` and solve the linear system
+//!      via Gaussian elimination over exact rationals.
+//!   5. Reconstruct `T(k) = B(k−1)·x(k)·a(k) / C(k)` and return
+//!      `T(hi+1) − T(lo)` as the closed-form IR.
+//!
+//! Coefficients use exact `i128` rationals — no floats — chosen so the
+//! intermediate Petkovšek shift-binomial products for the polynomial
+//! degrees Gosper actually sees (typically ≤ 5) stay well inside the
+//! 128-bit range.  This avoids a runtime dependency on `num-bigint`
+//! while preserving exact arithmetic for the test cases the Python
+//! reference covers.  The defensive `MAX_POLY_DEGREE = 64` cap below
+//! refuses adversarial polynomial exponents before they could grow the
+//! representation.
+
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, MUL, NEG, POW, SUB};
+
+use crate::GAMMA_FUNC;
+
+/// Defensive cap on polynomial degree.  Without this, an adversarial
+/// summand like `Pow(k, 10^9)` would balloon `ir_to_poly` (which does
+/// repeated multiplication) into a memory-bomb.  Gosper-summable
+/// expressions in practice have very small polynomial degree (typically
+/// ≤ 5) — anything above this cap is almost certainly not Gosper-
+/// accessible and the dispatcher's other paths handle it equally well.
+pub const MAX_POLY_DEGREE: i64 = 64;
+
+// ---------------------------------------------------------------------------
+// Exact i128 rational arithmetic (mirrors Python's `fractions.Fraction`).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Frac {
+    pub n: i128,
+    pub d: i128,
+}
+
+const F0: Frac = Frac { n: 0, d: 1 };
+const F1: Frac = Frac { n: 1, d: 1 };
+
+fn igcd(a: i128, b: i128) -> i128 {
+    let mut x = a.unsigned_abs();
+    let mut y = b.unsigned_abs();
+    while y != 0 {
+        let t = y;
+        y = x % y;
+        x = t;
+    }
+    if x == 0 {
+        1
+    } else {
+        x as i128
+    }
+}
+
+fn mkf(n: i128, d: i128) -> Frac {
+    if d == 0 {
+        panic!("Frac denominator cannot be zero");
+    }
+    let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
+    let g = igcd(n, d);
+    Frac { n: n / g, d: d / g }
+}
+
+fn f_add(a: Frac, b: Frac) -> Frac {
+    mkf(a.n * b.d + b.n * a.d, a.d * b.d)
+}
+fn f_sub(a: Frac, b: Frac) -> Frac {
+    mkf(a.n * b.d - b.n * a.d, a.d * b.d)
+}
+fn f_mul(a: Frac, b: Frac) -> Frac {
+    mkf(a.n * b.n, a.d * b.d)
+}
+fn f_div(a: Frac, b: Frac) -> Frac {
+    if b.n == 0 {
+        panic!("Frac division by zero");
+    }
+    mkf(a.n * b.d, a.d * b.n)
+}
+fn f_neg(a: Frac) -> Frac {
+    Frac { n: -a.n, d: a.d }
+}
+fn f_from_i128(n: i128) -> Frac {
+    Frac { n, d: 1 }
+}
+fn f_is_zero(a: Frac) -> bool {
+    a.n == 0
+}
+fn f_pow(base: Frac, exp: i128) -> Frac {
+    if exp == 0 {
+        return F1;
+    }
+    if exp < 0 {
+        if base.n == 0 {
+            panic!("0 to a negative power");
+        }
+        let sign: i128 = if base.n < 0 { -1 } else { 1 };
+        let inv = Frac {
+            n: base.d * sign,
+            d: base.n.abs(),
+        };
+        return f_pow(inv, -exp);
+    }
+    let mut result = F1;
+    let mut b = base;
+    let mut e = exp;
+    while e > 0 {
+        if e & 1 == 1 {
+            result = f_mul(result, b);
+        }
+        e >>= 1;
+        if e > 0 {
+            b = f_mul(b, b);
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Univariate polynomial arithmetic over `Frac`.  `Poly` is a `Vec<Frac>`
+// with `p[i]` the coefficient of `k^i`; trailing zeros trimmed.
+// ---------------------------------------------------------------------------
+
+pub type Poly = Vec<Frac>;
+
+fn poly_trim(p: &[Frac]) -> Poly {
+    let mut n = p.len();
+    while n > 0 && f_is_zero(p[n - 1]) {
+        n -= 1;
+    }
+    p[..n].to_vec()
+}
+
+fn poly_deg(p: &[Frac]) -> i64 {
+    let pp = poly_trim(p);
+    pp.len() as i64 - 1
+}
+
+fn poly_add(a: &[Frac], b: &[Frac]) -> Poly {
+    let n = a.len().max(b.len());
+    let mut out = vec![F0; n];
+    for i in 0..n {
+        let ai = if i < a.len() { a[i] } else { F0 };
+        let bi = if i < b.len() { b[i] } else { F0 };
+        out[i] = f_add(ai, bi);
+    }
+    poly_trim(&out)
+}
+
+fn poly_sub(a: &[Frac], b: &[Frac]) -> Poly {
+    let neg_b: Vec<Frac> = b.iter().map(|x| f_neg(*x)).collect();
+    poly_add(a, &neg_b)
+}
+
+fn poly_mul(a: &[Frac], b: &[Frac]) -> Poly {
+    let ta = poly_trim(a);
+    let tb = poly_trim(b);
+    if ta.is_empty() || tb.is_empty() {
+        return vec![];
+    }
+    let mut out = vec![F0; ta.len() + tb.len() - 1];
+    for i in 0..ta.len() {
+        if f_is_zero(ta[i]) {
+            continue;
+        }
+        for j in 0..tb.len() {
+            if f_is_zero(tb[j]) {
+                continue;
+            }
+            out[i + j] = f_add(out[i + j], f_mul(ta[i], tb[j]));
+        }
+    }
+    poly_trim(&out)
+}
+
+fn poly_scalar(p: &[Frac], c: Frac) -> Poly {
+    if f_is_zero(c) {
+        return vec![];
+    }
+    p.iter().map(|x| f_mul(*x, c)).collect()
+}
+
+/// Return `p(k + h)` via binomial expansion of `(k + h)^i`.
+fn poly_shift(p: &[Frac], h: i128) -> Poly {
+    let n = p.len();
+    let mut out = vec![F0; n];
+    for i in 0..n {
+        if f_is_zero(p[i]) {
+            continue;
+        }
+        // Pascal's row i: C(i, j) · h^(i - j) for j = 0..=i.
+        let mut binom: i128 = 1;
+        for j in 0..=i {
+            let hpow = h.pow((i - j) as u32);
+            let term = f_mul(p[i], f_from_i128(binom * hpow));
+            out[j] = f_add(out[j], term);
+            // next binom = binom * (i - j) / (j + 1)
+            binom = binom * ((i - j) as i128) / ((j + 1) as i128);
+        }
+    }
+    poly_trim(&out)
+}
+
+fn poly_divmod(a: &[Frac], b: &[Frac]) -> Option<(Poly, Poly)> {
+    let ta = poly_trim(a);
+    let tb = poly_trim(b);
+    if tb.is_empty() {
+        return None;
+    }
+    if poly_deg(&ta) < poly_deg(&tb) {
+        return Some((vec![], ta));
+    }
+    let q_len = ta.len() - tb.len() + 1;
+    let mut q = vec![F0; q_len];
+    let mut r = ta;
+    while poly_deg(&r) >= poly_deg(&tb) {
+        let deg_diff = (poly_deg(&r) - poly_deg(&tb)) as usize;
+        let coeff = f_div(r[r.len() - 1], tb[tb.len() - 1]);
+        q[deg_diff] = coeff;
+        let mut shifted = vec![F0; deg_diff];
+        for c in tb.iter() {
+            shifted.push(f_mul(*c, coeff));
+        }
+        r = poly_sub(&r, &shifted);
+    }
+    Some((poly_trim(&q), poly_trim(&r)))
+}
+
+fn poly_gcd(a: &[Frac], b: &[Frac]) -> Poly {
+    let mut x = poly_trim(a);
+    let mut y = poly_trim(b);
+    while !y.is_empty() {
+        let (_, r) = poly_divmod(&x, &y).expect("non-zero divisor");
+        x = y;
+        y = r;
+    }
+    if x.is_empty() {
+        return vec![];
+    }
+    let lc = x[x.len() - 1];
+    x.iter().map(|c| f_div(*c, lc)).collect()
+}
+
+fn poly_eq(a: &[Frac], b: &[Frac]) -> bool {
+    let ta = poly_trim(a);
+    let tb = poly_trim(b);
+    ta == tb
+}
+
+/// Solve `M · x = rhs` over the rationals via Gaussian elimination.
+fn solve_linear_system(matrix: Vec<Vec<Frac>>, rhs: Vec<Frac>) -> Option<Vec<Frac>> {
+    if matrix.is_empty() {
+        return if rhs.is_empty() { Some(vec![]) } else { None };
+    }
+    let rows = matrix.len();
+    let cols = matrix[0].len();
+    let mut m: Vec<Vec<Frac>> = matrix
+        .into_iter()
+        .enumerate()
+        .map(|(i, mut row)| {
+            row.push(rhs[i]);
+            row
+        })
+        .collect();
+    let mut row = 0;
+    for col in 0..cols {
+        let mut pivot: Option<usize> = None;
+        for r in row..rows {
+            if !f_is_zero(m[r][col]) {
+                pivot = Some(r);
+                break;
+            }
+        }
+        let Some(pivot) = pivot else { continue };
+        m.swap(row, pivot);
+        let piv = m[row][col];
+        for c in 0..=cols {
+            m[row][c] = f_div(m[row][c], piv);
+        }
+        for r in 0..rows {
+            if r == row {
+                continue;
+            }
+            let factor = m[r][col];
+            if f_is_zero(factor) {
+                continue;
+            }
+            for c in 0..=cols {
+                m[r][c] = f_sub(m[r][c], f_mul(factor, m[row][c]));
+            }
+        }
+        row += 1;
+    }
+    // Inconsistency check.
+    for r in 0..rows {
+        let all_zero = (0..cols).all(|c| f_is_zero(m[r][c]));
+        if all_zero && !f_is_zero(m[r][cols]) {
+            return None;
+        }
+    }
+    let mut x = vec![F0; cols];
+    for c in 0..cols {
+        // Find a row whose pivot column is `c`.
+        for r in 0..rows {
+            if m[r][c] == F1 && (0..rows).all(|r2| r2 == r || f_is_zero(m[r2][c])) {
+                x[c] = m[r][cols];
+                break;
+            }
+        }
+    }
+    Some(x)
+}
+
+// ---------------------------------------------------------------------------
+// IR ↔ polynomial bridge.
+// ---------------------------------------------------------------------------
+
+fn frac_of(node: &IRNode) -> Option<Frac> {
+    match node {
+        IRNode::Integer(v) => Some(f_from_i128(*v as i128)),
+        IRNode::Rational(n, d) => Some(mkf(*n as i128, *d as i128)),
+        _ => None,
+    }
+}
+
+fn head_is(node: &IRNode, name: &str) -> bool {
+    matches!(node, IRNode::Symbol(s) if s == name)
+}
+
+/// Convert an IR expression that is a polynomial in `k` to `Poly`.
+/// Returns `None` for any non-polynomial structure or when an exponent
+/// would exceed `MAX_POLY_DEGREE` (DoS cap).
+pub fn ir_to_poly(node: &IRNode, k: &IRNode) -> Option<Poly> {
+    if let Some(r) = frac_of(node) {
+        return Some(vec![r]);
+    }
+    if let IRNode::Symbol(_) = node {
+        if node == k {
+            return Some(vec![F0, F1]);
+        }
+        return None;
+    }
+    let IRNode::Apply(a) = node else {
+        return None;
+    };
+    if head_is(&a.head, NEG) && a.args.len() == 1 {
+        let inner = ir_to_poly(&a.args[0], k)?;
+        return Some(poly_scalar(&inner, f_from_i128(-1)));
+    }
+    if head_is(&a.head, ADD) {
+        let mut out: Poly = vec![];
+        for arg in &a.args {
+            let sub = ir_to_poly(arg, k)?;
+            out = poly_add(&out, &sub);
+        }
+        return Some(out);
+    }
+    if head_is(&a.head, SUB) && a.args.len() == 2 {
+        let x = ir_to_poly(&a.args[0], k)?;
+        let y = ir_to_poly(&a.args[1], k)?;
+        return Some(poly_sub(&x, &y));
+    }
+    if head_is(&a.head, MUL) {
+        let mut out: Poly = vec![F1];
+        for arg in &a.args {
+            let sub = ir_to_poly(arg, k)?;
+            out = poly_mul(&out, &sub);
+        }
+        return Some(out);
+    }
+    if head_is(&a.head, POW) && a.args.len() == 2 {
+        let base_poly = ir_to_poly(&a.args[0], k)?;
+        let IRNode::Integer(exp_val) = a.args[1] else {
+            return None;
+        };
+        if exp_val < 0 {
+            return None;
+        }
+        if exp_val > MAX_POLY_DEGREE {
+            return None;
+        }
+        let mut result: Poly = vec![F1];
+        for _ in 0..exp_val {
+            result = poly_mul(&result, &base_poly);
+            if poly_deg(&result) > MAX_POLY_DEGREE {
+                return None;
+            }
+        }
+        return Some(result);
+    }
+    if head_is(&a.head, DIV) && a.args.len() == 2 {
+        let np = ir_to_poly(&a.args[0], k)?;
+        let dp = ir_to_poly(&a.args[1], k)?;
+        if poly_deg(&dp) != 0 {
+            return None;
+        }
+        return Some(poly_scalar(&np, f_div(F1, dp[0])));
+    }
+    None
+}
+
+fn frac_to_ir(f: Frac) -> IRNode {
+    if f.d == 1 {
+        int(f.n as i64)
+    } else {
+        rat(f.n as i64, f.d as i64)
+    }
+}
+
+fn poly_to_ir(p: &[Frac], k: &IRNode) -> IRNode {
+    let tp = poly_trim(p);
+    if tp.is_empty() {
+        return int(0);
+    }
+    let mut terms: Vec<IRNode> = vec![];
+    for (i, c) in tp.iter().enumerate() {
+        if f_is_zero(*c) {
+            continue;
+        }
+        let term = if i == 0 {
+            frac_to_ir(*c)
+        } else if i == 1 {
+            if *c == F1 {
+                k.clone()
+            } else {
+                apply(sym(MUL), vec![frac_to_ir(*c), k.clone()])
+            }
+        } else {
+            let power = apply(sym(POW), vec![k.clone(), int(i as i64)]);
+            if *c == F1 {
+                power
+            } else {
+                apply(sym(MUL), vec![frac_to_ir(*c), power])
+            }
+        };
+        terms.push(term);
+    }
+    if terms.is_empty() {
+        return int(0);
+    }
+    if terms.len() == 1 {
+        return terms.into_iter().next().unwrap();
+    }
+    apply(sym(ADD), terms)
+}
+
+// ---------------------------------------------------------------------------
+// Structural factoring.
+// ---------------------------------------------------------------------------
+
+pub struct Hyp {
+    pub poly: Poly,
+    pub exp_factors: Vec<(Frac, Poly)>,
+    pub gamma_shifts: Vec<i128>,
+    pub recip_gamma_shifts: Vec<i128>,
+}
+
+impl Hyp {
+    fn new() -> Self {
+        Self {
+            poly: vec![F1],
+            exp_factors: vec![],
+            gamma_shifts: vec![],
+            recip_gamma_shifts: vec![],
+        }
+    }
+}
+
+fn try_linear_in_k(node: &IRNode, k: &IRNode) -> Option<(i128, i128)> {
+    let p = ir_to_poly(node, k)?;
+    if p.is_empty() {
+        return Some((0, 0));
+    }
+    if poly_deg(&p) > 1 {
+        return None;
+    }
+    let a = if p.len() >= 2 { p[1] } else { F0 };
+    let b = p[0];
+    if a.d != 1 || b.d != 1 {
+        return None;
+    }
+    Some((a.n, b.n))
+}
+
+pub fn decompose(node: &IRNode, k: &IRNode) -> Option<Hyp> {
+    let mut h = Hyp::new();
+    decompose_into(node, k, &mut h)?;
+    Some(h)
+}
+
+fn decompose_into(node: &IRNode, k: &IRNode, h: &mut Hyp) -> Option<()> {
+    if let Some(poly) = ir_to_poly(node, k) {
+        h.poly = poly_mul(&h.poly, &poly);
+        return Some(());
+    }
+    let IRNode::Apply(a) = node else {
+        return None;
+    };
+    if head_is(&a.head, MUL) {
+        for arg in &a.args {
+            decompose_into(arg, k, h)?;
+        }
+        return Some(());
+    }
+    if head_is(&a.head, NEG) && a.args.len() == 1 {
+        decompose_into(&a.args[0], k, h)?;
+        h.poly = poly_scalar(&h.poly, f_from_i128(-1));
+        return Some(());
+    }
+    if head_is(&a.head, DIV) && a.args.len() == 2 {
+        let num = &a.args[0];
+        let den = &a.args[1];
+        decompose_into(num, k, h)?;
+        if let Some(den_poly) = ir_to_poly(den, k) {
+            if poly_deg(&den_poly) != 0 || den_poly.is_empty() {
+                return None;
+            }
+            h.poly = poly_scalar(&h.poly, f_div(F1, den_poly[0]));
+            return Some(());
+        }
+        if let IRNode::Apply(dn) = den {
+            if head_is(&dn.head, GAMMA_FUNC) && dn.args.len() == 1 {
+                let (alpha, beta) = try_linear_in_k(&dn.args[0], k)?;
+                if alpha != 1 {
+                    return None;
+                }
+                h.recip_gamma_shifts.push(beta);
+                return Some(());
+            }
+        }
+        return None;
+    }
+    if head_is(&a.head, POW) && a.args.len() == 2 {
+        let base_poly = ir_to_poly(&a.args[0], k)?;
+        if poly_deg(&base_poly) != 0 || base_poly.is_empty() {
+            return None;
+        }
+        let b = base_poly[0];
+        if f_is_zero(b) {
+            return None;
+        }
+        let exp_poly = ir_to_poly(&a.args[1], k)?;
+        if poly_deg(&exp_poly) > 1 {
+            return None;
+        }
+        h.exp_factors.push((b, exp_poly));
+        return Some(());
+    }
+    if head_is(&a.head, GAMMA_FUNC) && a.args.len() == 1 {
+        let (alpha, beta) = try_linear_in_k(&a.args[0], k)?;
+        if alpha != 1 {
+            return None;
+        }
+        h.gamma_shifts.push(beta);
+        return Some(());
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Ratio computation.
+// ---------------------------------------------------------------------------
+
+pub fn hyp_ratio(h: &Hyp) -> Option<(Poly, Poly)> {
+    let poly = &h.poly;
+    if poly_trim(poly).is_empty() {
+        return None;
+    }
+    let mut numer = poly_shift(poly, 1);
+    let mut denom: Poly = poly.clone();
+    for (base, exp) in &h.exp_factors {
+        if poly_deg(exp) == 0 {
+            continue;
+        }
+        let alpha = exp[1];
+        if alpha.d != 1 {
+            return None;
+        }
+        let alpha_int = alpha.n;
+        let factor = if alpha_int >= 0 {
+            f_pow(*base, alpha_int)
+        } else {
+            if f_is_zero(*base) {
+                return None;
+            }
+            f_div(F1, f_pow(*base, -alpha_int))
+        };
+        numer = poly_scalar(&numer, factor);
+    }
+    for s in &h.gamma_shifts {
+        numer = poly_mul(&numer, &vec![f_from_i128(*s), F1]);
+    }
+    for t in &h.recip_gamma_shifts {
+        denom = poly_mul(&denom, &vec![f_from_i128(*t), F1]);
+    }
+    Some((numer, denom))
+}
+
+// ---------------------------------------------------------------------------
+// Petkovšek normalisation.
+// ---------------------------------------------------------------------------
+
+fn petkovsek_normalise(a: &[Frac], b: &[Frac]) -> Option<(Poly, Poly, Poly)> {
+    let mut a_poly: Poly = a.to_vec();
+    let mut b_poly: Poly = b.to_vec();
+    let mut c_poly: Poly = vec![F1];
+    let max_h = poly_deg(&a_poly).max(poly_deg(&b_poly)).max(0) as i128 + 2;
+    loop {
+        let mut peeled = false;
+        for h in 0..=max_h {
+            let b_shifted = poly_shift(&b_poly, h);
+            let g = poly_gcd(&a_poly, &b_shifted);
+            if poly_deg(&g) >= 1 {
+                let (a_new, rem_a) = poly_divmod(&a_poly, &g)?;
+                if !rem_a.is_empty() {
+                    return None;
+                }
+                let g_back = poly_shift(&g, -h);
+                let (b_new, rem_b) = poly_divmod(&b_poly, &g_back)?;
+                if !rem_b.is_empty() {
+                    return None;
+                }
+                let mut acc: Poly = vec![F1];
+                for i in 1..=h {
+                    acc = poly_mul(&acc, &poly_shift(&g, -i));
+                }
+                c_poly = poly_mul(&c_poly, &acc);
+                a_poly = a_new;
+                b_poly = b_new;
+                peeled = true;
+                break;
+            }
+        }
+        if !peeled {
+            return Some((a_poly, b_poly, c_poly));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gosper degree bound + linear solve.
+// ---------------------------------------------------------------------------
+
+fn gosper_degree_bound(a: &[Frac], b: &[Frac], c: &[Frac]) -> i64 {
+    let b_shifted = poly_shift(b, -1);
+    let s = poly_add(a, &b_shifted);
+    let d = poly_sub(a, &b_shifted);
+    let deg_s = poly_deg(&s);
+    let deg_d = poly_deg(&d);
+    let deg_c = poly_deg(c);
+    let bound: i64;
+    if deg_s > deg_d + 1 {
+        bound = deg_c - deg_s;
+    } else {
+        let m = poly_deg(a).max(poly_deg(&b_shifted));
+        if m < 0 {
+            return 0;
+        }
+        let s_top = if (m as usize) < s.len() { s[m as usize] } else { F0 };
+        if f_is_zero(s_top) {
+            bound = deg_c - m;
+        } else {
+            let d_at_m1 = if m >= 1 && ((m - 1) as usize) < d.len() {
+                d[(m - 1) as usize]
+            } else {
+                F0
+            };
+            // candidate = -2·d[m-1]/s[m] - 1; ceiling toward +∞.
+            let cand = f_sub(f_div(f_mul(f_from_i128(-2), d_at_m1), s_top), F1);
+            let cand_int: i64 = if cand.n < 0 {
+                0
+            } else {
+                let q = cand.n / cand.d;
+                let r = cand.n % cand.d;
+                if r == 0 {
+                    q as i64
+                } else {
+                    q as i64 + 1
+                }
+            };
+            bound = (deg_c - m).max(cand_int);
+        }
+    }
+    if bound < 0 {
+        return -1;
+    }
+    bound + 1
+}
+
+fn solve_key_equation(a: &[Frac], b: &[Frac], c: &[Frac], deg_bound: i64) -> Option<Poly> {
+    if deg_bound < 0 {
+        return None;
+    }
+    let n_unknowns = (deg_bound + 1) as usize;
+    let b_shifted = poly_shift(b, -1);
+    let mut basis_polys: Vec<Poly> = vec![];
+    let mut max_deg: i64 = 0;
+    for i in 0..n_unknowns {
+        let mut k_pow_i: Poly = vec![F0; i];
+        k_pow_i.push(F1);
+        let kp1_pow_i = poly_shift(&k_pow_i, 1);
+        let left = poly_mul(a, &kp1_pow_i);
+        let right = poly_mul(&b_shifted, &k_pow_i);
+        let bp = poly_sub(&left, &right);
+        if poly_deg(&bp) > max_deg {
+            max_deg = poly_deg(&bp);
+        }
+        basis_polys.push(bp);
+    }
+    let c_trim = poly_trim(c);
+    let mut rhs_len = ((max_deg + 1) as usize).max(c_trim.len());
+    if rhs_len == 0 {
+        rhs_len = 1;
+    }
+    let mut rhs = vec![F0; rhs_len];
+    for (j, cv) in c_trim.iter().enumerate() {
+        rhs[j] = *cv;
+    }
+    let mut matrix: Vec<Vec<Frac>> = vec![];
+    for j in 0..rhs_len {
+        let mut row: Vec<Frac> = vec![];
+        for i in 0..n_unknowns {
+            let bp = &basis_polys[i];
+            row.push(if j < bp.len() { bp[j] } else { F0 });
+        }
+        matrix.push(row);
+    }
+    let sol = solve_linear_system(matrix, rhs)?;
+    let x_poly = poly_trim(&sol);
+    if x_poly.is_empty() {
+        if !poly_trim(c).is_empty() {
+            return None;
+        }
+        return Some(vec![F0]);
+    }
+    let x_shifted = poly_shift(&x_poly, 1);
+    let lhs = poly_sub(&poly_mul(a, &x_shifted), &poly_mul(&b_shifted, &x_poly));
+    if !poly_eq(&lhs, c) {
+        return None;
+    }
+    Some(x_poly)
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry.
+// ---------------------------------------------------------------------------
+
+fn substitute(node: &IRNode, from: &IRNode, to: &IRNode) -> IRNode {
+    if node == from {
+        return to.clone();
+    }
+    match node {
+        IRNode::Apply(a) => apply(
+            a.head.clone(),
+            a.args.iter().map(|x| substitute(x, from, to)).collect(),
+        ),
+        _ => node.clone(),
+    }
+}
+
+/// Attempt Gosper's algorithm on `∑_{k=lo}^{hi} summand`.  Returns the
+/// IR closed form `T(hi+1) − T(lo)` on success, or `None` to signal
+/// fall-through.
+pub fn try_gosper_sum(summand: &IRNode, k: &IRNode, lo: &IRNode, hi: &IRNode) -> Option<IRNode> {
+    let hyp = decompose(summand, k)?;
+    let (a_top, b_bot) = hyp_ratio(&hyp)?;
+    if poly_trim(&hyp.poly).is_empty() {
+        return Some(int(0));
+    }
+    let (a_norm, b_norm, c_poly) = petkovsek_normalise(&a_top, &b_bot)?;
+    let deg_bound = gosper_degree_bound(&a_norm, &b_norm, &c_poly);
+    let x_poly = solve_key_equation(&a_norm, &b_norm, &c_poly, deg_bound)?;
+    if poly_trim(&x_poly).is_empty() {
+        return None;
+    }
+
+    // Reconstruct T(k) with boundary-singularity cancellation.
+    let b_at_k_minus_1 = poly_shift(&b_norm, -1);
+    let mut full_numer_poly = poly_mul(&poly_mul(&b_at_k_minus_1, &x_poly), &hyp.poly);
+    let mut denom_poly: Poly = c_poly.clone();
+    let g = poly_gcd(&full_numer_poly, &denom_poly);
+    if poly_deg(&g) >= 1 {
+        if let (Some((nq, rem_n)), Some((dq, rem_d))) = (
+            poly_divmod(&full_numer_poly, &g),
+            poly_divmod(&denom_poly, &g),
+        ) {
+            if rem_n.is_empty() && rem_d.is_empty() {
+                full_numer_poly = nq;
+                denom_poly = dq;
+            }
+        }
+    }
+
+    // Build the transcendental IR.
+    let transcendental_ir = {
+        let mut pieces: Vec<IRNode> = vec![];
+        for (base, exp_poly) in &hyp.exp_factors {
+            pieces.push(apply(
+                sym(POW),
+                vec![frac_to_ir(*base), poly_to_ir(exp_poly, k)],
+            ));
+        }
+        for s in &hyp.gamma_shifts {
+            let arg = if *s == 0 {
+                k.clone()
+            } else {
+                apply(sym(ADD), vec![k.clone(), int(*s as i64)])
+            };
+            pieces.push(apply(sym(GAMMA_FUNC), vec![arg]));
+        }
+        let mut denom_gammas: Vec<IRNode> = vec![];
+        for t in &hyp.recip_gamma_shifts {
+            let arg = if *t == 0 {
+                k.clone()
+            } else {
+                apply(sym(ADD), vec![k.clone(), int(*t as i64)])
+            };
+            denom_gammas.push(apply(sym(GAMMA_FUNC), vec![arg]));
+        }
+        if pieces.is_empty() && denom_gammas.is_empty() {
+            int(1)
+        } else {
+            let numer = if pieces.is_empty() {
+                int(1)
+            } else if pieces.len() == 1 {
+                pieces.into_iter().next().unwrap()
+            } else {
+                apply(sym(MUL), pieces)
+            };
+            if denom_gammas.is_empty() {
+                numer
+            } else {
+                let denom = if denom_gammas.len() == 1 {
+                    denom_gammas.into_iter().next().unwrap()
+                } else {
+                    apply(sym(MUL), denom_gammas)
+                };
+                apply(sym(DIV), vec![numer, denom])
+            }
+        }
+    };
+
+    let t_at = |k_value: &IRNode| -> IRNode {
+        let numer_ir = poly_to_ir(&full_numer_poly, k);
+        let denom_ir = poly_to_ir(&denom_poly, k);
+        let numer_at = substitute(&numer_ir, k, k_value);
+        let denom_at = substitute(&denom_ir, k, k_value);
+        let trans_at = substitute(&transcendental_ir, k, k_value);
+        apply(
+            sym(DIV),
+            vec![apply(sym(MUL), vec![numer_at, trans_at]), denom_at],
+        )
+    };
+
+    let hi_plus_one = apply(sym(ADD), vec![hi.clone(), int(1)]);
+    let t_hi = t_at(&hi_plus_one);
+    let t_lo = t_at(lo);
+    Some(apply(sym(SUB), vec![t_hi, t_lo]))
+}

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -2,9 +2,13 @@ use std::cmp::Ordering;
 
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, LOG, MUL, NEG, POW, SUB};
 
+pub mod gosper;
+
 pub const SUM: &str = "Sum";
 pub const PRODUCT: &str = "Product";
 pub const GAMMA_FUNC: &str = "GammaFunc";
+
+pub use gosper::{try_gosper_sum, MAX_POLY_DEGREE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rational {
@@ -367,6 +371,24 @@ fn evaluate_sum_inner(
             if ok {
                 return total.to_ir();
             }
+        }
+    }
+
+    // Track H2 — Gosper hypergeometric closed-form attempt.  Runs after
+    // all narrow recognisers (constant, geometric, Faulhaber, telescoping,
+    // special infinite series, small-range numeric) but before the
+    // Apart-retry telescope chain and the unevaluated fallthrough.
+    //
+    // Mirrors the Python dispatch insertion point in
+    // `cas_summation.summation` (step 5b): Gosper only runs for *finite*
+    // upper bounds because it returns `T(hi+1) − T(lo)` which is only
+    // meaningful when `hi+1` is a real value.  Infinite upper bounds
+    // belong to the dedicated limit-aware paths above (telescope at ∞,
+    // classic series).  This guard also preserves the Phase 41
+    // fall-through contract for non-vanishing telescopes.
+    if !inf_upper {
+        if let Some(gosper_result) = gosper::try_gosper_sum(&f, &k, &lo, &hi) {
+            return eval_fn(gosper_result);
         }
     }
 

--- a/code/packages/rust/cas-summation/tests/gosper_tests.rs
+++ b/code/packages/rust/cas-summation/tests/gosper_tests.rs
@@ -1,0 +1,326 @@
+//! Tests for Gosper's algorithm — Track H2 (Rust port of Python H1).
+//!
+//! Mirrors `code/packages/python/cas-summation/tests/test_gosper.py` —
+//! 15 tests: 4 polynomial helpers, 4 acceptance, 2 fall-through, 2
+//! regression, 2 structural pieces, 1 DoS cap.
+
+use cas_summation::gosper::{
+    decompose, hyp_ratio, ir_to_poly, try_gosper_sum, Frac, MAX_POLY_DEGREE,
+};
+use cas_summation::{evaluate_sum, rational_value, Rational, GAMMA_FUNC, SUM};
+use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, MUL, NEG, POW, SUB};
+
+// ---------------------------------------------------------------------------
+// Stub evaluator that reduces arithmetic and folds GammaFunc(integer)
+// down to the corresponding factorial so we can verify closed-form
+// numerics that contain Gamma terms.
+// ---------------------------------------------------------------------------
+
+fn eval(node: IRNode) -> IRNode {
+    match node {
+        IRNode::Apply(a) => {
+            let head = a.head.clone();
+            let args: Vec<IRNode> = a.args.into_iter().map(eval).collect();
+            let name = match &head {
+                IRNode::Symbol(s) => s.as_str(),
+                _ => return apply(head, args),
+            };
+            // GammaFunc(Integer n ≥ 1) → (n − 1)!
+            if name == GAMMA_FUNC && args.len() == 1 {
+                if let IRNode::Integer(v) = args[0] {
+                    if v >= 1 {
+                        let mut f: i64 = 1;
+                        for i in 1..v {
+                            f *= i;
+                        }
+                        return int(f);
+                    }
+                }
+                return apply(head, args);
+            }
+            let out: Option<IRNode> = match name {
+                ADD => fold_numeric(&args, Rational::new(0, 1), |a, b| a + b),
+                MUL => fold_numeric(&args, Rational::new(1, 1), |a, b| a * b),
+                SUB if args.len() == 2 => num_binary(&args[0], &args[1], |a, b| a - b),
+                DIV if args.len() == 2 => num_binary(&args[0], &args[1], |a, b| a / b),
+                POW if args.len() == 2 => num_pow(&args[0], &args[1]),
+                NEG if args.len() == 1 => rational_value(&args[0]).map(|v| (-v).to_ir()),
+                _ => None,
+            };
+            out.unwrap_or_else(|| apply(head, args))
+        }
+        other => other,
+    }
+}
+
+fn fold_numeric(
+    args: &[IRNode],
+    init: Rational,
+    op: impl Fn(Rational, Rational) -> Rational,
+) -> Option<IRNode> {
+    let mut acc = init;
+    for arg in args {
+        acc = op(acc, rational_value(arg)?);
+    }
+    Some(acc.to_ir())
+}
+
+fn num_binary(
+    a: &IRNode,
+    b: &IRNode,
+    op: impl FnOnce(Rational, Rational) -> Rational,
+) -> Option<IRNode> {
+    Some(op(rational_value(a)?, rational_value(b)?).to_ir())
+}
+
+fn num_pow(base: &IRNode, exp: &IRNode) -> Option<IRNode> {
+    let base = rational_value(base)?;
+    let IRNode::Integer(e) = exp else {
+        return None;
+    };
+    let mut r = Rational::new(1, 1);
+    if *e >= 0 {
+        for _ in 0..*e {
+            r = r * base;
+        }
+        Some(r.to_ir())
+    } else {
+        for _ in 0..-*e {
+            r = r * base;
+        }
+        Some((Rational::new(1, 1) / r).to_ir())
+    }
+}
+
+fn substitute(node: &IRNode, from: &IRNode, to: &IRNode) -> IRNode {
+    if node == from {
+        return to.clone();
+    }
+    match node {
+        IRNode::Apply(a) => apply(
+            a.head.clone(),
+            a.args.iter().map(|x| substitute(x, from, to)).collect(),
+        ),
+        _ => node.clone(),
+    }
+}
+
+fn eval_at(node: &IRNode, sym_node: &IRNode, value: i64) -> Option<Rational> {
+    rational_value(&eval(substitute(node, sym_node, &int(value))))
+}
+
+fn k_sym() -> IRNode {
+    sym("k")
+}
+fn n_sym() -> IRNode {
+    sym("N")
+}
+
+fn make_k_times_2_to_k() -> IRNode {
+    apply(sym(MUL), vec![k_sym(), apply(sym(POW), vec![int(2), k_sym()])])
+}
+fn make_k_times_k_fact() -> IRNode {
+    let g = apply(
+        sym(GAMMA_FUNC),
+        vec![apply(sym(ADD), vec![k_sym(), int(1)])],
+    );
+    apply(sym(MUL), vec![k_sym(), g])
+}
+
+fn fact_i64(n: i64) -> i64 {
+    let mut r: i64 = 1;
+    for i in 1..=n {
+        r *= i;
+    }
+    r
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper tests — polynomial primitives via the public surface
+// (using ir_to_poly to exercise them indirectly).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn poly_helpers_smoke() {
+    let k = k_sym();
+    // 1 + 2k as a polynomial: ir_to_poly should produce [1, 2].
+    let f = apply(sym(ADD), vec![int(1), apply(sym(MUL), vec![int(2), k.clone()])]);
+    let p = ir_to_poly(&f, &k).expect("polynomial");
+    assert_eq!(p.len(), 2);
+    assert_eq!(p[0], Frac { n: 1, d: 1 });
+    assert_eq!(p[1], Frac { n: 2, d: 1 });
+}
+
+#[test]
+fn poly_mul_via_pow() {
+    // (1 + k)^2 = 1 + 2k + k^2 via the POW handler.
+    let k = k_sym();
+    let f = apply(
+        sym(POW),
+        vec![apply(sym(ADD), vec![int(1), k.clone()]), int(2)],
+    );
+    let p = ir_to_poly(&f, &k).expect("polynomial");
+    assert_eq!(p.len(), 3);
+    assert_eq!(p[0], Frac { n: 1, d: 1 });
+    assert_eq!(p[1], Frac { n: 2, d: 1 });
+    assert_eq!(p[2], Frac { n: 1, d: 1 });
+}
+
+#[test]
+fn poly_shift_via_substitute() {
+    // (k+1)^2 = 1 + 2k + k^2: build via ADD(k, 1)^2 then ir_to_poly.
+    let k = k_sym();
+    let kp1 = apply(sym(ADD), vec![k.clone(), int(1)]);
+    let f = apply(sym(POW), vec![kp1, int(2)]);
+    let p = ir_to_poly(&f, &k).expect("polynomial");
+    assert_eq!(p.len(), 3);
+    assert_eq!(p[0], Frac { n: 1, d: 1 });
+    assert_eq!(p[1], Frac { n: 2, d: 1 });
+    assert_eq!(p[2], Frac { n: 1, d: 1 });
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn k_times_2_to_k_concrete_dispatcher() {
+    // ∑_{k=1}^{5} k·2^k = 258.
+    let f = make_k_times_2_to_k();
+    let result = evaluate_sum(f, k_sym(), int(1), int(5), eval);
+    assert_eq!(rational_value(&result), Some(Rational::new(258, 1)));
+}
+
+#[test]
+fn k_times_2_to_k_symbolic_closed_form() {
+    // With hi = N symbolic, Gosper must produce the closed form.
+    let f = make_k_times_2_to_k();
+    let result = try_gosper_sum(&f, &k_sym(), &int(1), &n_sym()).expect("Gosper should accept k·2^k");
+    // Not unevaluated SUM.
+    if let IRNode::Apply(a) = &result {
+        assert_ne!(a.head, sym(SUM));
+    }
+    for n in [1i64, 2, 3, 5, 7] {
+        let mut expected: i64 = 0;
+        for j in 1..=n {
+            expected += j * (1i64 << j);
+        }
+        let val = eval_at(&result, &n_sym(), n);
+        assert_eq!(val, Some(Rational::new(expected, 1)), "k·2^k mismatch at N={n}");
+    }
+}
+
+#[test]
+fn k_times_k_factorial_symbolic_closed_form() {
+    // ∑_{k=0}^{N} k·k! = (N+1)! − 1
+    let f = make_k_times_k_fact();
+    let result = try_gosper_sum(&f, &k_sym(), &int(0), &n_sym()).expect("Gosper should accept k·k!");
+    if let IRNode::Apply(a) = &result {
+        assert_ne!(a.head, sym(SUM));
+    }
+    for n in [0i64, 1, 2, 3, 4, 5] {
+        let mut expected: i64 = 0;
+        for j in 0..=n {
+            expected += j * fact_i64(j);
+        }
+        let val = eval_at(&result, &n_sym(), n);
+        assert_eq!(val, Some(Rational::new(expected, 1)), "k·k! mismatch at N={n}");
+    }
+}
+
+#[test]
+fn geometric_2_to_k_no_regression() {
+    // Still routed via the geometric handler.
+    let f = apply(sym(POW), vec![int(2), k_sym()]);
+    let result = evaluate_sum(f, k_sym(), int(0), int(5), eval);
+    assert_eq!(rational_value(&result), Some(Rational::new(63, 1)));
+}
+
+// ---------------------------------------------------------------------------
+// Fall-through safety.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sin_summand_falls_through() {
+    let f = apply(sym("Sin"), vec![k_sym()]);
+    let result = evaluate_sum(f, k_sym(), int(1), n_sym(), eval);
+    assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+}
+
+#[test]
+fn log_summand_falls_through() {
+    let f = apply(sym("Log"), vec![k_sym()]);
+    let result = evaluate_sum(f, k_sym(), int(1), n_sym(), eval);
+    assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+}
+
+// ---------------------------------------------------------------------------
+// Regression: existing handlers still take priority.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn faulhaber_still_works() {
+    let k = k_sym();
+    let result = evaluate_sum(k.clone(), k, int(1), int(4), eval);
+    assert_eq!(rational_value(&result), Some(Rational::new(10, 1)));
+}
+
+#[test]
+fn constant_summand_unchanged() {
+    let result = evaluate_sum(int(5), k_sym(), int(1), int(10), eval);
+    assert_eq!(rational_value(&result), Some(Rational::new(50, 1)));
+}
+
+// ---------------------------------------------------------------------------
+// Lower-level structural pieces.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decompose_k_times_2_to_k() {
+    let f = make_k_times_2_to_k();
+    let h = decompose(&f, &k_sym()).expect("decomposable");
+    // poly is [0, 1] (= k).
+    assert_eq!(h.poly.len(), 2);
+    assert_eq!(h.poly[0], Frac { n: 0, d: 1 });
+    assert_eq!(h.poly[1], Frac { n: 1, d: 1 });
+    assert_eq!(h.exp_factors.len(), 1);
+    let (base, exp_poly) = &h.exp_factors[0];
+    assert_eq!(*base, Frac { n: 2, d: 1 });
+    assert_eq!(exp_poly.len(), 2);
+    assert_eq!(exp_poly[0], Frac { n: 0, d: 1 });
+    assert_eq!(exp_poly[1], Frac { n: 1, d: 1 });
+}
+
+#[test]
+fn ratio_k_times_2_to_k() {
+    let f = make_k_times_2_to_k();
+    let h = decompose(&f, &k_sym()).expect("decomposable");
+    let (numer, denom) = hyp_ratio(&h).expect("ratio");
+    // numer = 2 + 2k
+    assert_eq!(numer.len(), 2);
+    assert_eq!(numer[0], Frac { n: 2, d: 1 });
+    assert_eq!(numer[1], Frac { n: 2, d: 1 });
+    // denom = k = [0, 1]
+    assert_eq!(denom.len(), 2);
+    assert_eq!(denom[0], Frac { n: 0, d: 1 });
+    assert_eq!(denom[1], Frac { n: 1, d: 1 });
+}
+
+// ---------------------------------------------------------------------------
+// DoS cap.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn max_poly_degree_cap_refuses_giant_exponent() {
+    assert_eq!(MAX_POLY_DEGREE, 64);
+    // Pow(k, large): the IR can't even hold 10^9 in i64 — use i64::MAX
+    // which is still > 64 and gets rejected by the cap.
+    let f = apply(sym(POW), vec![k_sym(), int(i64::MAX)]);
+    // Symbolic N — must fall through to unevaluated SUM, no memory
+    // blowup, prompt return.
+    let result = evaluate_sum(f, k_sym(), int(1), n_sym(), eval);
+    assert!(matches!(&result, IRNode::Apply(a) if a.head == sym(SUM)));
+}
+
+// Avoid unused-import warning when Frac changes shape.
+const _RAT_UNUSED: fn() -> IRNode = || rat(1, 2);

--- a/code/packages/typescript/cas-summation/BUILD
+++ b/code/packages/typescript/cas-summation/BUILD
@@ -1,4 +1,6 @@
 while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
+cd ../cas-pattern-matching && npm ci --quiet
+cd ../cas-simplify && npm ci --quiet
 cd ../cas-factor && npm ci --quiet
 cd ../symbolic-vm && npm ci --quiet
 npm ci --quiet

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## 2.27.0 — 2026-05-29
+
+### Added — Track H2 (Gosper hypergeometric summation port)
+
+Ports the Python ``cas_summation.gosper`` module (Track H1, PR #5366) to
+TypeScript ``cas-summation``.  When the summand ``a(k)`` is a
+hypergeometric term — a product of a polynomial in ``k`` with constant-
+base exponentials ``c^(αk+β)`` and ``GammaFunc(k+s)`` factors — and the
+upper bound is finite, ``evaluateSum`` now attempts Gosper's algorithm
+to find an antidifference ``T(k)`` satisfying ``T(k+1) − T(k) = a(k)``
+and returns the closed form ``T(hi+1) − T(lo)``.
+
+This unlocks closed forms for the classical hypergeometric shapes the
+existing narrow recognisers miss, e.g.:
+
+- ``∑_{k=1}^{N} k·2^k = (N−1)·2^(N+1) + 2``
+- ``∑_{k=0}^{N} k·k! = (N+1)! − 1``
+
+### Changes
+
+- ``src/gosper.ts``: new module — full Gosper pipeline (structural
+  decomposition → ratio computation → Petkovšek shift-coprime
+  normalisation → Gosper degree bound → linear system solve via
+  Gaussian elimination over exact ``bigint`` rationals).  Mirrors the
+  Python module 1:1 including the boundary-singularity cancellation
+  step that handles removable factorial denominators at ``k = lo``.
+
+- ``src/gosper.ts``: defensive ``MAX_POLY_DEGREE = 64`` cap on
+  polynomial exponents during IR-to-poly conversion.  Without this,
+  an adversarial summand like ``Pow(k, 10**9)`` would balloon the
+  internal polynomial representation into a memory-bomb.  Gosper-
+  summable expressions in practice have very small polynomial degree
+  (typically ≤ 5).
+
+- ``src/index.ts``: wire ``tryGosperSum`` into the dispatch chain at the
+  same insertion point as Python (step 5b in ``summation.py``) — after
+  all narrow recognisers (constant, geometric, Faulhaber, telescoping,
+  classic infinite series, small-range numeric) and before the
+  Apart-retry telescope chain and the unevaluated fallthrough.  Guarded
+  by ``if (!infUpper)`` to mirror Python: Gosper returns
+  ``T(hi+1) − T(lo)`` which is only meaningful for finite ``hi``;
+  infinite upper bounds belong to the limit-aware paths above.
+
+- ``tests/gosper.test.ts``: 15 tests — 4 acceptance cases (``k·2^k``,
+  ``k·k!``, ``2^k`` regression, mixed-handler dispatcher), 2 fall-
+  through safety cases (``sin(k)``, ``log(k)``), 2 regression cases
+  (Faulhaber and constant handlers still take priority), 4 internal
+  helper tests, 2 structural pieces (``decompose`` + ``hypRatio``),
+  and 1 DoS-cap test verifying ``Pow(k, 10**9)`` is refused promptly.
+
+- ``package.json``: minor bump to 2.27.0.
+
 ## 2.26.0 - 2026-06-06
 
 ### Added

--- a/code/packages/typescript/cas-summation/package-lock.json
+++ b/code/packages/typescript/cas-summation/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/cas-summation",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.1.0",
@@ -32,6 +34,36 @@
         "vitest": "^4.1.0"
       }
     },
+    "../cas-pattern-matching": {
+      "name": "@coding-adventures/cas-pattern-matching",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../cas-simplify": {
+      "name": "@coding-adventures/cas-simplify",
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
     "../symbolic-ir": {
       "name": "@coding-adventures/symbolic-ir",
       "version": "0.2.0",
@@ -44,11 +76,12 @@
     },
     "../symbolic-vm": {
       "name": "@coding-adventures/symbolic-vm",
-      "version": "0.16.0",
+      "version": "0.19.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@coding-adventures/cas-factor": "file:../cas-factor",
+        "@coding-adventures/cas-simplify": "file:../cas-simplify",
         "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
       },
       "devDependencies": {
@@ -115,6 +148,14 @@
     },
     "node_modules/@coding-adventures/cas-factor": {
       "resolved": "../cas-factor",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-pattern-matching": {
+      "resolved": "../cas-pattern-matching",
+      "link": true
+    },
+    "node_modules/@coding-adventures/cas-simplify": {
+      "resolved": "../cas-simplify",
       "link": true
     },
     "node_modules/@coding-adventures/symbolic-ir": {

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -17,6 +17,8 @@
   },
   "devDependencies": {
     "@coding-adventures/cas-factor": "file:../cas-factor",
+    "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+    "@coding-adventures/cas-simplify": "file:../cas-simplify",
     "@coding-adventures/symbolic-vm": "file:../symbolic-vm",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/cas-summation/src/gosper.ts
+++ b/code/packages/typescript/cas-summation/src/gosper.ts
@@ -1,0 +1,797 @@
+/**
+ * Gosper's algorithm for indefinite hypergeometric summation.
+ *
+ * Track H2 port of `code/packages/python/cas-summation/src/cas_summation/gosper.py`
+ * (Track H1, PR #5366).  See the Python source for the full mathematical
+ * background.  The structure mirrors the Python module 1:1:
+ *
+ *   1. Structural decomposition of the summand into a hypergeometric
+ *      product `poly(k) · ∏ base^exp(k) · ∏ Γ(k+s) / ∏ Γ(k+t)`.
+ *   2. Compute the shift ratio `a(k+1)/a(k)` as two polynomials.
+ *   3. Petkovšek-normalise the ratio: `r(k) = A(k)·C(k+1) / (B(k)·C(k))`
+ *      with `gcd(A(k), B(k+h)) = 1` for every integer `h ≥ 0`.
+ *   4. Bound the degree of `x(k)` in Gosper's key equation
+ *      `A(k)·x(k+1) − B(k−1)·x(k) = C(k)` and solve the linear system
+ *      via Gaussian elimination over rational coefficients.
+ *   5. Reconstruct `T(k) = B(k−1)·x(k)·a(k) / C(k)` and return
+ *      `T(hi+1) − T(lo)` as the closed-form IR.
+ *
+ * Coefficients are exact rationals built on `bigint` — no floats — to
+ * match the Python `fractions.Fraction` semantics bit-for-bit.
+ *
+ * Defensive cap `MAX_POLY_DEGREE = 64` rejects polynomial exponents
+ * larger than that during IR-to-poly conversion to prevent memory-bomb
+ * inputs like `Pow(k, 10**9)`.
+ */
+
+import {
+  ADD,
+  DIV,
+  MUL,
+  NEG,
+  POW,
+  SUB,
+  app,
+  equals as irEquals,
+  int,
+  rational,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+
+import { GAMMA_FUNC } from "./index";
+
+// ---------------------------------------------------------------------------
+// Exact rational arithmetic (mirrors Python's `fractions.Fraction`).
+// ---------------------------------------------------------------------------
+
+/** A reduced rational with `denom > 0`. */
+export interface Frac {
+  readonly n: bigint;
+  readonly d: bigint;
+}
+
+function absBig(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+function gcdBig(a: bigint, b: bigint): bigint {
+  let x = absBig(a);
+  let y = absBig(b);
+  while (y !== 0n) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x === 0n ? 1n : x;
+}
+
+function mkF(n: bigint, d: bigint): Frac {
+  if (d === 0n) throw new RangeError("Frac denominator cannot be zero");
+  if (d < 0n) {
+    n = -n;
+    d = -d;
+  }
+  const g = gcdBig(n, d);
+  return { n: n / g, d: d / g };
+}
+
+const F0: Frac = { n: 0n, d: 1n };
+const F1: Frac = { n: 1n, d: 1n };
+
+function fEq(a: Frac, b: Frac): boolean {
+  return a.n === b.n && a.d === b.d;
+}
+
+function fIsZero(a: Frac): boolean {
+  return a.n === 0n;
+}
+
+function fAdd(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+
+function fSub(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.d - b.n * a.d, a.d * b.d);
+}
+
+function fMul(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.n, a.d * b.d);
+}
+
+function fDiv(a: Frac, b: Frac): Frac {
+  if (b.n === 0n) throw new RangeError("Frac division by zero");
+  return mkF(a.n * b.d, a.d * b.n);
+}
+
+function fNeg(a: Frac): Frac {
+  return { n: -a.n, d: a.d };
+}
+
+function fFromInt(n: bigint): Frac {
+  return { n, d: 1n };
+}
+
+/** Integer power of a Frac.  `exp` may be negative. */
+function fPow(base: Frac, exp: bigint): Frac {
+  if (exp === 0n) return F1;
+  if (exp < 0n) {
+    if (base.n === 0n) throw new RangeError("0 to a negative power");
+    return fPow({ n: base.d * (base.n < 0n ? -1n : 1n), d: absBig(base.n) }, -exp);
+  }
+  let result = F1;
+  let b = base;
+  let e = exp;
+  while (e > 0n) {
+    if ((e & 1n) === 1n) result = fMul(result, b);
+    e >>= 1n;
+    if (e > 0n) b = fMul(b, b);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Univariate polynomial arithmetic over Frac.  `Poly` is the list of
+// coefficients with `p[i]` the coefficient of `k^i`; trailing zeros are
+// trimmed.  Zero polynomial → `[]`.
+// ---------------------------------------------------------------------------
+
+export type Poly = Frac[];
+
+/**
+ * Defensive cap on polynomial degree — without this, an adversarial
+ * summand like `Pow(k, 10n ** 9n)` would balloon `irToPoly` into a
+ * memory-bomb.  Gosper-summable expressions have very small polynomial
+ * degree in practice (typically ≤ 5).
+ */
+export const MAX_POLY_DEGREE = 64;
+
+function polyTrim(p: Poly): Poly {
+  let n = p.length;
+  while (n > 0 && fIsZero(p[n - 1])) n--;
+  return p.slice(0, n);
+}
+
+function polyDeg(p: Poly): number {
+  const pp = polyTrim(p);
+  return pp.length - 1;
+}
+
+function polyAdd(a: Poly, b: Poly): Poly {
+  const n = Math.max(a.length, b.length);
+  const out: Frac[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const ai = i < a.length ? a[i] : F0;
+    const bi = i < b.length ? b[i] : F0;
+    out[i] = fAdd(ai, bi);
+  }
+  return polyTrim(out);
+}
+
+function polySub(a: Poly, b: Poly): Poly {
+  return polyAdd(a, b.map(fNeg));
+}
+
+function polyMul(a: Poly, b: Poly): Poly {
+  const ta = polyTrim(a);
+  const tb = polyTrim(b);
+  if (ta.length === 0 || tb.length === 0) return [];
+  const out: Frac[] = new Array(ta.length + tb.length - 1).fill(F0);
+  for (let i = 0; i < ta.length; i++) {
+    if (fIsZero(ta[i])) continue;
+    for (let j = 0; j < tb.length; j++) {
+      if (fIsZero(tb[j])) continue;
+      out[i + j] = fAdd(out[i + j], fMul(ta[i], tb[j]));
+    }
+  }
+  return polyTrim(out);
+}
+
+function polyScalar(p: Poly, c: Frac): Poly {
+  if (fIsZero(c)) return [];
+  return p.map((x) => fMul(x, c));
+}
+
+/**
+ * Return `p(k + h)` as a new polynomial via the binomial expansion
+ * `(k + h)^i = Σ_j C(i, j) · h^(i - j) · k^j`.
+ */
+function polyShift(p: Poly, h: bigint): Poly {
+  const n = p.length;
+  const out: Frac[] = new Array(n).fill(F0);
+  for (let i = 0; i < n; i++) {
+    if (fIsZero(p[i])) continue;
+    // Pascal's row i.
+    let binom = 1n;
+    for (let j = 0; j <= i; j++) {
+      // C(i, j) · h^(i - j) — integer arithmetic.
+      const hpow = h ** BigInt(i - j);
+      const term = fMul(p[i], fFromInt(binom * hpow));
+      out[j] = fAdd(out[j], term);
+      // Advance Pascal: next binom = binom * (i - j) / (j + 1).
+      binom = (binom * BigInt(i - j)) / BigInt(j + 1);
+    }
+  }
+  return polyTrim(out);
+}
+
+/**
+ * Polynomial long division.  Returns `[q, r]` with `a = q·b + r` and
+ * `deg(r) < deg(b)`.  `b` must be non-zero.
+ */
+function polyDivmod(a: Poly, b: Poly): [Poly, Poly] {
+  const ta = polyTrim(a);
+  const tb = polyTrim(b);
+  if (tb.length === 0) throw new RangeError("polynomial division by zero");
+  if (polyDeg(ta) < polyDeg(tb)) return [[], ta];
+  const q: Frac[] = new Array(ta.length - tb.length + 1).fill(F0);
+  let r = ta.slice();
+  while (polyDeg(r) >= polyDeg(tb)) {
+    const degDiff = polyDeg(r) - polyDeg(tb);
+    const coeff = fDiv(r[r.length - 1], tb[tb.length - 1]);
+    q[degDiff] = coeff;
+    // Subtract coeff · k^degDiff · b from r.
+    const shifted: Frac[] = new Array(degDiff).fill(F0).concat(
+      tb.map((c) => fMul(c, coeff)),
+    );
+    r = polySub(r, shifted);
+  }
+  return [polyTrim(q), polyTrim(r)];
+}
+
+/** Monic GCD via Euclid; output has leading coefficient 1 (or empty). */
+function polyGcd(a: Poly, b: Poly): Poly {
+  let x = polyTrim(a);
+  let y = polyTrim(b);
+  while (y.length > 0) {
+    const [, r] = polyDivmod(x, y);
+    x = y;
+    y = r;
+  }
+  if (x.length === 0) return [];
+  // Monic-normalise.
+  const lc = x[x.length - 1];
+  return x.map((c) => fDiv(c, lc));
+}
+
+function polyEq(a: Poly, b: Poly): boolean {
+  const ta = polyTrim(a);
+  const tb = polyTrim(b);
+  if (ta.length !== tb.length) return false;
+  for (let i = 0; i < ta.length; i++) {
+    if (!fEq(ta[i], tb[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Solve `M · x = rhs` over the rationals via Gaussian elimination.
+ * Returns the solution vector (under-determined systems pick free
+ * variables = 0) or `undefined` if the system is inconsistent.
+ */
+function solveLinearSystem(matrix: Frac[][], rhs: Frac[]): Frac[] | undefined {
+  if (matrix.length === 0) return rhs.length === 0 ? [] : undefined;
+  const rows = matrix.length;
+  const cols = matrix[0].length;
+  const m: Frac[][] = matrix.map((row, i) => [...row, rhs[i]]);
+  let row = 0;
+  for (let col = 0; col < cols; col++) {
+    let pivot = -1;
+    for (let r = row; r < rows; r++) {
+      if (!fIsZero(m[r][col])) {
+        pivot = r;
+        break;
+      }
+    }
+    if (pivot === -1) continue;
+    [m[row], m[pivot]] = [m[pivot], m[row]];
+    const piv = m[row][col];
+    m[row] = m[row].map((c) => fDiv(c, piv));
+    for (let r = 0; r < rows; r++) {
+      if (r === row) continue;
+      const factor = m[r][col];
+      if (fIsZero(factor)) continue;
+      for (let i = 0; i <= cols; i++) {
+        m[r][i] = fSub(m[r][i], fMul(factor, m[row][i]));
+      }
+    }
+    row++;
+  }
+  // Inconsistency: 0 = non-zero anywhere.
+  for (let r = 0; r < rows; r++) {
+    let allZero = true;
+    for (let c = 0; c < cols; c++) {
+      if (!fIsZero(m[r][c])) {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero && !fIsZero(m[r][cols])) return undefined;
+  }
+  // Read off the solution.
+  const x: Frac[] = new Array(cols).fill(F0);
+  const rowForCol = new Map<number, number>();
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (fEq(m[r][c], F1)) {
+        let isPivotCol = true;
+        for (let r2 = 0; r2 < rows; r2++) {
+          if (r2 !== r && !fIsZero(m[r2][c])) {
+            isPivotCol = false;
+            break;
+          }
+        }
+        if (isPivotCol) {
+          rowForCol.set(c, r);
+          break;
+        }
+      }
+    }
+  }
+  for (let c = 0; c < cols; c++) {
+    const r = rowForCol.get(c);
+    if (r !== undefined) x[c] = m[r][cols];
+  }
+  return x;
+}
+
+// ---------------------------------------------------------------------------
+// IR ↔ polynomial bridge.
+// ---------------------------------------------------------------------------
+
+function rationalOf(node: IRNode): Frac | undefined {
+  if (node.kind === "integer") return fFromInt(node.value);
+  if (node.kind === "rational") return mkF(node.numer, node.denom);
+  return undefined;
+}
+
+/**
+ * Convert an IR expression that is a polynomial in `k` to a `Poly`.
+ * Returns `undefined` if the expression has any non-polynomial structure
+ * (division by k-bearing denominator, transcendentals, free non-k symbols,
+ * negative/fractional exponents, or exponents above `MAX_POLY_DEGREE`).
+ */
+export function irToPoly(node: IRNode, k: IRNode): Poly | undefined {
+  const r = rationalOf(node);
+  if (r !== undefined) return [r];
+  if (node.kind === "symbol") {
+    if (irEquals(node, k)) return [F0, F1];
+    return undefined;
+  }
+  if (node.kind !== "apply") return undefined;
+  if (irEquals(node.head, NEG) && node.args.length === 1) {
+    const inner = irToPoly(node.args[0], k);
+    return inner === undefined ? undefined : polyScalar(inner, fFromInt(-1n));
+  }
+  if (irEquals(node.head, ADD)) {
+    let out: Poly = [];
+    for (const arg of node.args) {
+      const sub = irToPoly(arg, k);
+      if (sub === undefined) return undefined;
+      out = polyAdd(out, sub);
+    }
+    return out;
+  }
+  if (irEquals(node.head, SUB) && node.args.length === 2) {
+    const a = irToPoly(node.args[0], k);
+    const b = irToPoly(node.args[1], k);
+    if (a === undefined || b === undefined) return undefined;
+    return polySub(a, b);
+  }
+  if (irEquals(node.head, MUL)) {
+    let out: Poly = [F1];
+    for (const arg of node.args) {
+      const sub = irToPoly(arg, k);
+      if (sub === undefined) return undefined;
+      out = polyMul(out, sub);
+    }
+    return out;
+  }
+  if (irEquals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    const basePoly = irToPoly(base, k);
+    if (basePoly === undefined) return undefined;
+    if (exp.kind !== "integer" || exp.value < 0n) return undefined;
+    if (exp.value > BigInt(MAX_POLY_DEGREE)) return undefined;
+    let result: Poly = [F1];
+    const e = Number(exp.value);
+    for (let i = 0; i < e; i++) {
+      result = polyMul(result, basePoly);
+      if (polyDeg(result) > MAX_POLY_DEGREE) return undefined;
+    }
+    return result;
+  }
+  if (irEquals(node.head, DIV) && node.args.length === 2) {
+    const np = irToPoly(node.args[0], k);
+    const dp = irToPoly(node.args[1], k);
+    if (np === undefined || dp === undefined) return undefined;
+    if (polyDeg(dp) !== 0) return undefined;
+    return polyScalar(np, fDiv(F1, dp[0]));
+  }
+  return undefined;
+}
+
+function fracToIr(f: Frac): IRNode {
+  if (f.d === 1n) return int(f.n);
+  return rational(f.n, f.d);
+}
+
+function polyToIr(p: Poly, k: IRNode): IRNode {
+  const tp = polyTrim(p);
+  if (tp.length === 0) return int(0);
+  const terms: IRNode[] = [];
+  for (let i = 0; i < tp.length; i++) {
+    const c = tp[i];
+    if (fIsZero(c)) continue;
+    if (i === 0) {
+      terms.push(fracToIr(c));
+    } else if (i === 1) {
+      if (fEq(c, F1)) {
+        terms.push(k);
+      } else {
+        terms.push(app(MUL, [fracToIr(c), k]));
+      }
+    } else {
+      const power = app(POW, [k, int(i)]);
+      if (fEq(c, F1)) {
+        terms.push(power);
+      } else {
+        terms.push(app(MUL, [fracToIr(c), power]));
+      }
+    }
+  }
+  if (terms.length === 0) return int(0);
+  if (terms.length === 1) return terms[0];
+  return app(ADD, terms);
+}
+
+// ---------------------------------------------------------------------------
+// Structural factoring: a(k) → (poly(k), exponentials, factorials).
+// ---------------------------------------------------------------------------
+
+interface Hyp {
+  poly: Poly;
+  expFactors: { base: Frac; exp: Poly }[];
+  gammaShifts: bigint[];
+  recipGammaShifts: bigint[];
+}
+
+function newHyp(): Hyp {
+  return { poly: [F1], expFactors: [], gammaShifts: [], recipGammaShifts: [] };
+}
+
+/**
+ * If `node = α·k + β` with integer α, β, return `[α, β]`; pure constants
+ * come back as `[0n, β]`.  Otherwise `undefined`.
+ */
+function tryLinearInK(node: IRNode, k: IRNode): [bigint, bigint] | undefined {
+  const p = irToPoly(node, k);
+  if (p === undefined) return undefined;
+  if (p.length === 0) return [0n, 0n];
+  if (polyDeg(p) > 1) return undefined;
+  const a = p.length >= 2 ? p[1] : F0;
+  const b = p[0];
+  if (a.d !== 1n || b.d !== 1n) return undefined;
+  return [a.n, b.n];
+}
+
+function decompose(node: IRNode, k: IRNode, hyp?: Hyp): Hyp | undefined {
+  const h = hyp ?? newHyp();
+  // Polynomial sub-tree.
+  const poly = irToPoly(node, k);
+  if (poly !== undefined) {
+    h.poly = polyMul(h.poly, poly);
+    return h;
+  }
+  if (node.kind !== "apply") return undefined;
+  if (irEquals(node.head, MUL)) {
+    for (const arg of node.args) {
+      if (decompose(arg, k, h) === undefined) return undefined;
+    }
+    return h;
+  }
+  if (irEquals(node.head, NEG) && node.args.length === 1) {
+    const inner = decompose(node.args[0], k, h);
+    if (inner === undefined) return undefined;
+    inner.poly = polyScalar(inner.poly, fFromInt(-1n));
+    return inner;
+  }
+  if (irEquals(node.head, DIV) && node.args.length === 2) {
+    const [num, den] = node.args;
+    if (decompose(num, k, h) === undefined) return undefined;
+    const denPoly = irToPoly(den, k);
+    if (denPoly !== undefined) {
+      if (polyDeg(denPoly) !== 0 || denPoly.length === 0) return undefined;
+      h.poly = polyScalar(h.poly, fDiv(F1, denPoly[0]));
+      return h;
+    }
+    if (den.kind === "apply" && irEquals(den.head, GAMMA_FUNC) && den.args.length === 1) {
+      const lin = tryLinearInK(den.args[0], k);
+      if (lin === undefined || lin[0] !== 1n) return undefined;
+      h.recipGammaShifts.push(lin[1]);
+      return h;
+    }
+    return undefined;
+  }
+  if (irEquals(node.head, POW) && node.args.length === 2) {
+    const [base, exp] = node.args;
+    const basePoly = irToPoly(base, k);
+    if (basePoly === undefined) return undefined;
+    if (polyDeg(basePoly) !== 0 || basePoly.length === 0) return undefined;
+    const b = basePoly[0];
+    if (fIsZero(b)) return undefined;
+    const expPoly = irToPoly(exp, k);
+    if (expPoly === undefined) return undefined;
+    if (polyDeg(expPoly) > 1) return undefined;
+    h.expFactors.push({ base: b, exp: expPoly });
+    return h;
+  }
+  if (irEquals(node.head, GAMMA_FUNC) && node.args.length === 1) {
+    const lin = tryLinearInK(node.args[0], k);
+    if (lin === undefined || lin[0] !== 1n) return undefined;
+    h.gammaShifts.push(lin[1]);
+    return h;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Ratio computation: r(k) = a(k+1) / a(k).
+// ---------------------------------------------------------------------------
+
+function hypRatio(h: Hyp): [Poly, Poly] | undefined {
+  const poly = h.poly;
+  if (polyTrim(poly).length === 0) return undefined;
+  let numer = polyShift(poly, 1n);
+  let denom: Poly = poly.slice();
+  for (const { base, exp } of h.expFactors) {
+    if (polyDeg(exp) === 0) continue;
+    const alpha = exp[1];
+    if (alpha.d !== 1n) return undefined;
+    const alphaInt = alpha.n;
+    let factor: Frac;
+    if (alphaInt >= 0n) {
+      factor = fPow(base, alphaInt);
+    } else {
+      if (fIsZero(base)) return undefined;
+      factor = fDiv(F1, fPow(base, -alphaInt));
+    }
+    numer = polyScalar(numer, factor);
+  }
+  for (const s of h.gammaShifts) {
+    numer = polyMul(numer, [fFromInt(s), F1]);
+  }
+  for (const t of h.recipGammaShifts) {
+    denom = polyMul(denom, [fFromInt(t), F1]);
+  }
+  return [numer, denom];
+}
+
+// ---------------------------------------------------------------------------
+// Petkovšek normalisation.
+// ---------------------------------------------------------------------------
+
+function petkovsekNormalise(a: Poly, b: Poly): [Poly, Poly, Poly] | undefined {
+  let A: Poly = a.slice();
+  let B: Poly = b.slice();
+  let C: Poly = [F1];
+  const maxH = Math.max(polyDeg(A), polyDeg(B), 0) + 2;
+  for (;;) {
+    let peeled = false;
+    for (let h = 0; h <= maxH; h++) {
+      const Bshifted = polyShift(B, BigInt(h));
+      const g = polyGcd(A, Bshifted);
+      if (polyDeg(g) >= 1) {
+        const [Anew, remA] = polyDivmod(A, g);
+        if (remA.length > 0) return undefined;
+        const gBack = polyShift(g, BigInt(-h));
+        const [Bnew, remB] = polyDivmod(B, gBack);
+        if (remB.length > 0) return undefined;
+        let acc: Poly = [F1];
+        for (let i = 1; i <= h; i++) {
+          acc = polyMul(acc, polyShift(g, BigInt(-i)));
+        }
+        C = polyMul(C, acc);
+        A = Anew;
+        B = Bnew;
+        peeled = true;
+        break;
+      }
+    }
+    if (!peeled) return [A, B, C];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gosper degree bound + linear solver for x(k) in
+//     A(k)·x(k+1) − B(k−1)·x(k) = C(k).
+// ---------------------------------------------------------------------------
+
+function gosperDegreeBound(A: Poly, B: Poly, C: Poly): number {
+  const Bshifted = polyShift(B, -1n);
+  const S = polyAdd(A, Bshifted);
+  const D = polySub(A, Bshifted);
+  const degS = polyDeg(S);
+  const degD = polyDeg(D);
+  const degC = polyDeg(C);
+  let bound: number;
+  if (degS > degD + 1) {
+    bound = degC - degS;
+  } else {
+    const m = Math.max(polyDeg(A), polyDeg(Bshifted));
+    if (m < 0) return 0;
+    const Stop = m < S.length ? S[m] : F0;
+    if (fIsZero(Stop)) {
+      bound = degC - m;
+    } else {
+      const DatM1 = m - 1 >= 0 && m - 1 < D.length ? D[m - 1] : F0;
+      // -2·D[m-1]/S[m] - 1 as a rational, then ceiling toward +∞.
+      const cand = fSub(fDiv(fMul(fFromInt(-2n), DatM1), Stop), F1);
+      let candInt: number;
+      if (cand.n < 0n) {
+        candInt = 0;
+      } else {
+        // Ceiling of n/d for non-negative rational.
+        const q = cand.n / cand.d;
+        const r = cand.n % cand.d;
+        candInt = r === 0n ? Number(q) : Number(q) + 1;
+      }
+      bound = Math.max(degC - m, candInt);
+    }
+  }
+  if (bound < 0) return -1;
+  return bound + 1;
+}
+
+function solveKeyEquation(
+  A: Poly,
+  B: Poly,
+  C: Poly,
+  degBound: number,
+): Poly | undefined {
+  if (degBound < 0) return undefined;
+  const nUnknowns = degBound + 1;
+  const Bshifted = polyShift(B, -1n);
+  const basisPolys: Poly[] = [];
+  let maxDeg = 0;
+  for (let i = 0; i < nUnknowns; i++) {
+    const kPowI: Poly = new Array(i).fill(F0).concat([F1]);
+    const kp1PowI = polyShift(kPowI, 1n);
+    const left = polyMul(A, kp1PowI);
+    const right = polyMul(Bshifted, kPowI);
+    const bp = polySub(left, right);
+    basisPolys.push(bp);
+    if (polyDeg(bp) > maxDeg) maxDeg = polyDeg(bp);
+  }
+  const Ctrim = polyTrim(C);
+  let rhsLen = Math.max(maxDeg + 1, Ctrim.length);
+  if (rhsLen === 0) rhsLen = 1;
+  const rhs: Frac[] = new Array(rhsLen).fill(F0);
+  for (let j = 0; j < Ctrim.length; j++) rhs[j] = Ctrim[j];
+  const matrix: Frac[][] = [];
+  for (let j = 0; j < rhsLen; j++) {
+    const row: Frac[] = [];
+    for (let i = 0; i < nUnknowns; i++) {
+      const bp = basisPolys[i];
+      row.push(j < bp.length ? bp[j] : F0);
+    }
+    matrix.push(row);
+  }
+  const sol = solveLinearSystem(matrix, rhs);
+  if (sol === undefined) return undefined;
+  const xPoly = polyTrim(sol);
+  if (xPoly.length === 0) {
+    if (polyTrim(C).length > 0) return undefined;
+    return [F0];
+  }
+  // Verify the solution.
+  const xShifted = polyShift(xPoly, 1n);
+  const lhs = polySub(polyMul(A, xShifted), polyMul(Bshifted, xPoly));
+  if (!polyEq(lhs, C)) return undefined;
+  return xPoly;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry: try Gosper on ∑_{k=lo}^{hi} summand.
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt Gosper's algorithm on `∑_{k=lo}^{hi} summand`.  Returns the IR
+ * closed form `T(hi+1) − T(lo)` on success, or `undefined` to signal
+ * fall-through.  Mirrors `try_gosper_sum` in the Python module.
+ */
+export function tryGosperSum(
+  summand: IRNode,
+  k: IRNode,
+  lo: IRNode,
+  hi: IRNode,
+): IRNode | undefined {
+  const hyp = decompose(summand, k);
+  if (hyp === undefined) return undefined;
+  const ratio = hypRatio(hyp);
+  if (ratio === undefined) return undefined;
+  const [aTop, bBot] = ratio;
+  if (polyTrim(hyp.poly).length === 0) return int(0);
+  const norm = petkovsekNormalise(aTop, bBot);
+  if (norm === undefined) return undefined;
+  const [Anorm, Bnorm, Cpoly] = norm;
+  const degBound = gosperDegreeBound(Anorm, Bnorm, Cpoly);
+  const xPoly = solveKeyEquation(Anorm, Bnorm, Cpoly, degBound);
+  if (xPoly === undefined || polyTrim(xPoly).length === 0) return undefined;
+
+  // Reconstruct T(k) = B(k−1)·x(k)·a(k) / C(k).  Cancel common polynomial
+  // factors against C(k) so removable singularities at the substitution
+  // boundary (k = lo) don't break the closed form.
+  const BatKminus1 = polyShift(Bnorm, -1n);
+  let fullNumerPoly = polyMul(polyMul(BatKminus1, xPoly), hyp.poly);
+  let denomPoly: Poly = Cpoly.slice();
+  const g = polyGcd(fullNumerPoly, denomPoly);
+  if (polyDeg(g) >= 1) {
+    const [nq, remN] = polyDivmod(fullNumerPoly, g);
+    const [dq, remD] = polyDivmod(denomPoly, g);
+    if (remN.length === 0 && remD.length === 0) {
+      fullNumerPoly = nq;
+      denomPoly = dq;
+    }
+  }
+
+  // Build the transcendental IR ∏ base^exp(k) · ∏ Γ(k+s) / ∏ Γ(k+t).
+  function buildTranscendentalPart(): IRNode {
+    const pieces: IRNode[] = [];
+    for (const { base, exp } of hyp!.expFactors) {
+      pieces.push(app(POW, [fracToIr(base), polyToIr(exp, k)]));
+    }
+    for (const s of hyp!.gammaShifts) {
+      const arg = s === 0n ? k : app(ADD, [k, int(s)]);
+      pieces.push(app(GAMMA_FUNC, [arg]));
+    }
+    const denominatorGammas: IRNode[] = [];
+    for (const t of hyp!.recipGammaShifts) {
+      const arg = t === 0n ? k : app(ADD, [k, int(t)]);
+      denominatorGammas.push(app(GAMMA_FUNC, [arg]));
+    }
+    if (pieces.length === 0 && denominatorGammas.length === 0) return int(1);
+    const numer = pieces.length === 0
+      ? int(1)
+      : pieces.length === 1
+        ? pieces[0]
+        : app(MUL, pieces);
+    if (denominatorGammas.length === 0) return numer;
+    const denom = denominatorGammas.length === 1
+      ? denominatorGammas[0]
+      : app(MUL, denominatorGammas);
+    return app(DIV, [numer, denom]);
+  }
+  const transcendentalIr = buildTranscendentalPart();
+
+  function substitute(node: IRNode, from: IRNode, to: IRNode): IRNode {
+    if (irEquals(node, from)) return to;
+    if (node.kind !== "apply") return node;
+    return app(node.head, node.args.map((arg) => substitute(arg, from, to)));
+  }
+
+  function tAt(kValue: IRNode): IRNode {
+    const numerIr = polyToIr(fullNumerPoly, k);
+    const denomIr = polyToIr(denomPoly, k);
+    const numerAt = substitute(numerIr, k, kValue);
+    const denomAt = substitute(denomIr, k, kValue);
+    const transAt = substitute(transcendentalIr, k, kValue);
+    return app(DIV, [app(MUL, [numerAt, transAt]), denomAt]);
+  }
+
+  const hiPlusOne = app(ADD, [hi, int(1)]);
+  return app(SUB, [tAt(hiPlusOne), tAt(lo)]);
+}
+
+// Re-exports for testing.
+export const __test = {
+  polyAdd,
+  polyMul,
+  polyShift,
+  polyGcd,
+  polyDivmod,
+  polyDeg,
+  fFromInt,
+  mkF,
+  decompose,
+  hypRatio,
+};

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -19,6 +19,10 @@ import {
 
 export const GAMMA_FUNC = sym("GammaFunc");
 
+// Re-exported from ``gosper.ts``.  Track H2 — see PR #5366 (H1, Python).
+export { tryGosperSum, MAX_POLY_DEGREE } from "./gosper";
+import { tryGosperSum } from "./gosper";
+
 export interface RationalValue {
   readonly numer: bigint;
   readonly denom: bigint;
@@ -217,6 +221,23 @@ function evaluateSumInner(
       total = addR(total, r);
     }
     if (ok) return rationalToIr(total);
+  }
+
+  // Track H2 — Gosper hypergeometric closed-form attempt.  Runs after
+  // all narrow recognisers (constant, geometric, Faulhaber, telescoping,
+  // small-range numeric, special infinite series) but before the
+  // Apart-retry telescope chain and the unevaluated fallthrough.
+  //
+  // Mirrors the Python dispatch insertion point in
+  // ``cas_summation.summation`` (step 5b): Gosper only runs for *finite*
+  // upper bounds because the algorithm returns ``T(hi+1) − T(lo)`` which
+  // is only meaningful when ``hi+1`` is a real value.  Infinite upper
+  // bounds belong to the dedicated limit-aware paths above (telescope at
+  // ∞, classic series).  This guard also preserves the Phase 41 fall-
+  // through contract for non-vanishing telescopes.
+  if (!infUpper) {
+    const gosper = tryGosperSum(f, k, lo, hi);
+    if (gosper !== undefined) return evalFn(gosper);
   }
 
   // Track B2 — Apart-retry telescope chain.  Mirrors the Python

--- a/code/packages/typescript/cas-summation/tests/gosper.test.ts
+++ b/code/packages/typescript/cas-summation/tests/gosper.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for Gosper's algorithm — Track H2 (port of Python H1, PR #5366).
+ *
+ * These mirror the 14 acceptance + structural cases from
+ * ``code/packages/python/cas-summation/tests/test_gosper.py``.  Each test
+ * verifies the closed form against the direct numeric sum at several
+ * concrete values of the free parameter ``N``.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  DIV,
+  MUL,
+  NEG,
+  POW,
+  SUB,
+  SUM,
+  app,
+  equals as irEquals,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+import {
+  GAMMA_FUNC,
+  MAX_POLY_DEGREE,
+  evaluateSum,
+  rationalValue,
+  tryGosperSum,
+  type RationalValue,
+} from "../src/index";
+import { __test } from "../src/gosper";
+
+// ---------------------------------------------------------------------------
+// Stub VM — evaluates arithmetic + reduces ``GammaFunc(integer)`` to the
+// corresponding factorial so we can verify closed-form numerics.
+// ---------------------------------------------------------------------------
+
+function rationalToIr(value: RationalValue): IRNode {
+  return value.denom === 1n ? int(value.numer) : rational(value.numer, value.denom);
+}
+
+function gcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x === 0n ? 1n : x;
+}
+
+function reduceR(value: RationalValue): RationalValue {
+  let n = value.numer;
+  let d = value.denom;
+  if (d < 0n) {
+    n = -n;
+    d = -d;
+  }
+  const g = gcd(n, d);
+  return { numer: n / g, denom: d / g };
+}
+
+function addR(a: RationalValue, b: RationalValue): RationalValue {
+  return reduceR({ numer: a.numer * b.denom + b.numer * a.denom, denom: a.denom * b.denom });
+}
+function subR(a: RationalValue, b: RationalValue): RationalValue {
+  return reduceR({ numer: a.numer * b.denom - b.numer * a.denom, denom: a.denom * b.denom });
+}
+function mulR(a: RationalValue, b: RationalValue): RationalValue {
+  return reduceR({ numer: a.numer * b.numer, denom: a.denom * b.denom });
+}
+function divR(a: RationalValue, b: RationalValue): RationalValue {
+  return reduceR({ numer: a.numer * b.denom, denom: a.denom * b.numer });
+}
+
+function evalNode(node: IRNode): IRNode {
+  if (node.kind !== "apply") return node;
+  const args = node.args.map(evalNode);
+  const head = node.head;
+  if (head.kind !== "symbol") return app(head, args);
+  // GammaFunc(IRInteger n ≥ 1) = (n-1)!
+  if (head.name === GAMMA_FUNC.name && args.length === 1) {
+    const a = args[0];
+    if (a.kind === "integer" && a.value >= 1n) {
+      let f = 1n;
+      for (let i = 1n; i < a.value; i++) f *= i;
+      return int(f);
+    }
+    return app(head, args);
+  }
+  switch (head.name) {
+    case ADD.name: {
+      let acc: RationalValue = { numer: 0n, denom: 1n };
+      for (const a of args) {
+        const v = rationalValue(a);
+        if (v === undefined) return app(head, args);
+        acc = addR(acc, v);
+      }
+      return rationalToIr(acc);
+    }
+    case SUB.name: {
+      if (args.length !== 2) return app(head, args);
+      const a = rationalValue(args[0]);
+      const b = rationalValue(args[1]);
+      if (a === undefined || b === undefined) return app(head, args);
+      return rationalToIr(subR(a, b));
+    }
+    case MUL.name: {
+      let acc: RationalValue = { numer: 1n, denom: 1n };
+      for (const a of args) {
+        const v = rationalValue(a);
+        if (v === undefined) return app(head, args);
+        acc = mulR(acc, v);
+      }
+      return rationalToIr(acc);
+    }
+    case DIV.name: {
+      if (args.length !== 2) return app(head, args);
+      const a = rationalValue(args[0]);
+      const b = rationalValue(args[1]);
+      if (a === undefined || b === undefined || b.numer === 0n) return app(head, args);
+      return rationalToIr(divR(a, b));
+    }
+    case POW.name: {
+      if (args.length !== 2) return app(head, args);
+      const base = rationalValue(args[0]);
+      if (base === undefined || args[1].kind !== "integer") return app(head, args);
+      const exp = args[1].value;
+      if (exp >= 0n) {
+        let r: RationalValue = { numer: 1n, denom: 1n };
+        for (let i = 0n; i < exp; i++) r = mulR(r, base);
+        return rationalToIr(r);
+      }
+      if (base.numer === 0n) return app(head, args);
+      let r: RationalValue = { numer: 1n, denom: 1n };
+      for (let i = 0n; i < -exp; i++) r = mulR(r, base);
+      return rationalToIr({ numer: r.denom, denom: r.numer });
+    }
+    case NEG.name: {
+      if (args.length !== 1) return app(head, args);
+      const a = rationalValue(args[0]);
+      if (a === undefined) return app(head, args);
+      return rationalToIr({ numer: -a.numer, denom: a.denom });
+    }
+    default:
+      return app(head, args);
+  }
+}
+
+const k = sym("k");
+const N = sym("N");
+
+function substitute(node: IRNode, from: IRNode, to: IRNode): IRNode {
+  if (irEquals(node, from)) return to;
+  if (node.kind !== "apply") return node;
+  return app(node.head, node.args.map((a) => substitute(a, from, to)));
+}
+
+function evalAt(node: IRNode, symNode: IRNode, value: bigint): RationalValue | undefined {
+  return rationalValue(evalNode(substitute(node, symNode, int(value))));
+}
+
+function rv(numer: bigint, denom: bigint = 1n): RationalValue {
+  return reduceR({ numer, denom });
+}
+
+function eqR(a: RationalValue | undefined, b: RationalValue): boolean {
+  if (a === undefined) return false;
+  return a.numer === b.numer && a.denom === b.denom;
+}
+
+function factorialBig(n: bigint): bigint {
+  let r = 1n;
+  for (let i = 1n; i <= n; i++) r *= i;
+  return r;
+}
+
+function makeKTimes2K(): IRNode {
+  return app(MUL, [k, app(POW, [int(2), k])]);
+}
+function makeKTimesKFact(): IRNode {
+  return app(MUL, [k, app(GAMMA_FUNC, [app(ADD, [k, int(1)])])]);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper tests — polynomial primitives.
+// ---------------------------------------------------------------------------
+
+describe("gosper: poly helpers", () => {
+  it("polyAdd basic: (1 + 2k) + (3 + k^2) = 4 + 2k + k^2", () => {
+    const { polyAdd, mkF, fFromInt } = __test;
+    const result = polyAdd(
+      [fFromInt(1n), fFromInt(2n)],
+      [fFromInt(3n), fFromInt(0n), fFromInt(1n)],
+    );
+    expect(result.map((f) => f.n)).toEqual([4n, 2n, 1n]);
+  });
+  it("polyMul basic: (1 + k)^2 = 1 + 2k + k^2", () => {
+    const { polyMul, fFromInt } = __test;
+    const result = polyMul([fFromInt(1n), fFromInt(1n)], [fFromInt(1n), fFromInt(1n)]);
+    expect(result.map((f) => f.n)).toEqual([1n, 2n, 1n]);
+  });
+  it("polyShift basic: shift k^2 by +1 → 1 + 2k + k^2", () => {
+    const { polyShift, fFromInt } = __test;
+    const p = [fFromInt(0n), fFromInt(0n), fFromInt(1n)];
+    const result = polyShift(p, 1n);
+    expect(result.map((f) => f.n)).toEqual([1n, 2n, 1n]);
+  });
+  it("polyGcd basic: gcd(k^2 − 1, k − 1) = k − 1 (monic)", () => {
+    const { polyGcd, fFromInt } = __test;
+    const a = [fFromInt(-1n), fFromInt(0n), fFromInt(1n)];
+    const b = [fFromInt(-1n), fFromInt(1n)];
+    const g = polyGcd(a, b);
+    expect(g.map((f) => `${f.n}/${f.d}`)).toEqual(["-1/1", "1/1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance cases.
+// ---------------------------------------------------------------------------
+
+describe("gosper: acceptance", () => {
+  it("∑_{k=1}^{5} k·2^k = 258 via dispatcher", () => {
+    const f = makeKTimes2K();
+    const result = evaluateSum(f, k, int(1), int(5), evalNode);
+    expect(rationalValue(result)).toEqual({ numer: 258n, denom: 1n });
+  });
+
+  it("∑_{k=1}^{N} k·2^k symbolic closed form: matches direct sums at small N", () => {
+    const f = makeKTimes2K();
+    const result = tryGosperSum(f, k, int(1), N);
+    expect(result).toBeDefined();
+    // Not the unevaluated SUM.
+    expect(result!.kind === "apply" && irEquals(result!.head, SUM)).toBe(false);
+    for (const n of [1n, 2n, 3n, 5n, 7n]) {
+      let expected = 0n;
+      for (let j = 1n; j <= n; j++) expected += j * (2n ** j);
+      expect(eqR(evalAt(result!, N, n), rv(expected))).toBe(true);
+    }
+  });
+
+  it("∑_{k=0}^{N} k·k! = (N+1)! − 1: matches direct sums at small N", () => {
+    const f = makeKTimesKFact();
+    const result = tryGosperSum(f, k, int(0), N);
+    expect(result).toBeDefined();
+    expect(result!.kind === "apply" && irEquals(result!.head, SUM)).toBe(false);
+    for (const n of [0n, 1n, 2n, 3n, 4n, 5n]) {
+      let expected = 0n;
+      for (let j = 0n; j <= n; j++) expected += j * factorialBig(j);
+      expect(eqR(evalAt(result!, N, n), rv(expected))).toBe(true);
+    }
+  });
+
+  it("∑_{k=0}^{5} 2^k = 63 via existing geometric handler (no regression)", () => {
+    const f = app(POW, [int(2), k]);
+    const result = evaluateSum(f, k, int(0), int(5), evalNode);
+    expect(rationalValue(result)).toEqual({ numer: 63n, denom: 1n });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fall-through safety.
+// ---------------------------------------------------------------------------
+
+describe("gosper: fall-through", () => {
+  it("∑ sin(k) falls through to unevaluated SUM", () => {
+    const f = app(sym("Sin"), [k]);
+    const result = evaluateSum(f, k, int(1), N, evalNode);
+    expect(result.kind === "apply" && irEquals(result.head, SUM)).toBe(true);
+  });
+  it("∑ log(k) falls through to unevaluated SUM", () => {
+    const f = app(sym("Log"), [k]);
+    const result = evaluateSum(f, k, int(1), N, evalNode);
+    expect(result.kind === "apply" && irEquals(result.head, SUM)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: existing handlers still fire first.
+// ---------------------------------------------------------------------------
+
+describe("gosper: regression — existing handlers still take priority", () => {
+  it("∑_{k=1}^{4} k = 10 via Faulhaber", () => {
+    const result = evaluateSum(k, k, int(1), int(4), evalNode);
+    expect(rationalValue(result)).toEqual({ numer: 10n, denom: 1n });
+  });
+  it("∑_{k=1}^{10} 5 = 50 via constant handler", () => {
+    const result = evaluateSum(int(5), k, int(1), int(10), evalNode);
+    expect(rationalValue(result)).toEqual({ numer: 50n, denom: 1n });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lower-level structural pieces.
+// ---------------------------------------------------------------------------
+
+describe("gosper: structural pieces", () => {
+  it("_decompose(k·2^k): poly = k, exp_factors = [(2, k)]", () => {
+    const { decompose } = __test;
+    const f = makeKTimes2K();
+    const h = decompose(f, k);
+    expect(h).toBeDefined();
+    expect(h!.poly.map((f) => `${f.n}/${f.d}`)).toEqual(["0/1", "1/1"]);
+    expect(h!.expFactors.length).toBe(1);
+    expect(h!.expFactors[0].base).toEqual({ n: 2n, d: 1n });
+    expect(h!.expFactors[0].exp.map((f) => `${f.n}/${f.d}`)).toEqual(["0/1", "1/1"]);
+  });
+  it("_hypRatio(k·2^k): numer = 2 + 2k, denom = k", () => {
+    const { decompose, hypRatio } = __test;
+    const f = makeKTimes2K();
+    const h = decompose(f, k);
+    const ratio = hypRatio(h!);
+    expect(ratio).toBeDefined();
+    const [numer, denom] = ratio!;
+    expect(numer.map((f) => `${f.n}/${f.d}`)).toEqual(["2/1", "2/1"]);
+    expect(denom.map((f) => `${f.n}/${f.d}`)).toEqual(["0/1", "1/1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DoS cap: very large polynomial exponents are refused before they
+// balloon memory.
+// ---------------------------------------------------------------------------
+
+describe("gosper: MAX_POLY_DEGREE DoS cap", () => {
+  it("Pow(k, 10**9) is refused — sum falls through, no memory blowup", () => {
+    expect(MAX_POLY_DEGREE).toBe(64);
+    const f = app(POW, [k, int(10n ** 9n)]);
+    // Should fall through and either return a small-range numeric or
+    // unevaluated SUM — what matters is it returns promptly.
+    const result = evaluateSum(f, k, int(1), N, evalNode);
+    // Symbolic N can't be numerically summed, so should be SUM.
+    expect(result.kind === "apply" && irEquals(result.head, SUM)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python `cas_summation.gosper` module (Track H1, PR #5366) to TypeScript and Rust `cas-summation`.

- TS port: `code/packages/typescript/cas-summation/src/gosper.ts` (bigint rationals)
- Rust port: `code/packages/rust/cas-summation/src/gosper.rs` (i128 rationals — no num-bigint runtime dep)
- Both apply defensive `MAX_POLY_DEGREE = 64` DoS cap on IR-to-poly conversion
- Dispatch insertion point mirrors Python step 5b: after narrow recognisers, before Apart-retry / unevaluated fallthrough, guarded by `!inf_upper`

Closed forms newly accepted:
- ∑_{k=1}^{N} k·2^k = (N−1)·2^(N+1) + 2
- ∑_{k=0}^{N} k·k! = (N+1)! − 1

## Pipeline (both ports)

1. **Structural decomposition** of summand into `poly(k) · ∏ base^exp(k) · ∏ Γ(k+s) / ∏ Γ(k+t)`
2. **Shift ratio** `a(k+1)/a(k)` as two polynomials over exact rationals
3. **Petkovšek normalisation** — shift-coprime decomposition `r(k) = A(k)·C(k+1)/(B(k)·C(k))`
4. **Gosper degree bound** for `x(k)` in `A(k)·x(k+1) − B(k−1)·x(k) = C(k)`
5. **Gaussian elimination** over Frac to solve the linear system
6. **Boundary-singularity GCD cancellation** between full numerator and `C(k)` to handle removable factorial denominators at `k = lo`
7. Reconstruct `T(k)` and emit `T(hi+1) − T(lo)` as IR

## Test plan — 15 TS + 14 Rust tests

- [x] TS: `npm run build` clean
- [x] TS: `npx vitest run` — 106/106 tests pass (91 existing + 15 new)
- [x] Rust: `cargo test` — 89/89 tests pass (75 existing + 14 new)
- [x] No regressions on existing handlers (Faulhaber, constant, geometric)
- [x] `MAX_POLY_DEGREE = 64` cap verified in both ports against `Pow(k, large)` adversarial input
- [x] Symbolic-N closed forms verified against direct sums at N = 1, 2, 3, 5, 7 (k·2^k) and N = 0..5 (k·k!)
- [x] sin(k), log(k) summands fall through to unevaluated SUM
- [x] Infinite upper bounds still routed via the Phase 41 limit-aware paths (Gosper skipped)

## Versions

- `cas-summation` (TS): 2.26.0 → 2.27.0
- `cas-summation` (Rust): 2.26.0 → 2.27.0

## Reference

- Track H1 (Python): PR #5366 — `code/packages/python/cas-summation/src/cas_summation/gosper.py`
- Track H2 spec: `code/specs/macsyma-truly-finish-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)