### PR TITLE
feat(clr-real): C1 — McCarthy on real CoreCLR (scalar) via textual .il + ilasm + dotnet

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.11.0] — 2026-06-11 — textual `.il` emitter for the real-CoreCLR path (CLR-real C1)
+
+New `il_text` module + `emit_il(module, config) -> String`: emits **textual CIL**
+(`.il`) — the real-runtime counterpart to the binary `lower_iir_to_cil` (which feeds
+the in-repo `clr-simulator`). The `.il` is assembled by real `ilasm` into a loadable
+PE that runs on real `dotnet`, exactly as the LLVM backend emits textual `.ll` for
+real `clang`. Metadata ownership (PE headers + the `#~`/`#Strings`/`#Blob` streams +
+token resolution) is delegated to `ilasm` (no hand-rolled ECMA-335).
+
+C1 covers scalar McCarthy: the entry function's `const`/`mov`/`ret` →
+`ldc.i4`/`ldloc`/`stloc`/`ret`, wrapped in a `MccarthyEntry()` method plus a printing
+`.entrypoint` launcher. Every other op returns `UnsupportedOp`, so later slices grow
+the op match (cons, predicates, COND, symbols, lambda). New unit tests
+`scalar_emits_well_formed_il`, `unsupported_op_is_rejected_not_emitted`.
+
 ## [0.10.0] — 2026-06-10 — McCarthy lambda: accept `call`/`ref<any>` (W8b, F7)
 
 The validator now accepts the `call` op with a `ref<any>` type — a lisp function

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -24,9 +24,17 @@ IIRModule
   → validate_iir_for_clr()      — pre-flight validation
   → lower_iir_to_cil()          — emit CIL body bytes per function
   → CILProgramArtifact          — structured multi-method artifact
-       ↓ (future) CLR packager  — wrap in PE/COFF .dll/.exe
-       ↓ CLR simulator          — run directly
+       ↓ CLR simulator          — run directly (fast, zero-dep)
+  → emit_il()                   — emit TEXTUAL CIL (.il)
+       ↓ real ilasm → PE → real dotnet   — run on REAL CoreCLR
 ```
+
+Two outputs from the same lowered program: binary method bodies for the in-repo
+`clr-simulator` (fast unit checks), and **textual `.il`** (`emit_il`) for the
+**real CoreCLR** path — assembled by real `ilasm`, run on real `dotnet`. This is
+the exact analog of how `iir-to-llvm` emits textual `.ll` for real `clang`; `ilasm`
+owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar today; cons/predicates/
+COND/symbols/lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist.)
 
 ## Quick start
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -1,0 +1,217 @@
+//! # Textual CIL (`.il`) emitter — the **real CoreCLR** path (CLR-real C1).
+//!
+//! The CLR backend's primary output ([`lower_iir_to_cil`](crate::lower_iir_to_cil))
+//! is a [`CILProgramArtifact`](crate::CILProgramArtifact) — raw CIL method bodies
+//! that the in-repo `clr-simulator` interprets. That gives zero-external-dep
+//! verification, but the simulator can't *independently* catch a backend bug the
+//! way a real runtime can.
+//!
+//! This module emits the **same program as textual CIL** (`.il`), which the real
+//! `ilasm` assembles into a loadable PE assembly that runs on real CoreCLR
+//! (`dotnet`). It is the exact CLR analog of [`iir-to-llvm`](../iir_to_llvm), which
+//! emits textual LLVM IR and runs it through real `clang`: hand the *symbolic*
+//! program to the real toolchain and let it own the metadata (PE headers, the
+//! `#~`/`#Strings`/`#Blob` streams, token resolution). No hand-rolled metadata.
+//!
+//! ## Scope (C1)
+//!
+//! Scalar McCarthy — the entry function as a straight line of integer `const` /
+//! `mov` / `ret`. Each register becomes an `int32` local; the entry computes an
+//! `int32`, and a generated launcher prints it so a runner reads the result by
+//! running. Every other op returns [`IIRClrError::UnsupportedOp`], so later slices
+//! (cons → `newarr object`, predicates, `COND`, symbols, lambda) extend the op
+//! match incrementally — `ilasm` already handles the metadata each will need.
+
+use crate::lower::{IIRClrConfig, IIRClrError};
+use interpreter_ir::{IIRFunction, IIRModule, Operand};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+/// Emit a complete, `ilasm`-assemblable `.il` source for `module`'s entry point.
+///
+/// The result defines one static class `<asm>Program` with two methods:
+/// `MccarthyEntry()` (the lowered McCarthy program, returning `int32`) and `Run()`
+/// (the `.entrypoint` launcher that prints the entry's result).
+pub fn emit_il(module: &IIRModule, config: &IIRClrConfig) -> Result<String, IIRClrError> {
+    let entry_name = module.entry_point.as_deref().unwrap_or("main");
+    let entry = module
+        .functions
+        .iter()
+        .find(|f| f.name == entry_name)
+        .ok_or_else(|| IIRClrError::InvalidOperand {
+            function: entry_name.to_string(),
+            detail: "module has no entry-point function".to_string(),
+        })?;
+
+    let asm = &config.assembly_name;
+    let mut il = String::new();
+    // External assembly references the runtime + Console live in. `ilasm` resolves
+    // these against the framework reference assemblies at assemble time.
+    let _ = writeln!(il, ".assembly extern System.Runtime {{ .ver 9:0:0:0 }}");
+    let _ = writeln!(il, ".assembly extern System.Console {{ .ver 9:0:0:0 }}");
+    let _ = writeln!(il, ".assembly {asm} {{ }}");
+    let _ = writeln!(il, ".module {asm}.dll");
+    let _ = writeln!(
+        il,
+        ".class public auto ansi abstract sealed beforefieldinit {asm}Program \
+         extends [System.Runtime]System.Object {{"
+    );
+
+    emit_entry_method(&mut il, entry, asm)?;
+
+    // Launcher: `Console.WriteLine(MccarthyEntry())` so the result is observable by
+    // running the assembly (matches how the BEAM/JVM e2e runners read a printout).
+    let _ = writeln!(il, "  .method public static void Run() cil managed {{");
+    let _ = writeln!(il, "    .entrypoint");
+    let _ = writeln!(il, "    .maxstack 1");
+    let _ = writeln!(il, "    call int32 {asm}Program::MccarthyEntry()");
+    let _ = writeln!(
+        il,
+        "    call void [System.Console]System.Console::WriteLine(int32)"
+    );
+    let _ = writeln!(il, "    ret");
+    let _ = writeln!(il, "  }}");
+    let _ = writeln!(il, "}}");
+    Ok(il)
+}
+
+/// Emit `int32 MccarthyEntry()` from the entry function's instructions.
+fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(), IIRClrError> {
+    // One `int32` local per distinct destination register, in first-seen order.
+    let mut slot_of: HashMap<&str, usize> = HashMap::new();
+    for instr in &f.instructions {
+        if let Some(dest) = &instr.dest {
+            let next = slot_of.len();
+            slot_of.entry(dest.as_str()).or_insert(next);
+        }
+    }
+    let slot = |name: &str| -> Result<usize, IIRClrError> {
+        slot_of
+            .get(name)
+            .copied()
+            .ok_or_else(|| IIRClrError::UndefinedVariable {
+                function: f.name.clone(),
+                name: name.to_string(),
+            })
+    };
+
+    let _ = writeln!(il, "  .method public static int32 MccarthyEntry() cil managed {{");
+    let _ = writeln!(il, "    .maxstack 8");
+    if !slot_of.is_empty() {
+        let locals: Vec<String> = (0..slot_of.len()).map(|i| format!("int32 V_{i}")).collect();
+        let _ = writeln!(il, "    .locals init ({})", locals.join(", "));
+    }
+
+    for instr in &f.instructions {
+        match instr.op.as_str() {
+            // const <dest> = Int(n)  →  ldc.i4 n; stloc V_<dest>
+            "const" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "const must have a dest".to_string(),
+                })?;
+                let n = match instr.srcs.first() {
+                    Some(Operand::Int(n)) => *n,
+                    other => {
+                        return Err(IIRClrError::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("const expects an integer literal, got {other:?}"),
+                        })
+                    }
+                };
+                // The CLR McCarthy model is `int32`; a scalar literal fits there.
+                let n32 = i32::try_from(n).map_err(|_| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: format!("integer literal {n} out of int32 range"),
+                })?;
+                let _ = writeln!(il, "    ldc.i4 {n32}");
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // mov <dest>, <src>  →  ldloc V_<src>; stloc V_<dest>
+            "mov" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "mov must have a dest".to_string(),
+                })?;
+                let src = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s.as_str(),
+                    other => {
+                        return Err(IIRClrError::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("mov source must be a variable, got {other:?}"),
+                        })
+                    }
+                };
+                let _ = writeln!(il, "    ldloc V_{}", slot(src)?);
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // ret <src>  →  ldloc V_<src>; ret   (the entry returns int32)
+            "ret" => {
+                let src = match instr.srcs.first() {
+                    Some(Operand::Var(s)) => s.as_str(),
+                    other => {
+                        return Err(IIRClrError::InvalidOperand {
+                            function: f.name.clone(),
+                            detail: format!("ret source must be a variable, got {other:?}"),
+                        })
+                    }
+                };
+                let _ = writeln!(il, "    ldloc V_{}", slot(src)?);
+                let _ = writeln!(il, "    ret");
+            }
+            // Later slices extend this match (cons, predicates, COND, symbols, lambda).
+            other => {
+                return Err(IIRClrError::UnsupportedOp {
+                    function: f.name.clone(),
+                    op: other.to_string(),
+                })
+            }
+        }
+    }
+
+    let _ = writeln!(il, "  }}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use interpreter_ir::{IIRFunction, IIRInstr, IIRModule};
+
+    fn scalar_module(n: i64) -> IIRModule {
+        let instrs = vec![
+            IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(n)], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "any"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "any", instrs));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    #[test]
+    fn scalar_emits_well_formed_il() {
+        let il = emit_il(&scalar_module(42), &IIRClrConfig::new("Main")).unwrap();
+        assert!(il.contains(".entrypoint"), "must declare a process entry point");
+        assert!(il.contains("int32 MccarthyEntry()"), "entry method returns int32");
+        assert!(il.contains("ldc.i4 42"), "loads the literal 42; got:\n{il}");
+        assert!(il.contains("System.Console]System.Console::WriteLine(int32)"));
+    }
+
+    #[test]
+    fn unsupported_op_is_rejected_not_emitted() {
+        // A cons (`call_builtin`) is C2 — C1 must reject it explicitly, not emit junk.
+        let mut m = scalar_module(1);
+        m.functions[0].instructions.insert(
+            0,
+            IIRInstr::new(
+                "call_builtin",
+                Some("p".into()),
+                vec![Operand::Var("lispy_cons".into())],
+                "ref<LispyPair>",
+            ),
+        );
+        let err = emit_il(&m, &IIRClrConfig::new("Main")).unwrap_err();
+        assert!(matches!(err, IIRClrError::UnsupportedOp { .. }));
+    }
+}

--- a/code/packages/rust/iir-to-cil-bytecode/src/lib.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/lib.rs
@@ -60,6 +60,7 @@
 //! ```
 
 pub mod codegen;
+pub mod il_text;
 pub mod lower;
 pub mod validate;
 
@@ -67,6 +68,7 @@ pub mod validate;
 pub use validate::validate_iir_for_clr;
 pub use lower::{IIRClrConfig, IIRClrError, lower_iir_to_cil};
 pub use codegen::IIRClrCodeGenerator;
+pub use il_text::emit_il;
 
 // Re-export the artifact types so callers don't need to depend on
 // `ir-to-cil-bytecode` directly.

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.48.0 — 2026-06-11 — McCarthy on **real CoreCLR** (scalar) — CLR real-runtime verification (CLR-real C1)
+
+New `compile_source_to_cil_text(language, source, name) -> String`: the CLR analog
+of `compile_source_to_llvm`. Where `compile_source_to_cil_artifact` yields raw method
+bodies for the in-repo `clr-simulator`, this emits textual `.il` (via
+`iir-to-cil-bytecode` 0.11.0) that real `ilasm` assembles into a loadable PE running
+on real `dotnet`. New e2e test `tests/clr_real_scalar.rs` (gated on `dotnet`+`ilasm`,
+skips when absent): `42`→42, `0`→0, `7`→7 on **real CoreCLR**. First slice of bringing
+the CLR backend up to the same real-runtime verification bar as JVM/BEAM/LLVM/native.
+
 ## 0.47.0 — 2026-06-11 — **McCarthy Lisp arc COMPLETE** — L6: byte-identical to Twig on every historical-arch backend
 
 The closing PR of the McCarthy Lisp arc.  One table-driven test

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -44,6 +44,14 @@ its own method, applied via `call <MethodDef>`, and run on `clr-simulator` 0.4.0
 inter-method call-frame model. The CLR is the third managed backend to reach full
 McCarthy support after WASM and JVM.
 
+`compile_source_to_cil_text` is the **real-CoreCLR** path (CLR-real C1): the same
+lowered program emitted as textual `.il`, assembled by real `ilasm` into a loadable
+PE, and run on real `dotnet` — the CLR analog of `compile_source_to_llvm` (`.ll` →
+real `clang`). Scalar runs today (`42`→42 on real CoreCLR; `tests/clr_real_scalar.rs`,
+gated on `dotnet`+`ilasm`); cons/predicates/COND/symbols/lambda land per the
+`CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR column of the W16
+conformance matrix is verified on real .NET rather than the in-repo simulator.
+
 `compile_source_to_beam` targets the **Erlang VM**: scalar McCarthy emits a
 `.beam` that **runs** on a real `erl` (OTP), `42` → 42 (W9a), and **cons** too —
 `(CAR (CONS 7 9))` → 7, `(CONS 7 9)` → `[7|9]` (W9b). BEAM uses the **native

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -705,6 +705,32 @@ pub fn compile_source_to_cil_artifact(
         .map_err(|e| LangAotError::ClrBackendError(format!("{e:?}")))
 }
 
+/// Compile `source` to **textual CIL** (`.il`) for the **real CoreCLR** path
+/// (CLR-real C1). Where [`compile_source_to_cil_artifact`] yields raw method bodies
+/// for the in-repo `clr-simulator`, this emits `.il` source that real `ilasm`
+/// assembles into a loadable PE assembly which runs on real `dotnet` — the CLR
+/// analog of [`compile_source_to_llvm`] (textual LLVM IR → real `clang`).
+///
+/// C1 covers scalar McCarthy; later slices grow the `iir-to-cil-bytecode::emit_il`
+/// op match (cons, predicates, `COND`, symbols, lambda).
+pub fn compile_source_to_cil_text(
+    language: Language,
+    source: &str,
+    name: &str,
+) -> Result<String, LangAotError> {
+    let mut module = compile_source_to_iir(language, source, name)?;
+    // The same managed value-model pipeline the binary CIL path uses, so the
+    // textual and binary emitters lower an identical program.
+    iir_builtin_lowering::lower_heap_builtins(&mut module);
+    iir_builtin_lowering::intern_symbols_structural(&mut module);
+    iir_builtin_lowering::lower_lisp_repr_structural(&mut module);
+    concretize_scalar_any_for_cil(&mut module);
+
+    let config = iir_to_cil_bytecode::IIRClrConfig::new(name);
+    iir_to_cil_bytecode::emit_il(&module, &config)
+        .map_err(|e| LangAotError::ClrBackendError(format!("{e:?}")))
+}
+
 /// Concretise a **scalar** module's `any`/`polymorphic` values to `i64` for the
 /// BEAM run-foundation (LANG77 / McCarthy W9a). Unlike the WASM/JVM/CLR
 /// simulators (32-bit), the BEAM has **native arbitrary-precision integers**, so

--- a/code/packages/rust/lang-aot/tests/clr_real_scalar.rs
+++ b/code/packages/rust/lang-aot/tests/clr_real_scalar.rs
@@ -1,0 +1,114 @@
+//! # McCarthy on **real CoreCLR** — scalar (CLR-real C1).
+//!
+//! `compile_source_to_cil_text` emits textual CIL (`.il`); this harness assembles
+//! it with the real `ilasm` into a loadable PE and runs it on real `dotnet`,
+//! asserting the printed result. The CLR analog of `llvm_*` (clang) — the CLR
+//! column is now verified on its **real runtime**, not only the in-repo simulator.
+//!
+//! Gated on `dotnet` + `ilasm` (skips gracefully when absent, like the other
+//! external-tool backends). `ilasm` ships as the NuGet runtime pack
+//! `runtime.<rid>.Microsoft.NETCore.ILAsm` (CI fetches it via `dotnet restore`);
+//! locally it is found on `PATH` or in the NuGet package cache.
+
+use lang_aot::{compile_source_to_cil_text, Language};
+use std::path::PathBuf;
+use std::process::Command;
+
+fn dotnet_ok() -> bool {
+    Command::new("dotnet").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Find `ilasm`: PATH first, then the NuGet package cache. The cache layout is
+/// `~/.nuget/packages/runtime.<rid>.microsoft.netcore.ilasm/<ver>/runtimes/<rid>/native/ilasm`,
+/// so we locate the (small) `*ilasm*` package directory and walk only that subtree.
+fn find_ilasm() -> Option<PathBuf> {
+    if Command::new("ilasm").arg("/?").output().is_ok() {
+        return Some(PathBuf::from("ilasm"));
+    }
+    let home = std::env::var_os("HOME")?;
+    let pkgs = PathBuf::from(home).join(".nuget/packages");
+    let pkg_dir = std::fs::read_dir(&pkgs)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .map(|n| n.to_string_lossy().to_ascii_lowercase().contains("ilasm"))
+                    .unwrap_or(false)
+        })?;
+    let mut stack = vec![pkg_dir];
+    let mut visited = 0usize;
+    while let Some(dir) = stack.pop() {
+        visited += 1;
+        if visited > 5_000 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for e in entries.flatten() {
+            let p = e.path();
+            if e.file_name() == "ilasm" && p.is_file() {
+                return Some(p);
+            }
+            if p.is_dir() {
+                stack.push(p);
+            }
+        }
+    }
+    None
+}
+
+/// Compile McCarthy `src` → `.il` → real PE (`ilasm`) → run on real `dotnet`,
+/// returning the printed integer. `None` if the toolchain is unavailable.
+fn run_on_real_clr(src: &str, tag: &str) -> Option<i64> {
+    if !dotnet_ok() {
+        return None;
+    }
+    let ilasm = find_ilasm()?;
+    let il = compile_source_to_cil_text(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("emit .il for {src:?}: {e}"));
+
+    let dir = std::env::temp_dir().join(format!("clr_real_c1_{}_{tag}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let il_path = dir.join("Main.il");
+    std::fs::write(&il_path, &il).expect("write .il");
+    let dll = dir.join("Main.dll");
+
+    let asm = Command::new(&ilasm)
+        .arg("-dll=false").arg("-exe")
+        .arg(format!("-output={}", dll.display()))
+        .arg(&il_path)
+        .output()
+        .expect("spawn ilasm");
+    assert!(
+        asm.status.success() && dll.exists(),
+        "ilasm failed for {src:?}: {}\n{}",
+        String::from_utf8_lossy(&asm.stdout),
+        String::from_utf8_lossy(&asm.stderr),
+    );
+    // Framework-dependent runtimeconfig so `dotnet Main.dll` resolves the shared FX.
+    std::fs::write(
+        dir.join("Main.runtimeconfig.json"),
+        r#"{ "runtimeOptions": { "tfm": "net9.0", "framework": { "name": "Microsoft.NETCore.App", "version": "9.0.0" } } }"#,
+    )
+    .expect("write runtimeconfig");
+
+    let out = Command::new("dotnet").arg(&dll).output().expect("spawn dotnet");
+    assert!(
+        out.status.success(),
+        "dotnet failed for {src:?}: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().parse::<i64>().ok()
+}
+
+#[test]
+fn mccarthy_scalar_runs_on_real_coreclr() {
+    let Some(v) = run_on_real_clr("42", "n42") else {
+        eprintln!("dotnet/ilasm absent — skipping real-CoreCLR scalar test");
+        return;
+    };
+    assert_eq!(v, 42, "McCarthy `42` on real CoreCLR");
+    assert_eq!(run_on_real_clr("0", "n0").unwrap(), 0);
+    assert_eq!(run_on_real_clr("7", "n7").unwrap(), 7);
+}

--- a/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
+++ b/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
@@ -1,0 +1,71 @@
+# CLR backend — real CoreCLR verification
+
+**Goal:** verify the CLR backend on a **real .NET runtime** (`dotnet`), not only the
+in-repo `clr-simulator`. CLR is the one McCarthy backend never run on its actual
+runtime — JVM uses real `java`, BEAM real `erl`, LLVM real `clang`, native a real
+linker; CLR uses only an in-house CIL interpreter. A simulator can't *independently*
+catch a backend bug (invalid CIL — stack imbalance, bad token, wrong `maxstack` —
+that real CoreCLR's verifier rejects could pass a lenient simulator). This chapter
+closes that gap.
+
+## Approach — textual CIL, exactly like the LLVM backend
+
+The CLR backend's binary path emits raw CIL method bodies (for the simulator). The
+real-runtime path mirrors the **proven LLVM strategy**: emit **textual** code and
+hand it to the **real toolchain**.
+
+```
+McCarthy source → IIR → managed value-model passes → emit_il (textual .il)
+                                                          │  real ilasm
+                                                          ▼
+                                                     real PE assembly
+                                                          │  real dotnet
+                                                          ▼
+                                                    printed result → assert
+```
+
+`iir-to-llvm` emits `.ll` text → real `clang`; `iir-to-cil-bytecode::emit_il` emits
+`.il` text → real `ilasm`. `ilasm` owns all the metadata (PE headers, the
+`#~`/`#Strings`/`#Blob` streams, token resolution) — no hand-rolled ECMA-335 tables.
+
+`ilasm` ships as the NuGet runtime pack `runtime.<rid>.Microsoft.NETCore.ILAsm`; CI
+fetches it via `dotnet restore`, locally it lives in the NuGet package cache. Both
+`ilasm` and `dotnet` are gated — the tests skip gracefully when absent, like the
+other external-tool backends.
+
+## Status legend
+
+`✅` done · `◑` in progress · `☐` not started.
+
+## Worklist (one PR per item; slice further if large)
+
+- ✅ **C1 — textual `.il` emitter + real-`dotnet` harness (scalar, F1).**
+  `iir-to-cil-bytecode::emit_il` (new `il_text` module) emits an assemblable `.il`
+  for the entry function (`const`/`mov`/`ret` → `ldc.i4`/`ldloc`/`stloc`/`ret`),
+  wrapped in a `MccarthyEntry()` method + a printing `.entrypoint` launcher. New
+  `lang_aot::compile_source_to_cil_text`. Verified by RUNNING on **real CoreCLR**
+  (`lang-aot/tests/clr_real_scalar.rs`): `42`→42, `0`→0, `7`→7 — `.il` → real
+  `ilasm` → real PE → real `dotnet`. Every other op returns `UnsupportedOp`, so the
+  op match grows per slice below.
+- ☐ **C2 — cons / car / cdr (F2).** `(CONS a b)` → `newarr object` + `stelem.ref`
+  ×2; `CAR`/`CDR` → `ldelem.ref` index 0/1; integer atoms `box`/`unbox.any
+  [System.Int32]`. Verify `(CAR (CONS 7 9))`→7, `(CDR …)`→9 on real `dotnet`.
+- ☐ **C3 — predicates + COND (F3–F5).** `pair?`→`isinst object[]`, `not`→`xor 1`,
+  `equal?`→`unbox;unbox;ceq`, `COND` truthiness → branch. Verify `(ATOM 7)`→1,
+  `(EQ 7 7)`→1, `(COND …)`→11.
+- ☐ **C4 — symbols (F6).** Interned symbol ids (the shared
+  `intern_symbols_structural`); `(EQ (QUOTE A) (QUOTE A))`→1, distinct→0.
+- ☐ **C5 — lambda / LABEL / recursion (F7).** Each hoisted lambda as its own
+  `.method`; application via `call <Method>`; recursion. Verify
+  `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 and a recursive `LABEL`.
+- ☐ **C6 — wire real-CoreCLR CLR into the conformance suite.** Add a `run_clr_real`
+  arm to `lang-aot/tests/conformance.rs` (gated on `dotnet`+`ilasm`) so the W16
+  table runs the CLR column on **real .NET**; ensure CI installs `ilasm`
+  (`dotnet restore` of the ILAsm pack) so the upgrade holds on every PR.
+
+## End state
+
+CLR joins JVM/BEAM/LLVM/native as a backend verified on its **real runtime**, and
+the cross-backend conformance matrix is genuinely stronger — the CLR column proven
+by real CoreCLR, not an in-house simulator. The `clr-simulator` remains for fast,
+zero-dependency unit checks; the real-runtime path is the verification of record.


### PR DESCRIPTION
## McCarthy now runs on real CoreCLR (scalar) — closing the CLR verification gap

The CLR backend was the **one** McCarthy backend never run on its real runtime — JVM uses real `java`, BEAM real `erl`, LLVM real `clang`, native a real linker; CLR used **only** the in-repo `clr-simulator`. A simulator can't *independently* catch a backend bug: invalid CIL (stack imbalance, bad token, wrong `maxstack`) that real CoreCLR's verifier rejects can sail past a lenient simulator. This is C1 of bringing CLR up to the same real-runtime bar as the others.

## Approach — mirror the proven LLVM strategy

Emit **textual** code, hand it to the **real toolchain**. `iir-to-llvm` emits `.ll` text → real `clang`; now `iir-to-cil-bytecode::emit_il` emits `.il` text → real `ilasm` → real PE → real `dotnet`. `ilasm` owns all the metadata (PE headers, the `#~`/`#Strings`/`#Blob` streams, token resolution) — **no hand-rolled ECMA-335**.

```
McCarthy source → IIR → managed value-model passes → emit_il (.il) → ilasm → PE → dotnet → result
```

## Change

- **`iir-to-cil-bytecode` 0.11.0** — new `il_text` module + `emit_il(module, config) → String`. C1 covers scalar: entry function `const`/`mov`/`ret` → `ldc.i4`/`ldloc`/`stloc`/`ret`, wrapped in a `MccarthyEntry()` method + a printing `.entrypoint` launcher. Every other op → `UnsupportedOp`, so later slices grow the op match.
- **`lang-aot` 0.48.0** — new `compile_source_to_cil_text` (the CLR analog of `compile_source_to_llvm`). e2e `tests/clr_real_scalar.rs` locates `ilasm` (PATH or the NuGet cache `runtime.<rid>.Microsoft.NETCore.ILAsm`) and runs on real `dotnet`; gated on `dotnet`+`ilasm` (skips when absent).

## Verified by RUNNING on real CoreCLR (`dotnet 9.0.313` + real `ilasm`)

| program | result |
|---|---|
| `42` | 42 |
| `0` | 0 |
| `7` | 7 |

`.il` → real `ilasm` → real PE → real `dotnet`, asserting the printed value.

## Chapter spec

`code/specs/CLR-REAL-RUNTIME-VERIFICATION.md` — the C1–C6 worklist: **C2** cons, **C3** predicates+COND, **C4** symbols, **C5** lambda/LABEL, **C6** wire real-CoreCLR into the W16 conformance suite + CI (`dotnet restore` the ILAsm pack).

## Security & safety

Security review **PASSED**: `emit_il` is a pure string builder (no `unsafe`/IO/recursion; i32 overflow + undefined-var + unsupported-op all return errors — no panic on adversarial IIR); identifiers are compiler-internal (assembly name + SSA temps), interpolated like the existing `iir-to-llvm`/JVM emitters, and **no shell** is used; the `find_ilasm` walk is capped at 5000 dirs; the PID-temp-dir+execute test pattern matches the established `llvm_*`/`beam_*`/`jvm_*`/`conformance` convention.

## Test plan

`iir-to-cil-bytecode` **35** (+2 `il_text`), `lang-aot` `clr_real_scalar` **1** (ran on real CoreCLR). clippy clean. No `twig-vm` dep → no Miri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)