### PR TITLE
docs(adj-constraints): design spec — dimensional types, currency/dates/times, inequalities, symbols, constraint solving

### DIFF
--- a/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
+++ b/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
@@ -1,0 +1,189 @@
+# ADJ-CONSTRAINTS — dimensional types, currency/dates/times, inequalities, symbols, and constraint solving
+
+> Design of record for growing adj-lang from a **computation** language (extract values → compute with
+> a derivation tree) into a **constraint** language: the model extracts typed values *and* the
+> policy's constraints; the engine **solves** them deterministically — solve-for-x, feasibility /
+> contradiction, optimization — with **provenance flowing from every solved value back to the
+> constraints and their source bytes**. Strict dimensional typing throughout.
+>
+> This is the sequel to [DESIGN.md](DESIGN.md) (steps 1–3b: predicates, typed values, `let`+arithmetic,
+> the derivation tree — all merged) and [STEP3-let-arithmetic-PLAN.md](STEP3-let-arithmetic-PLAN.md).
+
+## 1. Why — adjudication *is* constraint solving
+
+Eligibility (`income ≤ threshold ∧ age ≥ 18`), proration (`split bonus by tenure`), deadlines
+(`claim within 365 days of purchase`), break-even (`solve for the premium that zeroes the margin`),
+allocation (`maximise coverage subject to a cap`) — these are linear equations, inequalities, boolean
+rule-trees, and small optimizations. If the **model** solves them, the answer is un-auditable and
+wrong-by-arithmetic (the E2/HLE failure mode). The fix is the standing thesis
+([[feedback_deterministic_is_probabilistic_special_case]], [[project_cpu_bound_reasoning_problog]]):
+**the model decomposes** messy text into typed values + the constraint structure; the **CPU engine
+solves**, and every solved value / infeasibility certificate is traced back to the constraints that
+forced it. One engine: a solved constraint feeds the **differential** exactly as a predicate does
+(feasible ⇒ one verdict, infeasible ⇒ another), so deterministic = the saturating limit of
+probabilistic still holds.
+
+User-confirmed scope (all four classes, all four outputs, strict units):
+- **Solve:** linear eq+ineq · nonlinear/algebraic · boolean/SAT · optimization (LP).
+- **Produce:** solved values · feasibility/contradiction certificate · feed-a-verdict · optimal value.
+- **Units:** strict dimensional (reject `usd + eur`, `dollars + days` unless an explicit conversion
+  fact is present).
+
+## 2. The dimensional type system (the new foundation — strict)
+
+A value is a `(magnitude, dimension)` pair. The magnitude reuses exact arithmetic
+(`numeric-tower::Rational` = BigRational, falling back to f64 only at the numeric-solver boundary).
+The **dimension** is the new piece:
+
+| surface           | term shape                              | dimension            |
+|-------------------|-----------------------------------------|----------------------|
+| `18000`           | `Num`                                   | `Scalar`             |
+| `money(18000,usd)`| `Compound{money,[Num,usd]}`             | `Money("usd")`       |
+| `quantity(40,mg_dl)` | `Compound{quantity,[Num,mg_dl]}`     | `Unit("mg_dl")`      |
+| `percentage(40)`  | `Compound{percentage,[Num]}`            | `Percent`            |
+| `date(2025,1,15)` | `Compound{date,[Num,Num,Num]}`          | `Date`               |
+| `time(14,30,0)`   | `Compound{time,[Num,Num,Num]}`          | `TimeOfDay`          |
+| `datetime(…)`     | `Compound{datetime,[date,time]}`        | `DateTime`           |
+| `duration(365,days)` | `Compound{duration,[Num,days]}`      | `Duration("days")`   |
+| `true`/`false`    | `Atom`                                  | `Boolean`            |
+| `?x` (a symbol)   | `Compound{sym,[Atom]}`                  | `Unknown(sort)`      |
+
+**Dimensional algebra** (a small, total set of rules — the engine, not the model, enforces them):
+- `add/sub`: operands must share a dimension (`usd+usd`, `days+days`); `Money(a)+Money(b)` with `a≠b`
+  is an error unless a conversion fact exists (§2.1). `Date + Duration → Date`; `Date − Date →
+  Duration`. Scalar is the identity dimension.
+- `mul/div`: `Money / Money → Scalar` (a ratio), `Money × Scalar → Money`, `Unit(a)/Unit(a) → Scalar`
+  (units cancel — the CSF:serum ratio is dimensionless), `Percent` applied as `× p/100`. Cross-unit
+  products carry a composite dimension tag (`Unit("usd·day")`) the faithfulness gate can inspect.
+- comparisons (`< ≤ > ≥ = ≠`): only between same-dimension values; the result is `Boolean`.
+
+This is the `numeric_magnitude` reader of step 2 generalised: instead of "read the leading number," the
+engine reads `(magnitude, dimension)` and the **dimension travels through the derivation tree** so the
+faithfulness gate (step 3d) can reject `usd + days`.
+
+### 2.1 Conversions (explicit facts only)
+`convert money(1, usd) = money(0.92, eur)` (a fact with provenance) licenses `usd↔eur`; the engine
+applies the rate as a normal `Op` node so the conversion is itself in the derivation tree.
+`days_between`/`date_add` (datetime-core) are the `Date×Duration` operators. No implicit coercions.
+
+## 3. Symbols & constraints — the new surface
+
+```
+% the model extracts unknowns + the policy's constraints (NOT their solution)
+symbol premium : money(usd)
+symbol months  : scalar
+
+observe base_rate = money(1200, usd)
+observe claim     = money(5000, usd)
+
+% constraints the engine must satisfy
+constrain premium = base_rate + claim * percentage(10)        % a linear equation
+constrain premium <= money(2000, usd)                          % an inequality
+constrain months >= 6
+
+solve for { premium, months }                                  % → solved values + provenance
+% or:  minimize premium subject to { … }                       % → optimal value + assignment
+% or:  check { … }                                             % → SAT / UNSAT(core) feasibility
+```
+
+- `symbol <name> : <sort>` declares an unknown with a dimensional sort.
+- `constrain <expr> <relop> <expr>` asserts an (in)equality; `relop ∈ { = ≠ < ≤ > ≥ }`. Reuses the
+  step-3 `expr` grammar, extended so operands may be symbols.
+- `solve for { … }` / `minimize|maximize <expr> subject to { … }` / `check { … }` are the three
+  drivers (the three user-chosen outputs; "feed-a-verdict" is `check` wired into the differential).
+- Inequalities are now **first-class** both as constraints and (already) as predicate gates.
+
+## 4. Solver dispatch — classify, then route (mostly reuse)
+
+A `solve`/`check`/`minimize` block builds a **typed constraint system**, which a dispatcher classifies
+and routes. Each value/cert is provenance-tagged.
+
+| class detected | backend | reuse / build |
+|---|---|---|
+| linear **equations**, exact | `cas-solve::solve_linear_system` (Gaussian over ℚ) | **reuse** |
+| linear **integer** eq+ineq feasibility | `constraint-engine::LiaTactic` (Cooper) | **reuse** |
+| boolean / rule-trees | `constraint-engine::SatTactic` (DPLL) | **reuse** |
+| linear **real** eq+ineq feasibility (QF_LRA) | — (engine returns `Unknown` today) | **BUILD: LRA tactic** (Fourier–Motzkin / simplex feasibility) |
+| linear **optimization** | — | **BUILD: simplex** on the LRA layer |
+| nonlinear univariate (deg ≤ 4) | `cas-solve::{solve_quadratic,cubic,quartic}` | **reuse** |
+| nonlinear numeric / higher degree | `cas-solve::nsolve_poly` (Durand–Kerner), `cas-mnewton` | **reuse / extend** |
+| algebraic roots ℚ[√d] | `cas-algebraic` | **reference** |
+| mixed theories | `constraint-engine` Nelson-Oppen dispatch | **reuse** |
+
+The crux gaps are **QF_LRA + simplex** (adjudication is real-valued: money, ratios, percentages) and
+the **dimensional layer + surface sublanguage + provenance bridge**. Everything else is wiring.
+
+## 5. Provenance & output (the whole point)
+
+- **Solved value** → a derivation-tree-like `Solution { symbol, value, from_constraints: [ConstraintId] }`;
+  each `ConstraintId` cites the source bytes of the constraint (same Provenance/CV machinery as clauses).
+  Reuses the step-3a `DerivationNode` shape extended with a `FromSolve` node.
+- **Infeasibility** → an **UNSAT core / IIS** (irreducible infeasible subset): the *minimal* set of
+  conflicting constraints, each cited. This is the machine-checked "these two rules contradict" that
+  catches golden-rulebook bugs ([[project_mycin_prototype]]).
+- **Optimal value** → the objective value + the achieving assignment + the binding constraints (the
+  ones tight at the optimum), all cited.
+- **Feed-a-verdict** → `check{…}` result (SAT/UNSAT) becomes a saturating contribution in the
+  differential: feasible ⇒ verdict A, infeasible ⇒ verdict B. One engine; no new verdict logic.
+- A new `DerivationOrigin::FromSolve { … }` lets the proof DAG descend into the solver certificate, so
+  `adj-lang-cli` renders the solution/IIS under the verdict step — auditable without the model.
+
+## 6. Reuse map (grounded — verified by source read)
+
+| need | crate | path | verdict |
+|---|---|---|---|
+| exact rational arithmetic | `numeric-tower` (BigRational) | `code/packages/rust/numeric-tower/` | reuse-as-is |
+| linear systems (Gaussian/ℚ) + poly roots ≤4 + Durand–Kerner + inequality | `cas-solve` | `code/packages/rust/cas-solve/` | reuse-as-is |
+| SAT (DPLL) + LIA (Cooper) + Nelson-Oppen | `constraint-engine` (+ `constraint-core` predicate AST) | `code/packages/rust/constraint-engine/` | reuse; **build LRA + simplex tactics** |
+| Newton (nonlinear numeric) | `cas-mnewton` | `code/packages/rust/cas-mnewton/` | extend |
+| symbolic matrices (row-reduce/rank/nullspace/LU) | `cas-matrix` | `code/packages/rust/cas-matrix/` | reference/extend |
+| dates/durations (Howard-Hinnant, pure Rust) | `datetime-core` | `code/packages/rust/datetime-core/` | reuse-as-is |
+| expression IR + evaluator | `symbolic-ir` / `symbolic-vm` | `code/packages/rust/symbolic-{ir,vm}/` | reuse for nonlinear bridge |
+| derivation tree + differential + provenance | `logic-engine` (`compute`, `differential`, `proof_dag`, `provenance`) | `code/packages/rust/logic-engine/` | reuse/extend |
+| **dimensional types / units / currency** | — | — | **MUST BUILD** |
+| **LP / simplex (optimization)** | — | — | **MUST BUILD** |
+
+## 7. Roadmap (small specs-first PRs, each green + security-reviewed + babysat)
+
+**Track A — dimensional types & richer values (independent, lands first):**
+- **A1** Dimensional core in logic-engine: `Dimension` enum + `Dimensioned { magnitude, dim }`;
+  generalise `numeric_magnitude` → `dimensioned_value`; dimensional add/sub/mul/div rules + errors.
+- **A2** Currency + conversions: `money`, `convert … = …` facts, same/cross-currency algebra.
+- **A3** Dates/times/durations via `datetime-core`: `days_between`, `date_add`, `before/after`,
+  `date/time/datetime/duration` typed values; deadline predicates (`elapsed <= 365`).
+- **A4** Faithfulness gate over dimensions (step-3d, dimensional half): reject unit-mismatched ops.
+
+**Track B — symbols & constraint sublanguage (depends on A1):**
+- **B1** Surface: `symbol`, `constrain`, `check`/`solve for`/`minimize|maximize` grammar + AST + adapter;
+  a typed `ConstraintSystem` IR. No solver yet — just build + classify + dump.
+- **B2** Wire the **reuse** backends: linear equations → `cas-solve`; boolean → `SatTactic`; integer →
+  `LiaTactic`. `Solution` / UNSAT-core provenance + `FromSolve` proof origin + CLI render.
+
+**Track C — the build gaps (depends on B1):**
+- **C1** QF_LRA tactic (Fourier–Motzkin feasibility over ℚ) in `constraint-engine` — real-valued
+  feasibility/contradiction. (Also fills the documented `QF_LRA → Unknown` hole for the whole repo.)
+- **C2** Simplex on the LRA layer → `minimize|maximize` optimization + binding constraints.
+- **C3** Nonlinear bridge: `cas-solve`/`cas-mnewton` for `constrain` with quadratic+ terms.
+
+**Track D — payoff:**
+- **D1** Worked adjudication examples (eligibility, proration, deadline, break-even, allocation) as
+  `.adj` + golden tests, end-to-end through `adj-lang-cli` at **0 answer-time model calls**.
+- **D2** Fold into the Haiku run (DESIGN step 8): Haiku extracts values+constraints, engine solves.
+
+Ordering: A1→A2/A3 and B1→B2 can run in parallel after A1; C1 is the highest-value build (real-valued
+constraints) and unblocks C2; nonlinear (C3) and optimization (C2) are the long tail.
+
+## 8. Invariants & non-goals
+
+**Invariants** (carry from DESIGN §7):
+- The model emits **no solved values** — only extracted typed values + constraint structure.
+- Every solved value / infeasibility cert is **reconstructable from the solver certificate** without
+  the model, and cites the constraints (→ source bytes) that forced it.
+- **Strict dimensions**: no implicit unit/currency coercion; conversions are explicit, provenanced facts.
+- One engine: a solved/checked constraint feeds the differential; verdict families from the differential.
+- Exact arithmetic (ℚ) wherever the solver is exact; float only at the numeric-root boundary, screened
+  for non-finite (as `compute` already does).
+
+**Non-goals (this round):** quantified/first-order constraints; nonlinear *optimization* (only linear
+LP); floating-point interval arithmetic; a general SMT portfolio beyond Bool/LIA/LRA; physical-unit
+libraries beyond what adjudication needs (currency, time, and opaque `Unit(tag)` cancellation).


### PR DESCRIPTION
## What

Design of record for the **next major arc** of adj-lang: from a *computation* language (extract values → compute with a derivation tree, steps 1–3b, all merged) to a **constraint** language. The model extracts typed values **and the policy's constraints**; the engine **solves** them deterministically — solve-for-x, feasibility/contradiction, optimization — with **provenance from every solved value back to the constraints and their source bytes**. Strict dimensional typing throughout.

Directly addresses the requested capabilities: **math, currency, dates, times, inequalities, symbols, and constraints the language solves.**

## Scope (user-confirmed)

- **Solve:** linear eq+ineq · nonlinear/algebraic · boolean/SAT · optimization (LP)
- **Produce:** solved values · feasibility/contradiction certificate (UNSAT core) · feed-a-verdict · optimal value
- **Units:** strict dimensional (reject `usd + eur`, `dollars + days` unless an explicit conversion fact exists)

## Key finding — most of the solver machinery already exists

A source-verified reuse map (in the spec) shows the repo already has an SMT-lite stack and CAS:
- `constraint-engine` (DPLL **SAT** + **LIA** Cooper + Nelson-Oppen dispatch) + `constraint-core` predicate AST
- `cas-solve` (exact **linear systems** over ℚ, polynomial roots ≤4, Durand–Kerner), `cas-mnewton` (Newton), `cas-matrix`, `numeric-tower` (BigRational)
- `datetime-core` (Howard–Hinnant dates, pure Rust)
- `logic-engine` `compute`/`differential`/`proof_dag`/`provenance` (steps 1–3b)

**Real build gaps:** a dimensional type system, a **QF_LRA tactic** (linear *real* arithmetic — adjudication is real-valued; also fills the documented repo-wide `QF_LRA → Unknown` hole), **simplex** (optimization), and the surface constraint sublanguage + provenance bridge (`Solution` / UNSAT-core / `FromSolve` proof origin).

## Roadmap

Four tracks of small specs-first PRs: **A** dimensional types & richer values (currency/dates/times) · **B** symbols + the `constrain`/`solve`/`check`/`minimize` sublanguage wired to the reuse backends · **C** the build gaps (QF_LRA → simplex → nonlinear bridge) · **D** worked adjudication examples + the Haiku run at 0 answer-time model calls.

Docs-only; sibling to [DESIGN.md](code/specs/data/adj-language-expansion/DESIGN.md). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)