### PR TITLE
fix(closurec): CLOC12.76 — close gap-068 (parens around a `new` callee)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.80.0] - 2026-06-11
+
+### Changed
+- **CLOSES gap-068** — redundant parens around a `new` callee:
+  `new(f)()` → `new f`, `new(a.b)` → `new a.b`. Sibling of
+  gap-065/066.
+
+### Added — gap-068 token pre-pass
+
+Strips the grouping parens around a `new` callee when the callee
+is a simple reference (identifier + `.IDENT` chain), anchored on
+the `new` KEYWORD. The trailing empty `()` of the call form
+(`new(f)()`) is then dropped by the existing gap-050 empty-paren
+elision in the emit loop. Guards: operator `new` only (not a
+property named `new` — `o.new(f)` is a method call), not a
+string literal whose content is `new`; all bracket checks via
+`is_structural_punct`. Operator inner `new(a+b)` keeps its
+parens (`new a+b` would parse as `(new a)+b`). 5 new gap068_*
+unit tests.
+
 ## [0.79.0] - 2026-06-11
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.79.0"
+version = "0.80.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -691,6 +691,76 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-068: redundant parens around a `new` callee ------
+    // `new(f)()` → `new f`, `new(a.b)` → `new a.b`. After the
+    // `new` keyword a parenthesized simple reference is redundant
+    // — member access (`.`) binds tighter than an argument-less
+    // `new`, so `new a.b` constructs `a.b` just like `new(a.b)`.
+    //
+    // This pass only STRIPS the parens around the callee. For the
+    // call form `new(f)()` the trailing empty `()` is then
+    // dropped by the existing gap-050 empty-paren elision in the
+    // emit loop (which runs after this pre-pass): `new f()` →
+    // `new f`.
+    //
+    // Minimal safe slice (mirrors gap-066): the inner must be a
+    // *simple reference* — a plain identifier plus zero-or-more
+    // `.IDENT` accessors. The scan stops at the first non-`.IDENT`
+    // token, so an operator inner `new(a+b)` keeps its parens
+    // (`new a+b` would parse as `(new a)+b` — a different
+    // program). Computed `[...]` and call-chain inners are
+    // deferred.
+    //
+    // Guards:
+    //   - operator `new`, not a PROPERTY named `new`
+    //     (`o.new(f)` is a method call — prev-prev must not be
+    //     `.`/`?.`), and not a string literal whose content is
+    //     `new`,
+    //   - all bracket/accessor checks via `is_structural_punct`.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 1;
+        while i + 1 < kept.len() {
+            let after_new = kept[i - 1].value == "new"
+                && !is_string_literal(kept[i - 1])
+                && match i.checked_sub(2).and_then(|k| kept.get(k)) {
+                    None => true,
+                    Some(pp) => {
+                        !is_structural_punct(pp, ".")
+                            && !is_structural_punct(pp, "?.")
+                    }
+                };
+            if after_new
+                && is_structural_punct(&kept[i], "(")
+                && is_plain_identifier(&kept[i + 1])
+            {
+                // Consume the `.IDENT` member chain.
+                let mut p = i + 1;
+                while p + 2 < kept.len()
+                    && is_structural_punct(&kept[p + 1], ".")
+                    && is_plain_identifier(&kept[p + 2])
+                {
+                    p += 2;
+                }
+                let close_ok = kept
+                    .get(p + 1)
+                    .map(|t| is_structural_punct(t, ")"))
+                    .unwrap_or(false);
+                if close_ok {
+                    drops.push(i); // open `(`
+                    drops.push(p + 1); // close `)`
+                    i = p + 2;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // ---- gap-059: member/call on a `new` expression ----------
     // `new A().b` → `(new A).b`. When a NewExpression is the
     // OBJECT of a member access (`.`/`[`) or the CALLEE of a
@@ -3681,6 +3751,39 @@ mod tests {
     #[test]
     fn gap066_extends_property_not_stripped() {
         assert_eq!(minify("o.extends(x);"), "o.extends(x);");
+    }
+
+    // ---- gap-068: redundant parens around a `new` callee ----
+
+    /// gap-068: `new(f)()` → `new f` — strip the callee parens
+    /// (then the empty `()` is dropped by gap-050).
+    #[test]
+    fn gap068_new_call_paren_stripped() {
+        assert_eq!(minify("new(f)();"), "new f;");
+    }
+
+    /// gap-068: `new(a.b)` → `new a.b` — member-chain callee.
+    #[test]
+    fn gap068_new_member_paren_stripped() {
+        assert_eq!(minify("new(a.b);"), "new a.b;");
+        assert_eq!(minify("new(a.b.c);"), "new a.b.c;");
+    }
+
+    /// gap-068 SAFETY: an operator callee keeps its parens —
+    /// `new(a+b)` must NOT become `new a+b` (which parses as
+    /// `(new a)+b` — a different program).
+    #[test]
+    fn gap068_operator_callee_keeps_parens() {
+        // closurec keeps the parens; it does not strip (the
+        // emit-time `new`/`(` spacing is a separate concern).
+        assert!(minify("new(a+b);").contains("(a+b)"));
+    }
+
+    /// gap-068 SAFETY: a PROPERTY named `new` is a method call,
+    /// not a NewExpression — `o.new(f)` must NOT be stripped.
+    #[test]
+    fn gap068_new_property_not_stripped() {
+        assert_eq!(minify("o.new(f);"), "o.new(f);");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.79.0
+Version: 0.80.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -95,12 +95,9 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // A multi-statement labeled block keeps its braces (boundary
     // pinned by minify_label_block_multi).
     ("label_block_flatten", "gap-067: labeled single-statement block flatten"),
-    // gap-068 (CLOC14.34): redundant parens around a `new`
-    // callee — `new(f)()` → `new f`, `new(a.b)` → `new a.b`.
-    // (Composes with the gap-050 empty-paren drop for the call
-    // form.)
-    ("new_paren_callee", "gap-068: parens around new callee `new(f)()`"),
-    ("new_paren_member", "gap-068: parens around new member callee"),
+    // gap-068 RESOLVED in CLOC12.76 — redundant parens around a
+    // `new` callee (`new(f)()` → `new f`, `new(a.b)` → `new a.b`)
+    // are now stripped; both fixtures enforced.
     // gap-065 RESOLVED in CLOC12.74 — parens around a call /
     // tagged-template callee (`(f)(x)`→`f(x)`, `(a.b)(x)`→
     // `a.b(x)`) are now stripped; those three fixtures are

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -527,6 +527,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-068 — redundant parens around a `new` callee
 
-- **Status:** OPEN — discovered by CLOC14.34. `minify_new_paren_callee` + `minify_new_paren_member` ignored.
+- **Status:** **RESOLVED** in CLOC12.76. `minify_new_paren_callee` + `minify_new_paren_member` flip IGNORED → PASS.
 - **Input:** `new(f)();` → **Upstream:** `new f;` (also `new(a.b);` → `new a.b;`)
 - **What it needs:** Strip the grouping parens around the CALLEE of a `NewExpression` when the callee is a simple reference (identifier or member chain). For the call form `new(f)()` this composes with the gap-050 empty-paren drop (`new f()` → `new f`). The simple-reference / precedence caveat from gap-065 applies — an operator inner (`new(a+b)`) must keep its parens.
+- **CLOC12.76:** strips `new ( <identifier-dot chain> )`, anchored on the `new` KEYWORD (guarded against a property named `new` — `o.new(f)` is a method call). The trailing empty `()` of the call form is dropped by gap-050 in the emit loop. Operator inner `new(a+b)` keeps its parens (would parse as `(new a)+b`). **Note — separate pre-existing divergence (gap-069 candidate):** when the parens are KEPT, upstream emits a space `new (a+b)` while closurec emits `new(a+b)`; both are valid and equivalent, but not byte-identical. Deferred. 5 unit tests.


### PR DESCRIPTION
## What

Closes **gap-068** (found in CLOC14.34). Strips redundant grouping parens around a `new` callee:

```
new(f)()   →  new f
new(a.b)   →  new a.b
new(a.b.c) →  new a.b.c
```

Sibling of gap-065/066: member access binds tighter than an argument-less `new`, so `new a.b` constructs `a.b` just like `new(a.b)`.

## How

A token pre-pass strips `new ( <identifier-dot chain> )`, anchored on the `new` **keyword**. For the call form `new(f)()`, the trailing empty `()` is then dropped by the existing **gap-050** empty-paren elision in the emit loop (`new f()` → `new f`). Guards:
- operator `new` only — not a property named `new` (`o.new(f)` / `o?.new(f)` are method calls; prev-prev must not be `.`/`?.`), not a string literal whose content is `new`;
- all bracket checks via `is_structural_punct`.

`new(a+b)` / `new(a,b)` keep their parens (operator/sequence inner — `new a+b` parses as `(new a)+b`, different program).

## Tests

- New `gap068_*` unit tests (strip cases + operator-keep + property-call safety).
- 452 lib tests green; byte-identity harness with both `new_paren_*` fixtures un-ignored.
- Security-reviewed (read-only subagent): **PASS** — meaning preservation, operator-inner safety, property/string guards, gap-050 composition, member-chain scan, index/removal, gap-059/060/061 interaction (`new(f)().b`→`(new f).b` matches JAR), and gap-050/059 non-regression all verified; **every in-scope case JAR-identical**, no invalid JS on any tested (incl. degenerate) input.

> Acceptable cosmetic divergences (both sides valid, deferred): `new(a+b)` keeps parens as `new(a+b)` vs JAR `new (a+b)` (gap-069 emit-spacing candidate); `new(a.b)()` → `new a.b()` vs JAR `new a.b` (missed opt — gap-050 only handles single-ident callees).

Version 0.79→0.80; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)