### PR TITLE
fix(closurec): CLOC12.75 — close gap-066 (redundant parens after `extends`)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.79.0] - 2026-06-11
+
+### Changed
+- **CLOSES gap-066** (minimal safe slice) — redundant parens
+  after `extends`: `class A extends(B){}` → `class A extends B{}`
+  (also `extends(a.b)` → `extends a.b`, class expressions).
+
+### Added — gap-066 token pre-pass
+
+Strips the grouping parens after the `extends` KEYWORD when the
+superclass is a simple reference (identifier + `.IDENT` chain).
+Guards: anchored on the `extends` keyword, not a string literal
+whose content is `extends`, and not a PROPERTY named `extends`
+(`o.extends(x)` is a method call — prev-prev must not be
+`.`/`?.`); all bracket checks via `is_structural_punct`.
+
+DELIBERATELY CONSERVATIVE vs upstream: `extends(B||C)` keeps its
+parens because `B||C` is not a LeftHandSideExpression, so
+`extends B||C` would be INVALID JS (upstream strips it anyway,
+producing arguably-invalid output). Call-chain inners
+(`extends(f())`) are deferred. 5 new gap066_* unit tests.
+
 ## [0.78.0] - 2026-06-11
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.78.0"
+version = "0.79.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.78.0",
+  "version": "0.79.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -624,6 +624,73 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-066: redundant parens after `extends` ------------
+    // `class A extends(B){}` → `class A extends B{}`. After the
+    // `extends` keyword a parenthesized simple reference is
+    // redundant — the class body `{` delimits the heritage
+    // clause, so `extends B{` is unambiguous.
+    //
+    // Minimal safe slice: the inner must be a *simple reference*
+    // — a plain identifier plus zero-or-more `.IDENT` accessors
+    // (mirroring gap-065). The scan stops at the first non-
+    // `.IDENT` token, so:
+    //   - `extends(B||C)` keeps its parens — `B||C` is NOT a
+    //     LeftHandSideExpression, so `extends B||C` would be
+    //     INVALID JS (upstream strips it anyway, producing
+    //     arguably-invalid output; we stay safe and conservative).
+    //   - `extends(f())` (call-chain inner) is left for a
+    //     follow-up — not yet fixtured.
+    //
+    // Guards:
+    //   - the `(` must directly follow the `extends` KEYWORD, not
+    //     a string literal whose content is `extends` and not a
+    //     PROPERTY named `extends` (`obj.extends(x)` is a method
+    //     call — prev-prev must not be `.`/`?.`),
+    //   - all bracket/accessor checks via `is_structural_punct`.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 1;
+        while i + 1 < kept.len() {
+            let after_extends = kept[i - 1].value == "extends"
+                && !is_string_literal(kept[i - 1])
+                && match i.checked_sub(2).and_then(|k| kept.get(k)) {
+                    None => true,
+                    Some(pp) => {
+                        !is_structural_punct(pp, ".")
+                            && !is_structural_punct(pp, "?.")
+                    }
+                };
+            if after_extends
+                && is_structural_punct(&kept[i], "(")
+                && is_plain_identifier(&kept[i + 1])
+            {
+                // Consume the `.IDENT` member chain.
+                let mut p = i + 1;
+                while p + 2 < kept.len()
+                    && is_structural_punct(&kept[p + 1], ".")
+                    && is_plain_identifier(&kept[p + 2])
+                {
+                    p += 2;
+                }
+                let close_ok = kept
+                    .get(p + 1)
+                    .map(|t| is_structural_punct(t, ")"))
+                    .unwrap_or(false);
+                if close_ok {
+                    drops.push(i); // open `(`
+                    drops.push(p + 1); // close `)`
+                    i = p + 2;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // ---- gap-059: member/call on a `new` expression ----------
     // `new A().b` → `(new A).b`. When a NewExpression is the
     // OBJECT of a member access (`.`/`[`) or the CALLEE of a
@@ -3576,6 +3643,44 @@ mod tests {
     #[test]
     fn gap065_call_paren_not_stripped() {
         assert_eq!(minify("f(g)(x);"), "f(g)(x);");
+    }
+
+    // ---- gap-066: redundant parens after `extends` -------
+
+    /// gap-066: `class A extends(B){}` → `class A extends B{}`.
+    #[test]
+    fn gap066_extends_paren_stripped() {
+        assert_eq!(minify("class A extends(B){}"), "class A extends B{};");
+    }
+
+    /// gap-066: member-chain superclass — `extends(a.b)` →
+    /// `extends a.b`.
+    #[test]
+    fn gap066_extends_member_chain() {
+        assert_eq!(minify("class A extends(a.b){}"), "class A extends a.b{};");
+    }
+
+    /// gap-066: class EXPRESSION heritage also stripped.
+    #[test]
+    fn gap066_class_expression_extends() {
+        assert_eq!(minify("var x=class extends(B){};"), "var x=class extends B{};");
+    }
+
+    /// gap-066 SAFETY: an operator superclass keeps its parens —
+    /// `extends(B||C)` must NOT become `extends B||C` (which is
+    /// INVALID JS — `B||C` is not a LeftHandSideExpression).
+    /// closurec stays safe here even though upstream strips it.
+    #[test]
+    fn gap066_operator_heritage_keeps_parens() {
+        assert_eq!(minify("class A extends(B||C){}"), "class A extends(B||C){};");
+    }
+
+    /// gap-066 SAFETY: a PROPERTY named `extends` is a method
+    /// call, not a class heritage — `o.extends(x)` must NOT have
+    /// its call parens stripped.
+    #[test]
+    fn gap066_extends_property_not_stripped() {
+        assert_eq!(minify("o.extends(x);"), "o.extends(x);");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.78.0
+Version: 0.79.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -94,9 +94,9 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // tagged-template callee (`(f)(x)`→`f(x)`, `(a.b)(x)`→
     // `a.b(x)`) are now stripped; those three fixtures are
     // enforced again.
-    // gap-066 (CLOC14.33): redundant parens after `extends` —
-    // `class A extends(B){}` → `class A extends B{}`.
-    ("class_extends_paren", "gap-066: redundant parens after `extends`"),
+    // gap-066 RESOLVED in CLOC12.75 — redundant parens after
+    // `extends` (`class A extends(B){}` → `class A extends B{}`)
+    // are now stripped; `minify_class_extends_paren` enforced.
     // gap-064 RESOLVED in CLOC12.73 — `new A(")")` no longer
     // misreads the string `)` arg as the empty-paren close
     // (the gap-050 drop now gates on `is_structural_punct`).

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -509,9 +509,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-066 — redundant parens after `extends`
 
-- **Status:** OPEN — discovered by CLOC14.33. `minify_class_extends_paren` ignored.
+- **Status:** **RESOLVED** in CLOC12.75 (minimal safe slice). `minify_class_extends_paren` flips IGNORED → PASS.
 - **Input:** `class A extends(B){}` → **Upstream:** `class A extends B{}`
 - **What it needs:** After the `extends` keyword, a parenthesized simple reference (`(B)`) is redundant — strip the parens. Same simple-reference / precedence caveat as gap-065.
+- **CLOC12.75 (minimal safe slice):** strips `extends ( <identifier-dot chain> )` only (identifier + `.IDENT` accessors), anchored on the `extends` KEYWORD (guarded against a property named `extends` — `o.extends(x)` is a method call). **Deliberately conservative vs upstream:** `extends(B||C)` is KEPT — `B||C` is not a LeftHandSideExpression, so `extends B||C` would be invalid JS (upstream strips it anyway, emitting arguably-invalid output). Call-chain inners (`extends(f())`) deferred. 5 unit tests.
 
 ### Additional divergences observed by CLOC14.33 (deferred, not yet fixtured)
 


### PR DESCRIPTION
## What

Closes **gap-066** (found in CLOC14.33). Strips redundant grouping parens after the `extends` keyword when the superclass is a simple reference:

```
class A extends(B){}    →  class A extends B{}
class A extends(a.b){}  →  class A extends a.b{}
var x=class extends(B){};  →  var x=class extends B{};
```

The class body `{` delimits the heritage clause, so `extends B{` is unambiguous.

## How

A token pre-pass mirroring gap-065, anchored on the `extends` **keyword** and reusing the simple-reference (identifier + `.IDENT` chain) scan. Guards:
- not a string literal whose content is `extends`;
- not a **property** named `extends` — `o.extends(x)` / `o?.extends(x)` are method calls (prev-prev must not be `.`/`?.`);
- all bracket checks via `is_structural_punct`.

## Deliberately conservative vs upstream

`extends(B||C)` **keeps** its parens. `B||C` is not a `LeftHandSideExpression`, so `extends B||C` would be **invalid JS**. Upstream strips it anyway (emitting arguably-invalid output); closurec stays on the valid side. Call-chain inners (`extends(f())`) are deferred.

## Tests

- 5 new `gap066_*` unit tests (strip cases + the operator-keep and property-call safety cases).
- 448 lib tests green; byte-identity harness with `class_extends_paren` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — meaning preservation, the operator-inner safe divergence, property/string guards, member-chain scan, index/removal, and gap-065 disjointness all verified; every in-scope case byte-identical to the JAR (the lone `extends(B||C)` divergence is the intentional safe one).

Version 0.78→0.79; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)