### PR TITLE
feat(lang-matrix): LM-L Nib — Nib on LLVM via uniform i64 materialization

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `lang-aot`
 
+## 0.56.0 — 2026-06-11 — Nib joins the LLVM column (LANG-MATRIX LM-L Nib)
+
+`lang_matrix.rs` greens **Nib on LLVM** — the `Nib` program now lists `Llvm` among its
+proven backends. The fix is in `nib-iir-compiler` 0.7.0 (it materialises integer types
+to `i64` uniformly so the function signature and instruction bodies agree, which
+`iir-to-llvm` requires). Verified by RUNNING: Nib `double(21)` → 42 on real `clang`,
+and still → 42 on native AOT. The LLVM column is now green for Twig / Nib / Oct /
+ALGOL 60; Brainfuck/BASIC pend the stdout-capturing LLVM I/O runner.
+
 ## 0.55.0 — 2026-06-11 — LLVM column for the expression languages (LANG-MATRIX Phase L)
 
 `tests/lang_matrix.rs` refactored into a `Backend`-keyed grid: every `Prog` lists the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -126,10 +126,10 @@ backend, asserted by running. The **native-AOT** column is uniformly green — a
 non-Lisp languages (Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, ALGOL 60) compile to a
 host executable and produce the right result (exit code for the expression languages;
 stdout for the I/O languages). The **LLVM** column is green for the expression
-languages Twig / Oct / ALGOL 60 (textual `.ll` → real `clang` → run); Nib pends an
-`iir-to-llvm` `u8`-widening fix and Brainfuck/BASIC pend the stdout I/O runner. The
-WASM/JVM/CLR columns follow per the matrix spec; the VM/JIT columns are
-McCarthy-specialized and need op-coverage work.
+languages Twig / Nib / Oct / ALGOL 60 (textual `.ll` → real `clang` → run);
+Brainfuck/BASIC pend the stdout-capturing LLVM I/O runner. The WASM/JVM/CLR columns
+follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
+op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -13,8 +13,8 @@
 //! * **native-AOT** (LM0) — source → shared IIR → host object → system linker → run.
 //!   Uniformly green: all six languages.
 //! * **LLVM** (Phase L) — source → textual `.ll` (`iir-to-llvm`) → real `clang` → run.
-//!   Green for the expression languages Twig / Oct / ALGOL 60 today; Nib pends an
-//!   `iir-to-llvm` `u8`-widening fix and Brainfuck/BASIC pend the stdout I/O runner.
+//!   Green for the expression languages Twig / Nib / Oct / ALGOL 60; Brainfuck/BASIC
+//!   pend the stdout-capturing LLVM I/O runner.
 //!
 //! Later slices add the WASM / JVM / CLR columns (also general code generators) and
 //! tackle the two McCarthy-specialized backends — VM and JIT — which need
@@ -69,14 +69,16 @@ const PROGRAMS: &[Prog] = &[
     // Twig — the original AOT language; a bare expression is the whole program.
     Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm] },
     // Nib — typed functions: define `double`, call it, return the result.
-    // (LLVM column pending: `iir-to-llvm` mis-widens Nib's `u8` operands to `i64`
-    // — `'%x' defined with type 'i8' but expected 'i64'`; fixed in the LM-L Nib slice.)
+    // (LLVM cell greened in LM-L Nib: the Nib frontend now materialises its integer
+    // types to `i64` uniformly — completing its own stated convention — so a
+    // function's signature and its instruction bodies agree and `iir-to-llvm` emits
+    // valid, consistent LLVM.)
     Prog {
         lang: Language::Nib,
         ext: "nib",
         src: "fn double(x: u8) -> u8 { return x + x; } fn main() -> u8 { return double(21); }",
         expect: Expect::Exit(42),
-        backends: &[NativeAot],
+        backends: &[NativeAot, Llvm],
     },
     // Oct — `let` + `if` + comparison; `main` is void so the process exits 0.
     Prog {

--- a/code/packages/rust/nib-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/nib-iir-compiler/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — `nib-iir-compiler`
 
+## 0.7.0 — 2026-06-11 — materialise integer types to i64 uniformly (LANG-MATRIX LM-L Nib)
+
+Fixes a type-**inconsistency** in the emitted IIR that a strict backend (`iir-to-llvm`)
+rejected. The frontend's instruction bodies already use `i64` for integers
+(`compile_binary_chain` and the `ret` default both emit `"i64"`; the long-standing
+intent is "Nib's u4/u8/bool all materialise as i64 at the IIR level"), but
+`extract_params` / `extract_return_type` (and `let` types) left the **function
+signature** as the narrow `u8`. So a function compiled to `define i8 @double(i8 %x)`
+with an `add i64 %x, %x` body — `'%x' defined with type 'i8' but expected 'i64'`.
+
+`widen_nib_type` now maps the integer types (`u4`/`u8`/`bcd`) to `i64`, completing the
+frontend's own convention so signature and bodies agree (`bool`/`void` unchanged). The
+IIR is now uniformly `i64` for integers — matching the instruction convention, the
+native-AOT machine-word model, and McCarthy's lowering. Verified by RUNNING: Nib on
+LLVM → 42 (previously a clang type error), Nib on native still → 42 (no regression);
+all nib-iir-compiler unit tests and the `iir-to-llvm` backend tests stay green. The
+narrow semantic width (u4/u8 wraparound) remains a backend-masking concern, deferred.
+
 ## 0.6.0 — 2026-05-30 (NIB06 — source-location threading for debugger)
 
 ### Added — Real source positions in `IIRFunction.source_map`

--- a/code/packages/rust/nib-iir-compiler/Cargo.toml
+++ b/code/packages/rust/nib-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nib-iir-compiler"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Compile Nib source to InterpreterIR (IIRModule), feeding the LANG-runtime AOT/JIT pipeline.  v0.5.0: marks main function FullyTyped so the JITCore + GenericCirJit chain can run Nib programs JIT-compiled.  v0.6.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints."
 

--- a/code/packages/rust/nib-iir-compiler/src/lib.rs
+++ b/code/packages/rust/nib-iir-compiler/src/lib.rs
@@ -885,10 +885,21 @@ fn type_str_from_node(node: &GrammarASTNode) -> String {
 
 /// Map a raw Nib type name to the closest CIR-allowed type string.
 fn widen_nib_type(t: &str) -> &str {
+    // Nib's integer types all **materialise as `i64`** in the IIR — the same
+    // machine-word convention the instruction bodies already use (`compile_binary_chain`
+    // and the `ret` default both emit `"i64"`), and the model the native AOT backend
+    // runs in. Before, the *function signature* (`extract_params` / `extract_return_type`)
+    // and `let` types went through here as the narrow `"u8"` while the bodies were `i64`,
+    // leaving the IIR type-inconsistent. A strict backend then rejected it: `iir-to-llvm`
+    // faithfully emitted `define i8 @double(i8 %x)` but `add i64 %x, %x`
+    // (`'%x' defined with type 'i8' but expected 'i64'`). Materialising integers to `i64`
+    // here makes the whole function uniform (params/lets/arith/ret all `i64`), so the
+    // backend — which correctly emits *consistent* narrow types when given them
+    // (see `iir-to-llvm/tests/test_backend.rs`) — produces valid LLVM. The narrow
+    // semantic width (u4/u8 wraparound) is a backend-masking concern, deferred.
     match t {
-        "u4"  => "u8",  // Nib's nibble widens to u8 for CIR
-        "bcd" => "u8",  // BCD is byte-encoded
-        other => other, // u8, bool, void all pass through unchanged
+        "u4" | "u8" | "bcd" => "i64",
+        other => other, // bool, void, and any already-`i64` pass through unchanged
     }
 }
 

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -100,7 +100,7 @@ asserts the result** — never on "the frontend lowers to IIR so it *should* wor
 | Language        | VM | JIT | native-AOT | LLVM | WASM | JVM | CLR |
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ◑    | ◑   | ◑   |
-| Nib             | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
+| Nib             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | Brainfuck       | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
@@ -134,11 +134,18 @@ slice — the loop trusts running, not this table.)
   refactored into a `Backend`-keyed grid (each `Prog` lists its proven backends); a
   `clang`-gated LLVM runner (`.ll` → real `clang` → run) added. Verified by RUNNING:
   Twig→42, Oct→0, ALGOL `17 mod 5`→2. No C runtime needed — these link a bare `.ll`.
-- ☐ **LM-L Nib (on LLVM).** Blocked on a real `iir-to-llvm` bug the probe surfaced:
-  Nib's `u8` operands are mis-widened — `'%x' defined with type 'i8' but expected
-  'i64'` on `add`. This slice fixes the backend's integer-width coercion, then greens
-  Nib's LLVM cell. (Native AOT runs Nib fine, so the IIR is sound; only LLVM mishandles
-  the narrow type.)
+- ✅ **LM-L Nib (on LLVM).** Root cause (found by reading + running): the **Nib
+  frontend** emitted type-*inconsistent* IIR — its instruction bodies use `i64`
+  (`compile_binary_chain` and the `ret` default both emit `"i64"`; the frontend's own
+  comment says "Nib's u4/u8/bool all materialise as i64 at the IIR level") while
+  `extract_params`/`extract_return_type` left the **function signature** as the narrow
+  `u8`. `iir-to-llvm` faithfully emitted `define i8 @double(i8 %x)` but `add i64 %x, %x`
+  → `'%x' defined with type 'i8' but expected 'i64'`. (The backend is correct: its
+  `test_backend.rs` proves it emits *consistent* narrow types fine.) Fix: complete the
+  frontend's own convention — `widen_nib_type` now materialises the integer types
+  (`u4`/`u8`/`bcd`) to `i64`, so signature and bodies agree. Verified by RUNNING: Nib on
+  LLVM → 42, Nib on native still → 42 (no regression), nib-iir-compiler unit tests +
+  `iir-to-llvm` (51) all green.
 - ☐ **LM-L Brainfuck / BASIC (I/O languages on LLVM).** Need the stdout-capturing LLVM
   runner (link the C runtime providing `putchar`/`print_i64`) and assert stdout
   (`A` / `42`).


### PR DESCRIPTION
## Summary

Greens the **Nib → LLVM** cell of the language platform matrix — the first slice in this campaign to fix a backend-path bug rather than just add a test.

**Root cause (found by reading + running, not guessed):** the Nib frontend emitted type-*inconsistent* IIR. Its instruction bodies already use `i64` for integers (`compile_binary_chain` and the `ret` default both emit `"i64"`; the frontend's own comment says *"Nib's u4/u8/bool all materialise as i64 at the IIR level"*), but `extract_params` / `extract_return_type` left the **function signature** as the narrow `u8`. So `iir-to-llvm` faithfully emitted:

```llvm
define i8 @double(i8 %x) {
  %_n0 = add i64 %x, %x        ; ← '%x' defined with type 'i8' but expected 'i64'
  ret i64 %_n0
}
```

The **backend is correct** — its `test_backend.rs` proves it emits consistent narrow types (`define i32 @add(i32 %a, i32 %b)`) fine. The frontend simply wasn't following its own convention.

**Fix (one line of logic):** `widen_nib_type` now materialises the integer types (`u4`/`u8`/`bcd`) → `i64`, so the function signature and instruction bodies agree (`bool`/`void` unchanged). The Nib IIR is now uniformly `i64` for integers — matching the instruction convention, the native-AOT machine-word model, and McCarthy's lowering.

## Why the frontend, not the backend or a global widen

- `iir-to-llvm/tests/test_backend.rs` asserts `define i32 @add(i32 %a, i32 %b)` / `ret i32` — i.e. the backend MUST keep consistent narrow types. So a global "widen everything to i64" in the backend was wrong (would break those), and the backend isn't buggy.
- Native AOT already ran Nib in i64 machine words, so completing the frontend's i64 convention makes LLVM *agree* with native rather than diverging.

## Security

Review **PASSED**. This is compiler-internal type lowering, not an untrusted-input boundary. Widening `u8` arithmetic to 64-bit removes 8-bit wraparound, but Nib has no pointer/array/index/allocation constructs that derive sizes from these values, so there's no memory-safety or bounds implication — and it makes LLVM agree with the native backend (more consistent, not less safe). The narrow-width semantics (wraparound masking) remain a deferred backend concern, noted in the code.

## Test plan — verified by RUNNING

- **Nib on real `clang`:** `double(21)` → **42** (previously a clang type error).
- **Nib on native AOT:** still → **42** (no regression).
- `nib-iir-compiler` unit tests: all green. `iir-to-llvm` backend suite: **51** green (consistent-narrow-type tests unaffected — the change is in the frontend).
- `lang_matrix`: Nib now lists `Llvm`; **10 proven cells** (6 native + 4 LLVM: Twig/Nib/Oct/ALGOL) all agree.
- Nib is consumed only by native + LLVM + the matrix (no WASM/JVM/CLR Nib emit tests), so no other backend is affected.

## Versioning / docs

- `nib-iir-compiler` 0.6.0 → **0.7.0**; `lang-aot` 0.55.0 → **0.56.0**
- Spec: Nib LLVM cell ticked ✅ (LLVM column now Twig/Nib/Oct/ALGOL); both CHANGELOGs + README updated.

Next: **LM-L Brainfuck / BASIC** — the stdout-capturing LLVM I/O runner (link the C runtime), completing the LLVM column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)