### PR TITLE
feat(clr-real): C4 — symbols on real CoreCLR

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.14.0] — 2026-06-11 — textual `.il`: symbols (CLR-real C4)
+
+**No new emit ops** — symbols reuse the existing value model. The shared
+`intern_symbols_structural` pass lowers each `(QUOTE S)` to a *tagged integer id*
+(`A` → `0x20000000`, `B` → `0x20000001`, …); on the CLR that id is just a boxed
+`System.Int32` atom, the exact scalar/predicate shape C1–C3 already emit. So
+`(EQ (QUOTE A) (QUOTE A))` is two equal `ldc.i4 536870912` consts, boxed, then
+`equal?`-unboxed + `ceq`; `(ATOM (QUOTE A))` is `not (pair? boxed-int)`. New unit
+test `symbol_eq_emits_tagged_id_consts_unboxed_and_compared` pins the value model;
+the real-CoreCLR proof is `lang-aot/tests/clr_real_symbols.rs`.
+
 ## [0.13.0] — 2026-06-11 — textual `.il`: predicates + COND (CLR-real C3)
 
 `emit_il` grows the McCarthy predicate primitives and `COND` control flow:

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -33,11 +33,13 @@ Two outputs from the same lowered program: binary method bodies for the in-repo
 `clr-simulator` (fast unit checks), and **textual `.il`** (`emit_il`) for the
 **real CoreCLR** path — assembled by real `ilasm`, run on real `dotnet`. This is
 the exact analog of how `iir-to-llvm` emits textual `.ll` for real `clang`; `ilasm`
-owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar, cons/car/cdr, and
-**predicates + `COND`** today — cons is a 2-element `System.Object[]`, atoms `box`ed
-`System.Int32`; `pair?` is `isinst object[]`, `not` is `xor 1`, `equal?` is
-`unbox.any int32` ×2 + `ceq`, and `COND` lowers to `label`/`br`/`brfalse`. Symbols
-and lambda land per the `CLR-REAL-RUNTIME-VERIFICATION` worklist.)
+owns the PE/metadata so we don't hand-roll ECMA-335. (Scalar, cons/car/cdr,
+**predicates + `COND`**, and **symbols** today — cons is a 2-element
+`System.Object[]`, atoms `box`ed `System.Int32`; `pair?` is `isinst object[]`, `not`
+is `xor 1`, `equal?` is `unbox.any int32` ×2 + `ceq`, and `COND` lowers to
+`label`/`br`/`brfalse`. Symbols need no new ops — `intern_symbols_structural` makes
+each `(QUOTE S)` a tagged-int boxed atom. Lambda lands per the
+`CLR-REAL-RUNTIME-VERIFICATION` worklist.)
 
 ## Quick start
 

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -13,7 +13,7 @@
 //! program to the real toolchain and let it own the metadata (PE headers, the
 //! `#~`/`#Strings`/`#Blob` streams, token resolution). No hand-rolled metadata.
 //!
-//! ## Scope (C1–C3)
+//! ## Scope (C1–C4)
 //!
 //! * **C1 — scalar:** the entry function as a straight line of integer `const` /
 //!   `mov` / `ret`; each register an `int32` local, a generated launcher prints
@@ -26,9 +26,14 @@
 //!   to `label` (`<name>:`) / `jmp` (`br`) / `jmp_if_false` (`brfalse`), and a nil
 //!   fall-through `const … : ref<…>` becomes `ldnull` (never `ldc.i4 0`).
 //!
-//! Every other op returns [`IIRClrError::UnsupportedOp`], so the remaining slices
-//! (symbols, lambda / LABEL) extend the op match incrementally — `ilasm` already
-//! handles the metadata each will need.
+//! * **C4 — symbols:** no new ops. `intern_symbols_structural` lowers each `(QUOTE
+//!   S)` to a *tagged integer id* (`A` → `0x20000000`, …), which on the CLR is just
+//!   a boxed `System.Int32` atom — so `EQ`/`ATOM` on symbols reuse the C1–C3
+//!   `const`/`box`/`equal?`/`pair?` path unchanged.
+//!
+//! Every other op returns [`IIRClrError::UnsupportedOp`], so the remaining slice
+//! (lambda / LABEL) extends the op match incrementally — `ilasm` already handles
+//! the metadata it will need.
 
 use crate::lower::{IIRClrConfig, IIRClrError};
 use interpreter_ir::{IIRFunction, IIRInstr, IIRModule, Operand};
@@ -584,6 +589,44 @@ mod tests {
             "equal? unboxes both operands; got:\n{il}"
         );
         assert!(il.contains("ceq"), "equal? → ceq");
+    }
+
+    #[test]
+    fn symbol_eq_emits_tagged_id_consts_unboxed_and_compared() {
+        // `(EQ (QUOTE A) (QUOTE A))` after `intern_symbols_structural`: each symbol
+        // is a *tagged integer id* (here `A` → 0x20000000 = 536870912), boxed as an
+        // atom — the exact scalar/predicate shape C1–C3 already emit. Symbols need
+        // NO new CIL ops: two equal `ldc.i4 <id>`, boxed, then `equal?`-unboxed.
+        const SYM_A: i64 = 0x2000_0000; // 536870912, the interned id of `A`
+        let instrs = vec![
+            IIRInstr::new("const", Some("v0".into()), vec![Operand::Int(SYM_A)], "i32"),
+            IIRInstr::new("const", Some("v1".into()), vec![Operand::Int(SYM_A)], "i32"),
+            IIRInstr::new("box", Some("v0b".into()), vec![Operand::Var("v0".into())], "ref<any>"),
+            IIRInstr::new("box", Some("v1b".into()), vec![Operand::Var("v1".into())], "ref<any>"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("r".into()),
+                vec![
+                    Operand::Var("equal?".into()),
+                    Operand::Var("v0b".into()),
+                    Operand::Var("v1b".into()),
+                ],
+                "bool",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "mccarthy-lisp");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        assert!(il.contains("ldc.i4 536870912"), "tagged symbol id is a const; got:\n{il}");
+        assert!(il.contains("box [System.Runtime]System.Int32"), "symbol id boxed as an atom");
+        assert_eq!(
+            il.matches("unbox.any [System.Runtime]System.Int32").count(),
+            2,
+            "equal? unboxes both symbol ids"
+        );
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.51.0 — 2026-06-11 — McCarthy **symbols** on real CoreCLR (CLR-real C4)
+
+`compile_source_to_cil_text` now exercised on McCarthy symbol programs (via
+`iir-to-cil-bytecode` 0.14.0 — no new ops; `intern_symbols_structural` turns each
+`(QUOTE S)` into a tagged-int atom that reuses the existing const/box/equal? path).
+New e2e `tests/clr_real_symbols.rs` runs them on **real CoreCLR**:
+`(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0, `(ATOM (QUOTE A))`→1,
+`(EQ (QUOTE FOO) (QUOTE FOO))`→1, `(EQ (QUOTE FOO) (QUOTE BAR))`→0, plus int-EQ /
+cons regression. Gated on `dotnet`+`ilasm`; skips when absent.
+
 ## 0.50.0 — 2026-06-11 — McCarthy **predicates + COND** on real CoreCLR (CLR-real C3)
 
 `compile_source_to_cil_text` now compiles McCarthy predicate and `COND` programs

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -47,11 +47,12 @@ McCarthy support after WASM and JVM.
 `compile_source_to_cil_text` is the **real-CoreCLR** path (CLR-real C1): the same
 lowered program emitted as textual `.il`, assembled by real `ilasm` into a loadable
 PE, and run on real `dotnet` — the CLR analog of `compile_source_to_llvm` (`.ll` →
-real `clang`). Scalar, **cons/car/cdr**, and **predicates + `COND`** run today
-(`42`→42, `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1, `(EQ 7 7)`→1,
-`(COND ((ATOM 7) 11) …)`→11 on real CoreCLR; `tests/clr_real_scalar.rs` +
-`clr_real_cons.rs` + `clr_real_predicates.rs`, gated on `dotnet`+`ilasm` via the
-shared `tests/clr_support` harness); symbols and lambda land per the
+real `clang`). Scalar, **cons/car/cdr**, **predicates + `COND`**, and **symbols**
+run today (`42`→42, `(CAR (CONS 7 9))`→7, `(ATOM 7)`→1, `(EQ 7 7)`→1,
+`(COND ((ATOM 7) 11) …)`→11, `(EQ (QUOTE A) (QUOTE A))`→1 on real CoreCLR;
+`tests/clr_real_scalar.rs` + `clr_real_cons.rs` + `clr_real_predicates.rs` +
+`clr_real_symbols.rs`, gated on `dotnet`+`ilasm` via the shared `tests/clr_support`
+harness); lambda lands per the
 `CLR-REAL-RUNTIME-VERIFICATION` worklist, after which the CLR column of the W16
 conformance matrix is verified on real .NET rather than the in-repo simulator.
 

--- a/code/packages/rust/lang-aot/tests/clr_real_symbols.rs
+++ b/code/packages/rust/lang-aot/tests/clr_real_symbols.rs
@@ -1,0 +1,41 @@
+//! # McCarthy on **real CoreCLR** — symbols (CLR-real C4).
+//!
+//! McCarthy `(QUOTE A)` symbols are handled by the shared `intern_symbols_structural`
+//! pass, which assigns each distinct symbol a **tagged integer id** (e.g. `A` →
+//! `0x20000000`, `B` → `0x20000001`). On the CLR value model that id is just a
+//! boxed `System.Int32` atom — exactly the shape C1–C3 already emit — so symbols
+//! need **no new CIL ops**: `(EQ (QUOTE A) (QUOTE A))` is two equal interned ids,
+//! `equal?`-unboxed and compared; `(ATOM (QUOTE A))` is `not (pair? boxed-int)`.
+//!
+//! This test is the real-CoreCLR proof of that reduction — the same `.il` → real
+//! `ilasm` → real `dotnet` pipeline as the scalar/cons/predicate tests. Gated on
+//! `dotnet`+`ilasm` (skips when absent).
+
+#[path = "clr_support/mod.rs"]
+mod clr_support;
+use clr_support::run_on_real_clr;
+
+#[test]
+fn mccarthy_symbols_run_on_real_coreclr() {
+    // Probe once; if the toolchain is absent, skip the whole suite.
+    let Some(eq_same) = run_on_real_clr("(EQ (QUOTE A) (QUOTE A))", "sym_eq_t") else {
+        eprintln!("dotnet/ilasm absent — skipping real-CoreCLR symbol test");
+        return;
+    };
+
+    // F6 — symbol identity: the same quoted symbol interns to the same id (→ 1),
+    // distinct symbols to distinct ids (→ 0).
+    assert_eq!(eq_same, 1, "(EQ (QUOTE A) (QUOTE A)) on real CoreCLR");
+    assert_eq!(run_on_real_clr("(EQ (QUOTE A) (QUOTE B))", "sym_eq_f").unwrap(), 0);
+
+    // A symbol is an atom (not a cons cell) → ATOM is 1.
+    assert_eq!(run_on_real_clr("(ATOM (QUOTE A))", "sym_atom").unwrap(), 1);
+
+    // A third distinct symbol still interns distinctly (id space is stable).
+    assert_eq!(run_on_real_clr("(EQ (QUOTE FOO) (QUOTE FOO))", "sym_foo").unwrap(), 1);
+    assert_eq!(run_on_real_clr("(EQ (QUOTE FOO) (QUOTE BAR))", "sym_foobar").unwrap(), 0);
+
+    // No regression: predicates (C3), cons (C2), scalar (C1) still run.
+    assert_eq!(run_on_real_clr("(EQ 7 7)", "int_eq").unwrap(), 1);
+    assert_eq!(run_on_real_clr("(CAR (CONS 7 9))", "car").unwrap(), 7);
+}

--- a/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
+++ b/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
@@ -67,8 +67,15 @@ other external-tool backends.
   CoreCLR** (`tests/clr_real_predicates.rs`): `(ATOM 7)`→1, `(ATOM (CONS 1 2))`→0,
   `(EQ 7 7)`→1, `(EQ 7 8)`→0, `(COND ((ATOM 7) 11) …)`→11,
   `(COND ((ATOM (CONS 1 2)) 11) ((EQ 5 5) 22))`→22.
-- ☐ **C4 — symbols (F6).** Interned symbol ids (the shared
-  `intern_symbols_structural`); `(EQ (QUOTE A) (QUOTE A))`→1, distinct→0.
+- ✅ **C4 — symbols (F6).** **No new emit ops.** The shared
+  `intern_symbols_structural` pass lowers each `(QUOTE S)` to a *tagged integer id*
+  (`A` → `0x20000000`, `B` → `0x20000001`, …); on the CLR value model that id is
+  just a boxed `System.Int32` atom, so `EQ`/`ATOM` on symbols reuse the C1–C3
+  `const`/`box`/`equal?`/`pair?` path unchanged. Verified by RUNNING on **real
+  CoreCLR** (`tests/clr_real_symbols.rs`): `(EQ (QUOTE A) (QUOTE A))`→1,
+  `(EQ (QUOTE A) (QUOTE B))`→0, `(ATOM (QUOTE A))`→1,
+  `(EQ (QUOTE FOO) (QUOTE FOO))`→1, `(EQ (QUOTE FOO) (QUOTE BAR))`→0. Unit test
+  `symbol_eq_emits_tagged_id_consts_unboxed_and_compared` pins the value model.
 - ☐ **C5 — lambda / LABEL / recursion (F7).** Each hoisted lambda as its own
   `.method`; application via `call <Method>`; recursion. Verify
   `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7 and a recursive `LABEL`.


### PR DESCRIPTION
## Summary

Fifth slice of the **CLR real-CoreCLR verification** chapter (`code/specs/CLR-REAL-RUNTIME-VERIFICATION.md`, item **C4**). Verifies McCarthy **symbols** (F6) on **real CoreCLR** — real `ilasm` → PE → real `dotnet`.

**No new CIL emit ops.** The shared `intern_symbols_structural` pass lowers each `(QUOTE S)` to a *tagged integer id* (`A` → `0x20000000`, `B` → `0x20000001`, …). On the CLR value model that id is just a boxed `System.Int32` atom — the exact scalar/predicate shape C1–C3 already emit. So `EQ`/`ATOM` on symbols reduce to the existing `const`/`box`/`equal?`/`pair?` path unchanged, flowing through the same `i32::try_from`-guarded `const` arm as integer scalars. This slice is the real-runtime *proof* of that reduction.

## Security

Security review **PASSED** (first round). The "no new ops" claim was verified — the only `il_text.rs` change is doc comments + a `#[cfg(test)]` unit test; zero change to any emit arm. The tagged symbol id flows through the same range-checked `const` path that returns `InvalidOperand` (never overflow/panic) for out-of-`i32` values. Symbols become integer ids, not label names, so they never touch the `checked_label` injection surface added in C3. The new e2e test passes only fixed literal source strings — no injection.

## Test plan

- **Real CoreCLR e2e** (`lang-aot/tests/clr_real_symbols.rs`, gated on `dotnet`+`ilasm`, skips when absent): `(EQ (QUOTE A) (QUOTE A))`→1, `(EQ (QUOTE A) (QUOTE B))`→0, `(ATOM (QUOTE A))`→1, `(EQ (QUOTE FOO) (QUOTE FOO))`→1, `(EQ (QUOTE FOO) (QUOTE BAR))`→0, plus int-EQ + cons regression — **all pass on real dotnet 9.0.313 + real ilasm locally.**
- **Unit test** (`il_text.rs`): `symbol_eq_emits_tagged_id_consts_unboxed_and_compared` pins the value model (`ldc.i4 536870912`; `box int32`; `unbox.any int32` ×2). 9 `il_text` unit tests pass.
- Clippy clean for `iir-to-cil-bytecode`. (Pre-existing unrelated `iir-to-beam` lint untouched.)

## Versioning / docs

- `iir-to-cil-bytecode` 0.13.0 → **0.14.0**; `lang-aot` 0.50.0 → **0.51.0**
- Spec C4 ticked ☐→✅; both CHANGELOGs + both READMEs updated.

Remaining: **C5** (lambda / LABEL / recursion) and **C6** (wire real-CoreCLR into the W16 conformance suite + CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)