### PR TITLE
Add browser lifecycle event descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness lifecycle-event descriptors now expose document/body load
+  and unload hooks, visibility/history/network lifecycle handlers, and
+  element-level error recovery as a flat browser-planning inventory.
 - Browser-readiness composition-interaction descriptors now expose IME
   composition events, beforeinput/input hooks, text controls, editing hosts, and
   blocked composition paths as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -828,6 +828,7 @@ pub struct BrowserDocument {
     pub document_event_handlers: Vec<String>,
     pub body_event_handlers: Vec<String>,
     pub event_handler_descriptors: Vec<BrowserEventHandlerDescriptor>,
+    pub lifecycle_event_descriptors: Vec<BrowserLifecycleEventDescriptor>,
     pub body_text: String,
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
@@ -1348,6 +1349,29 @@ pub struct BrowserEventHandlerDescriptor {
     pub lifecycle_handlers: Vec<String>,
     pub error_handlers: Vec<String>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserLifecycleEventDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub role: Option<String>,
+    pub source: String,
+    pub lifecycle_kind: String,
+    pub text: String,
+    pub event_handlers: Vec<String>,
+    pub lifecycle_handlers: Vec<String>,
+    pub load_handlers: Vec<String>,
+    pub unload_handlers: Vec<String>,
+    pub visibility_handlers: Vec<String>,
+    pub history_handlers: Vec<String>,
+    pub network_handlers: Vec<String>,
+    pub error_handlers: Vec<String>,
+    pub handler_count: usize,
+    pub document_scope: bool,
+    pub body_scope: bool,
+    pub error_recovery: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3195,6 +3219,7 @@ impl BrowserDocument {
             browser_composition_interaction_descriptors(&summary);
         summary.pointer_interaction_descriptors = browser_pointer_interaction_descriptors(&summary);
         summary.scroll_interaction_descriptors = browser_scroll_interaction_descriptors(&summary);
+        summary.lifecycle_event_descriptors = browser_lifecycle_event_descriptors(&summary);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -15284,6 +15309,102 @@ fn browser_scroll_kind(
     }
 }
 
+fn browser_lifecycle_event_descriptors(
+    document: &BrowserDocument,
+) -> Vec<BrowserLifecycleEventDescriptor> {
+    document
+        .event_handler_descriptors
+        .iter()
+        .filter(|descriptor| browser_event_descriptor_has_lifecycle_state(descriptor))
+        .map(browser_lifecycle_event_descriptor)
+        .collect()
+}
+
+fn browser_event_descriptor_has_lifecycle_state(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !descriptor.lifecycle_handlers.is_empty() || !descriptor.error_handlers.is_empty()
+}
+
+fn browser_lifecycle_event_descriptor(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserLifecycleEventDescriptor {
+    let load_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_load_lifecycle_event);
+    let unload_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_unload_lifecycle_event);
+    let visibility_handlers = browser_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        browser_visibility_lifecycle_event,
+    );
+    let history_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_history_lifecycle_event);
+    let network_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_network_lifecycle_event);
+
+    BrowserLifecycleEventDescriptor {
+        element: descriptor.element.clone(),
+        id: descriptor.id.clone(),
+        classes: descriptor.classes.clone(),
+        role: descriptor.role.clone(),
+        source: descriptor.source.clone(),
+        lifecycle_kind: browser_lifecycle_kind(
+            &load_handlers,
+            &unload_handlers,
+            &visibility_handlers,
+            &history_handlers,
+            &network_handlers,
+            &descriptor.error_handlers,
+        ),
+        text: descriptor.text.clone(),
+        event_handlers: descriptor.event_handlers.clone(),
+        lifecycle_handlers: descriptor.lifecycle_handlers.clone(),
+        load_handlers,
+        unload_handlers,
+        visibility_handlers,
+        history_handlers,
+        network_handlers,
+        error_handlers: descriptor.error_handlers.clone(),
+        handler_count: descriptor.lifecycle_handlers.len() + descriptor.error_handlers.len(),
+        document_scope: descriptor.source == "document",
+        body_scope: descriptor.source == "body",
+        error_recovery: !descriptor.error_handlers.is_empty(),
+    }
+}
+
+fn browser_lifecycle_kind(
+    load_handlers: &[String],
+    unload_handlers: &[String],
+    visibility_handlers: &[String],
+    history_handlers: &[String],
+    network_handlers: &[String],
+    error_handlers: &[String],
+) -> String {
+    if !error_handlers.is_empty()
+        && (!load_handlers.is_empty()
+            || !unload_handlers.is_empty()
+            || !visibility_handlers.is_empty()
+            || !history_handlers.is_empty()
+            || !network_handlers.is_empty())
+    {
+        "lifecycle-error".to_string()
+    } else if !error_handlers.is_empty() {
+        "error-recovery".to_string()
+    } else if !unload_handlers.is_empty() {
+        "unload".to_string()
+    } else if !load_handlers.is_empty() {
+        "load".to_string()
+    } else if !visibility_handlers.is_empty() {
+        "visibility".to_string()
+    } else if !history_handlers.is_empty() {
+        "history".to_string()
+    } else if !network_handlers.is_empty() {
+        "network".to_string()
+    } else {
+        "lifecycle".to_string()
+    }
+}
+
 fn browser_command_role(element: &Element) -> String {
     browser_authored_role(element).unwrap_or_else(|| {
         browser_content_role(&element.name)
@@ -17304,7 +17425,35 @@ fn browser_lifecycle_event(handler: &str) -> bool {
             | "onpagehide"
             | "onreadystatechange"
             | "ondomcontentloaded"
+            | "onvisibilitychange"
+            | "onhashchange"
+            | "onpopstate"
+            | "ononline"
+            | "onoffline"
     )
+}
+
+fn browser_load_lifecycle_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onload" | "onpageshow" | "onreadystatechange" | "ondomcontentloaded"
+    )
+}
+
+fn browser_unload_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "onunload" | "onbeforeunload" | "onpagehide")
+}
+
+fn browser_visibility_lifecycle_event(handler: &str) -> bool {
+    handler == "onvisibilitychange"
+}
+
+fn browser_history_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "onhashchange" | "onpopstate")
+}
+
+fn browser_network_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "ononline" | "onoffline")
 }
 
 fn browser_error_event(handler: &str) -> bool {
@@ -23429,6 +23578,64 @@ mod tests {
         let input = &summary.event_handler_descriptors[6];
         assert_eq!(input.role.as_deref(), Some("control"));
         assert_eq!(input.form_handlers, vec!["oninput", "onchange"]);
+    }
+
+    #[test]
+    fn browser_lifecycle_event_descriptors_track_load_history_visibility_and_errors() {
+        let html = "<html onreadystatechange=ready onvisibilitychange=visible>\
+             <body onload=boot onbeforeunload=confirmExit onpagehide=hide ononline=online>\
+             <main id=app onhashchange=route onpopstate=state>App</main>\
+             <img id=hero src=hero.jpg alt=Hero onerror=fallback onabort=abortLoad>\
+             <dialog id=modal oncancel=cancelDialog>Dialog</dialog></body></html>";
+        let summary = parse_browser_document(html).expect("browser document should parse");
+
+        assert_eq!(summary.lifecycle_event_descriptors.len(), 5);
+
+        let document = &summary.lifecycle_event_descriptors[0];
+        assert_eq!(document.element, "html");
+        assert_eq!(document.source, "document");
+        assert_eq!(document.lifecycle_kind, "load");
+        assert_eq!(
+            document.lifecycle_handlers,
+            vec!["onreadystatechange", "onvisibilitychange"]
+        );
+        assert_eq!(document.load_handlers, vec!["onreadystatechange"]);
+        assert_eq!(document.visibility_handlers, vec!["onvisibilitychange"]);
+        assert_eq!(document.handler_count, 2);
+        assert!(document.document_scope);
+
+        let body = &summary.lifecycle_event_descriptors[1];
+        assert_eq!(body.element, "body");
+        assert_eq!(body.lifecycle_kind, "unload");
+        assert_eq!(body.unload_handlers, vec!["onbeforeunload", "onpagehide"]);
+        assert_eq!(body.network_handlers, vec!["ononline"]);
+        assert!(body.body_scope);
+
+        let main = summary
+            .lifecycle_event_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("app"))
+            .expect("main lifecycle descriptor");
+        assert_eq!(main.lifecycle_kind, "history");
+        assert_eq!(main.history_handlers, vec!["onhashchange", "onpopstate"]);
+        assert!(!main.error_recovery);
+
+        let image = summary
+            .lifecycle_event_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("hero"))
+            .expect("image lifecycle descriptor");
+        assert_eq!(image.lifecycle_kind, "error-recovery");
+        assert_eq!(image.error_handlers, vec!["onerror", "onabort"]);
+        assert!(image.error_recovery);
+
+        let dialog = summary
+            .lifecycle_event_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("modal"))
+            .expect("dialog lifecycle descriptor");
+        assert_eq!(dialog.lifecycle_kind, "error-recovery");
+        assert_eq!(dialog.error_handlers, vec!["oncancel"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -16,15 +16,16 @@ use coding_adventures_html_parser::{
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
     BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
     BrowserInputPlanningDescriptor, BrowserInteractiveElement,
-    BrowserKeyboardInteractionDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
-    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserScriptExecutionDescriptor, BrowserScrollInteractionDescriptor, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserSelectionInteractionDescriptor, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
+    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
+    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -69,6 +70,8 @@ struct ExpectedBrowserDocument {
     body_event_handlers: Vec<String>,
     #[serde(default)]
     event_handler_descriptors: Vec<ExpectedEventHandlerDescriptor>,
+    #[serde(default)]
+    lifecycle_event_descriptors: Option<Vec<ExpectedLifecycleEventDescriptor>>,
     body_text: String,
     metas: Vec<ExpectedMeta>,
     resources: Vec<ExpectedResource>,
@@ -627,6 +630,45 @@ struct ExpectedEventHandlerDescriptor {
     error_handlers: Vec<String>,
     #[serde(default)]
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedLifecycleEventDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    role: Option<String>,
+    source: String,
+    lifecycle_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    lifecycle_handlers: Vec<String>,
+    #[serde(default)]
+    load_handlers: Vec<String>,
+    #[serde(default)]
+    unload_handlers: Vec<String>,
+    #[serde(default)]
+    visibility_handlers: Vec<String>,
+    #[serde(default)]
+    history_handlers: Vec<String>,
+    #[serde(default)]
+    network_handlers: Vec<String>,
+    #[serde(default)]
+    error_handlers: Vec<String>,
+    #[serde(default)]
+    handler_count: usize,
+    #[serde(default)]
+    document_scope: bool,
+    #[serde(default)]
+    body_scope: bool,
+    #[serde(default)]
+    error_recovery: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5007,6 +5049,26 @@ fn browser_event_handler_descriptors_track_document_and_element_wiring() {
     );
 }
 
+#[test]
+fn browser_lifecycle_event_descriptors_track_load_and_error_recovery_hooks() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "event-handler-page")
+        .expect("event handler fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("event handler fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.lifecycle_event_descriptors,
+        case.expected.into_browser_document().lifecycle_event_descriptors,
+        "lifecycle-event descriptors should preserve document/body load hooks and element error-recovery handlers",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         let metadata = self.metadata.into_browser_document_metadata();
@@ -5045,6 +5107,15 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedEventHandlerDescriptor::into_browser_event_handler_descriptor)
             .collect();
+        let lifecycle_event_descriptors = self
+            .lifecycle_event_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedLifecycleEventDescriptor::into_browser_lifecycle_event_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_lifecycle_event_descriptors(&event_handler_descriptors));
         let global_state_descriptors: Vec<_> = self
             .global_state_descriptors
             .into_iter()
@@ -5307,6 +5378,7 @@ impl ExpectedBrowserDocument {
             document_event_handlers: self.document_event_handlers,
             body_event_handlers: self.body_event_handlers,
             event_handler_descriptors,
+            lifecycle_event_descriptors,
             body_text: self.body_text,
             metas: self
                 .metas
@@ -5708,6 +5780,32 @@ impl ExpectedEventHandlerDescriptor {
             lifecycle_handlers: self.lifecycle_handlers,
             error_handlers: self.error_handlers,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedLifecycleEventDescriptor {
+    fn into_browser_lifecycle_event_descriptor(self) -> BrowserLifecycleEventDescriptor {
+        BrowserLifecycleEventDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            role: self.role,
+            source: self.source,
+            lifecycle_kind: self.lifecycle_kind,
+            text: self.text,
+            event_handlers: self.event_handlers,
+            lifecycle_handlers: self.lifecycle_handlers,
+            load_handlers: self.load_handlers,
+            unload_handlers: self.unload_handlers,
+            visibility_handlers: self.visibility_handlers,
+            history_handlers: self.history_handlers,
+            network_handlers: self.network_handlers,
+            error_handlers: self.error_handlers,
+            handler_count: self.handler_count,
+            document_scope: self.document_scope,
+            body_scope: self.body_scope,
+            error_recovery: self.error_recovery,
         }
     }
 }
@@ -8704,6 +8802,107 @@ fn expected_event_handlers_by_kind(
         .collect()
 }
 
+fn expected_lifecycle_event_descriptors(
+    event_handler_descriptors: &[BrowserEventHandlerDescriptor],
+) -> Vec<BrowserLifecycleEventDescriptor> {
+    event_handler_descriptors
+        .iter()
+        .filter(|descriptor| expected_event_descriptor_has_lifecycle_state(descriptor))
+        .map(expected_lifecycle_event_descriptor)
+        .collect()
+}
+
+fn expected_event_descriptor_has_lifecycle_state(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !descriptor.lifecycle_handlers.is_empty() || !descriptor.error_handlers.is_empty()
+}
+
+fn expected_lifecycle_event_descriptor(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserLifecycleEventDescriptor {
+    let load_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_load_lifecycle_event);
+    let unload_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_unload_lifecycle_event,
+    );
+    let visibility_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_visibility_lifecycle_event,
+    );
+    let history_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_history_lifecycle_event,
+    );
+    let network_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_network_lifecycle_event,
+    );
+
+    BrowserLifecycleEventDescriptor {
+        element: descriptor.element.clone(),
+        id: descriptor.id.clone(),
+        classes: descriptor.classes.clone(),
+        role: descriptor.role.clone(),
+        source: descriptor.source.clone(),
+        lifecycle_kind: expected_lifecycle_kind(
+            &load_handlers,
+            &unload_handlers,
+            &visibility_handlers,
+            &history_handlers,
+            &network_handlers,
+            &descriptor.error_handlers,
+        ),
+        text: descriptor.text.clone(),
+        event_handlers: descriptor.event_handlers.clone(),
+        lifecycle_handlers: descriptor.lifecycle_handlers.clone(),
+        load_handlers,
+        unload_handlers,
+        visibility_handlers,
+        history_handlers,
+        network_handlers,
+        error_handlers: descriptor.error_handlers.clone(),
+        handler_count: descriptor.lifecycle_handlers.len() + descriptor.error_handlers.len(),
+        document_scope: descriptor.source == "document",
+        body_scope: descriptor.source == "body",
+        error_recovery: !descriptor.error_handlers.is_empty(),
+    }
+}
+
+fn expected_lifecycle_kind(
+    load_handlers: &[String],
+    unload_handlers: &[String],
+    visibility_handlers: &[String],
+    history_handlers: &[String],
+    network_handlers: &[String],
+    error_handlers: &[String],
+) -> String {
+    if !error_handlers.is_empty()
+        && (!load_handlers.is_empty()
+            || !unload_handlers.is_empty()
+            || !visibility_handlers.is_empty()
+            || !history_handlers.is_empty()
+            || !network_handlers.is_empty())
+    {
+        "lifecycle-error".to_string()
+    } else if !error_handlers.is_empty() {
+        "error-recovery".to_string()
+    } else if !unload_handlers.is_empty() {
+        "unload".to_string()
+    } else if !load_handlers.is_empty() {
+        "load".to_string()
+    } else if !visibility_handlers.is_empty() {
+        "visibility".to_string()
+    } else if !history_handlers.is_empty() {
+        "history".to_string()
+    } else if !network_handlers.is_empty() {
+        "network".to_string()
+    } else {
+        "lifecycle".to_string()
+    }
+}
+
 fn expected_keyboard_event(handler: &str) -> bool {
     matches!(handler, "onkeydown" | "onkeypress" | "onkeyup")
 }
@@ -8719,6 +8918,29 @@ fn expected_input_event(handler: &str) -> bool {
             | "oncompositionupdate"
             | "oncompositionend"
     )
+}
+
+fn expected_load_lifecycle_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onload" | "onpageshow" | "onreadystatechange" | "ondomcontentloaded"
+    )
+}
+
+fn expected_unload_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "onunload" | "onbeforeunload" | "onpagehide")
+}
+
+fn expected_visibility_lifecycle_event(handler: &str) -> bool {
+    handler == "onvisibilitychange"
+}
+
+fn expected_history_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "onhashchange" | "onpopstate")
+}
+
+fn expected_network_lifecycle_event(handler: &str) -> bool {
+    matches!(handler, "ononline" | "onoffline")
 }
 
 fn expected_pointer_event(handler: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -44,6 +44,9 @@ language/type hints, download/referrer policy, and area geometry.
 Event-handler descriptor cases pin document, body, and element inline handler
 metadata as a flat inventory categorized by activation, keyboard, form, media,
 lifecycle, and error/event-recovery concerns without evaluating script text.
+Lifecycle-event descriptor cases pin document/body load and unload hooks,
+visibility/history/network lifecycle handlers, and element-level error recovery
+as a flat browser-planning inventory.
 Disclosure-state descriptor cases pin details/dialog open state, grouped details
 names, summary text, dialog modal/closedby behavior, and accessible naming
 metadata as a flat browser-planning inventory.


### PR DESCRIPTION
## Summary
- Add browser lifecycle-event descriptors for document/body load and unload hooks, visibility/history/network handlers, and element-level error recovery.
- Wire derived browser-readiness fixture expectations and a dedicated fixture assertion.
- Update the html-parser changelog and fixture README inventory.

## Tests
- `cargo fmt -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-parser browser_lifecycle_event_descriptors`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `cargo test -p coding-adventures-html-parser browser_`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
