### PR TITLE
Add smart-home activation evidence tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -51,6 +51,7 @@ Chief of Staff job/session/agent
   -> activation-review list and summary reads for human-review queue planning
   -> activation-approval list and summary reads for bundled approval packets
   -> activation-decision list and summary reads for approve/block queue planning
+  -> activation-evidence list and summary reads for approval/block evidence rows
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -100,6 +101,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_approval_summary`
 - `smart_home.list_integration_activation_decisions`
 - `smart_home.get_integration_activation_decision_summary`
+- `smart_home.list_integration_activation_evidence`
+- `smart_home.get_integration_activation_evidence_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,32 +36,34 @@ use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_candidates_at_or_before_priority,
     activation_constraints_from_candidates, activation_decisions_from_candidates,
-    activation_dependency_graph_from_reports, activation_health_from_candidates,
-    activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDecisionItem,
-    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
+    activation_dependency_graph_from_reports, activation_evidence_from_candidates,
+    activation_health_from_candidates, activation_maintenance_from_candidates,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
+    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
     IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
@@ -213,6 +215,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DECISIONS_TOOL_ID: &str =
     "smart_home.list_integration_activation_decisions";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_decision_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_evidence";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_evidence_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -431,6 +437,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_decision_query(&arguments)?;
                     Ok(get_integration_activation_decision_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID => {
+                    let query = integration_activation_evidence_query(&arguments)?;
+                    Ok(list_integration_activation_evidence_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_evidence_query(&arguments)?;
+                    Ok(get_integration_activation_evidence_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1498,6 +1514,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation decision summary",
             "Return compact D23A activation decision counts for approval-ready and prerequisite-blocked human decisions.",
             integration_activation_decision_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID,
+            "List smart-home integration activation evidence",
+            "List compact D23A activation evidence rows that justify ready-to-approve and blocked human activation decisions.",
+            integration_activation_evidence_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_evidence", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_evidence",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation evidence summary",
+            "Return compact counts for activation evidence supporting approvals, policy review, and blocker decisions.",
+            integration_activation_evidence_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4106,6 +4156,19 @@ struct IntegrationActivationDecisionQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationEvidenceQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    evidence_kind: Option<IntegrationActivationEvidenceKind>,
+    evidence_status: Option<IntegrationActivationEvidenceStatus>,
+    decision_status: Option<IntegrationActivationDecisionStatus>,
+    required_tier: Option<PrivilegeTier>,
+    policy_surface: Option<IntegrationPolicySurface>,
+    blocked_only: Option<bool>,
+    requires_attention: Option<bool>,
+    evidence_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4273,6 +4336,39 @@ fn integration_activation_decision_query(
         blocked_only: optional_bool(arguments, "blocked_only")?,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         decision_limit: optional_u64(arguments, "decision_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_evidence_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationEvidenceQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let evidence_kind = optional_string(arguments, "evidence_kind")?
+        .map(|label| parse_activation_evidence_kind(&label))
+        .transpose()?;
+    let evidence_status = optional_string(arguments, "evidence_status")?
+        .map(|label| parse_activation_evidence_status(&label))
+        .transpose()?;
+    let decision_status = optional_string(arguments, "decision_status")?
+        .map(|label| parse_activation_decision_status(&label))
+        .transpose()?;
+    let required_tier = optional_string(arguments, "required_tier")?
+        .map(|tier| parse_privilege_tier(&tier))
+        .transpose()?;
+    let policy_surface = optional_string(arguments, "policy_surface")?
+        .map(|surface| parse_policy_surface(&surface))
+        .transpose()?;
+
+    Ok(IntegrationActivationEvidenceQuery {
+        candidates,
+        evidence_kind,
+        evidence_status,
+        decision_status,
+        required_tier,
+        policy_surface,
+        blocked_only: optional_bool(arguments, "blocked_only")?,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        evidence_limit: optional_u64(arguments, "evidence_limit")?.map(|value| value as usize),
     })
 }
 
@@ -4672,6 +4768,46 @@ fn integration_activation_decisions_for_query(
     }
 
     (decisions, catalog_count)
+}
+
+fn integration_activation_evidence_for_query(
+    query: &IntegrationActivationEvidenceQuery,
+) -> (Vec<IntegrationActivationEvidenceItem>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut evidence = activation_evidence_from_candidates(
+        &catalog,
+        candidates.iter(),
+        &query.candidates.readiness.enabled_integrations,
+    );
+
+    if let Some(kind) = query.evidence_kind {
+        evidence.retain(|item| item.kind == kind);
+    }
+    if let Some(status) = query.evidence_status {
+        evidence.retain(|item| item.status == status);
+    }
+    if let Some(decision_status) = query.decision_status {
+        evidence.retain(|item| item.decision_status == decision_status);
+    }
+    if let Some(required_tier) = query.required_tier {
+        evidence.retain(|item| item.required_tier == required_tier);
+    }
+    if let Some(policy_surface) = query.policy_surface {
+        evidence.retain(|item| item.policy_surface == Some(policy_surface));
+    }
+    if let Some(blocked_only) = query.blocked_only {
+        evidence.retain(|item| item.blocks_approval() == blocked_only);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        evidence.retain(|item| item.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.evidence_limit {
+        evidence.truncate(limit);
+    }
+
+    (evidence, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -5763,6 +5899,66 @@ fn get_integration_activation_decision_summary_output_handler_output(
                 "blocked_decisions",
                 integer(summary.blocked_decisions as i64),
             ),
+        ]),
+    )
+}
+
+fn list_integration_activation_evidence_output_handler_output(
+    query: IntegrationActivationEvidenceQuery,
+) -> ToolHandlerOutput {
+    let (evidence, catalog_count) = integration_activation_evidence_for_query(&query);
+    let summary = IntegrationActivationEvidenceSummary::from_evidence(evidence.iter());
+    let count = evidence.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_evidence",
+            JsonValue::Array(evidence.iter().map(activation_evidence_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_evidence_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_evidence")),
+            ("activation_evidence", integer(count as i64)),
+            (
+                "blocking_evidence",
+                integer(summary.blocking_evidence as i64),
+            ),
+            ("review_evidence", integer(summary.review_evidence as i64)),
+        ]),
+    )
+}
+
+fn get_integration_activation_evidence_summary_output_handler_output(
+    query: IntegrationActivationEvidenceQuery,
+) -> ToolHandlerOutput {
+    let (evidence, _) = integration_activation_evidence_for_query(&query);
+    let summary = IntegrationActivationEvidenceSummary::from_evidence(evidence.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_evidence_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_evidence_summary"),
+            ),
+            ("total_evidence", integer(summary.total_evidence as i64)),
+            (
+                "blocking_evidence",
+                integer(summary.blocking_evidence as i64),
+            ),
+            ("review_evidence", integer(summary.review_evidence as i64)),
         ]),
     )
 }
@@ -10148,6 +10344,193 @@ fn integration_activation_decision_summary_json(
     ])
 }
 
+fn activation_evidence_json(evidence: &IntegrationActivationEvidenceItem) -> JsonValue {
+    object([
+        ("evidence_kind", string(evidence.kind.as_str())),
+        ("evidence_status", string(evidence.status.as_str())),
+        ("decision_status", string(evidence.decision_status.as_str())),
+        (
+            "integration_id",
+            string(evidence.requested_integration_id.as_str()),
+        ),
+        (
+            "requested_integration_id",
+            string(evidence.requested_integration_id.as_str()),
+        ),
+        ("display_name", string(&evidence.display_name)),
+        ("priority", integer(evidence.priority as i64)),
+        ("detail_id", string(&evidence.detail_id)),
+        (
+            "primitive",
+            evidence
+                .primitive
+                .map(|primitive| string(primitive.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "capability_id",
+            evidence
+                .capability_id
+                .as_ref()
+                .map(|capability_id| string(capability_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependency_integration_id",
+            evidence
+                .dependency_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "policy_surface",
+            evidence
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(evidence.required_tier)),
+        ),
+        ("local_only", JsonValue::Bool(evidence.local_only)),
+        ("cloud_required", JsonValue::Bool(evidence.cloud_required)),
+        (
+            "blocks_approval",
+            JsonValue::Bool(evidence.blocks_approval()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(evidence.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_evidence_summary_json(
+    summary: &IntegrationActivationEvidenceSummary,
+) -> JsonValue {
+    object([
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        (
+            "approval_decision_evidence",
+            integer(summary.approval_decision_evidence as i64),
+        ),
+        (
+            "policy_review_evidence",
+            integer(summary.policy_review_evidence as i64),
+        ),
+        (
+            "primitive_blocker_evidence",
+            integer(summary.primitive_blocker_evidence as i64),
+        ),
+        (
+            "capability_blocker_evidence",
+            integer(summary.capability_blocker_evidence as i64),
+        ),
+        (
+            "dependency_blocker_evidence",
+            integer(summary.dependency_blocker_evidence as i64),
+        ),
+        (
+            "policy_risk_evidence",
+            integer(summary.policy_risk_evidence as i64),
+        ),
+        (
+            "dependency_edge_evidence",
+            integer(summary.dependency_edge_evidence as i64),
+        ),
+        (
+            "supporting_evidence",
+            integer(summary.supporting_evidence as i64),
+        ),
+        ("review_evidence", integer(summary.review_evidence as i64)),
+        (
+            "blocking_evidence",
+            integer(summary.blocking_evidence as i64),
+        ),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "ready_to_approve_integrations",
+            integer(summary.ready_to_approve_integrations as i64),
+        ),
+        (
+            "blocked_integrations",
+            integer(summary.blocked_integrations as i64),
+        ),
+        (
+            "local_only_integrations",
+            integer(summary.local_only_integrations as i64),
+        ),
+        (
+            "cloud_required_integrations",
+            integer(summary.cloud_required_integrations as i64),
+        ),
+        (
+            "unique_policy_surfaces",
+            integer(summary.unique_policy_surfaces as i64),
+        ),
+        (
+            "read_only_evidence",
+            integer(summary.read_only_evidence as i64),
+        ),
+        (
+            "low_risk_evidence",
+            integer(summary.low_risk_evidence as i64),
+        ),
+        (
+            "human_approval_evidence",
+            integer(summary.human_approval_evidence as i64),
+        ),
+        (
+            "high_risk_evidence",
+            integer(summary.high_risk_evidence as i64),
+        ),
+        (
+            "first_supporting_priority",
+            summary
+                .first_supporting_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocking_priority",
+            summary
+                .first_blocking_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_supporting_evidence",
+            JsonValue::Bool(summary.has_supporting_evidence()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -12631,6 +13014,52 @@ fn parse_activation_decision_status(
     }
 }
 
+fn parse_activation_evidence_kind(
+    label: &str,
+) -> Result<IntegrationActivationEvidenceKind, ToolCallError> {
+    match label {
+        "approval_decision" | "approval" | "decision" => {
+            Ok(IntegrationActivationEvidenceKind::ApprovalDecision)
+        }
+        "policy_review" | "policy" | "review" => {
+            Ok(IntegrationActivationEvidenceKind::PolicyReview)
+        }
+        "primitive_blocker" | "primitive" | "missing_primitive" => {
+            Ok(IntegrationActivationEvidenceKind::PrimitiveBlocker)
+        }
+        "capability_blocker" | "capability" | "missing_capability" => {
+            Ok(IntegrationActivationEvidenceKind::CapabilityBlocker)
+        }
+        "dependency_blocker" | "dependency" | "missing_dependency" => {
+            Ok(IntegrationActivationEvidenceKind::DependencyBlocker)
+        }
+        "policy_risk" | "risk" => Ok(IntegrationActivationEvidenceKind::PolicyRisk),
+        "dependency_edge" | "edge" => Ok(IntegrationActivationEvidenceKind::DependencyEdge),
+        _ => Err(validation_error(format!(
+            "unknown activation evidence kind `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_evidence_status(
+    label: &str,
+) -> Result<IntegrationActivationEvidenceStatus, ToolCallError> {
+    match label {
+        "supports_approval" | "supports" | "supporting" | "ready" => {
+            Ok(IntegrationActivationEvidenceStatus::SupportsApproval)
+        }
+        "requires_review" | "review" | "attention" => {
+            Ok(IntegrationActivationEvidenceStatus::RequiresReview)
+        }
+        "blocks_approval" | "blocked" | "blocks" | "blocker" => {
+            Ok(IntegrationActivationEvidenceStatus::BlocksApproval)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation evidence status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_constraint_kind(
     label: &str,
 ) -> Result<IntegrationActivationConstraintKind, ToolCallError> {
@@ -13565,6 +13994,34 @@ fn integration_activation_decision_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_evidence_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "evidence_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("evidence_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("evidence_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("decision_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("required_tier", JsonSchema::String));
+        properties.push(SchemaProperty::new("policy_surface", JsonSchema::String));
+        properties.push(SchemaProperty::new("blocked_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -13709,7 +14166,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 81);
+        assert_eq!(definitions.len(), 83);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -13920,9 +14377,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DECISION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            73
+            75
         );
         assert_eq!(
             export
@@ -14058,6 +14521,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -14312,11 +14783,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(81))
+            Some(&integer(83))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(73))
+            Some(&integer(75))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -15837,6 +16308,142 @@ mod tests {
         );
         assert_eq!(
             field(activation_decision_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let list_activation_evidence_request = request(
+            "call-list-integration-activation-evidence",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("evidence_limit", integer(4)),
+            ]),
+            5_015,
+        );
+        let list_activation_evidence_trace =
+            tool_runtime.invoke_with_events(&list_activation_evidence_request);
+        assert!(list_activation_evidence_trace.result.ok);
+        assert_eq!(
+            list_activation_evidence_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_evidence_output = list_activation_evidence_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_evidence_count =
+            integer_value(field(list_activation_evidence_output, "count").unwrap()).unwrap();
+        assert!((1..=4).contains(&activation_evidence_count));
+        let activation_evidence_summary =
+            field(list_activation_evidence_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_evidence_summary, "total_evidence").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_evidence_summary, "blocking_evidence").unwrap())
+                .unwrap()
+                + integer_value(field(activation_evidence_summary, "review_evidence").unwrap())
+                    .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_evidence_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_evidence = array_item(
+            field(list_activation_evidence_output, "activation_evidence").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(matches!(
+            field(activation_evidence, "evidence_kind"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(matches!(
+            field(activation_evidence, "evidence_status"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(matches!(
+            field(activation_evidence, "decision_status"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(matches!(
+            field(activation_evidence, "blocks_approval"),
+            Some(JsonValue::Bool(_))
+        ));
+        assert!(matches!(
+            field(activation_evidence, "requires_attention"),
+            Some(JsonValue::Bool(_))
+        ));
+
+        let activation_evidence_summary_request = request(
+            "call-integration-activation-evidence-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("evidence_status", string("blocked")),
+            ]),
+            5_016,
+        );
+        let activation_evidence_summary_trace =
+            tool_runtime.invoke_with_events(&activation_evidence_summary_request);
+        assert!(activation_evidence_summary_trace.result.ok);
+        assert_eq!(
+            activation_evidence_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_evidence_summary_output = activation_evidence_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_evidence_rollup =
+            field(activation_evidence_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_evidence_rollup, "blocking_evidence").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_evidence_rollup, "has_blockers"),
             Some(&JsonValue::Bool(true))
         );
 
@@ -17539,6 +18146,14 @@ mod tests {
             activation_decision_summary_request,
             activation_decision_summary_trace,
         );
+        journal.record_trace(
+            list_activation_evidence_request,
+            list_activation_evidence_trace,
+        );
+        journal.record_trace(
+            activation_evidence_summary_request,
+            activation_evidence_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -17612,9 +18227,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 81);
-        assert_eq!(journal_summary.completed_count, 81);
-        assert_eq!(journal.audit_records().len(), 81);
+        assert_eq!(journal_summary.invocation_count, 83);
+        assert_eq!(journal_summary.completed_count, 83);
+        assert_eq!(journal.audit_records().len(), 83);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -58,6 +58,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_decision_summary` tool descriptors
   for read-only approve/block queue planning derived from activation approval
   packets.
+- `smart_home.list_integration_activation_evidence` and
+  `smart_home.get_integration_activation_evidence_summary` tool descriptors
+  for read-only approval/block evidence row planning.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -75,6 +75,8 @@ Current scope:
   dependency blockers
 - D18D integration activation-decision descriptors for read-only approve/block
   queue planning derived from approval packets
+- D18D integration activation-evidence descriptors for read-only evidence rows
+  behind approval and blocker decisions
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1479,6 +1479,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationApprovalSummary,
     ListIntegrationActivationDecisions,
     GetIntegrationActivationDecisionSummary,
+    ListIntegrationActivationEvidence,
+    GetIntegrationActivationEvidenceSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1622,6 +1624,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationDecisionSummary => {
                 read_tool("smart_home.get_integration_activation_decision_summary")
+            }
+            Self::ListIntegrationActivationEvidence => {
+                read_tool("smart_home.list_integration_activation_evidence")
+            }
+            Self::GetIntegrationActivationEvidenceSummary => {
+                read_tool("smart_home.get_integration_activation_evidence_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2284,6 +2292,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationApprovalSummary,
         SmartHomeTool::ListIntegrationActivationDecisions,
         SmartHomeTool::GetIntegrationActivationDecisionSummary,
+        SmartHomeTool::ListIntegrationActivationEvidence,
+        SmartHomeTool::GetIntegrationActivationEvidenceSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3126,7 +3136,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 81);
+        assert_eq!(catalog.len(), 83);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3274,6 +3284,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_decision_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_evidence"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_evidence_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3464,15 +3482,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 81);
-        assert_eq!(summary.read_tools, 73);
+        assert_eq!(summary.total_tools, 83);
+        assert_eq!(summary.read_tools, 75);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 73);
+        assert_eq!(summary.read_only_tier_tools, 75);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 81);
+        assert_eq!(summary.total_required_capabilities, 83);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -58,6 +58,8 @@ runtime and Chief of Staff tools a typed catalog for:
   for approval preparation
 - activation decision rows that project approval packets into ready-to-approve
   and prerequisite-blocked queues for Chief planning
+- activation evidence rows that explain approval decisions with blocker,
+  policy-review, risk, and dependency evidence
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1044,6 +1044,52 @@ impl IntegrationActivationDecisionStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationEvidenceKind {
+    ApprovalDecision,
+    PolicyReview,
+    PrimitiveBlocker,
+    CapabilityBlocker,
+    DependencyBlocker,
+    PolicyRisk,
+    DependencyEdge,
+}
+
+impl IntegrationActivationEvidenceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApprovalDecision => "approval_decision",
+            Self::PolicyReview => "policy_review",
+            Self::PrimitiveBlocker => "primitive_blocker",
+            Self::CapabilityBlocker => "capability_blocker",
+            Self::DependencyBlocker => "dependency_blocker",
+            Self::PolicyRisk => "policy_risk",
+            Self::DependencyEdge => "dependency_edge",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationEvidenceStatus {
+    SupportsApproval,
+    RequiresReview,
+    BlocksApproval,
+}
+
+impl IntegrationActivationEvidenceStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SupportsApproval => "supports_approval",
+            Self::RequiresReview => "requires_review",
+            Self::BlocksApproval => "blocks_approval",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        !matches!(self, Self::SupportsApproval)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationActionKind {
     ActivateIntegration,
     ReviewPolicy,
@@ -1315,6 +1361,53 @@ pub struct IntegrationActivationDecisionSummary {
     pub high_risk_decisions: usize,
     pub first_approval_priority: Option<u8>,
     pub first_blocked_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationEvidenceItem {
+    pub kind: IntegrationActivationEvidenceKind,
+    pub status: IntegrationActivationEvidenceStatus,
+    pub decision_status: IntegrationActivationDecisionStatus,
+    pub requested_integration_id: IntegrationId,
+    pub display_name: String,
+    pub priority: u8,
+    pub detail_id: String,
+    pub primitive: Option<PrimitiveFamily>,
+    pub capability_id: Option<CapabilityId>,
+    pub dependency_integration_id: Option<IntegrationId>,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub required_tier: PrivilegeTier,
+    pub local_only: bool,
+    pub cloud_required: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationEvidenceSummary {
+    pub total_evidence: usize,
+    pub approval_decision_evidence: usize,
+    pub policy_review_evidence: usize,
+    pub primitive_blocker_evidence: usize,
+    pub capability_blocker_evidence: usize,
+    pub dependency_blocker_evidence: usize,
+    pub policy_risk_evidence: usize,
+    pub dependency_edge_evidence: usize,
+    pub supporting_evidence: usize,
+    pub review_evidence: usize,
+    pub blocking_evidence: usize,
+    pub unique_integrations: usize,
+    pub ready_to_approve_integrations: usize,
+    pub blocked_integrations: usize,
+    pub local_only_integrations: usize,
+    pub cloud_required_integrations: usize,
+    pub unique_policy_surfaces: usize,
+    pub read_only_evidence: usize,
+    pub low_risk_evidence: usize,
+    pub human_approval_evidence: usize,
+    pub high_risk_evidence: usize,
+    pub first_supporting_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocking_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
 }
 
@@ -3028,6 +3121,291 @@ impl IntegrationActivationDecisionSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.total_decisions > 0
+    }
+}
+
+impl IntegrationActivationEvidenceItem {
+    fn from_decision(
+        decision: &IntegrationActivationDecisionItem,
+    ) -> Vec<IntegrationActivationEvidenceItem> {
+        let packet = &decision.packet;
+        let mut evidence = Vec::new();
+        let approval_status =
+            if decision.decision_status == IntegrationActivationDecisionStatus::ReadyToApprove {
+                IntegrationActivationEvidenceStatus::SupportsApproval
+            } else {
+                IntegrationActivationEvidenceStatus::BlocksApproval
+            };
+
+        evidence.push(Self::for_decision(
+            decision,
+            IntegrationActivationEvidenceKind::ApprovalDecision,
+            approval_status,
+            decision.decision_status.as_str().to_string(),
+        ));
+
+        if packet.action_summary.review_policy_actions > 0 || packet.has_policy_surfaces() {
+            if packet.review.policy_surfaces.is_empty() {
+                evidence.push(Self::for_decision(
+                    decision,
+                    IntegrationActivationEvidenceKind::PolicyReview,
+                    IntegrationActivationEvidenceStatus::RequiresReview,
+                    "policy_review".to_string(),
+                ));
+            } else {
+                for surface in &packet.review.policy_surfaces {
+                    let mut row = Self::for_decision(
+                        decision,
+                        IntegrationActivationEvidenceKind::PolicyReview,
+                        IntegrationActivationEvidenceStatus::RequiresReview,
+                        surface.as_str().to_string(),
+                    );
+                    row.policy_surface = Some(*surface);
+                    row.required_tier = row.required_tier.max(surface.required_tier());
+                    evidence.push(row);
+                }
+            }
+        }
+
+        for primitive in &packet.review.missing_primitives {
+            let mut row = Self::for_decision(
+                decision,
+                IntegrationActivationEvidenceKind::PrimitiveBlocker,
+                IntegrationActivationEvidenceStatus::BlocksApproval,
+                primitive.as_str().to_string(),
+            );
+            row.primitive = Some(*primitive);
+            evidence.push(row);
+        }
+
+        for capability_id in &packet.review.missing_capabilities {
+            let mut row = Self::for_decision(
+                decision,
+                IntegrationActivationEvidenceKind::CapabilityBlocker,
+                IntegrationActivationEvidenceStatus::BlocksApproval,
+                capability_id.as_str().to_string(),
+            );
+            row.capability_id = Some(capability_id.clone());
+            evidence.push(row);
+        }
+
+        for dependency_id in &packet.review.missing_dependencies {
+            let mut row = Self::for_decision(
+                decision,
+                IntegrationActivationEvidenceKind::DependencyBlocker,
+                IntegrationActivationEvidenceStatus::BlocksApproval,
+                dependency_id.as_str().to_string(),
+            );
+            row.dependency_integration_id = Some(dependency_id.clone());
+            evidence.push(row);
+        }
+
+        for risk in &packet.risks {
+            let mut row = Self::for_decision(
+                decision,
+                IntegrationActivationEvidenceKind::PolicyRisk,
+                IntegrationActivationEvidenceStatus::RequiresReview,
+                risk.risk_id.clone(),
+            );
+            row.policy_surface = risk.policy_surface;
+            row.required_tier = row.required_tier.max(risk.required_tier);
+            evidence.push(row);
+        }
+
+        for edge in &packet.dependency_graph.edges {
+            let mut row = Self::for_decision(
+                decision,
+                IntegrationActivationEvidenceKind::DependencyEdge,
+                if edge.blocks_activation {
+                    IntegrationActivationEvidenceStatus::BlocksApproval
+                } else {
+                    IntegrationActivationEvidenceStatus::SupportsApproval
+                },
+                format!(
+                    "{}->{}",
+                    edge.dependency_integration_id.as_str(),
+                    edge.dependent_integration_id.as_str()
+                ),
+            );
+            row.dependency_integration_id = Some(edge.dependency_integration_id.clone());
+            evidence.push(row);
+        }
+
+        evidence
+    }
+
+    fn for_decision(
+        decision: &IntegrationActivationDecisionItem,
+        kind: IntegrationActivationEvidenceKind,
+        status: IntegrationActivationEvidenceStatus,
+        detail_id: String,
+    ) -> Self {
+        Self {
+            kind,
+            status,
+            decision_status: decision.decision_status,
+            requested_integration_id: decision.requested_integration_id().clone(),
+            display_name: decision.display_name().to_string(),
+            priority: decision.priority(),
+            detail_id,
+            primitive: None,
+            capability_id: None,
+            dependency_integration_id: None,
+            policy_surface: None,
+            required_tier: decision.required_tier(),
+            local_only: decision.packet.review.local_only,
+            cloud_required: decision.packet.review.cloud_required,
+        }
+    }
+
+    pub fn blocks_approval(&self) -> bool {
+        self.status == IntegrationActivationEvidenceStatus::BlocksApproval
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.status.requires_attention()
+    }
+}
+
+impl IntegrationActivationEvidenceSummary {
+    pub fn from_evidence<'a>(
+        evidence: impl IntoIterator<Item = &'a IntegrationActivationEvidenceItem>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut ready_integration_ids = BTreeSet::new();
+        let mut blocked_integration_ids = BTreeSet::new();
+        let mut local_only_ids = BTreeSet::new();
+        let mut cloud_required_ids = BTreeSet::new();
+        let mut policy_surfaces = BTreeSet::new();
+        let mut summary = Self {
+            total_evidence: 0,
+            approval_decision_evidence: 0,
+            policy_review_evidence: 0,
+            primitive_blocker_evidence: 0,
+            capability_blocker_evidence: 0,
+            dependency_blocker_evidence: 0,
+            policy_risk_evidence: 0,
+            dependency_edge_evidence: 0,
+            supporting_evidence: 0,
+            review_evidence: 0,
+            blocking_evidence: 0,
+            unique_integrations: 0,
+            ready_to_approve_integrations: 0,
+            blocked_integrations: 0,
+            local_only_integrations: 0,
+            cloud_required_integrations: 0,
+            unique_policy_surfaces: 0,
+            read_only_evidence: 0,
+            low_risk_evidence: 0,
+            human_approval_evidence: 0,
+            high_risk_evidence: 0,
+            first_supporting_priority: None,
+            first_review_priority: None,
+            first_blocking_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+        };
+
+        for item in evidence {
+            summary.total_evidence += 1;
+            integration_ids.insert(item.requested_integration_id.clone());
+            match item.decision_status {
+                IntegrationActivationDecisionStatus::ReadyToApprove => {
+                    ready_integration_ids.insert(item.requested_integration_id.clone());
+                }
+                IntegrationActivationDecisionStatus::BlockedOnPrerequisites => {
+                    blocked_integration_ids.insert(item.requested_integration_id.clone());
+                }
+            }
+            if item.local_only {
+                local_only_ids.insert(item.requested_integration_id.clone());
+            }
+            if item.cloud_required {
+                cloud_required_ids.insert(item.requested_integration_id.clone());
+            }
+            if let Some(surface) = item.policy_surface {
+                policy_surfaces.insert(surface);
+            }
+
+            match item.kind {
+                IntegrationActivationEvidenceKind::ApprovalDecision => {
+                    summary.approval_decision_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::PolicyReview => {
+                    summary.policy_review_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::PrimitiveBlocker => {
+                    summary.primitive_blocker_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::CapabilityBlocker => {
+                    summary.capability_blocker_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::DependencyBlocker => {
+                    summary.dependency_blocker_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::PolicyRisk => {
+                    summary.policy_risk_evidence += 1;
+                }
+                IntegrationActivationEvidenceKind::DependencyEdge => {
+                    summary.dependency_edge_evidence += 1;
+                }
+            }
+
+            match item.status {
+                IntegrationActivationEvidenceStatus::SupportsApproval => {
+                    summary.supporting_evidence += 1;
+                    summary.first_supporting_priority = min_optional_priority(
+                        summary.first_supporting_priority,
+                        Some(item.priority),
+                    );
+                }
+                IntegrationActivationEvidenceStatus::RequiresReview => {
+                    summary.review_evidence += 1;
+                    summary.first_review_priority =
+                        min_optional_priority(summary.first_review_priority, Some(item.priority));
+                }
+                IntegrationActivationEvidenceStatus::BlocksApproval => {
+                    summary.blocking_evidence += 1;
+                    summary.first_blocking_priority =
+                        min_optional_priority(summary.first_blocking_priority, Some(item.priority));
+                }
+            }
+
+            match item.required_tier {
+                PrivilegeTier::ReadOnly => summary.read_only_evidence += 1,
+                PrivilegeTier::LowRisk => summary.low_risk_evidence += 1,
+                PrivilegeTier::HumanApproval => summary.human_approval_evidence += 1,
+                PrivilegeTier::HighRisk => summary.high_risk_evidence += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(item.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.ready_to_approve_integrations = ready_integration_ids.len();
+        summary.blocked_integrations = blocked_integration_ids.len();
+        summary.local_only_integrations = local_only_ids.len();
+        summary.cloud_required_integrations = cloud_required_ids.len();
+        summary.unique_policy_surfaces = policy_surfaces.len();
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_evidence == 0
+    }
+
+    pub fn has_supporting_evidence(&self) -> bool {
+        self.supporting_evidence > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_evidence > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocking_evidence > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_review_work() || self.has_blockers()
     }
 }
 
@@ -5478,6 +5856,44 @@ pub fn activation_decisions_at_or_before_priority(
     activation_decisions_from_candidates(catalog, candidates.iter(), enabled_integrations)
 }
 
+pub fn activation_evidence_from_decisions<'a>(
+    decisions: impl IntoIterator<Item = &'a IntegrationActivationDecisionItem>,
+) -> Vec<IntegrationActivationEvidenceItem> {
+    let mut evidence = decisions
+        .into_iter()
+        .flat_map(IntegrationActivationEvidenceItem::from_decision)
+        .collect::<Vec<_>>();
+
+    evidence.sort_by(compare_activation_evidence);
+    evidence
+}
+
+pub fn activation_evidence_from_candidates<'a>(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: impl IntoIterator<Item = &'a IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationEvidenceItem> {
+    let decisions = activation_decisions_from_candidates(catalog, candidates, enabled_integrations);
+    activation_evidence_from_decisions(decisions.iter())
+}
+
+pub fn activation_evidence_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationEvidenceItem> {
+    let candidates = activation_candidates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_evidence_from_candidates(catalog, candidates.iter(), enabled_integrations)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -6715,6 +7131,23 @@ fn compare_activation_decisions(
             left.requested_integration_id()
                 .cmp(right.requested_integration_id())
         })
+}
+
+fn compare_activation_evidence(
+    left: &IntegrationActivationEvidenceItem,
+    right: &IntegrationActivationEvidenceItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.status.cmp(&right.status))
+        .then_with(|| left.kind.cmp(&right.kind))
+        .then_with(|| right.required_tier.cmp(&left.required_tier))
+        .then_with(|| left.display_name.cmp(&right.display_name))
+        .then_with(|| {
+            left.requested_integration_id
+                .cmp(&right.requested_integration_id)
+        })
+        .then_with(|| left.detail_id.cmp(&right.detail_id))
 }
 
 fn compare_activation_dependency_nodes(
@@ -8001,6 +8434,130 @@ mod tests {
         assert!(catalog_decisions
             .iter()
             .any(IntegrationActivationDecisionItem::has_policy_surfaces));
+    }
+
+    #[test]
+    fn activation_evidence_explains_decision_support_and_blockers() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+
+        let evidence = activation_evidence_from_candidates(&[], candidates.iter(), &[]);
+
+        assert!(evidence.iter().any(|item| {
+            item.kind == IntegrationActivationEvidenceKind::ApprovalDecision
+                && item.status == IntegrationActivationEvidenceStatus::SupportsApproval
+                && item.requested_integration_id.as_str() == "review_ready_bridge"
+        }));
+        assert!(evidence.iter().any(|item| {
+            item.kind == IntegrationActivationEvidenceKind::ApprovalDecision
+                && item.status == IntegrationActivationEvidenceStatus::BlocksApproval
+                && item.requested_integration_id.as_str() == "blocked_review_camera"
+        }));
+        assert!(evidence.iter().any(|item| {
+            item.kind == IntegrationActivationEvidenceKind::PrimitiveBlocker
+                && item.primitive == Some(PrimitiveFamily::CameraMedia)
+                && item.blocks_approval()
+        }));
+        assert!(evidence.iter().any(|item| {
+            item.kind == IntegrationActivationEvidenceKind::CapabilityBlocker
+                && item.capability_id.as_ref().is_some_and(|capability_id| {
+                    capability_id.as_str() == "smart_home.command.low_risk"
+                })
+                && item.blocks_approval()
+        }));
+        assert!(evidence.iter().any(|item| {
+            item.kind == IntegrationActivationEvidenceKind::DependencyBlocker
+                && item
+                    .dependency_integration_id
+                    .as_ref()
+                    .is_some_and(|integration_id| integration_id.as_str() == "mqtt")
+                && item.blocks_approval()
+        }));
+        assert!(evidence
+            .iter()
+            .any(|item| item.kind == IntegrationActivationEvidenceKind::PolicyRisk));
+
+        let summary = IntegrationActivationEvidenceSummary::from_evidence(evidence.iter());
+        assert_eq!(summary.approval_decision_evidence, 2);
+        assert_eq!(summary.ready_to_approve_integrations, 1);
+        assert_eq!(summary.blocked_integrations, 1);
+        assert!(summary.total_evidence > summary.approval_decision_evidence);
+        assert!(summary.supporting_evidence > 0);
+        assert!(summary.review_evidence > 0);
+        assert!(summary.blocking_evidence > 0);
+        assert!(summary.policy_risk_evidence > 0);
+        assert!(summary.primitive_blocker_evidence > 0);
+        assert!(summary.capability_blocker_evidence > 0);
+        assert!(summary.dependency_blocker_evidence > 0);
+        assert_eq!(summary.first_supporting_priority, Some(1));
+        assert_eq!(summary.first_blocking_priority, Some(2));
+        assert!(summary.has_supporting_evidence());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_evidence = activation_evidence_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_evidence
+            .iter()
+            .any(|item| item.policy_surface.is_some()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation evidence rows and summaries that explain ready/block approval decisions with policy, blocker, risk, and dependency evidence
- expose Chief read tools for listing activation evidence and getting compact evidence rollups
- register matching smart-home-core descriptors and update docs

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
- git diff --check