### PR TITLE
Add smart-home activation forecast tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -61,6 +61,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation timeline milestone planning:
   `smart_home.list_integration_activation_timeline` and
   `smart_home.get_integration_activation_timeline_summary`.
+- Added D18D handlers for D23A activation forecast next-action planning:
+  `smart_home.list_integration_activation_forecasts` and
+  `smart_home.get_integration_activation_forecast_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -55,6 +55,7 @@ Chief of Staff job/session/agent
   -> activation-dossier list and summary reads for bundled decision evidence
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
+  -> activation-forecast list and summary reads for next-action wave planning
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -116,6 +117,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_dashboard_summary`
 - `smart_home.list_integration_activation_timeline`
 - `smart_home.get_integration_activation_timeline_summary`
+- `smart_home.list_integration_activation_forecasts`
+- `smart_home.get_integration_activation_forecast_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -38,35 +38,37 @@ use smart_home_integration_catalog::{
     activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_evidence_from_candidates, activation_health_from_candidates,
-    activation_maintenance_from_candidates, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_readouts_from_candidates,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
-    describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
-    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
-    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDashboardCard,
-    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
-    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
-    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
-    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
+    activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
+    activation_health_from_candidates, activation_maintenance_from_candidates,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_readouts_from_candidates, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates,
+    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
+    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
+    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
+    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
+    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
+    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
+    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
     IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
     IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
     IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
@@ -248,6 +250,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_TIMELINE_TOOL_ID: &str =
     "smart_home.list_integration_activation_timeline";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_timeline_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_forecasts";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_forecast_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -524,6 +530,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_timeline_query(&arguments)?;
                     Ok(get_integration_activation_timeline_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID => {
+                    let query = integration_activation_forecast_query(&arguments)?;
+                    Ok(list_integration_activation_forecasts_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_forecast_query(&arguments)?;
+                    Ok(get_integration_activation_forecast_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1785,6 +1801,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation timeline summary",
             "Return compact D23A activation timeline counts across ordered milestones, priority waves, blockers, approvals, and activation work.",
             integration_activation_timeline_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID,
+            "List smart-home integration activation forecasts",
+            "List Chief-ready D23A activation forecast rows derived from timeline milestones, classifying each priority wave into the next activation, approval, review, blocker, dependency, risk, or monitor action.",
+            integration_activation_forecast_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_forecasts", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_forecasts", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation forecast summary",
+            "Return compact D23A activation forecast counts for next action, attention, activation, approval, review, blockers, dependencies, and risks.",
+            integration_activation_forecast_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4453,6 +4498,14 @@ struct IntegrationActivationTimelineQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationForecastQuery {
+    timeline: IntegrationActivationTimelineQuery,
+    forecast_action: Option<IntegrationActivationForecastAction>,
+    requires_attention: Option<bool>,
+    forecast_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4744,6 +4797,22 @@ fn integration_activation_timeline_query(
         dashboard: integration_activation_dashboard_query(arguments)?,
         milestone_kind,
         milestone_limit: optional_u64(arguments, "milestone_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_forecast_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationForecastQuery, ToolCallError> {
+    let forecast_action = optional_string(arguments, "forecast_action")?
+        .or(optional_string(arguments, "next_action")?)
+        .map(|label| parse_activation_forecast_action(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationForecastQuery {
+        timeline: integration_activation_timeline_query(arguments)?,
+        forecast_action,
+        requires_attention: optional_bool(arguments, "requires_attention")?,
+        forecast_limit: optional_u64(arguments, "forecast_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5328,6 +5397,26 @@ fn integration_activation_timeline_milestones_for_query(
     }
 
     (milestones, catalog_count)
+}
+
+fn integration_activation_forecasts_for_query(
+    query: &IntegrationActivationForecastQuery,
+) -> (Vec<IntegrationActivationForecastItem>, usize) {
+    let (milestones, catalog_count) =
+        integration_activation_timeline_milestones_for_query(&query.timeline);
+    let mut forecasts = activation_forecasts_from_timeline_milestones(milestones);
+
+    if let Some(action) = query.forecast_action {
+        forecasts.retain(|forecast| forecast.forecast_action == action);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        forecasts.retain(|forecast| forecast.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.forecast_limit {
+        forecasts.truncate(limit);
+    }
+
+    (forecasts, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6798,6 +6887,78 @@ fn get_integration_activation_timeline_summary_output_handler_output(
             (
                 "milestones_with_blockers",
                 integer(summary.milestones_with_blockers as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_forecasts_output_handler_output(
+    query: IntegrationActivationForecastQuery,
+) -> ToolHandlerOutput {
+    let (forecasts, catalog_count) = integration_activation_forecasts_for_query(&query);
+    let summary = IntegrationActivationForecastSummary::from_forecasts(forecasts.iter());
+    let count = forecasts.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_forecasts",
+            JsonValue::Array(forecasts.iter().map(activation_forecast_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_forecast_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_forecasts")),
+            ("activation_forecasts", integer(count as i64)),
+            (
+                "forecasts_requiring_attention",
+                integer(summary.forecasts_requiring_attention as i64),
+            ),
+            (
+                "next_action",
+                summary
+                    .next_action
+                    .map(|action| string(action.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_forecast_summary_output_handler_output(
+    query: IntegrationActivationForecastQuery,
+) -> ToolHandlerOutput {
+    let (forecasts, _) = integration_activation_forecasts_for_query(&query);
+    let summary = IntegrationActivationForecastSummary::from_forecasts(forecasts.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_forecast_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_forecast_summary"),
+            ),
+            ("total_forecasts", integer(summary.total_forecasts as i64)),
+            (
+                "forecasts_requiring_attention",
+                integer(summary.forecasts_requiring_attention as i64),
+            ),
+            (
+                "next_action",
+                summary
+                    .next_action
+                    .map(|action| string(action.as_str()))
+                    .unwrap_or(JsonValue::Null),
             ),
         ]),
     )
@@ -12460,6 +12621,316 @@ fn integration_activation_timeline_summary_json(
     ])
 }
 
+fn activation_forecast_json(forecast: &IntegrationActivationForecastItem) -> JsonValue {
+    object([
+        ("sequence", integer(forecast.sequence as i64)),
+        ("priority", integer(forecast.priority as i64)),
+        ("forecast_action", string(forecast.forecast_action.as_str())),
+        (
+            "milestone_kind",
+            forecast
+                .milestone_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("health_status", string(forecast.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                forecast
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(forecast.integration_count() as i64),
+        ),
+        (
+            "briefing_item_count",
+            integer(forecast.briefing_item_count as i64),
+        ),
+        ("action_count", integer(forecast.action_count as i64)),
+        ("dossier_count", integer(forecast.dossier_count as i64)),
+        ("evidence_count", integer(forecast.evidence_count as i64)),
+        ("risk_count", integer(forecast.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(forecast.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(forecast.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(forecast.highest_policy_tier)),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(forecast.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(forecast.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(forecast.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(forecast.has_blockers())),
+        ("has_risks", JsonValue::Bool(forecast.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(forecast.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(forecast.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_forecast_summary_json(
+    summary: &IntegrationActivationForecastSummary,
+) -> JsonValue {
+    object([
+        ("total_forecasts", integer(summary.total_forecasts as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        ("ready_forecasts", integer(summary.ready_forecasts as i64)),
+        ("review_forecasts", integer(summary.review_forecasts as i64)),
+        (
+            "blocked_forecasts",
+            integer(summary.blocked_forecasts as i64),
+        ),
+        ("empty_forecasts", integer(summary.empty_forecasts as i64)),
+        (
+            "activate_wave_forecasts",
+            integer(summary.activate_wave_forecasts as i64),
+        ),
+        (
+            "prepare_approval_forecasts",
+            integer(summary.prepare_approval_forecasts as i64),
+        ),
+        (
+            "queue_review_forecasts",
+            integer(summary.queue_review_forecasts as i64),
+        ),
+        (
+            "resolve_blocker_forecasts",
+            integer(summary.resolve_blocker_forecasts as i64),
+        ),
+        (
+            "enable_dependency_forecasts",
+            integer(summary.enable_dependency_forecasts as i64),
+        ),
+        (
+            "review_risk_forecasts",
+            integer(summary.review_risk_forecasts as i64),
+        ),
+        (
+            "monitor_wave_forecasts",
+            integer(summary.monitor_wave_forecasts as i64),
+        ),
+        (
+            "forecasts_requiring_attention",
+            integer(summary.forecasts_requiring_attention as i64),
+        ),
+        (
+            "forecasts_with_activation_work",
+            integer(summary.forecasts_with_activation_work as i64),
+        ),
+        (
+            "forecasts_with_approval_work",
+            integer(summary.forecasts_with_approval_work as i64),
+        ),
+        (
+            "forecasts_with_review_work",
+            integer(summary.forecasts_with_review_work as i64),
+        ),
+        (
+            "forecasts_with_blockers",
+            integer(summary.forecasts_with_blockers as i64),
+        ),
+        (
+            "forecasts_with_risks",
+            integer(summary.forecasts_with_risks as i64),
+        ),
+        (
+            "forecasts_with_dependency_blockers",
+            integer(summary.forecasts_with_dependency_blockers as i64),
+        ),
+        (
+            "total_briefing_items",
+            integer(summary.total_briefing_items as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "next_action",
+            summary
+                .next_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_action_sequence",
+            summary
+                .next_action_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_action_priority",
+            summary
+                .next_action_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_sequence",
+            summary
+                .first_activation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_sequence",
+            summary
+                .first_approval_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_sequence",
+            summary
+                .first_risk_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_sequence",
+            summary
+                .first_dependency_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_risk_priority",
+            summary
+                .first_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "has_approval_ready_work",
+            JsonValue::Bool(summary.has_approval_ready_work()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        ("has_risks", JsonValue::Bool(summary.has_risks())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(summary.has_dependency_blockers()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -15035,6 +15506,35 @@ fn parse_activation_briefing_item_kind(
     }
 }
 
+fn parse_activation_forecast_action(
+    label: &str,
+) -> Result<IntegrationActivationForecastAction, ToolCallError> {
+    match label {
+        "resolve_blockers" | "resolve_blocker" | "blocker" | "blockers" => {
+            Ok(IntegrationActivationForecastAction::ResolveBlockers)
+        }
+        "enable_dependencies" | "enable_dependency" | "dependency" | "dependencies" => {
+            Ok(IntegrationActivationForecastAction::EnableDependencies)
+        }
+        "prepare_approval" | "approval" | "approve" | "ready_to_approve" => {
+            Ok(IntegrationActivationForecastAction::PrepareApproval)
+        }
+        "queue_review" | "review" | "human_review" | "policy_review" => {
+            Ok(IntegrationActivationForecastAction::QueueReview)
+        }
+        "review_risk" | "risk" | "risks" => Ok(IntegrationActivationForecastAction::ReviewRisk),
+        "activate_wave" | "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationForecastAction::ActivateWave)
+        }
+        "monitor_wave" | "monitor" | "watch" => {
+            Ok(IntegrationActivationForecastAction::MonitorWave)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation forecast action `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -16088,6 +16588,21 @@ fn integration_activation_timeline_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_forecast_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_timeline_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("forecast_action", JsonSchema::String));
+        properties.push(SchemaProperty::new("next_action", JsonSchema::String));
+        properties.push(SchemaProperty::new("forecast_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -16232,7 +16747,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 93);
+        assert_eq!(definitions.len(), 95);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -16479,9 +16994,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            85
+            87
         );
         assert_eq!(
             export
@@ -16919,11 +17440,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(93))
+            Some(&integer(95))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(85))
+            Some(&integer(87))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -19247,6 +19768,139 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_forecasts_request = request(
+            "call-list-integration-activation-forecasts",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("requires_attention", JsonValue::Bool(true)),
+                ("forecast_limit", integer(3)),
+            ]),
+            5_027,
+        );
+        let list_activation_forecasts_trace =
+            tool_runtime.invoke_with_events(&list_activation_forecasts_request);
+        assert!(list_activation_forecasts_trace.result.ok);
+        assert_eq!(
+            list_activation_forecasts_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_forecasts_output = list_activation_forecasts_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_forecast_count =
+            integer_value(field(list_activation_forecasts_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_forecast_count));
+        let activation_forecast_summary =
+            field(list_activation_forecasts_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_forecast_summary, "total_forecasts"),
+            Some(&integer(activation_forecast_count))
+        );
+        assert_eq!(
+            field(activation_forecast_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(
+                field(activation_forecast_summary, "forecasts_requiring_attention").unwrap(),
+            )
+            .unwrap()
+                >= 1
+        );
+        let activation_forecast = array_item(
+            field(list_activation_forecasts_output, "activation_forecasts").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_forecast, "sequence").is_some());
+        assert!(field(activation_forecast, "priority").is_some());
+        assert!(field(activation_forecast, "forecast_action").is_some());
+        assert!(field(activation_forecast, "milestone_kind").is_some());
+        assert!(field(activation_forecast, "health_status").is_some());
+        assert!(field(activation_forecast, "integration_ids").is_some());
+        assert!(field(activation_forecast, "integration_count").is_some());
+        assert_eq!(
+            field(activation_forecast, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_forecast_summary_request = request(
+            "call-integration-activation-forecast-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("forecast_action", string("resolve_blockers")),
+                ("requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_028,
+        );
+        let activation_forecast_summary_trace =
+            tool_runtime.invoke_with_events(&activation_forecast_summary_request);
+        assert!(activation_forecast_summary_trace.result.ok);
+        assert_eq!(
+            activation_forecast_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_forecast_summary_output = activation_forecast_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_forecast_rollup =
+            field(activation_forecast_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_forecast_rollup, "resolve_blocker_forecasts").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_forecast_rollup, "next_action"),
+            Some(&string("resolve_blockers"))
+        );
+        assert_eq!(
+            field(activation_forecast_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -20994,6 +21648,14 @@ mod tests {
             activation_timeline_summary_request,
             activation_timeline_summary_trace,
         );
+        journal.record_trace(
+            list_activation_forecasts_request,
+            list_activation_forecasts_trace,
+        );
+        journal.record_trace(
+            activation_forecast_summary_request,
+            activation_forecast_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -21067,9 +21729,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 93);
-        assert_eq!(journal_summary.completed_count, 93);
-        assert_eq!(journal.audit_records().len(), 93);
+        assert_eq!(journal_summary.invocation_count, 95);
+        assert_eq!(journal_summary.completed_count, 95);
+        assert_eq!(journal.audit_records().len(), 95);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -79,6 +79,10 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_timeline` and
   `smart_home.get_integration_activation_timeline_summary` tool descriptors
   for read-only Chief activation milestone views derived from dashboard cards.
+- `smart_home.list_integration_activation_forecasts` and
+  `smart_home.get_integration_activation_forecast_summary` tool descriptors
+  for read-only Chief next-action classification derived from activation
+  timeline milestones.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -87,6 +87,8 @@ Current scope:
   priority-wave status cards derived from readouts and briefing rows
 - D18D integration activation-timeline descriptors for ordered milestone views
   derived from dashboard cards
+- D18D integration activation-forecast descriptors for Chief-ready next-action
+  classification derived from activation timeline milestones
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1491,6 +1491,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationDashboardSummary,
     ListIntegrationActivationTimeline,
     GetIntegrationActivationTimelineSummary,
+    ListIntegrationActivationForecast,
+    GetIntegrationActivationForecastSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1670,6 +1672,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationTimelineSummary => {
                 read_tool("smart_home.get_integration_activation_timeline_summary")
+            }
+            Self::ListIntegrationActivationForecast => {
+                read_tool("smart_home.list_integration_activation_forecasts")
+            }
+            Self::GetIntegrationActivationForecastSummary => {
+                read_tool("smart_home.get_integration_activation_forecast_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2344,6 +2352,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationDashboardSummary,
         SmartHomeTool::ListIntegrationActivationTimeline,
         SmartHomeTool::GetIntegrationActivationTimelineSummary,
+        SmartHomeTool::ListIntegrationActivationForecast,
+        SmartHomeTool::GetIntegrationActivationForecastSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3186,7 +3196,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 93);
+        assert_eq!(catalog.len(), 95);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3565,6 +3575,14 @@ mod tests {
             == "smart_home.get_integration_activation_dependency_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_forecasts"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_forecast_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3572,15 +3590,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 93);
-        assert_eq!(summary.read_tools, 85);
+        assert_eq!(summary.total_tools, 95);
+        assert_eq!(summary.read_tools, 87);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 85);
+        assert_eq!(summary.read_only_tier_tools, 87);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 93);
+        assert_eq!(summary.total_required_capabilities, 95);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -68,6 +68,10 @@ All notable changes to this package will be documented in this file.
   `IntegrationActivationApprovalSummary` for bundling review rows with concrete
   actions, grouped constraints, policy risk, and dependency blockers before a
   human approval request.
+- `IntegrationActivationForecastItem` and
+  `IntegrationActivationForecastSummary` for classifying activation timeline
+  milestones into Chief-ready next actions across blockers, dependencies,
+  approvals, reviews, risks, activation, and monitoring.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -70,6 +70,9 @@ runtime and Chief of Staff tools a typed catalog for:
   priority-wave Chief status cards
 - activation timeline milestones that order dashboard cards into a Chief-ready
   wave sequence
+- activation forecast rows that classify timeline milestones into Chief-ready
+  next actions for blockers, dependencies, approvals, reviews, risks,
+  activation, and monitoring
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1048,6 +1048,35 @@ impl IntegrationActivationBriefingItemKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationForecastAction {
+    ResolveBlockers,
+    EnableDependencies,
+    PrepareApproval,
+    QueueReview,
+    ReviewRisk,
+    ActivateWave,
+    MonitorWave,
+}
+
+impl IntegrationActivationForecastAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ResolveBlockers => "resolve_blockers",
+            Self::EnableDependencies => "enable_dependencies",
+            Self::PrepareApproval => "prepare_approval",
+            Self::QueueReview => "queue_review",
+            Self::ReviewRisk => "review_risk",
+            Self::ActivateWave => "activate_wave",
+            Self::MonitorWave => "monitor_wave",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        !matches!(self, Self::ActivateWave | Self::MonitorWave)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -1910,6 +1939,82 @@ pub struct IntegrationActivationTimelineSummary {
     pub total_risks: usize,
     pub total_dependency_edges: usize,
     pub blocking_dependency_edges: usize,
+    pub first_activation_sequence: Option<usize>,
+    pub first_approval_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_risk_sequence: Option<usize>,
+    pub first_dependency_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_activation_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_risk_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationForecastItem {
+    pub sequence: usize,
+    pub priority: u8,
+    pub forecast_action: IntegrationActivationForecastAction,
+    pub milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub briefing_item_count: usize,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub has_activation_work: bool,
+    pub has_approval_ready_work: bool,
+    pub has_review_work: bool,
+    pub has_blockers: bool,
+    pub has_risks: bool,
+    pub has_dependency_blockers: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationForecastSummary {
+    pub total_forecasts: usize,
+    pub unique_integrations: usize,
+    pub ready_forecasts: usize,
+    pub review_forecasts: usize,
+    pub blocked_forecasts: usize,
+    pub empty_forecasts: usize,
+    pub activate_wave_forecasts: usize,
+    pub prepare_approval_forecasts: usize,
+    pub queue_review_forecasts: usize,
+    pub resolve_blocker_forecasts: usize,
+    pub enable_dependency_forecasts: usize,
+    pub review_risk_forecasts: usize,
+    pub monitor_wave_forecasts: usize,
+    pub forecasts_requiring_attention: usize,
+    pub forecasts_with_activation_work: usize,
+    pub forecasts_with_approval_work: usize,
+    pub forecasts_with_review_work: usize,
+    pub forecasts_with_blockers: usize,
+    pub forecasts_with_risks: usize,
+    pub forecasts_with_dependency_blockers: usize,
+    pub total_briefing_items: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub next_action: Option<IntegrationActivationForecastAction>,
+    pub next_action_sequence: Option<usize>,
+    pub next_action_priority: Option<u8>,
     pub first_activation_sequence: Option<usize>,
     pub first_approval_sequence: Option<usize>,
     pub first_review_sequence: Option<usize>,
@@ -3588,6 +3693,317 @@ impl IntegrationActivationTimelineSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.overall_status.requires_attention()
+            || self.has_approval_ready_work()
+            || self.has_review_work()
+            || self.has_blockers()
+            || self.has_risks()
+            || self.has_dependency_blockers()
+    }
+}
+
+impl IntegrationActivationForecastItem {
+    fn from_milestone(milestone: IntegrationActivationTimelineMilestone) -> Self {
+        let card = &milestone.dashboard_card;
+        let forecast_action = if milestone.has_dependency_blockers() {
+            IntegrationActivationForecastAction::EnableDependencies
+        } else if milestone.has_blockers() {
+            IntegrationActivationForecastAction::ResolveBlockers
+        } else if milestone.has_approval_ready_work() {
+            IntegrationActivationForecastAction::PrepareApproval
+        } else if milestone.has_review_work() {
+            IntegrationActivationForecastAction::QueueReview
+        } else if milestone.has_activation_work() {
+            IntegrationActivationForecastAction::ActivateWave
+        } else if milestone.has_risks() {
+            IntegrationActivationForecastAction::ReviewRisk
+        } else {
+            IntegrationActivationForecastAction::MonitorWave
+        };
+        let requires_attention =
+            forecast_action.requires_attention() || milestone.requires_attention();
+
+        Self {
+            sequence: milestone.sequence,
+            priority: milestone.priority,
+            forecast_action,
+            milestone_kind: milestone.milestone_kind,
+            health_status: card.health_status,
+            integration_ids: card.integration_ids.clone(),
+            integration_count: card.integration_count(),
+            briefing_item_count: card.briefing_item_count,
+            action_count: card.action_count,
+            dossier_count: card.dossier_count,
+            evidence_count: card.evidence_count,
+            risk_count: card.risk_count,
+            dependency_edge_count: card.dependency_edge_count,
+            blocking_dependency_edge_count: card.blocking_dependency_edge_count,
+            highest_policy_tier: card.highest_policy_tier,
+            has_activation_work: card.has_activation_work,
+            has_approval_ready_work: card.has_approval_ready_work,
+            has_review_work: card.has_review_work,
+            has_blockers: card.has_blockers,
+            has_risks: card.has_risks,
+            has_dependency_blockers: card.has_dependency_blockers,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.has_activation_work
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.has_approval_ready_work
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.has_review_work
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.has_blockers
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.has_risks
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.has_dependency_blockers
+    }
+}
+
+impl IntegrationActivationForecastSummary {
+    pub fn from_forecasts<'a>(
+        forecasts: impl IntoIterator<Item = &'a IntegrationActivationForecastItem>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_forecasts: 0,
+            unique_integrations: 0,
+            ready_forecasts: 0,
+            review_forecasts: 0,
+            blocked_forecasts: 0,
+            empty_forecasts: 0,
+            activate_wave_forecasts: 0,
+            prepare_approval_forecasts: 0,
+            queue_review_forecasts: 0,
+            resolve_blocker_forecasts: 0,
+            enable_dependency_forecasts: 0,
+            review_risk_forecasts: 0,
+            monitor_wave_forecasts: 0,
+            forecasts_requiring_attention: 0,
+            forecasts_with_activation_work: 0,
+            forecasts_with_approval_work: 0,
+            forecasts_with_review_work: 0,
+            forecasts_with_blockers: 0,
+            forecasts_with_risks: 0,
+            forecasts_with_dependency_blockers: 0,
+            total_briefing_items: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            next_action: None,
+            next_action_sequence: None,
+            next_action_priority: None,
+            first_activation_sequence: None,
+            first_approval_sequence: None,
+            first_review_sequence: None,
+            first_blocked_sequence: None,
+            first_risk_sequence: None,
+            first_dependency_sequence: None,
+            first_attention_sequence: None,
+            first_activation_priority: None,
+            first_approval_priority: None,
+            first_review_priority: None,
+            first_blocked_priority: None,
+            first_risk_priority: None,
+            first_dependency_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for forecast in forecasts {
+            summary.total_forecasts += 1;
+            for integration_id in &forecast.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match forecast.health_status {
+                IntegrationActivationHealthStatus::Ready => summary.ready_forecasts += 1,
+                IntegrationActivationHealthStatus::NeedsReview => summary.review_forecasts += 1,
+                IntegrationActivationHealthStatus::Blocked => summary.blocked_forecasts += 1,
+                IntegrationActivationHealthStatus::Empty => summary.empty_forecasts += 1,
+            }
+
+            match forecast.forecast_action {
+                IntegrationActivationForecastAction::ActivateWave => {
+                    summary.activate_wave_forecasts += 1;
+                    summary.first_activation_sequence = summary
+                        .first_activation_sequence
+                        .or(Some(forecast.sequence));
+                    summary.first_activation_priority = min_optional_priority(
+                        summary.first_activation_priority,
+                        Some(forecast.priority),
+                    );
+                }
+                IntegrationActivationForecastAction::PrepareApproval => {
+                    summary.prepare_approval_forecasts += 1;
+                    summary.first_approval_sequence =
+                        summary.first_approval_sequence.or(Some(forecast.sequence));
+                    summary.first_approval_priority = min_optional_priority(
+                        summary.first_approval_priority,
+                        Some(forecast.priority),
+                    );
+                }
+                IntegrationActivationForecastAction::QueueReview => {
+                    summary.queue_review_forecasts += 1;
+                    summary.first_review_sequence =
+                        summary.first_review_sequence.or(Some(forecast.sequence));
+                    summary.first_review_priority = min_optional_priority(
+                        summary.first_review_priority,
+                        Some(forecast.priority),
+                    );
+                }
+                IntegrationActivationForecastAction::ResolveBlockers => {
+                    summary.resolve_blocker_forecasts += 1;
+                    summary.first_blocked_sequence =
+                        summary.first_blocked_sequence.or(Some(forecast.sequence));
+                    summary.first_blocked_priority = min_optional_priority(
+                        summary.first_blocked_priority,
+                        Some(forecast.priority),
+                    );
+                }
+                IntegrationActivationForecastAction::EnableDependencies => {
+                    summary.enable_dependency_forecasts += 1;
+                    summary.first_dependency_sequence = summary
+                        .first_dependency_sequence
+                        .or(Some(forecast.sequence));
+                    summary.first_dependency_priority = min_optional_priority(
+                        summary.first_dependency_priority,
+                        Some(forecast.priority),
+                    );
+                }
+                IntegrationActivationForecastAction::ReviewRisk => {
+                    summary.review_risk_forecasts += 1;
+                    summary.first_risk_sequence =
+                        summary.first_risk_sequence.or(Some(forecast.sequence));
+                    summary.first_risk_priority =
+                        min_optional_priority(summary.first_risk_priority, Some(forecast.priority));
+                }
+                IntegrationActivationForecastAction::MonitorWave => {
+                    summary.monitor_wave_forecasts += 1;
+                }
+            }
+
+            if summary.next_action.is_none()
+                && forecast.forecast_action != IntegrationActivationForecastAction::MonitorWave
+            {
+                summary.next_action = Some(forecast.forecast_action);
+                summary.next_action_sequence = Some(forecast.sequence);
+                summary.next_action_priority = Some(forecast.priority);
+            }
+
+            summary.total_briefing_items += forecast.briefing_item_count;
+            summary.total_actions += forecast.action_count;
+            summary.total_dossiers += forecast.dossier_count;
+            summary.total_evidence += forecast.evidence_count;
+            summary.total_risks += forecast.risk_count;
+            summary.total_dependency_edges += forecast.dependency_edge_count;
+            summary.blocking_dependency_edges += forecast.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(forecast.highest_policy_tier);
+
+            if forecast.requires_attention() {
+                summary.forecasts_requiring_attention += 1;
+                summary.first_attention_sequence =
+                    summary.first_attention_sequence.or(Some(forecast.sequence));
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(forecast.priority),
+                );
+            }
+            if forecast.has_activation_work() {
+                summary.forecasts_with_activation_work += 1;
+            }
+            if forecast.has_approval_ready_work() {
+                summary.forecasts_with_approval_work += 1;
+            }
+            if forecast.has_review_work() {
+                summary.forecasts_with_review_work += 1;
+            }
+            if forecast.has_blockers() {
+                summary.forecasts_with_blockers += 1;
+            }
+            if forecast.has_risks() {
+                summary.forecasts_with_risks += 1;
+            }
+            if forecast.has_dependency_blockers() {
+                summary.forecasts_with_dependency_blockers += 1;
+            }
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status =
+            if summary.blocked_forecasts > 0 || summary.forecasts_with_blockers > 0 {
+                IntegrationActivationHealthStatus::Blocked
+            } else if summary.review_forecasts > 0
+                || summary.forecasts_with_review_work > 0
+                || summary.forecasts_with_approval_work > 0
+            {
+                IntegrationActivationHealthStatus::NeedsReview
+            } else if summary.ready_forecasts > 0 || summary.forecasts_with_activation_work > 0 {
+                IntegrationActivationHealthStatus::Ready
+            } else {
+                IntegrationActivationHealthStatus::Empty
+            };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_forecasts == 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.forecasts_with_activation_work > 0 || self.activate_wave_forecasts > 0
+    }
+
+    pub fn has_approval_ready_work(&self) -> bool {
+        self.forecasts_with_approval_work > 0 || self.prepare_approval_forecasts > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.forecasts_with_review_work > 0 || self.queue_review_forecasts > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.forecasts_with_blockers > 0 || self.resolve_blocker_forecasts > 0
+    }
+
+    pub fn has_risks(&self) -> bool {
+        self.forecasts_with_risks > 0 || self.review_risk_forecasts > 0
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.forecasts_with_dependency_blockers > 0 || self.enable_dependency_forecasts > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.forecasts_requiring_attention > 0
+            || self.overall_status.requires_attention()
             || self.has_approval_ready_work()
             || self.has_review_work()
             || self.has_blockers()
@@ -7554,6 +7970,63 @@ pub fn activation_timeline_milestones_at_or_before_priority(
     )
 }
 
+pub fn activation_forecasts_from_timeline_milestones(
+    mut milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationForecastItem> {
+    milestones.sort_by(compare_activation_timeline_milestones);
+    let mut forecasts = milestones
+        .into_iter()
+        .map(IntegrationActivationForecastItem::from_milestone)
+        .collect::<Vec<_>>();
+    forecasts.sort_by(compare_activation_forecasts);
+    for (index, forecast) in forecasts.iter_mut().enumerate() {
+        forecast.sequence = index + 1;
+    }
+    forecasts
+}
+
+pub fn activation_forecasts_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationForecastItem> {
+    activation_forecasts_from_timeline_milestones(
+        activation_timeline_milestones_from_dashboard_cards(cards),
+    )
+}
+
+pub fn activation_forecasts_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationForecastItem> {
+    activation_forecasts_from_dashboard_cards(activation_dashboard_cards_from_readouts(readouts))
+}
+
+pub fn activation_forecasts_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationForecastItem> {
+    activation_forecasts_from_dashboard_cards(activation_dashboard_cards_from_candidates(
+        catalog,
+        candidates,
+        enabled_integrations,
+    ))
+}
+
+pub fn activation_forecasts_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationForecastItem> {
+    activation_forecasts_from_dashboard_cards(activation_dashboard_cards_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -8888,6 +9361,26 @@ fn compare_activation_timeline_milestones(
     left.priority
         .cmp(&right.priority)
         .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| left.milestone_kind.cmp(&right.milestone_kind))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| {
+            right
+                .has_approval_ready_work()
+                .cmp(&left.has_approval_ready_work())
+        })
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_forecasts(
+    left: &IntegrationActivationForecastItem,
+    right: &IntegrationActivationForecastItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| left.forecast_action.cmp(&right.forecast_action))
         .then_with(|| left.milestone_kind.cmp(&right.milestone_kind))
         .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
         .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
@@ -10924,6 +11417,121 @@ mod tests {
         assert!(catalog_milestones
             .iter()
             .any(IntegrationActivationTimelineMilestone::requires_attention));
+    }
+
+    #[test]
+    fn activation_forecasts_classify_timeline_milestones_into_next_actions() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let forecasts = activation_forecasts_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(forecasts.len(), 3);
+        assert_eq!(forecasts[0].sequence, 1);
+        assert_eq!(forecasts[0].priority, 1);
+        assert!(forecasts[0].requires_attention());
+        assert_eq!(forecasts[2].sequence, 3);
+        assert_eq!(forecasts[2].priority, 3);
+        assert_eq!(
+            forecasts[2].forecast_action,
+            IntegrationActivationForecastAction::ActivateWave
+        );
+        assert!(forecasts.iter().any(|forecast| forecast.forecast_action
+            == IntegrationActivationForecastAction::EnableDependencies
+            || forecast.forecast_action == IntegrationActivationForecastAction::ResolveBlockers));
+
+        let summary = IntegrationActivationForecastSummary::from_forecasts(forecasts.iter());
+        assert_eq!(summary.total_forecasts, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.activate_wave_forecasts, 1);
+        assert!(summary.resolve_blocker_forecasts + summary.enable_dependency_forecasts >= 1);
+        assert!(summary.forecasts_requiring_attention >= 1);
+        assert!(summary.forecasts_with_activation_work >= 1);
+        assert!(summary.forecasts_with_approval_work >= 1);
+        assert!(summary.forecasts_with_blockers >= 1);
+        assert!(summary.total_briefing_items >= 4);
+        assert!(summary.total_actions > 0);
+        assert!(summary.total_dossiers > 0);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.total_risks > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert!(summary.next_action.is_some());
+        assert_eq!(summary.next_action_sequence, Some(1));
+        assert_eq!(summary.next_action_priority, Some(1));
+        assert_eq!(summary.first_attention_sequence, Some(1));
+        assert_eq!(summary.first_activation_sequence, Some(3));
+        assert_eq!(summary.first_activation_priority, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_activation_work());
+        assert!(summary.has_approval_ready_work());
+        assert!(summary.has_blockers());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_forecasts = activation_forecasts_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_forecasts
+            .iter()
+            .any(IntegrationActivationForecastItem::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation forecast catalog rows and summaries that classify activation timeline milestones into Chief next actions
- expose the read-only forecast list/summary descriptors through smart-home-core
- wire Chief D18D handlers, JSON output, schema parsing, docs, and end-to-end runtime coverage for the new forecast tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
