### PR TITLE
feat(cas-summation): closed-form transcendental sums port (Track I2)

### DIFF
--- a/code/packages/rust/cas-summation/CHANGELOG.md
+++ b/code/packages/rust/cas-summation/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 2.28.0 — 2026-05-29
+
+### Added — Track I2 (Closed-form transcendental infinite sums port)
+
+Ports the Python ``cas_summation.series_closed_forms`` module (Track I1,
+PR #5382) to Rust ``cas-summation``.  Pattern-matches the canonical
+convergent infinite series and emits their closed forms when
+``hi = %inf``:
+
+- ``sum(1/k^(2m), k, 1, %inf) → ζ(2m) · π^(2m)`` for ``m = 1..6``
+  (Basel through ``ζ(12) = 691·π¹²/638512875``).
+- ``sum((-1)^(k-1)/k, k, 1, %inf) → log(2)`` (Mercator).
+- ``sum((-1)^(k-1)/k^(2m), k, 1, %inf) → η(2m) · π^(2m)`` for
+  ``m = 1..3`` (Dirichlet eta).
+- ``sum(1/k!, k, 0, %inf) → %e``.
+- ``sum(x^k/k!, k, 0, %inf) → exp(x)`` (symbolic ``x ≠ k``).
+- ``sum((-1)^k · x^(2k)/(2k)!, k, 0, %inf) → cos(x)``.
+- ``sum((-1)^k · x^(2k+1)/(2k+1)!, k, 0, %inf) → sin(x)``.
+- ``sum(x^(2k)/(2k)!, k, 0, %inf) → cosh(x)``.
+- ``sum(x^(2k+1)/(2k+1)!, k, 0, %inf) → sinh(x)``.
+
+The new ``try_closed_form_series`` handler is wired into
+``evaluate_sum`` between the existing ``try_special_infinite`` (legacy
+Basel + Leibniz table) and the small-range numeric path; pre-existing
+tests stay on their original routes because the legacy table fires
+first for the overlapping ``ζ(2)`` / ``ζ(4)`` / ``π/4`` patterns.
+
+One generic ``bernoulli_rational`` helper computes ``B_n`` via the
+textbook recurrence ``B_0 = 1; Σ_{j=0}^{n} C(n+1, j) · B_j = 0``.  Six
+even-zeta exponents and three even-eta exponents share the same code —
+no per-degree tables.  The recurrence depth is bounded by ``n ≤ 12``,
+so the helper is provably terminating, and the cache is initialised
+lazily via ``OnceLock``.
+
+All numeric work is exact: intermediate ``Frac`` values are ``i128``
+to handle the binomial-recurrence products without overflow, then
+down-cast to ``i64`` for the IR literal (every emitted value sits
+comfortably inside i64 — ``638_512_875`` is the largest denominator).
+
+### Notes
+
+Falls through (returns ``None``) for: odd zeta ``ζ(2m+1)``, indices
+past ``m > 6``, wrong lower bound (zeta requires ``lo=1``, Taylor
+requires ``lo=0``), finite upper bound, and any non-table summand
+(``sin(k)``, ``log(k)``, etc.).
+
 ## 2.27.0 — 2026-05-29
 
 ### Added — Track H2 (Gosper hypergeometric summation port)

--- a/code/packages/rust/cas-summation/Cargo.toml
+++ b/code/packages/rust/cas-summation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-summation"
-version = "2.27.0"
+version = "2.28.0"
 edition = "2021"
 description = "Symbolic summation and product evaluation over symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-summation/src/lib.rs
+++ b/code/packages/rust/cas-summation/src/lib.rs
@@ -3,12 +3,14 @@ use std::cmp::Ordering;
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, DIV, EXP, LOG, MUL, NEG, POW, SUB};
 
 pub mod gosper;
+pub mod series_closed_forms;
 
 pub const SUM: &str = "Sum";
 pub const PRODUCT: &str = "Product";
 pub const GAMMA_FUNC: &str = "GammaFunc";
 
 pub use gosper::{try_gosper_sum, MAX_POLY_DEGREE};
+pub use series_closed_forms::{bernoulli_rational, try_closed_form_series};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rational {
@@ -350,6 +352,20 @@ fn evaluate_sum_inner(
 
     if inf_upper {
         if let Some(raw) = try_special_infinite(&f, &k, &lo) {
+            return eval_fn(raw);
+        }
+    }
+
+    // Track I2 — closed-form transcendental infinite sums.  Recognises the
+    // canonical zeta(2m), eta(2m), eta(1) = log(2), e_series, exp/cos/sin/
+    // cosh/sinh Taylor series.  Mirrors the Python dispatch insertion point
+    // (step 5a): placed after `try_special_infinite` so its pre-existing
+    // patterns (Basel zeta(2)/zeta(4), Leibniz π/4) keep their IR shapes
+    // and tests; `try_closed_form_series` only fires on patterns the
+    // legacy handler refuses (e.g. ``Σ 1/k⁶``, the eta family, sin/cos/
+    // sinh/cosh).
+    if inf_upper {
+        if let Some(raw) = series_closed_forms::try_closed_form_series(&f, &k, &lo, &hi) {
             return eval_fn(raw);
         }
     }

--- a/code/packages/rust/cas-summation/src/series_closed_forms.rs
+++ b/code/packages/rust/cas-summation/src/series_closed_forms.rs
@@ -1,0 +1,990 @@
+//! Canonical infinite-series closed-form recogniser — Track I2.
+//!
+//! Rust port of
+//! `code/packages/python/cas-summation/src/cas_summation/series_closed_forms.py`
+//! (Track I1, PR #5382).  See the Python source for the full mathematical
+//! background — this module mirrors it 1:1.
+//!
+//! # Recognised series
+//!
+//! - `∑_{k=1}^∞ 1/k^(2m)`           (m = 1..6) → `(2π)^(2m) · |B_{2m}| / (2·(2m)!)`
+//! - `∑_{k=1}^∞ (-1)^(k-1)/k`                  → `log(2)`
+//! - `∑_{k=1}^∞ (-1)^(k-1)/k^(2m)`  (m = 1..3) → `(1 − 2^(1-2m)) · ζ(2m)`
+//! - `∑_{k=0}^∞ 1/k!`                          → `%e`
+//! - `∑_{k=0}^∞ x^k/k!`                        → `exp(x)`
+//! - `∑_{k=0}^∞ (-1)^k · x^(2k)/(2k)!`         → `cos(x)`
+//! - `∑_{k=0}^∞ (-1)^k · x^(2k+1)/(2k+1)!`     → `sin(x)`
+//! - `∑_{k=0}^∞ x^(2k)/(2k)!`                  → `cosh(x)`
+//! - `∑_{k=0}^∞ x^(2k+1)/(2k+1)!`              → `sinh(x)`
+//!
+//! # Design constraints (per Python reference)
+//!
+//! - One generic Bernoulli helper, computed via the textbook recurrence
+//!   `B_0 = 1; Σ_{j=0}^{n} C(n+1, j) · B_j = 0`.  Bounded depth: caller
+//!   never asks for `n > 12`.
+//! - Exact rational arithmetic; intermediate products use `i128` to stay
+//!   below i64 overflow even for the largest case (η(6) ≈ 31/30240).
+//! - Only fires when `hi = %inf`.
+
+use std::sync::OnceLock;
+
+use symbolic_ir::{
+    apply, int, rat, sym, IRNode, ADD, COS, COSH, DIV, EXP, LOG, MUL, NEG, POW, SIN, SINH, SUB,
+};
+
+use crate::GAMMA_FUNC;
+
+/// Maximum even-zeta exponent — spec covers k = 2..12 (m = 1..6).
+const MAX_ZETA_M: usize = 6;
+/// Maximum even-eta exponent — spec covers m = 1..3.
+const MAX_ETA_M: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Exact rational arithmetic on i128.  Mirrors Python's `Fraction` and the
+// outer `Rational` type in lib.rs.  Kept module-local so we don't widen the
+// public API; we use i128 internally to handle the binomial recurrence
+// intermediates without overflow even for η(6).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Frac {
+    /// Numerator (carries sign).
+    pub n: i128,
+    /// Denominator (always positive after normalisation).
+    pub d: i128,
+}
+
+fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
+    a = a.abs();
+    b = b.abs();
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    if a == 0 {
+        1
+    } else {
+        a
+    }
+}
+
+fn mk_f(n: i128, d: i128) -> Frac {
+    assert!(d != 0, "Frac denominator cannot be zero");
+    let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
+    let g = gcd_i128(n, d);
+    Frac { n: n / g, d: d / g }
+}
+
+const F0: Frac = Frac { n: 0, d: 1 };
+const F1: Frac = Frac { n: 1, d: 1 };
+
+fn f_add(a: Frac, b: Frac) -> Frac {
+    mk_f(a.n * b.d + b.n * a.d, a.d * b.d)
+}
+
+fn f_sub(a: Frac, b: Frac) -> Frac {
+    mk_f(a.n * b.d - b.n * a.d, a.d * b.d)
+}
+
+fn f_mul(a: Frac, b: Frac) -> Frac {
+    mk_f(a.n * b.n, a.d * b.d)
+}
+
+fn f_div(a: Frac, b: Frac) -> Frac {
+    assert!(b.n != 0, "Frac division by zero");
+    mk_f(a.n * b.d, a.d * b.n)
+}
+
+fn f_neg(a: Frac) -> Frac {
+    Frac { n: -a.n, d: a.d }
+}
+
+fn f_abs(a: Frac) -> Frac {
+    Frac { n: a.n.abs(), d: a.d }
+}
+
+/// Convert a Frac to the smallest IR literal.  Down-casts to i64 because
+/// every value we emit (Bernoulli, factorial denominators, etc.) is well
+/// within i64 range — `638512875` for ζ(12), much smaller for η(6).
+fn frac_to_ir(c: Frac) -> IRNode {
+    let n = i128_to_i64(c.n);
+    let d = i128_to_i64(c.d);
+    if d == 1 {
+        int(n)
+    } else {
+        rat(n, d)
+    }
+}
+
+fn i128_to_i64(v: i128) -> i64 {
+    assert!(v >= i64::MIN as i128 && v <= i64::MAX as i128, "value overflows i64");
+    v as i64
+}
+
+// ---------------------------------------------------------------------------
+// IR construction helpers
+// ---------------------------------------------------------------------------
+
+fn binary(head: &str, a: IRNode, b: IRNode) -> IRNode {
+    apply(sym(head), vec![a, b])
+}
+
+fn unary(head: &str, a: IRNode) -> IRNode {
+    apply(sym(head), vec![a])
+}
+
+fn pow_ir(base: IRNode, exp: IRNode) -> IRNode {
+    binary(POW, base, exp)
+}
+
+fn mul_ir(a: IRNode, b: IRNode) -> IRNode {
+    binary(MUL, a, b)
+}
+
+fn div_ir(a: IRNode, b: IRNode) -> IRNode {
+    binary(DIV, a, b)
+}
+
+fn pi() -> IRNode {
+    sym("%pi")
+}
+
+fn e_sym() -> IRNode {
+    sym("%e")
+}
+
+fn head_is(node: &IRNode, name: &str) -> bool {
+    matches!(node, IRNode::Symbol(actual) if actual == name)
+}
+
+fn is_int_val(node: &IRNode, value: i64) -> bool {
+    matches!(node, IRNode::Integer(actual) if *actual == value)
+}
+
+/// True for `-1` whether stored as `Integer(-1)` or `Neg(1)`.
+fn is_neg_one_base(node: &IRNode) -> bool {
+    if is_int_val(node, -1) {
+        return true;
+    }
+    matches!(node, IRNode::Apply(a)
+        if head_is(&a.head, NEG)
+            && a.args.len() == 1
+            && is_int_val(&a.args[0], 1))
+}
+
+/// True iff `node` is structurally constant in `k`.
+fn is_constant_in_k(node: &IRNode, k: &IRNode) -> bool {
+    if node == k {
+        return false;
+    }
+    match node {
+        IRNode::Apply(a) => a.args.iter().all(|arg| is_constant_in_k(arg, k)),
+        _ => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bernoulli numbers (one generic helper)
+// ---------------------------------------------------------------------------
+
+/// Lazily-initialised cache of `B_0..B_12`.  Filled on first call;
+/// thread-safe via `OnceLock`.  Bounded depth: caller never asks for
+/// indices beyond `2 · MAX_ZETA_M = 12`.
+fn bernoulli_cache() -> &'static Vec<Frac> {
+    static CACHE: OnceLock<Vec<Frac>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        // Compute B_0..B_12 once via the textbook recurrence:
+        //   B_0 = 1
+        //   B_m = − (1 / (m+1)) · Σ_{j=0}^{m-1} C(m+1, j) · B_j   (m ≥ 1)
+        // Iterative `for j in 0..m` loop — depth `m`, bounded.
+        const N: usize = 2 * MAX_ZETA_M; // = 12
+        let mut bs: Vec<Frac> = vec![F0; N + 1];
+        bs[0] = F1;
+        for m in 1..=N {
+            let mut total = F0;
+            // C(m+1, 0) = 1, then update C(m+1, j) → C(m+1, j+1) iteratively.
+            let mut binom: i128 = 1;
+            let m_big = m as i128;
+            for j in 0..m {
+                total = f_add(total, f_mul(Frac { n: binom, d: 1 }, bs[j]));
+                let j_big = j as i128;
+                binom = (binom * (m_big + 1 - j_big)) / (j_big + 1);
+            }
+            bs[m] = f_div(f_neg(total), Frac { n: m_big + 1, d: 1 });
+        }
+        bs
+    })
+}
+
+/// Return `B_n` (the n-th Bernoulli number) as an exact `Frac`.
+///
+/// Cached: first call computes B_0..B_12; subsequent calls are O(1).
+/// Caller must pass `n ≤ 12` (the cache size); larger `n` panics.
+pub fn bernoulli_rational(n: usize) -> Frac {
+    let cache = bernoulli_cache();
+    assert!(n < cache.len(), "Bernoulli index {} exceeds cache size", n);
+    cache[n]
+}
+
+/// Return the rational coefficient `c` such that `ζ(2m) = c · π^(2m)`.
+///
+///   c = 2^(2m) · |B_{2m}| / (2 · (2m)!)
+fn zeta_even_coeff(m: usize) -> Frac {
+    assert!(m >= 1, "zeta-even index must be ≥ 1");
+    let b = bernoulli_rational(2 * m);
+    let mut factorial_2m: i128 = 1;
+    for i in 1..=(2 * m) as i128 {
+        factorial_2m *= i;
+    }
+    let two_to_two_m: i128 = 1_i128 << (2 * m);
+    f_div(
+        f_mul(Frac { n: two_to_two_m, d: 1 }, f_abs(b)),
+        Frac { n: 2 * factorial_2m, d: 1 },
+    )
+}
+
+/// Return the rational coefficient `c` such that `η(2m) = c · π^(2m)`.
+///
+///   η(2m) = (1 − 2^(1−2m)) · ζ(2m)
+fn eta_even_coeff(m: usize) -> Frac {
+    assert!(m >= 1, "eta-even index must be ≥ 1");
+    // 1 − 2^(1−2m) = 1 − 1/2^(2m-1).
+    let two_exp: i128 = 1_i128 << (2 * m - 1);
+    let one_minus = f_sub(F1, Frac { n: 1, d: two_exp });
+    f_mul(one_minus, zeta_even_coeff(m))
+}
+
+/// Build IR for `coeff · π^power`.  Emits the canonical form
+/// `π^power / denom` when `coeff = 1/denom`; otherwise the general
+/// `coeff · π^power` shape.
+fn pi_power_with_coeff(coeff: Frac, power: i64) -> IRNode {
+    if coeff.n == 1 && coeff.d > 1 {
+        return div_ir(pow_ir(pi(), int(power)), int(i128_to_i64(coeff.d)));
+    }
+    mul_ir(frac_to_ir(coeff), pow_ir(pi(), int(power)))
+}
+
+// ---------------------------------------------------------------------------
+// Pattern recognisers
+// ---------------------------------------------------------------------------
+
+/// Match `1/k^m` (or `1/k` ≡ m=1) and return `m`; else `None`.
+fn extract_inv_k_pow(f: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, DIV) || node.args.len() != 2 {
+        return None;
+    }
+    if !is_int_val(&node.args[0], 1) {
+        return None;
+    }
+    let denom = &node.args[1];
+    if denom == k {
+        return Some(1);
+    }
+    let IRNode::Apply(d) = denom else {
+        return None;
+    };
+    if !head_is(&d.head, POW) || d.args.len() != 2 {
+        return None;
+    }
+    if &d.args[0] != k {
+        return None;
+    }
+    if let IRNode::Integer(m) = d.args[1] {
+        if m >= 1 {
+            return Some(m);
+        }
+    }
+    None
+}
+
+/// Match `(-1)^(k-1) / k^m` and return `m`; else `None`.
+fn extract_alt_inv_k_pow(f: &IRNode, k: &IRNode) -> Option<i64> {
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, DIV) || node.args.len() != 2 {
+        return None;
+    }
+    let numer = &node.args[0];
+    let denom = &node.args[1];
+    // Numerator: (-1)^(k-1).
+    let IRNode::Apply(num) = numer else {
+        return None;
+    };
+    if !head_is(&num.head, POW) || num.args.len() != 2 {
+        return None;
+    }
+    if !is_neg_one_base(&num.args[0]) {
+        return None;
+    }
+    let exp = &num.args[1];
+    let IRNode::Apply(e) = exp else {
+        return None;
+    };
+    if !head_is(&e.head, SUB) || e.args.len() != 2 {
+        return None;
+    }
+    if &e.args[0] != k || !is_int_val(&e.args[1], 1) {
+        return None;
+    }
+    // Denominator: k or k^m.
+    if denom == k {
+        return Some(1);
+    }
+    let IRNode::Apply(d) = denom else {
+        return None;
+    };
+    if !head_is(&d.head, POW) || d.args.len() != 2 {
+        return None;
+    }
+    if &d.args[0] != k {
+        return None;
+    }
+    if let IRNode::Integer(m) = d.args[1] {
+        if m >= 1 {
+            return Some(m);
+        }
+    }
+    None
+}
+
+/// `Σ_{k=1}^∞ 1/k^(2m) → ζ(2m) · π^(2m)` for `m = 1..6`.
+fn try_zeta_2m(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    if !is_int_val(lo, 1) {
+        return None;
+    }
+    let m_exp = extract_inv_k_pow(f, k)?;
+    if m_exp % 2 != 0 {
+        return None;
+    }
+    let m = (m_exp / 2) as usize;
+    if !(1..=MAX_ZETA_M).contains(&m) {
+        return None;
+    }
+    Some(pi_power_with_coeff(zeta_even_coeff(m), 2 * m as i64))
+}
+
+/// `Σ_{k=1}^∞ (-1)^(k-1)/k^(2m) → η(2m) · π^(2m)` for `m = 1..3`.
+fn try_eta_2m(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    if !is_int_val(lo, 1) {
+        return None;
+    }
+    let m_exp = extract_alt_inv_k_pow(f, k)?;
+    if m_exp % 2 != 0 {
+        return None;
+    }
+    let m = (m_exp / 2) as usize;
+    if !(1..=MAX_ETA_M).contains(&m) {
+        return None;
+    }
+    Some(pi_power_with_coeff(eta_even_coeff(m), 2 * m as i64))
+}
+
+/// `Σ_{k=1}^∞ (-1)^(k-1)/k → log(2)`.
+fn try_eta_1(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    if !is_int_val(lo, 1) {
+        return None;
+    }
+    if extract_alt_inv_k_pow(f, k)? != 1 {
+        return None;
+    }
+    Some(unary(LOG, int(2)))
+}
+
+/// True iff `node = GammaFunc(k + 1)` (= `k!`).
+fn match_gamma_kp1(node: &IRNode, k: &IRNode) -> bool {
+    let IRNode::Apply(n) = node else {
+        return false;
+    };
+    if !head_is(&n.head, GAMMA_FUNC) || n.args.len() != 1 {
+        return false;
+    }
+    let IRNode::Apply(arg) = &n.args[0] else {
+        return false;
+    };
+    head_is(&arg.head, ADD)
+        && arg.args.len() == 2
+        && &arg.args[0] == k
+        && is_int_val(&arg.args[1], 1)
+}
+
+/// True iff `node = GammaFunc(slope·k + intercept + 1)`.
+fn match_gamma_of_linear_in_k_plus_1(
+    node: &IRNode,
+    k: &IRNode,
+    slope: i64,
+    intercept: i64,
+) -> bool {
+    let IRNode::Apply(n) = node else {
+        return false;
+    };
+    if !head_is(&n.head, GAMMA_FUNC) || n.args.len() != 1 {
+        return false;
+    }
+    let IRNode::Apply(arg) = &n.args[0] else {
+        return false;
+    };
+    if !head_is(&arg.head, ADD) || arg.args.len() != 2 {
+        return false;
+    }
+    let left = &arg.args[0];
+    let right = &arg.args[1];
+    let IRNode::Apply(l) = left else {
+        return false;
+    };
+    if !head_is(&l.head, MUL) || l.args.len() != 2 {
+        return false;
+    }
+    if !is_int_val(&l.args[0], slope) || &l.args[1] != k {
+        return false;
+    }
+    is_int_val(right, intercept + 1)
+}
+
+/// `Σ_{k=0}^∞ 1/k! → %e`.
+fn try_e_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    if !is_int_val(lo, 0) {
+        return None;
+    }
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, DIV) || node.args.len() != 2 {
+        return None;
+    }
+    if !is_int_val(&node.args[0], 1) {
+        return None;
+    }
+    if !match_gamma_kp1(&node.args[1], k) {
+        return None;
+    }
+    Some(e_sym())
+}
+
+/// If `node = Pow(x, k)` with `x` constant in `k` and `x ≠ k`, return `x`.
+fn extract_pow_of_x_in_k(node: &IRNode, k: &IRNode) -> Option<IRNode> {
+    let IRNode::Apply(n) = node else {
+        return None;
+    };
+    if !head_is(&n.head, POW) || n.args.len() != 2 {
+        return None;
+    }
+    if &n.args[1] != k {
+        return None;
+    }
+    if &n.args[0] == k {
+        return None;
+    }
+    if !is_constant_in_k(&n.args[0], k) {
+        return None;
+    }
+    Some(n.args[0].clone())
+}
+
+/// `Σ_{k=0}^∞ x^k/k! → exp(x)` (symbolic `x ≠ k`).
+fn try_exp_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    if !is_int_val(lo, 0) {
+        return None;
+    }
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, DIV) || node.args.len() != 2 {
+        return None;
+    }
+    let x = extract_pow_of_x_in_k(&node.args[0], k)?;
+    if !match_gamma_kp1(&node.args[1], k) {
+        return None;
+    }
+    Some(unary(EXP, x))
+}
+
+/// If `node = Pow(x, slope·k + intercept)` (or `Pow(x, slope·k)` when
+/// `intercept == 0`) with `x` constant in `k`, return `x`.
+fn extract_pow_of_x_in_linear_k(
+    node: &IRNode,
+    k: &IRNode,
+    slope: i64,
+    intercept: i64,
+) -> Option<IRNode> {
+    let IRNode::Apply(n) = node else {
+        return None;
+    };
+    if !head_is(&n.head, POW) || n.args.len() != 2 {
+        return None;
+    }
+    let base = &n.args[0];
+    let exp = &n.args[1];
+    if base == k || !is_constant_in_k(base, k) {
+        return None;
+    }
+    // Bare slope·k form.
+    if intercept == 0 {
+        let IRNode::Apply(e) = exp else {
+            return None;
+        };
+        if !head_is(&e.head, MUL) || e.args.len() != 2 {
+            return None;
+        }
+        if !is_int_val(&e.args[0], slope) || &e.args[1] != k {
+            return None;
+        }
+        return Some(base.clone());
+    }
+    // slope·k + intercept form.
+    let IRNode::Apply(e) = exp else {
+        return None;
+    };
+    if !head_is(&e.head, ADD) || e.args.len() != 2 {
+        return None;
+    }
+    let left = &e.args[0];
+    let right = &e.args[1];
+    let IRNode::Apply(l) = left else {
+        return None;
+    };
+    if !head_is(&l.head, MUL) || l.args.len() != 2 {
+        return None;
+    }
+    if !is_int_val(&l.args[0], slope) || &l.args[1] != k {
+        return None;
+    }
+    if !is_int_val(right, intercept) {
+        return None;
+    }
+    Some(base.clone())
+}
+
+/// Generic alternating Taylor series.
+///
+///   Σ_{k=0}^∞ (-1)^k · x^(slope·k + intercept) / (slope·k + intercept)!
+///
+/// Used by try_cos_series (2, 0, COS) and try_sin_series (2, 1, SIN).
+/// Tries both operand orientations of the outer Mul.
+fn try_alt_taylor_series(
+    f: &IRNode,
+    k: &IRNode,
+    lo: &IRNode,
+    slope: i64,
+    intercept: i64,
+    head: &str,
+) -> Option<IRNode> {
+    if !is_int_val(lo, 0) {
+        return None;
+    }
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, MUL) || node.args.len() != 2 {
+        return None;
+    }
+    let a = &node.args[0];
+    let b = &node.args[1];
+
+    fn try_orient(
+        sign_term: &IRNode,
+        body: &IRNode,
+        k: &IRNode,
+        slope: i64,
+        intercept: i64,
+        head: &str,
+    ) -> Option<IRNode> {
+        // sign_term must be (-1)^k.
+        let IRNode::Apply(s) = sign_term else {
+            return None;
+        };
+        if !head_is(&s.head, POW) || s.args.len() != 2 {
+            return None;
+        }
+        if !is_neg_one_base(&s.args[0]) || &s.args[1] != k {
+            return None;
+        }
+        // body must be Div(Pow(x, slope·k + intercept), GammaFunc(... + 1)).
+        let IRNode::Apply(bo) = body else {
+            return None;
+        };
+        if !head_is(&bo.head, DIV) || bo.args.len() != 2 {
+            return None;
+        }
+        let x = extract_pow_of_x_in_linear_k(&bo.args[0], k, slope, intercept)?;
+        if !match_gamma_of_linear_in_k_plus_1(&bo.args[1], k, slope, intercept) {
+            return None;
+        }
+        Some(unary(head, x))
+    }
+
+    if let Some(r) = try_orient(a, b, k, slope, intercept, head) {
+        return Some(r);
+    }
+    try_orient(b, a, k, slope, intercept, head)
+}
+
+fn try_cos_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    try_alt_taylor_series(f, k, lo, 2, 0, COS)
+}
+
+fn try_sin_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    try_alt_taylor_series(f, k, lo, 2, 1, SIN)
+}
+
+/// Generic hyperbolic Taylor series.
+///
+///   Σ_{k=0}^∞ x^(slope·k + intercept) / (slope·k + intercept)!
+///
+/// No alternating sign; the body is just Div(Pow(x, …), GammaFunc(… + 1)).
+fn try_hyperbolic_taylor_series(
+    f: &IRNode,
+    k: &IRNode,
+    lo: &IRNode,
+    slope: i64,
+    intercept: i64,
+    head: &str,
+) -> Option<IRNode> {
+    if !is_int_val(lo, 0) {
+        return None;
+    }
+    let IRNode::Apply(node) = f else {
+        return None;
+    };
+    if !head_is(&node.head, DIV) || node.args.len() != 2 {
+        return None;
+    }
+    let x = extract_pow_of_x_in_linear_k(&node.args[0], k, slope, intercept)?;
+    if !match_gamma_of_linear_in_k_plus_1(&node.args[1], k, slope, intercept) {
+        return None;
+    }
+    Some(unary(head, x))
+}
+
+fn try_cosh_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    try_hyperbolic_taylor_series(f, k, lo, 2, 0, COSH)
+}
+
+fn try_sinh_series(f: &IRNode, k: &IRNode, lo: &IRNode) -> Option<IRNode> {
+    try_hyperbolic_taylor_series(f, k, lo, 2, 1, SINH)
+}
+
+// ---------------------------------------------------------------------------
+// Public dispatcher
+// ---------------------------------------------------------------------------
+
+/// Return the closed form for a recognised canonical infinite series, or
+/// `None` when no pattern matches.
+///
+/// Mirrors `try_closed_form_series` in the Python reference.  Only fires
+/// when `hi = %inf`; finite `hi` returns `None` so the caller falls
+/// through to Faulhaber / geometric / Gosper.
+pub fn try_closed_form_series(
+    summand: &IRNode,
+    k: &IRNode,
+    lo: &IRNode,
+    hi: &IRNode,
+) -> Option<IRNode> {
+    // Infinite-bound only.
+    match hi {
+        IRNode::Symbol(name) if name == "inf" || name == "%inf" => {}
+        _ => return None,
+    }
+
+    let patterns: &[fn(&IRNode, &IRNode, &IRNode) -> Option<IRNode>] = &[
+        try_zeta_2m,
+        try_eta_2m,
+        try_eta_1,
+        try_e_series,
+        try_exp_series,
+        try_cos_series,
+        try_sin_series,
+        try_cosh_series,
+        try_sinh_series,
+    ];
+    for pattern in patterns {
+        if let Some(result) = pattern(summand, k, lo) {
+            return Some(result);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k_sym() -> IRNode {
+        sym("k")
+    }
+
+    fn x_sym() -> IRNode {
+        sym("x")
+    }
+
+    fn inf() -> IRNode {
+        sym("%inf")
+    }
+
+    // ---- Bernoulli table ----
+
+    #[test]
+    fn bernoulli_known_values() {
+        assert_eq!(bernoulli_rational(0), Frac { n: 1, d: 1 });
+        assert_eq!(bernoulli_rational(1), Frac { n: -1, d: 2 });
+        assert_eq!(bernoulli_rational(2), Frac { n: 1, d: 6 });
+        assert_eq!(bernoulli_rational(3), Frac { n: 0, d: 1 });
+        assert_eq!(bernoulli_rational(4), Frac { n: -1, d: 30 });
+        assert_eq!(bernoulli_rational(6), Frac { n: 1, d: 42 });
+        assert_eq!(bernoulli_rational(8), Frac { n: -1, d: 30 });
+        assert_eq!(bernoulli_rational(10), Frac { n: 5, d: 66 });
+        assert_eq!(bernoulli_rational(12), Frac { n: -691, d: 2730 });
+    }
+
+    #[test]
+    fn bernoulli_odd_indices_zero() {
+        for n in [3, 5, 7, 9, 11] {
+            assert_eq!(bernoulli_rational(n), Frac { n: 0, d: 1 });
+        }
+    }
+
+    #[test]
+    fn zeta_coefficient_table() {
+        assert_eq!(zeta_even_coeff(1), Frac { n: 1, d: 6 });
+        assert_eq!(zeta_even_coeff(2), Frac { n: 1, d: 90 });
+        assert_eq!(zeta_even_coeff(3), Frac { n: 1, d: 945 });
+        assert_eq!(zeta_even_coeff(4), Frac { n: 1, d: 9450 });
+        assert_eq!(zeta_even_coeff(5), Frac { n: 1, d: 93555 });
+        assert_eq!(zeta_even_coeff(6), Frac { n: 691, d: 638_512_875 });
+    }
+
+    #[test]
+    fn eta_coefficient_table() {
+        assert_eq!(eta_even_coeff(1), Frac { n: 1, d: 12 });
+        assert_eq!(eta_even_coeff(2), Frac { n: 7, d: 720 });
+        assert_eq!(eta_even_coeff(3), Frac { n: 31, d: 30_240 });
+    }
+
+    // ---- IR-shape helpers (mirror Python tests) ----
+
+    fn inv_k_pow(m: i64) -> IRNode {
+        if m == 1 {
+            div_ir(int(1), k_sym())
+        } else {
+            div_ir(int(1), pow_ir(k_sym(), int(m)))
+        }
+    }
+
+    fn alt_inv_k_pow(m: i64) -> IRNode {
+        let neg_one_pow = pow_ir(int(-1), binary(SUB, k_sym(), int(1)));
+        if m == 1 {
+            div_ir(neg_one_pow, k_sym())
+        } else {
+            div_ir(neg_one_pow, pow_ir(k_sym(), int(m)))
+        }
+    }
+
+    fn inv_factorial() -> IRNode {
+        let gamma = unary(GAMMA_FUNC, binary(ADD, k_sym(), int(1)));
+        div_ir(int(1), gamma)
+    }
+
+    fn xk_over_factorial() -> IRNode {
+        let gamma = unary(GAMMA_FUNC, binary(ADD, k_sym(), int(1)));
+        div_ir(pow_ir(x_sym(), k_sym()), gamma)
+    }
+
+    fn gamma_lin(slope: i64, intercept: i64) -> IRNode {
+        unary(
+            GAMMA_FUNC,
+            binary(
+                ADD,
+                binary(MUL, int(slope), k_sym()),
+                int(intercept + 1),
+            ),
+        )
+    }
+
+    fn pow_x_lin(slope: i64, intercept: i64) -> IRNode {
+        let exp = if intercept == 0 {
+            binary(MUL, int(slope), k_sym())
+        } else {
+            binary(ADD, binary(MUL, int(slope), k_sym()), int(intercept))
+        };
+        pow_ir(x_sym(), exp)
+    }
+
+    fn cos_summand() -> IRNode {
+        let sign = pow_ir(int(-1), k_sym());
+        let body = div_ir(pow_x_lin(2, 0), gamma_lin(2, 0));
+        binary(MUL, sign, body)
+    }
+
+    fn sin_summand() -> IRNode {
+        let sign = pow_ir(int(-1), k_sym());
+        let body = div_ir(pow_x_lin(2, 1), gamma_lin(2, 1));
+        binary(MUL, sign, body)
+    }
+
+    fn cosh_summand() -> IRNode {
+        div_ir(pow_x_lin(2, 0), gamma_lin(2, 0))
+    }
+
+    fn sinh_summand() -> IRNode {
+        div_ir(pow_x_lin(2, 1), gamma_lin(2, 1))
+    }
+
+    // ---- Zeta(2m) family ----
+
+    #[test]
+    fn zeta_2m_basel() {
+        // ζ(2) = π²/6
+        let result = try_closed_form_series(&inv_k_pow(2), &k_sym(), &int(1), &inf()).unwrap();
+        // π²/6 emitted as Div(Pow(%pi, 2), 6).
+        assert_eq!(
+            result,
+            div_ir(pow_ir(pi(), int(2)), int(6))
+        );
+    }
+
+    #[test]
+    fn zeta_2m_through_m6() {
+        for (two_m, expected_den) in [(2, 6), (4, 90), (6, 945), (8, 9450), (10, 93555)] {
+            let result =
+                try_closed_form_series(&inv_k_pow(two_m), &k_sym(), &int(1), &inf()).unwrap();
+            assert_eq!(result, div_ir(pow_ir(pi(), int(two_m)), int(expected_den)));
+        }
+    }
+
+    #[test]
+    fn zeta_12() {
+        // ζ(12) = 691·π¹²/638512875 — non-1 numerator branch.
+        let result = try_closed_form_series(&inv_k_pow(12), &k_sym(), &int(1), &inf()).unwrap();
+        assert_eq!(
+            result,
+            mul_ir(rat(691, 638_512_875), pow_ir(pi(), int(12)))
+        );
+    }
+
+    #[test]
+    fn odd_zeta_falls_through() {
+        assert!(try_closed_form_series(&inv_k_pow(3), &k_sym(), &int(1), &inf()).is_none());
+    }
+
+    #[test]
+    fn zeta_past_m6_falls_through() {
+        assert!(try_closed_form_series(&inv_k_pow(14), &k_sym(), &int(1), &inf()).is_none());
+    }
+
+    #[test]
+    fn zeta_wrong_lo_falls_through() {
+        assert!(try_closed_form_series(&inv_k_pow(2), &k_sym(), &int(2), &inf()).is_none());
+    }
+
+    // ---- Eta family ----
+
+    #[test]
+    fn eta_1_mercator() {
+        let result = try_closed_form_series(&alt_inv_k_pow(1), &k_sym(), &int(1), &inf()).unwrap();
+        assert_eq!(result, unary(LOG, int(2)));
+    }
+
+    #[test]
+    fn eta_2() {
+        // η(2) = π²/12
+        let result = try_closed_form_series(&alt_inv_k_pow(2), &k_sym(), &int(1), &inf()).unwrap();
+        assert_eq!(result, div_ir(pow_ir(pi(), int(2)), int(12)));
+    }
+
+    #[test]
+    fn eta_4() {
+        // η(4) = 7π⁴/720
+        let result = try_closed_form_series(&alt_inv_k_pow(4), &k_sym(), &int(1), &inf()).unwrap();
+        assert_eq!(result, mul_ir(rat(7, 720), pow_ir(pi(), int(4))));
+    }
+
+    #[test]
+    fn eta_6() {
+        // η(6) = 31π⁶/30240
+        let result = try_closed_form_series(&alt_inv_k_pow(6), &k_sym(), &int(1), &inf()).unwrap();
+        assert_eq!(result, mul_ir(rat(31, 30_240), pow_ir(pi(), int(6))));
+    }
+
+    // ---- Factorial-based series ----
+
+    #[test]
+    fn e_series_inv_factorial() {
+        let result =
+            try_closed_form_series(&inv_factorial(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, e_sym());
+    }
+
+    #[test]
+    fn exp_series_x_k_over_factorial() {
+        let result =
+            try_closed_form_series(&xk_over_factorial(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(EXP, x_sym()));
+    }
+
+    #[test]
+    fn cos_taylor_series() {
+        let result =
+            try_closed_form_series(&cos_summand(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(COS, x_sym()));
+    }
+
+    #[test]
+    fn sin_taylor_series() {
+        let result =
+            try_closed_form_series(&sin_summand(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(SIN, x_sym()));
+    }
+
+    #[test]
+    fn cosh_taylor_series() {
+        let result =
+            try_closed_form_series(&cosh_summand(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(COSH, x_sym()));
+    }
+
+    #[test]
+    fn sinh_taylor_series() {
+        let result =
+            try_closed_form_series(&sinh_summand(), &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(SINH, x_sym()));
+    }
+
+    #[test]
+    fn wrong_lo_factorial_falls_through() {
+        assert!(try_closed_form_series(&inv_factorial(), &k_sym(), &int(1), &inf()).is_none());
+    }
+
+    // ---- Fall-through ----
+
+    #[test]
+    fn unrecognised_sin_k_falls_through() {
+        let f = unary(SIN, k_sym());
+        assert!(try_closed_form_series(&f, &k_sym(), &int(1), &inf()).is_none());
+    }
+
+    #[test]
+    fn finite_hi_falls_through() {
+        assert!(
+            try_closed_form_series(&inv_k_pow(2), &k_sym(), &int(1), &int(100)).is_none()
+        );
+    }
+
+    #[test]
+    fn negative_x_in_exp_series_still_matches() {
+        // Use Neg(y) as the symbolic base — still constant in k.
+        let y = sym("y");
+        let gamma = unary(GAMMA_FUNC, binary(ADD, k_sym(), int(1)));
+        let neg_y = unary(NEG, y.clone());
+        let f = div_ir(pow_ir(neg_y.clone(), k_sym()), gamma);
+        let result = try_closed_form_series(&f, &k_sym(), &int(0), &inf()).unwrap();
+        assert_eq!(result, unary(EXP, neg_y));
+    }
+}

--- a/code/packages/rust/cas-summation/tests/series_closed_forms_test.rs
+++ b/code/packages/rust/cas-summation/tests/series_closed_forms_test.rs
@@ -1,0 +1,111 @@
+//! Track I2 — end-to-end integration tests for the closed-form series
+//! recogniser through `evaluate_sum`.
+//!
+//! Confirms the dispatcher routes ``hi = %inf`` patterns through the new
+//! handler and that the finite-bound paths (Faulhaber, small-range
+//! numeric, Gosper) stay untouched.
+
+use cas_summation::{evaluate_sum, GAMMA_FUNC, SUM};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, POW, SIN, SUB};
+
+/// Identity-ish evaluator: fully recurses into Apply but does no numeric
+/// folding.  Sufficient for verifying the dispatcher hands back the
+/// recogniser's emitted IR shape.
+fn ident(node: IRNode) -> IRNode {
+    if let IRNode::Apply(a) = node {
+        apply(
+            a.head.clone(),
+            a.args.iter().map(|x| ident(x.clone())).collect(),
+        )
+    } else {
+        node
+    }
+}
+
+fn k_sym() -> IRNode {
+    sym("k")
+}
+
+fn inf() -> IRNode {
+    sym("%inf")
+}
+
+fn binary(head: &str, a: IRNode, b: IRNode) -> IRNode {
+    apply(sym(head), vec![a, b])
+}
+
+fn unary(head: &str, a: IRNode) -> IRNode {
+    apply(sym(head), vec![a])
+}
+
+fn inv_k_pow(m: i64) -> IRNode {
+    binary(DIV, int(1), binary(POW, k_sym(), int(m)))
+}
+
+fn alt_inv_k_pow(m: i64) -> IRNode {
+    let neg_one_pow = binary(POW, int(-1), binary(SUB, k_sym(), int(1)));
+    if m == 1 {
+        binary(DIV, neg_one_pow, k_sym())
+    } else {
+        binary(DIV, neg_one_pow, binary(POW, k_sym(), int(m)))
+    }
+}
+
+#[test]
+fn evaluate_sum_zeta_6() {
+    // Σ 1/k^6 = π^6/945
+    let result = evaluate_sum(inv_k_pow(6), k_sym(), int(1), inf(), ident);
+    assert_eq!(
+        result,
+        binary(DIV, binary(POW, sym("%pi"), int(6)), int(945))
+    );
+}
+
+#[test]
+fn evaluate_sum_eta_1_log_2() {
+    // Σ (-1)^(k-1)/k = log(2)
+    let result = evaluate_sum(alt_inv_k_pow(1), k_sym(), int(1), inf(), ident);
+    assert_eq!(result, unary(LOG, int(2)));
+}
+
+#[test]
+fn evaluate_sum_cos_series() {
+    // Σ (-1)^k · x^(2k)/(2k)! = cos(x)
+    let x = sym("x");
+    let sign = binary(POW, int(-1), k_sym());
+    let body = binary(
+        DIV,
+        binary(POW, x.clone(), binary(MUL, int(2), k_sym())),
+        unary(
+            GAMMA_FUNC,
+            binary(ADD, binary(MUL, int(2), k_sym()), int(1)),
+        ),
+    );
+    let summand = binary(MUL, sign, body);
+    let result = evaluate_sum(summand, k_sym(), int(0), inf(), ident);
+    assert_eq!(result, unary(COS, x));
+}
+
+#[test]
+fn evaluate_sum_exp_series() {
+    // Σ x^k/k! = exp(x)
+    let x = sym("x");
+    let summand = binary(
+        DIV,
+        binary(POW, x.clone(), k_sym()),
+        unary(GAMMA_FUNC, binary(ADD, k_sym(), int(1))),
+    );
+    let result = evaluate_sum(summand, k_sym(), int(0), inf(), ident);
+    assert_eq!(result, unary(EXP, x));
+}
+
+#[test]
+fn unrecognised_sin_k_stays_unevaluated() {
+    // Σ sin(k) at infinity — recogniser returns None; dispatcher emits SUM.
+    let f = unary(SIN, k_sym());
+    let result = evaluate_sum(f.clone(), k_sym(), int(1), inf(), ident);
+    assert_eq!(
+        result,
+        apply(sym(SUM), vec![f, k_sym(), int(1), inf()])
+    );
+}

--- a/code/packages/typescript/cas-summation/CHANGELOG.md
+++ b/code/packages/typescript/cas-summation/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 2.28.0 — 2026-05-29
+
+### Added — Track I2 (Closed-form transcendental infinite sums port)
+
+Ports the Python ``cas_summation.series_closed_forms`` module (Track I1,
+PR #5382) to TypeScript ``cas-summation``.  Pattern-matches the
+canonical convergent infinite series and emits their closed forms when
+``hi = %inf``:
+
+- ``sum(1/k^(2m), k, 1, %inf) → ζ(2m) · π^(2m)`` for ``m = 1..6``
+  (Basel through ``ζ(12) = 691·π¹²/638512875``).
+- ``sum((-1)^(k-1)/k, k, 1, %inf) → log(2)`` (Mercator).
+- ``sum((-1)^(k-1)/k^(2m), k, 1, %inf) → η(2m) · π^(2m)`` for
+  ``m = 1..3`` (Dirichlet eta).
+- ``sum(1/k!, k, 0, %inf) → %e``.
+- ``sum(x^k/k!, k, 0, %inf) → exp(x)`` (symbolic ``x ≠ k``).
+- ``sum((-1)^k · x^(2k)/(2k)!, k, 0, %inf) → cos(x)``.
+- ``sum((-1)^k · x^(2k+1)/(2k+1)!, k, 0, %inf) → sin(x)``.
+- ``sum(x^(2k)/(2k)!, k, 0, %inf) → cosh(x)``.
+- ``sum(x^(2k+1)/(2k+1)!, k, 0, %inf) → sinh(x)``.
+
+The new ``tryClosedFormSeries`` handler is wired into ``evaluateSum``
+between the existing ``trySpecialInfinite`` (legacy Basel + Leibniz
+table) and the small-range numeric path; pre-existing tests stay on
+their original routes because the legacy table fires first for the
+overlapping ``ζ(2)`` / ``ζ(4)`` / ``π/4`` patterns.
+
+One generic ``bernoulliRational`` helper computes ``B_n`` via the
+textbook recurrence ``B_0 = 1; Σ_{j=0}^{n} C(n+1, j) · B_j = 0``.  Six
+even-zeta exponents and three even-eta exponents share the same code —
+no per-degree tables.  The recurrence depth is bounded by ``n ≤ 12``,
+so the helper is provably terminating, and results are cached in a
+module-level array.
+
+All numeric work is exact (BigInt-backed ``Frac``); the closed forms
+emerge as ``π^(2m) / denom`` IR shapes that match the parser-emitted
+forms verified by the test suite.
+
+### Notes
+
+Falls through (returns ``undefined``) for: odd zeta ``ζ(2m+1)``,
+indices past ``m > 6``, wrong lower bound (zeta requires ``lo=1``,
+Taylor requires ``lo=0``), finite upper bound, and any non-table
+summand (``sin(k)``, ``log(k)``, etc.).
+
 ## 2.27.0 — 2026-05-29
 
 ### Added — Track H2 (Gosper hypergeometric summation port)

--- a/code/packages/typescript/cas-summation/package.json
+++ b/code/packages/typescript/cas-summation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-summation",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Pure TypeScript symbolic summation and product evaluation over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-summation/src/index.ts
+++ b/code/packages/typescript/cas-summation/src/index.ts
@@ -22,6 +22,9 @@ export const GAMMA_FUNC = sym("GammaFunc");
 // Re-exported from ``gosper.ts``.  Track H2 — see PR #5366 (H1, Python).
 export { tryGosperSum, MAX_POLY_DEGREE } from "./gosper";
 import { tryGosperSum } from "./gosper";
+// Re-exported from ``seriesClosedForms.ts``.  Track I2 — see PR #5382 (I1, Python).
+export { tryClosedFormSeries, bernoulliRational } from "./seriesClosedForms";
+import { tryClosedFormSeries } from "./seriesClosedForms";
 
 export interface RationalValue {
   readonly numer: bigint;
@@ -205,6 +208,19 @@ function evaluateSumInner(
 
   if (infUpper) {
     const raw = trySpecialInfinite(f, k, lo);
+    if (raw !== undefined) return evalFn(raw);
+  }
+
+  // Track I2 — closed-form transcendental infinite sums.  Recognises the
+  // canonical zeta(2m), eta(2m), eta(1) = log(2), e_series, exp/cos/sin/
+  // cosh/sinh Taylor series.  Mirrors the Python dispatch insertion
+  // point (step 5a): placed after ``trySpecialInfinite`` so its
+  // pre-existing patterns (Basel zeta(2)/zeta(4), Leibniz π/4) keep
+  // their IR shapes and tests; ``tryClosedFormSeries`` only fires on
+  // patterns the legacy handler refuses (e.g. ``Σ 1/k⁶``, the eta
+  // family, sin/cos/sinh/cosh).
+  if (infUpper) {
+    const raw = tryClosedFormSeries(f, k, lo, hi);
     if (raw !== undefined) return evalFn(raw);
   }
 

--- a/code/packages/typescript/cas-summation/src/seriesClosedForms.ts
+++ b/code/packages/typescript/cas-summation/src/seriesClosedForms.ts
@@ -1,0 +1,668 @@
+/**
+ * Canonical infinite-series closed-form recogniser — Track I2.
+ *
+ * TypeScript port of
+ * ``code/packages/python/cas-summation/src/cas_summation/series_closed_forms.py``
+ * (Track I1, PR #5382).  See the Python source for the full mathematical
+ * background — this module mirrors it 1:1.
+ *
+ * Recognised series
+ * -----------------
+ *   ∑_{k=1}^∞ 1/k^(2m)        (m = 1..6)   → (2π)^(2m) · |B_{2m}| / (2·(2m)!)
+ *   ∑_{k=1}^∞ (-1)^(k-1)/k                  → log(2)
+ *   ∑_{k=1}^∞ (-1)^(k-1)/k^(2m) (m = 1..3) → (1 − 2^(1-2m)) · ζ(2m)
+ *   ∑_{k=0}^∞ 1/k!                          → %e
+ *   ∑_{k=0}^∞ x^k/k!                        → exp(x)
+ *   ∑_{k=0}^∞ (-1)^k · x^(2k)/(2k)!         → cos(x)
+ *   ∑_{k=0}^∞ (-1)^k · x^(2k+1)/(2k+1)!     → sin(x)
+ *   ∑_{k=0}^∞ x^(2k)/(2k)!                  → cosh(x)
+ *   ∑_{k=0}^∞ x^(2k+1)/(2k+1)!              → sinh(x)
+ *
+ * Design constraints (per Python reference):
+ *   - One generic Bernoulli helper, computed via the textbook recurrence
+ *     ``B_0 = 1; Σ_{j=0}^{n} C(n+1, j) · B_j = 0``.  Bounded depth
+ *     (n ≤ 12).
+ *   - Exact arithmetic via BigInt-backed Frac (mirrors fractions.Fraction).
+ *   - Only fires when ``hi = %inf``; finite ``hi`` returns ``undefined``.
+ */
+
+import {
+  ADD,
+  COS,
+  COSH,
+  DIV,
+  EXP,
+  LOG,
+  MUL,
+  NEG,
+  POW,
+  SIN,
+  SINH,
+  SUB,
+  app,
+  equals as irEquals,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+
+import { GAMMA_FUNC } from "./index";
+
+// π / %e as IR symbols (MACSYMA convention).
+const PI = sym("%pi");
+const E_SYM = sym("%e");
+
+/** Maximum even-zeta exponent — spec table covers k = 2..12 (m = 1..6). */
+const MAX_ZETA_M = 6;
+/** Maximum even-eta exponent — spec table covers m = 1..3. */
+const MAX_ETA_M = 3;
+
+// ---------------------------------------------------------------------------
+// Exact rational arithmetic on BigInt.  Mirrors Python's ``Fraction`` and the
+// gosper.ts ``Frac`` type but kept module-local so we don't widen the public
+// API of cas-summation.
+// ---------------------------------------------------------------------------
+
+interface Frac {
+  readonly n: bigint;
+  readonly d: bigint;
+}
+
+function absBig(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+function gcdBig(a: bigint, b: bigint): bigint {
+  let x = absBig(a);
+  let y = absBig(b);
+  while (y !== 0n) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x === 0n ? 1n : x;
+}
+
+function mkF(n: bigint, d: bigint): Frac {
+  if (d === 0n) throw new RangeError("Frac denominator cannot be zero");
+  if (d < 0n) {
+    n = -n;
+    d = -d;
+  }
+  const g = gcdBig(n, d);
+  return { n: n / g, d: d / g };
+}
+
+const F0: Frac = { n: 0n, d: 1n };
+const F1: Frac = { n: 1n, d: 1n };
+
+function fAdd(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+
+function fSub(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.d - b.n * a.d, a.d * b.d);
+}
+
+function fMul(a: Frac, b: Frac): Frac {
+  return mkF(a.n * b.n, a.d * b.d);
+}
+
+function fDiv(a: Frac, b: Frac): Frac {
+  if (b.n === 0n) throw new RangeError("Frac division by zero");
+  return mkF(a.n * b.d, a.d * b.n);
+}
+
+function fNeg(a: Frac): Frac {
+  return { n: -a.n, d: a.d };
+}
+
+function fAbs(a: Frac): Frac {
+  return a.n < 0n ? { n: -a.n, d: a.d } : a;
+}
+
+function fFromInt(n: bigint): Frac {
+  return { n, d: 1n };
+}
+
+function fToIr(c: Frac): IRNode {
+  if (c.d === 1n) return int(c.n);
+  return rational(c.n, c.d);
+}
+
+// ---------------------------------------------------------------------------
+// IR construction helpers (private)
+// ---------------------------------------------------------------------------
+
+function powIr(base: IRNode, exp: IRNode): IRNode {
+  return app(POW, [base, exp]);
+}
+
+function mulIr(a: IRNode, b: IRNode): IRNode {
+  return app(MUL, [a, b]);
+}
+
+function divIr(a: IRNode, b: IRNode): IRNode {
+  return app(DIV, [a, b]);
+}
+
+function isIntNode(node: IRNode, value: bigint): boolean {
+  return node.kind === "integer" && node.value === value;
+}
+
+/** True for ``-1`` whether stored as ``Integer(-1)`` or ``Neg(1)``. */
+function isNegOneBase(node: IRNode): boolean {
+  if (isIntNode(node, -1n)) return true;
+  return (
+    node.kind === "apply" &&
+    irEquals(node.head, NEG) &&
+    node.args.length === 1 &&
+    isIntNode(node.args[0], 1n)
+  );
+}
+
+/** True iff ``node`` is structurally constant in ``k``. */
+function isConstantInK(node: IRNode, k: IRNode): boolean {
+  if (irEquals(node, k)) return false;
+  if (node.kind !== "apply") return true;
+  return node.args.every((arg) => isConstantInK(arg, k));
+}
+
+// ---------------------------------------------------------------------------
+// Bernoulli numbers (one generic helper) and ζ(2m) / η(2m) coefficients
+// ---------------------------------------------------------------------------
+
+/**
+ * Cache of Bernoulli numbers computed up to the maximum index we ever
+ * need (2 · MAX_ZETA_M = 12).  Mutated lazily on first call.
+ */
+const BERNOULLI_CACHE: (Frac | undefined)[] = [];
+
+/**
+ * Return ``B_n`` (the n-th Bernoulli number) as an exact ``Frac``.
+ *
+ * Computed via the textbook recurrence:
+ *   B_0 = 1
+ *   B_n = − (1 / (n+1)) · Σ_{j=0}^{n-1} C(n+1, j) · B_j   (n ≥ 1)
+ *
+ * Pure iterative ``for`` loop, depth ``n``.  Caller only ever asks for
+ * ``n ≤ 12``, so the helper is provably terminating in O(n²) BigInt ops.
+ *
+ * Convention: ``B_1 = −1/2`` (Knuth / MACSYMA).  Matches the Python port.
+ */
+export function bernoulliRational(n: number): Frac {
+  if (n < 0 || !Number.isInteger(n)) {
+    throw new RangeError(`Bernoulli index must be a non-negative integer, got ${n}`);
+  }
+  const cached = BERNOULLI_CACHE[n];
+  if (cached !== undefined) return cached;
+  // Build all values from 0 up to n in one pass; cache each.
+  const startFrom = BERNOULLI_CACHE.length;
+  // Ensure index 0 exists in the cache before the loop.
+  if (BERNOULLI_CACHE[0] === undefined) {
+    BERNOULLI_CACHE[0] = F1;
+  }
+  for (let m = Math.max(1, startFrom); m <= n; m++) {
+    // B_m = − (1 / (m+1)) · Σ_{j=0}^{m-1} C(m+1, j) · B_j
+    let total: Frac = F0;
+    // Iterative binomial: C(m+1, 0) = 1, then update C(m+1, j) → C(m+1, j+1).
+    let binom = 1n;
+    const mBig = BigInt(m);
+    for (let j = 0; j < m; j++) {
+      const bj = BERNOULLI_CACHE[j];
+      if (bj === undefined) throw new Error("Bernoulli cache hole");
+      total = fAdd(total, fMul({ n: binom, d: 1n }, bj));
+      // C(m+1, j+1) = C(m+1, j) · (m + 1 − j) / (j + 1).  Exact integer
+      // division because binomials are integers.
+      const jBig = BigInt(j);
+      binom = (binom * (mBig + 1n - jBig)) / (jBig + 1n);
+    }
+    BERNOULLI_CACHE[m] = fDiv(fNeg(total), { n: mBig + 1n, d: 1n });
+  }
+  const result = BERNOULLI_CACHE[n];
+  if (result === undefined) throw new Error("Bernoulli cache failed to populate");
+  return result;
+}
+
+/**
+ * Return the rational coefficient ``c`` such that ``ζ(2m) = c · π^(2m)``.
+ *
+ *   c = 2^(2m) · |B_{2m}| / (2 · (2m)!)
+ */
+function zetaEvenCoeff(m: number): Frac {
+  if (m < 1) {
+    throw new RangeError(`zeta-even index must be ≥ 1, got ${m}`);
+  }
+  const b = bernoulliRational(2 * m);
+  let factorial2m = 1n;
+  for (let i = 1; i <= 2 * m; i++) {
+    factorial2m *= BigInt(i);
+  }
+  const twoToTwoM = 1n << BigInt(2 * m); // 2^(2m).
+  // c = 2^(2m) · |B_{2m}| / (2 · (2m)!)
+  return fDiv(fMul({ n: twoToTwoM, d: 1n }, fAbs(b)), { n: 2n * factorial2m, d: 1n });
+}
+
+/**
+ * Return the rational coefficient ``c`` such that ``η(2m) = c · π^(2m)``.
+ *
+ *   η(2m) = (1 − 2^(1−2m)) · ζ(2m)
+ */
+function etaEvenCoeff(m: number): Frac {
+  if (m < 1) {
+    throw new RangeError(`eta-even index must be ≥ 1, got ${m}`);
+  }
+  // 1 − 2^(1−2m) = 1 − 1/2^(2m-1).
+  const twoExp = 1n << BigInt(2 * m - 1);
+  const oneMinus = fSub(F1, { n: 1n, d: twoExp });
+  return fMul(oneMinus, zetaEvenCoeff(m));
+}
+
+/**
+ * Build the IR for ``coeff · π^power``.
+ *
+ * Emits ``π^power / denom`` when the coefficient is ``1/denom``
+ * (canonical form ``π²/6`` rather than ``(1/6)·π²``); otherwise emits
+ * the general ``coeff · π^power`` shape.
+ */
+function piPowerWithCoeff(coeff: Frac, power: number): IRNode {
+  if (coeff.n === 1n && coeff.d > 1n) {
+    return divIr(powIr(PI, int(power)), int(coeff.d));
+  }
+  return mulIr(fToIr(coeff), powIr(PI, int(power)));
+}
+
+// ---------------------------------------------------------------------------
+// Pattern recognisers — each matches a structural shape and returns the IR
+// for the closed form, or undefined when the shape doesn't match.
+// ---------------------------------------------------------------------------
+
+/** Match ``1/k^m`` (or ``1/k`` ≡ m=1) and return ``m``; else undefined. */
+function extractInvKPow(f: IRNode, k: IRNode): number | undefined {
+  if (f.kind !== "apply" || !irEquals(f.head, DIV) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [numer, denom] = f.args;
+  if (!isIntNode(numer, 1n)) return undefined;
+  if (irEquals(denom, k)) return 1;
+  if (
+    denom.kind === "apply" &&
+    irEquals(denom.head, POW) &&
+    denom.args.length === 2 &&
+    irEquals(denom.args[0], k) &&
+    denom.args[1].kind === "integer" &&
+    denom.args[1].value >= 1n
+  ) {
+    return Number(denom.args[1].value);
+  }
+  return undefined;
+}
+
+/** Match ``(-1)^(k-1) / k^m`` and return ``m``; else undefined. */
+function extractAltInvKPow(f: IRNode, k: IRNode): number | undefined {
+  if (f.kind !== "apply" || !irEquals(f.head, DIV) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [numer, denom] = f.args;
+  // Numerator: (-1)^(k-1).
+  if (
+    numer.kind !== "apply" ||
+    !irEquals(numer.head, POW) ||
+    numer.args.length !== 2 ||
+    !isNegOneBase(numer.args[0])
+  ) {
+    return undefined;
+  }
+  const exp = numer.args[1];
+  if (
+    exp.kind !== "apply" ||
+    !irEquals(exp.head, SUB) ||
+    exp.args.length !== 2 ||
+    !irEquals(exp.args[0], k) ||
+    !isIntNode(exp.args[1], 1n)
+  ) {
+    return undefined;
+  }
+  // Denominator: k or k^m.
+  if (irEquals(denom, k)) return 1;
+  if (
+    denom.kind === "apply" &&
+    irEquals(denom.head, POW) &&
+    denom.args.length === 2 &&
+    irEquals(denom.args[0], k) &&
+    denom.args[1].kind === "integer" &&
+    denom.args[1].value >= 1n
+  ) {
+    return Number(denom.args[1].value);
+  }
+  return undefined;
+}
+
+/** ``Σ_{k=1}^∞ 1/k^(2m) → ζ(2m) · π^(2m)`` for ``m = 1..6``. */
+function tryZeta2m(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  if (!isIntNode(lo, 1n)) return undefined;
+  const mExp = extractInvKPow(f, k);
+  if (mExp === undefined) return undefined;
+  if (mExp % 2 !== 0) return undefined; // Odd zeta is not closed form.
+  const m = mExp / 2;
+  if (m < 1 || m > MAX_ZETA_M) return undefined;
+  return piPowerWithCoeff(zetaEvenCoeff(m), 2 * m);
+}
+
+/** ``Σ_{k=1}^∞ (-1)^(k-1)/k^(2m) → η(2m) · π^(2m)`` for ``m = 1..3``. */
+function tryEta2m(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  if (!isIntNode(lo, 1n)) return undefined;
+  const mExp = extractAltInvKPow(f, k);
+  if (mExp === undefined) return undefined;
+  if (mExp % 2 !== 0) return undefined;
+  const m = mExp / 2;
+  if (m < 1 || m > MAX_ETA_M) return undefined;
+  return piPowerWithCoeff(etaEvenCoeff(m), 2 * m);
+}
+
+/** ``Σ_{k=1}^∞ (-1)^(k-1)/k → log(2)`` (Mercator series). */
+function tryEta1(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  if (!isIntNode(lo, 1n)) return undefined;
+  const mExp = extractAltInvKPow(f, k);
+  if (mExp !== 1) return undefined;
+  return app(LOG, [int(2)]);
+}
+
+/** True iff ``node = GammaFunc(k + 1)`` (= ``k!``). */
+function matchGammaKp1(node: IRNode, k: IRNode): boolean {
+  if (
+    node.kind !== "apply" ||
+    !irEquals(node.head, GAMMA_FUNC) ||
+    node.args.length !== 1
+  ) {
+    return false;
+  }
+  const arg = node.args[0];
+  return (
+    arg.kind === "apply" &&
+    irEquals(arg.head, ADD) &&
+    arg.args.length === 2 &&
+    irEquals(arg.args[0], k) &&
+    isIntNode(arg.args[1], 1n)
+  );
+}
+
+/**
+ * True iff ``node = GammaFunc(slope·k + intercept + 1)``.
+ *
+ * Matches the IR ``GammaFunc(Add(Mul(slope, k), intercept+1))`` used for
+ * ``(slope·k + intercept)!``.  E.g. ``(2k)!`` is ``GammaFunc(2k + 1)``;
+ * ``(2k+1)!`` is ``GammaFunc(2k + 2)``.
+ */
+function matchGammaOfLinearInKPlus1(
+  node: IRNode,
+  k: IRNode,
+  slope: number,
+  intercept: number,
+): boolean {
+  if (
+    node.kind !== "apply" ||
+    !irEquals(node.head, GAMMA_FUNC) ||
+    node.args.length !== 1
+  ) {
+    return false;
+  }
+  const arg = node.args[0];
+  if (arg.kind !== "apply" || !irEquals(arg.head, ADD) || arg.args.length !== 2) {
+    return false;
+  }
+  const [left, right] = arg.args;
+  if (
+    left.kind !== "apply" ||
+    !irEquals(left.head, MUL) ||
+    left.args.length !== 2 ||
+    !isIntNode(left.args[0], BigInt(slope)) ||
+    !irEquals(left.args[1], k)
+  ) {
+    return false;
+  }
+  return isIntNode(right, BigInt(intercept + 1));
+}
+
+/** ``Σ_{k=0}^∞ 1/k! → %e``. */
+function tryESeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  if (!isIntNode(lo, 0n)) return undefined;
+  if (f.kind !== "apply" || !irEquals(f.head, DIV) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [numer, denom] = f.args;
+  if (!isIntNode(numer, 1n)) return undefined;
+  if (!matchGammaKp1(denom, k)) return undefined;
+  return E_SYM;
+}
+
+/**
+ * If ``node = Pow(x, k)`` with ``x`` constant in ``k`` and ``x ≠ k``,
+ * return ``x``; else undefined.
+ */
+function extractPowOfXInK(node: IRNode, k: IRNode): IRNode | undefined {
+  if (
+    node.kind !== "apply" ||
+    !irEquals(node.head, POW) ||
+    node.args.length !== 2
+  ) {
+    return undefined;
+  }
+  const [base, exp] = node.args;
+  if (!irEquals(exp, k)) return undefined;
+  if (irEquals(base, k)) return undefined;
+  if (!isConstantInK(base, k)) return undefined;
+  return base;
+}
+
+/** ``Σ_{k=0}^∞ x^k/k! → exp(x)`` (symbolic ``x ≠ k``). */
+function tryExpSeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  if (!isIntNode(lo, 0n)) return undefined;
+  if (f.kind !== "apply" || !irEquals(f.head, DIV) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [numer, denom] = f.args;
+  const x = extractPowOfXInK(numer, k);
+  if (x === undefined) return undefined;
+  if (!matchGammaKp1(denom, k)) return undefined;
+  return app(EXP, [x]);
+}
+
+/**
+ * If ``node = Pow(x, slope·k + intercept)`` (or ``Pow(x, slope·k)`` when
+ * ``intercept == 0``) with ``x`` constant in ``k``, return ``x``.
+ */
+function extractPowOfXInLinearK(
+  node: IRNode,
+  k: IRNode,
+  slope: number,
+  intercept: number,
+): IRNode | undefined {
+  if (
+    node.kind !== "apply" ||
+    !irEquals(node.head, POW) ||
+    node.args.length !== 2
+  ) {
+    return undefined;
+  }
+  const [base, exp] = node.args;
+  if (irEquals(base, k) || !isConstantInK(base, k)) return undefined;
+  // Bare slope·k form (intercept = 0).
+  if (intercept === 0) {
+    if (
+      exp.kind !== "apply" ||
+      !irEquals(exp.head, MUL) ||
+      exp.args.length !== 2 ||
+      !isIntNode(exp.args[0], BigInt(slope)) ||
+      !irEquals(exp.args[1], k)
+    ) {
+      return undefined;
+    }
+    return base;
+  }
+  // slope·k + intercept form.
+  if (exp.kind !== "apply" || !irEquals(exp.head, ADD) || exp.args.length !== 2) {
+    return undefined;
+  }
+  const [left, right] = exp.args;
+  if (
+    left.kind !== "apply" ||
+    !irEquals(left.head, MUL) ||
+    left.args.length !== 2 ||
+    !isIntNode(left.args[0], BigInt(slope)) ||
+    !irEquals(left.args[1], k)
+  ) {
+    return undefined;
+  }
+  if (!isIntNode(right, BigInt(intercept))) return undefined;
+  return base;
+}
+
+/**
+ * Generic ``Σ_{k=0}^∞ (-1)^k · x^(slope·k + intercept) / (slope·k + intercept)!``.
+ *
+ * Used by :func:`tryCosSeries` (slope=2, intercept=0, head=COS) and
+ * :func:`trySinSeries` (slope=2, intercept=1, head=SIN).
+ *
+ * Expected IR shape:
+ *   Mul(Pow(-1, k), Div(Pow(x, slope·k + intercept),
+ *                       GammaFunc(slope·k + intercept + 1)))
+ *
+ * Symmetric: tries both operand orders.
+ */
+function tryAltTaylorSeries(
+  f: IRNode,
+  k: IRNode,
+  lo: IRNode,
+  slope: number,
+  intercept: number,
+  head: IRNode,
+): IRNode | undefined {
+  if (!isIntNode(lo, 0n)) return undefined;
+  if (f.kind !== "apply" || !irEquals(f.head, MUL) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [a, b] = f.args;
+
+  function tryOrientation(signTerm: IRNode, body: IRNode): IRNode | undefined {
+    // signTerm must be (-1)^k.
+    if (
+      signTerm.kind !== "apply" ||
+      !irEquals(signTerm.head, POW) ||
+      signTerm.args.length !== 2 ||
+      !isNegOneBase(signTerm.args[0]) ||
+      !irEquals(signTerm.args[1], k)
+    ) {
+      return undefined;
+    }
+    // body must be Div(Pow(x, slope·k + intercept), GammaFunc(... + 1)).
+    if (
+      body.kind !== "apply" ||
+      !irEquals(body.head, DIV) ||
+      body.args.length !== 2
+    ) {
+      return undefined;
+    }
+    const [numer, denom] = body.args;
+    const x = extractPowOfXInLinearK(numer, k, slope, intercept);
+    if (x === undefined) return undefined;
+    if (!matchGammaOfLinearInKPlus1(denom, k, slope, intercept)) return undefined;
+    return app(head, [x]);
+  }
+
+  const r1 = tryOrientation(a, b);
+  if (r1 !== undefined) return r1;
+  return tryOrientation(b, a);
+}
+
+/** ``Σ_{k=0}^∞ (−1)^k · x^(2k) / (2k)! → cos(x)``. */
+function tryCosSeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  return tryAltTaylorSeries(f, k, lo, 2, 0, COS);
+}
+
+/** ``Σ_{k=0}^∞ (−1)^k · x^(2k+1) / (2k+1)! → sin(x)``. */
+function trySinSeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  return tryAltTaylorSeries(f, k, lo, 2, 1, SIN);
+}
+
+/**
+ * Generic ``Σ_{k=0}^∞ x^(slope·k + intercept) / (slope·k + intercept)!``.
+ *
+ * Returns ``head(x)`` (``cosh(x)`` or ``sinh(x)``) when the shape matches.
+ * The sign factor is absent (hyperbolic series); the body is just
+ * ``Div(Pow(x, …), GammaFunc(… + 1))``.
+ */
+function tryHyperbolicTaylorSeries(
+  f: IRNode,
+  k: IRNode,
+  lo: IRNode,
+  slope: number,
+  intercept: number,
+  head: IRNode,
+): IRNode | undefined {
+  if (!isIntNode(lo, 0n)) return undefined;
+  if (f.kind !== "apply" || !irEquals(f.head, DIV) || f.args.length !== 2) {
+    return undefined;
+  }
+  const [numer, denom] = f.args;
+  const x = extractPowOfXInLinearK(numer, k, slope, intercept);
+  if (x === undefined) return undefined;
+  if (!matchGammaOfLinearInKPlus1(denom, k, slope, intercept)) return undefined;
+  return app(head, [x]);
+}
+
+/** ``Σ_{k=0}^∞ x^(2k) / (2k)! → cosh(x)``. */
+function tryCoshSeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  return tryHyperbolicTaylorSeries(f, k, lo, 2, 0, COSH);
+}
+
+/** ``Σ_{k=0}^∞ x^(2k+1) / (2k+1)! → sinh(x)``. */
+function trySinhSeries(f: IRNode, k: IRNode, lo: IRNode): IRNode | undefined {
+  return tryHyperbolicTaylorSeries(f, k, lo, 2, 1, SINH);
+}
+
+// ---------------------------------------------------------------------------
+// Public dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the closed form for a recognised canonical infinite series, or
+ * undefined when no pattern matches.
+ *
+ * Mirrors :func:`series_closed_forms.try_closed_form_series` in the
+ * Python reference.  Only fires when ``hi = %inf``; finite ``hi``
+ * returns ``undefined`` so the caller falls through to Faulhaber /
+ * geometric / Gosper.
+ */
+export function tryClosedFormSeries(
+  summand: IRNode,
+  k: IRNode,
+  lo: IRNode,
+  hi: IRNode,
+): IRNode | undefined {
+  // Infinite-bound only.
+  if (
+    hi.kind !== "symbol" ||
+    (hi.name !== "inf" && hi.name !== "%inf")
+  ) {
+    return undefined;
+  }
+  // The patterns are non-overlapping; order matters only for clarity.
+  const patterns = [
+    tryZeta2m,
+    tryEta2m,
+    tryEta1,
+    tryESeries,
+    tryExpSeries,
+    tryCosSeries,
+    trySinSeries,
+    tryCoshSeries,
+    trySinhSeries,
+  ];
+  for (const pattern of patterns) {
+    const result = pattern(summand, k, lo);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}

--- a/code/packages/typescript/cas-summation/tests/seriesClosedForms.test.ts
+++ b/code/packages/typescript/cas-summation/tests/seriesClosedForms.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for the Track I2 canonical infinite-series recogniser.
+ *
+ * Mirrors
+ * ``code/packages/python/cas-summation/tests/test_series_closed_forms.py``
+ * (Track I1, PR #5382).  Constructs each summand IR by hand, calls
+ * ``tryClosedFormSeries`` directly to verify the structural recogniser,
+ * numerically evaluates the returned IR via a tiny recursive helper,
+ * and compares to the expected mathematical value.  End-to-end smoke
+ * tests through ``evaluateSum`` confirm the dispatcher wiring routes
+ * ``hi = %inf`` cases through the new path without disturbing the
+ * pre-existing finite Gosper / Faulhaber routes.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  COS,
+  COSH,
+  DIV,
+  EXP,
+  LOG,
+  MUL,
+  NEG,
+  POW,
+  SIN,
+  SINH,
+  SUB,
+  SUM,
+  app,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+import {
+  GAMMA_FUNC,
+  bernoulliRational,
+  evaluateSum,
+  tryClosedFormSeries,
+} from "../src/index";
+
+const k = sym("k");
+const x = sym("x");
+const INF = sym("%inf");
+
+// ---------------------------------------------------------------------------
+// Tiny numeric evaluator — folds Integer/Rational arithmetic and the few
+// transcendental heads we need (Pi, %e, log, exp).  Used only by the test
+// assertions; production code never needs floats.
+// ---------------------------------------------------------------------------
+
+function numeric(node: IRNode): number {
+  if (node.kind === "integer") return Number(node.value);
+  if (node.kind === "rational") return Number(node.numer) / Number(node.denom);
+  if (node.kind === "float") return node.value;
+  if (node.kind === "symbol") {
+    if (node.name === "%pi") return Math.PI;
+    if (node.name === "%e") return Math.E;
+    throw new Error(`Free symbol ${node.name} in numeric eval`);
+  }
+  if (node.kind !== "apply") throw new Error(`Unsupported node kind ${node.kind}`);
+  const head = node.head;
+  if (head.kind !== "symbol") throw new Error("Unsupported head kind");
+  const args = node.args;
+  switch (head.name) {
+    case "Add":
+      return args.reduce((acc: number, a: IRNode) => acc + numeric(a), 0);
+    case "Sub":
+      return numeric(args[0]) - numeric(args[1]);
+    case "Mul":
+      return args.reduce((acc: number, a: IRNode) => acc * numeric(a), 1);
+    case "Div":
+      return numeric(args[0]) / numeric(args[1]);
+    case "Neg":
+      return -numeric(args[0]);
+    case "Pow":
+      return Math.pow(numeric(args[0]), numeric(args[1]));
+    case "Log":
+      return Math.log(numeric(args[0]));
+    case "Exp":
+      return Math.exp(numeric(args[0]));
+    default:
+      throw new Error(`Unsupported head ${head.name} in numeric eval`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IR-shape helpers — match the parser's emitted forms for the summands.
+// ---------------------------------------------------------------------------
+
+function invKPow(m: bigint): IRNode {
+  if (m === 1n) return app(DIV, [int(1), k]);
+  return app(DIV, [int(1), app(POW, [k, int(m)])]);
+}
+
+function altInvKPow(m: bigint): IRNode {
+  const negOnePow = app(POW, [int(-1n), app(SUB, [k, int(1)])]);
+  if (m === 1n) return app(DIV, [negOnePow, k]);
+  return app(DIV, [negOnePow, app(POW, [k, int(m)])]);
+}
+
+function invFactorial(): IRNode {
+  const gamma = app(GAMMA_FUNC, [app(ADD, [k, int(1)])]);
+  return app(DIV, [int(1), gamma]);
+}
+
+function xkOverFactorial(): IRNode {
+  const gamma = app(GAMMA_FUNC, [app(ADD, [k, int(1)])]);
+  return app(DIV, [app(POW, [x, k]), gamma]);
+}
+
+function gammaLin(slope: bigint, intercept: bigint): IRNode {
+  return app(GAMMA_FUNC, [
+    app(ADD, [app(MUL, [int(slope), k]), int(intercept + 1n)]),
+  ]);
+}
+
+function powXLin(slope: bigint, intercept: bigint): IRNode {
+  const exp =
+    intercept === 0n
+      ? app(MUL, [int(slope), k])
+      : app(ADD, [app(MUL, [int(slope), k]), int(intercept)]);
+  return app(POW, [x, exp]);
+}
+
+function cosSummand(): IRNode {
+  const sign = app(POW, [int(-1n), k]);
+  const body = app(DIV, [powXLin(2n, 0n), gammaLin(2n, 0n)]);
+  return app(MUL, [sign, body]);
+}
+
+function sinSummand(): IRNode {
+  const sign = app(POW, [int(-1n), k]);
+  const body = app(DIV, [powXLin(2n, 1n), gammaLin(2n, 1n)]);
+  return app(MUL, [sign, body]);
+}
+
+function coshSummand(): IRNode {
+  return app(DIV, [powXLin(2n, 0n), gammaLin(2n, 0n)]);
+}
+
+function sinhSummand(): IRNode {
+  return app(DIV, [powXLin(2n, 1n), gammaLin(2n, 1n)]);
+}
+
+// ---------------------------------------------------------------------------
+// Minimal identity eval (mirrors the Python ``_StubVM`` minus the fold).
+// We only need the wired dispatcher to behave; closed-form IR returned by
+// the recogniser does not require simplification for the tests.
+// ---------------------------------------------------------------------------
+
+function identityEval(node: IRNode): IRNode {
+  if (node.kind !== "apply") return node;
+  return app(node.head, node.args.map(identityEval));
+}
+
+describe("bernoulli helper", () => {
+  it("matches known values (Knuth convention B_1 = -1/2)", () => {
+    expect(bernoulliRational(0)).toEqual({ n: 1n, d: 1n });
+    expect(bernoulliRational(1)).toEqual({ n: -1n, d: 2n });
+    expect(bernoulliRational(2)).toEqual({ n: 1n, d: 6n });
+    expect(bernoulliRational(3)).toEqual({ n: 0n, d: 1n });
+    expect(bernoulliRational(4)).toEqual({ n: -1n, d: 30n });
+    expect(bernoulliRational(6)).toEqual({ n: 1n, d: 42n });
+    expect(bernoulliRational(8)).toEqual({ n: -1n, d: 30n });
+    expect(bernoulliRational(10)).toEqual({ n: 5n, d: 66n });
+    expect(bernoulliRational(12)).toEqual({ n: -691n, d: 2730n });
+  });
+
+  it("odd indices ≥ 3 are zero", () => {
+    for (const n of [3, 5, 7, 9, 11]) {
+      expect(bernoulliRational(n)).toEqual({ n: 0n, d: 1n });
+    }
+  });
+});
+
+describe("zeta(2m) family", () => {
+  const cases: Array<[bigint, number]> = [
+    [2n, Math.PI ** 2 / 6],
+    [4n, Math.PI ** 4 / 90],
+    [6n, Math.PI ** 6 / 945],
+    [8n, Math.PI ** 8 / 9450],
+    [10n, Math.PI ** 10 / 93555],
+    [12n, (691 * Math.PI ** 12) / 638512875],
+  ];
+  for (const [twoM, expected] of cases) {
+    it(`recognises Σ 1/k^${twoM}`, () => {
+      const result = tryClosedFormSeries(invKPow(twoM), k, int(1), INF);
+      expect(result).not.toBeUndefined();
+      expect(numeric(result as IRNode)).toBeCloseTo(expected, 10);
+    });
+  }
+
+  it("Σ 1/k^3 (odd zeta) falls through", () => {
+    expect(tryClosedFormSeries(invKPow(3n), k, int(1), INF)).toBeUndefined();
+  });
+
+  it("Σ 1/k^14 (past m=6) falls through", () => {
+    expect(tryClosedFormSeries(invKPow(14n), k, int(1), INF)).toBeUndefined();
+  });
+
+  it("wrong lo=2 falls through", () => {
+    expect(tryClosedFormSeries(invKPow(2n), k, int(2), INF)).toBeUndefined();
+  });
+});
+
+describe("eta family", () => {
+  it("Mercator: Σ (-1)^(k-1)/k → log(2)", () => {
+    const result = tryClosedFormSeries(altInvKPow(1n), k, int(1), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(LOG);
+      expect(r.args[0]).toEqual(int(2));
+    }
+    expect(numeric(r)).toBeCloseTo(Math.log(2), 10);
+  });
+
+  const cases: Array<[bigint, number]> = [
+    [2n, Math.PI ** 2 / 12],
+    [4n, (7 * Math.PI ** 4) / 720],
+    [6n, (31 * Math.PI ** 6) / 30240],
+  ];
+  for (const [twoM, expected] of cases) {
+    it(`recognises Σ (-1)^(k-1)/k^${twoM}`, () => {
+      const result = tryClosedFormSeries(altInvKPow(twoM), k, int(1), INF);
+      expect(result).not.toBeUndefined();
+      expect(numeric(result as IRNode)).toBeCloseTo(expected, 10);
+    });
+  }
+});
+
+describe("factorial-based series", () => {
+  it("Σ_{k=0}^∞ 1/k! = %e", () => {
+    const result = tryClosedFormSeries(invFactorial(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("symbol");
+    if (r.kind === "symbol") {
+      expect(r.name).toBe("%e");
+    }
+  });
+
+  it("Σ_{k=0}^∞ x^k/k! = exp(x)", () => {
+    const result = tryClosedFormSeries(xkOverFactorial(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(EXP);
+      expect(r.args[0]).toEqual(x);
+    }
+  });
+
+  it("Σ (-1)^k · x^(2k)/(2k)! = cos(x)", () => {
+    const result = tryClosedFormSeries(cosSummand(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(COS);
+      expect(r.args[0]).toEqual(x);
+    }
+  });
+
+  it("Σ (-1)^k · x^(2k+1)/(2k+1)! = sin(x)", () => {
+    const result = tryClosedFormSeries(sinSummand(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(SIN);
+      expect(r.args[0]).toEqual(x);
+    }
+  });
+
+  it("Σ x^(2k)/(2k)! = cosh(x)", () => {
+    const result = tryClosedFormSeries(coshSummand(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(COSH);
+      expect(r.args[0]).toEqual(x);
+    }
+  });
+
+  it("Σ x^(2k+1)/(2k+1)! = sinh(x)", () => {
+    const result = tryClosedFormSeries(sinhSummand(), k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(SINH);
+      expect(r.args[0]).toEqual(x);
+    }
+  });
+
+  it("wrong lo=1 for factorial falls through", () => {
+    expect(tryClosedFormSeries(invFactorial(), k, int(1), INF)).toBeUndefined();
+  });
+});
+
+describe("fall-through cases", () => {
+  it("Σ sin(k) (not in table) returns undefined", () => {
+    const f = app(SIN, [k]);
+    expect(tryClosedFormSeries(f, k, int(1), INF)).toBeUndefined();
+  });
+
+  it("finite hi → undefined (Faulhaber/Gosper handles it)", () => {
+    expect(tryClosedFormSeries(invKPow(2n), k, int(1), int(100))).toBeUndefined();
+  });
+
+  it("symbolic x = Neg(y) in exp series still matches", () => {
+    const y = sym("y");
+    const gamma = app(GAMMA_FUNC, [app(ADD, [k, int(1)])]);
+    const negY = app(NEG, [y]);
+    const f = app(DIV, [app(POW, [negY, k]), gamma]);
+    const result = tryClosedFormSeries(f, k, int(0), INF);
+    expect(result).not.toBeUndefined();
+    const r = result as IRNode;
+    expect(r.kind).toBe("apply");
+    if (r.kind === "apply") {
+      expect(r.head).toEqual(EXP);
+    }
+  });
+});
+
+describe("dispatcher integration", () => {
+  it("evaluateSum(1/k^6, k, 1, inf) → π^6/945", () => {
+    const result = evaluateSum(invKPow(6n), k, int(1), INF, identityEval);
+    expect(numeric(result)).toBeCloseTo(Math.PI ** 6 / 945, 10);
+  });
+
+  it("evaluateSum((-1)^(k-1)/k, k, 1, inf) → log(2) head", () => {
+    const result = evaluateSum(altInvKPow(1n), k, int(1), INF, identityEval);
+    expect(result.kind).toBe("apply");
+    if (result.kind === "apply") expect(result.head).toEqual(LOG);
+  });
+
+  it("evaluateSum(cos summand, k, 0, inf) → Cos(x)", () => {
+    const result = evaluateSum(cosSummand(), k, int(0), INF, identityEval);
+    expect(result.kind).toBe("apply");
+    if (result.kind === "apply") {
+      expect(result.head).toEqual(COS);
+      expect(result.args[0]).toEqual(x);
+    }
+  });
+
+  it("evaluateSum(1/k^2, k, 1, 100) does NOT use I2 path (finite)", () => {
+    // Provide a folding eval so the small-range numeric handler can
+    // accumulate rationals; otherwise dispatcher falls through to the
+    // unevaluated Sum.  We only need Div folding for ``1/k^m`` terms
+    // and a Pow folder for the denominator.
+    const foldEval = (node: IRNode): IRNode => {
+      if (node.kind !== "apply") return node;
+      const args = node.args.map(foldEval);
+      const head = node.head;
+      if (head.kind === "symbol") {
+        if (head.name === "Pow" && args[0].kind === "integer" && args[1].kind === "integer" && args[1].value >= 0n) {
+          let acc = 1n;
+          for (let i = 0n; i < args[1].value; i++) acc *= args[0].value;
+          return int(acc);
+        }
+        if (head.name === "Div" && args[0].kind === "integer" && args[1].kind === "integer" && args[1].value !== 0n) {
+          if (args[0].value % args[1].value === 0n) return int(args[0].value / args[1].value);
+          return rational(args[0].value, args[1].value);
+        }
+      }
+      return app(head, args);
+    };
+    const result = evaluateSum(invKPow(2n), k, int(1), int(100), foldEval);
+    // The small-range numeric handler returns an exact rational.
+    expect(result.kind === "rational" || result.kind === "integer").toBe(true);
+    let expected = 0;
+    for (let i = 1; i <= 100; i++) expected += 1 / (i * i);
+    expect(numeric(result)).toBeCloseTo(expected, 9);
+  });
+
+  it("Σ sin(k) (unrecognised) → unevaluated Sum", () => {
+    const f = app(SIN, [k]);
+    const result = evaluateSum(f, k, int(1), INF, identityEval);
+    expect(result.kind).toBe("apply");
+    if (result.kind === "apply") expect(result.head).toEqual(SUM);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python `cas_summation.series_closed_forms` module (Track I1,
PR #5382) to TypeScript and Rust `cas-summation`.  Pattern-matches the
canonical convergent infinite series and emits their closed forms when
`hi = %inf`.

Recognised series (per Track I2 of `code/specs/macsyma-truly-finish-plan.md`):

- `Σ_{k=1}^∞ 1/k^(2m)` for `m=1..6` → `ζ(2m) · π^(2m)` (Basel through `ζ(12) = 691·π¹²/638512875`)
- `Σ_{k=1}^∞ (-1)^(k-1)/k` → `log(2)` (Mercator)
- `Σ_{k=1}^∞ (-1)^(k-1)/k^(2m)` for `m=1..3` → `η(2m) · π^(2m)` (Dirichlet eta)
- `Σ_{k=0}^∞ 1/k!` → `%e`
- `Σ_{k=0}^∞ x^k/k!` → `exp(x)` (symbolic `x ≠ k`)
- `Σ_{k=0}^∞ (-1)^k · x^(2k)/(2k)!` → `cos(x)`
- `Σ_{k=0}^∞ (-1)^k · x^(2k+1)/(2k+1)!` → `sin(x)`
- `Σ_{k=0}^∞ x^(2k)/(2k)!` → `cosh(x)`
- `Σ_{k=0}^∞ x^(2k+1)/(2k+1)!` → `sinh(x)`

## Design

- **One generic Bernoulli helper** (textbook recurrence
  `B_0 = 1; Σ_{j=0}^{n} C(n+1,j)·B_j = 0`) — bounded depth `n ≤ 12`,
  cached, iterative (no unbounded recursion).
- **Exact arithmetic**: TS uses BigInt-backed `Frac`; Rust uses `i128`
  intermediates down-cast to `i64` for the IR literal.
- **Dispatch insertion** mirrors Python (step 5a): after
  `trySpecialInfinite` / `try_special_infinite` (legacy Basel + Leibniz
  table) and before the small-range numeric path / Gosper.  Pre-existing
  tests stay on their original routes — the legacy table fires first
  for the overlapping `ζ(2)` / `ζ(4)` / `π/4` patterns.

## Test plan

- [x] TS: 30 new tests covering Bernoulli table (incl. `B_12 = -691/2730`),
      ζ(2)..ζ(12), η(1)..η(6), e/exp/cos/sin/cosh/sinh series,
      fall-throughs (odd zeta, m > 6, wrong lo, finite hi, unrecognised
      `sin(k)`), and end-to-end dispatcher integration.
- [x] TS: all 136 vitest tests pass, `tsc` clean.
- [x] Rust: 24 unit tests + 5 integration tests covering the same matrix.
- [x] Rust: all 132 cargo tests pass.
- [x] Versions bumped to 2.28.0 in both packages.
- [x] Changelogs updated, referencing Python PR #5382 as the reference.

## References

- Track I2 of `code/specs/macsyma-truly-finish-plan.md`
- Track I1 Python: #5382

🤖 Generated with [Claude Code](https://claude.com/claude-code)