### PR TITLE
Add smart-home activation readout tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -49,6 +49,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation approval packet planning:
   `smart_home.list_integration_activation_approvals` and
   `smart_home.get_integration_activation_approval_summary`.
+- Added D18D handlers for D23A activation readout planning:
+  `smart_home.list_integration_activation_readouts` and
+  `smart_home.get_integration_activation_readout_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -106,6 +106,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_evidence_summary`
 - `smart_home.list_integration_activation_dossiers`
 - `smart_home.get_integration_activation_dossier_summary`
+- `smart_home.list_integration_activation_readouts`
+- `smart_home.get_integration_activation_readout_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -39,33 +39,34 @@ use smart_home_integration_catalog::{
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
     activation_evidence_from_candidates, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDecisionItem,
-    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
-    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
-    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationReviewItem,
+    activation_plans_at_or_before_priority, activation_readouts_from_candidates,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
+    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
+    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationReadoutStage,
+    IntegrationActivationReadoutSummary, IntegrationActivationReviewItem,
     IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
@@ -225,6 +226,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DOSSIERS_TOOL_ID: &str =
     "smart_home.list_integration_activation_dossiers";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_dossier_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_readouts";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_readout_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -463,6 +468,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID => {
                     let query = integration_activation_dossier_query(&arguments)?;
                     Ok(get_integration_activation_dossier_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID => {
+                    let query = integration_activation_readout_query(&arguments)?;
+                    Ok(list_integration_activation_readouts_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_readout_query(&arguments)?;
+                    Ok(get_integration_activation_readout_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1598,6 +1613,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation dossier summary",
             "Return compact counts for D23A activation dossiers and their bundled decision evidence.",
             integration_activation_dossier_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID,
+            "List smart-home integration activation readouts",
+            "List D23A priority-wave activation readouts that combine health, maintenance, approval dossiers, evidence, risk, and dependency blocker rollups.",
+            integration_activation_readout_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_readouts", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_readouts",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation readout summary",
+            "Return compact D23A activation readout counts across priority-wave health, approval, evidence, risk, and blocker work.",
+            integration_activation_readout_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4231,6 +4280,21 @@ struct IntegrationActivationDossierQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationReadoutQuery {
+    candidates: IntegrationActivationCandidateQuery,
+    health_status: Option<IntegrationActivationHealthStatus>,
+    requires_attention: Option<bool>,
+    has_activation_work: Option<bool>,
+    has_approval_ready_work: Option<bool>,
+    has_review_work: Option<bool>,
+    blocked_only: Option<bool>,
+    has_risks: Option<bool>,
+    has_dependency_blockers: Option<bool>,
+    readout_limit: Option<usize>,
+    dossiers_per_readout_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4457,6 +4521,31 @@ fn integration_activation_dossier_query(
         blocked_only: optional_bool(arguments, "blocked_only")?,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         dossier_limit: optional_u64(arguments, "dossier_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_readout_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationReadoutQuery, ToolCallError> {
+    let candidates = integration_activation_candidate_query(arguments)?;
+    let health_status = optional_string(arguments, "health_status")?
+        .or(optional_string(arguments, "readout_status")?)
+        .map(|label| parse_activation_health_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationReadoutQuery {
+        candidates,
+        health_status,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        has_activation_work: optional_bool(arguments, "has_activation_work")?,
+        has_approval_ready_work: optional_bool(arguments, "has_approval_ready_work")?,
+        has_review_work: optional_bool(arguments, "has_review_work")?,
+        blocked_only: optional_bool(arguments, "blocked_only")?,
+        has_risks: optional_bool(arguments, "has_risks")?,
+        has_dependency_blockers: optional_bool(arguments, "has_dependency_blockers")?,
+        readout_limit: optional_u64(arguments, "readout_limit")?.map(|value| value as usize),
+        dossiers_per_readout_limit: optional_u64(arguments, "dossiers_per_readout_limit")?
+            .map(|value| value as usize),
     })
 }
 
@@ -4940,6 +5029,62 @@ fn integration_activation_dossiers_for_query(
     }
 
     (dossiers, catalog_count)
+}
+
+fn integration_activation_readouts_for_query(
+    query: &IntegrationActivationReadoutQuery,
+) -> (Vec<IntegrationActivationReadoutStage>, usize) {
+    let catalog = first_party_catalog();
+    let catalog_count = catalog.len();
+    let (candidates, _) = integration_activation_candidates_for_query(&query.candidates);
+    let mut readouts = activation_readouts_from_candidates(
+        &catalog,
+        candidates,
+        &query.candidates.readiness.enabled_integrations,
+    );
+
+    if let Some(health_status) = query.health_status {
+        readouts.retain(|readout| readout.health_status == health_status);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        readouts.retain(|readout| readout.requires_attention() == requires_attention);
+    }
+    if let Some(has_activation_work) = query.has_activation_work {
+        readouts.retain(|readout| readout.has_activation_work() == has_activation_work);
+    }
+    if let Some(has_approval_ready_work) = query.has_approval_ready_work {
+        readouts.retain(|readout| readout.has_approval_ready_work() == has_approval_ready_work);
+    }
+    if let Some(has_review_work) = query.has_review_work {
+        readouts.retain(|readout| readout.has_review_work() == has_review_work);
+    }
+    if let Some(blocked_only) = query.blocked_only {
+        readouts.retain(|readout| readout.has_blockers() == blocked_only);
+    }
+    if let Some(has_risks) = query.has_risks {
+        readouts.retain(|readout| readout.has_risks() == has_risks);
+    }
+    if let Some(has_dependency_blockers) = query.has_dependency_blockers {
+        readouts.retain(|readout| readout.has_dependency_blockers() == has_dependency_blockers);
+    }
+    if let Some(dossier_limit) = query.dossiers_per_readout_limit {
+        for readout in &mut readouts {
+            readout.dossiers.truncate(dossier_limit);
+            readout.dossier_summary =
+                IntegrationActivationDossierSummary::from_dossiers(readout.dossiers.iter());
+            readout.evidence_summary = IntegrationActivationEvidenceSummary::from_evidence(
+                readout
+                    .dossiers
+                    .iter()
+                    .flat_map(|dossier| dossier.evidence.iter()),
+            );
+        }
+    }
+    if let Some(limit) = query.readout_limit {
+        readouts.truncate(limit);
+    }
+
+    (readouts, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6151,6 +6296,72 @@ fn get_integration_activation_dossier_summary_output_handler_output(
                 integer(summary.ready_to_approve_dossiers as i64),
             ),
             ("blocked_dossiers", integer(summary.blocked_dossiers as i64)),
+        ]),
+    )
+}
+
+fn list_integration_activation_readouts_output_handler_output(
+    query: IntegrationActivationReadoutQuery,
+) -> ToolHandlerOutput {
+    let (readouts, catalog_count) = integration_activation_readouts_for_query(&query);
+    let summary = IntegrationActivationReadoutSummary::from_readouts(readouts.iter());
+    let count = readouts.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_readouts",
+            JsonValue::Array(readouts.iter().map(activation_readout_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_readout_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_readouts")),
+            ("activation_readouts", integer(count as i64)),
+            (
+                "readouts_with_blockers",
+                integer(summary.readouts_with_blockers as i64),
+            ),
+            (
+                "readouts_with_approval_work",
+                integer(summary.readouts_with_approval_work as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_readout_summary_output_handler_output(
+    query: IntegrationActivationReadoutQuery,
+) -> ToolHandlerOutput {
+    let (readouts, _) = integration_activation_readouts_for_query(&query);
+    let summary = IntegrationActivationReadoutSummary::from_readouts(readouts.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_readout_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_readout_summary"),
+            ),
+            ("total_readouts", integer(summary.total_readouts as i64)),
+            (
+                "readouts_with_blockers",
+                integer(summary.readouts_with_blockers as i64),
+            ),
+            (
+                "readouts_with_approval_work",
+                integer(summary.readouts_with_approval_work as i64),
+            ),
         ]),
     )
 }
@@ -10887,6 +11098,282 @@ fn integration_activation_dossier_summary_json(
     ])
 }
 
+fn activation_readout_json(readout: &IntegrationActivationReadoutStage) -> JsonValue {
+    object([
+        ("priority", integer(readout.priority as i64)),
+        ("health_status", string(readout.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                readout
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(readout.integration_ids.len() as i64),
+        ),
+        (
+            "ready_to_activate_integration_ids",
+            JsonValue::Array(
+                readout
+                    .maintenance_window
+                    .ready_to_activate_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "review_integration_ids",
+            JsonValue::Array(
+                readout
+                    .maintenance_window
+                    .review_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocked_integration_ids",
+            JsonValue::Array(
+                readout
+                    .maintenance_window
+                    .blocked_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "candidate_summary",
+            integration_activation_candidate_summary_json(readout.candidate_summary()),
+        ),
+        (
+            "action_summary",
+            integration_activation_action_summary_json(readout.action_summary()),
+        ),
+        (
+            "constraint_summary",
+            integration_activation_constraint_summary_json(readout.constraint_summary()),
+        ),
+        (
+            "risk_summary",
+            integration_activation_risk_summary_json(readout.risk_summary()),
+        ),
+        (
+            "dependency_summary",
+            integration_activation_dependency_summary_json(readout.dependency_summary()),
+        ),
+        (
+            "maintenance_window",
+            activation_maintenance_window_json(&readout.maintenance_window),
+        ),
+        (
+            "activation_dossiers",
+            JsonValue::Array(
+                readout
+                    .dossiers
+                    .iter()
+                    .map(activation_dossier_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "dossier_summary",
+            integration_activation_dossier_summary_json(&readout.dossier_summary),
+        ),
+        (
+            "evidence_summary",
+            integration_activation_evidence_summary_json(&readout.evidence_summary),
+        ),
+        ("has_ready_work", JsonValue::Bool(readout.has_ready_work())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(readout.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(readout.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(readout.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(readout.has_blockers())),
+        ("has_risks", JsonValue::Bool(readout.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(readout.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(readout.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_readout_summary_json(
+    summary: &IntegrationActivationReadoutSummary,
+) -> JsonValue {
+    object([
+        ("total_readouts", integer(summary.total_readouts as i64)),
+        (
+            "total_integrations",
+            integer(summary.total_integrations as i64),
+        ),
+        ("ready_readouts", integer(summary.ready_readouts as i64)),
+        ("review_readouts", integer(summary.review_readouts as i64)),
+        ("blocked_readouts", integer(summary.blocked_readouts as i64)),
+        ("empty_readouts", integer(summary.empty_readouts as i64)),
+        (
+            "activation_ready_integrations",
+            integer(summary.activation_ready_integrations as i64),
+        ),
+        (
+            "ready_to_activate_integrations",
+            integer(summary.ready_to_activate_integrations as i64),
+        ),
+        (
+            "review_integrations",
+            integer(summary.review_integrations as i64),
+        ),
+        (
+            "blocked_integrations",
+            integer(summary.blocked_integrations as i64),
+        ),
+        (
+            "readouts_with_activation_work",
+            integer(summary.readouts_with_activation_work as i64),
+        ),
+        (
+            "readouts_with_approval_work",
+            integer(summary.readouts_with_approval_work as i64),
+        ),
+        (
+            "readouts_with_review_work",
+            integer(summary.readouts_with_review_work as i64),
+        ),
+        (
+            "readouts_with_blockers",
+            integer(summary.readouts_with_blockers as i64),
+        ),
+        (
+            "readouts_with_risks",
+            integer(summary.readouts_with_risks as i64),
+        ),
+        (
+            "readouts_with_dependency_blockers",
+            integer(summary.readouts_with_dependency_blockers as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        (
+            "activate_integration_actions",
+            integer(summary.activate_integration_actions as i64),
+        ),
+        (
+            "review_policy_actions",
+            integer(summary.review_policy_actions as i64),
+        ),
+        (
+            "blocking_constraints",
+            integer(summary.blocking_constraints as i64),
+        ),
+        (
+            "review_constraints",
+            integer(summary.review_constraints as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        (
+            "ready_to_approve_dossiers",
+            integer(summary.ready_to_approve_dossiers as i64),
+        ),
+        ("blocked_dossiers", integer(summary.blocked_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        (
+            "supporting_evidence",
+            integer(summary.supporting_evidence as i64),
+        ),
+        ("review_evidence", integer(summary.review_evidence as i64)),
+        (
+            "blocking_evidence",
+            integer(summary.blocking_evidence as i64),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -14405,6 +14892,49 @@ fn integration_activation_dossier_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_readout_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_candidate_query_schema(true);
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        if let Some(limit) = properties
+            .iter_mut()
+            .find(|property| property.name == "limit")
+        {
+            limit.name = "readout_limit".to_string();
+        }
+        properties.push(SchemaProperty::new("health_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("readout_status", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_activation_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_approval_ready_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("has_review_work", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("has_risks", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "has_dependency_blockers",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "dossiers_per_readout_limit",
+            JsonSchema::Integer,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -14549,7 +15079,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 85);
+        assert_eq!(definitions.len(), 87);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -14772,9 +15302,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            77
+            79
         );
         assert_eq!(
             export
@@ -14926,6 +15462,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_DOSSIER_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -15180,11 +15724,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(85))
+            Some(&integer(87))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(77))
+            Some(&integer(79))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -16963,6 +17507,145 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_readouts_request = request(
+            "call-list-integration-activation-readouts",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("readout_limit", integer(3)),
+                ("dossiers_per_readout_limit", integer(2)),
+            ]),
+            5_019,
+        );
+        let list_activation_readouts_trace =
+            tool_runtime.invoke_with_events(&list_activation_readouts_request);
+        assert!(list_activation_readouts_trace.result.ok);
+        assert_eq!(
+            list_activation_readouts_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_readouts_output = list_activation_readouts_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_readout_count =
+            integer_value(field(list_activation_readouts_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_readout_count));
+        let activation_readout_summary = field(list_activation_readouts_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_readout_summary, "total_readouts"),
+            Some(&integer(activation_readout_count))
+        );
+        assert_eq!(
+            field(activation_readout_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_readout_work =
+            integer_value(field(activation_readout_summary, "readouts_with_blockers").unwrap())
+                .unwrap()
+                + integer_value(
+                    field(activation_readout_summary, "readouts_with_approval_work").unwrap(),
+                )
+                .unwrap();
+        assert!(activation_readout_work >= 1);
+        let activation_readout = array_item(
+            field(list_activation_readouts_output, "activation_readouts").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(matches!(
+            field(activation_readout, "health_status"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(field(activation_readout, "maintenance_window").is_some());
+        assert!(field(activation_readout, "candidate_summary").is_some());
+        assert!(field(activation_readout, "action_summary").is_some());
+        assert!(field(activation_readout, "constraint_summary").is_some());
+        assert!(field(activation_readout, "risk_summary").is_some());
+        assert!(field(activation_readout, "dependency_summary").is_some());
+        assert!(field(activation_readout, "dossier_summary").is_some());
+        assert!(field(activation_readout, "evidence_summary").is_some());
+        assert!(field(activation_readout, "activation_dossiers").is_some());
+        assert_eq!(
+            field(activation_readout, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_readout_summary_request = request(
+            "call-integration-activation-readout-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            5_020,
+        );
+        let activation_readout_summary_trace =
+            tool_runtime.invoke_with_events(&activation_readout_summary_request);
+        assert!(activation_readout_summary_trace.result.ok);
+        assert_eq!(
+            activation_readout_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_readout_summary_output = activation_readout_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_readout_rollup =
+            field(activation_readout_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_readout_rollup, "readouts_with_blockers").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_readout_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_readout_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -18678,6 +19361,14 @@ mod tests {
             activation_dossier_summary_request,
             activation_dossier_summary_trace,
         );
+        journal.record_trace(
+            list_activation_readouts_request,
+            list_activation_readouts_trace,
+        );
+        journal.record_trace(
+            activation_readout_summary_request,
+            activation_readout_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -18751,9 +19442,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 85);
-        assert_eq!(journal_summary.completed_count, 85);
-        assert_eq!(journal.audit_records().len(), 85);
+        assert_eq!(journal_summary.invocation_count, 87);
+        assert_eq!(journal_summary.completed_count, 87);
+        assert_eq!(journal.audit_records().len(), 87);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -64,6 +64,10 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_dossiers` and
   `smart_home.get_integration_activation_dossier_summary` tool descriptors
   for read-only bundled activation decision and evidence planning.
+- `smart_home.list_integration_activation_readouts` and
+  `smart_home.get_integration_activation_readout_summary` tool descriptors
+  for read-only priority-wave activation readouts across health, dossiers,
+  evidence, risk, action, and dependency blockers.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -79,6 +79,8 @@ Current scope:
   behind approval and blocker decisions
 - D18D integration activation-dossier descriptors for read-only bundled
   decision and evidence planning
+- D18D integration activation-readout descriptors for priority-wave health,
+  dossier, evidence, risk, action, and dependency blocker rollups
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1483,6 +1483,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationEvidenceSummary,
     ListIntegrationActivationDossiers,
     GetIntegrationActivationDossierSummary,
+    ListIntegrationActivationReadouts,
+    GetIntegrationActivationReadoutSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1638,6 +1640,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationDossierSummary => {
                 read_tool("smart_home.get_integration_activation_dossier_summary")
+            }
+            Self::ListIntegrationActivationReadouts => {
+                read_tool("smart_home.list_integration_activation_readouts")
+            }
+            Self::GetIntegrationActivationReadoutSummary => {
+                read_tool("smart_home.get_integration_activation_readout_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2304,6 +2312,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationEvidenceSummary,
         SmartHomeTool::ListIntegrationActivationDossiers,
         SmartHomeTool::GetIntegrationActivationDossierSummary,
+        SmartHomeTool::ListIntegrationActivationReadouts,
+        SmartHomeTool::GetIntegrationActivationReadoutSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3146,7 +3156,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 85);
+        assert_eq!(catalog.len(), 87);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3310,6 +3320,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_dossier_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_readouts"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_readout_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3500,15 +3518,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 85);
-        assert_eq!(summary.read_tools, 77);
+        assert_eq!(summary.total_tools, 87);
+        assert_eq!(summary.read_tools, 79);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 77);
+        assert_eq!(summary.read_only_tier_tools, 79);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 85);
+        assert_eq!(summary.total_required_capabilities, 87);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -62,6 +62,8 @@ runtime and Chief of Staff tools a typed catalog for:
   policy-review, risk, and dependency evidence
 - activation dossier rows that bundle approval decisions with their evidence
   rows and compact evidence rollups for Chief planning
+- activation readout rows that combine priority-wave health, maintenance,
+  dossier, evidence, risk, action, and dependency blocker rollups
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1682,6 +1682,59 @@ pub struct IntegrationActivationMaintenanceSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReadoutStage {
+    pub priority: u8,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub maintenance_window: IntegrationActivationMaintenanceWindow,
+    pub dossiers: Vec<IntegrationActivationDossierItem>,
+    pub dossier_summary: IntegrationActivationDossierSummary,
+    pub evidence_summary: IntegrationActivationEvidenceSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReadoutSummary {
+    pub total_readouts: usize,
+    pub total_integrations: usize,
+    pub ready_readouts: usize,
+    pub review_readouts: usize,
+    pub blocked_readouts: usize,
+    pub empty_readouts: usize,
+    pub activation_ready_integrations: usize,
+    pub ready_to_activate_integrations: usize,
+    pub review_integrations: usize,
+    pub blocked_integrations: usize,
+    pub readouts_with_activation_work: usize,
+    pub readouts_with_approval_work: usize,
+    pub readouts_with_review_work: usize,
+    pub readouts_with_blockers: usize,
+    pub readouts_with_risks: usize,
+    pub readouts_with_dependency_blockers: usize,
+    pub total_actions: usize,
+    pub activate_integration_actions: usize,
+    pub review_policy_actions: usize,
+    pub blocking_constraints: usize,
+    pub review_constraints: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_dossiers: usize,
+    pub ready_to_approve_dossiers: usize,
+    pub blocked_dossiers: usize,
+    pub total_evidence: usize,
+    pub supporting_evidence: usize,
+    pub review_evidence: usize,
+    pub blocking_evidence: usize,
+    pub first_ready_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -2388,6 +2441,273 @@ impl IntegrationActivationMaintenanceSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.overall_status.requires_attention() || self.has_review_work() || self.has_blockers()
+    }
+}
+
+impl IntegrationActivationReadoutStage {
+    pub fn from_candidates(
+        catalog: &[IntegrationCatalogEntry],
+        priority: u8,
+        mut candidates: Vec<IntegrationActivationCandidate>,
+        enabled_integrations: &[IntegrationId],
+    ) -> Self {
+        candidates.sort_by(compare_activation_candidates);
+        let integration_ids = candidates
+            .iter()
+            .map(|candidate| candidate.readiness_report.requested_integration_id.clone())
+            .collect::<Vec<_>>();
+        let maintenance_window = IntegrationActivationMaintenanceWindow::from_candidates(
+            catalog,
+            priority,
+            candidates.clone(),
+            enabled_integrations,
+        );
+        let dossiers =
+            activation_dossiers_from_candidates(catalog, candidates.iter(), enabled_integrations);
+        let dossier_summary = IntegrationActivationDossierSummary::from_dossiers(dossiers.iter());
+        let evidence_summary = IntegrationActivationEvidenceSummary::from_evidence(
+            dossiers.iter().flat_map(|dossier| dossier.evidence.iter()),
+        );
+        let health_status = maintenance_window.health_status;
+
+        Self {
+            priority,
+            health_status,
+            integration_ids,
+            maintenance_window,
+            dossiers,
+            dossier_summary,
+            evidence_summary,
+        }
+    }
+
+    pub fn candidate_summary(&self) -> &IntegrationActivationCandidateSummary {
+        &self.maintenance_window.candidate_summary
+    }
+
+    pub fn action_summary(&self) -> &IntegrationActivationActionSummary {
+        &self.maintenance_window.action_summary
+    }
+
+    pub fn constraint_summary(&self) -> &IntegrationActivationConstraintSummary {
+        &self.maintenance_window.constraint_summary
+    }
+
+    pub fn risk_summary(&self) -> &IntegrationActivationRiskSummary {
+        &self.maintenance_window.risk_summary
+    }
+
+    pub fn dependency_summary(&self) -> &IntegrationActivationDependencySummary {
+        &self.maintenance_window.dependency_summary
+    }
+
+    pub fn has_ready_work(&self) -> bool {
+        self.maintenance_window.has_ready_work()
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.maintenance_window.has_activation_work()
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.dossier_summary.has_approval_ready_work()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.maintenance_window.has_review_work()
+            || self.dossier_summary.has_review_work()
+            || self.evidence_summary.has_review_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.maintenance_window.has_blockers()
+            || self.dossier_summary.has_blockers()
+            || self.evidence_summary.has_blockers()
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.maintenance_window.has_risks()
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.maintenance_window.has_dependency_blockers()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.maintenance_window.requires_attention()
+            || self.dossier_summary.requires_attention()
+            || self.evidence_summary.requires_attention()
+    }
+}
+
+impl IntegrationActivationReadoutSummary {
+    pub fn from_readouts<'a>(
+        readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+    ) -> Self {
+        let mut summary = Self {
+            total_readouts: 0,
+            total_integrations: 0,
+            ready_readouts: 0,
+            review_readouts: 0,
+            blocked_readouts: 0,
+            empty_readouts: 0,
+            activation_ready_integrations: 0,
+            ready_to_activate_integrations: 0,
+            review_integrations: 0,
+            blocked_integrations: 0,
+            readouts_with_activation_work: 0,
+            readouts_with_approval_work: 0,
+            readouts_with_review_work: 0,
+            readouts_with_blockers: 0,
+            readouts_with_risks: 0,
+            readouts_with_dependency_blockers: 0,
+            total_actions: 0,
+            activate_integration_actions: 0,
+            review_policy_actions: 0,
+            blocking_constraints: 0,
+            review_constraints: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_dossiers: 0,
+            ready_to_approve_dossiers: 0,
+            blocked_dossiers: 0,
+            total_evidence: 0,
+            supporting_evidence: 0,
+            review_evidence: 0,
+            blocking_evidence: 0,
+            first_ready_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_activation_priority: None,
+            first_approval_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for readout in readouts {
+            summary.total_readouts += 1;
+            summary.total_integrations += readout.candidate_summary().total_candidates;
+            summary.activation_ready_integrations +=
+                readout.candidate_summary().activation_ready_candidates;
+            summary.ready_to_activate_integrations +=
+                readout.candidate_summary().ready_to_activate_candidates;
+            summary.review_integrations +=
+                readout.candidate_summary().needs_human_review_candidates;
+            summary.blocked_integrations += readout.candidate_summary().blocked_candidates;
+
+            summary.total_actions += readout.action_summary().total_actions;
+            summary.activate_integration_actions +=
+                readout.action_summary().activate_integration_actions;
+            summary.review_policy_actions += readout.action_summary().review_policy_actions;
+            summary.blocking_constraints += readout.constraint_summary().blocking_constraints;
+            summary.review_constraints += readout.constraint_summary().review_constraints;
+            summary.total_risks += readout.risk_summary().total_risks;
+            summary.total_dependency_edges += readout.dependency_summary().total_edges;
+            summary.blocking_dependency_edges += readout.dependency_summary().blocking_edges;
+
+            summary.total_dossiers += readout.dossier_summary.total_dossiers;
+            summary.ready_to_approve_dossiers += readout.dossier_summary.ready_to_approve_dossiers;
+            summary.blocked_dossiers += readout.dossier_summary.blocked_dossiers;
+            summary.total_evidence += readout.evidence_summary.total_evidence;
+            summary.supporting_evidence += readout.evidence_summary.supporting_evidence;
+            summary.review_evidence += readout.evidence_summary.review_evidence;
+            summary.blocking_evidence += readout.evidence_summary.blocking_evidence;
+
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(readout.candidate_summary().highest_policy_tier)
+                .max(readout.action_summary().highest_policy_tier)
+                .max(readout.constraint_summary().highest_policy_tier)
+                .max(readout.risk_summary().highest_policy_tier)
+                .max(readout.dependency_summary().highest_policy_tier)
+                .max(readout.dossier_summary.highest_policy_tier)
+                .max(readout.evidence_summary.highest_policy_tier);
+
+            match readout.health_status {
+                IntegrationActivationHealthStatus::Ready => summary.ready_readouts += 1,
+                IntegrationActivationHealthStatus::NeedsReview => summary.review_readouts += 1,
+                IntegrationActivationHealthStatus::Blocked => summary.blocked_readouts += 1,
+                IntegrationActivationHealthStatus::Empty => summary.empty_readouts += 1,
+            }
+
+            if readout.has_activation_work() {
+                summary.readouts_with_activation_work += 1;
+                summary.first_activation_priority = min_optional_priority(
+                    summary.first_activation_priority,
+                    Some(readout.priority),
+                );
+            }
+            if readout.has_approval_ready_work() {
+                summary.readouts_with_approval_work += 1;
+                summary.first_approval_priority =
+                    min_optional_priority(summary.first_approval_priority, Some(readout.priority));
+            }
+            if readout.has_ready_work() {
+                summary.first_ready_priority =
+                    min_optional_priority(summary.first_ready_priority, Some(readout.priority));
+            }
+            if readout.has_review_work() {
+                summary.readouts_with_review_work += 1;
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(readout.priority));
+            }
+            if readout.has_blockers() {
+                summary.readouts_with_blockers += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(readout.priority));
+            }
+            if readout.has_risks() {
+                summary.readouts_with_risks += 1;
+            }
+            if readout.has_dependency_blockers() {
+                summary.readouts_with_dependency_blockers += 1;
+            }
+        }
+
+        summary.overall_status = activation_health_status_from_counts(
+            summary.ready_to_activate_integrations,
+            summary.review_integrations,
+            summary.blocked_integrations,
+        );
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_readouts == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activate_integration_actions > 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.ready_to_approve_dossiers > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_integrations > 0
+            || self.review_policy_actions > 0
+            || self.review_constraints > 0
+            || self.review_evidence > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_integrations > 0
+            || self.blocking_constraints > 0
+            || self.blocking_dependency_edges > 0
+            || self.blocking_evidence > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.total_risks > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention()
+            || self.has_approval_ready_work()
+            || self.has_review_work()
+            || self.has_blockers()
     }
 }
 
@@ -6135,6 +6455,55 @@ pub fn activation_dossiers_at_or_before_priority(
     activation_dossiers_from_candidates(catalog, candidates.iter(), enabled_integrations)
 }
 
+pub fn activation_readouts_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationReadoutStage> {
+    let mut readouts_by_priority: BTreeMap<u8, Vec<IntegrationActivationCandidate>> =
+        BTreeMap::new();
+    for candidate in candidates {
+        readouts_by_priority
+            .entry(candidate.readiness_report.priority)
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut readouts = readouts_by_priority
+        .into_iter()
+        .map(|(priority, candidates)| {
+            IntegrationActivationReadoutStage::from_candidates(
+                catalog,
+                priority,
+                candidates,
+                enabled_integrations,
+            )
+        })
+        .collect::<Vec<_>>();
+    readouts.sort_by(compare_activation_readouts);
+    readouts
+}
+
+pub fn activation_readouts_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationReadoutStage> {
+    activation_readouts_from_candidates(
+        catalog,
+        activation_candidates_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+        enabled_integrations,
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -7414,6 +7783,23 @@ fn compare_activation_dossiers(
                 .total_evidence
                 .cmp(&left.evidence_summary.total_evidence)
         })
+}
+
+fn compare_activation_readouts(
+    left: &IntegrationActivationReadoutStage,
+    right: &IntegrationActivationReadoutStage,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| {
+            right
+                .has_approval_ready_work()
+                .cmp(&left.has_approval_ready_work())
+        })
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.has_risks().cmp(&left.has_risks()))
 }
 
 fn compare_activation_dependency_nodes(
@@ -8931,6 +9317,145 @@ mod tests {
         assert!(catalog_dossiers
             .iter()
             .any(IntegrationActivationDossierItem::has_policy_surfaces));
+    }
+
+    #[test]
+    fn activation_readouts_roll_up_wave_health_dossiers_and_evidence() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+
+        let readouts = activation_readouts_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(readouts.len(), 3);
+        let approval_ready = readouts
+            .iter()
+            .find(|readout| readout.priority == 1)
+            .unwrap();
+        assert_eq!(
+            approval_ready.health_status,
+            IntegrationActivationHealthStatus::NeedsReview
+        );
+        assert!(approval_ready.has_approval_ready_work());
+        assert!(approval_ready.has_review_work());
+        assert_eq!(approval_ready.dossier_summary.ready_to_approve_dossiers, 1);
+        assert!(approval_ready.evidence_summary.has_supporting_evidence());
+
+        let blocked = readouts
+            .iter()
+            .find(|readout| readout.priority == 2)
+            .unwrap();
+        assert_eq!(
+            blocked.health_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(blocked.has_blockers());
+        assert!(blocked.has_review_work());
+        assert_eq!(blocked.dossier_summary.blocked_dossiers, 1);
+        assert!(blocked.evidence_summary.has_blockers());
+        assert!(blocked.dependency_summary().has_blocking_dependencies());
+
+        let ready = readouts
+            .iter()
+            .find(|readout| readout.priority == 3)
+            .unwrap();
+        assert_eq!(
+            ready.health_status,
+            IntegrationActivationHealthStatus::Ready
+        );
+        assert!(ready.has_activation_work());
+        assert!(!ready.has_approval_ready_work());
+
+        let summary = IntegrationActivationReadoutSummary::from_readouts(readouts.iter());
+        assert_eq!(summary.total_readouts, 3);
+        assert_eq!(summary.ready_readouts, 1);
+        assert_eq!(summary.review_readouts, 1);
+        assert_eq!(summary.blocked_readouts, 1);
+        assert_eq!(summary.total_dossiers, 2);
+        assert_eq!(summary.ready_to_approve_dossiers, 1);
+        assert_eq!(summary.blocked_dossiers, 1);
+        assert_eq!(summary.readouts_with_activation_work, 1);
+        assert_eq!(summary.readouts_with_approval_work, 1);
+        assert_eq!(summary.readouts_with_blockers, 2);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.supporting_evidence > 0);
+        assert!(summary.review_evidence > 0);
+        assert!(summary.blocking_evidence > 0);
+        assert_eq!(summary.first_approval_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(1));
+        assert_eq!(summary.first_activation_priority, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_activation_work());
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_readouts = activation_readouts_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_readouts
+            .iter()
+            .any(|readout| readout.dossier_summary.total_dossiers > 0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-level activation readout stages and summaries that combine priority-wave health, maintenance, dossier, evidence, risk, action, and dependency blocker rollups
- expose Chief read tools for listing activation readouts and retrieving compact readout summaries
- register the new readout descriptors in smart-home-core and document the surfaces

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools