### PR TITLE
Add smart-home activation operator queue tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -67,6 +67,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation playbook planning:
   `smart_home.list_integration_activation_playbook` and
   `smart_home.get_integration_activation_playbook_summary`.
+- Added D18D handlers for D23A activation operator queue planning:
+  `smart_home.list_integration_activation_operator_queue` and
+  `smart_home.get_integration_activation_operator_queue_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -57,6 +57,7 @@ Chief of Staff job/session/agent
   -> activation-timeline list and summary reads for ordered wave milestones
   -> activation-forecast list and summary reads for next-action wave planning
   -> activation-playbook list and summary reads for operator-ready planning steps
+  -> activation-operator queue list and summary reads for actionable work
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -122,6 +123,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_forecast_summary`
 - `smart_home.list_integration_activation_playbook`
 - `smart_home.get_integration_activation_playbook_summary`
+- `smart_home.list_integration_activation_operator_queue`
+- `smart_home.get_integration_activation_operator_queue_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -40,38 +40,40 @@ use smart_home_integration_catalog::{
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
     activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
     activation_health_from_candidates, activation_maintenance_from_candidates,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
-    describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
-    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
-    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationDashboardCard,
-    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
-    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
-    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
-    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
-    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
-    IntegrationActivationForecastSummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    activation_operator_tasks_from_playbook_steps, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
+    activation_readouts_from_candidates, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates,
+    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
+    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
+    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
+    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
+    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
+    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
+    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
+    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
     IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
@@ -259,6 +261,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID: &str =
     "smart_home.list_integration_activation_playbook";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_playbook_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_operator_queue";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_operator_queue_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -555,6 +561,18 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID => {
                     let query = integration_activation_playbook_query(&arguments)?;
                     Ok(get_integration_activation_playbook_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID => {
+                    let query = integration_activation_operator_queue_query(&arguments)?;
+                    Ok(list_integration_activation_operator_queue_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_operator_queue_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_operator_queue_summary_output_handler_output(
+                            query,
+                        ),
+                    )
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -1874,6 +1892,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation playbook summary",
             "Return compact D23A activation playbook counts for operator work, recommended planning views, blockers, review work, activation, and monitoring.",
             integration_activation_playbook_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
+            "List smart-home integration activation operator queue",
+            "List D23A activation operator queue tasks derived from playbook steps, including next human action kind, recommended view, and actionable flags.",
+            integration_activation_operator_queue_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_operator_queue", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_operator_queue",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation operator queue summary",
+            "Return compact D23A activation operator queue counts for actionable work, blockers, review work, activation, and monitor tasks.",
+            integration_activation_operator_queue_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4559,6 +4611,17 @@ struct IntegrationActivationPlaybookQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationOperatorQueueQuery {
+    playbook: IntegrationActivationPlaybookQuery,
+    task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    recommended_view: Option<IntegrationActivationPlaybookView>,
+    operator_required: Option<bool>,
+    actionable: Option<bool>,
+    include_monitor: bool,
+    task_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4886,6 +4949,28 @@ fn integration_activation_playbook_query(
         recommended_view,
         operator_required: optional_bool(arguments, "operator_required")?,
         playbook_limit: optional_u64(arguments, "playbook_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_operator_queue_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationOperatorQueueQuery, ToolCallError> {
+    let task_kind = optional_string(arguments, "operator_task_kind")?
+        .or(optional_string(arguments, "task_kind")?)
+        .map(|label| parse_activation_operator_task_kind(&label))
+        .transpose()?;
+    let recommended_view = optional_string(arguments, "operator_view")?
+        .map(|label| parse_activation_playbook_view(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationOperatorQueueQuery {
+        playbook: integration_activation_playbook_query(arguments)?,
+        task_kind,
+        recommended_view,
+        operator_required: optional_bool(arguments, "queue_operator_required")?,
+        actionable: optional_bool(arguments, "actionable")?,
+        include_monitor: optional_bool(arguments, "include_monitor")?.unwrap_or(false),
+        task_limit: optional_u64(arguments, "task_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5512,6 +5597,34 @@ fn integration_activation_playbook_steps_for_query(
     }
 
     (steps, catalog_count)
+}
+
+fn integration_activation_operator_tasks_for_query(
+    query: &IntegrationActivationOperatorQueueQuery,
+) -> (Vec<IntegrationActivationOperatorTask>, usize) {
+    let (steps, catalog_count) = integration_activation_playbook_steps_for_query(&query.playbook);
+    let mut tasks = activation_operator_tasks_from_playbook_steps(steps);
+
+    if !query.include_monitor {
+        tasks.retain(|task| !task.monitor_only());
+    }
+    if let Some(kind) = query.task_kind {
+        tasks.retain(|task| task.task_kind == kind);
+    }
+    if let Some(view) = query.recommended_view {
+        tasks.retain(|task| task.recommended_view == view);
+    }
+    if let Some(operator_required) = query.operator_required {
+        tasks.retain(|task| task.operator_required() == operator_required);
+    }
+    if let Some(actionable) = query.actionable {
+        tasks.retain(|task| task.actionable() == actionable);
+    }
+    if let Some(limit) = query.task_limit {
+        tasks.truncate(limit);
+    }
+
+    (tasks, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -7139,6 +7252,83 @@ fn get_integration_activation_playbook_summary_output_handler_output(
                 summary
                     .next_recommended_view
                     .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_operator_queue_output_handler_output(
+    query: IntegrationActivationOperatorQueueQuery,
+) -> ToolHandlerOutput {
+    let (tasks, catalog_count) = integration_activation_operator_tasks_for_query(&query);
+    let summary = IntegrationActivationOperatorTaskSummary::from_tasks(tasks.iter());
+    let count = tasks.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_operator_queue",
+            JsonValue::Array(tasks.iter().map(activation_operator_task_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_operator_queue_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_operator_queue"),
+            ),
+            ("operator_tasks", integer(count as i64)),
+            ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+            (
+                "operator_required_tasks",
+                integer(summary.operator_required_tasks as i64),
+            ),
+            (
+                "next_task_kind",
+                summary
+                    .next_task_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_operator_queue_summary_output_handler_output(
+    query: IntegrationActivationOperatorQueueQuery,
+) -> ToolHandlerOutput {
+    let (tasks, _) = integration_activation_operator_tasks_for_query(&query);
+    let summary = IntegrationActivationOperatorTaskSummary::from_tasks(tasks.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_operator_queue_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_operator_queue_summary"),
+            ),
+            ("total_tasks", integer(summary.total_tasks as i64)),
+            ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+            (
+                "operator_required_tasks",
+                integer(summary.operator_required_tasks as i64),
+            ),
+            (
+                "next_task_kind",
+                summary
+                    .next_task_kind
+                    .map(|kind| string(kind.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -13353,6 +13543,265 @@ fn integration_activation_playbook_summary_json(
     ])
 }
 
+fn activation_operator_task_json(task: &IntegrationActivationOperatorTask) -> JsonValue {
+    object([
+        ("sequence", integer(task.sequence as i64)),
+        ("playbook_sequence", integer(task.playbook_sequence as i64)),
+        ("priority", integer(task.priority as i64)),
+        ("task_kind", string(task.task_kind.as_str())),
+        ("playbook_action", string(task.playbook_action.as_str())),
+        ("recommended_view", string(task.recommended_view.as_str())),
+        (
+            "milestone_kind",
+            task.milestone_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("health_status", string(task.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                task.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(task.integration_count() as i64),
+        ),
+        ("action_count", integer(task.action_count as i64)),
+        ("dossier_count", integer(task.dossier_count as i64)),
+        ("evidence_count", integer(task.evidence_count as i64)),
+        ("risk_count", integer(task.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(task.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(task.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(task.highest_policy_tier)),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(task.operator_required()),
+        ),
+        ("actionable", JsonValue::Bool(task.actionable())),
+        ("activation_ready", JsonValue::Bool(task.activation_ready())),
+        ("blocked", JsonValue::Bool(task.blocked())),
+        ("review_required", JsonValue::Bool(task.review_required())),
+        ("monitor_only", JsonValue::Bool(task.monitor_only())),
+        (
+            "requires_attention",
+            JsonValue::Bool(task.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_operator_queue_summary_json(
+    summary: &IntegrationActivationOperatorTaskSummary,
+) -> JsonValue {
+    object([
+        ("total_tasks", integer(summary.total_tasks as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "operator_required_tasks",
+            integer(summary.operator_required_tasks as i64),
+        ),
+        ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+        (
+            "activation_ready_tasks",
+            integer(summary.activation_ready_tasks as i64),
+        ),
+        ("blocked_tasks", integer(summary.blocked_tasks as i64)),
+        (
+            "review_required_tasks",
+            integer(summary.review_required_tasks as i64),
+        ),
+        ("monitor_tasks", integer(summary.monitor_tasks as i64)),
+        (
+            "resolve_constraint_tasks",
+            integer(summary.resolve_constraint_tasks as i64),
+        ),
+        (
+            "enable_dependency_tasks",
+            integer(summary.enable_dependency_tasks as i64),
+        ),
+        (
+            "prepare_approval_tasks",
+            integer(summary.prepare_approval_tasks as i64),
+        ),
+        (
+            "complete_review_tasks",
+            integer(summary.complete_review_tasks as i64),
+        ),
+        (
+            "review_risk_tasks",
+            integer(summary.review_risk_tasks as i64),
+        ),
+        (
+            "activate_wave_tasks",
+            integer(summary.activate_wave_tasks as i64),
+        ),
+        (
+            "monitor_wave_tasks",
+            integer(summary.monitor_wave_tasks as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_sequence",
+            summary
+                .next_task_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_priority",
+            summary
+                .next_task_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_sequence",
+            summary
+                .first_operator_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_sequence",
+            summary
+                .first_actionable_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_sequence",
+            summary
+                .first_activation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_priority",
+            summary
+                .first_operator_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_priority",
+            summary
+                .first_actionable_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(summary.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -15986,6 +16435,37 @@ fn parse_activation_playbook_view(
     }
 }
 
+fn parse_activation_operator_task_kind(
+    label: &str,
+) -> Result<IntegrationActivationOperatorTaskKind, ToolCallError> {
+    match label {
+        "resolve_constraints"
+        | "resolve_constraint"
+        | "resolve_blockers"
+        | "constraints"
+        | "blockers" => Ok(IntegrationActivationOperatorTaskKind::ResolveConstraints),
+        "enable_dependencies" | "enable_dependency" | "dependencies" | "dependency" => {
+            Ok(IntegrationActivationOperatorTaskKind::EnableDependencies)
+        }
+        "prepare_approval" | "approval" | "approve" | "ready_to_approve" => {
+            Ok(IntegrationActivationOperatorTaskKind::PrepareApproval)
+        }
+        "complete_review" | "queue_review" | "review" | "human_review" | "policy_review" => {
+            Ok(IntegrationActivationOperatorTaskKind::CompleteReview)
+        }
+        "review_risk" | "risk" | "risks" => Ok(IntegrationActivationOperatorTaskKind::ReviewRisk),
+        "activate_wave" | "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationOperatorTaskKind::ActivateWave)
+        }
+        "monitor_wave" | "monitor" | "watch" => {
+            Ok(IntegrationActivationOperatorTaskKind::MonitorWave)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation operator task kind `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -17074,6 +17554,31 @@ fn integration_activation_playbook_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_operator_queue_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_playbook_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new(
+            "operator_task_kind",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("task_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("operator_view", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "queue_operator_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("actionable", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("include_monitor", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("task_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -17218,7 +17723,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 97);
+        assert_eq!(definitions.len(), 99);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -17477,9 +17982,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            89
+            91
         );
         assert_eq!(
             export
@@ -17663,6 +18174,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -17917,11 +18436,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(97))
+            Some(&integer(99))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(89))
+            Some(&integer(91))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -20512,6 +21031,153 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_operator_queue_request = request(
+            "call-list-integration-activation-operator-queue",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("actionable", JsonValue::Bool(true)),
+                ("task_limit", integer(3)),
+            ]),
+            5_031,
+        );
+        let list_activation_operator_queue_trace =
+            tool_runtime.invoke_with_events(&list_activation_operator_queue_request);
+        assert!(list_activation_operator_queue_trace.result.ok);
+        assert_eq!(
+            list_activation_operator_queue_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_operator_queue_output = list_activation_operator_queue_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_operator_queue_count =
+            integer_value(field(list_activation_operator_queue_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_operator_queue_count));
+        let activation_operator_queue_summary =
+            field(list_activation_operator_queue_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_operator_queue_summary, "total_tasks"),
+            Some(&integer(activation_operator_queue_count))
+        );
+        assert!(
+            integer_value(field(activation_operator_queue_summary, "actionable_tasks").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_operator_queue_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_operator_task = array_item(
+            field(
+                list_activation_operator_queue_output,
+                "activation_operator_queue",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_operator_task, "sequence").is_some());
+        assert!(field(activation_operator_task, "playbook_sequence").is_some());
+        assert!(field(activation_operator_task, "task_kind").is_some());
+        assert!(field(activation_operator_task, "playbook_action").is_some());
+        assert!(field(activation_operator_task, "recommended_view").is_some());
+        assert_eq!(
+            field(activation_operator_task, "actionable"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_operator_task, "monitor_only"),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let activation_operator_queue_summary_request = request(
+            "call-integration-activation-operator-queue-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("operator_task_kind", string("resolve_constraints")),
+                ("queue_operator_required", JsonValue::Bool(true)),
+            ]),
+            5_032,
+        );
+        let activation_operator_queue_summary_trace =
+            tool_runtime.invoke_with_events(&activation_operator_queue_summary_request);
+        assert!(activation_operator_queue_summary_trace.result.ok);
+        assert_eq!(
+            activation_operator_queue_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_operator_queue_summary_output = activation_operator_queue_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_operator_queue_rollup =
+            field(activation_operator_queue_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(
+                field(activation_operator_queue_rollup, "resolve_constraint_tasks").unwrap()
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_operator_queue_rollup, "next_task_kind"),
+            Some(&string("resolve_constraints"))
+        );
+        assert_eq!(
+            field(activation_operator_queue_rollup, "next_playbook_action"),
+            Some(&string("resolve_blockers"))
+        );
+        assert_eq!(
+            field(activation_operator_queue_rollup, "next_recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_operator_queue_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -22275,6 +22941,14 @@ mod tests {
             activation_playbook_summary_request,
             activation_playbook_summary_trace,
         );
+        journal.record_trace(
+            list_activation_operator_queue_request,
+            list_activation_operator_queue_trace,
+        );
+        journal.record_trace(
+            activation_operator_queue_summary_request,
+            activation_operator_queue_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -22348,9 +23022,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 97);
-        assert_eq!(journal_summary.completed_count, 97);
-        assert_eq!(journal.audit_records().len(), 97);
+        assert_eq!(journal_summary.invocation_count, 99);
+        assert_eq!(journal_summary.completed_count, 99);
+        assert_eq!(journal.audit_records().len(), 99);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -87,6 +87,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_playbook_summary` tool descriptors
   for read-only operator-ready planning steps derived from activation
   forecasts.
+- `smart_home.list_integration_activation_operator_queue` and
+  `smart_home.get_integration_activation_operator_queue_summary` tool
+  descriptors for read-only actionable human/operator work derived from
+  playbook steps.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -91,6 +91,8 @@ Current scope:
   classification derived from activation timeline milestones
 - D18D integration activation-playbook descriptors for operator-ready planning
   steps derived from forecast next actions
+- D18D integration activation-operator queue descriptors for actionable
+  human/operator work derived from playbook steps
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1495,6 +1495,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationForecastSummary,
     ListIntegrationActivationPlaybook,
     GetIntegrationActivationPlaybookSummary,
+    ListIntegrationActivationOperatorQueue,
+    GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1686,6 +1688,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationPlaybookSummary => {
                 read_tool("smart_home.get_integration_activation_playbook_summary")
+            }
+            Self::ListIntegrationActivationOperatorQueue => {
+                read_tool("smart_home.list_integration_activation_operator_queue")
+            }
+            Self::GetIntegrationActivationOperatorQueueSummary => {
+                read_tool("smart_home.get_integration_activation_operator_queue_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2364,6 +2372,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationForecastSummary,
         SmartHomeTool::ListIntegrationActivationPlaybook,
         SmartHomeTool::GetIntegrationActivationPlaybookSummary,
+        SmartHomeTool::ListIntegrationActivationOperatorQueue,
+        SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3206,7 +3216,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 97);
+        assert_eq!(catalog.len(), 99);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3601,6 +3611,14 @@ mod tests {
             == "smart_home.get_integration_activation_playbook_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_operator_queue"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_operator_queue_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3608,15 +3626,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 97);
-        assert_eq!(summary.read_tools, 89);
+        assert_eq!(summary.total_tools, 99);
+        assert_eq!(summary.read_tools, 91);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 89);
+        assert_eq!(summary.read_only_tier_tools, 91);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 97);
+        assert_eq!(summary.total_required_capabilities, 99);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -75,6 +75,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationPlaybookStep` and
   `IntegrationActivationPlaybookSummary` for pairing forecast next actions with
   recommended planning views and operator-readiness flags.
+- `IntegrationActivationOperatorTask` and
+  `IntegrationActivationOperatorTaskSummary` for turning playbook steps into
+  actionable human/operator queue rows.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -75,6 +75,8 @@ runtime and Chief of Staff tools a typed catalog for:
   activation, and monitoring
 - activation playbook steps that pair forecast next actions with recommended
   planning views and operator-readiness flags
+- activation operator tasks that turn playbook steps into actionable
+  human/operator queue rows
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1114,6 +1114,43 @@ impl IntegrationActivationPlaybookView {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationOperatorTaskKind {
+    ResolveConstraints,
+    EnableDependencies,
+    PrepareApproval,
+    CompleteReview,
+    ReviewRisk,
+    ActivateWave,
+    MonitorWave,
+}
+
+impl IntegrationActivationOperatorTaskKind {
+    pub fn from_playbook_action(action: IntegrationActivationForecastAction) -> Self {
+        match action {
+            IntegrationActivationForecastAction::ResolveBlockers => Self::ResolveConstraints,
+            IntegrationActivationForecastAction::EnableDependencies => Self::EnableDependencies,
+            IntegrationActivationForecastAction::PrepareApproval => Self::PrepareApproval,
+            IntegrationActivationForecastAction::QueueReview => Self::CompleteReview,
+            IntegrationActivationForecastAction::ReviewRisk => Self::ReviewRisk,
+            IntegrationActivationForecastAction::ActivateWave => Self::ActivateWave,
+            IntegrationActivationForecastAction::MonitorWave => Self::MonitorWave,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ResolveConstraints => "resolve_constraints",
+            Self::EnableDependencies => "enable_dependencies",
+            Self::PrepareApproval => "prepare_approval",
+            Self::CompleteReview => "complete_review",
+            Self::ReviewRisk => "review_risk",
+            Self::ActivateWave => "activate_wave",
+            Self::MonitorWave => "monitor_wave",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2131,6 +2168,76 @@ pub struct IntegrationActivationPlaybookSummary {
     pub first_blocked_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
     pub first_monitor_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationOperatorTask {
+    pub sequence: usize,
+    pub playbook_sequence: usize,
+    pub priority: u8,
+    pub task_kind: IntegrationActivationOperatorTaskKind,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_required: bool,
+    pub actionable: bool,
+    pub activation_ready: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub monitor_only: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationOperatorTaskSummary {
+    pub total_tasks: usize,
+    pub unique_integrations: usize,
+    pub operator_required_tasks: usize,
+    pub actionable_tasks: usize,
+    pub activation_ready_tasks: usize,
+    pub blocked_tasks: usize,
+    pub review_required_tasks: usize,
+    pub monitor_tasks: usize,
+    pub resolve_constraint_tasks: usize,
+    pub enable_dependency_tasks: usize,
+    pub prepare_approval_tasks: usize,
+    pub complete_review_tasks: usize,
+    pub review_risk_tasks: usize,
+    pub activate_wave_tasks: usize,
+    pub monitor_wave_tasks: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_task_sequence: Option<usize>,
+    pub next_task_priority: Option<u8>,
+    pub first_operator_sequence: Option<usize>,
+    pub first_actionable_sequence: Option<usize>,
+    pub first_activation_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_operator_priority: Option<u8>,
+    pub first_actionable_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -4352,6 +4459,259 @@ impl IntegrationActivationPlaybookSummary {
             || self.approval_view_steps > 0
             || self.review_view_steps > 0
             || self.risk_view_steps > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_operator_work()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationOperatorTask {
+    fn from_playbook_step(step: IntegrationActivationPlaybookStep) -> Self {
+        let task_kind =
+            IntegrationActivationOperatorTaskKind::from_playbook_action(step.playbook_action);
+        let operator_required = step.operator_required();
+        let activation_ready = step.activation_ready();
+        let blocked = step.blocked();
+        let review_required = step.review_required();
+        let monitor_only = step.monitor_only();
+        let actionable = !monitor_only && (operator_required || activation_ready);
+        let requires_attention = operator_required || step.requires_attention();
+
+        Self {
+            sequence: step.sequence,
+            playbook_sequence: step.sequence,
+            priority: step.priority,
+            task_kind,
+            playbook_action: step.playbook_action,
+            recommended_view: step.recommended_view,
+            milestone_kind: step.milestone_kind,
+            health_status: step.health_status,
+            integration_ids: step.integration_ids,
+            integration_count: step.integration_count,
+            action_count: step.action_count,
+            dossier_count: step.dossier_count,
+            evidence_count: step.evidence_count,
+            risk_count: step.risk_count,
+            dependency_edge_count: step.dependency_edge_count,
+            blocking_dependency_edge_count: step.blocking_dependency_edge_count,
+            highest_policy_tier: step.highest_policy_tier,
+            operator_required,
+            actionable,
+            activation_ready,
+            blocked,
+            review_required,
+            monitor_only,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn actionable(&self) -> bool {
+        self.actionable
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.activation_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationOperatorTaskSummary {
+    pub fn from_tasks<'a>(
+        tasks: impl IntoIterator<Item = &'a IntegrationActivationOperatorTask>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_tasks: 0,
+            unique_integrations: 0,
+            operator_required_tasks: 0,
+            actionable_tasks: 0,
+            activation_ready_tasks: 0,
+            blocked_tasks: 0,
+            review_required_tasks: 0,
+            monitor_tasks: 0,
+            resolve_constraint_tasks: 0,
+            enable_dependency_tasks: 0,
+            prepare_approval_tasks: 0,
+            complete_review_tasks: 0,
+            review_risk_tasks: 0,
+            activate_wave_tasks: 0,
+            monitor_wave_tasks: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            next_task_kind: None,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_task_sequence: None,
+            next_task_priority: None,
+            first_operator_sequence: None,
+            first_actionable_sequence: None,
+            first_activation_sequence: None,
+            first_blocked_sequence: None,
+            first_review_sequence: None,
+            first_operator_priority: None,
+            first_actionable_priority: None,
+            first_activation_priority: None,
+            first_blocked_priority: None,
+            first_review_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for task in tasks {
+            summary.total_tasks += 1;
+            for integration_id in &task.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match task.task_kind {
+                IntegrationActivationOperatorTaskKind::ResolveConstraints => {
+                    summary.resolve_constraint_tasks += 1
+                }
+                IntegrationActivationOperatorTaskKind::EnableDependencies => {
+                    summary.enable_dependency_tasks += 1
+                }
+                IntegrationActivationOperatorTaskKind::PrepareApproval => {
+                    summary.prepare_approval_tasks += 1
+                }
+                IntegrationActivationOperatorTaskKind::CompleteReview => {
+                    summary.complete_review_tasks += 1
+                }
+                IntegrationActivationOperatorTaskKind::ReviewRisk => summary.review_risk_tasks += 1,
+                IntegrationActivationOperatorTaskKind::ActivateWave => {
+                    summary.activate_wave_tasks += 1
+                }
+                IntegrationActivationOperatorTaskKind::MonitorWave => {
+                    summary.monitor_wave_tasks += 1
+                }
+            }
+
+            if summary.next_task_kind.is_none() && !task.monitor_only() {
+                summary.next_task_kind = Some(task.task_kind);
+                summary.next_playbook_action = Some(task.playbook_action);
+                summary.next_recommended_view = Some(task.recommended_view);
+                summary.next_task_sequence = Some(task.sequence);
+                summary.next_task_priority = Some(task.priority);
+            }
+
+            if task.operator_required() {
+                summary.operator_required_tasks += 1;
+                summary.first_operator_sequence =
+                    summary.first_operator_sequence.or(Some(task.sequence));
+                summary.first_operator_priority =
+                    min_optional_priority(summary.first_operator_priority, Some(task.priority));
+            }
+            if task.actionable() {
+                summary.actionable_tasks += 1;
+                summary.first_actionable_sequence =
+                    summary.first_actionable_sequence.or(Some(task.sequence));
+                summary.first_actionable_priority =
+                    min_optional_priority(summary.first_actionable_priority, Some(task.priority));
+            }
+            if task.activation_ready() {
+                summary.activation_ready_tasks += 1;
+                summary.first_activation_sequence =
+                    summary.first_activation_sequence.or(Some(task.sequence));
+                summary.first_activation_priority =
+                    min_optional_priority(summary.first_activation_priority, Some(task.priority));
+            }
+            if task.blocked() {
+                summary.blocked_tasks += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(task.sequence));
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(task.priority));
+            }
+            if task.review_required() {
+                summary.review_required_tasks += 1;
+                summary.first_review_sequence =
+                    summary.first_review_sequence.or(Some(task.sequence));
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(task.priority));
+            }
+            if task.monitor_only() {
+                summary.monitor_tasks += 1;
+            }
+
+            summary.total_actions += task.action_count;
+            summary.total_dossiers += task.dossier_count;
+            summary.total_evidence += task.evidence_count;
+            summary.total_risks += task.risk_count;
+            summary.total_dependency_edges += task.dependency_edge_count;
+            summary.blocking_dependency_edges += task.blocking_dependency_edge_count;
+            summary.highest_policy_tier = summary.highest_policy_tier.max(task.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_tasks > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.review_required_tasks > 0 || summary.operator_required_tasks > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.activation_ready_tasks > 0 || summary.actionable_tasks > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_tasks == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.operator_required_tasks > 0
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.actionable_tasks > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activation_ready_tasks > 0 || self.activate_wave_tasks > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_tasks > 0
+            || self.resolve_constraint_tasks > 0
+            || self.enable_dependency_tasks > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_tasks > 0
+            || self.prepare_approval_tasks > 0
+            || self.complete_review_tasks > 0
+            || self.review_risk_tasks > 0
     }
 
     pub fn requires_attention(&self) -> bool {
@@ -8442,6 +8802,79 @@ pub fn activation_playbook_steps_at_or_before_priority(
     ))
 }
 
+pub fn activation_operator_tasks_from_playbook_steps(
+    mut steps: Vec<IntegrationActivationPlaybookStep>,
+) -> Vec<IntegrationActivationOperatorTask> {
+    steps.sort_by(compare_activation_playbook_steps);
+    let mut tasks = steps
+        .into_iter()
+        .map(IntegrationActivationOperatorTask::from_playbook_step)
+        .collect::<Vec<_>>();
+    tasks.sort_by(compare_activation_operator_tasks);
+    for (index, task) in tasks.iter_mut().enumerate() {
+        task.sequence = index + 1;
+    }
+    tasks
+}
+
+pub fn activation_operator_tasks_from_forecasts(
+    forecasts: Vec<IntegrationActivationForecastItem>,
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(activation_playbook_steps_from_forecasts(
+        forecasts,
+    ))
+}
+
+pub fn activation_operator_tasks_from_timeline_milestones(
+    milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(
+        activation_playbook_steps_from_timeline_milestones(milestones),
+    )
+}
+
+pub fn activation_operator_tasks_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(activation_playbook_steps_from_dashboard_cards(
+        cards,
+    ))
+}
+
+pub fn activation_operator_tasks_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(activation_playbook_steps_from_readouts(readouts))
+}
+
+pub fn activation_operator_tasks_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(activation_playbook_steps_from_candidates(
+        catalog,
+        candidates,
+        enabled_integrations,
+    ))
+}
+
+pub fn activation_operator_tasks_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationOperatorTask> {
+    activation_operator_tasks_from_playbook_steps(activation_playbook_steps_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    ))
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -9820,6 +10253,22 @@ fn compare_activation_playbook_steps(
         .then_with(|| right.blocked().cmp(&left.blocked()))
         .then_with(|| right.review_required().cmp(&left.review_required()))
         .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_operator_tasks(
+    left: &IntegrationActivationOperatorTask,
+    right: &IntegrationActivationOperatorTask,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.operator_required().cmp(&left.operator_required()))
+        .then_with(|| right.actionable().cmp(&left.actionable()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.review_required().cmp(&left.review_required()))
+        .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
+        .then_with(|| left.task_kind.cmp(&right.task_kind))
+        .then_with(|| left.recommended_view.cmp(&right.recommended_view))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -12093,6 +12542,141 @@ mod tests {
         assert!(catalog_steps
             .iter()
             .any(IntegrationActivationPlaybookStep::requires_attention));
+    }
+
+    #[test]
+    fn activation_operator_tasks_prioritize_human_action_queue() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let tasks = activation_operator_tasks_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0].sequence, 1);
+        assert_eq!(tasks[0].playbook_sequence, 1);
+        assert_eq!(tasks[0].priority, 1);
+        assert_eq!(
+            tasks[0].task_kind,
+            IntegrationActivationOperatorTaskKind::ResolveConstraints
+        );
+        assert_eq!(
+            tasks[0].recommended_view,
+            IntegrationActivationPlaybookView::ConstraintQueue
+        );
+        assert!(tasks[0].operator_required());
+        assert!(tasks[0].actionable());
+        assert!(tasks[0].blocked());
+        assert!(tasks[1].blocked());
+        assert_eq!(
+            tasks[1].task_kind,
+            IntegrationActivationOperatorTaskKind::EnableDependencies
+        );
+        assert!(tasks[2].activation_ready());
+        assert!(tasks[2].actionable());
+        assert_eq!(
+            tasks[2].task_kind,
+            IntegrationActivationOperatorTaskKind::ActivateWave
+        );
+
+        let summary = IntegrationActivationOperatorTaskSummary::from_tasks(tasks.iter());
+        assert_eq!(summary.total_tasks, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert!(summary.operator_required_tasks >= 2);
+        assert_eq!(summary.actionable_tasks, 3);
+        assert_eq!(summary.activation_ready_tasks, 1);
+        assert!(summary.blocked_tasks >= 1);
+        assert!(summary.review_required_tasks >= 1);
+        assert_eq!(summary.resolve_constraint_tasks, 1);
+        assert_eq!(summary.enable_dependency_tasks, 1);
+        assert_eq!(summary.activate_wave_tasks, 1);
+        assert_eq!(
+            summary.next_task_kind,
+            Some(IntegrationActivationOperatorTaskKind::ResolveConstraints)
+        );
+        assert_eq!(
+            summary.next_playbook_action,
+            Some(IntegrationActivationForecastAction::ResolveBlockers)
+        );
+        assert_eq!(
+            summary.next_recommended_view,
+            Some(IntegrationActivationPlaybookView::ConstraintQueue)
+        );
+        assert_eq!(summary.next_task_sequence, Some(1));
+        assert_eq!(summary.first_actionable_sequence, Some(1));
+        assert_eq!(summary.first_activation_sequence, Some(3));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_operator_work());
+        assert!(summary.has_actionable_work());
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_tasks = activation_operator_tasks_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_tasks
+            .iter()
+            .any(IntegrationActivationOperatorTask::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add smart-home activation operator task rows and queue summaries derived from playbook steps
- expose shared read-only D18D descriptors for listing and summarizing activation operator queue work
- wire Chief-of-Staff handlers, schemas, JSON output, runtime coverage, and docs for the new queue tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools