### PR TITLE
Add smart-home activation dashboard tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -55,6 +55,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation briefing item planning:
   `smart_home.list_integration_activation_briefing_items` and
   `smart_home.get_integration_activation_briefing_summary`.
+- Added D18D handlers for D23A activation dashboard card planning:
+  `smart_home.list_integration_activation_dashboard` and
+  `smart_home.get_integration_activation_dashboard_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -53,6 +53,7 @@ Chief of Staff job/session/agent
   -> activation-decision list and summary reads for approve/block queue planning
   -> activation-evidence list and summary reads for approval/block evidence rows
   -> activation-dossier list and summary reads for bundled decision evidence
+  -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -110,6 +111,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_readout_summary`
 - `smart_home.list_integration_activation_briefing_items`
 - `smart_home.get_integration_activation_briefing_summary`
+- `smart_home.list_integration_activation_dashboard`
+- `smart_home.get_integration_activation_dashboard_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,38 +36,40 @@ use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_briefing_items_from_readouts,
     activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
-    activation_decisions_from_candidates, activation_dependency_graph_from_reports,
-    activation_dossiers_from_candidates, activation_evidence_from_candidates,
-    activation_health_from_candidates, activation_maintenance_from_candidates,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_readouts_from_candidates, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
-    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
-    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
-    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
-    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
-    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
-    IntegrationActivationEvidenceSummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationReadoutStage,
+    activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
+    activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
+    activation_evidence_from_candidates, activation_health_from_candidates,
+    activation_maintenance_from_candidates, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_readouts_from_candidates,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
+    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationDashboardCard,
+    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
+    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
+    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
+    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationReadoutStage,
     IntegrationActivationReadoutSummary, IntegrationActivationReviewItem,
     IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
@@ -236,6 +238,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_BRIEFING_ITEMS_TOOL_ID: &str =
     "smart_home.list_integration_activation_briefing_items";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_briefing_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID: &str =
+    "smart_home.list_integration_activation_dashboard";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_dashboard_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -492,6 +498,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID => {
                     let query = integration_activation_briefing_query(&arguments)?;
                     Ok(get_integration_activation_briefing_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID => {
+                    let query = integration_activation_dashboard_query(&arguments)?;
+                    Ok(list_integration_activation_dashboard_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_dashboard_query(&arguments)?;
+                    Ok(get_integration_activation_dashboard_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1695,6 +1711,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation briefing summary",
             "Return compact D23A activation briefing counts across action, approval, review, blocker, risk, and dependency sections.",
             integration_activation_briefing_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID,
+            "List smart-home integration activation dashboard",
+            "List Chief-ready D23A activation dashboard cards derived from readouts and briefing rows by priority wave.",
+            integration_activation_dashboard_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_dashboard", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_dashboard", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation dashboard summary",
+            "Return compact D23A activation dashboard counts across priority-wave cards, briefing sections, actions, risk, and blockers.",
+            integration_activation_dashboard_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4350,6 +4395,12 @@ struct IntegrationActivationBriefingQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationDashboardQuery {
+    readouts: IntegrationActivationReadoutQuery,
+    card_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4617,6 +4668,15 @@ fn integration_activation_briefing_query(
         readouts,
         item_kind,
         item_limit: optional_u64(arguments, "item_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_dashboard_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationDashboardQuery, ToolCallError> {
+    Ok(IntegrationActivationDashboardQuery {
+        readouts: integration_activation_readout_query(arguments)?,
+        card_limit: optional_u64(arguments, "card_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5172,6 +5232,19 @@ fn integration_activation_briefing_items_for_query(
     }
 
     (items, catalog_count)
+}
+
+fn integration_activation_dashboard_cards_for_query(
+    query: &IntegrationActivationDashboardQuery,
+) -> (Vec<IntegrationActivationDashboardCard>, usize) {
+    let (readouts, catalog_count) = integration_activation_readouts_for_query(&query.readouts);
+    let mut cards = activation_dashboard_cards_from_readouts(readouts.iter());
+
+    if let Some(limit) = query.card_limit {
+        cards.truncate(limit);
+    }
+
+    (cards, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6506,6 +6579,72 @@ fn get_integration_activation_briefing_summary_output_handler_output(
             ("total_items", integer(summary.total_items as i64)),
             ("blocker_items", integer(summary.blocker_items as i64)),
             ("approval_items", integer(summary.approval_items as i64)),
+        ]),
+    )
+}
+
+fn list_integration_activation_dashboard_output_handler_output(
+    query: IntegrationActivationDashboardQuery,
+) -> ToolHandlerOutput {
+    let (cards, catalog_count) = integration_activation_dashboard_cards_for_query(&query);
+    let summary = IntegrationActivationDashboardSummary::from_cards(cards.iter());
+    let count = cards.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_dashboard",
+            JsonValue::Array(cards.iter().map(activation_dashboard_card_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_dashboard_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_dashboard")),
+            ("activation_dashboard_cards", integer(count as i64)),
+            (
+                "cards_requiring_attention",
+                integer(summary.cards_requiring_attention as i64),
+            ),
+            (
+                "cards_with_blockers",
+                integer(summary.cards_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_dashboard_summary_output_handler_output(
+    query: IntegrationActivationDashboardQuery,
+) -> ToolHandlerOutput {
+    let (cards, _) = integration_activation_dashboard_cards_for_query(&query);
+    let summary = IntegrationActivationDashboardSummary::from_cards(cards.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_dashboard_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_dashboard_summary"),
+            ),
+            ("total_cards", integer(summary.total_cards as i64)),
+            (
+                "cards_requiring_attention",
+                integer(summary.cards_requiring_attention as i64),
+            ),
+            (
+                "cards_with_blockers",
+                integer(summary.cards_with_blockers as i64),
+            ),
         ]),
     )
 }
@@ -11699,6 +11838,215 @@ fn integration_activation_briefing_summary_json(
     ])
 }
 
+fn activation_dashboard_card_json(card: &IntegrationActivationDashboardCard) -> JsonValue {
+    object([
+        ("priority", integer(card.priority as i64)),
+        ("health_status", string(card.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                card.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(card.integration_count() as i64),
+        ),
+        (
+            "briefing_item_count",
+            integer(card.briefing_item_count as i64),
+        ),
+        (
+            "next_briefing_kind",
+            card.next_briefing_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "briefing_summary",
+            integration_activation_briefing_summary_json(&card.briefing_summary),
+        ),
+        ("action_count", integer(card.action_count as i64)),
+        ("dossier_count", integer(card.dossier_count as i64)),
+        ("evidence_count", integer(card.evidence_count as i64)),
+        ("risk_count", integer(card.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(card.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(card.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(card.highest_policy_tier)),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(card.has_activation_work),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(card.has_approval_ready_work),
+        ),
+        ("has_review_work", JsonValue::Bool(card.has_review_work)),
+        ("has_blockers", JsonValue::Bool(card.has_blockers)),
+        ("has_risks", JsonValue::Bool(card.has_risks)),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(card.has_dependency_blockers),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(card.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_dashboard_summary_json(
+    summary: &IntegrationActivationDashboardSummary,
+) -> JsonValue {
+    object([
+        ("total_cards", integer(summary.total_cards as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        ("ready_cards", integer(summary.ready_cards as i64)),
+        ("review_cards", integer(summary.review_cards as i64)),
+        ("blocked_cards", integer(summary.blocked_cards as i64)),
+        ("empty_cards", integer(summary.empty_cards as i64)),
+        (
+            "cards_requiring_attention",
+            integer(summary.cards_requiring_attention as i64),
+        ),
+        (
+            "cards_with_activation_work",
+            integer(summary.cards_with_activation_work as i64),
+        ),
+        (
+            "cards_with_approval_work",
+            integer(summary.cards_with_approval_work as i64),
+        ),
+        (
+            "cards_with_review_work",
+            integer(summary.cards_with_review_work as i64),
+        ),
+        (
+            "cards_with_blockers",
+            integer(summary.cards_with_blockers as i64),
+        ),
+        ("cards_with_risks", integer(summary.cards_with_risks as i64)),
+        (
+            "cards_with_dependency_blockers",
+            integer(summary.cards_with_dependency_blockers as i64),
+        ),
+        (
+            "total_briefing_items",
+            integer(summary.total_briefing_items as i64),
+        ),
+        ("activation_items", integer(summary.activation_items as i64)),
+        ("approval_items", integer(summary.approval_items as i64)),
+        ("review_items", integer(summary.review_items as i64)),
+        ("blocker_items", integer(summary.blocker_items as i64)),
+        ("risk_items", integer(summary.risk_items as i64)),
+        ("dependency_items", integer(summary.dependency_items as i64)),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_priority",
+            summary
+                .first_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(summary.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -15299,6 +15647,19 @@ fn integration_activation_briefing_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_dashboard_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_readout_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("card_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -15443,7 +15804,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 89);
+        assert_eq!(definitions.len(), 91);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -15678,9 +16039,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            81
+            83
         );
         assert_eq!(
             export
@@ -15848,6 +16215,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_BRIEFING_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -16102,11 +16477,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(89))
+            Some(&integer(91))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(81))
+            Some(&integer(83))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -18166,6 +18541,136 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_dashboard_request = request(
+            "call-list-integration-activation-dashboard",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("card_limit", integer(3)),
+            ]),
+            5_023,
+        );
+        let list_activation_dashboard_trace =
+            tool_runtime.invoke_with_events(&list_activation_dashboard_request);
+        assert!(list_activation_dashboard_trace.result.ok);
+        assert_eq!(
+            list_activation_dashboard_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_dashboard_output = list_activation_dashboard_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_dashboard_count =
+            integer_value(field(list_activation_dashboard_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_dashboard_count));
+        let activation_dashboard_summary =
+            field(list_activation_dashboard_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_dashboard_summary, "total_cards"),
+            Some(&integer(activation_dashboard_count))
+        );
+        assert_eq!(
+            field(activation_dashboard_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_dashboard_attention = integer_value(
+            field(activation_dashboard_summary, "cards_requiring_attention").unwrap(),
+        )
+        .unwrap();
+        assert!(activation_dashboard_attention >= 1);
+        let activation_dashboard_card = array_item(
+            field(list_activation_dashboard_output, "activation_dashboard").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_dashboard_card, "priority").is_some());
+        assert!(field(activation_dashboard_card, "health_status").is_some());
+        assert!(field(activation_dashboard_card, "integration_ids").is_some());
+        assert!(field(activation_dashboard_card, "integration_count").is_some());
+        assert!(field(activation_dashboard_card, "briefing_summary").is_some());
+        assert!(field(activation_dashboard_card, "briefing_item_count").is_some());
+        assert!(field(activation_dashboard_card, "next_briefing_kind").is_some());
+        assert_eq!(
+            field(activation_dashboard_card, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_dashboard_summary_request = request(
+            "call-integration-activation-dashboard-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("blocked_only", JsonValue::Bool(true)),
+            ]),
+            5_024,
+        );
+        let activation_dashboard_summary_trace =
+            tool_runtime.invoke_with_events(&activation_dashboard_summary_request);
+        assert!(activation_dashboard_summary_trace.result.ok);
+        assert_eq!(
+            activation_dashboard_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_dashboard_summary_output = activation_dashboard_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_dashboard_rollup =
+            field(activation_dashboard_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_dashboard_rollup, "cards_with_blockers").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_dashboard_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_dashboard_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -19897,6 +20402,14 @@ mod tests {
             activation_briefing_summary_request,
             activation_briefing_summary_trace,
         );
+        journal.record_trace(
+            list_activation_dashboard_request,
+            list_activation_dashboard_trace,
+        );
+        journal.record_trace(
+            activation_dashboard_summary_request,
+            activation_dashboard_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -19970,9 +20483,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 89);
-        assert_eq!(journal_summary.completed_count, 89);
-        assert_eq!(journal.audit_records().len(), 89);
+        assert_eq!(journal_summary.invocation_count, 91);
+        assert_eq!(journal_summary.completed_count, 91);
+        assert_eq!(journal.audit_records().len(), 91);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -72,6 +72,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_briefing_summary` tool descriptors
   for read-only Chief activation briefing sections derived from priority-wave
   readouts.
+- `smart_home.list_integration_activation_dashboard` and
+  `smart_home.get_integration_activation_dashboard_summary` tool descriptors
+  for read-only Chief activation dashboard cards derived from readouts and
+  briefing rows.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -83,6 +83,8 @@ Current scope:
   dossier, evidence, risk, action, and dependency blocker rollups
 - D18D integration activation-briefing descriptors for Chief-ready activation,
   approval, review, blocker, risk, and dependency briefing sections
+- D18D integration activation-dashboard descriptors for Chief-ready
+  priority-wave status cards derived from readouts and briefing rows
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1487,6 +1487,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationReadoutSummary,
     ListIntegrationActivationBriefingItems,
     GetIntegrationActivationBriefingSummary,
+    ListIntegrationActivationDashboard,
+    GetIntegrationActivationDashboardSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1654,6 +1656,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationBriefingSummary => {
                 read_tool("smart_home.get_integration_activation_briefing_summary")
+            }
+            Self::ListIntegrationActivationDashboard => {
+                read_tool("smart_home.list_integration_activation_dashboard")
+            }
+            Self::GetIntegrationActivationDashboardSummary => {
+                read_tool("smart_home.get_integration_activation_dashboard_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2324,6 +2332,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationReadoutSummary,
         SmartHomeTool::ListIntegrationActivationBriefingItems,
         SmartHomeTool::GetIntegrationActivationBriefingSummary,
+        SmartHomeTool::ListIntegrationActivationDashboard,
+        SmartHomeTool::GetIntegrationActivationDashboardSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3166,7 +3176,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 89);
+        assert_eq!(catalog.len(), 91);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3346,6 +3356,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_briefing_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_dashboard"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_dashboard_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3536,15 +3554,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 89);
-        assert_eq!(summary.read_tools, 81);
+        assert_eq!(summary.total_tools, 91);
+        assert_eq!(summary.read_tools, 83);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 81);
+        assert_eq!(summary.read_only_tier_tools, 83);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 89);
+        assert_eq!(summary.total_required_capabilities, 91);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -66,6 +66,8 @@ runtime and Chief of Staff tools a typed catalog for:
   dossier, evidence, risk, action, and dependency blocker rollups
 - activation briefing rows that split readouts into Chief-ready activation,
   approval, review, blocker, risk, and dependency briefing sections
+- activation dashboard cards that condense readouts and briefing rows into
+  priority-wave Chief status cards
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1812,6 +1812,68 @@ pub struct IntegrationActivationBriefingSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDashboardCard {
+    pub priority: u8,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub briefing_item_count: usize,
+    pub next_briefing_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub briefing_summary: IntegrationActivationBriefingSummary,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub has_activation_work: bool,
+    pub has_approval_ready_work: bool,
+    pub has_review_work: bool,
+    pub has_blockers: bool,
+    pub has_risks: bool,
+    pub has_dependency_blockers: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDashboardSummary {
+    pub total_cards: usize,
+    pub unique_integrations: usize,
+    pub ready_cards: usize,
+    pub review_cards: usize,
+    pub blocked_cards: usize,
+    pub empty_cards: usize,
+    pub cards_requiring_attention: usize,
+    pub cards_with_activation_work: usize,
+    pub cards_with_approval_work: usize,
+    pub cards_with_review_work: usize,
+    pub cards_with_blockers: usize,
+    pub cards_with_risks: usize,
+    pub cards_with_dependency_blockers: usize,
+    pub total_briefing_items: usize,
+    pub activation_items: usize,
+    pub approval_items: usize,
+    pub review_items: usize,
+    pub blocker_items: usize,
+    pub risk_items: usize,
+    pub dependency_items: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub first_activation_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_risk_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -2999,6 +3061,220 @@ impl IntegrationActivationBriefingSummary {
 
     pub fn has_dependency_blockers(&self) -> bool {
         self.dependency_items > 0 || self.items_with_dependency_blockers > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention()
+            || self.has_approval_ready_work()
+            || self.has_review_work()
+            || self.has_blockers()
+            || self.has_risks()
+            || self.has_dependency_blockers()
+    }
+}
+
+impl IntegrationActivationDashboardCard {
+    fn from_readout(readout: &IntegrationActivationReadoutStage) -> Self {
+        let briefing_items = activation_briefing_items_from_readouts(std::iter::once(readout));
+        let briefing_summary =
+            IntegrationActivationBriefingSummary::from_items(briefing_items.iter());
+        let next_briefing_kind = briefing_items.first().map(|item| item.kind);
+
+        Self {
+            priority: readout.priority,
+            health_status: readout.health_status,
+            integration_ids: readout.integration_ids.clone(),
+            briefing_item_count: briefing_items.len(),
+            next_briefing_kind,
+            briefing_summary,
+            action_count: readout.action_summary().total_actions,
+            dossier_count: readout.dossier_summary.total_dossiers,
+            evidence_count: readout.evidence_summary.total_evidence,
+            risk_count: readout.risk_summary().total_risks,
+            dependency_edge_count: readout.dependency_summary().total_edges,
+            blocking_dependency_edge_count: readout.dependency_summary().blocking_edges,
+            highest_policy_tier: readout
+                .candidate_summary()
+                .highest_policy_tier
+                .max(readout.action_summary().highest_policy_tier)
+                .max(readout.constraint_summary().highest_policy_tier)
+                .max(readout.risk_summary().highest_policy_tier)
+                .max(readout.dependency_summary().highest_policy_tier)
+                .max(readout.dossier_summary.highest_policy_tier)
+                .max(readout.evidence_summary.highest_policy_tier),
+            has_activation_work: readout.has_activation_work(),
+            has_approval_ready_work: readout.has_approval_ready_work(),
+            has_review_work: readout.has_review_work(),
+            has_blockers: readout.has_blockers(),
+            has_risks: readout.has_risks(),
+            has_dependency_blockers: readout.has_dependency_blockers(),
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.health_status.requires_attention()
+            || self.has_approval_ready_work
+            || self.has_review_work
+            || self.has_blockers
+            || self.has_risks
+            || self.has_dependency_blockers
+    }
+}
+
+impl IntegrationActivationDashboardSummary {
+    pub fn from_cards<'a>(
+        cards: impl IntoIterator<Item = &'a IntegrationActivationDashboardCard>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_cards: 0,
+            unique_integrations: 0,
+            ready_cards: 0,
+            review_cards: 0,
+            blocked_cards: 0,
+            empty_cards: 0,
+            cards_requiring_attention: 0,
+            cards_with_activation_work: 0,
+            cards_with_approval_work: 0,
+            cards_with_review_work: 0,
+            cards_with_blockers: 0,
+            cards_with_risks: 0,
+            cards_with_dependency_blockers: 0,
+            total_briefing_items: 0,
+            activation_items: 0,
+            approval_items: 0,
+            review_items: 0,
+            blocker_items: 0,
+            risk_items: 0,
+            dependency_items: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            first_activation_priority: None,
+            first_approval_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_risk_priority: None,
+            first_dependency_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for card in cards {
+            summary.total_cards += 1;
+            for integration_id in &card.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match card.health_status {
+                IntegrationActivationHealthStatus::Ready => summary.ready_cards += 1,
+                IntegrationActivationHealthStatus::NeedsReview => summary.review_cards += 1,
+                IntegrationActivationHealthStatus::Blocked => summary.blocked_cards += 1,
+                IntegrationActivationHealthStatus::Empty => summary.empty_cards += 1,
+            }
+
+            summary.total_briefing_items += card.briefing_item_count;
+            summary.activation_items += card.briefing_summary.activation_items;
+            summary.approval_items += card.briefing_summary.approval_items;
+            summary.review_items += card.briefing_summary.review_items;
+            summary.blocker_items += card.briefing_summary.blocker_items;
+            summary.risk_items += card.briefing_summary.risk_items;
+            summary.dependency_items += card.briefing_summary.dependency_items;
+            summary.total_actions += card.action_count;
+            summary.total_dossiers += card.dossier_count;
+            summary.total_evidence += card.evidence_count;
+            summary.total_risks += card.risk_count;
+            summary.total_dependency_edges += card.dependency_edge_count;
+            summary.blocking_dependency_edges += card.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary.highest_policy_tier.max(card.highest_policy_tier);
+
+            if card.requires_attention() {
+                summary.cards_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(card.priority));
+            }
+            if card.has_activation_work {
+                summary.cards_with_activation_work += 1;
+                summary.first_activation_priority =
+                    min_optional_priority(summary.first_activation_priority, Some(card.priority));
+            }
+            if card.has_approval_ready_work {
+                summary.cards_with_approval_work += 1;
+                summary.first_approval_priority =
+                    min_optional_priority(summary.first_approval_priority, Some(card.priority));
+            }
+            if card.has_review_work {
+                summary.cards_with_review_work += 1;
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(card.priority));
+            }
+            if card.has_blockers {
+                summary.cards_with_blockers += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(card.priority));
+            }
+            if card.has_risks {
+                summary.cards_with_risks += 1;
+                summary.first_risk_priority =
+                    min_optional_priority(summary.first_risk_priority, Some(card.priority));
+            }
+            if card.has_dependency_blockers {
+                summary.cards_with_dependency_blockers += 1;
+                summary.first_dependency_priority =
+                    min_optional_priority(summary.first_dependency_priority, Some(card.priority));
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_cards > 0 || summary.cards_with_blockers > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.review_cards > 0
+            || summary.cards_with_review_work > 0
+            || summary.cards_with_approval_work > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_cards > 0 || summary.cards_with_activation_work > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_cards == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.cards_with_activation_work > 0 || self.activation_items > 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.cards_with_approval_work > 0 || self.approval_items > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.cards_with_review_work > 0 || self.review_items > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.cards_with_blockers > 0 || self.blocker_items > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.cards_with_risks > 0 || self.risk_items > 0
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.cards_with_dependency_blockers > 0 || self.dependency_items > 0
     }
 
     pub fn requires_attention(&self) -> bool {
@@ -6876,6 +7152,43 @@ pub fn activation_briefing_items_at_or_before_priority(
     activation_briefing_items_from_readouts(readouts.iter())
 }
 
+pub fn activation_dashboard_cards_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationDashboardCard> {
+    let mut cards = readouts
+        .into_iter()
+        .map(IntegrationActivationDashboardCard::from_readout)
+        .collect::<Vec<_>>();
+    cards.sort_by(compare_activation_dashboard_cards);
+    cards
+}
+
+pub fn activation_dashboard_cards_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDashboardCard> {
+    let readouts = activation_readouts_from_candidates(catalog, candidates, enabled_integrations);
+    activation_dashboard_cards_from_readouts(readouts.iter())
+}
+
+pub fn activation_dashboard_cards_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDashboardCard> {
+    let readouts = activation_readouts_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_dashboard_cards_from_readouts(readouts.iter())
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -8182,6 +8495,24 @@ fn compare_activation_briefing_items(
         .cmp(&right.priority)
         .then_with(|| left.kind.cmp(&right.kind))
         .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_dashboard_cards(
+    left: &IntegrationActivationDashboardCard,
+    right: &IntegrationActivationDashboardCard,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.has_blockers.cmp(&left.has_blockers))
+        .then_with(|| right.has_review_work.cmp(&left.has_review_work))
+        .then_with(|| {
+            right
+                .has_approval_ready_work
+                .cmp(&left.has_approval_ready_work)
+        })
+        .then_with(|| right.has_activation_work.cmp(&left.has_activation_work))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -9954,6 +10285,142 @@ mod tests {
         assert!(catalog_items
             .iter()
             .any(|item| item.kind == IntegrationActivationBriefingItemKind::Blocker));
+    }
+
+    #[test]
+    fn activation_dashboard_cards_condense_readouts_and_briefing_sections() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let cards = activation_dashboard_cards_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(cards.len(), 3);
+        let approval_ready = cards.iter().find(|card| card.priority == 1).unwrap();
+        assert!(approval_ready.has_approval_ready_work);
+        assert!(approval_ready.has_review_work);
+        assert!(approval_ready.requires_attention());
+        assert!(approval_ready.briefing_item_count >= 2);
+        assert_eq!(
+            approval_ready.next_briefing_kind,
+            Some(IntegrationActivationBriefingItemKind::Blocker)
+        );
+
+        let blocked = cards.iter().find(|card| card.priority == 2).unwrap();
+        assert_eq!(
+            blocked.health_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(blocked.has_blockers);
+        assert!(blocked.has_risks);
+        assert!(blocked.has_dependency_blockers);
+        assert!(blocked.blocking_dependency_edge_count > 0);
+
+        let ready = cards.iter().find(|card| card.priority == 3).unwrap();
+        assert_eq!(
+            ready.health_status,
+            IntegrationActivationHealthStatus::Ready
+        );
+        assert!(ready.has_activation_work);
+        assert!(!ready.has_approval_ready_work);
+        assert!(cards.iter().all(|card| card.integration_count() >= 1));
+
+        let summary = IntegrationActivationDashboardSummary::from_cards(cards.iter());
+        assert_eq!(summary.total_cards, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.ready_cards, 1);
+        assert_eq!(summary.review_cards, 1);
+        assert_eq!(summary.blocked_cards, 1);
+        assert!(summary.total_briefing_items >= 4);
+        assert!(summary.activation_items >= 1);
+        assert!(summary.approval_items >= 1);
+        assert!(summary.review_items >= 1);
+        assert!(summary.blocker_items >= 1);
+        assert!(summary.risk_items >= 1);
+        assert!(summary.dependency_items >= 1);
+        assert!(summary.cards_requiring_attention >= 1);
+        assert!(summary.total_actions > 0);
+        assert!(summary.total_dossiers > 0);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(summary.first_approval_priority, Some(1));
+        assert_eq!(summary.first_blocked_priority, Some(1));
+        assert_eq!(summary.first_activation_priority, Some(3));
+        assert_eq!(summary.first_attention_priority, Some(1));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_activation_work());
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_risks());
+        assert!(summary.has_dependency_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_cards = activation_dashboard_cards_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_cards
+            .iter()
+            .any(IntegrationActivationDashboardCard::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add reusable activation dashboard cards and summaries that condense priority-wave readouts plus briefing sections.
- Register `smart_home.list_integration_activation_dashboard` and `smart_home.get_integration_activation_dashboard_summary` in the shared smart-home catalog and Chief bridge.
- Cover the dashboard path in catalog unit tests and the Chief in-memory runtime end-to-end test.

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`, `smart-home-integration-catalog`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, `smart-home-local-http`, `smart-home-discovery`, and `chief-of-staff-smart-home-tools`
