### PR TITLE
feat(lang-matrix): LM-L BASIC — Dartmouth BASIC on LLVM (stdout path)

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — `lang-aot`
 
+## 0.57.0 — 2026-06-11 — Dartmouth BASIC on LLVM (stdout path) (LANG-MATRIX LM-L BASIC)
+
+Greens **Dartmouth BASIC on LLVM**, the first I/O language in the LLVM column. The
+`lang_matrix` `run_llvm` runner grew a stdout path: a BASIC program's `.ll` emits
+`call void @__print_i64(i64 42)`, so when the emitted `.ll` references `@__print_i64`
+the runner compiles in a tiny **generic** `__print_i64` C runtime (the LLVM analog of
+wasm's `env.__print_i64` / JVM `BasicRuntime.println(J)V` / CLR `Console.WriteLine`)
+and the harness compares the program's **stdout**. Verified by RUNNING: `10 PRINT 42`
+→ stdout `42` on real `clang`. The LLVM column is now green for Twig / Nib / Oct /
+ALGOL 60 / BASIC; only **Brainfuck** remains — it needs the tape ops
+(`alloc_bytes`/`load_byte`/`store_byte` + `putchar`) added to `iir-to-llvm`, a backend
+codegen slice. (Test-only change; the print runtime links only when a program
+actually prints, so the bare expression-language cells are unaffected.)
+
 ## 0.56.0 — 2026-06-11 — Nib joins the LLVM column (LANG-MATRIX LM-L Nib)
 
 `lang_matrix.rs` greens **Nib on LLVM** — the `Nib` program now lists `Llvm` among its

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -125,11 +125,11 @@ proof the platform is complete and uniform.
 backend, asserted by running. The **native-AOT** column is uniformly green — all six
 non-Lisp languages (Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, ALGOL 60) compile to a
 host executable and produce the right result (exit code for the expression languages;
-stdout for the I/O languages). The **LLVM** column is green for the expression
-languages Twig / Nib / Oct / ALGOL 60 (textual `.ll` → real `clang` → run);
-Brainfuck/BASIC pend the stdout-capturing LLVM I/O runner. The WASM/JVM/CLR columns
-follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
-op-coverage work.
+stdout for the I/O languages). The **LLVM** column is green for Twig / Nib / Oct /
+ALGOL 60 (exit code) and Dartmouth BASIC (stdout, via a generic `__print_i64`
+runtime); only Brainfuck pends — `iir-to-llvm` needs the tape ops. The WASM/JVM/CLR
+columns follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and
+need op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -13,8 +13,10 @@
 //! * **native-AOT** (LM0) — source → shared IIR → host object → system linker → run.
 //!   Uniformly green: all six languages.
 //! * **LLVM** (Phase L) — source → textual `.ll` (`iir-to-llvm`) → real `clang` → run.
-//!   Green for the expression languages Twig / Nib / Oct / ALGOL 60; Brainfuck/BASIC
-//!   pend the stdout-capturing LLVM I/O runner.
+//!   Green for Twig / Nib / Oct / ALGOL 60 (exit code) and Dartmouth BASIC (stdout —
+//!   the `.ll`'s `@__print_i64` is satisfied by a generic print runtime). Only
+//!   Brainfuck pends: `iir-to-llvm` lacks the tape ops (`alloc_bytes`/`load_byte`/
+//!   `store_byte` + `putchar`), a backend codegen slice.
 //!
 //! Later slices add the WASM / JVM / CLR columns (also general code generators) and
 //! tackle the two McCarthy-specialized backends — VM and JIT — which need
@@ -97,7 +99,8 @@ const PROGRAMS: &[Prog] = &[
         backends: &[NativeAot, Llvm],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
-    // (LLVM column pending: needs the stdout-capturing I/O runner — a later slice.)
+    // (LLVM column pending: `iir-to-llvm` lacks the tape ops `alloc_bytes`/`load_byte`/
+    // `store_byte` + `putchar` — a backend codegen slice of its own.)
     Prog {
         lang: Language::Brainfuck,
         ext: "bf",
@@ -105,13 +108,15 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("A"),
         backends: &[NativeAot],
     },
-    // Dartmouth BASIC — `PRINT 42` writes `42` to stdout.
+    // Dartmouth BASIC — `PRINT 42` writes `42` to stdout. On LLVM the `.ll` emits
+    // `call void @__print_i64(i64 42)`, so `run_llvm` links the generic print runtime
+    // and the harness compares stdout (LM-L BASIC).
     Prog {
         lang: Language::DartmouthBasic,
         ext: "bas",
         src: "10 PRINT 42\n20 END\n",
         expect: Expect::Stdout("42"),
-        backends: &[NativeAot],
+        backends: &[NativeAot, Llvm],
     },
 ];
 
@@ -201,12 +206,24 @@ fn clang_ok() -> bool {
         .unwrap_or(false)
 }
 
+/// A minimal C runtime providing the generic `__print_i64` primitive that
+/// `iir-to-llvm` emits for a `print_i64` builtin (Dartmouth BASIC's `PRINT` is the
+/// first user — the same convention as wasm's `env.__print_i64` / JVM's
+/// `BasicRuntime.println(J)V` / CLR's `Console.WriteLine(int64)`). It is *not*
+/// language-specific: any IIR that calls `print_i64` links it. Linked only when the
+/// emitted `.ll` actually references `@__print_i64`, so the bare expression-language
+/// programs still link a standalone `.ll`.
+const PRINT_RUNTIME_C: &str =
+    "#include <stdio.h>\n#include <stdint.h>\nvoid __print_i64(int64_t x){printf(\"%lld\\n\",(long long)x);}\n";
+
 /// LLVM runner: source → textual `.ll` (`iir-to-llvm`) → real `clang` → run, the
 /// exact CLR-real/McCarthy strategy of handing symbolic code to the real toolchain.
-/// `None` when `clang` is absent or the build fails (skip). Exit-code programs only
-/// (the expression languages); the I/O languages get their stdout-capturing LLVM
-/// runner — which links the C runtime — in a later slice. The expression languages
-/// need no runtime (verified: Twig/Oct/ALGOL link a bare `.ll` standalone).
+/// `None` when `clang` is absent or the build fails (skip).
+///
+/// Handles both result kinds: the expression languages return an exit code from a
+/// bare `.ll`; an I/O language (Dartmouth BASIC) emits `call void @__print_i64(...)`,
+/// so when the `.ll` references that symbol the generic `PRINT_RUNTIME_C` is compiled
+/// in and the harness compares the program's **stdout**.
 ///
 /// Same temp-file hardening as `run_native`: a fresh `tempfile::tempdir()` whose
 /// guard outlives the run, so the executed `prog` cannot be substituted (CWE-377/367).
@@ -225,14 +242,15 @@ fn run_llvm(p: &Prog) -> Option<(Option<i32>, String)> {
     let ll_path = dir.path().join("prog.ll");
     std::fs::write(&ll_path, &ll).ok()?;
     let exe = dir.path().join("prog");
-    let built = Command::new("clang")
-        .arg("-x")
-        .arg("ir")
-        .arg(&ll_path)
-        .arg("-o")
-        .arg(&exe)
-        .output()
-        .ok()?;
+    let mut cmd = Command::new("clang");
+    cmd.arg("-x").arg("ir").arg(&ll_path);
+    // Link the generic print runtime iff the program actually prints.
+    if ll.contains("@__print_i64") {
+        let rt_path = dir.path().join("rt.c");
+        std::fs::write(&rt_path, PRINT_RUNTIME_C).ok()?;
+        cmd.arg("-x").arg("c").arg(&rt_path);
+    }
+    let built = cmd.arg("-x").arg("none").arg("-o").arg(&exe).output().ok()?;
     if !built.status.success() {
         return None;
     }

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -102,7 +102,7 @@ asserts the result** — never on "the frontend lowers to IIR so it *should* wor
 | Twig            | ☐  | ☐   | ✅        | ✅   | ◑    | ◑   | ◑   |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | Brainfuck       | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
-| Dartmouth BASIC | ☐  | ☐   | ✅        | ☐    | ☐    | ☐   | ☐   |
+| Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 
@@ -146,9 +146,16 @@ slice — the loop trusts running, not this table.)
   (`u4`/`u8`/`bcd`) to `i64`, so signature and bodies agree. Verified by RUNNING: Nib on
   LLVM → 42, Nib on native still → 42 (no regression), nib-iir-compiler unit tests +
   `iir-to-llvm` (51) all green.
-- ☐ **LM-L Brainfuck / BASIC (I/O languages on LLVM).** Need the stdout-capturing LLVM
-  runner (link the C runtime providing `putchar`/`print_i64`) and assert stdout
-  (`A` / `42`).
+- ✅ **LM-L BASIC (on LLVM).** `run_llvm` grew the stdout path: BASIC's `.ll` emits
+  `call void @__print_i64(i64 42)`, so when the `.ll` references `@__print_i64` the
+  runner compiles in a generic `__print_i64` C runtime and the harness compares
+  **stdout**. Verified by RUNNING: `10 PRINT 42` → stdout `42` on real `clang`.
+- ☐ **LM-L Brainfuck (on LLVM).** A backend codegen slice: `iir-to-llvm` does **not**
+  support the Brainfuck tape ops — emit fails with
+  `UnsupportedOp: "alloc_bytes" / "load_byte" / "store_byte"`. Grow `iir-to-llvm` to
+  lower the tape (`alloc_bytes` → an `i8` array / `alloca`+`memset`, `load_byte`/
+  `store_byte` → `getelementptr`+`load`/`store`) and `putchar`, mirroring how the
+  native backend already runs Brainfuck; then assert stdout `A`.
 
 ### Phase V — VM op-coverage for every language
 


### PR DESCRIPTION
## Summary

Greens **Dartmouth BASIC → LLVM**, the first I/O (stdout-producing) language in the LLVM column. The `lang_matrix` `run_llvm` runner grew a stdout path:

- A BASIC program's `.ll` emits `call void @__print_i64(i64 42)`. When the emitted `.ll` references `@__print_i64`, the runner compiles in a tiny **generic** `__print_i64` C runtime (`printf("%lld\n", x)`) alongside the `.ll` (`clang -x ir prog.ll -x c rt.c -x none -o prog`) and the harness compares the program's **stdout**.
- The runtime is the LLVM analog of wasm's `env.__print_i64` / JVM `BasicRuntime.println(J)V` / CLR `Console.WriteLine(int64)` — a generic IIR print primitive, not BASIC-specific. It links **only** when a program actually prints, so the bare expression-language cells (Twig/Nib/Oct/ALGOL) still link a standalone `.ll`, unchanged.

**Verified by running:** `10 PRINT 42` → stdout `42` on real `clang`. **11 proven matrix cells** now pass (6 native + 5 LLVM: Twig/Nib/Oct/ALGOL/BASIC).

## Why Brainfuck is a separate slice

Probing surfaced that **Brainfuck on LLVM fails at emit**, not link: `iir-to-llvm` doesn't support the tape ops — `UnsupportedOp: "alloc_bytes" / "load_byte" / "store_byte"`. That's a real backend codegen addition (lower the tape to an `i8` array + `getelementptr`/`load`/`store`, plus `putchar`), so per "slice further if large" it's its own slice. The spec's `LM-L Brainfuck` item is refined accordingly.

## Security

Review **PASSED**. Test-only. Same hardened `tempfile::tempdir()` flow (random `0700`, guard outlives the run — CWE-377/367 safe); `clang` gets fixed flags + `PathBuf` args (no shell); the embedded C runtime is a compile-time `&'static str` with a **literal** `printf` format (`"%lld\n"`) whose only argument is the compiled in-repo BASIC literal `42` — no untrusted data, no format-string issue.

## Test plan

- `cargo test --test lang_matrix` → both tests pass: BASIC `PRINT 42` → stdout `42` on real clang; 11 cells exercised, all agree. Skips gracefully when clang absent.
- Clippy clean.

## Versioning / docs

- `lang-aot` 0.56.0 → **0.57.0**
- Spec: BASIC LLVM cell ticked ✅ (LLVM column now Twig/Nib/Oct/ALGOL/BASIC); the Brainfuck-LLVM item refined to name the missing backend ops; CHANGELOG + README updated.

Next: **LM-L Brainfuck** — add the tape ops to `iir-to-llvm`, completing the LLVM column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)