### PR TITLE
feat(adj-constraint-solver): substitute observed facts into constraints (ADJ constraints B3)

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.0] - 2026-06-11 — observed-value substitution (ADJ constraints track B3)
+
+### Changed
+
+- **`solve(&ConstraintSystem, &KnowledgeBase)`** — now takes the program's KB.
+  A constraint reference that is **not** an unknown but **is** an observed fact
+  (`observe base_rate(1200)`) is substituted by its value before solving, so a
+  realistic mixed program solves:
+  `symbol premium; constrain premium = base_rate + 300; solve for {premium}`
+  → `premium = 1500`. (Previously every reference was treated as an unknown, so
+  any constraint mentioning an observed fact was singular.) Unknowns and
+  unobserved references are left symbolic. 2 new tests.
+
 ## [0.1.0] - 2026-06-11 — linear-equality solving (ADJ constraints track B2a)
 
 ### Added

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -20,8 +20,10 @@
 //! infeasibility (UNSAT-core) certificate. A system this slice can't handle
 //! returns [`SolveOutcome::Unsupported`] with a reason, never a wrong answer.
 
+use std::collections::HashSet;
+
 use adj_lang::{ConstraintSystem, RelOp};
-use logic_engine::{ComputeExpr, ComputeOp};
+use logic_engine::{ComputeExpr, ComputeOp, KnowledgeBase};
 use symbolic_ir::{apply, int, rat, sym, IRNode, ADD, EQUAL, MUL, SUB};
 
 /// What solving a [`ConstraintSystem`] produced.
@@ -43,9 +45,15 @@ pub enum SolveOutcome {
     Unsupported { reason: String },
 }
 
-/// Solve a [`ConstraintSystem`]'s linear-equality core. See the module docs for
-/// scope. Pure and deterministic.
-pub fn solve(cs: &ConstraintSystem) -> SolveOutcome {
+/// Solve a [`ConstraintSystem`]'s linear-equality core against the program's
+/// observed facts. See the module docs for scope. Pure and deterministic.
+///
+/// A constraint reference that is **not** one of the unknowns but **is** an
+/// observed fact (`observe base_rate(1200)`) is substituted by its value, so a
+/// mixed program — `symbol p; constrain p = base_rate + 300; solve for {p}` —
+/// solves (`p = 1500`). A reference that is neither an unknown nor observed is
+/// left as a free variable (which typically makes the system singular).
+pub fn solve(cs: &ConstraintSystem, kb: &KnowledgeBase) -> SolveOutcome {
     // The unknowns: the `solve for { … }` targets, or (failing that) every
     // declared `symbol`. Order is the column order of the linear system.
     let variables: Vec<String> = if !cs.solve_for.is_empty() {
@@ -56,6 +64,7 @@ pub fn solve(cs: &ConstraintSystem) -> SolveOutcome {
     if variables.is_empty() {
         return unsupported("no symbols / solve-for targets to solve for");
     }
+    let var_set: HashSet<&str> = variables.iter().map(String::as_str).collect();
 
     // This slice solves pure-equality systems. Any inequality means the
     // problem is feasibility/optimization, not a linear solve — defer it.
@@ -63,12 +72,15 @@ pub fn solve(cs: &ConstraintSystem) -> SolveOutcome {
         return unsupported("inequality constraints — feasibility/LP is track C1/C2");
     }
 
-    // Translate each `lhs = rhs` into a symbolic-ir Equal equation. A
-    // non-linear term (symbol×symbol, division by a symbol, an aggregation)
-    // makes the translation fail → Unsupported.
+    // Translate each `lhs = rhs` into a symbolic-ir Equal equation, first
+    // substituting observed-fact references by their values. A non-linear term
+    // (symbol×symbol, division by a symbol, an aggregation) makes the
+    // translation fail → Unsupported.
     let mut equations = Vec::with_capacity(cs.constraints.len());
     for c in &cs.constraints {
-        let (Some(lhs), Some(rhs)) = (expr_to_ir(&c.lhs), expr_to_ir(&c.rhs)) else {
+        let lhs_s = substitute_observed(&c.lhs, &var_set, kb);
+        let rhs_s = substitute_observed(&c.rhs, &var_set, kb);
+        let (Some(lhs), Some(rhs)) = (expr_to_ir(&lhs_s), expr_to_ir(&rhs_s)) else {
             return unsupported("a constraint is non-linear or uses an unsupported term");
         };
         equations.push(apply(sym(EQUAL), vec![lhs, rhs]));
@@ -102,6 +114,34 @@ pub fn solve(cs: &ConstraintSystem) -> SolveOutcome {
 fn unsupported(reason: &str) -> SolveOutcome {
     SolveOutcome::Unsupported {
         reason: reason.to_string(),
+    }
+}
+
+/// Rewrite a constraint expression, replacing each reference that is **not** an
+/// unknown but **is** an observed fact with its value as a literal. Unknowns
+/// (the solve-for variables) and unobserved references are left as-is.
+fn substitute_observed(
+    e: &ComputeExpr,
+    variables: &HashSet<&str>,
+    kb: &KnowledgeBase,
+) -> ComputeExpr {
+    match e {
+        ComputeExpr::Ref(name) => {
+            if variables.contains(name.as_str()) {
+                e.clone() // an unknown we are solving for — keep it symbolic
+            } else if let Some(v) = kb.observed_value(name) {
+                ComputeExpr::Lit(v) // a known observed fact — substitute its value
+            } else {
+                e.clone() // neither — a free reference (likely makes it singular)
+            }
+        }
+        ComputeExpr::Lit(_) => e.clone(),
+        ComputeExpr::Bin(op, a, b) => ComputeExpr::Bin(
+            *op,
+            Box::new(substitute_observed(a, variables, kb)),
+            Box::new(substitute_observed(b, variables, kb)),
+        ),
+        ComputeExpr::Agg(_, _) => e.clone(),
     }
 }
 
@@ -224,7 +264,8 @@ mod tests {
     use adj_lang::compile;
 
     fn solve_src(src: &str) -> SolveOutcome {
-        solve(&compile(src).unwrap().constraints)
+        let lowered = compile(src).unwrap();
+        solve(&lowered.constraints, &lowered.kb)
     }
 
     #[test]
@@ -274,6 +315,42 @@ mod tests {
         match out {
             SolveOutcome::Solved { assignments, .. } => {
                 assert!((assignments[0].1 - 92.0).abs() < 1e-6, "{assignments:?}");
+            }
+            other => panic!("expected Solved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn substitutes_observed_facts_into_a_constraint() {
+        // base_rate is observed (1200), not an unknown → substituted as a
+        // constant, so premium = 1200 + 300 = 1500.
+        let out = solve_src(
+            "symbol premium : money(usd)\n\
+             observe base_rate(1200)\n\
+             constrain premium = base_rate + 300\n\
+             solve for { premium }\n",
+        );
+        match out {
+            SolveOutcome::Solved { assignments, .. } => {
+                assert!((assignments[0].1 - 1500.0).abs() < 1e-9, "{assignments:?}");
+            }
+            other => panic!("expected Solved, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn observed_coefficient_keeps_the_system_linear() {
+        // rate observed (3) → cost = p * 3 - ... wait, p * rate is symbol×const
+        // after substitution, still linear. p * 3 = 1500 → p = 500.
+        let out = solve_src(
+            "symbol p : scalar\n\
+             observe rate(3)\n\
+             constrain p * rate = 1500\n\
+             solve for { p }\n",
+        );
+        match out {
+            SolveOutcome::Solved { assignments, .. } => {
+                assert!((assignments[0].1 - 500.0).abs() < 1e-9, "{assignments:?}");
             }
             other => panic!("expected Solved, got {other:?}"),
         }

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1] - 2026-06-11 — solver substitutes observed facts (ADJ constraints track B3)
+
+### Changed
+
+- The `solve` call now passes the KB (`solve(&lowered.constraints, &lowered.kb)`),
+  so a constraint that references an observed fact is solved with that fact's
+  value substituted (`adj-constraint-solver` 0.2.0). 1 new golden test.
+
 ## [0.3.0] - 2026-06-11 — constraint solving in the CLI (ADJ constraints track B2b)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -278,7 +278,10 @@ fn main() -> ExitCode {
     let solve_section = if lowered.constraints.is_empty() {
         String::new()
     } else {
-        format!(",\"solve\":{}", solve_json(&solve(&lowered.constraints)))
+        format!(
+            ",\"solve\":{}",
+            solve_json(&solve(&lowered.constraints, &lowered.kb))
+        )
     };
 
     println!(

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -196,6 +196,22 @@ fn solve_for_emits_solved_values() {
 }
 
 #[test]
+fn solve_substitutes_observed_facts() {
+    // base_rate is observed (not an unknown) → substituted as a constant, so
+    // premium = base_rate + 300 = 1500. This is the realistic mixed case.
+    let (ok, s) = run(
+        "adjcli_solve_subst.adj",
+        "symbol premium : money(usd)\n\
+         observe base_rate(1200)\n\
+         constrain premium = base_rate + 300\n\
+         solve for { premium }\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"solved\""), "{s}");
+    assert!(s.contains("\"name\":\"premium\",\"value\":1500"), "{s}");
+}
+
+#[test]
 fn unsupported_constraint_reports_a_reason_not_an_answer() {
     // An inequality is out of this slice's scope → unsupported, never a fake value.
     let (ok, s) = run(


### PR DESCRIPTION
## What

Makes the constraint solver usable for **realistic adjudication**: a constraint that references an *observed fact* now solves, with the fact's value substituted. Previously only pure-symbol/literal systems solved — any constraint mentioning an `observe`d value treated it as a free variable and went singular.

```
symbol premium : money(usd)
observe base_rate(1200)
constrain premium = base_rate + 300
solve for { premium }        →  premium = 1500
```

## Changes

- **`adj-constraint-solver` 0.2.0:** `solve(&ConstraintSystem, &KnowledgeBase)` — takes the program's KB; a new `substitute_observed` pass rewrites each constraint expression, replacing a reference that is **not** an unknown but **is** an observed fact with its value (`Lit`). Unknowns (solve-for targets) and unobserved references stay symbolic.
- **`adj-lang-cli` 0.3.1:** pass the KB at the call site.

A non-finite observed value can't corrupt a result — it flows to `Unsupported` via `num_to_ir`, **never a wrong answer** (confirmed in review).

## Tests

2 solver unit tests (`premium = base_rate + 300 → 1500`; `p * rate = 1500` with observed `rate=3 → p=500`) + 1 CLI golden test. `cargo test -p adj-constraint-solver -p adj-lang-cli` → 10 + 12 + 4 pass. `/security-review` PASSED.

## Sprint context

Resumes the ADJ-CONSTRAINTS sprint. Remaining: **C3** nonlinear (cas-solve quad/cubic/quartic), **B2c** feasibility (`check` via LiaTactic), **C1** QF_LRA real feasibility, **C2** simplex optimization, **D2** the Haiku decompose→solve run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)