### PR TITLE
feat(lang-matrix): LM0 — cross-language matrix harness + native-AOT column

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — `lang-aot`
 
+## 0.54.0 — 2026-06-11 — cross-language platform-matrix harness (LANG-MATRIX LM0)
+
+First slice of the `LANG-PLATFORM-MATRIX` campaign (every language on every non-BEAM
+backend). New `tests/lang_matrix.rs`: a per-language program battery (`Expect::Exit`
+for the expression languages Twig/Nib/Oct/ALGOL, `Expect::Stdout` for the I/O
+languages Brainfuck/BASIC) and a host-gated **native-AOT** runner. Proven by RUNNING
+— all six non-Lisp languages compile to a host executable and run with the expected
+result: Twig→42, Nib `double(21)`→42, Oct→0, ALGOL `17 mod 5`→2, Brainfuck→stdout `A`,
+Dartmouth BASIC `PRINT 42`→stdout `42`. native-AOT is now a uniformly-green floor for
+the matrix. Also fixed the stale `Language` enum doc comments (DartmouthBasic/Oct were
+wrongly labelled "placeholder / no Rust frontend"; all six are wired into
+`compile_source_to_iir`).
+
+Ground truth the probe established (and recorded in the spec): the **VM and JIT are
+McCarthy-specialized** — `mccarthy_lisp_vm::run` rejects ordinary `add`/`mul`/`cmp_*`/
+`mod` and the I/O ops, so those two columns are real op-coverage work, while the
+code-gen backends (native/LLVM/WASM/JVM/CLR) are general and need mostly conformance
+tests.
+
 ## 0.53.0 — 2026-06-11 — wire **real CoreCLR** into the W16 conformance suite (CLR-real C6)
 
 The capstone of the CLR-real verification chapter. `tests/conformance.rs` gains a

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -120,6 +120,15 @@ their tool is absent. One source, eight code generators, three value models
 (tagged-word / uniform-anyref / object-boxing / Erlang-terms), **one answer** — the
 proof the platform is complete and uniform.
 
+`tests/lang_matrix.rs` generalizes that idea from McCarthy to **every** language
+(`LANG-PLATFORM-MATRIX`): a per-language program battery run through each non-BEAM
+backend, asserted by running. As of LM0 the **native-AOT** column is uniformly green —
+all six non-Lisp languages (Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, ALGOL 60)
+compile to a host executable and produce the right result (exit code for the
+expression languages; stdout for the I/O languages). The LLVM/WASM/JVM/CLR columns
+follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
+op-coverage work.
+
 ## Stack position
 
 ```

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -58,11 +58,14 @@ pub enum Language {
     Twig,
     /// Nib — typed expression language, multi-language implementation.
     Nib,
-    /// Brainfuck — minimalist tape language.
+    /// Brainfuck — minimalist tape language; `brainfuck-iir-compiler` frontend
+    /// lowered for AOT by `lower_brainfuck_for_aot`.
     Brainfuck,
-    /// Dartmouth BASIC — placeholder; no IIR-emitting frontend yet.
+    /// Dartmouth BASIC — integer subset (PRINT/LET/FOR/GOTO/IF) via the
+    /// `dartmouth-basic-iir-compiler` Rust frontend over the shared IIR.
     DartmouthBasic,
-    /// Oct — placeholder; no Rust frontend yet (Python only).
+    /// Oct — integer subset (let/if/while/calls) via the `oct-iir-compiler`
+    /// Rust frontend over the shared IIR; `main` is void (exits 0).
     Oct,
     /// McCarthy Lisp — the 1960 Lisp 1.0, compiled via
     /// `mccarthy-lisp-iir-compiler` over the `lispy-runtime` value model.

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -1,0 +1,201 @@
+//! # Cross-language platform matrix — LANG-PLATFORM-MATRIX (LM0 foundation).
+//!
+//! The generalization of the McCarthy W16 capstone (`conformance.rs`) from one
+//! reference language to **every language frontend in the repo**. Each language has
+//! a small battery of programs with a known result; each backend is a runner gated
+//! on its toolchain; every `(program, backend)` cell is asserted **by running**.
+//!
+//! LM0 establishes the harness and the **native-AOT** column — the genuinely
+//! already-green path: source → shared IIR → host object (`aarch64`/`x86_64-backend`)
+//! → system linker → run. Native AOT is a *general* IIR code generator, so it runs
+//! all six languages today (verified below). Later slices add the LLVM / WASM / JVM /
+//! CLR columns (also general code generators) and tackle the two McCarthy-specialized
+//! backends — VM and JIT — which need arithmetic/comparison op-coverage to run the
+//! non-McCarthy languages (see `code/specs/LANG-PLATFORM-MATRIX.md`).
+//!
+//! ## Two result kinds
+//!
+//! * **Expression languages** (Twig, Nib, Oct, ALGOL 60) return an integer — the
+//!   process **exit code** (`& 0xFF` via the C runtime's `exit()`). Oct's `main` is
+//!   void, so it exits `0`; the program still proves the whole chain runs.
+//! * **I/O languages** (Brainfuck, Dartmouth BASIC) produce their result on
+//!   **stdout** (`putchar` / `PRINT`), so the harness captures and compares stdout.
+
+use lang_aot::Language;
+use std::process::Command;
+
+/// The known, backend-independent observable result of a conformance program.
+enum Expect {
+    /// The process exit code (an expression language's returned value, `& 0xFF`).
+    Exit(i32),
+    /// A trimmed stdout string (an I/O language's printed output).
+    Stdout(&'static str),
+}
+
+/// One conformance program: a language, a source-file extension, the source, and
+/// the result it must produce on any backend that can run it.
+struct Prog {
+    lang: Language,
+    ext: &'static str,
+    src: &'static str,
+    expect: Expect,
+}
+
+/// The cross-language battery. Each program is deliberately tiny but exercises real
+/// computation (arithmetic, calls, comparisons, loops, I/O) — not just constants —
+/// so a backend that merely emits a literal would not pass.
+const PROGRAMS: &[Prog] = &[
+    // Twig — the original AOT language; a bare expression is the whole program.
+    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42) },
+    // Nib — typed functions: define `double`, call it, return the result.
+    Prog {
+        lang: Language::Nib,
+        ext: "nib",
+        src: "fn double(x: u8) -> u8 { return x + x; } fn main() -> u8 { return double(21); }",
+        expect: Expect::Exit(42),
+    },
+    // Oct — `let` + `if` + comparison; `main` is void so the process exits 0.
+    Prog {
+        lang: Language::Oct,
+        ext: "oct",
+        src: "fn main() { let x: u8 = 1; if x == 1 { let y: u8 = 2; } else { let z: u8 = 3; } }",
+        expect: Expect::Exit(0),
+    },
+    // ALGOL 60 — a begin/end block with real integer arithmetic (`17 mod 5` = 2).
+    Prog {
+        lang: Language::Algol60,
+        ext: "alg",
+        src: "begin integer result; result := 17 mod 5 end",
+        expect: Expect::Exit(2),
+    },
+    // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
+    Prog {
+        lang: Language::Brainfuck,
+        ext: "bf",
+        src: "++++++++[>++++++++<-]>+.",
+        expect: Expect::Stdout("A"),
+    },
+    // Dartmouth BASIC — `PRINT 42` writes `42` to stdout.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 PRINT 42\n20 END\n",
+        expect: Expect::Stdout("42"),
+    },
+];
+
+/// Is a usable native linker present on this host? On Linux/macOS the AOT path uses
+/// the always-present system linker; on Windows it needs a real MSVC/LLD/gcc linker.
+fn native_linker_ok() -> bool {
+    if cfg!(target_os = "windows") {
+        // Mirror twig-aot's probe: confirm a genuine linker, not git-bash's `link`.
+        let probes: &[(&str, &str, &[&str])] = &[
+            ("link.exe", "", &["Microsoft", "Linker"]),
+            ("lld-link.exe", "", &["LLD"]),
+            ("gcc.exe", "--version", &["gcc"]),
+        ];
+        probes.iter().any(|(name, arg, markers)| {
+            let mut cmd = Command::new(name);
+            if !arg.is_empty() {
+                cmd.arg(arg);
+            }
+            cmd.output()
+                .map(|o| {
+                    let banner = format!(
+                        "{}{}",
+                        String::from_utf8_lossy(&o.stdout),
+                        String::from_utf8_lossy(&o.stderr)
+                    );
+                    markers.iter().all(|m| banner.contains(m))
+                })
+                .unwrap_or(false)
+        })
+    } else {
+        cfg!(any(target_os = "linux", target_os = "macos"))
+    }
+}
+
+/// Compile `p` to a native executable for the host OS. `None` when the host can't
+/// produce a native exe (skip), so the suite degrades gracefully off Linux/macOS.
+fn compile_native(src_path: &std::path::Path, exe: &std::path::Path, lang: Language) -> Option<()> {
+    #[cfg(target_os = "linux")]
+    {
+        lang_aot::compile_file_to_linux_executable(src_path, exe, lang).ok()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        lang_aot::compile_file_to_macos_executable(src_path, exe, lang).ok()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        lang_aot::compile_file_to_windows_executable(src_path, exe, lang).ok()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = (src_path, exe, lang);
+        None
+    }
+}
+
+/// Native-AOT runner: write the source, compile to a host executable, run it, and
+/// return `(exit_code, trimmed_stdout)`. `None` when native AOT is unavailable here.
+///
+/// The programs are fixed literals (no untrusted input), and each terminates by
+/// construction — there is no unbounded loop or recursion in the harness itself.
+/// The work happens in a fresh `tempfile::tempdir()` (a random, `0700`, auto-removed
+/// directory) rather than a predictable `temp_dir()/<pid>` path, so a local attacker
+/// cannot pre-create the directory or plant a symlink at `prog` and have the harness
+/// execute substituted code in the compile→run window (CWE-377/367). The `_dir`
+/// guard is held until after the executable runs so it is not removed early.
+fn run_native(p: &Prog) -> Option<(Option<i32>, String)> {
+    if !native_linker_ok() {
+        return None;
+    }
+    let dir = tempfile::tempdir().ok()?;
+    let src_path = dir.path().join(format!("prog.{}", p.ext));
+    std::fs::write(&src_path, p.src).ok()?;
+    let exe = dir.path().join("prog");
+    compile_native(&src_path, &exe, p.lang)?;
+    let out = Command::new(&exe).output().ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Some((out.status.code(), stdout))
+}
+
+/// LM0: every language runs on **native AOT** with its known result, on any host
+/// that can link. Native AOT is a general IIR code generator, so this is the
+/// conformance floor the later (LLVM/WASM/JVM/CLR) columns are measured against.
+#[test]
+fn native_aot_runs_every_language() {
+    let mut ran = 0usize;
+    for p in PROGRAMS {
+        let Some((code, stdout)) = run_native(p) else {
+            continue; // host can't link — skip gracefully
+        };
+        match &p.expect {
+            Expect::Exit(n) => assert_eq!(
+                code,
+                Some(*n),
+                "native-AOT {:?}: expected exit {n}, got {code:?} (stdout {stdout:?})",
+                p.lang
+            ),
+            Expect::Stdout(s) => assert_eq!(
+                stdout, *s,
+                "native-AOT {:?}: expected stdout {s:?}, got {stdout:?}",
+                p.lang
+            ),
+        }
+        ran += 1;
+    }
+
+    // On a host with a system linker (Linux/macOS CI runners), native AOT MUST run
+    // every language — it is the general code-gen floor for the whole matrix.
+    if cfg!(any(target_os = "linux", target_os = "macos")) {
+        assert_eq!(
+            ran,
+            PROGRAMS.len(),
+            "every language must run on native AOT on a Linux/macOS host"
+        );
+    } else {
+        eprintln!("native-AOT lang-matrix: ran {ran}/{} (non-Linux/macOS host)", PROGRAMS.len());
+    }
+}

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -36,19 +36,30 @@ for free. The work here is therefore mostly **(a)** adding cross-language confor
 that proves each `(language, backend)` cell by running it, and **(b)** fixing the
 real lowering / runtime gaps that running surfaces — not writing new code generators.
 
-The two genuine exceptions, where new wiring (not just a test) is required:
+The genuine exceptions, where new wiring (not just a test) is required — and a
+correction the LM0 probe surfaced by **running** each backend:
 
-- **JIT** — the only JIT entrypoint today is `run_mccarthy_on_jit` (McCarthy-only).
-  A generic `run_on_jit(language, source)` must be wired (Phase I).
-- **I/O languages on managed/LLVM backends** — Brainfuck (`putchar`/`getchar`) and
-  Dartmouth BASIC (`PRINT`) produce results via **stdout**, not an exit code, so
-  their conformance harness must capture stdout, and each backend's I/O intrinsics
-  (`io_out`/`putchar`/`print_i64`) must be exercised end-to-end.
+- **VM and JIT are McCarthy-*specialized*, not general IIR interpreters.** Verified
+  in LM0: `mccarthy_lisp_vm::run` rejects ordinary arithmetic/comparison ops with
+  `UnsupportedOp("add" / "mul" / "cmp_eq" / "cmp_lt" / "mod")` and the I/O ops with
+  `UnknownBuiltin("print_i64")` / `UnsupportedOp("alloc_bytes")`. It only ran the
+  *constant* programs (Twig `42`, Nib `return 42`, ALGOL `result := 42`, Oct void→0).
+  So the **VM and JIT columns are real op-coverage work**, not free: each must grow
+  the integer-arithmetic / comparison / (for I/O langs) tape + print ops before it
+  can run the non-McCarthy languages. The JIT additionally needs a generic
+  `run_on_jit(language, source)` (it has only `run_mccarthy_on_jit` today).
+- **The code-generator backends are general.** Native AOT, LLVM, WASM, JVM, and CLR
+  all compile the full IIR (existing tests already run Twig and ALGOL arithmetic on
+  WASM; LM0 runs all six languages on native AOT). So those five columns are mostly
+  **conformance tests + I/O wiring**, not new code generators.
+- **I/O languages produce results via stdout.** Brainfuck (`putchar`/`getchar`) and
+  Dartmouth BASIC (`PRINT`) print rather than return an exit code, so their
+  conformance captures stdout, and each backend's I/O intrinsics (`io_out` /
+  `putchar` / `print_i64`) must be exercised end-to-end.
 
-> **Note:** the `Language` enum doc comments in `lang-aot/src/lib.rs` are **stale**
-> (they call DartmouthBasic / Oct "placeholders / no Rust frontend"); all six
-> frontends are in fact wired into `compile_source_to_iir`. Fixing those comments is
-> part of LM0.
+> **Note (fixed in LM0):** the `Language` enum doc comments in `lang-aot/src/lib.rs`
+> were **stale** (they called DartmouthBasic / Oct "placeholders / no Rust
+> frontend"); all six frontends are in fact wired into `compile_source_to_iir`.
 
 ## Scope
 
@@ -93,7 +104,13 @@ asserts the result** — never on "the frontend lowers to IIR so it *should* wor
 | Brainfuck       | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
 | Oct             | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
-| ALGOL 60        | ☐  | ☐   | ☐         | ☐    | ☐    | ☐   | ☐   |
+| ALGOL 60        | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
+
+**native-AOT is uniformly ✅ as of LM0** — all six languages compile to a host
+executable and run with the expected result (`lang-aot/tests/lang_matrix.rs`:
+Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2, Brainfuck→stdout `A`, BASIC→stdout `42`).
+The VM/JIT columns are op-coverage work (see above); the code-gen columns
+(LLVM/WASM/JVM/CLR) are conformance + I/O wiring.
 
 (`◑` = partial today: Twig is proven at *scalar* level on LLVM/WASM/JVM/CLR; the
 slice promotes it to a full feature battery. The starting state is re-verified per
@@ -103,12 +120,13 @@ slice — the loop trusts running, not this table.)
 
 ### Phase 0 — matrix harness
 
-- ☐ **LM0 — cross-language conformance harness.** New `lang-aot/tests/lang_matrix.rs`:
-  per-language program batteries + a `(Language, backend-runner)` table generalized
-  from the McCarthy conformance runners (integer-exit and stdout variants). Wire only
-  the **already-green** cells first (native-AOT for the five non-ALGOL languages, plus
-  whatever VM/LLVM/etc. pass out of the box) so the grid exists and is honest. Fix the
-  stale `Language` enum doc comments.
+- ✅ **LM0 — cross-language conformance harness.** New `lang-aot/tests/lang_matrix.rs`:
+  per-language program batteries (`Expect::Exit` for Twig/Nib/Oct/ALGOL, `Expect::Stdout`
+  for Brainfuck/BASIC) + a host-gated **native-AOT** runner. Proven by RUNNING — all
+  six languages run on native AOT (Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2,
+  Brainfuck→`A`, BASIC→`42`). Fixed the stale `Language` enum doc comments. The probe
+  also established the ground truth that the **VM/JIT are McCarthy-specialized**
+  (reframed Phase V below) while the code-gen backends are general.
 
 ### Phase L — LLVM for every language (priority)
 
@@ -119,11 +137,19 @@ slice — the loop trusts running, not this table.)
 - ☐ **LM-L BASIC** — `PRINT`/`LET`/`FOR`/`GOTO`/`IF` on `clang`; assert stdout.
 - ☐ **LM-L ALGOL** — ALGOL 60 scalar/boolean on `clang`.
 
-### Phase V — VM (generic IIR interpreter) for every language
+### Phase V — VM op-coverage for every language
 
-- ☐ **LM-V** — Twig, Nib, Oct, Brainfuck, BASIC, ALGOL on `mccarthy_lisp_vm::run`
-  (the generic IIR interpreter). Likely a single slice; split if a language surfaces
-  an interpreter gap.
+> ⚠ Reclassified by the LM0 probe: `mccarthy_lisp_vm` is **McCarthy-specialized**, not
+> a general interpreter. It must grow the integer-arithmetic (`add`/`sub`/`mul`/
+> `div`/`mod`), comparison (`cmp_*`), and bitwise ops — and, for the I/O languages, a
+> `print_i64` (capturing) + Brainfuck tape (`alloc_bytes`/load/store) — before it can
+> run the non-McCarthy languages. This is real interpreter work, not just a test.
+
+- ☐ **LM-V arithmetic/comparison** — grow the VM to run the expression languages
+  (Twig, Nib, Oct, ALGOL) by adding the integer/comparison/bitwise op coverage; add
+  them to the VM column of `lang_matrix.rs`.
+- ☐ **LM-V I/O** — VM `print_i64` (capture) + Brainfuck tape ops, so Brainfuck/BASIC
+  run on the VM too (or record a justified VM-column exemption for the I/O languages).
 
 ### Phase W — WASM for every language
 


### PR DESCRIPTION
## Summary

First slice of the **LANG-PLATFORM-MATRIX** campaign — generalizing the McCarthy W16 conformance idea from one reference language to **every language frontend in the repo**, on every non-BEAM backend.

LM0 lays the foundation: a new `lang-aot/tests/lang_matrix.rs` harness with a per-language program battery and the **native-AOT column** — the genuinely-already-green path (a general IIR code generator). Verified **by running** — all six non-Lisp languages compile to a host executable and produce the expected result:

| Language | program | result |
|----------|---------|--------|
| Twig | `42` | exit 42 |
| Nib | `double(21)` | exit 42 |
| Oct | `let`+`if`+`==` (void main) | exit 0 |
| ALGOL 60 | `17 mod 5` | exit 2 |
| Brainfuck | `++++++++[>++++++++<-]>+.` | stdout `A` |
| Dartmouth BASIC | `PRINT 42` | stdout `42` |

Two result kinds: `Expect::Exit` for the expression languages, `Expect::Stdout` for the I/O languages (Brainfuck/BASIC print rather than return).

## Ground truth the probe established (and why it matters)

Before writing the harness I **ran each backend** to find the real gaps — and corrected two wrong assumptions:

- **The VM and JIT are McCarthy-*specialized*, not general interpreters.** `mccarthy_lisp_vm::run` rejects ordinary arithmetic/comparison with `UnsupportedOp("add"/"mul"/"cmp_eq"/"mod")` and the I/O ops with `UnknownBuiltin("print_i64")` / `UnsupportedOp("alloc_bytes")` — it only ran the *constant* programs. So those two columns are **real op-coverage work**, not free; the spec's Phase V is reframed accordingly.
- **The code-gen backends (native/LLVM/WASM/JVM/CLR) are general** — they compile the full IIR (existing tests already run ALGOL arithmetic on WASM; LM0 runs all six on native AOT). Those five columns are mostly **conformance tests + I/O wiring**.

Also fixes a real doc bug found while scoping: the `Language` enum comments labelled DartmouthBasic/Oct "placeholder / no Rust frontend" — both are fully wired into `compile_source_to_iir`.

## Security

Review **PASSED** (one LOW finding, fixed). `run_native` originally used a predictable `temp_dir()/lang_matrix_<pid>_<ext>` path that then gets *executed* — a local-attacker TOCTOU/symlink foothold (CWE-377/367). Hardened to `tempfile::tempdir()` (random, `0700`, auto-removed), matching the sibling `end_to_end_smoke.rs` idiom. The programs are fixed in-repo literals (no untrusted input); `Command` calls pass `PathBuf` args (no shell).

## Test plan

- `cargo test --test lang_matrix` → `native_aot_runs_every_language` passes locally (macOS): all 6 languages run with the expected exit code / stdout. On a host with no linker it skips gracefully; on Linux/macOS it asserts all 6 ran.
- Clippy clean; `lang-aot` lib builds clean.

## Versioning / docs

- `lang-aot` 0.53.0 → **0.54.0**
- Spec LM0 ticked ✅, native-AOT column marked uniformly green, Phase V (VM) reframed as op-coverage work; CHANGELOG + README updated.

Next per the matrix: **Phase L — LLVM for every language** (the stated priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)