### PR TITLE
fix(closurec): CLOC12.77 — close gap-067 (labeled single-statement block flatten)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.81.0] - 2026-06-11
+
+### Changed
+- **CLOSES gap-067** (provably-safe minimal slice) — a labeled
+  single-statement block flattens: `label:{break label}` →
+  `label:break label;`.
+
+### Added — gap-067 token pre-pass + synthetic `;`
+
+Flattens `IDENT : { <completion-keyword> … }` (body starting
+with `break`/`continue`/`return`/`throw`) when the label sits at
+a hard statement boundary. CRITICAL SAFETY: the boundary set is
+`;`/`}`/start and DELIBERATELY EXCLUDES `{`, so an object-literal
+value `{x:{break:1}}` (whose inner `IDENT:{…}` is preceded by the
+object's `{`) and a ternary `a?b:{c}` are never touched. The
+completion-keyword body guard proves the `{` is a block, not an
+object. The opening `{` is dropped; the closing `}` becomes the
+statement terminator — a synthetic `;` token (cloned from the
+stream and re-typed) is injected when the body had no trailing
+`;`. Multi-statement bodies keep their braces; nested labels
+flatten only the innermost (conservative). 5 new gap067_* unit
+tests (incl. object-literal + ternary safety).
+
 ## [0.80.0] - 2026-06-11
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.80.0"
+version = "0.81.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -163,6 +163,21 @@ pub fn whitespace_only_minify(
         .find(|t| is_structural_punct(t, ")"))
         .cloned();
 
+    // gap-067 needs a synthetic `;` to terminate a flattened
+    // labeled body that had no trailing `;` of its own (the block
+    // braces it dropped were doing the termination). Cloned from
+    // any source token (the stream always has ≥1, the EOF
+    // sentinel) and re-typed to a Semicolon — only `.value`
+    // matters for re-stitching. Declared before `kept` so it
+    // outlives the `&Token` reference inserted into it.
+    let synth_semi: Option<lexer::token::Token> = tokens.first().map(|t| {
+        let mut s = t.clone();
+        s.value = ";".to_string();
+        s.type_ = lexer::token::TokenType::Semicolon;
+        s.type_name = None;
+        s
+    });
+
     let mut kept: Vec<_> = tokens
         .iter()
         .filter(|t| !is_trivia(t))
@@ -1030,6 +1045,130 @@ pub fn whitespace_only_minify(
                 }
             }
             i += 1;
+        }
+    }
+
+    // ---- gap-067: labeled single-statement block flatten ------
+    // `label:{break label}` → `label:break label;`. A labeled
+    // statement whose body is a single-statement block drops the
+    // braces.
+    //
+    // PROVABLY-SAFE minimal slice (matches the byte-identity
+    // fixture `minify_label_block_flatten`):
+    //   - the label `IDENT :` must sit at a hard STATEMENT
+    //     boundary — the token before the identifier is `;`, `}`,
+    //     or start-of-stream. `{` is DELIBERATELY EXCLUDED: a `{`
+    //     is ambiguous (block vs object literal), so an inner
+    //     `x:{...}` of an object (`{x:{break:1}}`, whose `x` is
+    //     preceded by the object's `{`) must never be touched.
+    //   - the block body's FIRST token is a COMPLETION keyword:
+    //     `break`/`continue`/`return`/`throw`. These are
+    //     unambiguously STATEMENTS — never an object value, never
+    //     a `let`/`const`/`class`/`function` declaration — which
+    //     proves the `{` is a block and `IDENT:` is a label.
+    //   - the block is a SINGLE statement: no top-level `;`
+    //     separates a second statement (a lone trailing `;`
+    //     before `}` is fine).
+    //
+    // The `{`/`}` pair is then dropped; the emit loop supplies
+    // the statement-terminating `;`. Multi-statement bodies
+    // (`label:{a();break label}`) and non-completion-keyword
+    // bodies keep their braces. All bracket checks route through
+    // `is_structural_punct` so a literal can never be mistaken
+    // for a delimiter.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 0;
+        while i + 3 < kept.len() {
+            let at_stmt_boundary = match i.checked_sub(1).and_then(|k| kept.get(k)) {
+                None => true,
+                Some(p) => {
+                    is_structural_punct(p, ";") || is_structural_punct(p, "}")
+                }
+            };
+            if at_stmt_boundary
+                && is_plain_identifier(&kept[i])
+                && is_structural_punct(&kept[i + 1], ":")
+                && is_structural_punct(&kept[i + 2], "{")
+                && !is_string_literal(&kept[i + 3])
+                && matches!(
+                    kept[i + 3].value.as_str(),
+                    "break" | "continue" | "return" | "throw"
+                )
+            {
+                // Depth-scan to the matching `}`, flagging a
+                // statement-separating top-level `;` (one
+                // followed by something other than the `}`).
+                let mut depth: i32 = 1;
+                let mut close: Option<usize> = None;
+                let mut multi = false;
+                let mut j = i + 3;
+                while j < kept.len() {
+                    let t = &kept[j];
+                    if is_structural_punct(t, "{")
+                        || is_structural_punct(t, "(")
+                        || is_structural_punct(t, "[")
+                    {
+                        depth += 1;
+                    } else if is_structural_punct(t, "}") {
+                        depth -= 1;
+                        if depth == 0 {
+                            close = Some(j);
+                            break;
+                        }
+                    } else if is_structural_punct(t, ")")
+                        || is_structural_punct(t, "]")
+                    {
+                        depth -= 1;
+                    } else if depth == 1 && is_structural_punct(t, ";") {
+                        let next_is_close = kept
+                            .get(j + 1)
+                            .map(|n| is_structural_punct(n, "}"))
+                            .unwrap_or(false);
+                        if !next_is_close {
+                            multi = true;
+                        }
+                    }
+                    j += 1;
+                }
+                if let Some(c) = close {
+                    if !multi {
+                        // Drop the opening `{`. The closing `}`
+                        // becomes the statement terminator: if the
+                        // body already ends in a top-level `;`,
+                        // just drop the `}`; otherwise REPLACE the
+                        // `}` in place with a synthetic `;` so the
+                        // flattened statement stays terminated
+                        // (`label:break label` → `label:break
+                        // label;`).
+                        let body_ends_with_semi = c
+                            .checked_sub(1)
+                            .and_then(|k| kept.get(k))
+                            .map(|t| is_structural_punct(t, ";"))
+                            .unwrap_or(false);
+                        drops.push(i + 2); // block `{`
+                        if body_ends_with_semi {
+                            drops.push(c); // block `}`
+                        } else if let Some(semi) = synth_semi.as_ref() {
+                            kept[c] = semi; // `}` → `;`
+                        } else {
+                            // No synthetic `;` available (cannot
+                            // happen — the stream always has a
+                            // token to clone). Bail conservatively.
+                            drops.pop();
+                            i += 1;
+                            continue;
+                        }
+                        i = c + 1;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
         }
     }
 
@@ -3784,6 +3923,47 @@ mod tests {
     #[test]
     fn gap068_new_property_not_stripped() {
         assert_eq!(minify("o.new(f);"), "o.new(f);");
+    }
+
+    // ---- gap-067: labeled single-statement block flatten ----
+
+    /// gap-067: `label:{break label}` → `label:break label;` —
+    /// the single-statement block's braces drop and a synthetic
+    /// `;` terminates the flattened statement.
+    #[test]
+    fn gap067_labeled_block_flattens() {
+        assert_eq!(minify("label:{break label}"), "label:break label;");
+    }
+
+    /// gap-067: a body that already ends in `;` reuses it (no
+    /// double `;`).
+    #[test]
+    fn gap067_labeled_block_trailing_semi() {
+        assert_eq!(minify("label:{break label;}"), "label:break label;");
+        assert_eq!(minify("label:{throw e}"), "label:throw e;");
+    }
+
+    /// gap-067 boundary: a MULTI-statement labeled block keeps
+    /// its braces.
+    #[test]
+    fn gap067_multi_statement_keeps_braces() {
+        assert_eq!(minify("label:{a();break label}"), "label:{a();break label};");
+    }
+
+    /// gap-067 SAFETY: an object literal whose nested value
+    /// resembles `IDENT:{...}` must NOT be flattened — the inner
+    /// `{` is an object, preceded by the outer object `{` (which
+    /// the pass excludes as a statement boundary).
+    #[test]
+    fn gap067_object_literal_not_flattened() {
+        assert_eq!(minify("var o={x:{break:1}};"), "var o={x:{break:1}};");
+    }
+
+    /// gap-067 SAFETY: a ternary `a?b:{c}` is not a labeled
+    /// block — must be untouched.
+    #[test]
+    fn gap067_ternary_not_flattened() {
+        assert_eq!(minify("a?b:{c};"), "a?b:{c};");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.80.0
+Version: 0.81.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,9 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-067 (CLOC14.34): a labeled SINGLE-statement block
-    // flattens — `label:{break label}` → `label:break label;`.
-    // A multi-statement labeled block keeps its braces (boundary
-    // pinned by minify_label_block_multi).
-    ("label_block_flatten", "gap-067: labeled single-statement block flatten"),
+    // gap-067 RESOLVED in CLOC12.77 — a labeled single-statement
+    // block (`label:{break label}` → `label:break label;`) now
+    // flattens; `minify_label_block_flatten` enforced.
     // gap-068 RESOLVED in CLOC12.76 — redundant parens around a
     // `new` callee (`new(f)()` → `new f`, `new(a.b)` → `new a.b`)
     // are now stripped; both fixtures enforced.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -521,9 +521,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-067 — labeled single-statement block flatten
 
-- **Status:** OPEN — discovered by CLOC14.34. `minify_label_block_flatten` ignored.
+- **Status:** **RESOLVED** in CLOC12.77 (provably-safe minimal slice). `minify_label_block_flatten` flips IGNORED → PASS.
 - **Input:** `label:{break label}` → **Upstream:** `label:break label;`
 - **What it needs:** When a `LabeledStatement`'s body is a `BlockStatement` containing exactly ONE statement, the braces are redundant — flatten `label:{S}` → `label:S`. A multi-statement block keeps its braces (`label:{a();break label}` stays — pinned by `minify_label_block_multi`). Same family as gap-010/032 (block flattening) but in a labeled-statement context.
+- **CLOC12.77 (provably-safe slice):** flattens `IDENT : { <completion-keyword> … }` where the label sits at a hard statement boundary (prev token is `;`/`}`/start — `{` is EXCLUDED, since a `{`-preceded `IDENT:{…}` is an object-literal value like `{x:{break:1}}`), the body's first token is `break`/`continue`/`return`/`throw` (unambiguously a statement — never an object value or a declaration), and it is a single statement. The `{` is dropped and the `}` becomes the terminating `;` (a synthetic `;` is injected when the body had no trailing `;`). **Conservative trade-off:** nested labels (`outer:{inner:{break outer}}`) only flatten the innermost (a missed optimization, not a corruption); expression-statement and `var`-declaration bodies are deferred. 5 unit tests; object-literal/ternary safety verified.
 
 ### gap-068 — redundant parens around a `new` callee
 


### PR DESCRIPTION
## What

Closes **gap-067** (found in CLOC14.34) — the **last remaining whitespace_only gap**. Flattens a labeled single-statement block:

```
label:{break label}   →  label:break label;
label:{throw e}       →  label:throw e;
```

Same family as gap-010/032 (block flattening), in a labeled-statement context. This is the first **block-flatten / statement-context** pass in the re-stitcher (all prior passes were paren/operator elision).

## How

A token pre-pass flattens `IDENT : { <completion-keyword> … }` where the body's first token is `break`/`continue`/`return`/`throw`. The `{` is dropped; the `}` becomes the terminator — a **synthetic `;`** (cloned from the stream, re-typed to `Semicolon`, declared before `kept` so it outlives the inserted reference) replaces the `}` when the body had no trailing `;`.

## Critical safety (must never corrupt object literals / ternaries)

`IDENT:{…}` also appears as an **object value** (`{x:{break:1}}`) and after a **ternary** `:`. Two guards prevent any corruption:
- the label must sit at a **hard statement boundary** — prev token is `;`/`}`/start. **`{` is deliberately excluded** (an object value's key is preceded by `{`/`,`).
- the body's first token is a **completion keyword** — never an object value, never a `let`/`const`/`class`/`function` declaration — which proves the `{` is a block.

Plus: single-statement only (a top-level `;` followed by more tokens ⇒ keep braces); all bracket checks via `is_structural_punct`.

## Tests

- 5 new `gap067_*` unit tests (flatten, trailing-`;`, multi-statement boundary, **object-literal safety**, **ternary safety**).
- 457 lib tests green; byte-identity harness with `label_block_flatten` un-ignored.
- Security-reviewed (read-only subagent): **PASS** — verified **no object/ternary/array corruption** across ~19 adversarial cases (`f({x:{break:1}})`, `[{x:{break:1}}]`, `var o={break:{x:1}}`, `({a:{return:1}})`, …), synthetic-`;` lifetime/uniqueness, single-statement detection over nested brackets, index/removal correctness, two-match files, and no-panic on malformed input.

> Conservative trade-offs (missed optimizations, never corruption, deferred): nested labels flatten only the innermost; expression-statement and `var`-declaration bodies keep braces.

Version 0.80→0.81; help-markdown regenerated from the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)