### PR TITLE
feat(clr-real): C2 — cons/car/cdr on real CoreCLR

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.12.0] — 2026-06-11 — textual `.il`: cons / car / cdr (CLR-real C2)
+
+`emit_il` grows the cons value model: `alloc` → `ldc.i4.2; newarr
+[System.Runtime]System.Object` (a McCarthy cons cell is a 2-element reference
+array), `box`/`unbox.any [System.Runtime]System.Int32` for integer atoms,
+`field_store` → `stelem.ref`, `field_load` → `ldelem.ref`. Locals are now typed
+per producing instruction — a cons cell local is `object[]`, a boxed atom `object`,
+a raw int `int32` (`cil_local_type`) — so `ilasm` verifies the program. Verified by
+RUNNING on real CoreCLR (`lang-aot/tests/clr_real_cons.rs`): `(CAR (CONS 7 9))`→7,
+`(CDR …)`→9, nested→2. New unit test `cons_car_emits_object_array_box_and_unbox`.
+
 ## [0.11.0] — 2026-06-11 — textual `.il` emitter for the real-CoreCLR path (CLR-real C1)
 
 New `il_text` module + `emit_il(module, config) -> String`: emits **textual CIL**

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -33,7 +33,8 @@ Two outputs from the same lowered program: binary method bodies for the in-repo
 `clr-simulator` (fast unit checks), and **textual `.il`** (`emit_il`) for the
 **real CoreCLR** path — assembled by real `ilasm`, run on real `dotnet`. This is
 the exact analog of how `iir-to-llvm` emits textual `.ll` for real `clang`; `ilasm`
-owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar today; cons/predicates/
+owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar + cons/car/cdr today —
+cons is a 2-element `System.Object[]`, atoms `box`ed `System.Int32`; predicates/
 COND/symbols/lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist.)
 
 ## Quick start

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -23,9 +23,39 @@
 //! match incrementally — `ilasm` already handles the metadata each will need.
 
 use crate::lower::{IIRClrConfig, IIRClrError};
-use interpreter_ir::{IIRFunction, IIRModule, Operand};
+use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
 use std::collections::HashMap;
 use std::fmt::Write as _;
+
+/// The variable name at `instr.srcs[idx]`, or an `InvalidOperand` error.
+fn var_src<'a>(
+    f: &IIRFunction,
+    instr: &'a IIRInstr,
+    idx: usize,
+    op: &str,
+) -> Result<&'a str, IIRClrError> {
+    match instr.srcs.get(idx) {
+        Some(Operand::Var(s)) => Ok(s.as_str()),
+        other => Err(IIRClrError::InvalidOperand {
+            function: f.name.clone(),
+            detail: format!("{op} src[{idx}] must be a variable, got {other:?}"),
+        }),
+    }
+}
+
+/// The (int32-range-checked) integer literal at `instr.srcs[idx]`.
+fn int_src(f: &IIRFunction, instr: &IIRInstr, idx: usize, op: &str) -> Result<i32, IIRClrError> {
+    match instr.srcs.get(idx) {
+        Some(Operand::Int(n)) => i32::try_from(*n).map_err(|_| IIRClrError::InvalidOperand {
+            function: f.name.clone(),
+            detail: format!("{op} index {n} out of int32 range"),
+        }),
+        other => Err(IIRClrError::InvalidOperand {
+            function: f.name.clone(),
+            detail: format!("{op} src[{idx}] must be an integer literal, got {other:?}"),
+        }),
+    }
+}
 
 /// Emit a complete, `ilasm`-assemblable `.il` source for `module`'s entry point.
 ///
@@ -75,14 +105,32 @@ pub fn emit_il(module: &IIRModule, config: &IIRClrConfig) -> Result<String, IIRC
     Ok(il)
 }
 
+/// The CIL local type for an IIR register, from the producing instruction's
+/// `type_hint`. A cons cell (`ref<LispyPair>`) is a `System.Object[]`; a boxed
+/// atom or a loaded field (`ref<any>`) is a `System.Object`; everything else is a
+/// raw machine `int32` (the McCarthy CLR value model boxes ints into the cells).
+fn cil_local_type(type_hint: &str) -> &'static str {
+    if type_hint == "ref<LispyPair>" {
+        "object[]"
+    } else if type_hint.starts_with("ref<") {
+        "object"
+    } else {
+        "int32"
+    }
+}
+
 /// Emit `int32 MccarthyEntry()` from the entry function's instructions.
 fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(), IIRClrError> {
-    // One `int32` local per distinct destination register, in first-seen order.
+    // One local per distinct destination register, in first-seen order, typed from
+    // the instruction that produces it (int32 / object / object[]).
     let mut slot_of: HashMap<&str, usize> = HashMap::new();
+    let mut local_tys: Vec<&'static str> = Vec::new();
     for instr in &f.instructions {
         if let Some(dest) = &instr.dest {
-            let next = slot_of.len();
-            slot_of.entry(dest.as_str()).or_insert(next);
+            if !slot_of.contains_key(dest.as_str()) {
+                slot_of.insert(dest.as_str(), local_tys.len());
+                local_tys.push(cil_local_type(&instr.type_hint));
+            }
         }
     }
     let slot = |name: &str| -> Result<usize, IIRClrError> {
@@ -97,8 +145,12 @@ fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(),
 
     let _ = writeln!(il, "  .method public static int32 MccarthyEntry() cil managed {{");
     let _ = writeln!(il, "    .maxstack 8");
-    if !slot_of.is_empty() {
-        let locals: Vec<String> = (0..slot_of.len()).map(|i| format!("int32 V_{i}")).collect();
+    if !local_tys.is_empty() {
+        let locals: Vec<String> = local_tys
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| format!("{ty} V_{i}"))
+            .collect();
         let _ = writeln!(il, "    .locals init ({})", locals.join(", "));
     }
 
@@ -159,7 +211,68 @@ fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(),
                 let _ = writeln!(il, "    ldloc V_{}", slot(src)?);
                 let _ = writeln!(il, "    ret");
             }
-            // Later slices extend this match (cons, predicates, COND, symbols, lambda).
+            // alloc <dest> : ref<LispyPair>  →  a fresh 2-element System.Object[]
+            //   ldc.i4.2; newarr [System.Runtime]System.Object; stloc V_<dest>
+            // A McCarthy cons cell is a 2-slot reference array; the CLR GC owns it.
+            "alloc" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "alloc must have a dest".to_string(),
+                })?;
+                let _ = writeln!(il, "    ldc.i4.2");
+                let _ = writeln!(il, "    newarr [System.Runtime]System.Object");
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // box <dest> = <src> : ref<any>  →  box a raw int32 atom into an object
+            //   ldloc V_<src>; box [System.Runtime]System.Int32; stloc V_<dest>
+            "box" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "box must have a dest".to_string(),
+                })?;
+                let src = var_src(f, instr, 0, "box")?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(src)?);
+                let _ = writeln!(il, "    box [System.Runtime]System.Int32");
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // unbox <dest> = <src> : i32  →  unbox an object back to a raw int32
+            //   ldloc V_<src>; unbox.any [System.Runtime]System.Int32; stloc V_<dest>
+            "unbox" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "unbox must have a dest".to_string(),
+                })?;
+                let src = var_src(f, instr, 0, "unbox")?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(src)?);
+                let _ = writeln!(il, "    unbox.any [System.Runtime]System.Int32");
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // field_store <arr>[<idx>] = <val>  (srcs = arr, Int(idx), val)
+            //   ldloc V_<arr>; ldc.i4 <idx>; ldloc V_<val>; stelem.ref
+            "field_store" => {
+                let arr = var_src(f, instr, 0, "field_store")?;
+                let idx = int_src(f, instr, 1, "field_store")?;
+                let val = var_src(f, instr, 2, "field_store")?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(arr)?);
+                let _ = writeln!(il, "    ldc.i4 {idx}");
+                let _ = writeln!(il, "    ldloc V_{}", slot(val)?);
+                let _ = writeln!(il, "    stelem.ref");
+            }
+            // field_load <dest> = <arr>[<idx>] : ref<any>  (srcs = arr, Int(idx))
+            //   ldloc V_<arr>; ldc.i4 <idx>; ldelem.ref; stloc V_<dest>
+            "field_load" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "field_load must have a dest".to_string(),
+                })?;
+                let arr = var_src(f, instr, 0, "field_load")?;
+                let idx = int_src(f, instr, 1, "field_load")?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(arr)?);
+                let _ = writeln!(il, "    ldc.i4 {idx}");
+                let _ = writeln!(il, "    ldelem.ref");
+                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+            }
+            // Later slices extend this match (predicates, COND, symbols, lambda).
             other => {
                 return Err(IIRClrError::UnsupportedOp {
                     function: f.name.clone(),
@@ -199,8 +312,54 @@ mod tests {
     }
 
     #[test]
+    fn cons_car_emits_object_array_box_and_unbox() {
+        // The lowered shape of `(CAR (CONS 7 9))` (C2): a 2-element object[] cons
+        // cell, boxed int atoms, ldelem.ref for CAR, unbox.any for the int result.
+        let instrs = vec![
+            IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("const", Some("v1".into()), vec![Operand::Int(9)], "i32"),
+            IIRInstr::new("alloc", Some("v2".into()), vec![], "ref<LispyPair>"),
+            IIRInstr::new("box", Some("v0b".into()), vec![Operand::Var("v0".into())], "ref<any>"),
+            IIRInstr::new(
+                "field_store",
+                None,
+                vec![Operand::Var("v2".into()), Operand::Int(0), Operand::Var("v0b".into())],
+                "void",
+            ),
+            IIRInstr::new("box", Some("v1b".into()), vec![Operand::Var("v1".into())], "ref<any>"),
+            IIRInstr::new(
+                "field_store",
+                None,
+                vec![Operand::Var("v2".into()), Operand::Int(1), Operand::Var("v1b".into())],
+                "void",
+            ),
+            IIRInstr::new(
+                "field_load",
+                Some("v3".into()),
+                vec![Operand::Var("v2".into()), Operand::Int(0)],
+                "ref<any>",
+            ),
+            IIRInstr::new("unbox", Some("v3u".into()), vec![Operand::Var("v3".into())], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v3u".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert!(il.contains("newarr [System.Runtime]System.Object"), "cons → object[]:\n{il}");
+        assert!(il.contains("box [System.Runtime]System.Int32"), "atoms are boxed");
+        assert!(il.contains("stelem.ref"), "field_store → stelem.ref");
+        assert!(il.contains("ldelem.ref"), "CAR → ldelem.ref");
+        assert!(il.contains("unbox.any [System.Runtime]System.Int32"), "result unboxed");
+        // The cons cell local is typed object[], the boxed atoms object, ints int32.
+        assert!(il.contains("object[] V_2"), "cons cell local is object[]; got:\n{il}");
+        assert!(il.contains("object V_3"), "loaded field local is object");
+    }
+
+    #[test]
     fn unsupported_op_is_rejected_not_emitted() {
-        // A cons (`call_builtin`) is C2 — C1 must reject it explicitly, not emit junk.
+        // A predicate (`call_builtin`) is C3 — C2 must reject it explicitly, not emit junk.
         let mut m = scalar_module(1);
         m.functions[0].instructions.insert(
             0,

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.49.0 — 2026-06-11 — McCarthy **cons/car/cdr** on real CoreCLR (CLR-real C2)
+
+`compile_source_to_cil_text` now compiles cons programs (via `iir-to-cil-bytecode`
+0.12.0). The `ilasm`/`dotnet` e2e harness is extracted to `tests/clr_support/mod.rs`
+(shared by all CLR-real test files) with a robust `find_ilasm` that searches every
+`*ilasm*` NuGet package — the binary ships only in the `runtime.<rid>.*` pack, not
+the ref-only `microsoft.netcore.ilasm`, so picking the first match was fragile. New
+e2e `tests/clr_real_cons.rs`: `(CAR (CONS 7 9))`→7, `(CDR …)`→9, nested→2 on **real
+CoreCLR**; `clr_real_scalar.rs` refactored onto the shared harness.
+
 ## 0.48.0 — 2026-06-11 — McCarthy on **real CoreCLR** (scalar) — CLR real-runtime verification (CLR-real C1)
 
 New `compile_source_to_cil_text(language, source, name) -> String`: the CLR analog

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -47,10 +47,12 @@ McCarthy support after WASM and JVM.
 `compile_source_to_cil_text` is the **real-CoreCLR** path (CLR-real C1): the same
 lowered program emitted as textual `.il`, assembled by real `ilasm` into a loadable
 PE, and run on real `dotnet` — the CLR analog of `compile_source_to_llvm` (`.ll` →
-real `clang`). Scalar runs today (`42`→42 on real CoreCLR; `tests/clr_real_scalar.rs`,
-gated on `dotnet`+`ilasm`); cons/predicates/COND/symbols/lambda land per the
-`CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR column of the W16
-conformance matrix is verified on real .NET rather than the in-repo simulator.
+real `clang`). Scalar + **cons/car/cdr** run today (`42`→42, `(CAR (CONS 7 9))`→7 on
+real CoreCLR; `tests/clr_real_scalar.rs` + `clr_real_cons.rs`, gated on
+`dotnet`+`ilasm` via the shared `tests/clr_support` harness); predicates/COND/symbols/
+lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR
+column of the W16 conformance matrix is verified on real .NET rather than the in-repo
+simulator.
 
 `compile_source_to_beam` targets the **Erlang VM**: scalar McCarthy emits a
 `.beam` that **runs** on a real `erl` (OTP), `42` → 42 (W9a), and **cons** too —

--- a/code/packages/rust/lang-aot/tests/clr_real_cons.rs
+++ b/code/packages/rust/lang-aot/tests/clr_real_cons.rs
@@ -1,0 +1,24 @@
+//! # McCarthy on **real CoreCLR** — cons / car / cdr (CLR-real C2).
+//!
+//! A McCarthy cons cell lowers to a 2-element `System.Object[]` with integer atoms
+//! boxed (`box [System.Runtime]System.Int32`); `CAR`/`CDR` are `ldelem.ref` at
+//! index 0/1 + `unbox.any`. `emit_il` emits this textual CIL; real `ilasm` + real
+//! `dotnet` execute it. Gated on `dotnet`+`ilasm` (skips when absent).
+
+#[path = "clr_support/mod.rs"]
+mod clr_support;
+use clr_support::run_on_real_clr;
+
+#[test]
+fn mccarthy_cons_car_cdr_runs_on_real_coreclr() {
+    let Some(car) = run_on_real_clr("(CAR (CONS 7 9))", "car") else {
+        eprintln!("dotnet/ilasm absent — skipping real-CoreCLR cons test");
+        return;
+    };
+    assert_eq!(car, 7, "(CAR (CONS 7 9)) on real CoreCLR");
+    assert_eq!(run_on_real_clr("(CDR (CONS 7 9))", "cdr").unwrap(), 9);
+    // Nested: CAR of CDR of a cons-of-cons.
+    assert_eq!(run_on_real_clr("(CAR (CDR (CONS 1 (CONS 2 3))))", "nest").unwrap(), 2);
+    // Scalar still runs through the same emitter (no regression).
+    assert_eq!(run_on_real_clr("42", "sc").unwrap(), 42);
+}

--- a/code/packages/rust/lang-aot/tests/clr_real_scalar.rs
+++ b/code/packages/rust/lang-aot/tests/clr_real_scalar.rs
@@ -1,114 +1,22 @@
 //! # McCarthy on **real CoreCLR** — scalar (CLR-real C1).
 //!
-//! `compile_source_to_cil_text` emits textual CIL (`.il`); this harness assembles
-//! it with the real `ilasm` into a loadable PE and runs it on real `dotnet`,
-//! asserting the printed result. The CLR analog of `llvm_*` (clang) — the CLR
-//! column is now verified on its **real runtime**, not only the in-repo simulator.
-//!
-//! Gated on `dotnet` + `ilasm` (skips gracefully when absent, like the other
-//! external-tool backends). `ilasm` ships as the NuGet runtime pack
-//! `runtime.<rid>.Microsoft.NETCore.ILAsm` (CI fetches it via `dotnet restore`);
-//! locally it is found on `PATH` or in the NuGet package cache.
+//! `compile_source_to_cil_text` emits textual CIL (`.il`); the shared `clr_support`
+//! harness assembles it with real `ilasm` into a loadable PE and runs it on real
+//! `dotnet`, asserting the printed result — the CLR analog of `llvm_*` (clang). The
+//! CLR column is verified on its **real runtime**, not only the in-repo simulator.
+//! Gated on `dotnet`+`ilasm` (skips gracefully when absent).
 
-use lang_aot::{compile_source_to_cil_text, Language};
-use std::path::PathBuf;
-use std::process::Command;
-
-fn dotnet_ok() -> bool {
-    Command::new("dotnet").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
-}
-
-/// Find `ilasm`: PATH first, then the NuGet package cache. The cache layout is
-/// `~/.nuget/packages/runtime.<rid>.microsoft.netcore.ilasm/<ver>/runtimes/<rid>/native/ilasm`,
-/// so we locate the (small) `*ilasm*` package directory and walk only that subtree.
-fn find_ilasm() -> Option<PathBuf> {
-    if Command::new("ilasm").arg("/?").output().is_ok() {
-        return Some(PathBuf::from("ilasm"));
-    }
-    let home = std::env::var_os("HOME")?;
-    let pkgs = PathBuf::from(home).join(".nuget/packages");
-    let pkg_dir = std::fs::read_dir(&pkgs)
-        .ok()?
-        .flatten()
-        .map(|e| e.path())
-        .find(|p| {
-            p.is_dir()
-                && p.file_name()
-                    .map(|n| n.to_string_lossy().to_ascii_lowercase().contains("ilasm"))
-                    .unwrap_or(false)
-        })?;
-    let mut stack = vec![pkg_dir];
-    let mut visited = 0usize;
-    while let Some(dir) = stack.pop() {
-        visited += 1;
-        if visited > 5_000 {
-            break;
-        }
-        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
-        for e in entries.flatten() {
-            let p = e.path();
-            if e.file_name() == "ilasm" && p.is_file() {
-                return Some(p);
-            }
-            if p.is_dir() {
-                stack.push(p);
-            }
-        }
-    }
-    None
-}
-
-/// Compile McCarthy `src` → `.il` → real PE (`ilasm`) → run on real `dotnet`,
-/// returning the printed integer. `None` if the toolchain is unavailable.
-fn run_on_real_clr(src: &str, tag: &str) -> Option<i64> {
-    if !dotnet_ok() {
-        return None;
-    }
-    let ilasm = find_ilasm()?;
-    let il = compile_source_to_cil_text(Language::McCarthyLisp, src, "Main")
-        .unwrap_or_else(|e| panic!("emit .il for {src:?}: {e}"));
-
-    let dir = std::env::temp_dir().join(format!("clr_real_c1_{}_{tag}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("temp dir");
-    let il_path = dir.join("Main.il");
-    std::fs::write(&il_path, &il).expect("write .il");
-    let dll = dir.join("Main.dll");
-
-    let asm = Command::new(&ilasm)
-        .arg("-dll=false").arg("-exe")
-        .arg(format!("-output={}", dll.display()))
-        .arg(&il_path)
-        .output()
-        .expect("spawn ilasm");
-    assert!(
-        asm.status.success() && dll.exists(),
-        "ilasm failed for {src:?}: {}\n{}",
-        String::from_utf8_lossy(&asm.stdout),
-        String::from_utf8_lossy(&asm.stderr),
-    );
-    // Framework-dependent runtimeconfig so `dotnet Main.dll` resolves the shared FX.
-    std::fs::write(
-        dir.join("Main.runtimeconfig.json"),
-        r#"{ "runtimeOptions": { "tfm": "net9.0", "framework": { "name": "Microsoft.NETCore.App", "version": "9.0.0" } } }"#,
-    )
-    .expect("write runtimeconfig");
-
-    let out = Command::new("dotnet").arg(&dll).output().expect("spawn dotnet");
-    assert!(
-        out.status.success(),
-        "dotnet failed for {src:?}: {}",
-        String::from_utf8_lossy(&out.stderr),
-    );
-    String::from_utf8_lossy(&out.stdout).trim().parse::<i64>().ok()
-}
+#[path = "clr_support/mod.rs"]
+mod clr_support;
+use clr_support::run_on_real_clr;
 
 #[test]
 fn mccarthy_scalar_runs_on_real_coreclr() {
-    let Some(v) = run_on_real_clr("42", "n42") else {
+    let Some(v) = run_on_real_clr("42", "s42") else {
         eprintln!("dotnet/ilasm absent — skipping real-CoreCLR scalar test");
         return;
     };
     assert_eq!(v, 42, "McCarthy `42` on real CoreCLR");
-    assert_eq!(run_on_real_clr("0", "n0").unwrap(), 0);
-    assert_eq!(run_on_real_clr("7", "n7").unwrap(), 7);
+    assert_eq!(run_on_real_clr("0", "s0").unwrap(), 0);
+    assert_eq!(run_on_real_clr("7", "s7").unwrap(), 7);
 }

--- a/code/packages/rust/lang-aot/tests/clr_support/mod.rs
+++ b/code/packages/rust/lang-aot/tests/clr_support/mod.rs
@@ -1,0 +1,111 @@
+//! Shared harness for the **real CoreCLR** McCarthy tests (CLR-real chapter).
+//!
+//! `compile_source_to_cil_text` → write `.il` → assemble with real `ilasm` →
+//! run on real `dotnet` → parse the printed integer. Gated on `dotnet` + `ilasm`
+//! (returns `None`, i.e. *skip*, when either is absent — like the other
+//! external-tool backends). Each CLR-real test file (`clr_real_scalar`,
+//! `clr_real_cons`, …) `#[path]`-includes this module and asserts on the result.
+//!
+//! NOTE: this lives under `tests/clr_support/` (a subdirectory), so Cargo does not
+//! compile it as its own test binary.
+
+#![allow(dead_code)] // each test binary uses a subset of these helpers
+
+use lang_aot::{compile_source_to_cil_text, Language};
+use std::path::PathBuf;
+use std::process::Command;
+
+fn dotnet_ok() -> bool {
+    Command::new("dotnet").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Locate the `ilasm` binary: `PATH` first, then the NuGet package cache. The
+/// assembler ships in the *runtime* pack `runtime.<rid>.microsoft.netcore.ilasm`
+/// (the bare `microsoft.netcore.ilasm` is a ref-only package with **no** binary),
+/// so we search **every** `*ilasm*` package directory — robust to `read_dir`
+/// ordering — rather than the first match.
+pub fn find_ilasm() -> Option<PathBuf> {
+    if Command::new("ilasm").arg("/?").output().is_ok() {
+        return Some(PathBuf::from("ilasm"));
+    }
+    let home = std::env::var_os("HOME")?;
+    let pkgs = PathBuf::from(home).join(".nuget/packages");
+
+    // Every package dir whose name mentions ilasm (handles the ref pack + the
+    // runtime pack; only the latter actually contains the binary).
+    let ilasm_pkgs: Vec<PathBuf> = std::fs::read_dir(&pkgs)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .map(|n| n.to_string_lossy().to_ascii_lowercase().contains("ilasm"))
+                    .unwrap_or(false)
+        })
+        .collect();
+
+    // Bounded DFS over those (small) package subtrees for an `ilasm` file.
+    let mut stack = ilasm_pkgs;
+    let mut visited = 0usize;
+    while let Some(dir) = stack.pop() {
+        visited += 1;
+        if visited > 10_000 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for e in entries.flatten() {
+            let p = e.path();
+            if e.file_name() == "ilasm" && p.is_file() {
+                return Some(p);
+            }
+            if p.is_dir() {
+                stack.push(p);
+            }
+        }
+    }
+    None
+}
+
+/// Compile McCarthy `src` → `.il` → real PE (`ilasm`) → run on real `dotnet`,
+/// returning the printed integer. `None` if the toolchain is unavailable (skip).
+pub fn run_on_real_clr(src: &str, tag: &str) -> Option<i64> {
+    if !dotnet_ok() {
+        return None;
+    }
+    let ilasm = find_ilasm()?;
+    let il = compile_source_to_cil_text(Language::McCarthyLisp, src, "Main")
+        .unwrap_or_else(|e| panic!("emit .il for {src:?}: {e}"));
+
+    let dir = std::env::temp_dir().join(format!("clr_real_{}_{tag}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let il_path = dir.join("Main.il");
+    std::fs::write(&il_path, &il).expect("write .il");
+    let dll = dir.join("Main.dll");
+
+    let asm = Command::new(&ilasm)
+        .arg("-dll=false").arg("-exe")
+        .arg(format!("-output={}", dll.display()))
+        .arg(&il_path)
+        .output()
+        .expect("spawn ilasm");
+    assert!(
+        asm.status.success() && dll.exists(),
+        "ilasm failed for {src:?}: {}\n{}\n--- emitted .il ---\n{il}",
+        String::from_utf8_lossy(&asm.stdout),
+        String::from_utf8_lossy(&asm.stderr),
+    );
+    std::fs::write(
+        dir.join("Main.runtimeconfig.json"),
+        r#"{ "runtimeOptions": { "tfm": "net9.0", "framework": { "name": "Microsoft.NETCore.App", "version": "9.0.0" } } }"#,
+    )
+    .expect("write runtimeconfig");
+
+    let out = Command::new("dotnet").arg(&dll).output().expect("spawn dotnet");
+    assert!(
+        out.status.success(),
+        "dotnet failed for {src:?}: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().parse::<i64>().ok()
+}

--- a/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
+++ b/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
@@ -47,9 +47,16 @@ other external-tool backends.
   (`lang-aot/tests/clr_real_scalar.rs`): `42`→42, `0`→0, `7`→7 — `.il` → real
   `ilasm` → real PE → real `dotnet`. Every other op returns `UnsupportedOp`, so the
   op match grows per slice below.
-- ☐ **C2 — cons / car / cdr (F2).** `(CONS a b)` → `newarr object` + `stelem.ref`
-  ×2; `CAR`/`CDR` → `ldelem.ref` index 0/1; integer atoms `box`/`unbox.any
-  [System.Int32]`. Verify `(CAR (CONS 7 9))`→7, `(CDR …)`→9 on real `dotnet`.
+- ✅ **C2 — cons / car / cdr (F2).** `emit_il` gained `alloc` → `newarr
+  [System.Runtime]System.Object` (a 2-element cons cell), `box`/`unbox.any
+  [System.Runtime]System.Int32`, `field_store` → `stelem.ref`, `field_load` →
+  `ldelem.ref`, and **mixed-type locals** (a cons cell is `object[]`, a boxed atom
+  `object`, a raw int `int32`). The shared `ilasm`/`dotnet` harness was extracted to
+  `tests/clr_support/mod.rs` (with a robust `find_ilasm` that searches *every*
+  `*ilasm*` NuGet package — the binary lives only in the `runtime.<rid>.*` pack, not
+  the ref-only `microsoft.netcore.ilasm`). Verified by RUNNING on **real CoreCLR**
+  (`tests/clr_real_cons.rs`): `(CAR (CONS 7 9))`→7, `(CDR …)`→9,
+  `(CAR (CDR (CONS 1 (CONS 2 3))))`→2.
 - ☐ **C3 — predicates + COND (F3–F5).** `pair?`→`isinst object[]`, `not`→`xor 1`,
   `equal?`→`unbox;unbox;ceq`, `COND` truthiness → branch. Verify `(ATOM 7)`→1,
   `(EQ 7 7)`→1, `(COND …)`→11.


### PR DESCRIPTION
## McCarthy cons programs now run on **real CoreCLR**

C2 extends the textual `.il` emitter so cons/car/cdr run on real `dotnet` (not just the in-repo `clr-simulator`). `emit_il` grows the cons value model, mirroring the binary CIL emitter:

| IIR op | textual CIL |
|---|---|
| `alloc` (cons cell) | `ldc.i4.2; newarr [System.Runtime]System.Object` |
| `box` (atom) | `box [System.Runtime]System.Int32` |
| `unbox` | `unbox.any [System.Runtime]System.Int32` |
| `field_store` | `ldloc arr; ldc.i4 idx; ldloc val; stelem.ref` |
| `field_load` | `ldloc arr; ldc.i4 idx; ldelem.ref; stloc dest` |

Locals are now **typed per producing instruction** (`cil_local_type`): a cons cell is `object[]`, a boxed atom `object`, a raw int `int32` — so `ilasm` verifies the program.

## Shared harness + a real robustness fix

The `ilasm`/`dotnet` e2e harness is extracted to **`tests/clr_support/mod.rs`** (each CLR-real test `#[path]`-includes it). Its `find_ilasm` now searches **every** `*ilasm*` NuGet package, not the first match — the binary ships only in `runtime.<rid>.microsoft.netcore.ilasm` (the bare `microsoft.netcore.ilasm` is a **ref-only** pack with no binary), so first-match was fragile across `read_dir` ordering. `clr_real_scalar.rs` refactored onto the shared harness.

## Verified by RUNNING on real CoreCLR (`dotnet 9.0.313` + real `ilasm`)

| program | result |
|---|---|
| `(CAR (CONS 7 9))` / `(CDR (CONS 7 9))` | 7 / 9 |
| `(CAR (CDR (CONS 1 (CONS 2 3))))` | 2 |
| `42` | 42 (no regression) |

## Security & safety

Security review **PASSED**: the new arms emit fixed mnemonics + `i32`-checked indices + slot numbers (no source-derived strings beyond C1's; no shell); `var_src`/`int_src`/`slot` return errors (`UndefinedVariable`/`InvalidOperand`) on malformed IIR — no panic/unwrap/index; `cil_local_type` is total; invalid CIL is caught by CoreCLR's **load-time verifier** (test failure, not a vuln); `find_ilasm` DFS capped at 10k dirs; the PID-temp-dir+execute pattern matches the established `llvm_*`/`beam_*`/`conformance` convention.

## Test plan

`iir-to-cil-bytecode` `il_text` **3** (+1 `cons_car_emits_object_array_box_and_unbox`), `lang-aot` `clr_real_scalar` 1 + `clr_real_cons` 1 (ran on real CoreCLR). clippy clean. No `twig-vm` dep → no Miri.

## Spec

**C2 → ✅** in `code/specs/CLR-REAL-RUNTIME-VERIFICATION.md`. Next: **C3** predicates + COND.

🤖 Generated with [Claude Code](https://claude.com/claude-code)