### PR TITLE
feat(clr-real): C3 — predicates + COND on real CoreCLR

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.13.0] — 2026-06-11 — textual `.il`: predicates + COND (CLR-real C3)
+
+`emit_il` grows the McCarthy predicate primitives and `COND` control flow:
+
+- `call_builtin "pair?"` → `isinst object[]; ldnull; ceq; ldc.i4.0; ceq` (a clean
+  0/1 bool: is the boxed value a cons cell?). Note the **textual** form is
+  `isinst object[]` — `ilasm` rejects an explicit `[System.Runtime]System.Object[]`
+  assembly scope in that position (syntax error), unlike the `newarr` element type.
+- `call_builtin "not"` → `ldc.i4.1; xor` (boolean negation of a 0/1 value).
+- `call_builtin "equal?"` → `unbox.any [System.Runtime]System.Int32` on both
+  operands + `ceq` (atom identity reduces to integer equality; symbols are interned
+  to ints upstream).
+- `COND` lowering: `label` → a `<name>:` anchor, `jmp` → `br <name>`,
+  `jmp_if_false` → `ldloc cond; brfalse <name>` (and `jmp_if_true` → `brtrue`).
+- `const` of a **reference** type (`ref<…>`) is the McCarthy nil — emit `ldnull`
+  (the canonical null `object[]`), never `ldc.i4 0`, which would be an ill-typed
+  store into an object-typed local. A non-zero reference constant is rejected.
+
+**Security:** branch-target / label names are the one IIR-supplied *string* (not a
+numeric slot) that reaches the `.il` text, so they are validated by a new
+`checked_label` helper — only `[A-Za-z0-9_$]` passes, anything else (newlines,
+braces, `.`-directives, `//` comments) is rejected as `InvalidOperand`. This closes
+a latent CIL-injection vector before the source-derived names of C4/C5 land. Unit
+test `malicious_label_name_is_rejected_not_injected`.
+
+Verified by RUNNING on real CoreCLR (`lang-aot/tests/clr_real_predicates.rs`):
+`(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(EQ 7 8)`→0,
+`(COND ((ATOM 7) 11) …)`→11, `(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))`→22. New
+unit tests: `atom_emits_isinst_xor_predicate_chain`, `eq_emits_double_unbox_then_ceq`,
+`cond_emits_branches_labels_and_nil_fallthrough`, `const_of_reference_type_rejects_non_nil`.
+
 ## [0.12.0] — 2026-06-11 — textual `.il`: cons / car / cdr (CLR-real C2)
 
 `emit_il` grows the cons value model: `alloc` → `ldc.i4.2; newarr

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -33,9 +33,11 @@ Two outputs from the same lowered program: binary method bodies for the in-repo
 `clr-simulator` (fast unit checks), and **textual `.il`** (`emit_il`) for the
 **real CoreCLR** path — assembled by real `ilasm`, run on real `dotnet`. This is
 the exact analog of how `iir-to-llvm` emits textual `.ll` for real `clang`; `ilasm`
-owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar + cons/car/cdr today —
-cons is a 2-element `System.Object[]`, atoms `box`ed `System.Int32`; predicates/
-COND/symbols/lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist.)
+owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar, cons/car/cdr, and
+**predicates + `COND`** today — cons is a 2-element `System.Object[]`, atoms `box`ed
+`System.Int32`; `pair?` is `isinst object[]`, `not` is `xor 1`, `equal?` is
+`unbox.any int32` ×2 + `ceq`, and `COND` lowers to `label`/`br`/`brfalse`. Symbols
+and lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist.)
 
 ## Quick start
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -13,14 +13,22 @@
 //! program to the real toolchain and let it own the metadata (PE headers, the
 //! `#~`/`#Strings`/`#Blob` streams, token resolution). No hand-rolled metadata.
 //!
-//! ## Scope (C1)
+//! ## Scope (C1–C3)
 //!
-//! Scalar McCarthy — the entry function as a straight line of integer `const` /
-//! `mov` / `ret`. Each register becomes an `int32` local; the entry computes an
-//! `int32`, and a generated launcher prints it so a runner reads the result by
-//! running. Every other op returns [`IIRClrError::UnsupportedOp`], so later slices
-//! (cons → `newarr object`, predicates, `COND`, symbols, lambda) extend the op
-//! match incrementally — `ilasm` already handles the metadata each will need.
+//! * **C1 — scalar:** the entry function as a straight line of integer `const` /
+//!   `mov` / `ret`; each register an `int32` local, a generated launcher prints
+//!   the result so a runner reads it by running.
+//! * **C2 — cons / car / cdr:** a cons cell is a 2-element `System.Object[]`
+//!   (`alloc` → `newarr object`), atoms are `box`ed `System.Int32`, `field_*` are
+//!   `stelem.ref`/`ldelem.ref`, with mixed-type locals (`object[]`/`object`/`int32`).
+//! * **C3 — predicates + COND:** `pair?` → `isinst object[]; ldnull; ceq; ldc.i4.0;
+//!   ceq`, `not` → `xor 1`, `equal?` → `unbox.any int32` ×2 + `ceq`; `COND` lowers
+//!   to `label` (`<name>:`) / `jmp` (`br`) / `jmp_if_false` (`brfalse`), and a nil
+//!   fall-through `const … : ref<…>` becomes `ldnull` (never `ldc.i4 0`).
+//!
+//! Every other op returns [`IIRClrError::UnsupportedOp`], so the remaining slices
+//! (symbols, lambda / LABEL) extend the op match incrementally — `ilasm` already
+//! handles the metadata each will need.
 
 use crate::lower::{IIRClrConfig, IIRClrError};
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
@@ -40,6 +48,36 @@ fn var_src<'a>(
             function: f.name.clone(),
             detail: format!("{op} src[{idx}] must be a variable, got {other:?}"),
         }),
+    }
+}
+
+/// Validate a branch-target / label name before it is written **verbatim** into
+/// the `.il` text that real `ilasm` assembles.
+///
+/// Unlike register operands — which never reach the output as names (they are
+/// resolved to numeric `V_<slot>` indices) — a `label`/`jmp`/`jmp_if_*` target is
+/// an `Operand::Var(String)`, an arbitrary unbounded string, emitted directly as
+/// `<name>:` / `br <name>`. If that string carried whitespace, newlines, `}`, or
+/// CIL directives (`.entrypoint`, `.method`, `//` comments…), a hostile IIR could
+/// inject arbitrary CIL into the assembled program. We therefore fail **closed**:
+/// only a non-empty run of `[A-Za-z0-9_$]` (a safe subset of legal CIL identifier
+/// characters) is accepted; anything else is an `InvalidOperand`. The binary
+/// emitter is immune by construction (it resolves labels to numeric offsets); this
+/// gives the textual emitter the same guarantee. Synthetic COND labels
+/// (`L_cond_next_<n>`) always pass; source-derived names (C4/C5 symbols, LABEL)
+/// are checked here before they can reach `ilasm`.
+fn checked_label<'a>(f: &IIRFunction, name: &'a str) -> Result<&'a str, IIRClrError> {
+    let valid = !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$');
+    if valid {
+        Ok(name)
+    } else {
+        Err(IIRClrError::InvalidOperand {
+            function: f.name.clone(),
+            detail: format!("label/branch target {name:?} is not a valid CIL identifier"),
+        })
     }
 }
 
@@ -157,27 +195,53 @@ fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(),
     for instr in &f.instructions {
         match instr.op.as_str() {
             // const <dest> = Int(n)  →  ldc.i4 n; stloc V_<dest>
+            //
+            // A `const` whose *result type* is a reference (`ref<…>`) is the
+            // McCarthy **nil** — an empty list is a null `object[]`. The structural
+            // `COND` lowering emits `const <r> = 0 : ref<LispyPair>` for the
+            // fall-through when no clause matched. Storing an `int32` into an
+            // object-typed local is ill-typed CIL, so emit a genuine `ldnull` (the
+            // canonical nil), never `ldc.i4 0`. (Mirrors the binary emitter's
+            // `ldnull` nil case in `lower.rs`.)
             "const" => {
                 let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
                     function: f.name.clone(),
                     detail: "const must have a dest".to_string(),
                 })?;
-                let n = match instr.srcs.first() {
-                    Some(Operand::Int(n)) => *n,
-                    other => {
-                        return Err(IIRClrError::InvalidOperand {
-                            function: f.name.clone(),
-                            detail: format!("const expects an integer literal, got {other:?}"),
-                        })
+                if instr.type_hint.starts_with("ref<") {
+                    // Only nil (0 / absent) is representable as a constant reference.
+                    match instr.srcs.first() {
+                        Some(Operand::Int(0)) | None => {}
+                        other => {
+                            return Err(IIRClrError::InvalidOperand {
+                                function: f.name.clone(),
+                                detail: format!(
+                                    "const of reference type {:?} must be nil (0), got {other:?}",
+                                    instr.type_hint
+                                ),
+                            })
+                        }
                     }
-                };
-                // The CLR McCarthy model is `int32`; a scalar literal fits there.
-                let n32 = i32::try_from(n).map_err(|_| IIRClrError::InvalidOperand {
-                    function: f.name.clone(),
-                    detail: format!("integer literal {n} out of int32 range"),
-                })?;
-                let _ = writeln!(il, "    ldc.i4 {n32}");
-                let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                    let _ = writeln!(il, "    ldnull");
+                    let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                } else {
+                    let n = match instr.srcs.first() {
+                        Some(Operand::Int(n)) => *n,
+                        other => {
+                            return Err(IIRClrError::InvalidOperand {
+                                function: f.name.clone(),
+                                detail: format!("const expects an integer literal, got {other:?}"),
+                            })
+                        }
+                    };
+                    // The CLR McCarthy model is `int32`; a scalar literal fits there.
+                    let n32 = i32::try_from(n).map_err(|_| IIRClrError::InvalidOperand {
+                        function: f.name.clone(),
+                        detail: format!("integer literal {n} out of int32 range"),
+                    })?;
+                    let _ = writeln!(il, "    ldc.i4 {n32}");
+                    let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                }
             }
             // mov <dest>, <src>  →  ldloc V_<src>; stloc V_<dest>
             "mov" => {
@@ -272,7 +336,104 @@ fn emit_entry_method(il: &mut String, f: &IIRFunction, _asm: &str) -> Result<(),
                 let _ = writeln!(il, "    ldelem.ref");
                 let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
             }
-            // Later slices extend this match (predicates, COND, symbols, lambda).
+            // ── Control flow (COND lowers to label / jmp / jmp_if_*) ──────────
+            //
+            // McCarthy `COND` is lowered by the shared structural pass to a chain
+            // of `jmp_if_false`/`jmp` over `label`s. CIL labels are not opcodes —
+            // they are named positions in the byte stream — so a `label` emits a
+            // `<name>:` anchor and the branches reference it by name. `ilasm`
+            // resolves every name to the right offset.
+            //
+            // label <name>  →  `<name>:`
+            "label" => {
+                let name = checked_label(f, var_src(f, instr, 0, "label")?)?;
+                let _ = writeln!(il, "  {name}:");
+            }
+            // jmp <label>  →  br <label>   (unconditional branch)
+            "jmp" => {
+                let label = checked_label(f, var_src(f, instr, 0, "jmp")?)?;
+                let _ = writeln!(il, "    br {label}");
+            }
+            // jmp_if_false <cond>, <label>  →  ldloc cond; brfalse <label>
+            "jmp_if_false" => {
+                let cond = var_src(f, instr, 0, "jmp_if_false")?;
+                let label = checked_label(f, var_src(f, instr, 1, "jmp_if_false")?)?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(cond)?);
+                let _ = writeln!(il, "    brfalse {label}");
+            }
+            // jmp_if_true <cond>, <label>  →  ldloc cond; brtrue <label>
+            "jmp_if_true" => {
+                let cond = var_src(f, instr, 0, "jmp_if_true")?;
+                let label = checked_label(f, var_src(f, instr, 1, "jmp_if_true")?)?;
+                let _ = writeln!(il, "    ldloc V_{}", slot(cond)?);
+                let _ = writeln!(il, "    brtrue {label}");
+            }
+            // ── McCarthy predicate primitives (call_builtin) ──────────────────
+            //
+            // The structural pass decomposes the source predicates into three
+            // boolean builtins, each a small CIL idiom (the CLR twins of the JVM
+            // `instanceof`/`ixor`/`if_icmpeq` and the wasm `ref.test`/`i32.eqz`/
+            // `i32.eq`). Mirrors the binary emitter's `call_builtin` arm in
+            // `lower.rs`.
+            //
+            // | builtin  | layout                            | CIL |
+            // |----------|-----------------------------------|-----|
+            // | `pair?`  | [Var("pair?"), Var(x)]; dest      | `ldloc x; isinst object[]; ldnull; ceq; ldc.i4.0; ceq` |
+            // | `not`    | [Var("not"), Var(x)]; dest        | `ldloc x; ldc.i4.1; xor` |
+            // | `equal?` | [Var("equal?"), Var(a), Var(b)]   | `ldloc a; unbox.any int32; ldloc b; unbox.any int32; ceq` |
+            "call_builtin" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: "call_builtin must have a dest".to_string(),
+                })?;
+                let builtin = var_src(f, instr, 0, "call_builtin")?;
+                match builtin {
+                    // Is the (boxed) lisp value a cons cell? A cons is an `object[]`
+                    // (heap ref); an atom is a boxed int; nil is null. `isinst`
+                    // leaves the ref or null; the two `ceq`s turn that into a clean
+                    // 1 (pair) / 0 (not): the first `ceq ldnull` answers "is it null
+                    // (≠ pair)?", the second (`== 0`) flips it back to "was a pair".
+                    "pair?" => {
+                        let arg = var_src(f, instr, 1, "pair?")?;
+                        let _ = writeln!(il, "    ldloc V_{}", slot(arg)?);
+                        let _ = writeln!(il, "    isinst object[]");
+                        let _ = writeln!(il, "    ldnull");
+                        let _ = writeln!(il, "    ceq");
+                        let _ = writeln!(il, "    ldc.i4.0");
+                        let _ = writeln!(il, "    ceq");
+                        let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                    }
+                    // Logical not of a 0/1 bool: `x ^ 1`. (Distinct from a machine
+                    // bitwise-complement `not`; this is McCarthy's boolean not.)
+                    "not" => {
+                        let arg = var_src(f, instr, 1, "not")?;
+                        let _ = writeln!(il, "    ldloc V_{}", slot(arg)?);
+                        let _ = writeln!(il, "    ldc.i4.1");
+                        let _ = writeln!(il, "    xor");
+                        let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                    }
+                    // `EQ` on atoms: unbox both and compare. The structural pass
+                    // guarantees both args are boxed atoms (symbols interned to ints,
+                    // integers as ints), so identity reduces to integer equality.
+                    "equal?" => {
+                        let a = var_src(f, instr, 1, "equal?")?;
+                        let b = var_src(f, instr, 2, "equal?")?;
+                        let _ = writeln!(il, "    ldloc V_{}", slot(a)?);
+                        let _ = writeln!(il, "    unbox.any [System.Runtime]System.Int32");
+                        let _ = writeln!(il, "    ldloc V_{}", slot(b)?);
+                        let _ = writeln!(il, "    unbox.any [System.Runtime]System.Int32");
+                        let _ = writeln!(il, "    ceq");
+                        let _ = writeln!(il, "    stloc V_{}", slot(dest)?);
+                    }
+                    other => {
+                        return Err(IIRClrError::UnsupportedOp {
+                            function: f.name.clone(),
+                            op: format!("call_builtin {other:?}"),
+                        })
+                    }
+                }
+            }
+            // Later slices extend this match (symbols, lambda).
             other => {
                 return Err(IIRClrError::UnsupportedOp {
                     function: f.name.clone(),
@@ -358,8 +519,165 @@ mod tests {
     }
 
     #[test]
+    fn atom_emits_isinst_xor_predicate_chain() {
+        // `(ATOM 7)` lowers to `not (pair? (box 7))`: box the int, test it against
+        // object[], collapse to a 0/1 bool, then xor-1 to negate.
+        let instrs = vec![
+            IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("box", Some("v0b".into()), vec![Operand::Var("v0".into())], "ref<any>"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("v1".into()),
+                vec![Operand::Var("pair?".into()), Operand::Var("v0b".into())],
+                "bool",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("v2".into()),
+                vec![Operand::Var("not".into()), Operand::Var("v1".into())],
+                "bool",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("v2".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        // pair?: isinst object[]; ldnull; ceq; ldc.i4.0; ceq
+        assert!(il.contains("isinst object[]"), "pair? → isinst object[]; got:\n{il}");
+        assert!(il.contains("ceq"), "pair? collapses ref/null to a bool with ceq");
+        // not: ldc.i4.1; xor
+        assert!(il.contains("ldc.i4.1\n    xor"), "not → xor 1; got:\n{il}");
+        // The bool register is a raw int32 local.
+        assert!(il.contains("int32 V_"), "predicate result is an int32 local");
+    }
+
+    #[test]
+    fn eq_emits_double_unbox_then_ceq() {
+        // `(EQ 7 7)` lowers to `equal? (box 7) (box 7)`: unbox both, compare.
+        let instrs = vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new("box", Some("ab".into()), vec![Operand::Var("a".into())], "ref<any>"),
+            IIRInstr::new("box", Some("bb".into()), vec![Operand::Var("b".into())], "ref<any>"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("equal?".into()),
+                    Operand::Var("ab".into()),
+                    Operand::Var("bb".into()),
+                ],
+                "bool",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert_eq!(
+            il.matches("unbox.any [System.Runtime]System.Int32").count(),
+            2,
+            "equal? unboxes both operands; got:\n{il}"
+        );
+        assert!(il.contains("ceq"), "equal? → ceq");
+    }
+
+    #[test]
+    fn cond_emits_branches_labels_and_nil_fallthrough() {
+        // A minimal COND skeleton: branch on a bool to a label, an unconditional
+        // jump to the end, and a nil (`const 0 : ref<LispyPair>`) fall-through that
+        // must become `ldnull` (not `ldc.i4 0`) so the object-typed local is sound.
+        let instrs = vec![
+            IIRInstr::new("const", Some("c".into()), vec![Operand::Int(1)], "bool"),
+            IIRInstr::new(
+                "jmp_if_false",
+                None,
+                vec![Operand::Var("c".into()), Operand::Var("L_next".into())],
+                "void",
+            ),
+            IIRInstr::new("const", Some("r".into()), vec![Operand::Int(11)], "i32"),
+            IIRInstr::new("jmp", None, vec![Operand::Var("L_end".into())], "void"),
+            IIRInstr::new("label", None, vec![Operand::Var("L_next".into())], "void"),
+            IIRInstr::new("const", Some("nil".into()), vec![Operand::Int(0)], "ref<LispyPair>"),
+            IIRInstr::new("label", None, vec![Operand::Var("L_end".into())], "void"),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert!(il.contains("brfalse L_next"), "jmp_if_false → brfalse; got:\n{il}");
+        assert!(il.contains("br L_end"), "jmp → br");
+        assert!(il.contains("L_next:"), "label → named anchor");
+        assert!(il.contains("L_end:"), "label → named anchor");
+        // The nil const must be ldnull, and its local must be object[] (a list).
+        assert!(il.contains("ldnull"), "const-of-ref-type nil → ldnull; got:\n{il}");
+        assert!(il.contains("object[] V_"), "nil local is object[]");
+        // It must NOT store an int 0 into the reference local.
+        assert!(!il.contains("ldc.i4 0\n    stloc"), "nil must not be ldc.i4 0");
+    }
+
+    #[test]
+    fn malicious_label_name_is_rejected_not_injected() {
+        // A hostile IIR label carrying CIL directives / newlines must NOT reach the
+        // `.il` text — `checked_label` fails closed on any non-identifier character.
+        for bad in [
+            "L_end\n    .entrypoint\n  ", // newline + directive injection
+            "L }",                        // brace closes the method early
+            "L_end // comment",           // line comment
+            "",                           // empty
+        ] {
+            let instrs = vec![
+                IIRInstr::new("label", None, vec![Operand::Var(bad.into())], "void"),
+                IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(1)], "i32"),
+                IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "i32"),
+            ];
+            let mut m = IIRModule::new("Main", "mccarthy-lisp");
+            m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+            m.entry_point = Some("main".into());
+            let err = emit_il(&m, &IIRClrConfig::new("Main")).unwrap_err();
+            assert!(
+                matches!(err, IIRClrError::InvalidOperand { .. }),
+                "label {bad:?} must be rejected, got {err:?}"
+            );
+        }
+        // A legitimate synthetic COND label still passes.
+        let instrs = vec![
+            IIRInstr::new("label", None, vec![Operand::Var("L_cond_next_1".into())], "void"),
+            IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(1)], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("v0".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        assert!(emit_il(&m, &IIRClrConfig::new("Main")).unwrap().contains("L_cond_next_1:"));
+    }
+
+    #[test]
+    fn const_of_reference_type_rejects_non_nil() {
+        // A non-zero constant of reference type is not representable (only nil is a
+        // constant ref) — reject rather than emit an ill-typed store.
+        let instrs = vec![
+            IIRInstr::new("const", Some("x".into()), vec![Operand::Int(5)], "ref<LispyPair>"),
+            IIRInstr::new("ret", None, vec![Operand::Var("x".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        let err = emit_il(&m, &IIRClrConfig::new("Main")).unwrap_err();
+        assert!(matches!(err, IIRClrError::InvalidOperand { .. }));
+    }
+
+    #[test]
     fn unsupported_op_is_rejected_not_emitted() {
-        // A predicate (`call_builtin`) is C3 — C2 must reject it explicitly, not emit junk.
+        // A `call_builtin` to a name outside the CLR whitelist (only pair?/not/
+        // equal? are emittable today) must be rejected explicitly, not emit junk —
+        // e.g. `lispy_cons` is a heap builtin handled structurally, never here.
         let mut m = scalar_module(1);
         m.functions[0].instructions.insert(
             0,

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.50.0 — 2026-06-11 — McCarthy **predicates + COND** on real CoreCLR (CLR-real C3)
+
+`compile_source_to_cil_text` now compiles McCarthy predicate and `COND` programs
+(via `iir-to-cil-bytecode` 0.13.0). New e2e `tests/clr_real_predicates.rs` runs them
+on **real CoreCLR** (real `ilasm` → PE → real `dotnet`, via the shared
+`tests/clr_support` harness): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1,
+`(EQ 7 8)`→0, `(COND ((ATOM 7) 11) ((ATOM 8) 22))`→11, and
+`(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))`→22 (a false first clause falling
+through to a matching `EQ`). Gated on `dotnet`+`ilasm`; skips when absent.
+
 ## 0.49.0 — 2026-06-11 — McCarthy **cons/car/cdr** on real CoreCLR (CLR-real C2)
 
 `compile_source_to_cil_text` now compiles cons programs (via `iir-to-cil-bytecode`

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -47,12 +47,13 @@ McCarthy support after WASM and JVM.
 `compile_source_to_cil_text` is the **real-CoreCLR** path (CLR-real C1): the same
 lowered program emitted as textual `.il`, assembled by real `ilasm` into a loadable
 PE, and run on real `dotnet` — the CLR analog of `compile_source_to_llvm` (`.ll` →
-real `clang`). Scalar + **cons/car/cdr** run today (`42`→42, `(CAR (CONS 7 9))`→7 on
-real CoreCLR; `tests/clr_real_scalar.rs` + `clr_real_cons.rs`, gated on
-`dotnet`+`ilasm` via the shared `tests/clr_support` harness); predicates/COND/symbols/
-lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR
-column of the W16 conformance matrix is verified on real .NET rather than the in-repo
-simulator.
+real `clang`). Scalar, **cons/car/cdr**, and **predicates + `COND`** run today
+(`42`→42, `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1, `(EQ 7 7)`→1,
+`(COND ((ATOM 7) 11) …)`→11 on real CoreCLR; `tests/clr_real_scalar.rs` +
+`clr_real_cons.rs` + `clr_real_predicates.rs`, gated on `dotnet`+`ilasm` via the
+shared `tests/clr_support` harness); symbols and lambda land per the
+`CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR column of the W16
+conformance matrix is verified on real .NET rather than the in-repo simulator.
 
 `compile_source_to_beam` targets the **Erlang VM**: scalar McCarthy emits a
 `.beam` that **runs** on a real `erl` (OTP), `42` → 42 (W9a), and **cons** too —

--- a/code/packages/rust/lang-aot/tests/clr_real_predicates.rs
+++ b/code/packages/rust/lang-aot/tests/clr_real_predicates.rs
@@ -1,0 +1,50 @@
+//! # McCarthy on **real CoreCLR** — predicates + COND (CLR-real C3).
+//!
+//! The McCarthy predicate primitives lower to small CIL idioms that `emit_il`
+//! emits as textual CIL, which real `ilasm` assembles and real `dotnet` runs:
+//!
+//! | source     | lowered builtin(s)        | CIL idiom |
+//! |------------|---------------------------|-----------|
+//! | `ATOM x`   | `not (pair? x)`           | `isinst object[]; ldnull; ceq; ldc.i4.0; ceq` then `xor 1` |
+//! | `EQ a b`   | `equal? a b`              | `unbox.any int32` ×2; `ceq` |
+//! | `COND …`   | `jmp_if_false`/`jmp`/`label` | `brfalse`/`br` over named anchors; nil fall-through `ldnull` |
+//!
+//! Gated on `dotnet`+`ilasm` (skips gracefully when absent), exactly like the
+//! scalar (C1) and cons (C2) real-CoreCLR tests.
+
+#[path = "clr_support/mod.rs"]
+mod clr_support;
+use clr_support::run_on_real_clr;
+
+#[test]
+fn mccarthy_predicates_and_cond_run_on_real_coreclr() {
+    // Probe once; if the toolchain is absent, skip the whole suite.
+    let Some(atom_int) = run_on_real_clr("(ATOM 7)", "atom_int") else {
+        eprintln!("dotnet/ilasm absent — skipping real-CoreCLR predicate test");
+        return;
+    };
+
+    // F3 — ATOM: an integer is an atom (1), a cons cell is not (0).
+    assert_eq!(atom_int, 1, "(ATOM 7) on real CoreCLR");
+    assert_eq!(run_on_real_clr("(ATOM (CONS 1 2))", "atom_cons").unwrap(), 0);
+
+    // F4 — EQ on integers: equal → 1, unequal → 0.
+    assert_eq!(run_on_real_clr("(EQ 7 7)", "eq_t").unwrap(), 1);
+    assert_eq!(run_on_real_clr("(EQ 7 8)", "eq_f").unwrap(), 0);
+
+    // F5 — COND: the first truthy clause wins; later clauses (incl. EQ) reachable.
+    assert_eq!(
+        run_on_real_clr("(COND ((ATOM 7) 11) ((ATOM 8) 22))", "cond1").unwrap(),
+        11,
+        "first clause matches → 11"
+    );
+    assert_eq!(
+        run_on_real_clr("(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))", "cond2").unwrap(),
+        22,
+        "first clause false (a cons is not an atom), second (EQ 5 5) matches → 22"
+    );
+
+    // No regression: cons (C2) and scalar (C1) still run through the same emitter.
+    assert_eq!(run_on_real_clr("(CAR (CONS 7 9))", "car").unwrap(), 7);
+    assert_eq!(run_on_real_clr("42", "scalar").unwrap(), 42);
+}

--- a/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
+++ b/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
@@ -57,9 +57,16 @@ other external-tool backends.
   the ref-only `microsoft.netcore.ilasm`). Verified by RUNNING on **real CoreCLR**
   (`tests/clr_real_cons.rs`): `(CAR (CONS 7 9))`→7, `(CDR …)`→9,
   `(CAR (CDR (CONS 1 (CONS 2 3))))`→2.
-- ☐ **C3 — predicates + COND (F3–F5).** `pair?`→`isinst object[]`, `not`→`xor 1`,
-  `equal?`→`unbox;unbox;ceq`, `COND` truthiness → branch. Verify `(ATOM 7)`→1,
-  `(EQ 7 7)`→1, `(COND …)`→11.
+- ✅ **C3 — predicates + COND (F3–F5).** `emit_il` gained `call_builtin "pair?"` →
+  `isinst object[]; ldnull; ceq; ldc.i4.0; ceq` (the **textual** `isinst object[]`
+  form — `ilasm` rejects an explicit `[System.Runtime]System.Object[]` scope there),
+  `"not"` → `ldc.i4.1; xor`, `"equal?"` → `unbox.any int32` ×2 + `ceq`; and the
+  `COND` control flow `label` → `<name>:`, `jmp` → `br`, `jmp_if_false` → `brfalse`
+  (`jmp_if_true` → `brtrue`). A `const` of reference type (the `COND` nil
+  fall-through) emits `ldnull`, not `ldc.i4 0`. Verified by RUNNING on **real
+  CoreCLR** (`tests/clr_real_predicates.rs`): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0,
+  `(EQ 7 7)`→1, `(EQ 7 8)`→0, `(COND ((ATOM 7) 11) …)`→11,
+  `(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))`→22.
 - ☐ **C4 — symbols (F6).** Interned symbol ids (the shared
   `intern_symbols_structural`); `(EQ (QUOTE A) (QUOTE A))`→1, distinct→0.
 - ☐ **C5 — lambda / LABEL / recursion (F7).** Each hoisted lambda as its own


### PR DESCRIPTION
## Summary

Fourth slice of the **CLR real-CoreCLR verification** chapter (`code/specs/CLR-REAL-RUNTIME-VERIFICATION.md`, item **C3**). Grows the textual-CIL emitter `iir-to-cil-bytecode::emit_il` to handle the McCarthy **predicate primitives** and **`COND`** control flow, then proves them by **running on real CoreCLR** — real `ilasm` → PE → real `dotnet` — exactly mirroring how the LLVM backend emits textual `.ll` for real `clang`. `ilasm` owns all ECMA-335 metadata; we never hand-roll PE tables.

This is the verification of record for the CLR column that the W16 cross-backend conformance matrix has so far only checked on the in-repo `clr-simulator`.

### Ops added to `emit_il`

| IIR | CIL |
|-----|-----|
| `call_builtin "pair?"` | `isinst object[]; ldnull; ceq; ldc.i4.0; ceq` (is the boxed value a cons cell? → clean 0/1) |
| `call_builtin "not"` | `ldc.i4.1; xor` (boolean negation of a 0/1) |
| `call_builtin "equal?"` | `unbox.any int32` ×2; `ceq` (atom identity ≡ integer equality) |
| `label <n>` / `jmp <n>` | `<n>:` / `br <n>` |
| `jmp_if_false` / `jmp_if_true` | `ldloc cond; brfalse <n>` / `brtrue <n>` |
| `const … : ref<…>` (COND nil fall-through) | `ldnull` (never `ldc.i4 0`, an ill-typed store into an object-typed local) |

The **textual** predicate-test form is `isinst object[]` — `ilasm` rejects an explicit `[System.Runtime]System.Object[]` assembly scope in that position (a syntax error), unlike the `newarr` element type. Found by running.

## Security

Branch-target / label names are the **one** IIR-supplied *string* (not a numeric slot) that reaches the assembled `.il` text — every register operand is resolved to a numeric `V_<slot>`. A two-round security review flagged this as a latent **CIL-injection** vector (a hostile IIR label with a newline + `.entrypoint`, a `}`, or a `//` comment could inject directives). Fixed with a new `checked_label` helper that fails **closed**: only non-empty `[A-Za-z0-9_$]` passes; anything else is `InvalidOperand`. Applied at all four label/branch sites. Synthetic COND labels (`L_cond_next_<n>`) pass unchanged; this closes the vector before the source-derived names of C4 (symbols) / C5 (LABEL) land. Second review round returned **SECURITY REVIEW PASSED**.

## Test plan

- **Real CoreCLR e2e** (`lang-aot/tests/clr_real_predicates.rs`, gated on `dotnet`+`ilasm`, skips when absent): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0, `(EQ 7 7)`→1, `(EQ 7 8)`→0, `(COND ((ATOM 7) 11) ((ATOM 8) 22))`→11, `(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))`→22, plus cons + scalar regression — **all pass on real dotnet 9.0.313 + real ilasm locally.**
- **Unit tests** (`il_text.rs`): `atom_emits_isinst_xor_predicate_chain`, `eq_emits_double_unbox_then_ceq`, `cond_emits_branches_labels_and_nil_fallthrough`, `const_of_reference_type_rejects_non_nil`, `malicious_label_name_is_rejected_not_injected` — 8 `il_text` unit tests pass; full crate suite green (40+86+4).
- Clippy clean for `iir-to-cil-bytecode`. (Pre-existing unrelated `iir-to-beam` `atom_nil` lint from the newer local toolchain is untouched.)

## Versioning / docs

- `iir-to-cil-bytecode` 0.12.0 → **0.13.0**; `lang-aot` 0.49.0 → **0.50.0**
- Spec C3 ticked ☐→✅; both CHANGELOGs + both READMEs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)