### PR TITLE
Add smart-home activation playbook tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -64,6 +64,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation forecast next-action planning:
   `smart_home.list_integration_activation_forecasts` and
   `smart_home.get_integration_activation_forecast_summary`.
+- Added D18D handlers for D23A activation playbook planning:
+  `smart_home.list_integration_activation_playbook` and
+  `smart_home.get_integration_activation_playbook_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -56,6 +56,7 @@ Chief of Staff job/session/agent
   -> activation-dashboard list and summary reads for priority-wave status cards
   -> activation-timeline list and summary reads for ordered wave milestones
   -> activation-forecast list and summary reads for next-action wave planning
+  -> activation-playbook list and summary reads for operator-ready planning steps
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -119,6 +120,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_timeline_summary`
 - `smart_home.list_integration_activation_forecasts`
 - `smart_home.get_integration_activation_forecast_summary`
+- `smart_home.list_integration_activation_playbook`
+- `smart_home.get_integration_activation_playbook_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -41,41 +41,42 @@ use smart_home_integration_catalog::{
     activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
     activation_health_from_candidates, activation_maintenance_from_candidates,
     activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_readouts_from_candidates, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates,
-    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
-    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
-    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
-    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
-    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
-    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
-    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
-    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
-    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationReadoutStage,
-    IntegrationActivationReadoutSummary, IntegrationActivationReviewItem,
-    IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
-    IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
+    activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
+    describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
+    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationDashboardCard,
+    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
+    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
+    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
+    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
+    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
+    IntegrationActivationForecastSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
+    IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
+    IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
+    IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
     IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
     IntegrationActivationTimelineSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
@@ -254,6 +255,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_FORECASTS_TOOL_ID: &str =
     "smart_home.list_integration_activation_forecasts";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_forecast_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID: &str =
+    "smart_home.list_integration_activation_playbook";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_playbook_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -540,6 +545,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID => {
                     let query = integration_activation_forecast_query(&arguments)?;
                     Ok(get_integration_activation_forecast_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID => {
+                    let query = integration_activation_playbook_query(&arguments)?;
+                    Ok(list_integration_activation_playbook_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_playbook_query(&arguments)?;
+                    Ok(get_integration_activation_playbook_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1830,6 +1845,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation forecast summary",
             "Return compact D23A activation forecast counts for next action, attention, activation, approval, review, blockers, dependencies, and risks.",
             integration_activation_forecast_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID,
+            "List smart-home integration activation playbook",
+            "List Chief-ready D23A activation playbook steps derived from forecast rows, including recommended planning views and operator/action readiness flags.",
+            integration_activation_playbook_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_playbook", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_playbook", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation playbook summary",
+            "Return compact D23A activation playbook counts for operator work, recommended planning views, blockers, review work, activation, and monitoring.",
+            integration_activation_playbook_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4506,6 +4550,15 @@ struct IntegrationActivationForecastQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationPlaybookQuery {
+    forecast: IntegrationActivationForecastQuery,
+    playbook_action: Option<IntegrationActivationForecastAction>,
+    recommended_view: Option<IntegrationActivationPlaybookView>,
+    operator_required: Option<bool>,
+    playbook_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4813,6 +4866,26 @@ fn integration_activation_forecast_query(
         forecast_action,
         requires_attention: optional_bool(arguments, "requires_attention")?,
         forecast_limit: optional_u64(arguments, "forecast_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_playbook_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationPlaybookQuery, ToolCallError> {
+    let playbook_action = optional_string(arguments, "playbook_action")?
+        .map(|label| parse_activation_forecast_action(&label))
+        .transpose()?;
+    let recommended_view = optional_string(arguments, "recommended_view")?
+        .or(optional_string(arguments, "playbook_view")?)
+        .map(|label| parse_activation_playbook_view(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationPlaybookQuery {
+        forecast: integration_activation_forecast_query(arguments)?,
+        playbook_action,
+        recommended_view,
+        operator_required: optional_bool(arguments, "operator_required")?,
+        playbook_limit: optional_u64(arguments, "playbook_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5417,6 +5490,28 @@ fn integration_activation_forecasts_for_query(
     }
 
     (forecasts, catalog_count)
+}
+
+fn integration_activation_playbook_steps_for_query(
+    query: &IntegrationActivationPlaybookQuery,
+) -> (Vec<IntegrationActivationPlaybookStep>, usize) {
+    let (forecasts, catalog_count) = integration_activation_forecasts_for_query(&query.forecast);
+    let mut steps = activation_playbook_steps_from_forecasts(forecasts);
+
+    if let Some(action) = query.playbook_action {
+        steps.retain(|step| step.playbook_action == action);
+    }
+    if let Some(view) = query.recommended_view {
+        steps.retain(|step| step.recommended_view == view);
+    }
+    if let Some(operator_required) = query.operator_required {
+        steps.retain(|step| step.operator_required() == operator_required);
+    }
+    if let Some(limit) = query.playbook_limit {
+        steps.truncate(limit);
+    }
+
+    (steps, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -6958,6 +7053,92 @@ fn get_integration_activation_forecast_summary_output_handler_output(
                 summary
                     .next_action
                     .map(|action| string(action.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_playbook_output_handler_output(
+    query: IntegrationActivationPlaybookQuery,
+) -> ToolHandlerOutput {
+    let (steps, catalog_count) = integration_activation_playbook_steps_for_query(&query);
+    let summary = IntegrationActivationPlaybookSummary::from_steps(steps.iter());
+    let count = steps.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_playbook",
+            JsonValue::Array(steps.iter().map(activation_playbook_step_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_playbook_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_playbook")),
+            ("activation_playbook_steps", integer(count as i64)),
+            (
+                "operator_required_steps",
+                integer(summary.operator_required_steps as i64),
+            ),
+            (
+                "next_playbook_action",
+                summary
+                    .next_playbook_action
+                    .map(|action| string(action.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "next_recommended_view",
+                summary
+                    .next_recommended_view
+                    .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_playbook_summary_output_handler_output(
+    query: IntegrationActivationPlaybookQuery,
+) -> ToolHandlerOutput {
+    let (steps, _) = integration_activation_playbook_steps_for_query(&query);
+    let summary = IntegrationActivationPlaybookSummary::from_steps(steps.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_playbook_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_playbook_summary"),
+            ),
+            ("total_steps", integer(summary.total_steps as i64)),
+            (
+                "operator_required_steps",
+                integer(summary.operator_required_steps as i64),
+            ),
+            (
+                "next_playbook_action",
+                summary
+                    .next_playbook_action
+                    .map(|action| string(action.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "next_recommended_view",
+                summary
+                    .next_recommended_view
+                    .map(|view| string(view.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -12931,6 +13112,247 @@ fn integration_activation_forecast_summary_json(
     ])
 }
 
+fn activation_playbook_step_json(step: &IntegrationActivationPlaybookStep) -> JsonValue {
+    object([
+        ("sequence", integer(step.sequence as i64)),
+        ("priority", integer(step.priority as i64)),
+        ("playbook_action", string(step.playbook_action.as_str())),
+        ("recommended_view", string(step.recommended_view.as_str())),
+        (
+            "milestone_kind",
+            step.milestone_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("health_status", string(step.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                step.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(step.integration_count() as i64),
+        ),
+        ("action_count", integer(step.action_count as i64)),
+        ("dossier_count", integer(step.dossier_count as i64)),
+        ("evidence_count", integer(step.evidence_count as i64)),
+        ("risk_count", integer(step.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(step.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(step.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(step.highest_policy_tier)),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(step.operator_required()),
+        ),
+        ("activation_ready", JsonValue::Bool(step.activation_ready())),
+        ("blocked", JsonValue::Bool(step.blocked())),
+        ("review_required", JsonValue::Bool(step.review_required())),
+        ("monitor_only", JsonValue::Bool(step.monitor_only())),
+        (
+            "requires_attention",
+            JsonValue::Bool(step.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_playbook_summary_json(
+    summary: &IntegrationActivationPlaybookSummary,
+) -> JsonValue {
+    object([
+        ("total_steps", integer(summary.total_steps as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "operator_required_steps",
+            integer(summary.operator_required_steps as i64),
+        ),
+        (
+            "activation_ready_steps",
+            integer(summary.activation_ready_steps as i64),
+        ),
+        ("blocked_steps", integer(summary.blocked_steps as i64)),
+        (
+            "review_required_steps",
+            integer(summary.review_required_steps as i64),
+        ),
+        ("monitor_steps", integer(summary.monitor_steps as i64)),
+        (
+            "constraint_view_steps",
+            integer(summary.constraint_view_steps as i64),
+        ),
+        (
+            "dependency_view_steps",
+            integer(summary.dependency_view_steps as i64),
+        ),
+        (
+            "approval_view_steps",
+            integer(summary.approval_view_steps as i64),
+        ),
+        (
+            "review_view_steps",
+            integer(summary.review_view_steps as i64),
+        ),
+        ("risk_view_steps", integer(summary.risk_view_steps as i64)),
+        (
+            "action_view_steps",
+            integer(summary.action_view_steps as i64),
+        ),
+        (
+            "dashboard_view_steps",
+            integer(summary.dashboard_view_steps as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_step_sequence",
+            summary
+                .next_step_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_step_priority",
+            summary
+                .next_step_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_sequence",
+            summary
+                .first_operator_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_sequence",
+            summary
+                .first_activation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_monitor_sequence",
+            summary
+                .first_monitor_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_priority",
+            summary
+                .first_operator_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_monitor_priority",
+            summary
+                .first_monitor_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -15535,6 +15957,35 @@ fn parse_activation_forecast_action(
     }
 }
 
+fn parse_activation_playbook_view(
+    label: &str,
+) -> Result<IntegrationActivationPlaybookView, ToolCallError> {
+    match label {
+        "constraints" | "constraint" | "constraint_queue" | "blockers" | "blocker_queue" => {
+            Ok(IntegrationActivationPlaybookView::ConstraintQueue)
+        }
+        "dependencies" | "dependency" | "dependency_graph" | "dependency_edges" => {
+            Ok(IntegrationActivationPlaybookView::DependencyGraph)
+        }
+        "approvals" | "approval" | "approval_packets" | "approval_packet" => {
+            Ok(IntegrationActivationPlaybookView::ApprovalPackets)
+        }
+        "reviews" | "review" | "review_queue" | "human_review" => {
+            Ok(IntegrationActivationPlaybookView::ReviewQueue)
+        }
+        "risk" | "risks" | "risk_register" => Ok(IntegrationActivationPlaybookView::RiskRegister),
+        "actions" | "action" | "activation_actions" | "activation" => {
+            Ok(IntegrationActivationPlaybookView::ActivationActions)
+        }
+        "dashboard" | "status" | "status_dashboard" | "monitor" => {
+            Ok(IntegrationActivationPlaybookView::StatusDashboard)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation playbook view `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -16603,6 +17054,26 @@ fn integration_activation_forecast_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_playbook_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_forecast_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("playbook_action", JsonSchema::String));
+        properties.push(SchemaProperty::new("recommended_view", JsonSchema::String));
+        properties.push(SchemaProperty::new("playbook_view", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "operator_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("playbook_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -16747,7 +17218,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 95);
+        assert_eq!(definitions.len(), 97);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -17000,9 +17471,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_FORECAST_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            87
+            89
         );
         assert_eq!(
             export
@@ -17440,11 +17917,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(95))
+            Some(&integer(97))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(87))
+            Some(&integer(89))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -19901,6 +20378,140 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_playbook_request = request(
+            "call-list-integration-activation-playbook",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("operator_required", JsonValue::Bool(true)),
+                ("playbook_limit", integer(3)),
+            ]),
+            5_029,
+        );
+        let list_activation_playbook_trace =
+            tool_runtime.invoke_with_events(&list_activation_playbook_request);
+        assert!(list_activation_playbook_trace.result.ok);
+        assert_eq!(
+            list_activation_playbook_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_playbook_output = list_activation_playbook_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_playbook_count =
+            integer_value(field(list_activation_playbook_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_playbook_count));
+        let activation_playbook_summary =
+            field(list_activation_playbook_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_playbook_summary, "total_steps"),
+            Some(&integer(activation_playbook_count))
+        );
+        assert_eq!(
+            field(activation_playbook_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_playbook_summary, "operator_required_steps").unwrap(),)
+                .unwrap()
+                >= 1
+        );
+        let activation_playbook_step = array_item(
+            field(list_activation_playbook_output, "activation_playbook").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_playbook_step, "sequence").is_some());
+        assert!(field(activation_playbook_step, "priority").is_some());
+        assert!(field(activation_playbook_step, "playbook_action").is_some());
+        assert!(field(activation_playbook_step, "recommended_view").is_some());
+        assert!(field(activation_playbook_step, "health_status").is_some());
+        assert!(field(activation_playbook_step, "integration_ids").is_some());
+        assert_eq!(
+            field(activation_playbook_step, "operator_required"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_playbook_summary_request = request(
+            "call-integration-activation-playbook-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("playbook_action", string("resolve_blockers")),
+                ("operator_required", JsonValue::Bool(true)),
+            ]),
+            5_030,
+        );
+        let activation_playbook_summary_trace =
+            tool_runtime.invoke_with_events(&activation_playbook_summary_request);
+        assert!(activation_playbook_summary_trace.result.ok);
+        assert_eq!(
+            activation_playbook_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_playbook_summary_output = activation_playbook_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_playbook_rollup =
+            field(activation_playbook_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_playbook_rollup, "constraint_view_steps").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_playbook_rollup, "next_playbook_action"),
+            Some(&string("resolve_blockers"))
+        );
+        assert_eq!(
+            field(activation_playbook_rollup, "next_recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_playbook_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -21656,6 +22267,14 @@ mod tests {
             activation_forecast_summary_request,
             activation_forecast_summary_trace,
         );
+        journal.record_trace(
+            list_activation_playbook_request,
+            list_activation_playbook_trace,
+        );
+        journal.record_trace(
+            activation_playbook_summary_request,
+            activation_playbook_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -21729,9 +22348,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 95);
-        assert_eq!(journal_summary.completed_count, 95);
-        assert_eq!(journal.audit_records().len(), 95);
+        assert_eq!(journal_summary.invocation_count, 97);
+        assert_eq!(journal_summary.completed_count, 97);
+        assert_eq!(journal.audit_records().len(), 97);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -83,6 +83,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_forecast_summary` tool descriptors
   for read-only Chief next-action classification derived from activation
   timeline milestones.
+- `smart_home.list_integration_activation_playbook` and
+  `smart_home.get_integration_activation_playbook_summary` tool descriptors
+  for read-only operator-ready planning steps derived from activation
+  forecasts.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -89,6 +89,8 @@ Current scope:
   derived from dashboard cards
 - D18D integration activation-forecast descriptors for Chief-ready next-action
   classification derived from activation timeline milestones
+- D18D integration activation-playbook descriptors for operator-ready planning
+  steps derived from forecast next actions
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1493,6 +1493,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationTimelineSummary,
     ListIntegrationActivationForecast,
     GetIntegrationActivationForecastSummary,
+    ListIntegrationActivationPlaybook,
+    GetIntegrationActivationPlaybookSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1678,6 +1680,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationForecastSummary => {
                 read_tool("smart_home.get_integration_activation_forecast_summary")
+            }
+            Self::ListIntegrationActivationPlaybook => {
+                read_tool("smart_home.list_integration_activation_playbook")
+            }
+            Self::GetIntegrationActivationPlaybookSummary => {
+                read_tool("smart_home.get_integration_activation_playbook_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2354,6 +2362,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationTimelineSummary,
         SmartHomeTool::ListIntegrationActivationForecast,
         SmartHomeTool::GetIntegrationActivationForecastSummary,
+        SmartHomeTool::ListIntegrationActivationPlaybook,
+        SmartHomeTool::GetIntegrationActivationPlaybookSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3196,7 +3206,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 95);
+        assert_eq!(catalog.len(), 97);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3583,6 +3593,14 @@ mod tests {
             == "smart_home.get_integration_activation_forecast_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_playbook"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_playbook_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3590,15 +3608,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 95);
-        assert_eq!(summary.read_tools, 87);
+        assert_eq!(summary.total_tools, 97);
+        assert_eq!(summary.read_tools, 89);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 87);
+        assert_eq!(summary.read_only_tier_tools, 89);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 95);
+        assert_eq!(summary.total_required_capabilities, 97);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -72,6 +72,9 @@ All notable changes to this package will be documented in this file.
   `IntegrationActivationForecastSummary` for classifying activation timeline
   milestones into Chief-ready next actions across blockers, dependencies,
   approvals, reviews, risks, activation, and monitoring.
+- `IntegrationActivationPlaybookStep` and
+  `IntegrationActivationPlaybookSummary` for pairing forecast next actions with
+  recommended planning views and operator-readiness flags.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -73,6 +73,8 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation forecast rows that classify timeline milestones into Chief-ready
   next actions for blockers, dependencies, approvals, reviews, risks,
   activation, and monitoring
+- activation playbook steps that pair forecast next actions with recommended
+  planning views and operator-readiness flags
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1077,6 +1077,43 @@ impl IntegrationActivationForecastAction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationPlaybookView {
+    ConstraintQueue,
+    DependencyGraph,
+    ApprovalPackets,
+    ReviewQueue,
+    RiskRegister,
+    ActivationActions,
+    StatusDashboard,
+}
+
+impl IntegrationActivationPlaybookView {
+    pub fn from_forecast_action(action: IntegrationActivationForecastAction) -> Self {
+        match action {
+            IntegrationActivationForecastAction::ResolveBlockers => Self::ConstraintQueue,
+            IntegrationActivationForecastAction::EnableDependencies => Self::DependencyGraph,
+            IntegrationActivationForecastAction::PrepareApproval => Self::ApprovalPackets,
+            IntegrationActivationForecastAction::QueueReview => Self::ReviewQueue,
+            IntegrationActivationForecastAction::ReviewRisk => Self::RiskRegister,
+            IntegrationActivationForecastAction::ActivateWave => Self::ActivationActions,
+            IntegrationActivationForecastAction::MonitorWave => Self::StatusDashboard,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ConstraintQueue => "constraints",
+            Self::DependencyGraph => "dependencies",
+            Self::ApprovalPackets => "approvals",
+            Self::ReviewQueue => "reviews",
+            Self::RiskRegister => "risk",
+            Self::ActivationActions => "actions",
+            Self::StatusDashboard => "dashboard",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2029,6 +2066,71 @@ pub struct IntegrationActivationForecastSummary {
     pub first_risk_priority: Option<u8>,
     pub first_dependency_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationPlaybookStep {
+    pub sequence: usize,
+    pub priority: u8,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_required: bool,
+    pub activation_ready: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub monitor_only: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationPlaybookSummary {
+    pub total_steps: usize,
+    pub unique_integrations: usize,
+    pub operator_required_steps: usize,
+    pub activation_ready_steps: usize,
+    pub blocked_steps: usize,
+    pub review_required_steps: usize,
+    pub monitor_steps: usize,
+    pub constraint_view_steps: usize,
+    pub dependency_view_steps: usize,
+    pub approval_view_steps: usize,
+    pub review_view_steps: usize,
+    pub risk_view_steps: usize,
+    pub action_view_steps: usize,
+    pub dashboard_view_steps: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_step_sequence: Option<usize>,
+    pub next_step_priority: Option<u8>,
+    pub first_operator_sequence: Option<usize>,
+    pub first_activation_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_monitor_sequence: Option<usize>,
+    pub first_operator_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_monitor_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -4009,6 +4111,254 @@ impl IntegrationActivationForecastSummary {
             || self.has_blockers()
             || self.has_risks()
             || self.has_dependency_blockers()
+    }
+}
+
+impl IntegrationActivationPlaybookStep {
+    fn from_forecast(forecast: IntegrationActivationForecastItem) -> Self {
+        let recommended_view =
+            IntegrationActivationPlaybookView::from_forecast_action(forecast.forecast_action);
+        let activation_ready =
+            forecast.forecast_action == IntegrationActivationForecastAction::ActivateWave;
+        let monitor_only =
+            forecast.forecast_action == IntegrationActivationForecastAction::MonitorWave;
+        let blocked = matches!(
+            forecast.forecast_action,
+            IntegrationActivationForecastAction::ResolveBlockers
+                | IntegrationActivationForecastAction::EnableDependencies
+        ) || forecast.has_blockers()
+            || forecast.has_dependency_blockers();
+        let review_required = matches!(
+            forecast.forecast_action,
+            IntegrationActivationForecastAction::PrepareApproval
+                | IntegrationActivationForecastAction::QueueReview
+                | IntegrationActivationForecastAction::ReviewRisk
+        ) || forecast.has_approval_ready_work()
+            || forecast.has_review_work()
+            || forecast.has_risks();
+        let operator_required = forecast.forecast_action.requires_attention()
+            || blocked
+            || review_required
+            || forecast.requires_attention();
+        let requires_attention = operator_required || forecast.requires_attention();
+
+        Self {
+            sequence: forecast.sequence,
+            priority: forecast.priority,
+            playbook_action: forecast.forecast_action,
+            recommended_view,
+            milestone_kind: forecast.milestone_kind,
+            health_status: forecast.health_status,
+            integration_ids: forecast.integration_ids,
+            integration_count: forecast.integration_count,
+            action_count: forecast.action_count,
+            dossier_count: forecast.dossier_count,
+            evidence_count: forecast.evidence_count,
+            risk_count: forecast.risk_count,
+            dependency_edge_count: forecast.dependency_edge_count,
+            blocking_dependency_edge_count: forecast.blocking_dependency_edge_count,
+            highest_policy_tier: forecast.highest_policy_tier,
+            operator_required,
+            activation_ready,
+            blocked,
+            review_required,
+            monitor_only,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.activation_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+}
+
+impl IntegrationActivationPlaybookSummary {
+    pub fn from_steps<'a>(
+        steps: impl IntoIterator<Item = &'a IntegrationActivationPlaybookStep>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_steps: 0,
+            unique_integrations: 0,
+            operator_required_steps: 0,
+            activation_ready_steps: 0,
+            blocked_steps: 0,
+            review_required_steps: 0,
+            monitor_steps: 0,
+            constraint_view_steps: 0,
+            dependency_view_steps: 0,
+            approval_view_steps: 0,
+            review_view_steps: 0,
+            risk_view_steps: 0,
+            action_view_steps: 0,
+            dashboard_view_steps: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_step_sequence: None,
+            next_step_priority: None,
+            first_operator_sequence: None,
+            first_activation_sequence: None,
+            first_blocked_sequence: None,
+            first_review_sequence: None,
+            first_monitor_sequence: None,
+            first_operator_priority: None,
+            first_activation_priority: None,
+            first_blocked_priority: None,
+            first_review_priority: None,
+            first_monitor_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for step in steps {
+            summary.total_steps += 1;
+            for integration_id in &step.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match step.recommended_view {
+                IntegrationActivationPlaybookView::ConstraintQueue => {
+                    summary.constraint_view_steps += 1
+                }
+                IntegrationActivationPlaybookView::DependencyGraph => {
+                    summary.dependency_view_steps += 1
+                }
+                IntegrationActivationPlaybookView::ApprovalPackets => {
+                    summary.approval_view_steps += 1
+                }
+                IntegrationActivationPlaybookView::ReviewQueue => summary.review_view_steps += 1,
+                IntegrationActivationPlaybookView::RiskRegister => summary.risk_view_steps += 1,
+                IntegrationActivationPlaybookView::ActivationActions => {
+                    summary.action_view_steps += 1
+                }
+                IntegrationActivationPlaybookView::StatusDashboard => {
+                    summary.dashboard_view_steps += 1
+                }
+            }
+
+            if summary.next_playbook_action.is_none() && !step.monitor_only() {
+                summary.next_playbook_action = Some(step.playbook_action);
+                summary.next_recommended_view = Some(step.recommended_view);
+                summary.next_step_sequence = Some(step.sequence);
+                summary.next_step_priority = Some(step.priority);
+            }
+
+            if step.operator_required() {
+                summary.operator_required_steps += 1;
+                summary.first_operator_sequence =
+                    summary.first_operator_sequence.or(Some(step.sequence));
+                summary.first_operator_priority =
+                    min_optional_priority(summary.first_operator_priority, Some(step.priority));
+            }
+            if step.activation_ready() {
+                summary.activation_ready_steps += 1;
+                summary.first_activation_sequence =
+                    summary.first_activation_sequence.or(Some(step.sequence));
+                summary.first_activation_priority =
+                    min_optional_priority(summary.first_activation_priority, Some(step.priority));
+            }
+            if step.blocked() {
+                summary.blocked_steps += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(step.sequence));
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(step.priority));
+            }
+            if step.review_required() {
+                summary.review_required_steps += 1;
+                summary.first_review_sequence =
+                    summary.first_review_sequence.or(Some(step.sequence));
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(step.priority));
+            }
+            if step.monitor_only() {
+                summary.monitor_steps += 1;
+                summary.first_monitor_sequence =
+                    summary.first_monitor_sequence.or(Some(step.sequence));
+                summary.first_monitor_priority =
+                    min_optional_priority(summary.first_monitor_priority, Some(step.priority));
+            }
+
+            summary.total_actions += step.action_count;
+            summary.total_dossiers += step.dossier_count;
+            summary.total_evidence += step.evidence_count;
+            summary.total_risks += step.risk_count;
+            summary.total_dependency_edges += step.dependency_edge_count;
+            summary.blocking_dependency_edges += step.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary.highest_policy_tier.max(step.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_steps > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.review_required_steps > 0 || summary.operator_required_steps > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.activation_ready_steps > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_steps == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.operator_required_steps > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activation_ready_steps > 0 || self.action_view_steps > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_steps > 0 || self.constraint_view_steps > 0 || self.dependency_view_steps > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_steps > 0
+            || self.approval_view_steps > 0
+            || self.review_view_steps > 0
+            || self.risk_view_steps > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_operator_work()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.overall_status.requires_attention()
     }
 }
 
@@ -8027,6 +8377,71 @@ pub fn activation_forecasts_at_or_before_priority(
     ))
 }
 
+pub fn activation_playbook_steps_from_forecasts(
+    mut forecasts: Vec<IntegrationActivationForecastItem>,
+) -> Vec<IntegrationActivationPlaybookStep> {
+    forecasts.sort_by(compare_activation_forecasts);
+    let mut steps = forecasts
+        .into_iter()
+        .map(IntegrationActivationPlaybookStep::from_forecast)
+        .collect::<Vec<_>>();
+    steps.sort_by(compare_activation_playbook_steps);
+    for (index, step) in steps.iter_mut().enumerate() {
+        step.sequence = index + 1;
+    }
+    steps
+}
+
+pub fn activation_playbook_steps_from_timeline_milestones(
+    milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationPlaybookStep> {
+    activation_playbook_steps_from_forecasts(activation_forecasts_from_timeline_milestones(
+        milestones,
+    ))
+}
+
+pub fn activation_playbook_steps_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationPlaybookStep> {
+    activation_playbook_steps_from_forecasts(activation_forecasts_from_dashboard_cards(cards))
+}
+
+pub fn activation_playbook_steps_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationPlaybookStep> {
+    activation_playbook_steps_from_dashboard_cards(activation_dashboard_cards_from_readouts(
+        readouts,
+    ))
+}
+
+pub fn activation_playbook_steps_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationPlaybookStep> {
+    activation_playbook_steps_from_forecasts(activation_forecasts_from_candidates(
+        catalog,
+        candidates,
+        enabled_integrations,
+    ))
+}
+
+pub fn activation_playbook_steps_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationPlaybookStep> {
+    activation_playbook_steps_from_forecasts(activation_forecasts_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -9390,6 +9805,21 @@ fn compare_activation_forecasts(
                 .cmp(&left.has_approval_ready_work())
         })
         .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_playbook_steps(
+    left: &IntegrationActivationPlaybookStep,
+    right: &IntegrationActivationPlaybookStep,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.operator_required().cmp(&left.operator_required()))
+        .then_with(|| left.playbook_action.cmp(&right.playbook_action))
+        .then_with(|| left.recommended_view.cmp(&right.recommended_view))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.review_required().cmp(&left.review_required()))
+        .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -11532,6 +11962,137 @@ mod tests {
         assert!(catalog_forecasts
             .iter()
             .any(IntegrationActivationForecastItem::requires_attention));
+    }
+
+    #[test]
+    fn activation_playbook_steps_recommend_next_planning_views() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let steps = activation_playbook_steps_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[0].sequence, 1);
+        assert_eq!(steps[0].priority, 1);
+        assert_eq!(
+            steps[0].playbook_action,
+            IntegrationActivationForecastAction::ResolveBlockers
+        );
+        assert_eq!(
+            steps[0].recommended_view,
+            IntegrationActivationPlaybookView::ConstraintQueue
+        );
+        assert!(steps[0].operator_required());
+        assert!(steps[0].blocked());
+        assert!(steps[1].blocked());
+        assert_eq!(
+            steps[1].recommended_view,
+            IntegrationActivationPlaybookView::DependencyGraph
+        );
+        assert!(steps[2].activation_ready());
+        assert_eq!(
+            steps[2].recommended_view,
+            IntegrationActivationPlaybookView::ActivationActions
+        );
+
+        let summary = IntegrationActivationPlaybookSummary::from_steps(steps.iter());
+        assert_eq!(summary.total_steps, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert!(summary.operator_required_steps >= 2);
+        assert_eq!(summary.activation_ready_steps, 1);
+        assert!(summary.blocked_steps >= 1);
+        assert!(summary.review_required_steps >= 1);
+        assert!(summary.constraint_view_steps >= 1);
+        assert!(summary.dependency_view_steps >= 1);
+        assert!(summary.action_view_steps >= 1);
+        assert!(summary.total_actions > 0);
+        assert!(summary.total_dossiers > 0);
+        assert!(summary.total_evidence > 0);
+        assert!(summary.blocking_dependency_edges > 0);
+        assert_eq!(
+            summary.next_playbook_action,
+            Some(IntegrationActivationForecastAction::ResolveBlockers)
+        );
+        assert_eq!(
+            summary.next_recommended_view,
+            Some(IntegrationActivationPlaybookView::ConstraintQueue)
+        );
+        assert_eq!(summary.next_step_sequence, Some(1));
+        assert_eq!(summary.next_step_priority, Some(1));
+        assert_eq!(summary.first_operator_sequence, Some(1));
+        assert_eq!(summary.first_activation_sequence, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_operator_work());
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_steps = activation_playbook_steps_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_steps
+            .iter()
+            .any(IntegrationActivationPlaybookStep::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add integration activation playbook rows and summaries that map forecast next actions to recommended planning views and operator flags
- expose read-only `smart_home.list_integration_activation_playbook` and `smart_home.get_integration_activation_playbook_summary` descriptors from smart-home-core
- wire Chief-of-Staff smart-home handlers, schemas, JSON outputs, runtime coverage, and docs for the new playbook tools

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`, `smart-home-integration-catalog`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, `smart-home-local-http`, `smart-home-discovery`, and `chief-of-staff-smart-home-tools`
