### PR TITLE
feat(clr-real): C6 — wire real CoreCLR into the W16 conformance suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,41 @@ jobs:
           # actions/setup-dotnet@v4 works identically on Ubuntu, macOS, and Windows.
           dotnet-version: '9.0.x'
 
+      - name: Install ILAsm (real-CoreCLR assembler for the CLR-real conformance column)
+        # The W16 conformance suite's `CLR-real` backend assembles textual `.il`
+        # with `ilasm` and runs it on real `dotnet`. `ilasm` ships only in the
+        # RID-specific NuGet runtime pack `runtime.<rid>.Microsoft.NETCore.ILAsm`
+        # (the bare `Microsoft.NETCore.ILAsm` is ref-only, no binary). A
+        # `<PackageDownload>` restore drops the binary into `~/.nuget/packages`,
+        # exactly where the test harness's `find_ilasm()` searches — so the CLR
+        # column is verified on the *real* runtime, not just the simulator.
+        if: needs.detect.outputs.needs_dotnet == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rid=$(dotnet --info | sed -n 's/^[[:space:]]*RID:[[:space:]]*//p' | head -1)
+          echo "Host RID: ${rid:-<unknown>}"
+          if [ -z "${rid:-}" ]; then
+            echo "Could not determine RID; the CLR-real column will skip gracefully."
+            exit 0
+          fi
+          work=$(mktemp -d)
+          cat > "$work/ilasm.csproj" <<EOF
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <TargetFramework>net9.0</TargetFramework>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageDownload Include="runtime.$rid.Microsoft.NETCore.ILAsm" Version="[9.0.0]" />
+            </ItemGroup>
+          </Project>
+          EOF
+          # Non-fatal: if the pack is unavailable for this RID, the conformance
+          # CLR-real arm simply returns None (skip), leaving the simulator floor.
+          dotnet restore "$work/ilasm.csproj" || echo "ILAsm restore failed; CLR-real column will skip."
+          found=$(find "$HOME/.nuget/packages" -iname ilasm -type f 2>/dev/null | head -1 || true)
+          echo "ilasm binary: ${found:-<not found>}"
+
       - name: Install test runners
         shell: bash
         run: |

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — `lang-aot`
 
+## 0.53.0 — 2026-06-11 — wire **real CoreCLR** into the W16 conformance suite (CLR-real C6)
+
+The capstone of the CLR-real verification chapter. `tests/conformance.rs` gains a
+ninth backend column, **`CLR-real`**, that runs each McCarthy program on the actual
+.NET runtime — textual `.il` → real `ilasm` → real `dotnet` — via the shared
+`clr_support` harness. It is gated on `dotnet`+`ilasm` (skips when absent, exactly
+like the JVM/BEAM/LLVM columns), so the in-process `clr-simulator` `CLR` column
+remains the conformance floor while `CLR-real` proves the **same 19 programs**
+agree on real CoreCLR when the toolchain is installed. Locally: 19 programs × 9
+backends, all agree. CI (`ci.yml`) now installs `ilasm` whenever .NET is set up — a
+`<PackageDownload>` of the RID-specific `runtime.<rid>.Microsoft.NETCore.ILAsm`
+runtime pack into the NuGet cache where `find_ilasm()` looks — so the CLR column is
+verified on the real runtime rather than only the simulator. This completes
+**C1–C6: the CLR backend is verified on real CoreCLR.**
+
 ## 0.52.0 — 2026-06-11 — McCarthy **lambda / LABEL / recursion** on real CoreCLR (CLR-real C5)
 
 `compile_source_to_cil_text` now compiles multi-function McCarthy programs (via

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -53,9 +53,11 @@ real `clang`). The full McCarthy **F1–F7** set runs today — scalar, **cons/c
 `(EQ (QUOTE A) (QUOTE A))`→1, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7, and a recursive
 `LABEL`→7 on real CoreCLR; `tests/clr_real_scalar.rs` + `clr_real_cons.rs` +
 `clr_real_predicates.rs` + `clr_real_symbols.rs` + `clr_real_lambda.rs`, gated on
-`dotnet`+`ilasm` via the shared `tests/clr_support` harness). The remaining worklist
-item (C6) wires this real-CoreCLR path into the W16 conformance matrix, after which
-the CLR column is verified on real .NET rather than the in-repo simulator.
+`dotnet`+`ilasm` via the shared `tests/clr_support` harness). The W16 conformance
+suite (`tests/conformance.rs`) now carries a ninth **`CLR-real`** column that runs
+the same programs on real .NET (19 programs × 9 backends all agree locally), so the
+CLR column is verified on real CoreCLR rather than only the in-repo simulator — the
+**CLR-real verification chapter (C1–C6) is complete**.
 
 `compile_source_to_beam` targets the **Erlang VM**: scalar McCarthy emits a
 `.beam` that **runs** on a real `erl` (OTP), `42` → 42 (W9a), and **cons** too —

--- a/code/packages/rust/lang-aot/tests/conformance.rs
+++ b/code/packages/rust/lang-aot/tests/conformance.rs
@@ -14,14 +14,19 @@
 //! | JIT         | tagged-word    | `lang_aot::run_mccarthy_on_jit`               |
 //! | WASM        | uniform-anyref | `wasm-runtime`                                |
 //! | JVM         | object/boxing  | a real `java` (cons is `Object[]`) — gated    |
-//! | CLR         | object/boxing  | `clr-simulator`                               |
+//! | CLR         | object/boxing  | `clr-simulator` (in-process floor)            |
+//! | CLR-real    | object/boxing  | real `ilasm` + real `dotnet` (`.il`) — gated  |
 //! | BEAM        | Erlang terms   | a real `erl` — gated                          |
 //! | LLVM        | tagged-word    | `clang` + `lispy_runtime.c` — gated           |
 //! | native AOT  | tagged-word    | `aarch64`/`x86_64` object + system `ld` — gated, macOS |
 //!
 //! External-tool backends return `None` (skip) when the tool is absent, so the
 //! suite still proves uniformity across whatever is installed; the in-process
-//! backends (VM / JIT / WASM / CLR) always run and must agree.
+//! backends (VM / JIT / WASM / CLR) always run and must agree. The **CLR-real**
+//! column is the capstone of the CLR-real verification chapter: it runs the same
+//! McCarthy programs on the actual .NET runtime (textual `.il` → real `ilasm` →
+//! real `dotnet`), upgrading the CLR column from an in-house simulator to the real
+//! runtime whenever `dotnet`+`ilasm` are present.
 //!
 //! ## Why integer-result programs
 //!
@@ -38,6 +43,12 @@ use lang_aot::{
 };
 
 use lispy_runtime::LispyValue;
+
+// The shared real-CoreCLR harness (`compile_source_to_cil_text` → real `ilasm` →
+// real `dotnet`), reused by the per-feature `clr_real_*` tests. Lives in a
+// subdirectory so Cargo doesn't compile it as its own test binary.
+#[path = "clr_support/mod.rs"]
+mod clr_support;
 
 // ── The conformance table: McCarthy F1–F7, every result an integer. ──
 const PROGRAMS: &[(&str, i64)] = &[
@@ -277,6 +288,16 @@ fn run_native(_src: &str) -> Option<i64> {
     None // the in-repo native-executable link path is macOS-only today
 }
 
+// ── Backend 9: CLR on **real CoreCLR** — the CLR-real chapter's capstone wiring.
+//    Emits textual `.il`, assembles it with real `ilasm`, and runs it on real
+//    `dotnet` (via the shared `clr_support` harness). Gated on `dotnet`+`ilasm`:
+//    skips (returns `None`) when either is absent, so the in-process simulator
+//    `CLR` column above remains the conformance floor while this column proves the
+//    SAME programs on the actual .NET runtime when the toolchain is installed. ──
+fn run_clr_real(src: &str) -> Option<i64> {
+    clr_support::run_on_real_clr(src, "w16")
+}
+
 /// The capstone: every backend that can run a program computes the same integer.
 #[test]
 fn mccarthy_is_uniform_across_every_backend() {
@@ -289,6 +310,7 @@ fn mccarthy_is_uniform_across_every_backend() {
         ("BEAM", run_beam),
         ("LLVM", run_llvm),
         ("native-AOT", run_native),
+        ("CLR-real", run_clr_real),
     ];
 
     let mut exercised: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();

--- a/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
+++ b/code/specs/CLR-REAL-RUNTIME-VERIFICATION.md
@@ -89,14 +89,22 @@ other external-tool backends.
   `((LAMBDA (X) X) 5)`→5, `((LAMBDA (X) (CAR X)) (CONS 7 9))`→7,
   `((LAMBDA (X Y) (EQ X Y)) 3 3)`→1, a COND-body lambda→100, and a recursive
   `LABEL` descending CARs→7. **This closes McCarthy F1–F7 on the CLR's real runtime.**
-- ☐ **C6 — wire real-CoreCLR CLR into the conformance suite.** Add a `run_clr_real`
-  arm to `lang-aot/tests/conformance.rs` (gated on `dotnet`+`ilasm`) so the W16
-  table runs the CLR column on **real .NET**; ensure CI installs `ilasm`
-  (`dotnet restore` of the ILAsm pack) so the upgrade holds on every PR.
+- ✅ **C6 — wire real-CoreCLR CLR into the conformance suite.** `lang-aot/tests/
+  conformance.rs` gained a ninth backend column, **`CLR-real`** (`run_clr_real`),
+  that runs each McCarthy program on real .NET via the shared `clr_support` harness
+  (textual `.il` → real `ilasm` → real `dotnet`), gated on `dotnet`+`ilasm` so the
+  in-process simulator `CLR` column stays the floor. Locally: **19 programs × 9
+  backends, all agree.** CI (`.github/workflows/ci.yml`) installs `ilasm` whenever
+  .NET is set up — a `<PackageDownload>` of the RID-specific
+  `runtime.<rid>.Microsoft.NETCore.ILAsm` runtime pack into the NuGet cache where
+  `find_ilasm()` searches — so the upgrade holds in CI, not just locally.
 
-## End state
+## End state — ACHIEVED ✅
 
 CLR joins JVM/BEAM/LLVM/native as a backend verified on its **real runtime**, and
 the cross-backend conformance matrix is genuinely stronger — the CLR column proven
 by real CoreCLR, not an in-house simulator. The `clr-simulator` remains for fast,
 zero-dependency unit checks; the real-runtime path is the verification of record.
+All of C1–C6 are complete: McCarthy F1–F7 (scalar, cons, predicates+COND, symbols,
+lambda/LABEL/recursion) all run on **real CoreCLR**, and the W16 capstone exercises
+the CLR column on real .NET.


### PR DESCRIPTION
## Summary

The **final slice** of the CLR real-CoreCLR verification chapter (`code/specs/CLR-REAL-RUNTIME-VERIFICATION.md`, item **C6**) — and the capstone of the whole effort. Wires the **real-CoreCLR** CLR path into the W16 cross-backend McCarthy conformance matrix so the CLR column is proven on the actual .NET runtime, not just the in-repo simulator.

### What changed

- **`tests/conformance.rs`** gains a ninth backend column, **`CLR-real`** (`run_clr_real`), that runs each McCarthy program on real .NET — textual `.il` → real `ilasm` → real `dotnet` — via the shared `clr_support` harness (the same one the per-feature `clr_real_*` tests use). It is **gated on `dotnet`+`ilasm`** (skips when absent, exactly like the JVM/BEAM/LLVM columns), so the in-process `clr-simulator` `CLR` column remains the conformance floor while `CLR-real` proves the **same 19 programs** agree on real CoreCLR.
- **`.github/workflows/ci.yml`** installs `ilasm` whenever .NET is set up: a `<PackageDownload>` of the RID-specific `runtime.<rid>.Microsoft.NETCore.ILAsm` runtime pack (the bare `Microsoft.NETCore.ILAsm` is ref-only — no binary) drops the assembler into the NuGet cache where the harness's `find_ilasm()` searches. The RID is read from `dotnet --info`; the restore is non-fatal (the column skips gracefully if the pack is unavailable).

### Result — the chapter is complete

McCarthy **F1–F7** (scalar, cons/car/cdr, predicates+`COND`, symbols, lambda/`LABEL`/recursion) all run on **real CoreCLR**, and the W16 capstone now exercises the CLR column on the real runtime. **C1–C6 done.**

## Security

Security review **PASSED**. The new CI step interpolates only `$rid` (from the trusted `dotnet --info` SDK output, constrained to `[a-z0-9.-]`) into a heredoc'd csproj *file* — not into a command — so there is no shell-injection path; worst case is a malformed csproj that fails the already-non-fatal restore. `<PackageDownload>` at an exact pinned version `[9.0.0]` from nuget.org is the right call (narrower surface than `<PackageReference>`, no version drift). The conformance test runs only fixed literal McCarthy source from the `PROGRAMS` const table — no attacker-controlled program reaches `ilasm`/`dotnet`. `set -euo pipefail` + empty-RID guard + `mktemp -d` (mode 0700) are sound.

## Test plan

- **Local W16 run** (with real `dotnet` 9.0.313 + real `ilasm`): `19 programs × 9 backends exercised → {BEAM, CLR, CLR-real, JIT, JVM, LLVM, VM, WASM, native-AOT}`, all agree — **the `CLR-real` column passes on real CoreCLR.**
- **CI `<PackageDownload>` validated locally**: resolves `runtime.osx-arm64.Microsoft.NETCore.ILAsm@9.0.0` and lands the binary at the path `find_ilasm()` searches; on CI Linux it resolves `runtime.linux-x64.*`.
- `conformance.rs` clippy clean.

## Versioning / docs

- `lang-aot` 0.52.0 → **0.53.0** (test + CI wiring; the emitter `iir-to-cil-bytecode` needed no change after C5).
- Spec C6 ticked ☐→✅ and **End state marked ACHIEVED**; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)