### PR TITLE
Add smart-home activation briefing tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -52,6 +52,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation readout planning:
   `smart_home.list_integration_activation_readouts` and
   `smart_home.get_integration_activation_readout_summary`.
+- Added D18D handlers for D23A activation briefing item planning:
+  `smart_home.list_integration_activation_briefing_items` and
+  `smart_home.get_integration_activation_briefing_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -108,6 +108,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_dossier_summary`
 - `smart_home.list_integration_activation_readouts`
 - `smart_home.get_integration_activation_readout_summary`
+- `smart_home.list_integration_activation_briefing_items`
+- `smart_home.get_integration_activation_briefing_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,25 +34,27 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
-    activation_approval_packets_from_candidates, activation_candidates_at_or_before_priority,
-    activation_constraints_from_candidates, activation_decisions_from_candidates,
-    activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_evidence_from_candidates, activation_health_from_candidates,
-    activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_readouts_from_candidates,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    activation_approval_packets_from_candidates, activation_briefing_items_from_readouts,
+    activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
+    activation_decisions_from_candidates, activation_dependency_graph_from_reports,
+    activation_dossiers_from_candidates, activation_evidence_from_candidates,
+    activation_health_from_candidates, activation_maintenance_from_candidates,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_readouts_from_candidates, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
+    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
+    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
     IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
     IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
     IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
@@ -230,6 +232,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_READOUTS_TOOL_ID: &str =
     "smart_home.list_integration_activation_readouts";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_readout_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_briefing_items";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_briefing_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -478,6 +484,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID => {
                     let query = integration_activation_readout_query(&arguments)?;
                     Ok(get_integration_activation_readout_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID => {
+                    let query = integration_activation_briefing_query(&arguments)?;
+                    Ok(list_integration_activation_briefing_items_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_briefing_query(&arguments)?;
+                    Ok(get_integration_activation_briefing_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1647,6 +1661,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation readout summary",
             "Return compact D23A activation readout counts across priority-wave health, approval, evidence, risk, and blocker work.",
             integration_activation_readout_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID,
+            "List smart-home integration activation briefing items",
+            "List Chief-ready D23A activation briefing rows derived from readouts across activation, approval, review, blocker, risk, and dependency sections.",
+            integration_activation_briefing_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_briefing_items", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_briefing_items",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation briefing summary",
+            "Return compact D23A activation briefing counts across action, approval, review, blocker, risk, and dependency sections.",
+            integration_activation_briefing_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4295,6 +4343,13 @@ struct IntegrationActivationReadoutQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationBriefingQuery {
+    readouts: IntegrationActivationReadoutQuery,
+    item_kind: Option<IntegrationActivationBriefingItemKind>,
+    item_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4546,6 +4601,22 @@ fn integration_activation_readout_query(
         readout_limit: optional_u64(arguments, "readout_limit")?.map(|value| value as usize),
         dossiers_per_readout_limit: optional_u64(arguments, "dossiers_per_readout_limit")?
             .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_briefing_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationBriefingQuery, ToolCallError> {
+    let readouts = integration_activation_readout_query(arguments)?;
+    let item_kind = optional_string(arguments, "item_kind")?
+        .or(optional_string(arguments, "briefing_kind")?)
+        .map(|label| parse_activation_briefing_item_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationBriefingQuery {
+        readouts,
+        item_kind,
+        item_limit: optional_u64(arguments, "item_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5085,6 +5156,22 @@ fn integration_activation_readouts_for_query(
     }
 
     (readouts, catalog_count)
+}
+
+fn integration_activation_briefing_items_for_query(
+    query: &IntegrationActivationBriefingQuery,
+) -> (Vec<IntegrationActivationBriefingItem>, usize) {
+    let (readouts, catalog_count) = integration_activation_readouts_for_query(&query.readouts);
+    let mut items = activation_briefing_items_from_readouts(readouts.iter());
+
+    if let Some(item_kind) = query.item_kind {
+        items.retain(|item| item.kind == item_kind);
+    }
+    if let Some(limit) = query.item_limit {
+        items.truncate(limit);
+    }
+
+    (items, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6362,6 +6449,63 @@ fn get_integration_activation_readout_summary_output_handler_output(
                 "readouts_with_approval_work",
                 integer(summary.readouts_with_approval_work as i64),
             ),
+        ]),
+    )
+}
+
+fn list_integration_activation_briefing_items_output_handler_output(
+    query: IntegrationActivationBriefingQuery,
+) -> ToolHandlerOutput {
+    let (items, catalog_count) = integration_activation_briefing_items_for_query(&query);
+    let summary = IntegrationActivationBriefingSummary::from_items(items.iter());
+    let count = items.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_briefing_items",
+            JsonValue::Array(items.iter().map(activation_briefing_item_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_briefing_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_briefing_items"),
+            ),
+            ("activation_briefing_items", integer(count as i64)),
+            ("blocker_items", integer(summary.blocker_items as i64)),
+            ("approval_items", integer(summary.approval_items as i64)),
+        ]),
+    )
+}
+
+fn get_integration_activation_briefing_summary_output_handler_output(
+    query: IntegrationActivationBriefingQuery,
+) -> ToolHandlerOutput {
+    let (items, _) = integration_activation_briefing_items_for_query(&query);
+    let summary = IntegrationActivationBriefingSummary::from_items(items.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_briefing_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_briefing_summary"),
+            ),
+            ("total_items", integer(summary.total_items as i64)),
+            ("blocker_items", integer(summary.blocker_items as i64)),
+            ("approval_items", integer(summary.approval_items as i64)),
         ]),
     )
 }
@@ -11374,6 +11518,187 @@ fn integration_activation_readout_summary_json(
     ])
 }
 
+fn activation_briefing_item_json(item: &IntegrationActivationBriefingItem) -> JsonValue {
+    object([
+        ("item_kind", string(item.kind.as_str())),
+        ("priority", integer(item.priority as i64)),
+        ("health_status", string(item.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                item.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(item.integration_count() as i64),
+        ),
+        ("action_count", integer(item.action_count as i64)),
+        ("dossier_count", integer(item.dossier_count as i64)),
+        ("evidence_count", integer(item.evidence_count as i64)),
+        ("risk_count", integer(item.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(item.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(item.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(item.highest_policy_tier)),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(item.has_activation_work),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(item.has_approval_ready_work),
+        ),
+        ("has_review_work", JsonValue::Bool(item.has_review_work)),
+        ("has_blockers", JsonValue::Bool(item.has_blockers)),
+        ("has_risks", JsonValue::Bool(item.has_risks)),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(item.has_dependency_blockers),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(item.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_briefing_summary_json(
+    summary: &IntegrationActivationBriefingSummary,
+) -> JsonValue {
+    object([
+        ("total_items", integer(summary.total_items as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        ("activation_items", integer(summary.activation_items as i64)),
+        ("approval_items", integer(summary.approval_items as i64)),
+        ("review_items", integer(summary.review_items as i64)),
+        ("blocker_items", integer(summary.blocker_items as i64)),
+        ("risk_items", integer(summary.risk_items as i64)),
+        ("dependency_items", integer(summary.dependency_items as i64)),
+        (
+            "items_requiring_attention",
+            integer(summary.items_requiring_attention as i64),
+        ),
+        (
+            "items_with_activation_work",
+            integer(summary.items_with_activation_work as i64),
+        ),
+        (
+            "items_with_approval_work",
+            integer(summary.items_with_approval_work as i64),
+        ),
+        (
+            "items_with_review_work",
+            integer(summary.items_with_review_work as i64),
+        ),
+        (
+            "items_with_blockers",
+            integer(summary.items_with_blockers as i64),
+        ),
+        ("items_with_risks", integer(summary.items_with_risks as i64)),
+        (
+            "items_with_dependency_blockers",
+            integer(summary.items_with_dependency_blockers as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_priority",
+            summary
+                .first_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(summary.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -13925,6 +14250,30 @@ fn parse_activation_constraint_kind(
     }
 }
 
+fn parse_activation_briefing_item_kind(
+    label: &str,
+) -> Result<IntegrationActivationBriefingItemKind, ToolCallError> {
+    match label {
+        "blocker" | "blockers" | "blocked" => Ok(IntegrationActivationBriefingItemKind::Blocker),
+        "review" | "human_review" | "policy_review" => {
+            Ok(IntegrationActivationBriefingItemKind::Review)
+        }
+        "approval" | "approve" | "ready_to_approve" => {
+            Ok(IntegrationActivationBriefingItemKind::Approval)
+        }
+        "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationBriefingItemKind::Activation)
+        }
+        "risk" | "risks" => Ok(IntegrationActivationBriefingItemKind::Risk),
+        "dependency" | "dependencies" | "dependency_blocker" => {
+            Ok(IntegrationActivationBriefingItemKind::Dependency)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation briefing item kind `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -14935,6 +15284,21 @@ fn integration_activation_readout_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_briefing_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_readout_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("item_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("briefing_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("item_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -15079,7 +15443,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 87);
+        assert_eq!(definitions.len(), 89);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -15308,9 +15672,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            79
+            81
         );
         assert_eq!(
             export
@@ -15470,6 +15840,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_READOUT_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -15724,11 +16102,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(87))
+            Some(&integer(89))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(79))
+            Some(&integer(81))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -17646,6 +18024,148 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_briefing_items_request = request(
+            "call-list-integration-activation-briefing-items",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("item_limit", integer(4)),
+            ]),
+            5_021,
+        );
+        let list_activation_briefing_items_trace =
+            tool_runtime.invoke_with_events(&list_activation_briefing_items_request);
+        assert!(list_activation_briefing_items_trace.result.ok);
+        assert_eq!(
+            list_activation_briefing_items_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_briefing_items_output = list_activation_briefing_items_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_briefing_item_count =
+            integer_value(field(list_activation_briefing_items_output, "count").unwrap()).unwrap();
+        assert!((1..=4).contains(&activation_briefing_item_count));
+        let activation_briefing_summary =
+            field(list_activation_briefing_items_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_briefing_summary, "total_items"),
+            Some(&integer(activation_briefing_item_count))
+        );
+        assert_eq!(
+            field(activation_briefing_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_briefing_work =
+            integer_value(field(activation_briefing_summary, "blocker_items").unwrap()).unwrap()
+                + integer_value(field(activation_briefing_summary, "approval_items").unwrap())
+                    .unwrap();
+        assert!(activation_briefing_work >= 1);
+        let activation_briefing_item = array_item(
+            field(
+                list_activation_briefing_items_output,
+                "activation_briefing_items",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(matches!(
+            field(activation_briefing_item, "item_kind"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(matches!(
+            field(activation_briefing_item, "health_status"),
+            Some(JsonValue::String(_))
+        ));
+        assert!(field(activation_briefing_item, "integration_ids").is_some());
+        assert!(field(activation_briefing_item, "integration_count").is_some());
+        assert!(field(activation_briefing_item, "action_count").is_some());
+        assert!(field(activation_briefing_item, "dossier_count").is_some());
+        assert!(field(activation_briefing_item, "evidence_count").is_some());
+        assert!(field(activation_briefing_item, "risk_count").is_some());
+        assert!(field(activation_briefing_item, "dependency_edge_count").is_some());
+        assert!(field(activation_briefing_item, "has_blockers").is_some());
+        assert_eq!(
+            field(activation_briefing_item, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_briefing_summary_request = request(
+            "call-integration-activation-briefing-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("item_kind", string("blocker")),
+            ]),
+            5_022,
+        );
+        let activation_briefing_summary_trace =
+            tool_runtime.invoke_with_events(&activation_briefing_summary_request);
+        assert!(activation_briefing_summary_trace.result.ok);
+        assert_eq!(
+            activation_briefing_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_briefing_summary_output = activation_briefing_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_briefing_rollup =
+            field(activation_briefing_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_briefing_rollup, "blocker_items").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_briefing_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_briefing_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -19369,6 +19889,14 @@ mod tests {
             activation_readout_summary_request,
             activation_readout_summary_trace,
         );
+        journal.record_trace(
+            list_activation_briefing_items_request,
+            list_activation_briefing_items_trace,
+        );
+        journal.record_trace(
+            activation_briefing_summary_request,
+            activation_briefing_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -19442,9 +19970,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 87);
-        assert_eq!(journal_summary.completed_count, 87);
-        assert_eq!(journal.audit_records().len(), 87);
+        assert_eq!(journal_summary.invocation_count, 89);
+        assert_eq!(journal_summary.completed_count, 89);
+        assert_eq!(journal.audit_records().len(), 89);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -68,6 +68,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_readout_summary` tool descriptors
   for read-only priority-wave activation readouts across health, dossiers,
   evidence, risk, action, and dependency blockers.
+- `smart_home.list_integration_activation_briefing_items` and
+  `smart_home.get_integration_activation_briefing_summary` tool descriptors
+  for read-only Chief activation briefing sections derived from priority-wave
+  readouts.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -81,6 +81,8 @@ Current scope:
   decision and evidence planning
 - D18D integration activation-readout descriptors for priority-wave health,
   dossier, evidence, risk, action, and dependency blocker rollups
+- D18D integration activation-briefing descriptors for Chief-ready activation,
+  approval, review, blocker, risk, and dependency briefing sections
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1485,6 +1485,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationDossierSummary,
     ListIntegrationActivationReadouts,
     GetIntegrationActivationReadoutSummary,
+    ListIntegrationActivationBriefingItems,
+    GetIntegrationActivationBriefingSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1646,6 +1648,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationReadoutSummary => {
                 read_tool("smart_home.get_integration_activation_readout_summary")
+            }
+            Self::ListIntegrationActivationBriefingItems => {
+                read_tool("smart_home.list_integration_activation_briefing_items")
+            }
+            Self::GetIntegrationActivationBriefingSummary => {
+                read_tool("smart_home.get_integration_activation_briefing_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2314,6 +2322,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationDossierSummary,
         SmartHomeTool::ListIntegrationActivationReadouts,
         SmartHomeTool::GetIntegrationActivationReadoutSummary,
+        SmartHomeTool::ListIntegrationActivationBriefingItems,
+        SmartHomeTool::GetIntegrationActivationBriefingSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3156,7 +3166,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 87);
+        assert_eq!(catalog.len(), 89);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3328,6 +3338,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_readout_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_briefing_items"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_briefing_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3518,15 +3536,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 87);
-        assert_eq!(summary.read_tools, 79);
+        assert_eq!(summary.total_tools, 89);
+        assert_eq!(summary.read_tools, 81);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 79);
+        assert_eq!(summary.read_only_tier_tools, 81);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 87);
+        assert_eq!(summary.total_required_capabilities, 89);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -64,6 +64,8 @@ runtime and Chief of Staff tools a typed catalog for:
   rows and compact evidence rollups for Chief planning
 - activation readout rows that combine priority-wave health, maintenance,
   dossier, evidence, risk, action, and dependency blocker rollups
+- activation briefing rows that split readouts into Chief-ready activation,
+  approval, review, blocker, risk, and dependency briefing sections
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1025,6 +1025,29 @@ impl IntegrationActivationHealthStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationBriefingItemKind {
+    Blocker,
+    Review,
+    Approval,
+    Activation,
+    Risk,
+    Dependency,
+}
+
+impl IntegrationActivationBriefingItemKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocker => "blocker",
+            Self::Review => "review",
+            Self::Approval => "approval",
+            Self::Activation => "activation",
+            Self::Risk => "risk",
+            Self::Dependency => "dependency",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -1731,6 +1754,60 @@ pub struct IntegrationActivationReadoutSummary {
     pub first_blocked_priority: Option<u8>,
     pub first_activation_priority: Option<u8>,
     pub first_approval_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationBriefingItem {
+    pub kind: IntegrationActivationBriefingItemKind,
+    pub priority: u8,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub has_activation_work: bool,
+    pub has_approval_ready_work: bool,
+    pub has_review_work: bool,
+    pub has_blockers: bool,
+    pub has_risks: bool,
+    pub has_dependency_blockers: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationBriefingSummary {
+    pub total_items: usize,
+    pub unique_integrations: usize,
+    pub activation_items: usize,
+    pub approval_items: usize,
+    pub review_items: usize,
+    pub blocker_items: usize,
+    pub risk_items: usize,
+    pub dependency_items: usize,
+    pub items_requiring_attention: usize,
+    pub items_with_activation_work: usize,
+    pub items_with_approval_work: usize,
+    pub items_with_review_work: usize,
+    pub items_with_blockers: usize,
+    pub items_with_risks: usize,
+    pub items_with_dependency_blockers: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub first_activation_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_risk_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -2708,6 +2785,229 @@ impl IntegrationActivationReadoutSummary {
             || self.has_approval_ready_work()
             || self.has_review_work()
             || self.has_blockers()
+    }
+}
+
+impl IntegrationActivationBriefingItem {
+    fn from_readout(
+        kind: IntegrationActivationBriefingItemKind,
+        readout: &IntegrationActivationReadoutStage,
+    ) -> Self {
+        Self {
+            kind,
+            priority: readout.priority,
+            health_status: readout.health_status,
+            integration_ids: readout.integration_ids.clone(),
+            action_count: readout.action_summary().total_actions,
+            dossier_count: readout.dossier_summary.total_dossiers,
+            evidence_count: readout.evidence_summary.total_evidence,
+            risk_count: readout.risk_summary().total_risks,
+            dependency_edge_count: readout.dependency_summary().total_edges,
+            blocking_dependency_edge_count: readout.dependency_summary().blocking_edges,
+            highest_policy_tier: readout
+                .candidate_summary()
+                .highest_policy_tier
+                .max(readout.action_summary().highest_policy_tier)
+                .max(readout.constraint_summary().highest_policy_tier)
+                .max(readout.risk_summary().highest_policy_tier)
+                .max(readout.dependency_summary().highest_policy_tier)
+                .max(readout.dossier_summary.highest_policy_tier)
+                .max(readout.evidence_summary.highest_policy_tier),
+            has_activation_work: readout.has_activation_work(),
+            has_approval_ready_work: readout.has_approval_ready_work(),
+            has_review_work: readout.has_review_work(),
+            has_blockers: readout.has_blockers(),
+            has_risks: readout.has_risks(),
+            has_dependency_blockers: readout.has_dependency_blockers(),
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.health_status.requires_attention()
+            || self.has_approval_ready_work
+            || self.has_review_work
+            || self.has_blockers
+            || self.has_risks
+            || self.has_dependency_blockers
+    }
+}
+
+impl IntegrationActivationBriefingSummary {
+    pub fn from_items<'a>(
+        items: impl IntoIterator<Item = &'a IntegrationActivationBriefingItem>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut ready_items = 0;
+        let mut review_status_items = 0;
+        let mut blocked_status_items = 0;
+        let mut empty_items = 0;
+        let mut summary = Self {
+            total_items: 0,
+            unique_integrations: 0,
+            activation_items: 0,
+            approval_items: 0,
+            review_items: 0,
+            blocker_items: 0,
+            risk_items: 0,
+            dependency_items: 0,
+            items_requiring_attention: 0,
+            items_with_activation_work: 0,
+            items_with_approval_work: 0,
+            items_with_review_work: 0,
+            items_with_blockers: 0,
+            items_with_risks: 0,
+            items_with_dependency_blockers: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            first_activation_priority: None,
+            first_approval_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_risk_priority: None,
+            first_dependency_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for item in items {
+            summary.total_items += 1;
+            for integration_id in &item.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            summary.total_actions += item.action_count;
+            summary.total_dossiers += item.dossier_count;
+            summary.total_evidence += item.evidence_count;
+            summary.total_risks += item.risk_count;
+            summary.total_dependency_edges += item.dependency_edge_count;
+            summary.blocking_dependency_edges += item.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary.highest_policy_tier.max(item.highest_policy_tier);
+
+            match item.health_status {
+                IntegrationActivationHealthStatus::Ready => ready_items += 1,
+                IntegrationActivationHealthStatus::NeedsReview => review_status_items += 1,
+                IntegrationActivationHealthStatus::Blocked => blocked_status_items += 1,
+                IntegrationActivationHealthStatus::Empty => empty_items += 1,
+            }
+
+            match item.kind {
+                IntegrationActivationBriefingItemKind::Activation => {
+                    summary.activation_items += 1;
+                    summary.first_activation_priority = min_optional_priority(
+                        summary.first_activation_priority,
+                        Some(item.priority),
+                    );
+                }
+                IntegrationActivationBriefingItemKind::Approval => {
+                    summary.approval_items += 1;
+                    summary.first_approval_priority =
+                        min_optional_priority(summary.first_approval_priority, Some(item.priority));
+                }
+                IntegrationActivationBriefingItemKind::Review => {
+                    summary.review_items += 1;
+                    summary.first_review_priority =
+                        min_optional_priority(summary.first_review_priority, Some(item.priority));
+                }
+                IntegrationActivationBriefingItemKind::Blocker => {
+                    summary.blocker_items += 1;
+                    summary.first_blocked_priority =
+                        min_optional_priority(summary.first_blocked_priority, Some(item.priority));
+                }
+                IntegrationActivationBriefingItemKind::Risk => {
+                    summary.risk_items += 1;
+                    summary.first_risk_priority =
+                        min_optional_priority(summary.first_risk_priority, Some(item.priority));
+                }
+                IntegrationActivationBriefingItemKind::Dependency => {
+                    summary.dependency_items += 1;
+                    summary.first_dependency_priority = min_optional_priority(
+                        summary.first_dependency_priority,
+                        Some(item.priority),
+                    );
+                }
+            }
+
+            if item.requires_attention() {
+                summary.items_requiring_attention += 1;
+            }
+            if item.has_activation_work {
+                summary.items_with_activation_work += 1;
+            }
+            if item.has_approval_ready_work {
+                summary.items_with_approval_work += 1;
+            }
+            if item.has_review_work {
+                summary.items_with_review_work += 1;
+            }
+            if item.has_blockers {
+                summary.items_with_blockers += 1;
+            }
+            if item.has_risks {
+                summary.items_with_risks += 1;
+            }
+            if item.has_dependency_blockers {
+                summary.items_with_dependency_blockers += 1;
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if blocked_status_items > 0 || summary.blocker_items > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if review_status_items > 0 || summary.review_items > 0 || summary.approval_items > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if ready_items > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else if empty_items > 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_items == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activation_items > 0 || self.items_with_activation_work > 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.approval_items > 0 || self.items_with_approval_work > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_items > 0 || self.items_with_review_work > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocker_items > 0 || self.items_with_blockers > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.risk_items > 0 || self.items_with_risks > 0
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.dependency_items > 0 || self.items_with_dependency_blockers > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention()
+            || self.has_approval_ready_work()
+            || self.has_review_work()
+            || self.has_blockers()
+            || self.has_risks()
+            || self.has_dependency_blockers()
     }
 }
 
@@ -6504,6 +6804,78 @@ pub fn activation_readouts_at_or_before_priority(
     )
 }
 
+pub fn activation_briefing_items_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationBriefingItem> {
+    let mut items = Vec::new();
+    for readout in readouts {
+        if readout.has_blockers() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Blocker,
+                readout,
+            ));
+        }
+        if readout.has_review_work() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Review,
+                readout,
+            ));
+        }
+        if readout.has_approval_ready_work() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Approval,
+                readout,
+            ));
+        }
+        if readout.has_activation_work() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Activation,
+                readout,
+            ));
+        }
+        if readout.has_risks() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Risk,
+                readout,
+            ));
+        }
+        if readout.has_dependency_blockers() {
+            items.push(IntegrationActivationBriefingItem::from_readout(
+                IntegrationActivationBriefingItemKind::Dependency,
+                readout,
+            ));
+        }
+    }
+    items.sort_by(compare_activation_briefing_items);
+    items
+}
+
+pub fn activation_briefing_items_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationBriefingItem> {
+    let readouts = activation_readouts_from_candidates(catalog, candidates, enabled_integrations);
+    activation_briefing_items_from_readouts(readouts.iter())
+}
+
+pub fn activation_briefing_items_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationBriefingItem> {
+    let readouts = activation_readouts_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_briefing_items_from_readouts(readouts.iter())
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -7800,6 +8172,17 @@ fn compare_activation_readouts(
         })
         .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
         .then_with(|| right.has_risks().cmp(&left.has_risks()))
+}
+
+fn compare_activation_briefing_items(
+    left: &IntegrationActivationBriefingItem,
+    right: &IntegrationActivationBriefingItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.kind.cmp(&right.kind))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
 fn compare_activation_dependency_nodes(
@@ -9456,6 +9839,121 @@ mod tests {
         assert!(catalog_readouts
             .iter()
             .any(|readout| readout.dossier_summary.total_dossiers > 0));
+    }
+
+    #[test]
+    fn activation_briefing_items_summarize_readout_attention_sections() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let items = activation_briefing_items_from_candidates(&[], candidates, &[]);
+
+        assert!(items.iter().any(|item| {
+            item.priority == 1 && item.kind == IntegrationActivationBriefingItemKind::Approval
+        }));
+        assert!(items.iter().any(|item| {
+            item.priority == 2 && item.kind == IntegrationActivationBriefingItemKind::Blocker
+        }));
+        assert!(items.iter().any(|item| {
+            item.priority == 2 && item.kind == IntegrationActivationBriefingItemKind::Dependency
+        }));
+        assert!(items.iter().any(|item| {
+            item.priority == 3 && item.kind == IntegrationActivationBriefingItemKind::Activation
+        }));
+        assert!(items.iter().all(|item| item.integration_count() >= 1));
+
+        let summary = IntegrationActivationBriefingSummary::from_items(items.iter());
+        assert!(summary.total_items >= 4);
+        assert_eq!(summary.unique_integrations, 3);
+        assert!(summary.activation_items >= 1);
+        assert!(summary.approval_items >= 1);
+        assert!(summary.review_items >= 1);
+        assert!(summary.blocker_items >= 1);
+        assert!(summary.risk_items >= 1);
+        assert!(summary.dependency_items >= 1);
+        assert!(summary.items_requiring_attention >= 1);
+        assert!(summary.total_actions > 0);
+        assert!(summary.total_dossiers > 0);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(summary.first_approval_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(1));
+        assert_eq!(summary.first_activation_priority, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_activation_work());
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_risks());
+        assert!(summary.has_dependency_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_items = activation_briefing_items_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_items
+            .iter()
+            .any(|item| item.kind == IntegrationActivationBriefingItemKind::Blocker));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Add reusable activation briefing item and summary primitives derived from D23A activation readouts.
- Expose Chief read tools for briefing rows and compact briefing summaries across activation, approval, review, blocker, risk, and dependency sections.
- Register the new read-only descriptors in smart-home-core and document the new surfaces.

Validation:
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools