### PR TITLE
fix(closurec): CLOC12.74 — close gap-065 (callee paren elision)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.78.0] - 2026-06-11
+
+### Changed
+- **CLOSES gap-065** — callee paren elision: `(f)(x)` → `f(x)`,
+  `(a.b)(x)` → `a.b(x)`, `` (f)`t` `` → `` f`t` ``. Sibling of
+  gap-057 (member-object paren elision).
+
+### Added — gap-065 token pre-pass
+
+A pre-pass (mirroring gap-057's structure) strips the grouping
+parens around the CALLEE of a call / tagged template when the
+callee is a *simple reference* — a plain identifier plus
+zero-or-more `.IDENT` accessors. Guards: GROUPING-not-CALL (the
+`(` must follow punctuation other than `)`/`]`/`?.`, or start —
+so `f(g)(x)` keeps `(g)`); the inner must be a bare
+identifier-dot chain (the scan stops at the first non-`.IDENT`
+token, so `(a,b)(x)` and `(a+b)(x)` keep their parens); the
+follower must be a real `(` call paren or a template literal
+(tagged template, gated on `is_word_like`). All bracket checks
+via `is_structural_punct`. 6 new gap065_* unit tests.
+
 ## [0.77.0] - 2026-06-11
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.77.0"
+version = "0.78.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -539,6 +539,91 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-065: callee paren elision ------------------------
+    // `(f)(x)` → `f(x)`. Sibling of gap-057: upstream strips the
+    // grouping parens around the CALLEE of a call / tagged
+    // template when the callee is a *simple reference* — a plain
+    // identifier optionally followed by a `.IDENT` member chain:
+    //
+    //   `(f)(x)`      →  `f(x)`
+    //   `(a.b)(x)`    →  `a.b(x)`
+    //   `(f)`tpl``    →  `f`tpl``   (tagged template)
+    //
+    // `.` and `(`/`` ` `` all bind tighter than anything a
+    // grouping paren could be protecting around a bare reference,
+    // so removal is meaning-preserving. The guards mirror gap-057:
+    //
+    //   1. GROUPING, NOT CALL: the `(` must be a grouping paren
+    //      (prev token is punct other than `)`/`]`/`?.`, or start
+    //      of stream) — never a call/index paren. `f(g)(x)` keeps
+    //      its parens (the `(g)` is f's call).
+    //   2. SIMPLE REFERENCE: the inner is a plain identifier plus
+    //      zero-or-more `.IDENT` accessors. NO commas, operators,
+    //      computed `[...]`, or calls inside — `(a,b)(x)` (a
+    //      sequence) and `(a+b)(x)` keep their parens because
+    //      unwrapping would change meaning. (The scan simply
+    //      stops at the first non-`.IDENT` token; if that isn't
+    //      the matching `)`, nothing is dropped.)
+    //   3. CALL / TAG FOLLOWS: the token after `)` must be a real
+    //      `(` call paren or a template literal (tagged template).
+    //
+    // All bracket checks route through `is_structural_punct`; the
+    // tagged-template follower is gated on `is_word_like` so a
+    // string whose content starts with `` ` `` can't trigger it.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 0;
+        while i + 2 < kept.len() {
+            if is_structural_punct(&kept[i], "(")
+                && is_plain_identifier(&kept[i + 1])
+            {
+                let grouping = match i.checked_sub(1).and_then(|k| kept.get(k)) {
+                    None => true,
+                    Some(p) => {
+                        is_punct(p)
+                            && !is_structural_punct(p, ")")
+                            && !is_structural_punct(p, "]")
+                            && !is_structural_punct(p, "?.")
+                    }
+                };
+                if grouping {
+                    // Consume the `.IDENT` member chain.
+                    let mut p = i + 1;
+                    while p + 2 < kept.len()
+                        && is_structural_punct(&kept[p + 1], ".")
+                        && is_plain_identifier(&kept[p + 2])
+                    {
+                        p += 2;
+                    }
+                    // Expect the matching `)` immediately, then a
+                    // call `(` or a tagged-template literal.
+                    let close_ok = kept
+                        .get(p + 1)
+                        .map(|t| is_structural_punct(t, ")"))
+                        .unwrap_or(false);
+                    let call_or_tag = kept
+                        .get(p + 2)
+                        .map(|t| {
+                            is_structural_punct(t, "(")
+                                || (is_word_like(t) && t.value.starts_with('`'))
+                        })
+                        .unwrap_or(false);
+                    if close_ok && call_or_tag {
+                        drops.push(i); // open `(`
+                        drops.push(p + 1); // close `)`
+                        i = p + 2;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // ---- gap-059: member/call on a `new` expression ----------
     // `new A().b` → `(new A).b`. When a NewExpression is the
     // OBJECT of a member access (`.`/`[`) or the CALLEE of a
@@ -3449,6 +3534,48 @@ mod tests {
     #[test]
     fn gap057_member_object_paren_stripped() {
         assert_eq!(minify("var x=(a).b;"), "var x=a.b;");
+    }
+
+    // ---- gap-065: callee paren elision -------------------
+
+    /// gap-065: `(f)(x)` → `f(x)` — parens around a bare
+    /// identifier callee are redundant.
+    #[test]
+    fn gap065_call_callee_paren_stripped() {
+        assert_eq!(minify("(f)(x);"), "f(x);");
+    }
+
+    /// gap-065: `(a.b)(x)` → `a.b(x)` — member-chain callee.
+    #[test]
+    fn gap065_member_callee_paren_stripped() {
+        assert_eq!(minify("(a.b)(x);"), "a.b(x);");
+    }
+
+    /// gap-065: `` (f)`t` `` → `` f`t` `` — tagged-template callee.
+    #[test]
+    fn gap065_tagged_callee_paren_stripped() {
+        assert_eq!(minify("(f)`t`;"), "f`t`;");
+    }
+
+    /// gap-065 boundary: a SEQUENCE callee keeps its parens —
+    /// `(a,b)(x)` must NOT become `a,b(x)` (different program).
+    #[test]
+    fn gap065_sequence_callee_keeps_parens() {
+        assert_eq!(minify("(a,b)(x);"), "(a,b)(x);");
+    }
+
+    /// gap-065 boundary: an OPERATOR callee keeps its parens —
+    /// `(a+b)(x)` must NOT become `a+b(x)`.
+    #[test]
+    fn gap065_operator_callee_keeps_parens() {
+        assert_eq!(minify("(a+b)(x);"), "(a+b)(x);");
+    }
+
+    /// gap-065 safety: a CALL paren must never be stripped —
+    /// `f(g)(x)` keeps `(g)` (it is f's call, not a grouping).
+    #[test]
+    fn gap065_call_paren_not_stripped() {
+        assert_eq!(minify("f(g)(x);"), "f(g)(x);");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.77.0
+Version: 0.78.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,15 +90,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-065 (CLOC14.33): upstream strips redundant parens
-    // around the CALLEE of a call / tagged template when the
-    // inner expression is a simple reference (identifier or
-    // member access): `(f)(x)` → `f(x)`, `(a.b)(x)` → `a.b(x)`,
-    // `(f)`t`` → `f`t``. A sequence-expr callee `(a,b)(x)` keeps
-    // its parens (lower precedence) — that's the boundary.
-    ("paren_call_callee",   "gap-065: parens around call callee `(f)(x)`"),
-    ("paren_member_callee", "gap-065: parens around member-expr call callee"),
-    ("paren_tagged_callee", "gap-065: parens around tagged-template callee"),
+    // gap-065 RESOLVED in CLOC12.74 — parens around a call /
+    // tagged-template callee (`(f)(x)`→`f(x)`, `(a.b)(x)`→
+    // `a.b(x)`) are now stripped; those three fixtures are
+    // enforced again.
     // gap-066 (CLOC14.33): redundant parens after `extends` —
     // `class A extends(B){}` → `class A extends B{}`.
     ("class_extends_paren", "gap-066: redundant parens after `extends`"),

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -503,7 +503,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-065 — redundant parens around a call / tagged-template callee
 
-- **Status:** OPEN — discovered by CLOC14.33. `minify_paren_call_callee` + `minify_paren_member_callee` + `minify_paren_tagged_callee` ignored.
+- **Status:** **RESOLVED** in CLOC12.74. `minify_paren_call_callee` + `minify_paren_member_callee` + `minify_paren_tagged_callee` flip IGNORED → PASS.
 - **Input:** `(f)(x);` → **Upstream:** `f(x);` (also `(a.b)(x)` → `a.b(x)`, `` (f)`t` `` → `` f`t` ``)
 - **What it needs:** Strip redundant parens around the CALLEE of a `CallExpression` / `TaggedTemplateExpression` when the inner expression is a *simple reference* — a bare identifier or a member-access chain (`.`/`[]`/`?.`). **Boundary (must NOT strip):** a sequence-expr callee `(a,b)(x)` keeps its parens (comma binds looser than call); any inner expression of lower precedence than the call/member would change meaning if unwrapped. Token-level: when a `(` is at an expression-callee position, its inner group is a plain reference chain, and the matching `)` is immediately followed by `(`/`` ` `` (call/tag), drop the paren pair. All bracket checks via `is_structural_punct`.
 


### PR DESCRIPTION
## What

Closes **gap-065** (found in CLOC14.33). Strips redundant grouping parens around the **callee** of a call / tagged template when the callee is a simple reference:

```
(f)(x)     →  f(x)
(a.b)(x)   →  a.b(x)
(f)`t`     →  f`t`
```

Sibling of the already-closed gap-057 (member-object paren elision `(a).b`→`a.b`).

## How

A token pre-pass mirroring gap-057's drops-collection structure. The inner scan consumes only an identifier + `.IDENT` member chain, so the boundaries fall out naturally:

| input | result | why |
|---|---|---|
| `(a,b)(x)` | unchanged | sequence callee — scan stops at `,`, matching `)` no longer lines up |
| `(a+b)(x)` | unchanged | operator callee — same |
| `f(g)(x)` | unchanged | `(g)` is f's CALL paren, not grouping |

Guards: GROUPING-not-CALL (the `(` must follow punctuation other than `)`/`]`/`?.`, or start); CALL/TAG follower (real `(` or a template literal, gated on `is_word_like` so a string `` `…` `` content can't trigger it); all bracket checks via `is_structural_punct`.

## Tests

- 6 new `gap065_*` unit tests (3 strip cases + sequence/operator/call-paren boundaries).
- 443 lib tests green; byte-identity harness with the 3 `paren_*_callee` fixtures un-ignored.
- Security-reviewed (read-only subagent): **PASS** — meaning preservation, all boundaries, GROUPING-not-CALL guard (incl. `a[i](x)`, `x?.(a)(y)`), member-chain scan, follower guard, index/removal correctness, and gap-057 non-regression all verified; **every in-scope case byte-identical to the JAR** (incl. `(a)(b)(c)`, `(a).b(c)`, two-match removal).

Version 0.77→0.78; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)