### PR TITLE
Add browser animation interaction descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness animation-interaction descriptors now expose CSS animation
+  and transition event hooks, timeline phase grouping, document/body scope, and
+  cancellation paths as a flat browser-planning inventory.
 - Browser-readiness lifecycle-event descriptors now expose document/body load
   and unload hooks, visibility/history/network lifecycle handlers, and
   element-level error recovery as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -829,6 +829,7 @@ pub struct BrowserDocument {
     pub body_event_handlers: Vec<String>,
     pub event_handler_descriptors: Vec<BrowserEventHandlerDescriptor>,
     pub lifecycle_event_descriptors: Vec<BrowserLifecycleEventDescriptor>,
+    pub animation_interaction_descriptors: Vec<BrowserAnimationInteractionDescriptor>,
     pub body_text: String,
     pub metas: Vec<BrowserMeta>,
     pub resources: Vec<BrowserResource>,
@@ -1372,6 +1373,31 @@ pub struct BrowserLifecycleEventDescriptor {
     pub document_scope: bool,
     pub body_scope: bool,
     pub error_recovery: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAnimationInteractionDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub role: Option<String>,
+    pub source: String,
+    pub animation_kind: String,
+    pub text: String,
+    pub event_handlers: Vec<String>,
+    pub animation_handlers: Vec<String>,
+    pub animation_start_handlers: Vec<String>,
+    pub animation_iteration_handlers: Vec<String>,
+    pub animation_end_handlers: Vec<String>,
+    pub animation_cancel_handlers: Vec<String>,
+    pub transition_handlers: Vec<String>,
+    pub transition_run_handlers: Vec<String>,
+    pub transition_start_handlers: Vec<String>,
+    pub transition_end_handlers: Vec<String>,
+    pub transition_cancel_handlers: Vec<String>,
+    pub handler_count: usize,
+    pub document_scope: bool,
+    pub body_scope: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3220,6 +3246,8 @@ impl BrowserDocument {
         summary.pointer_interaction_descriptors = browser_pointer_interaction_descriptors(&summary);
         summary.scroll_interaction_descriptors = browser_scroll_interaction_descriptors(&summary);
         summary.lifecycle_event_descriptors = browser_lifecycle_event_descriptors(&summary);
+        summary.animation_interaction_descriptors =
+            browser_animation_interaction_descriptors(&summary);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
     }
@@ -15405,6 +15433,124 @@ fn browser_lifecycle_kind(
     }
 }
 
+fn browser_animation_interaction_descriptors(
+    document: &BrowserDocument,
+) -> Vec<BrowserAnimationInteractionDescriptor> {
+    document
+        .event_handler_descriptors
+        .iter()
+        .filter(|descriptor| browser_event_descriptor_has_animation_interaction_state(descriptor))
+        .map(browser_animation_interaction_descriptor)
+        .collect()
+}
+
+fn browser_event_descriptor_has_animation_interaction_state(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !browser_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        browser_animation_interaction_event,
+    )
+    .is_empty()
+}
+
+fn browser_animation_interaction_descriptor(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserAnimationInteractionDescriptor {
+    let animation_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_animation_event);
+    let animation_start_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_animation_start_event);
+    let animation_iteration_handlers = browser_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        browser_animation_iteration_event,
+    );
+    let animation_end_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_animation_end_event);
+    let animation_cancel_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_animation_cancel_event);
+    let transition_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_transition_event);
+    let transition_run_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_transition_run_event);
+    let transition_start_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_transition_start_event);
+    let transition_end_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_transition_end_event);
+    let transition_cancel_handlers =
+        browser_event_handlers_by_kind(&descriptor.event_handlers, browser_transition_cancel_event);
+
+    BrowserAnimationInteractionDescriptor {
+        element: descriptor.element.clone(),
+        id: descriptor.id.clone(),
+        classes: descriptor.classes.clone(),
+        role: descriptor.role.clone(),
+        source: descriptor.source.clone(),
+        animation_kind: browser_animation_interaction_kind(
+            &animation_handlers,
+            &animation_start_handlers,
+            &animation_iteration_handlers,
+            &animation_end_handlers,
+            &animation_cancel_handlers,
+            &transition_handlers,
+            &transition_run_handlers,
+            &transition_start_handlers,
+            &transition_end_handlers,
+            &transition_cancel_handlers,
+        ),
+        text: descriptor.text.clone(),
+        event_handlers: descriptor.event_handlers.clone(),
+        handler_count: animation_handlers.len() + transition_handlers.len(),
+        animation_handlers,
+        animation_start_handlers,
+        animation_iteration_handlers,
+        animation_end_handlers,
+        animation_cancel_handlers,
+        transition_handlers,
+        transition_run_handlers,
+        transition_start_handlers,
+        transition_end_handlers,
+        transition_cancel_handlers,
+        document_scope: descriptor.source == "document",
+        body_scope: descriptor.source == "body",
+    }
+}
+
+fn browser_animation_interaction_kind(
+    animation_handlers: &[String],
+    animation_start_handlers: &[String],
+    animation_iteration_handlers: &[String],
+    animation_end_handlers: &[String],
+    animation_cancel_handlers: &[String],
+    transition_handlers: &[String],
+    transition_run_handlers: &[String],
+    transition_start_handlers: &[String],
+    transition_end_handlers: &[String],
+    transition_cancel_handlers: &[String],
+) -> String {
+    if !animation_cancel_handlers.is_empty() || !transition_cancel_handlers.is_empty() {
+        "animation-cancel".to_string()
+    } else if !animation_handlers.is_empty() && !transition_handlers.is_empty() {
+        "animation-transition".to_string()
+    } else if !animation_iteration_handlers.is_empty() {
+        "animation-iteration".to_string()
+    } else if !animation_end_handlers.is_empty() {
+        "animation-end".to_string()
+    } else if !animation_start_handlers.is_empty() {
+        "animation-start".to_string()
+    } else if !transition_end_handlers.is_empty() {
+        "transition-end".to_string()
+    } else if !transition_start_handlers.is_empty() {
+        "transition-start".to_string()
+    } else if !transition_run_handlers.is_empty() {
+        "transition-run".to_string()
+    } else if !animation_handlers.is_empty() {
+        "animation".to_string()
+    } else {
+        "transition".to_string()
+    }
+}
+
 fn browser_command_role(element: &Element) -> String {
     browser_authored_role(element).unwrap_or_else(|| {
         browser_content_role(&element.name)
@@ -17380,6 +17526,56 @@ fn browser_input_event(handler: &str) -> bool {
             | "oncompositionupdate"
             | "oncompositionend"
     )
+}
+
+fn browser_animation_interaction_event(handler: &str) -> bool {
+    browser_animation_event(handler) || browser_transition_event(handler)
+}
+
+fn browser_animation_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onanimationstart" | "onanimationiteration" | "onanimationend" | "onanimationcancel"
+    )
+}
+
+fn browser_animation_start_event(handler: &str) -> bool {
+    handler == "onanimationstart"
+}
+
+fn browser_animation_iteration_event(handler: &str) -> bool {
+    handler == "onanimationiteration"
+}
+
+fn browser_animation_end_event(handler: &str) -> bool {
+    handler == "onanimationend"
+}
+
+fn browser_animation_cancel_event(handler: &str) -> bool {
+    handler == "onanimationcancel"
+}
+
+fn browser_transition_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "ontransitionrun" | "ontransitionstart" | "ontransitionend" | "ontransitioncancel"
+    )
+}
+
+fn browser_transition_run_event(handler: &str) -> bool {
+    handler == "ontransitionrun"
+}
+
+fn browser_transition_start_event(handler: &str) -> bool {
+    handler == "ontransitionstart"
+}
+
+fn browser_transition_end_event(handler: &str) -> bool {
+    handler == "ontransitionend"
+}
+
+fn browser_transition_cancel_event(handler: &str) -> bool {
+    handler == "ontransitioncancel"
 }
 
 fn browser_form_event(handler: &str) -> bool {
@@ -23636,6 +23832,74 @@ mod tests {
             .expect("dialog lifecycle descriptor");
         assert_eq!(dialog.lifecycle_kind, "error-recovery");
         assert_eq!(dialog.error_handlers, vec!["oncancel"]);
+    }
+
+    #[test]
+    fn browser_animation_interaction_descriptors_track_css_animation_and_transition_hooks() {
+        let html = "<html onanimationstart=docIntro>\
+             <body ontransitionend=bodyDone>\
+             <section id=hero onanimationstart=start onanimationiteration=loop onanimationend=end>Hero</section>\
+             <aside id=panel ontransitionrun=run ontransitionstart=startTransition ontransitionend=endTransition>Panel</aside>\
+             <div id=mixed onanimationend=endAnimation ontransitioncancel=cancelTransition>Mixed</div>\
+             <p id=cancelled onanimationcancel=cancelAnimation>Cancelled</p></body></html>";
+        let summary = parse_browser_document(html).expect("browser document should parse");
+
+        assert_eq!(summary.animation_interaction_descriptors.len(), 6);
+
+        let document = &summary.animation_interaction_descriptors[0];
+        assert_eq!(document.element, "html");
+        assert_eq!(document.source, "document");
+        assert_eq!(document.animation_kind, "animation-start");
+        assert_eq!(document.animation_start_handlers, vec!["onanimationstart"]);
+        assert!(document.document_scope);
+
+        let body = &summary.animation_interaction_descriptors[1];
+        assert_eq!(body.element, "body");
+        assert_eq!(body.animation_kind, "transition-end");
+        assert_eq!(body.transition_end_handlers, vec!["ontransitionend"]);
+        assert!(body.body_scope);
+
+        let hero = summary
+            .animation_interaction_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("hero"))
+            .expect("hero animation descriptor");
+        assert_eq!(hero.animation_kind, "animation-iteration");
+        assert_eq!(
+            hero.animation_handlers,
+            vec!["onanimationstart", "onanimationiteration", "onanimationend"]
+        );
+        assert_eq!(hero.handler_count, 3);
+
+        let panel = summary
+            .animation_interaction_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("panel"))
+            .expect("panel transition descriptor");
+        assert_eq!(panel.animation_kind, "transition-end");
+        assert_eq!(panel.transition_run_handlers, vec!["ontransitionrun"]);
+        assert_eq!(panel.transition_start_handlers, vec!["ontransitionstart"]);
+        assert_eq!(panel.transition_end_handlers, vec!["ontransitionend"]);
+
+        let mixed = summary
+            .animation_interaction_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("mixed"))
+            .expect("mixed animation descriptor");
+        assert_eq!(mixed.animation_kind, "animation-cancel");
+        assert_eq!(mixed.animation_end_handlers, vec!["onanimationend"]);
+        assert_eq!(mixed.transition_cancel_handlers, vec!["ontransitioncancel"]);
+
+        let cancelled = summary
+            .animation_interaction_descriptors
+            .iter()
+            .find(|descriptor| descriptor.id.as_deref() == Some("cancelled"))
+            .expect("cancelled animation descriptor");
+        assert_eq!(cancelled.animation_kind, "animation-cancel");
+        assert_eq!(
+            cancelled.animation_cancel_handlers,
+            vec!["onanimationcancel"]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,31 +1,31 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserActivationDescriptor, BrowserAnchor, BrowserAriaCollection,
-    BrowserAriaCollectionItem, BrowserAriaLiveRegion, BrowserAriaRange,
-    BrowserAriaRelationDescriptor, BrowserClipboardInteractionDescriptor, BrowserCommandElement,
-    BrowserComponentHydrationTarget, BrowserCompositionInteractionDescriptor, BrowserDataAttribute,
-    BrowserDataAttributeDescriptor, BrowserDatalistOption, BrowserDisclosure,
-    BrowserDisclosureStateDescriptor, BrowserDocument, BrowserDocumentMetadata,
-    BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor, BrowserEmbeddedContext,
-    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
-    BrowserFocusNavigationDescriptor, BrowserForm, BrowserFormButton, BrowserFormChoiceControl,
-    BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
-    BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
-    BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInputPlanningDescriptor, BrowserInteractiveElement,
-    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
-    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
-    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
-    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    parse_browser_document, BrowserActivationDescriptor, BrowserAnchor,
+    BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
+    BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor,
+    BrowserClipboardInteractionDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
+    BrowserCompositionInteractionDescriptor, BrowserDataAttribute, BrowserDataAttributeDescriptor,
+    BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
+    BrowserDocumentMetadata, BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor,
+    BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor,
+    BrowserFetchPolicyDescriptor, BrowserFocusNavigationDescriptor, BrowserForm, BrowserFormButton,
+    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
+    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
+    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormSelect,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
+    BrowserImageMapArea, BrowserImageSource, BrowserInputPlanningDescriptor,
+    BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
+    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserScrollInteractionDescriptor, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserSelectionInteractionDescriptor, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -72,6 +72,8 @@ struct ExpectedBrowserDocument {
     event_handler_descriptors: Vec<ExpectedEventHandlerDescriptor>,
     #[serde(default)]
     lifecycle_event_descriptors: Option<Vec<ExpectedLifecycleEventDescriptor>>,
+    #[serde(default)]
+    animation_interaction_descriptors: Option<Vec<ExpectedAnimationInteractionDescriptor>>,
     body_text: String,
     metas: Vec<ExpectedMeta>,
     resources: Vec<ExpectedResource>,
@@ -669,6 +671,49 @@ struct ExpectedLifecycleEventDescriptor {
     body_scope: bool,
     #[serde(default)]
     error_recovery: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAnimationInteractionDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    role: Option<String>,
+    source: String,
+    animation_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    animation_handlers: Vec<String>,
+    #[serde(default)]
+    animation_start_handlers: Vec<String>,
+    #[serde(default)]
+    animation_iteration_handlers: Vec<String>,
+    #[serde(default)]
+    animation_end_handlers: Vec<String>,
+    #[serde(default)]
+    animation_cancel_handlers: Vec<String>,
+    #[serde(default)]
+    transition_handlers: Vec<String>,
+    #[serde(default)]
+    transition_run_handlers: Vec<String>,
+    #[serde(default)]
+    transition_start_handlers: Vec<String>,
+    #[serde(default)]
+    transition_end_handlers: Vec<String>,
+    #[serde(default)]
+    transition_cancel_handlers: Vec<String>,
+    #[serde(default)]
+    handler_count: usize,
+    #[serde(default)]
+    document_scope: bool,
+    #[serde(default)]
+    body_scope: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5069,6 +5114,28 @@ fn browser_lifecycle_event_descriptors_track_load_and_error_recovery_hooks() {
     );
 }
 
+#[test]
+fn browser_animation_interaction_descriptors_track_css_timeline_hooks() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "event-handler-page")
+        .expect("event handler fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("event handler fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.animation_interaction_descriptors,
+        case.expected
+            .into_browser_document()
+            .animation_interaction_descriptors,
+        "animation-interaction descriptors should preserve CSS animation and transition inline hooks",
+    );
+}
+
 impl ExpectedBrowserDocument {
     fn into_browser_document(self) -> BrowserDocument {
         let metadata = self.metadata.into_browser_document_metadata();
@@ -5116,6 +5183,19 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_lifecycle_event_descriptors(&event_handler_descriptors));
+        let animation_interaction_descriptors = self
+            .animation_interaction_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedAnimationInteractionDescriptor::into_browser_animation_interaction_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                expected_animation_interaction_descriptors(&event_handler_descriptors)
+            });
         let global_state_descriptors: Vec<_> = self
             .global_state_descriptors
             .into_iter()
@@ -5379,6 +5459,7 @@ impl ExpectedBrowserDocument {
             body_event_handlers: self.body_event_handlers,
             event_handler_descriptors,
             lifecycle_event_descriptors,
+            animation_interaction_descriptors,
             body_text: self.body_text,
             metas: self
                 .metas
@@ -5806,6 +5887,36 @@ impl ExpectedLifecycleEventDescriptor {
             document_scope: self.document_scope,
             body_scope: self.body_scope,
             error_recovery: self.error_recovery,
+        }
+    }
+}
+
+impl ExpectedAnimationInteractionDescriptor {
+    fn into_browser_animation_interaction_descriptor(
+        self,
+    ) -> BrowserAnimationInteractionDescriptor {
+        BrowserAnimationInteractionDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            role: self.role,
+            source: self.source,
+            animation_kind: self.animation_kind,
+            text: self.text,
+            event_handlers: self.event_handlers,
+            animation_handlers: self.animation_handlers,
+            animation_start_handlers: self.animation_start_handlers,
+            animation_iteration_handlers: self.animation_iteration_handlers,
+            animation_end_handlers: self.animation_end_handlers,
+            animation_cancel_handlers: self.animation_cancel_handlers,
+            transition_handlers: self.transition_handlers,
+            transition_run_handlers: self.transition_run_handlers,
+            transition_start_handlers: self.transition_start_handlers,
+            transition_end_handlers: self.transition_end_handlers,
+            transition_cancel_handlers: self.transition_cancel_handlers,
+            handler_count: self.handler_count,
+            document_scope: self.document_scope,
+            body_scope: self.body_scope,
         }
     }
 }
@@ -8903,6 +9014,133 @@ fn expected_lifecycle_kind(
     }
 }
 
+fn expected_animation_interaction_descriptors(
+    event_handler_descriptors: &[BrowserEventHandlerDescriptor],
+) -> Vec<BrowserAnimationInteractionDescriptor> {
+    event_handler_descriptors
+        .iter()
+        .filter(|descriptor| expected_event_descriptor_has_animation_interaction_state(descriptor))
+        .map(expected_animation_interaction_descriptor)
+        .collect()
+}
+
+fn expected_event_descriptor_has_animation_interaction_state(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> bool {
+    !expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_animation_interaction_event,
+    )
+    .is_empty()
+}
+
+fn expected_animation_interaction_descriptor(
+    descriptor: &BrowserEventHandlerDescriptor,
+) -> BrowserAnimationInteractionDescriptor {
+    let animation_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_animation_event);
+    let animation_start_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_animation_start_event);
+    let animation_iteration_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_animation_iteration_event,
+    );
+    let animation_end_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_animation_end_event);
+    let animation_cancel_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_animation_cancel_event,
+    );
+    let transition_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_transition_event);
+    let transition_run_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_transition_run_event);
+    let transition_start_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_transition_start_event,
+    );
+    let transition_end_handlers =
+        expected_event_handlers_by_kind(&descriptor.event_handlers, expected_transition_end_event);
+    let transition_cancel_handlers = expected_event_handlers_by_kind(
+        &descriptor.event_handlers,
+        expected_transition_cancel_event,
+    );
+
+    BrowserAnimationInteractionDescriptor {
+        element: descriptor.element.clone(),
+        id: descriptor.id.clone(),
+        classes: descriptor.classes.clone(),
+        role: descriptor.role.clone(),
+        source: descriptor.source.clone(),
+        animation_kind: expected_animation_interaction_kind(
+            &animation_handlers,
+            &animation_start_handlers,
+            &animation_iteration_handlers,
+            &animation_end_handlers,
+            &animation_cancel_handlers,
+            &transition_handlers,
+            &transition_run_handlers,
+            &transition_start_handlers,
+            &transition_end_handlers,
+            &transition_cancel_handlers,
+        ),
+        text: descriptor.text.clone(),
+        event_handlers: descriptor.event_handlers.clone(),
+        animation_handlers,
+        animation_start_handlers,
+        animation_iteration_handlers,
+        animation_end_handlers,
+        animation_cancel_handlers,
+        transition_handlers,
+        transition_run_handlers,
+        transition_start_handlers,
+        transition_end_handlers,
+        transition_cancel_handlers,
+        handler_count: descriptor
+            .event_handlers
+            .iter()
+            .filter(|handler| expected_animation_interaction_event(handler.as_str()))
+            .count(),
+        document_scope: descriptor.source == "document",
+        body_scope: descriptor.source == "body",
+    }
+}
+
+fn expected_animation_interaction_kind(
+    animation_handlers: &[String],
+    animation_start_handlers: &[String],
+    animation_iteration_handlers: &[String],
+    animation_end_handlers: &[String],
+    animation_cancel_handlers: &[String],
+    transition_handlers: &[String],
+    transition_run_handlers: &[String],
+    transition_start_handlers: &[String],
+    transition_end_handlers: &[String],
+    transition_cancel_handlers: &[String],
+) -> String {
+    if !animation_cancel_handlers.is_empty() || !transition_cancel_handlers.is_empty() {
+        "animation-cancel".to_string()
+    } else if !animation_handlers.is_empty() && !transition_handlers.is_empty() {
+        "animation-transition".to_string()
+    } else if !animation_iteration_handlers.is_empty() {
+        "animation-iteration".to_string()
+    } else if !animation_end_handlers.is_empty() {
+        "animation-end".to_string()
+    } else if !animation_start_handlers.is_empty() {
+        "animation-start".to_string()
+    } else if !transition_end_handlers.is_empty() {
+        "transition-end".to_string()
+    } else if !transition_start_handlers.is_empty() {
+        "transition-start".to_string()
+    } else if !transition_run_handlers.is_empty() {
+        "transition-run".to_string()
+    } else if !animation_handlers.is_empty() {
+        "animation".to_string()
+    } else {
+        "transition".to_string()
+    }
+}
+
 fn expected_keyboard_event(handler: &str) -> bool {
     matches!(handler, "onkeydown" | "onkeypress" | "onkeyup")
 }
@@ -8918,6 +9156,56 @@ fn expected_input_event(handler: &str) -> bool {
             | "oncompositionupdate"
             | "oncompositionend"
     )
+}
+
+fn expected_animation_interaction_event(handler: &str) -> bool {
+    expected_animation_event(handler) || expected_transition_event(handler)
+}
+
+fn expected_animation_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "onanimationstart" | "onanimationiteration" | "onanimationend" | "onanimationcancel"
+    )
+}
+
+fn expected_animation_start_event(handler: &str) -> bool {
+    handler == "onanimationstart"
+}
+
+fn expected_animation_iteration_event(handler: &str) -> bool {
+    handler == "onanimationiteration"
+}
+
+fn expected_animation_end_event(handler: &str) -> bool {
+    handler == "onanimationend"
+}
+
+fn expected_animation_cancel_event(handler: &str) -> bool {
+    handler == "onanimationcancel"
+}
+
+fn expected_transition_event(handler: &str) -> bool {
+    matches!(
+        handler,
+        "ontransitionrun" | "ontransitionstart" | "ontransitionend" | "ontransitioncancel"
+    )
+}
+
+fn expected_transition_run_event(handler: &str) -> bool {
+    handler == "ontransitionrun"
+}
+
+fn expected_transition_start_event(handler: &str) -> bool {
+    handler == "ontransitionstart"
+}
+
+fn expected_transition_end_event(handler: &str) -> bool {
+    handler == "ontransitionend"
+}
+
+fn expected_transition_cancel_event(handler: &str) -> bool {
+    handler == "ontransitioncancel"
 }
 
 fn expected_load_lifecycle_event(handler: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -47,6 +47,9 @@ lifecycle, and error/event-recovery concerns without evaluating script text.
 Lifecycle-event descriptor cases pin document/body load and unload hooks,
 visibility/history/network lifecycle handlers, and element-level error recovery
 as a flat browser-planning inventory.
+Animation-interaction descriptor cases pin CSS animation and transition event
+hooks, timeline phase grouping, document/body scope, and cancellation paths as a
+flat browser-planning inventory.
 Disclosure-state descriptor cases pin details/dialog open state, grouped details
 names, summary text, dialog modal/closedby behavior, and accessible naming
 metadata as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1277,17 +1277,17 @@
     {
       "id": "event-handler-page",
       "description": "Browser document summaries expose inline event handler attributes without evaluating script text.",
-      "input": "<html onreadystatechange=ready><body onload=boot onunload=teardown><main id=app onclick=delegate><button onclick=save onkeydown=shortcut>Save</button><video controls onplay=play onpause=pause></video><img src=hero.jpg alt=Hero onerror=fallback><input value=Draft oninput=edit onchange=commit></main></body></html>",
+      "input": "<html onreadystatechange=ready><body onload=boot onunload=teardown ontransitionend=bodyTransition><main id=app onclick=delegate onanimationstart=animate ontransitionend=transitioned><button onclick=save onkeydown=shortcut>Save</button><video controls onplay=play onpause=pause></video><img src=hero.jpg alt=Hero onerror=fallback><input value=Draft oninput=edit onchange=commit></main></body></html>",
       "expected": {
         "title": null,
         "base_href": null,
         "base_target": null,
         "document_event_handlers": ["onreadystatechange"],
-        "body_event_handlers": ["onload", "onunload"],
+        "body_event_handlers": ["onload", "onunload", "ontransitionend"],
         "event_handler_descriptors": [
           { "element": "html", "role": "block", "source": "document", "event_handlers": ["onreadystatechange"], "handler_count": 1, "lifecycle_handlers": ["onreadystatechange"], "text": "Save" },
-          { "element": "body", "role": "block", "source": "body", "event_handlers": ["onload", "onunload"], "handler_count": 2, "lifecycle_handlers": ["onload", "onunload"], "text": "Save" },
-          { "element": "main", "id": "app", "role": "main", "source": "element", "event_handlers": ["onclick"], "handler_count": 1, "activation_handlers": ["onclick"], "text": "Save" },
+          { "element": "body", "role": "block", "source": "body", "event_handlers": ["onload", "onunload", "ontransitionend"], "handler_count": 3, "lifecycle_handlers": ["onload", "onunload"], "text": "Save" },
+          { "element": "main", "id": "app", "role": "main", "source": "element", "event_handlers": ["onclick", "onanimationstart", "ontransitionend"], "handler_count": 3, "activation_handlers": ["onclick"], "text": "Save" },
           { "element": "button", "role": "control", "source": "element", "event_handlers": ["onclick", "onkeydown"], "handler_count": 2, "activation_handlers": ["onclick"], "keyboard_handlers": ["onkeydown"], "text": "Save" },
           { "element": "video", "role": "media", "source": "element", "event_handlers": ["onplay", "onpause"], "handler_count": 2, "media_handlers": ["onplay", "onpause"] },
           { "element": "img", "role": "image", "source": "element", "event_handlers": ["onerror"], "handler_count": 1, "error_handlers": ["onerror"] },
@@ -1313,7 +1313,7 @@
           { "kind": "video", "src": null, "resolved_src": null, "controls": true }
         ],
         "interactive_elements": [
-          { "element": "main", "id": "app", "role": "main", "text": "Save", "event_handlers": ["onclick"] },
+          { "element": "main", "id": "app", "role": "main", "text": "Save", "event_handlers": ["onclick", "onanimationstart", "ontransitionend"] },
           { "element": "button", "role": "control", "text": "Save", "accessible_name": "Save", "event_handlers": ["onclick", "onkeydown"] },
           { "element": "video", "role": "media", "text": "", "event_handlers": ["onplay", "onpause"] },
           { "element": "img", "role": "image", "text": "", "event_handlers": ["onerror"] },


### PR DESCRIPTION
## Summary
- Add browser animation-interaction descriptors for CSS animation and transition inline handlers, including timeline phase grouping and document/body scope.
- Wire derived browser-readiness fixture expectations and extend the event-handler fixture with animation/transition hooks.
- Update the html-parser changelog and fixture README inventory.

## Tests
- `cargo fmt -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-parser browser_animation_interaction_descriptors`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `cargo test -p coding-adventures-html-parser browser_`
- `cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
