### PR TITLE
Add smart-home activation timeline tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -58,6 +58,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation dashboard card planning:
   `smart_home.list_integration_activation_dashboard` and
   `smart_home.get_integration_activation_dashboard_summary`.
+- Added D18D handlers for D23A activation timeline milestone planning:
+  `smart_home.list_integration_activation_timeline` and
+  `smart_home.get_integration_activation_timeline_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -54,6 +54,7 @@ Chief of Staff job/session/agent
   -> activation-evidence list and summary reads for approval/block evidence rows
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
+  -> activation-timeline list and summary reads for ordered wave milestones
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -113,6 +114,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_briefing_summary`
 - `smart_home.list_integration_activation_dashboard`
 - `smart_home.get_integration_activation_dashboard_summary`
+- `smart_home.list_integration_activation_timeline`
+- `smart_home.get_integration_activation_timeline_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -42,7 +42,8 @@ use smart_home_integration_catalog::{
     activation_maintenance_from_candidates, activation_plan_for_entry,
     activation_plans_at_or_before_priority, activation_readouts_from_candidates,
     activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, describe_primitive_family, ecosystem_platform_coverage,
+    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
+    describe_primitive_family, ecosystem_platform_coverage,
     ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
     find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
     primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
@@ -74,7 +75,8 @@ use smart_home_integration_catalog::{
     IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
-    IntegrationActivationTarget, IntegrationCatalogEntry, IntegrationCatalogQuery,
+    IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
+    IntegrationActivationTimelineSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
     IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
     IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
     IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
@@ -242,6 +244,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DASHBOARD_TOOL_ID: &str =
     "smart_home.list_integration_activation_dashboard";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_dashboard_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_timeline";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_timeline_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -508,6 +514,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID => {
                     let query = integration_activation_dashboard_query(&arguments)?;
                     Ok(get_integration_activation_dashboard_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID => {
+                    let query = integration_activation_timeline_query(&arguments)?;
+                    Ok(list_integration_activation_timeline_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_timeline_query(&arguments)?;
+                    Ok(get_integration_activation_timeline_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1740,6 +1756,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation dashboard summary",
             "Return compact D23A activation dashboard counts across priority-wave cards, briefing sections, actions, risk, and blockers.",
             integration_activation_dashboard_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID,
+            "List smart-home integration activation timeline",
+            "List Chief-ready D23A activation timeline milestones ordered from priority-wave dashboard cards.",
+            integration_activation_timeline_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_timeline", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_timeline", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation timeline summary",
+            "Return compact D23A activation timeline counts across ordered milestones, priority waves, blockers, approvals, and activation work.",
+            integration_activation_timeline_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4401,6 +4446,13 @@ struct IntegrationActivationDashboardQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationTimelineQuery {
+    dashboard: IntegrationActivationDashboardQuery,
+    milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    milestone_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4677,6 +4729,21 @@ fn integration_activation_dashboard_query(
     Ok(IntegrationActivationDashboardQuery {
         readouts: integration_activation_readout_query(arguments)?,
         card_limit: optional_u64(arguments, "card_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_timeline_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationTimelineQuery, ToolCallError> {
+    let milestone_kind = optional_string(arguments, "milestone_kind")?
+        .or(optional_string(arguments, "timeline_kind")?)
+        .map(|label| parse_activation_briefing_item_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationTimelineQuery {
+        dashboard: integration_activation_dashboard_query(arguments)?,
+        milestone_kind,
+        milestone_limit: optional_u64(arguments, "milestone_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5245,6 +5312,22 @@ fn integration_activation_dashboard_cards_for_query(
     }
 
     (cards, catalog_count)
+}
+
+fn integration_activation_timeline_milestones_for_query(
+    query: &IntegrationActivationTimelineQuery,
+) -> (Vec<IntegrationActivationTimelineMilestone>, usize) {
+    let (cards, catalog_count) = integration_activation_dashboard_cards_for_query(&query.dashboard);
+    let mut milestones = activation_timeline_milestones_from_dashboard_cards(cards);
+
+    if let Some(milestone_kind) = query.milestone_kind {
+        milestones.retain(|milestone| milestone.milestone_kind == Some(milestone_kind));
+    }
+    if let Some(limit) = query.milestone_limit {
+        milestones.truncate(limit);
+    }
+
+    (milestones, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6644,6 +6727,77 @@ fn get_integration_activation_dashboard_summary_output_handler_output(
             (
                 "cards_with_blockers",
                 integer(summary.cards_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_timeline_output_handler_output(
+    query: IntegrationActivationTimelineQuery,
+) -> ToolHandlerOutput {
+    let (milestones, catalog_count) = integration_activation_timeline_milestones_for_query(&query);
+    let summary = IntegrationActivationTimelineSummary::from_milestones(milestones.iter());
+    let count = milestones.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_timeline",
+            JsonValue::Array(
+                milestones
+                    .iter()
+                    .map(activation_timeline_milestone_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_timeline_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_timeline")),
+            ("activation_timeline_milestones", integer(count as i64)),
+            (
+                "milestones_requiring_attention",
+                integer(summary.milestones_requiring_attention as i64),
+            ),
+            (
+                "milestones_with_blockers",
+                integer(summary.milestones_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_timeline_summary_output_handler_output(
+    query: IntegrationActivationTimelineQuery,
+) -> ToolHandlerOutput {
+    let (milestones, _) = integration_activation_timeline_milestones_for_query(&query);
+    let summary = IntegrationActivationTimelineSummary::from_milestones(milestones.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_timeline_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_timeline_summary"),
+            ),
+            ("total_milestones", integer(summary.total_milestones as i64)),
+            (
+                "milestones_requiring_attention",
+                integer(summary.milestones_requiring_attention as i64),
+            ),
+            (
+                "milestones_with_blockers",
+                integer(summary.milestones_with_blockers as i64),
             ),
         ]),
     )
@@ -12047,6 +12201,265 @@ fn integration_activation_dashboard_summary_json(
     ])
 }
 
+fn activation_timeline_milestone_json(
+    milestone: &IntegrationActivationTimelineMilestone,
+) -> JsonValue {
+    object([
+        ("sequence", integer(milestone.sequence as i64)),
+        ("priority", integer(milestone.priority as i64)),
+        (
+            "milestone_kind",
+            milestone
+                .milestone_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dashboard_card",
+            activation_dashboard_card_json(&milestone.dashboard_card),
+        ),
+        (
+            "integration_count",
+            integer(milestone.integration_count() as i64),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(milestone.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(milestone.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(milestone.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(milestone.has_blockers())),
+        ("has_risks", JsonValue::Bool(milestone.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(milestone.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(milestone.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_timeline_summary_json(
+    summary: &IntegrationActivationTimelineSummary,
+) -> JsonValue {
+    object([
+        ("total_milestones", integer(summary.total_milestones as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        ("ready_milestones", integer(summary.ready_milestones as i64)),
+        (
+            "review_milestones",
+            integer(summary.review_milestones as i64),
+        ),
+        (
+            "blocked_milestones",
+            integer(summary.blocked_milestones as i64),
+        ),
+        ("empty_milestones", integer(summary.empty_milestones as i64)),
+        (
+            "blocker_milestones",
+            integer(summary.blocker_milestones as i64),
+        ),
+        (
+            "review_queue_milestones",
+            integer(summary.review_queue_milestones as i64),
+        ),
+        (
+            "approval_milestones",
+            integer(summary.approval_milestones as i64),
+        ),
+        (
+            "activation_milestones",
+            integer(summary.activation_milestones as i64),
+        ),
+        ("risk_milestones", integer(summary.risk_milestones as i64)),
+        (
+            "dependency_milestones",
+            integer(summary.dependency_milestones as i64),
+        ),
+        (
+            "milestones_requiring_attention",
+            integer(summary.milestones_requiring_attention as i64),
+        ),
+        (
+            "milestones_with_activation_work",
+            integer(summary.milestones_with_activation_work as i64),
+        ),
+        (
+            "milestones_with_approval_work",
+            integer(summary.milestones_with_approval_work as i64),
+        ),
+        (
+            "milestones_with_review_work",
+            integer(summary.milestones_with_review_work as i64),
+        ),
+        (
+            "milestones_with_blockers",
+            integer(summary.milestones_with_blockers as i64),
+        ),
+        (
+            "milestones_with_risks",
+            integer(summary.milestones_with_risks as i64),
+        ),
+        (
+            "milestones_with_dependency_blockers",
+            integer(summary.milestones_with_dependency_blockers as i64),
+        ),
+        (
+            "total_briefing_items",
+            integer(summary.total_briefing_items as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "first_activation_sequence",
+            summary
+                .first_activation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_sequence",
+            summary
+                .first_approval_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_sequence",
+            summary
+                .first_risk_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_sequence",
+            summary
+                .first_dependency_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_priority",
+            summary
+                .first_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(summary.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -15660,6 +16073,21 @@ fn integration_activation_dashboard_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_timeline_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_dashboard_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("milestone_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("timeline_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("milestone_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -15804,7 +16232,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 91);
+        assert_eq!(definitions.len(), 93);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -16045,9 +16473,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            83
+            85
         );
         assert_eq!(
             export
@@ -16223,6 +16657,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_DASHBOARD_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -16477,11 +16919,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(91))
+            Some(&integer(93))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(83))
+            Some(&integer(85))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -18671,6 +19113,140 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_timeline_request = request(
+            "call-list-integration-activation-timeline",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("milestone_limit", integer(3)),
+            ]),
+            5_025,
+        );
+        let list_activation_timeline_trace =
+            tool_runtime.invoke_with_events(&list_activation_timeline_request);
+        assert!(list_activation_timeline_trace.result.ok);
+        assert_eq!(
+            list_activation_timeline_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_timeline_output = list_activation_timeline_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_timeline_count =
+            integer_value(field(list_activation_timeline_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_timeline_count));
+        let activation_timeline_summary =
+            field(list_activation_timeline_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_timeline_summary, "total_milestones"),
+            Some(&integer(activation_timeline_count))
+        );
+        assert_eq!(
+            field(activation_timeline_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(
+                field(
+                    activation_timeline_summary,
+                    "milestones_requiring_attention"
+                )
+                .unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        let activation_timeline_milestone = array_item(
+            field(list_activation_timeline_output, "activation_timeline").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_timeline_milestone, "sequence").is_some());
+        assert!(field(activation_timeline_milestone, "priority").is_some());
+        assert!(field(activation_timeline_milestone, "milestone_kind").is_some());
+        assert!(field(activation_timeline_milestone, "dashboard_card").is_some());
+        assert!(field(activation_timeline_milestone, "integration_count").is_some());
+        assert_eq!(
+            field(activation_timeline_milestone, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_timeline_summary_request = request(
+            "call-integration-activation-timeline-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("milestone_kind", string("blocker")),
+            ]),
+            5_026,
+        );
+        let activation_timeline_summary_trace =
+            tool_runtime.invoke_with_events(&activation_timeline_summary_request);
+        assert!(activation_timeline_summary_trace.result.ok);
+        assert_eq!(
+            activation_timeline_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_timeline_summary_output = activation_timeline_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_timeline_rollup =
+            field(activation_timeline_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_timeline_rollup, "blocker_milestones").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_timeline_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_timeline_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -20410,6 +20986,14 @@ mod tests {
             activation_dashboard_summary_request,
             activation_dashboard_summary_trace,
         );
+        journal.record_trace(
+            list_activation_timeline_request,
+            list_activation_timeline_trace,
+        );
+        journal.record_trace(
+            activation_timeline_summary_request,
+            activation_timeline_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -20483,9 +21067,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 91);
-        assert_eq!(journal_summary.completed_count, 91);
-        assert_eq!(journal.audit_records().len(), 91);
+        assert_eq!(journal_summary.invocation_count, 93);
+        assert_eq!(journal_summary.completed_count, 93);
+        assert_eq!(journal.audit_records().len(), 93);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -76,6 +76,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_dashboard_summary` tool descriptors
   for read-only Chief activation dashboard cards derived from readouts and
   briefing rows.
+- `smart_home.list_integration_activation_timeline` and
+  `smart_home.get_integration_activation_timeline_summary` tool descriptors
+  for read-only Chief activation milestone views derived from dashboard cards.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -85,6 +85,8 @@ Current scope:
   approval, review, blocker, risk, and dependency briefing sections
 - D18D integration activation-dashboard descriptors for Chief-ready
   priority-wave status cards derived from readouts and briefing rows
+- D18D integration activation-timeline descriptors for ordered milestone views
+  derived from dashboard cards
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1489,6 +1489,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationBriefingSummary,
     ListIntegrationActivationDashboard,
     GetIntegrationActivationDashboardSummary,
+    ListIntegrationActivationTimeline,
+    GetIntegrationActivationTimelineSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1662,6 +1664,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationDashboardSummary => {
                 read_tool("smart_home.get_integration_activation_dashboard_summary")
+            }
+            Self::ListIntegrationActivationTimeline => {
+                read_tool("smart_home.list_integration_activation_timeline")
+            }
+            Self::GetIntegrationActivationTimelineSummary => {
+                read_tool("smart_home.get_integration_activation_timeline_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2334,6 +2342,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationBriefingSummary,
         SmartHomeTool::ListIntegrationActivationDashboard,
         SmartHomeTool::GetIntegrationActivationDashboardSummary,
+        SmartHomeTool::ListIntegrationActivationTimeline,
+        SmartHomeTool::GetIntegrationActivationTimelineSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3176,7 +3186,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 91);
+        assert_eq!(catalog.len(), 93);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3364,6 +3374,14 @@ mod tests {
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.get_integration_activation_dashboard_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_timeline"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_timeline_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(
@@ -3554,15 +3572,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 91);
-        assert_eq!(summary.read_tools, 83);
+        assert_eq!(summary.total_tools, 93);
+        assert_eq!(summary.read_tools, 85);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 83);
+        assert_eq!(summary.read_only_tier_tools, 85);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 91);
+        assert_eq!(summary.total_required_capabilities, 93);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -68,6 +68,8 @@ runtime and Chief of Staff tools a typed catalog for:
   approval, review, blocker, risk, and dependency briefing sections
 - activation dashboard cards that condense readouts and briefing rows into
   priority-wave Chief status cards
+- activation timeline milestones that order dashboard cards into a Chief-ready
+  wave sequence
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1874,6 +1874,60 @@ pub struct IntegrationActivationDashboardSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationTimelineMilestone {
+    pub sequence: usize,
+    pub priority: u8,
+    pub milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub dashboard_card: IntegrationActivationDashboardCard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationTimelineSummary {
+    pub total_milestones: usize,
+    pub unique_integrations: usize,
+    pub ready_milestones: usize,
+    pub review_milestones: usize,
+    pub blocked_milestones: usize,
+    pub empty_milestones: usize,
+    pub blocker_milestones: usize,
+    pub review_queue_milestones: usize,
+    pub approval_milestones: usize,
+    pub activation_milestones: usize,
+    pub risk_milestones: usize,
+    pub dependency_milestones: usize,
+    pub milestones_requiring_attention: usize,
+    pub milestones_with_activation_work: usize,
+    pub milestones_with_approval_work: usize,
+    pub milestones_with_review_work: usize,
+    pub milestones_with_blockers: usize,
+    pub milestones_with_risks: usize,
+    pub milestones_with_dependency_blockers: usize,
+    pub total_briefing_items: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub first_activation_sequence: Option<usize>,
+    pub first_approval_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_risk_sequence: Option<usize>,
+    pub first_dependency_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_activation_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_risk_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -3275,6 +3329,261 @@ impl IntegrationActivationDashboardSummary {
 
     pub fn has_dependency_blockers(&self) -> bool {
         self.cards_with_dependency_blockers > 0 || self.dependency_items > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.overall_status.requires_attention()
+            || self.has_approval_ready_work()
+            || self.has_review_work()
+            || self.has_blockers()
+            || self.has_risks()
+            || self.has_dependency_blockers()
+    }
+}
+
+impl IntegrationActivationTimelineMilestone {
+    fn from_dashboard_card(
+        sequence: usize,
+        dashboard_card: IntegrationActivationDashboardCard,
+    ) -> Self {
+        Self {
+            sequence,
+            priority: dashboard_card.priority,
+            milestone_kind: dashboard_card.next_briefing_kind,
+            dashboard_card,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.dashboard_card.integration_count()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.dashboard_card.requires_attention()
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.dashboard_card.has_activation_work
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.dashboard_card.has_approval_ready_work
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.dashboard_card.has_review_work
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.dashboard_card.has_blockers
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.dashboard_card.has_risks
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.dashboard_card.has_dependency_blockers
+    }
+}
+
+impl IntegrationActivationTimelineSummary {
+    pub fn from_milestones<'a>(
+        milestones: impl IntoIterator<Item = &'a IntegrationActivationTimelineMilestone>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_milestones: 0,
+            unique_integrations: 0,
+            ready_milestones: 0,
+            review_milestones: 0,
+            blocked_milestones: 0,
+            empty_milestones: 0,
+            blocker_milestones: 0,
+            review_queue_milestones: 0,
+            approval_milestones: 0,
+            activation_milestones: 0,
+            risk_milestones: 0,
+            dependency_milestones: 0,
+            milestones_requiring_attention: 0,
+            milestones_with_activation_work: 0,
+            milestones_with_approval_work: 0,
+            milestones_with_review_work: 0,
+            milestones_with_blockers: 0,
+            milestones_with_risks: 0,
+            milestones_with_dependency_blockers: 0,
+            total_briefing_items: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            first_activation_sequence: None,
+            first_approval_sequence: None,
+            first_review_sequence: None,
+            first_blocked_sequence: None,
+            first_risk_sequence: None,
+            first_dependency_sequence: None,
+            first_attention_sequence: None,
+            first_activation_priority: None,
+            first_approval_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_risk_priority: None,
+            first_dependency_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for milestone in milestones {
+            summary.total_milestones += 1;
+            for integration_id in &milestone.dashboard_card.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match milestone.dashboard_card.health_status {
+                IntegrationActivationHealthStatus::Ready => summary.ready_milestones += 1,
+                IntegrationActivationHealthStatus::NeedsReview => summary.review_milestones += 1,
+                IntegrationActivationHealthStatus::Blocked => summary.blocked_milestones += 1,
+                IntegrationActivationHealthStatus::Empty => summary.empty_milestones += 1,
+            }
+            match milestone.milestone_kind {
+                Some(IntegrationActivationBriefingItemKind::Blocker) => {
+                    summary.blocker_milestones += 1
+                }
+                Some(IntegrationActivationBriefingItemKind::Review) => {
+                    summary.review_queue_milestones += 1
+                }
+                Some(IntegrationActivationBriefingItemKind::Approval) => {
+                    summary.approval_milestones += 1
+                }
+                Some(IntegrationActivationBriefingItemKind::Activation) => {
+                    summary.activation_milestones += 1
+                }
+                Some(IntegrationActivationBriefingItemKind::Risk) => summary.risk_milestones += 1,
+                Some(IntegrationActivationBriefingItemKind::Dependency) => {
+                    summary.dependency_milestones += 1
+                }
+                None => {}
+            }
+
+            let card = &milestone.dashboard_card;
+            summary.total_briefing_items += card.briefing_item_count;
+            summary.total_actions += card.action_count;
+            summary.total_dossiers += card.dossier_count;
+            summary.total_evidence += card.evidence_count;
+            summary.total_risks += card.risk_count;
+            summary.total_dependency_edges += card.dependency_edge_count;
+            summary.blocking_dependency_edges += card.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary.highest_policy_tier.max(card.highest_policy_tier);
+
+            if milestone.requires_attention() {
+                summary.milestones_requiring_attention += 1;
+                summary.first_attention_sequence = summary
+                    .first_attention_sequence
+                    .or(Some(milestone.sequence));
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(milestone.priority),
+                );
+            }
+            if milestone.has_activation_work() {
+                summary.milestones_with_activation_work += 1;
+                summary.first_activation_sequence = summary
+                    .first_activation_sequence
+                    .or(Some(milestone.sequence));
+                summary.first_activation_priority = min_optional_priority(
+                    summary.first_activation_priority,
+                    Some(milestone.priority),
+                );
+            }
+            if milestone.has_approval_ready_work() {
+                summary.milestones_with_approval_work += 1;
+                summary.first_approval_sequence =
+                    summary.first_approval_sequence.or(Some(milestone.sequence));
+                summary.first_approval_priority = min_optional_priority(
+                    summary.first_approval_priority,
+                    Some(milestone.priority),
+                );
+            }
+            if milestone.has_review_work() {
+                summary.milestones_with_review_work += 1;
+                summary.first_review_sequence =
+                    summary.first_review_sequence.or(Some(milestone.sequence));
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(milestone.priority));
+            }
+            if milestone.has_blockers() {
+                summary.milestones_with_blockers += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(milestone.sequence));
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(milestone.priority));
+            }
+            if milestone.has_risks() {
+                summary.milestones_with_risks += 1;
+                summary.first_risk_sequence =
+                    summary.first_risk_sequence.or(Some(milestone.sequence));
+                summary.first_risk_priority =
+                    min_optional_priority(summary.first_risk_priority, Some(milestone.priority));
+            }
+            if milestone.has_dependency_blockers() {
+                summary.milestones_with_dependency_blockers += 1;
+                summary.first_dependency_sequence = summary
+                    .first_dependency_sequence
+                    .or(Some(milestone.sequence));
+                summary.first_dependency_priority = min_optional_priority(
+                    summary.first_dependency_priority,
+                    Some(milestone.priority),
+                );
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status =
+            if summary.blocked_milestones > 0 || summary.milestones_with_blockers > 0 {
+                IntegrationActivationHealthStatus::Blocked
+            } else if summary.review_milestones > 0
+                || summary.milestones_with_review_work > 0
+                || summary.milestones_with_approval_work > 0
+            {
+                IntegrationActivationHealthStatus::NeedsReview
+            } else if summary.ready_milestones > 0 || summary.milestones_with_activation_work > 0 {
+                IntegrationActivationHealthStatus::Ready
+            } else {
+                IntegrationActivationHealthStatus::Empty
+            };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_milestones == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.milestones_with_activation_work > 0 || self.activation_milestones > 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.milestones_with_approval_work > 0 || self.approval_milestones > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.milestones_with_review_work > 0 || self.review_queue_milestones > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.milestones_with_blockers > 0 || self.blocker_milestones > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.milestones_with_risks > 0 || self.risk_milestones > 0
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.milestones_with_dependency_blockers > 0 || self.dependency_milestones > 0
     }
 
     pub fn requires_attention(&self) -> bool {
@@ -7189,6 +7498,62 @@ pub fn activation_dashboard_cards_at_or_before_priority(
     activation_dashboard_cards_from_readouts(readouts.iter())
 }
 
+pub fn activation_timeline_milestones_from_dashboard_cards(
+    mut cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationTimelineMilestone> {
+    cards.sort_by(compare_activation_dashboard_cards);
+    let mut milestones = cards
+        .into_iter()
+        .enumerate()
+        .map(|(index, card)| {
+            IntegrationActivationTimelineMilestone::from_dashboard_card(index + 1, card)
+        })
+        .collect::<Vec<_>>();
+    milestones.sort_by(compare_activation_timeline_milestones);
+    for (index, milestone) in milestones.iter_mut().enumerate() {
+        milestone.sequence = index + 1;
+    }
+    milestones
+}
+
+pub fn activation_timeline_milestones_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationTimelineMilestone> {
+    activation_timeline_milestones_from_dashboard_cards(activation_dashboard_cards_from_readouts(
+        readouts,
+    ))
+}
+
+pub fn activation_timeline_milestones_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationTimelineMilestone> {
+    activation_timeline_milestones_from_dashboard_cards(activation_dashboard_cards_from_candidates(
+        catalog,
+        candidates,
+        enabled_integrations,
+    ))
+}
+
+pub fn activation_timeline_milestones_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationTimelineMilestone> {
+    activation_timeline_milestones_from_dashboard_cards(
+        activation_dashboard_cards_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -8513,6 +8878,25 @@ fn compare_activation_dashboard_cards(
                 .cmp(&left.has_approval_ready_work)
         })
         .then_with(|| right.has_activation_work.cmp(&left.has_activation_work))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_timeline_milestones(
+    left: &IntegrationActivationTimelineMilestone,
+    right: &IntegrationActivationTimelineMilestone,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| left.milestone_kind.cmp(&right.milestone_kind))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| {
+            right
+                .has_approval_ready_work()
+                .cmp(&left.has_approval_ready_work())
+        })
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -10421,6 +10805,125 @@ mod tests {
         assert!(catalog_cards
             .iter()
             .any(IntegrationActivationDashboardCard::requires_attention));
+    }
+
+    #[test]
+    fn activation_timeline_milestones_order_dashboard_cards_by_wave() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let milestones = activation_timeline_milestones_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(milestones.len(), 3);
+        assert_eq!(milestones[0].sequence, 1);
+        assert_eq!(milestones[0].priority, 1);
+        assert_eq!(
+            milestones[0].milestone_kind,
+            Some(IntegrationActivationBriefingItemKind::Blocker)
+        );
+        assert!(milestones[0].requires_attention());
+        assert!(milestones[0].has_approval_ready_work());
+        assert_eq!(milestones[1].sequence, 2);
+        assert_eq!(milestones[1].priority, 2);
+        assert!(milestones[1].has_dependency_blockers());
+        assert_eq!(milestones[2].sequence, 3);
+        assert_eq!(milestones[2].priority, 3);
+        assert!(milestones[2].has_activation_work());
+
+        let summary = IntegrationActivationTimelineSummary::from_milestones(milestones.iter());
+        assert_eq!(summary.total_milestones, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.ready_milestones, 1);
+        assert_eq!(summary.review_milestones, 1);
+        assert_eq!(summary.blocked_milestones, 1);
+        assert!(summary.blocker_milestones >= 1);
+        assert!(summary.activation_milestones >= 1);
+        assert!(summary.milestones_requiring_attention >= 1);
+        assert!(summary.total_briefing_items >= 4);
+        assert!(summary.total_actions > 0);
+        assert!(summary.total_dossiers > 0);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(summary.first_attention_sequence, Some(1));
+        assert_eq!(summary.first_attention_priority, Some(1));
+        assert_eq!(summary.first_approval_sequence, Some(1));
+        assert_eq!(summary.first_blocked_sequence, Some(1));
+        assert_eq!(summary.first_activation_sequence, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_activation_work());
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_review_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_risks());
+        assert!(summary.has_dependency_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_milestones = activation_timeline_milestones_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_milestones
+            .iter()
+            .any(IntegrationActivationTimelineMilestone::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add integration activation timeline milestones and summary rollups derived from dashboard cards/readouts/candidates
- expose list/get activation timeline tools through smart-home-core descriptors and Chief-of-Staff D18D handlers
- cover timeline JSON/query behavior plus runtime facade call coverage and docs/changelog updates

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools