### PR TITLE
Add browser form submission descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness form-submission descriptors now expose successful controls,
+  submission values, form action/method/target defaults, and submitter routing
+  overrides as a flat browser-planning inventory.
 - Browser-readiness form-validation descriptors now expose validation
   candidates, constraint attributes, barred controls, form-level `novalidate`,
   and submitter-level validation bypass hints as a flat browser-planning

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -844,6 +844,7 @@ pub struct BrowserDocument {
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
     pub resource_endpoint_descriptors: Vec<BrowserResourceEndpointDescriptor>,
     pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
+    pub form_submission_descriptors: Vec<BrowserFormSubmissionDescriptor>,
     pub form_validation_descriptors: Vec<BrowserFormValidationDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
@@ -1297,6 +1298,40 @@ pub struct BrowserComponentHydrationTarget {
 pub struct BrowserDataAttribute {
     pub name: String,
     pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormSubmissionDescriptor {
+    pub form_id: Option<String>,
+    pub form_name: Option<String>,
+    pub form_action: Option<String>,
+    pub resolved_form_action: Option<String>,
+    pub form_method: String,
+    pub form_enctype: Option<String>,
+    pub form_target: Option<String>,
+    pub effective_form_target: Option<String>,
+    pub element: String,
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub submission_kind: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub value: Option<String>,
+    pub submission_values: Vec<String>,
+    pub submission_value_count: usize,
+    pub successful: bool,
+    pub checked: bool,
+    pub disabled: bool,
+    pub submitter: bool,
+    pub submitter_action: Option<String>,
+    pub resolved_submitter_action: Option<String>,
+    pub submitter_method: Option<String>,
+    pub submitter_enctype: Option<String>,
+    pub submitter_target: Option<String>,
+    pub effective_submitter_target: Option<String>,
+    pub submitter_novalidate: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3341,6 +3376,7 @@ impl BrowserDocument {
             browser_fullscreen_interaction_descriptors(&summary);
         summary.context_menu_interaction_descriptors =
             browser_context_menu_interaction_descriptors(&summary);
+        summary.form_submission_descriptors = browser_form_submission_descriptors(&summary.forms);
         summary.form_validation_descriptors = browser_form_validation_descriptors(&summary.forms);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
@@ -19753,6 +19789,89 @@ fn browser_form_policy_submitter_descriptor(
     }
 }
 
+fn browser_form_submission_descriptors(
+    forms: &[BrowserForm],
+) -> Vec<BrowserFormSubmissionDescriptor> {
+    forms
+        .iter()
+        .flat_map(|form| {
+            form.controls
+                .iter()
+                .filter_map(|control| browser_form_submission_descriptor(form, control))
+        })
+        .collect()
+}
+
+fn browser_form_submission_descriptor(
+    form: &BrowserForm,
+    control: &BrowserFormControl,
+) -> Option<BrowserFormSubmissionDescriptor> {
+    if !control.successful && !is_browser_form_submitter(control) {
+        return None;
+    }
+
+    Some(BrowserFormSubmissionDescriptor {
+        form_id: form.id.clone(),
+        form_name: form.name.clone(),
+        form_action: form.action.clone(),
+        resolved_form_action: form.resolved_action.clone(),
+        form_method: form.method.clone(),
+        form_enctype: form.enctype.clone(),
+        form_target: form.target.clone(),
+        effective_form_target: form.effective_target.clone(),
+        element: browser_form_submission_element(control),
+        id: control.id.clone(),
+        control_type: control.control_type.clone(),
+        name: control.name.clone(),
+        form_owner: control.form_owner.clone(),
+        submission_kind: browser_form_submission_kind(control),
+        text: control.text.clone(),
+        accessible_name: control
+            .accessible_name
+            .clone()
+            .or_else(|| control.alt.clone()),
+        value: control.value.clone(),
+        submission_value_count: control.submission_values.len(),
+        submission_values: control.submission_values.clone(),
+        successful: control.successful,
+        checked: control.checked,
+        disabled: control.disabled,
+        submitter: is_browser_form_submitter(control),
+        submitter_action: control.form_action.clone(),
+        resolved_submitter_action: control.resolved_form_action.clone(),
+        submitter_method: control.form_method.clone(),
+        submitter_enctype: control.form_enctype.clone(),
+        submitter_target: control.form_target.clone(),
+        effective_submitter_target: control
+            .form_target
+            .clone()
+            .or_else(|| form.target.clone())
+            .or_else(|| form.effective_target.clone()),
+        submitter_novalidate: form.novalidate || control.form_novalidate,
+    })
+}
+
+fn browser_form_submission_kind(control: &BrowserFormControl) -> String {
+    if is_browser_form_submitter(control) && control.successful {
+        "successful-submitter".to_string()
+    } else if is_browser_form_submitter(control) {
+        "submitter".to_string()
+    } else if control.successful {
+        "successful-control".to_string()
+    } else {
+        "submission-metadata".to_string()
+    }
+}
+
+fn browser_form_submission_element(control: &BrowserFormControl) -> String {
+    match control.control_type.as_str() {
+        "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file"
+        | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset"
+        | "search" | "submit" | "tel" | "text" | "time" | "url" | "week" => "input".to_string(),
+        other => other.to_string(),
+    }
+}
+
 fn browser_form_validation_descriptors(
     forms: &[BrowserForm],
 ) -> Vec<BrowserFormValidationDescriptor> {
@@ -23670,6 +23789,91 @@ mod tests {
         assert_eq!(summary_control.target_kind, "disclosure");
         assert_eq!(summary_control.text, "More");
         assert!(summary_control.focusable);
+    }
+
+    #[test]
+    fn browser_form_submission_descriptors_track_successful_controls_and_submitters() {
+        let document = parse_browser_document(
+            "<base href=https://example.test/app/>\
+             <form id=checkout name=checkout action=pay method=post target=receipt>\
+             <input id=item name=item value=book>\
+             <input id=gift name=gift type=checkbox value=yes checked>\
+             <input id=off name=off type=checkbox value=no>\
+             <select id=ship name=ship><option value=ground selected>Ground</option><option value=air>Air</option></select>\
+             <textarea id=note name=note>Leave at door</textarea>\
+             <input id=upload name=upload type=file>\
+             <button id=pay name=pay value=now formaction=pay-now formtarget=fast formnovalidate>Pay</button>\
+             <input id=imagePay type=image name=spot src=pay.png alt=Pay image>\
+             <input id=disabled name=disabled value=no disabled>\
+             </form>\
+             <input id=external form=checkout name=outside value=extra>",
+        )
+        .expect("form submission descriptor document should parse");
+
+        let descriptors = &document.form_submission_descriptors;
+        let ids: Vec<&str> = descriptors
+            .iter()
+            .filter_map(|descriptor| descriptor.id.as_deref())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["item", "gift", "ship", "note", "upload", "pay", "imagePay", "external"]
+        );
+
+        let item = &descriptors[0];
+        assert_eq!(item.form_id.as_deref(), Some("checkout"));
+        assert_eq!(item.form_name.as_deref(), Some("checkout"));
+        assert_eq!(item.form_action.as_deref(), Some("pay"));
+        assert_eq!(
+            item.resolved_form_action.as_deref(),
+            Some("https://example.test/app/pay")
+        );
+        assert_eq!(item.form_method, "post");
+        assert_eq!(item.effective_form_target.as_deref(), Some("receipt"));
+        assert_eq!(item.element, "input");
+        assert_eq!(item.control_type, "text");
+        assert_eq!(item.submission_kind, "successful-control");
+        assert_eq!(item.value.as_deref(), Some("book"));
+        assert_eq!(item.submission_values, vec!["book"]);
+        assert_eq!(item.submission_value_count, 1);
+        assert!(item.successful);
+        assert!(!item.submitter);
+
+        let gift = &descriptors[1];
+        assert_eq!(gift.control_type, "checkbox");
+        assert!(gift.checked);
+        assert_eq!(gift.submission_values, vec!["yes"]);
+
+        let ship = &descriptors[2];
+        assert_eq!(ship.element, "select");
+        assert_eq!(ship.submission_values, vec!["ground"]);
+
+        let upload = &descriptors[4];
+        assert_eq!(upload.control_type, "file");
+        assert!(upload.submission_values.is_empty());
+        assert_eq!(upload.submission_value_count, 0);
+
+        let pay = &descriptors[5];
+        assert_eq!(pay.submission_kind, "submitter");
+        assert!(pay.submitter);
+        assert_eq!(pay.submitter_action.as_deref(), Some("pay-now"));
+        assert_eq!(
+            pay.resolved_submitter_action.as_deref(),
+            Some("https://example.test/app/pay-now")
+        );
+        assert_eq!(pay.submitter_target.as_deref(), Some("fast"));
+        assert_eq!(pay.effective_submitter_target.as_deref(), Some("fast"));
+        assert!(pay.submitter_novalidate);
+
+        let image = &descriptors[6];
+        assert_eq!(image.control_type, "image");
+        assert_eq!(image.accessible_name.as_deref(), Some("Pay"));
+        assert_eq!(image.submission_kind, "submitter");
+        assert!(image.submitter);
+
+        let external = &descriptors[7];
+        assert_eq!(external.form_owner.as_deref(), Some("checkout"));
+        assert_eq!(external.submission_values, vec!["extra"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -12,22 +12,22 @@ use coding_adventures_html_parser::{
     BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
     BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
     BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserFormValidationDescriptor, BrowserFullscreenInteractionDescriptor,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInputPlanningDescriptor, BrowserInteractiveElement,
-    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
-    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
-    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
-    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmissionDescriptor,
+    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
+    BrowserFormValidationControl, BrowserFormValidationDescriptor,
+    BrowserFullscreenInteractionDescriptor, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
+    BrowserImageMapArea, BrowserImageSource, BrowserInputPlanningDescriptor,
+    BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
+    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserScrollInteractionDescriptor, BrowserSectionLandmark,
+    BrowserSelectOption, BrowserSelectionInteractionDescriptor, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
+    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -101,6 +101,8 @@ struct ExpectedBrowserDocument {
     resource_endpoint_descriptors: Option<Vec<ExpectedResourceEndpointDescriptor>>,
     #[serde(default)]
     form_policy_descriptors: Vec<ExpectedFormPolicyDescriptor>,
+    #[serde(default)]
+    form_submission_descriptors: Option<Vec<ExpectedFormSubmissionDescriptor>>,
     #[serde(default)]
     form_validation_descriptors: Option<Vec<ExpectedFormValidationDescriptor>>,
     anchors: Vec<ExpectedAnchor>,
@@ -889,6 +891,66 @@ struct ExpectedFormPolicySubmitterDescriptor {
     novalidate: bool,
     #[serde(default)]
     value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormSubmissionDescriptor {
+    #[serde(default)]
+    form_id: Option<String>,
+    #[serde(default)]
+    form_name: Option<String>,
+    #[serde(default)]
+    form_action: Option<String>,
+    #[serde(default)]
+    resolved_form_action: Option<String>,
+    form_method: String,
+    #[serde(default)]
+    form_enctype: Option<String>,
+    #[serde(default)]
+    form_target: Option<String>,
+    #[serde(default)]
+    effective_form_target: Option<String>,
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    submission_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    submission_values: Vec<String>,
+    #[serde(default)]
+    submission_value_count: usize,
+    #[serde(default)]
+    successful: bool,
+    #[serde(default)]
+    checked: bool,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    submitter: bool,
+    #[serde(default)]
+    submitter_action: Option<String>,
+    #[serde(default)]
+    resolved_submitter_action: Option<String>,
+    #[serde(default)]
+    submitter_method: Option<String>,
+    #[serde(default)]
+    submitter_enctype: Option<String>,
+    #[serde(default)]
+    submitter_target: Option<String>,
+    #[serde(default)]
+    effective_submitter_target: Option<String>,
+    #[serde(default)]
+    submitter_novalidate: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4267,6 +4329,26 @@ fn browser_form_successful_control_descriptor_metadata_tracks_submission_entries
 }
 
 #[test]
+fn browser_form_submission_descriptors_track_flat_successful_controls_and_submitters() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "form-accessibility-document-page")
+        .expect("form accessibility fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("form submission descriptor fixture should parse");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.form_submission_descriptors, expected.form_submission_descriptors,
+        "form submission descriptors should flatten successful controls and submitter routing",
+    );
+}
+
+#[test]
 fn browser_form_hidden_descriptor_metadata_tracks_hidden_entries_and_form_owners() {
     let document = parse_browser_document(
         "<form id=session>\
@@ -5530,6 +5612,15 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedForm::into_browser_form)
             .collect();
+        let form_submission_descriptors = self
+            .form_submission_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedFormSubmissionDescriptor::into_browser_form_submission_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_form_submission_descriptors(&forms));
         let form_validation_descriptors = self
             .form_validation_descriptors
             .map(|descriptors| {
@@ -5758,6 +5849,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedFormPolicyDescriptor::into_browser_form_policy_descriptor)
                 .collect(),
+            form_submission_descriptors,
             form_validation_descriptors,
             anchors: self
                 .anchors
@@ -10562,6 +10654,133 @@ impl ExpectedFormPolicySubmitterDescriptor {
             novalidate: self.novalidate,
             value: self.value,
         }
+    }
+}
+
+impl ExpectedFormSubmissionDescriptor {
+    fn into_browser_form_submission_descriptor(self) -> BrowserFormSubmissionDescriptor {
+        BrowserFormSubmissionDescriptor {
+            form_id: self.form_id,
+            form_name: self.form_name,
+            form_action: self.form_action,
+            resolved_form_action: self.resolved_form_action,
+            form_method: self.form_method,
+            form_enctype: self.form_enctype,
+            form_target: self.form_target,
+            effective_form_target: self.effective_form_target,
+            element: self.element,
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            submission_kind: self.submission_kind,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            value: self.value,
+            submission_values: self.submission_values,
+            submission_value_count: self.submission_value_count,
+            successful: self.successful,
+            checked: self.checked,
+            disabled: self.disabled,
+            submitter: self.submitter,
+            submitter_action: self.submitter_action,
+            resolved_submitter_action: self.resolved_submitter_action,
+            submitter_method: self.submitter_method,
+            submitter_enctype: self.submitter_enctype,
+            submitter_target: self.submitter_target,
+            effective_submitter_target: self.effective_submitter_target,
+            submitter_novalidate: self.submitter_novalidate,
+        }
+    }
+}
+
+fn expected_form_submission_descriptors(
+    forms: &[BrowserForm],
+) -> Vec<BrowserFormSubmissionDescriptor> {
+    forms
+        .iter()
+        .flat_map(|form| {
+            form.controls
+                .iter()
+                .filter_map(|control| expected_form_submission_descriptor(form, control))
+        })
+        .collect()
+}
+
+fn expected_form_submission_descriptor(
+    form: &BrowserForm,
+    control: &BrowserFormControl,
+) -> Option<BrowserFormSubmissionDescriptor> {
+    if !control.successful && !expected_form_submitter(control) {
+        return None;
+    }
+
+    Some(BrowserFormSubmissionDescriptor {
+        form_id: form.id.clone(),
+        form_name: form.name.clone(),
+        form_action: form.action.clone(),
+        resolved_form_action: form.resolved_action.clone(),
+        form_method: form.method.clone(),
+        form_enctype: form.enctype.clone(),
+        form_target: form.target.clone(),
+        effective_form_target: form.effective_target.clone(),
+        element: expected_form_submission_element(control),
+        id: control.id.clone(),
+        control_type: control.control_type.clone(),
+        name: control.name.clone(),
+        form_owner: control.form_owner.clone(),
+        submission_kind: expected_form_submission_kind(control),
+        text: control.text.clone(),
+        accessible_name: control
+            .accessible_name
+            .clone()
+            .or_else(|| control.alt.clone()),
+        value: control.value.clone(),
+        submission_value_count: control.submission_values.len(),
+        submission_values: control.submission_values.clone(),
+        successful: control.successful,
+        checked: control.checked,
+        disabled: control.disabled,
+        submitter: expected_form_submitter(control),
+        submitter_action: control.form_action.clone(),
+        resolved_submitter_action: control.resolved_form_action.clone(),
+        submitter_method: control.form_method.clone(),
+        submitter_enctype: control.form_enctype.clone(),
+        submitter_target: control.form_target.clone(),
+        effective_submitter_target: control
+            .form_target
+            .clone()
+            .or_else(|| form.target.clone())
+            .or_else(|| form.effective_target.clone()),
+        submitter_novalidate: form.novalidate || control.form_novalidate,
+    })
+}
+
+fn expected_form_submission_kind(control: &BrowserFormControl) -> String {
+    if expected_form_submitter(control) && control.successful {
+        "successful-submitter".to_string()
+    } else if expected_form_submitter(control) {
+        "submitter".to_string()
+    } else if control.successful {
+        "successful-control".to_string()
+    } else {
+        "submission-metadata".to_string()
+    }
+}
+
+fn expected_form_submitter(control: &BrowserFormControl) -> bool {
+    matches!(
+        control.control_type.as_str(),
+        "submit" | "image" | "button" | "reset"
+    )
+}
+
+fn expected_form_submission_element(control: &BrowserFormControl) -> String {
+    match control.control_type.as_str() {
+        "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file"
+        | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset"
+        | "search" | "submit" | "tel" | "text" | "time" | "url" | "week" => "input".to_string(),
+        other => other.to_string(),
     }
 }
 

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -38,6 +38,9 @@ Resource-endpoint descriptor cases pin refresh redirects plus resolved document
 resources as a flat endpoint inventory for fetch/navigation planning.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel
 policy tokens, validation bypass state, and submitter overrides.
+Form-submission descriptor cases pin successful controls, submission values,
+form action/method/target defaults, and submitter routing overrides as a flat
+browser-planning inventory.
 Form-validation descriptor cases pin validation candidates, constraint
 attributes, barred controls, form-level `novalidate`, and submitter-level
 validation bypass hints as a flat browser-planning inventory.


### PR DESCRIPTION
## Summary
- add BrowserFormSubmissionDescriptor and populate BrowserDocument with a flat form submission inventory
- expose successful controls, submission values, form defaults, and submitter routing overrides
- wire expected browser-readiness fixture derivation and docs for the new descriptor slice

## Tests
- cargo fmt -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_form_submission_descriptors
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser