### PR TITLE
docs(adj-examples): worked adjudication examples — the whole stack end-to-end at 0 model calls (ADJ constraints D1)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
+++ b/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
@@ -1,0 +1,72 @@
+//! Golden tests for the worked adjudication examples (ADJ constraints track D).
+//!
+//! Each `.adj` file in `code/specs/data/adj-language-expansion/examples/`
+//! exercises a slice of the whole stack — typed values, dimensions, `let`
+//! arithmetic, predicate verdicts, constraint solving — end-to-end through the
+//! CPU reasoner at **zero model calls**. These tests run the built CLI on each
+//! file and assert the documented outcome, so the examples stay runnable as the
+//! language evolves.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The examples directory, relative to this crate's manifest:
+/// `code/packages/rust/adj-lang-cli` → `code/specs/data/adj-language-expansion/examples`.
+fn example(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-language-expansion/examples")
+        .join(name)
+}
+
+/// Run the CLI on an example file; return (success, stdout).
+fn run_example(name: &str) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(example(name))
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn eligibility_fires_the_filing_threshold() {
+    let (ok, s) = run_example("eligibility.adj");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"kind\":\"predicate\""), "{s}");
+    assert!(s.contains("\"slot\":\"gross_income\""), "{s}");
+    assert!(s.contains("\"threshold\":14600"), "{s}");
+    assert!(s.contains("\"observed\":18000"), "{s}");
+    assert!(s.contains("\"type\":\"determinate\""), "{s}");
+    assert!(
+        s.contains("\"leader\":\"required_to_file\""),
+        "{s}"
+    );
+}
+
+#[test]
+fn debt_to_income_ratio_drives_eligibility() {
+    let (ok, s) = run_example("debt_to_income.adj");
+    assert!(ok, "non-zero exit: {s}");
+    // dti = 1800/6000 = 0.3 (dimensionless), <= 0.43 fires.
+    assert!(s.contains("\"slot\":\"dti\""), "{s}");
+    assert!(s.contains("\"observed\":0.3"), "{s}");
+    assert!(s.contains("\"leader\":\"mortgage_eligible\""), "{s}");
+}
+
+#[test]
+fn proration_computes_and_clears_the_floor() {
+    let (ok, s) = run_example("proration.adj");
+    assert!(ok, "non-zero exit: {s}");
+    // prorated = 12000 * 9 / 12 = 9000, >= 8000 fires.
+    assert!(s.contains("\"slot\":\"prorated\""), "{s}");
+    assert!(s.contains("\"observed\":9000"), "{s}");
+    assert!(s.contains("\"leader\":\"senior_tier\""), "{s}");
+}
+
+#[test]
+fn break_even_solves_for_the_unit_price() {
+    let (ok, s) = run_example("break_even.adj");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"outcome\":\"solved\""), "{s}");
+    assert!(s.contains("\"name\":\"p\",\"value\":8"), "{s}");
+    assert!(s.contains("\"from_constraints\":[0]"), "{s}");
+}

--- a/code/specs/data/adj-language-expansion/examples/README.md
+++ b/code/specs/data/adj-language-expansion/examples/README.md
@@ -1,0 +1,28 @@
+# Worked adjudication examples (ADJ constraints track D)
+
+Runnable `.adj` programs that exercise the **whole** adj-lang stack end-to-end —
+typed values, strict dimensions, `let` arithmetic, predicate-gated verdicts, and
+constraint solving — **at zero answer-time model calls**. The model's only job
+is to decompose the messy input into these clauses; the engine does all the
+math and solving on the CPU, and every answer is cited back to its source.
+
+Run any of them through the CPU reasoner:
+
+```
+cargo build -p adj-lang-cli
+./target/debug/adj-lang-cli code/specs/data/adj-language-expansion/examples/eligibility.adj
+```
+
+| file | demonstrates | expected |
+|---|---|---|
+| [`eligibility.adj`](eligibility.adj) | a **predicate over a typed value** (`gross_income >= 14600` over `money(18000, usd)`) — a deterministic rule as a saturating LR | `required_to_file` ≈ 1.0, determinate; proof shows the `>= 14600 / observed 18000` comparison + IRS citation |
+| [`debt_to_income.adj`](debt_to_income.adj) | a **computed ratio** (`money / money → dimensionless`) driving a rule | `dti = 0.30 <= 0.43` fires → `mortgage_eligible` ≈ 1.0 |
+| [`proration.adj`](proration.adj) | **`let` arithmetic** (`annual_bonus * months_worked / 12`) feeding a predicate | `prorated = 9000 >= 8000` fires → `senior_tier` ≈ 1.0 |
+| [`break_even.adj`](break_even.adj) | **solving for an unknown** (`p * 1000 = 5000 + 3 * 1000`) | `solve → { p = 8 }`, cited to constraint `[0]` |
+
+These are covered by golden tests in
+[`adj-lang-cli/tests/worked_examples.rs`](../../../../packages/rust/adj-lang-cli/tests/worked_examples.rs),
+so they stay runnable as the language evolves.
+
+See [`ADJ-CONSTRAINTS-DESIGN.md`](../ADJ-CONSTRAINTS-DESIGN.md) for the arc and
+[`DESIGN.md`](../DESIGN.md) for the computation layer these build on.

--- a/code/specs/data/adj-language-expansion/examples/break_even.adj
+++ b/code/specs/data/adj-language-expansion/examples/break_even.adj
@@ -1,0 +1,19 @@
+% Worked example — break-even unit price (solve for an unknown).
+%
+% Find the unit price `p` at which revenue equals total cost, for a run of
+% 1,000 units with $5,000 fixed cost and $3/unit variable cost:
+%
+%     revenue = p * 1000
+%     cost    = 5000 + 3 * 1000 = 8000
+%     break-even: p * 1000 = 8000  →  p = 8
+%
+% The model wrote the equation; the engine SOLVES it (exact rational Gaussian
+% elimination), and the answer is cited to the constraint that determined it.
+%
+% Expected: solve → { p = 8 }, from_constraints [0].
+
+symbol p : money(usd)
+
+constrain p * 1000 = 5000 + 3 * 1000
+
+solve for { p }

--- a/code/specs/data/adj-language-expansion/examples/debt_to_income.adj
+++ b/code/specs/data/adj-language-expansion/examples/debt_to_income.adj
@@ -1,0 +1,20 @@
+% Worked example — mortgage debt-to-income ratio (computed value → predicate).
+%
+% The model extracted the two dollar amounts; the engine computes the ratio on
+% the CPU (a derivation tree cites both facts) and the ratio — dimensionless,
+% because money/money cancels — drives the eligibility rule.
+%
+% Expected: dti = 1800/6000 = 0.30 <= 0.43 fires → mortgage_eligible ≈ 1.0.
+
+prior 0.20 for mortgage_eligible
+  source "CFPB Qualified Mortgage rule" trust authoritative
+
+observe monthly_debt(money(1800, usd))
+observe monthly_income(money(6000, usd))
+
+let dti = monthly_debt / monthly_income
+
+contributes 1000000 from dti <= 0.43 to mortgage_eligible
+  source "12 CFR 1026.43(e)(2)(vi) — 43% DTI limit" trust authoritative
+
+? mortgage_eligible

--- a/code/specs/data/adj-language-expansion/examples/eligibility.adj
+++ b/code/specs/data/adj-language-expansion/examples/eligibility.adj
@@ -1,0 +1,21 @@
+% Worked example — tax filing eligibility (predicate over a typed value).
+%
+% A single filer under 65 must file a federal return if gross income reaches
+% the standard deduction. The model extracted the income as a typed value; the
+% engine evaluates the threshold comparison on the CPU. A "deterministic" rule
+% is just a saturating likelihood ratio.
+%
+% Expected: gross_income 18000 >= 14600 fires → required_to_file ≈ 1.0,
+% a determinate verdict, with the comparison (>= 14600, observed 18000) and its
+% IRS citation in the proof.
+
+prior 0.10 for required_to_file
+  source "IRS Pub 501 (2024)" trust authoritative
+
+contributes 1000000 from gross_income >= 14600 to required_to_file
+  source "IRS Pub 501 (2024), single filer under 65 filing threshold"
+  trust authoritative
+
+observe gross_income(money(18000, usd))
+
+? required_to_file

--- a/code/specs/data/adj-language-expansion/examples/proration.adj
+++ b/code/specs/data/adj-language-expansion/examples/proration.adj
@@ -1,0 +1,20 @@
+% Worked example — prorated bonus by months of service (arithmetic → predicate).
+%
+% The model extracted the annual bonus and the months worked; the engine
+% prorates on the CPU. A prorated bonus at or above $8,000 unlocks the senior
+% tier. The model wrote only the formula `annual_bonus * months_worked / 12`;
+% it never computed the 9000.
+%
+% Expected: prorated = 12000 * 9 / 12 = 9000 >= 8000 → senior_tier ≈ 1.0.
+
+prior 0.10 for senior_tier
+
+observe annual_bonus(money(12000, usd))
+observe months_worked(9)
+
+let prorated = annual_bonus * months_worked / 12
+
+contributes 1000000 from prorated >= 8000 to senior_tier
+  source "Plan §4.2 — senior-tier proration floor" trust authoritative
+
+? senior_tier


### PR DESCRIPTION
## What

The **capstone** of the ADJ-CONSTRAINTS arc: four runnable `.adj` programs that exercise the *entire* adj-lang stack — typed values, strict dimensions, `let` arithmetic, predicate verdicts, and constraint solving — end-to-end through the CPU reasoner at **zero answer-time model calls**. The model only decomposes the messy input into clauses; the engine does all the math and solving, and every answer is cited back to its source.

| example | demonstrates | result |
|---|---|---|
| `eligibility.adj` | predicate over a typed value (`gross_income >= 14600` over `money(18000, usd)`) | `required_to_file` determinate; proof shows `>= 14600 / observed 18000` + IRS citation |
| `debt_to_income.adj` | `money / money → dimensionless` ratio driving a rule | `dti = 0.30 <= 0.43` → `mortgage_eligible` |
| `proration.adj` | `let` arithmetic (`annual_bonus * months_worked / 12`) → predicate | `prorated = 9000 >= 8000` → `senior_tier` |
| `break_even.adj` | **solving for an unknown** (`p * 1000 = 5000 + 3 * 1000`) | `solve → { p = 8 }`, cited to constraint `[0]` |

Verified output (break-even):
```
$ adj-lang-cli break_even.adj
{"queries":[],"ranked":[],"decision":{"type":"empty"},
 "solve":{"outcome":"solved","assignments":[{"name":"p","value":8}],"from_constraints":[0]}}
```

## Contents

- `code/specs/data/adj-language-expansion/examples/*.adj` (4) + a `README` documenting each (what it shows + expected output).
- Golden tests (`adj-lang-cli/tests/worked_examples.rs`) that run each example through the built CLI and assert the documented outcome, so they **stay runnable** as the language evolves.

Spec/test only — **no production code**, so no version bump or security review. `cargo test -p adj-lang-cli --test worked_examples` → 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)