### PR TITLE
feat(adj-lang-cli): emit constraint solutions — solve for/check wired into the CLI (ADJ constraints B2b)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.3.0] - 2026-06-11 — constraint solving in the CLI (ADJ constraints track B2b)
+
+### Added
+
+- When a `.adj` program declares a constraint system (`symbol` / `constrain` /
+  `solve for`), the CLI now calls `adj_constraint_solver::solve` and emits a
+  **`solve`** section in the JSON output:
+  - `{"outcome":"solved","assignments":[{"name","value"}],"from_constraints":[…]}`
+    — solved values, each cited to the constraints that determined them.
+  - `{"outcome":"no_unique_solution"}` (singular / non-square), or
+    `{"outcome":"unsupported","reason":…}` (inequality, non-linear term,
+    aggregation) — **never a fabricated answer**.
+  - The `solve` key is omitted entirely for a pure prior/contributes rulebook.
+- New dependency on `adj-constraint-solver`. Linear-equality systems only this
+  slice; feasibility (`check` → SAT/UNSAT via `constraint-engine`) and
+  optimization follow.
+
 ## [0.2.0] - 2026-06-10 — predicate proof steps
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 adj-lang = { path = "../adj-lang" }
+adj-constraint-solver = { path = "../adj-constraint-solver" }
 logic-engine = { path = "../logic-engine" }
 logic-core = { path = "../logic-core" }
 cli-builder = { path = "../cli-builder" }

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -13,7 +13,10 @@
 //!                 "proof": [ { "kind":"prior|contribution|interaction|predicate", "logit",
 //!                              "evidence?", "slot?", "op?", "threshold?", "observed?",
 //!                              "source", "locator", "trust" } ] } ],
-//!   "decision": { "type":"determinate|kickback|empty", ... } }
+//!   "decision": { "type":"determinate|kickback|empty", ... },
+//!   "solve": { "outcome":"solved", "assignments":[{"name","value"}],
+//!              "from_constraints":[...] } }   // present only when the program
+//!                                              // declared a constraint system
 //! ```
 //!
 //! Every proof step carries the cited `source`/`locator`/`trust` of the clause it
@@ -26,6 +29,7 @@ use std::process::ExitCode;
 use cli_builder::types::ParserOutput;
 use cli_builder::{load_spec_from_str, Parser};
 
+use adj_constraint_solver::{solve, SolveOutcome};
 use adj_lang::{compile, decide};
 use logic_core::Term;
 use logic_engine::{
@@ -267,11 +271,54 @@ fn main() -> ExitCode {
         .iter()
         .map(|q| format!("\"{}\"", esc(&format!("{}", q))))
         .collect();
+
+    // The constraint sublanguage (ADJ constraints): if the program declared a
+    // constraint system, solve it on the CPU and emit the outcome. Absent a
+    // constraint system, the `solve` key is omitted entirely.
+    let solve_section = if lowered.constraints.is_empty() {
+        String::new()
+    } else {
+        format!(",\"solve\":{}", solve_json(&solve(&lowered.constraints)))
+    };
+
     println!(
-        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}}}",
+        "{{\"queries\":[{}],\"ranked\":[{}],\"decision\":{}{}}}",
         queries.join(","),
         ranked.join(","),
-        decision
+        decision,
+        solve_section
     );
     ExitCode::SUCCESS
+}
+
+/// Render a [`SolveOutcome`] as JSON. A solved system lists each unknown's
+/// value plus the constraints that determined it (provenance); an
+/// out-of-scope or singular system reports why, never a fabricated answer.
+fn solve_json(outcome: &SolveOutcome) -> String {
+    match outcome {
+        SolveOutcome::Solved {
+            assignments,
+            from_constraints,
+        } => {
+            let vars: Vec<String> = assignments
+                .iter()
+                .map(|(name, value)| {
+                    format!("{{\"name\":\"{}\",\"value\":{}}}", esc(name), jnum(*value))
+                })
+                .collect();
+            let cites: Vec<String> = from_constraints.iter().map(|i| i.to_string()).collect();
+            format!(
+                "{{\"outcome\":\"solved\",\"assignments\":[{}],\"from_constraints\":[{}]}}",
+                vars.join(","),
+                cites.join(",")
+            )
+        }
+        SolveOutcome::NoUniqueSolution => "{\"outcome\":\"no_unique_solution\"}".to_string(),
+        SolveOutcome::Unsupported { reason } => {
+            format!(
+                "{{\"outcome\":\"unsupported\",\"reason\":\"{}\"}}",
+                esc(reason)
+            )
+        }
+    }
 }

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -173,3 +173,49 @@ fn malformed_numeric_clauses_do_not_panic_the_cli() {
         assert!(!s.contains("panic"), "must not panic for {src:?}: {s}");
     }
 }
+
+// ---- constraint solving in the CLI (ADJ constraints track B2b) ----
+
+#[test]
+fn solve_for_emits_solved_values() {
+    // x + y = 10 ; x - y = 2 → x = 6, y = 4.
+    let (ok, s) = run(
+        "adjcli_solve.adj",
+        "symbol x : scalar\n\
+             symbol y : scalar\n\
+             constrain x + y = 10\n\
+             constrain x - y = 2\n\
+             solve for { x, y }\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"solve\":{"), "expected a solve section: {s}");
+    assert!(s.contains("\"outcome\":\"solved\""), "{s}");
+    assert!(s.contains("\"name\":\"x\",\"value\":6"), "{s}");
+    assert!(s.contains("\"name\":\"y\",\"value\":4"), "{s}");
+    assert!(s.contains("\"from_constraints\":[0,1]"), "{s}");
+}
+
+#[test]
+fn unsupported_constraint_reports_a_reason_not_an_answer() {
+    // An inequality is out of this slice's scope → unsupported, never a fake value.
+    let (ok, s) = run(
+        "adjcli_unsupported.adj",
+        "symbol x : scalar\nconstrain x <= 10\nsolve for { x }\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"unsupported\""), "{s}");
+    assert!(s.contains("\"reason\""), "{s}");
+}
+
+#[test]
+fn a_pure_rulebook_emits_no_solve_section() {
+    let (ok, s) = run(
+        "adjcli_nosolve.adj",
+        "prior 0.10 for acs\n  source \"x\" trust empirical\n? acs\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(
+        !s.contains("\"solve\""),
+        "no constraint system → no solve key: {s}"
+    );
+}


### PR DESCRIPTION
## What

**Work item B2b** — completes the core of B2: the CLI now **solves the constraint sublanguage end-to-end**. B2a built the solver; this wires it into `adj-lang-cli` so a `.adj` program's `solve for` actually produces values in the JSON output.

```
$ adj-lang-cli eligibility.adj
{ … "solve": { "outcome":"solved",
               "assignments":[{"name":"x","value":6},{"name":"y","value":4}],
               "from_constraints":[0,1] } }
```

for:
```
symbol x : scalar
symbol y : scalar
constrain x + y = 10
constrain x - y = 2
solve for { x, y }
```

## Changes (adj-lang-cli 0.2.0 → 0.3.0)

- Depend on `adj-constraint-solver`; new `solve_json` renderer.
- When `lowered.constraints` is non-empty, call `solve(&lowered.constraints)` and emit a **`solve`** section:
  - `{"outcome":"solved","assignments":[…],"from_constraints":[…]}` — solved values cited to the constraints that determined them.
  - `{"outcome":"no_unique_solution"}` / `{"outcome":"unsupported","reason":…}` — **never a fabricated answer**.
  - The key is **omitted** for a pure prior/contributes rulebook (no constraint system).

Strings go through the existing `esc()`, numbers through `jnum()` — no JSON-injection, no panics (`/security-review` PASSED).

## Scope / next

Linear-equality systems this slice. **Feasibility** (`check` → SAT/UNSAT via `constraint-engine`'s `LiaTactic`) + the **UNSAT-core** certificate are **B2c**; **QF_LRA** real feasibility is **C1**, **simplex** optimization **C2**.

## Tests

3 new CLI golden tests (solve emits `x=6/y=4` cited to `[0,1]`; inequality → `unsupported`; pure rulebook → no `solve` key) + all existing. `cargo test -p adj-lang-cli` → **11 pass**. `/security-review` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)