### PR TITLE
[codex] Add SPICE netlist analysis plan execution

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add a deck execution layer with `build_analysis_plan()`, `run_analysis_plan()`,
+  `run_netlist()`, plus matching `ParsedNetlist` methods for runnable `.op`,
+  `.dc`, `.ac dec` / `.ac log`, and `.tran` cards.
+
 ## 0.3.0 — 2026-06-05
 
 - Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit

--- a/code/packages/python/spice-netlist-parser/README.md
+++ b/code/packages/python/spice-netlist-parser/README.md
@@ -33,6 +33,22 @@ cards can carry `method=euler|trap|gear2`; when omitted,
 `netlist.transient_method()` falls back to `.options method=<...>` if present.
 Selected `.options` keys can also be turned into engine-call arguments with
 `netlist.dc_op_kwargs()` and `netlist.transient_kwargs()`.
+Runnable `.op`, `.dc`, `.ac dec` / `.ac log`, and `.tran` cards can be planned
+and executed directly:
+
+```python
+from spice_netlist_parser import run_netlist
+
+results = run_netlist("""
+V1 in 0 DC 1 AC 1
+R1 in out 1k
+R2 out 0 1k
+.op
+.ac dec 1 1k 1k
+.end
+""")
+```
+
 Deck-level `.temp` cards can be resolved into Kelvin with
 `netlist.operating_temperature_kelvin()`, and
 `netlist.noise_temperature_kelvin(noise_card)` applies the SPICE precedence

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/__init__.py
@@ -2,6 +2,10 @@
 
 from spice_netlist_parser.parser import (
     AcAnalysis,
+    AnalysisExecutionResult,
+    AnalysisKind,
+    AnalysisPlanStep,
+    AnalysisResult,
     DcAnalysis,
     DistortionAnalysis,
     FourAnalysis,
@@ -22,7 +26,10 @@ from spice_netlist_parser.parser import (
     TfAnalysis,
     TranAnalysis,
     TransientMethod,
+    build_analysis_plan,
     parse_netlist,
+    run_analysis_plan,
+    run_netlist,
 )
 
 parse = parse_netlist
@@ -30,6 +37,10 @@ __version__ = "0.3.0"
 
 __all__ = [
     "AcAnalysis",
+    "AnalysisExecutionResult",
+    "AnalysisKind",
+    "AnalysisPlanStep",
+    "AnalysisResult",
     "DcAnalysis",
     "DistortionAnalysis",
     "FourAnalysis",
@@ -51,6 +62,9 @@ __all__ = [
     "TranAnalysis",
     "TransientMethod",
     "__version__",
+    "build_analysis_plan",
     "parse",
     "parse_netlist",
+    "run_analysis_plan",
+    "run_netlist",
 ]

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -10,28 +10,36 @@ from typing import Literal
 
 from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
 from spice_engine import (
-    AcSource,
     BJT,
     CCCS,
     CCVS,
+    JFET,
     VCCS,
     VCVS,
+    AcResult,
+    AcSource,
     Capacitor,
     Circuit,
     CurrentSource,
+    DcResult,
+    DcSweepResult,
     Diode,
     ExpWaveform,
     Inductor,
-    JFET,
     Mosfet,
     MutualInductor,
     PulseWaveform,
     PwlWaveform,
     Resistor,
     SinWaveform,
+    TransientResult,
     TransmissionLine,
     VoltageSource,
     Waveform,
+    ac_sweep,
+    dc_op,
+    dc_sweep,
+    transient,
 )
 
 
@@ -197,6 +205,28 @@ type Analysis = (
     | PoleZeroAnalysis
     | OptionsAnalysis
 )
+type RunnableAnalysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis
+type AnalysisKind = Literal["op", "tran", "dc", "ac"]
+type AnalysisResult = DcResult | DcSweepResult | AcResult | TransientResult
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisPlanStep:
+    """One executable `.op`, `.dc`, `.ac`, or `.tran` card in deck order."""
+
+    index: int
+    kind: AnalysisKind
+    analysis: RunnableAnalysis
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisExecutionResult:
+    """Result from executing one analysis-plan step."""
+
+    index: int
+    kind: AnalysisKind
+    analysis: RunnableAnalysis
+    result: AnalysisResult
 
 
 @dataclass(frozen=True, slots=True)
@@ -396,6 +426,19 @@ class ParsedNetlist:
             default=default,
         )
 
+    def analysis_plan(self) -> list[AnalysisPlanStep]:
+        """Return runnable `.op`, `.dc`, `.ac`, and `.tran` cards in deck order."""
+
+        return build_analysis_plan(self)
+
+    def run_analysis_plan(
+        self,
+        plan: list[AnalysisPlanStep] | None = None,
+    ) -> list[AnalysisExecutionResult]:
+        """Execute runnable analysis cards against this parsed circuit."""
+
+        return run_analysis_plan(self, plan)
+
 
 _VALUE_RE = re.compile(
     r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)([a-zA-Zµ]*)\s*$"
@@ -527,6 +570,40 @@ def parse_netlist(text: str) -> ParsedNetlist:
     return parsed
 
 
+def build_analysis_plan(parsed: ParsedNetlist) -> list[AnalysisPlanStep]:
+    """Build the executable `.op`, `.dc`, `.ac`, and `.tran` plan for a deck."""
+
+    plan: list[AnalysisPlanStep] = []
+    for index, analysis in enumerate(parsed.analyses):
+        step = _analysis_plan_step(index, analysis)
+        if step is not None:
+            plan.append(step)
+    return plan
+
+
+def run_analysis_plan(
+    parsed: ParsedNetlist,
+    plan: list[AnalysisPlanStep] | None = None,
+) -> list[AnalysisExecutionResult]:
+    """Execute the runnable plan for a parsed netlist."""
+
+    return [
+        AnalysisExecutionResult(
+            index=step.index,
+            kind=step.kind,
+            analysis=step.analysis,
+            result=_execute_analysis_step(parsed, step),
+        )
+        for step in (build_analysis_plan(parsed) if plan is None else plan)
+    ]
+
+
+def run_netlist(text: str) -> list[AnalysisExecutionResult]:
+    """Parse a deck and execute its runnable `.op`, `.dc`, `.ac`, and `.tran` cards."""
+
+    return run_analysis_plan(parse_netlist(text))
+
+
 def parse_value(token: str) -> float:
     """Parse a SPICE numeric token with an engineering suffix."""
 
@@ -537,6 +614,63 @@ def parse_value(token: str) -> float:
     if suffix not in _SUFFIXES:
         raise NetlistParseError(f"unsupported numeric suffix {match.group(2)!r}")
     return float(match.group(1)) * _SUFFIXES[suffix]
+
+
+def _analysis_plan_step(index: int, analysis: Analysis) -> AnalysisPlanStep | None:
+    if isinstance(analysis, OpAnalysis):
+        return AnalysisPlanStep(index=index, kind="op", analysis=analysis)
+    if isinstance(analysis, TranAnalysis):
+        return AnalysisPlanStep(index=index, kind="tran", analysis=analysis)
+    if isinstance(analysis, DcAnalysis):
+        return AnalysisPlanStep(index=index, kind="dc", analysis=analysis)
+    if isinstance(analysis, AcAnalysis):
+        return AnalysisPlanStep(index=index, kind="ac", analysis=analysis)
+    return None
+
+
+def _execute_analysis_step(parsed: ParsedNetlist, step: AnalysisPlanStep) -> AnalysisResult:
+    analysis = step.analysis
+    if isinstance(analysis, OpAnalysis):
+        return dc_op(parsed.circuit, **parsed.dc_op_kwargs())
+    if isinstance(analysis, DcAnalysis):
+        dc_kwargs = parsed.dc_op_kwargs()
+        sweep_kwargs = {
+            key: dc_kwargs[key] for key in ("max_iterations", "tol") if key in dc_kwargs
+        }
+        return dc_sweep(
+            parsed.circuit,
+            analysis.source_name,
+            analysis.start,
+            analysis.stop,
+            analysis.step,
+            **sweep_kwargs,
+        )
+    if isinstance(analysis, AcAnalysis):
+        return ac_sweep(
+            parsed.circuit,
+            f_start=analysis.start_hz,
+            f_stop=analysis.stop_hz,
+            n_points=analysis.points,
+            sweep=_ac_sweep_mode(analysis),
+        )
+    if isinstance(analysis, TranAnalysis):
+        transient_kwargs = parsed.transient_kwargs(analysis)
+        transient_kwargs.setdefault("method", "euler")
+        return transient(
+            parsed.circuit,
+            t_step=analysis.t_step,
+            t_stop=analysis.t_stop,
+            **transient_kwargs,
+        )
+    raise NetlistParseError(f"analysis card at index {step.index} is not executable")
+
+
+def _ac_sweep_mode(analysis: AcAnalysis) -> Literal["log", "lin"]:
+    if analysis.mode in ("dec", "log"):
+        return "log"
+    raise NetlistParseError(
+        f".ac mode {analysis.mode!r} is not executable; supported modes are 'dec' and 'log'"
+    )
 
 
 def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -48,7 +48,9 @@ from spice_netlist_parser import (
     TfAnalysis,
     TranAnalysis,
     __version__,
+    build_analysis_plan,
     parse_netlist,
+    run_netlist,
 )
 from spice_netlist_parser.parser import parse_value
 
@@ -80,6 +82,43 @@ R2 mid 0 1k
     result = dc_op(parsed.circuit)
     assert result.converged
     assert isclose(result.node_voltages["mid"], 5.0, abs_tol=1e-9)
+
+
+def test_builds_and_runs_core_analysis_plan() -> None:
+    deck = """
+V1 in 0 DC 1 AC 1
+R1 in out 1k
+R2 out 0 1k
+C1 out 0 1u IC=0
+.options method=trap
+.op
+.dc V1 0 1 0.5
+.ac dec 1 1k 1k
+.tran 1m 1m
+.end
+"""
+    parsed = parse_netlist(deck)
+
+    plan = parsed.analysis_plan()
+    assert plan == build_analysis_plan(parsed)
+    assert [(step.index, step.kind) for step in plan] == [
+        (1, "op"),
+        (2, "dc"),
+        (3, "ac"),
+        (4, "tran"),
+    ]
+
+    results = parsed.run_analysis_plan()
+    assert [result.kind for result in results] == ["op", "dc", "ac", "tran"]
+    assert isclose(results[0].result.node_voltages["out"], 0.5, abs_tol=1e-9)
+    assert len(results[1].result.points) == 3
+    assert isclose(results[1].result.points[-1].node_voltages["out"], 0.5, abs_tol=1e-9)
+    assert len(results[2].result.points) == 1
+    assert abs(results[2].result.points[0].node_voltages["out"]) > 0.0
+    assert results[3].result.method == "trap"
+    assert results[3].result.points[-1].node_voltages["out"] > 0.0
+
+    assert len(run_netlist(deck)) == 4
 
 
 def test_parse_reactive_elements_and_analysis_cards() -> None:

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add a deck execution layer with `build_analysis_plan()`, `run_analysis_plan()`,
+  `run_netlist()`, plus matching `ParsedNetlist` methods for runnable `.op`,
+  `.dc`, `.ac dec` / `.ac log`, and `.tran` cards.
+
 ## 0.3.0 — 2026-06-05
 
 - Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -35,6 +35,9 @@ Transient cards can carry `method=euler|trap|gear2`; when omitted,
 present.
 Selected `.options` keys can also be turned into engine-call options with
 `parsed.dc_op_options()?` and `parsed.adaptive_transient_options(None)?`.
+Runnable `.op`, `.dc`, `.ac dec` / `.ac log`, and `.tran` cards can be planned
+and executed directly with `parsed.analysis_plan()`, `parsed.run_analysis_plan()`,
+or `run_netlist(deck)`.
 Deck-level `.temp` cards can be resolved into Kelvin with
 `parsed.operating_temperature_kelvin(0, 300.0)?`, and
 `parsed.noise_temperature_kelvin(Some(noise_card), 0, 300.0)?` applies the

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1,10 +1,12 @@
 use std::{collections::HashMap, fmt};
 
 use spice_engine::{
+    ac_sweep, dc_op_with_options, dc_sweep, transient_with_method, AcPoint,
     AdaptiveTransientOptions, Bjt, BjtPolarity, Capacitor, Cccs, Ccvs, Circuit, CurrentSource,
-    DcOpOptions, Diode, Element, ExpWaveform, Inductor, Jfet, JfetPolarity, Mosfet,
-    MosfetLevel1Params, MosfetType, MutualInductor, PulseWaveform, PwlWaveform, Resistor,
-    SinWaveform, TransientMethod, TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
+    DcOpOptions, DcResult, DcSweepPoint, Diode, Element, ExpWaveform, Inductor, Jfet, JfetPolarity,
+    Mosfet, MosfetLevel1Params, MosfetType, MutualInductor, PulseWaveform, PwlWaveform, Resistor,
+    SinWaveform, SpiceError, TransientMethod, TransientPoint, TransmissionLine, Vccs, Vcvs,
+    VoltageSource, Waveform,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +166,85 @@ pub enum Analysis {
     Distortion(DistortionAnalysis),
     PoleZero(PoleZeroAnalysis),
     Options(OptionsAnalysis),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AnalysisKind {
+    Op,
+    Tran,
+    Dc,
+    Ac,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunnableAnalysis {
+    Op(OpAnalysis),
+    Tran(TranAnalysis),
+    Dc(DcAnalysis),
+    Ac(AcAnalysis),
+}
+
+impl RunnableAnalysis {
+    pub fn kind(&self) -> AnalysisKind {
+        match self {
+            Self::Op(_) => AnalysisKind::Op,
+            Self::Tran(_) => AnalysisKind::Tran,
+            Self::Dc(_) => AnalysisKind::Dc,
+            Self::Ac(_) => AnalysisKind::Ac,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalysisPlanStep {
+    pub index: usize,
+    pub kind: AnalysisKind,
+    pub analysis: RunnableAnalysis,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnalysisResult {
+    Op(DcResult),
+    Tran(Vec<TransientPoint>),
+    Dc(Vec<DcSweepPoint>),
+    Ac(Vec<AcPoint>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalysisExecutionResult {
+    pub index: usize,
+    pub kind: AnalysisKind,
+    pub analysis: RunnableAnalysis,
+    pub result: AnalysisResult,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnalysisExecutionError {
+    Netlist(NetlistParseError),
+    Spice(SpiceError),
+}
+
+impl fmt::Display for AnalysisExecutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Netlist(error) => write!(f, "{error}"),
+            Self::Spice(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for AnalysisExecutionError {}
+
+impl From<NetlistParseError> for AnalysisExecutionError {
+    fn from(error: NetlistParseError) -> Self {
+        Self::Netlist(error)
+    }
+}
+
+impl From<SpiceError> for AnalysisExecutionError {
+    fn from(error: SpiceError) -> Self {
+        Self::Spice(error)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -428,6 +509,16 @@ impl ParsedNetlist {
         self.operating_temperature_kelvin(temperature_index, default_temperature_kelvin)
     }
 
+    pub fn analysis_plan(&self) -> Vec<AnalysisPlanStep> {
+        build_analysis_plan(self)
+    }
+
+    pub fn run_analysis_plan(
+        &self,
+    ) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
+        run_analysis_plan(self)
+    }
+
     fn merged_options(&self) -> HashMap<String, OptionValue> {
         let mut values = HashMap::new();
         for options in self.options_cards() {
@@ -614,6 +705,98 @@ pub fn parse_netlist(text: &str) -> Result<ParsedNetlist, NetlistParseError> {
         models,
         title,
     })
+}
+
+pub fn build_analysis_plan(parsed: &ParsedNetlist) -> Vec<AnalysisPlanStep> {
+    parsed
+        .analyses
+        .iter()
+        .enumerate()
+        .filter_map(|(index, analysis)| analysis_plan_step(index, analysis))
+        .collect()
+}
+
+pub fn run_analysis_plan(
+    parsed: &ParsedNetlist,
+) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
+    build_analysis_plan(parsed)
+        .into_iter()
+        .map(|step| {
+            let result = execute_analysis_step(parsed, &step)?;
+            Ok(AnalysisExecutionResult {
+                index: step.index,
+                kind: step.kind,
+                analysis: step.analysis,
+                result,
+            })
+        })
+        .collect()
+}
+
+pub fn run_netlist(text: &str) -> Result<Vec<AnalysisExecutionResult>, AnalysisExecutionError> {
+    let parsed = parse_netlist(text)?;
+    run_analysis_plan(&parsed)
+}
+
+fn analysis_plan_step(index: usize, analysis: &Analysis) -> Option<AnalysisPlanStep> {
+    let analysis = match analysis {
+        Analysis::Op(card) => RunnableAnalysis::Op(*card),
+        Analysis::Tran(card) => RunnableAnalysis::Tran(*card),
+        Analysis::Dc(card) => RunnableAnalysis::Dc(card.clone()),
+        Analysis::Ac(card) => RunnableAnalysis::Ac(card.clone()),
+        _ => return None,
+    };
+    Some(AnalysisPlanStep {
+        index,
+        kind: analysis.kind(),
+        analysis,
+    })
+}
+
+fn execute_analysis_step(
+    parsed: &ParsedNetlist,
+    step: &AnalysisPlanStep,
+) -> Result<AnalysisResult, AnalysisExecutionError> {
+    match &step.analysis {
+        RunnableAnalysis::Op(_) => Ok(AnalysisResult::Op(dc_op_with_options(
+            &parsed.circuit,
+            parsed.dc_op_options()?,
+        )?)),
+        RunnableAnalysis::Tran(card) => {
+            let method = parsed
+                .transient_method(Some(card))?
+                .unwrap_or(TransientMethod::Euler);
+            Ok(AnalysisResult::Tran(transient_with_method(
+                &parsed.circuit,
+                card.time_step,
+                card.stop_time,
+                method,
+            )?))
+        }
+        RunnableAnalysis::Dc(card) => Ok(AnalysisResult::Dc(dc_sweep(
+            &parsed.circuit,
+            &card.source_name,
+            card.start,
+            card.stop,
+            card.step,
+        )?)),
+        RunnableAnalysis::Ac(card) => Ok(AnalysisResult::Ac(ac_sweep(
+            &parsed.circuit,
+            card.start_hz,
+            card.stop_hz,
+            executable_ac_points_per_decade(card)?,
+        )?)),
+    }
+}
+
+fn executable_ac_points_per_decade(card: &AcAnalysis) -> Result<usize, NetlistParseError> {
+    if card.mode == "dec" || card.mode == "log" {
+        return Ok(card.points);
+    }
+    Err(NetlistParseError::new(format!(
+        ".ac mode {:?} is not executable; supported modes are \"dec\" and \"log\"",
+        card.mode
+    )))
 }
 
 fn validate_mutual_inductors(circuit: &Circuit) -> Result<(), NetlistParseError> {

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -3,10 +3,11 @@ use spice_engine::{
     BjtPolarity, Element, JfetPolarity, McDistribution, McOptions, MosfetType, TransientMethod,
 };
 use spice_netlist_parser::{
-    parse_netlist, parse_value, AcAnalysis, Analysis, DcAnalysis, DistortionAnalysis, FourAnalysis,
-    McAnalysis, NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue, OutputProbe,
-    PlotAnalysis, PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, SensAnalysis, TempAnalysis,
-    TfAnalysis, TranAnalysis,
+    build_analysis_plan, parse_netlist, parse_value, run_netlist, AcAnalysis, Analysis,
+    AnalysisKind, AnalysisResult, DcAnalysis, DistortionAnalysis, FourAnalysis, McAnalysis,
+    NetlistParseError, NoiseAnalysis, OpAnalysis, OptionValue, OutputProbe, PlotAnalysis,
+    PoleZeroAnalysis, PoleZeroKind, PrintAnalysis, SensAnalysis, TempAnalysis, TfAnalysis,
+    TranAnalysis,
 };
 
 fn assert_close(actual: f64, expected: f64) {
@@ -43,6 +44,72 @@ R2 mid 0 1k
 
     let result = dc_op(&parsed.circuit).unwrap();
     assert_close(result.voltage("mid").unwrap(), 5.0);
+}
+
+#[test]
+fn builds_and_runs_core_analysis_plan() {
+    let deck = r#"
+V1 in 0 DC 1 AC 1
+R1 in out 1k
+R2 out 0 1k
+C1 out 0 1u IC=0
+.options method=trap
+.op
+.dc V1 0 1 0.5
+.ac dec 1 1k 1k
+.tran 1m 1m
+.end
+"#;
+    let parsed = parse_netlist(deck).unwrap();
+
+    let plan = parsed.analysis_plan();
+    assert_eq!(plan, build_analysis_plan(&parsed));
+    assert_eq!(
+        plan.iter()
+            .map(|step| (step.index, step.kind))
+            .collect::<Vec<_>>(),
+        vec![
+            (1, AnalysisKind::Op),
+            (2, AnalysisKind::Dc),
+            (3, AnalysisKind::Ac),
+            (4, AnalysisKind::Tran),
+        ]
+    );
+
+    let results = parsed.run_analysis_plan().unwrap();
+    assert_eq!(
+        results.iter().map(|result| result.kind).collect::<Vec<_>>(),
+        vec![
+            AnalysisKind::Op,
+            AnalysisKind::Dc,
+            AnalysisKind::Ac,
+            AnalysisKind::Tran
+        ]
+    );
+    let AnalysisResult::Op(op) = &results[0].result else {
+        panic!("expected .op result");
+    };
+    assert_close(op.voltage("out").unwrap(), 0.5);
+    let AnalysisResult::Dc(dc_points) = &results[1].result else {
+        panic!("expected .dc result");
+    };
+    assert_eq!(dc_points.len(), 3);
+    assert_close(
+        dc_points.last().unwrap().result.voltage("out").unwrap(),
+        0.5,
+    );
+    let AnalysisResult::Ac(ac_points) = &results[2].result else {
+        panic!("expected .ac result");
+    };
+    assert_eq!(ac_points.len(), 1);
+    assert!(ac_points[0].voltage("out").unwrap().abs() > 0.0);
+    let AnalysisResult::Tran(transient_points) = &results[3].result else {
+        panic!("expected .tran result");
+    };
+    assert_eq!(transient_points.len(), 1);
+    assert!(transient_points[0].voltage("out").unwrap() > 0.0);
+
+    assert_eq!(run_netlist(deck).unwrap().len(), 4);
 }
 
 #[test]

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add a deck execution layer with `buildAnalysisPlan()`, `runAnalysisPlan()`,
+  `runNetlist()`, plus matching `ParsedNetlist` methods for runnable `.op`,
+  `.dc`, `.ac dec` / `.ac log`, and `.tran` cards.
+
 ## 0.3.0 — 2026-06-05
 
 - Resolve `.temp` cards into Kelvin engine-call temperatures and let explicit

--- a/code/packages/typescript/spice-netlist-parser/README.md
+++ b/code/packages/typescript/spice-netlist-parser/README.md
@@ -37,6 +37,22 @@ omitted, `netlist.transientMethod()` falls back to `.options method=<...>` if
 present.
 Selected `.options` keys can also be turned into engine-call options with
 `netlist.dcOpOptions()` and `netlist.adaptiveTransientOptions()`.
+Runnable `.op`, `.dc`, `.ac dec` / `.ac log`, and `.tran` cards can be planned
+and executed directly:
+
+```ts
+import { runNetlist } from "@coding-adventures/spice-netlist-parser";
+
+const results = runNetlist(`
+V1 in 0 DC 1 AC 1
+R1 in out 1k
+R2 out 0 1k
+.op
+.ac dec 1 1k 1k
+.end
+`);
+```
+
 Deck-level `.temp` cards can be resolved into Kelvin with
 `netlist.operatingTemperatureKelvin()`, and
 `netlist.noiseTemperatureKelvin(noiseCard)` applies the SPICE precedence where

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -12,7 +12,9 @@ import {
   currentSourceWithAc,
   currentSourceWithWaveform,
   diode,
+  acSweep,
   dcOp,
+  dcSweep,
   inductorWithInitialCurrent,
   jfet,
   mosfet,
@@ -24,11 +26,16 @@ import {
   voltageSource,
   voltageSourceWithAc,
   voltageSourceWithWaveform,
+  transient,
   type AdaptiveTransientOptions,
+  type AcPoint,
   type DcOpOptions,
+  type DcResult,
+  type DcSweepPoint,
   type Element,
   type JfetPolarity,
   type MosfetLevel1Params,
+  type TransientPoint,
   type TransientMethod,
   type Waveform,
 } from "@coding-adventures/spice-engine";
@@ -164,6 +171,27 @@ export type Analysis =
   | PoleZeroAnalysis
   | OptionsAnalysis;
 
+export type RunnableAnalysis = OpAnalysis | TranAnalysis | DcAnalysis | AcAnalysis;
+export type AnalysisKind = RunnableAnalysis["kind"];
+export type AnalysisResult =
+  | DcResult
+  | readonly DcSweepPoint[]
+  | readonly AcPoint[]
+  | readonly TransientPoint[];
+
+export interface AnalysisPlanStep {
+  readonly index: number;
+  readonly kind: AnalysisKind;
+  readonly analysis: RunnableAnalysis;
+}
+
+export interface AnalysisExecutionResult {
+  readonly index: number;
+  readonly kind: AnalysisKind;
+  readonly analysis: RunnableAnalysis;
+  readonly result: AnalysisResult;
+}
+
 export interface ModelCard {
   readonly name: string;
   readonly kind: string;
@@ -240,6 +268,14 @@ export class ParsedNetlist {
 
   poleZeroCards(): PoleZeroAnalysis[] {
     return this.analyses.filter((analysis): analysis is PoleZeroAnalysis => analysis.kind === "pz");
+  }
+
+  analysisPlan(): AnalysisPlanStep[] {
+    return buildAnalysisPlan(this);
+  }
+
+  runAnalysisPlan(plan?: readonly AnalysisPlanStep[]): AnalysisExecutionResult[] {
+    return runAnalysisPlan(this, plan);
   }
 
   transientMethod(tran?: TranAnalysis): TransientMethod | undefined {
@@ -527,6 +563,29 @@ export function parseNetlist(text: string): ParsedNetlist {
 
 export const parse = parseNetlist;
 
+export function buildAnalysisPlan(parsed: ParsedNetlist): AnalysisPlanStep[] {
+  return parsed.analyses.flatMap((analysis, index): AnalysisPlanStep[] => {
+    const step = analysisPlanStep(index, analysis);
+    return step === undefined ? [] : [step];
+  });
+}
+
+export function runAnalysisPlan(
+  parsed: ParsedNetlist,
+  plan: readonly AnalysisPlanStep[] = buildAnalysisPlan(parsed),
+): AnalysisExecutionResult[] {
+  return plan.map((step) => ({
+    index: step.index,
+    kind: step.kind,
+    analysis: step.analysis,
+    result: executeAnalysisStep(parsed, step),
+  }));
+}
+
+export function runNetlist(text: string): AnalysisExecutionResult[] {
+  return runAnalysisPlan(parseNetlist(text));
+}
+
 export function parseValue(token: string): number {
   const match = VALUE_RE.exec(token);
   if (match === null) {
@@ -538,6 +597,60 @@ export function parseValue(token: string): number {
     throw new NetlistParseError(`unsupported numeric suffix ${JSON.stringify(match[2])}`);
   }
   return Number.parseFloat(match[1]) * multiplier;
+}
+
+function analysisPlanStep(index: number, analysis: Analysis): AnalysisPlanStep | undefined {
+  if (
+    analysis.kind === "op" ||
+    analysis.kind === "tran" ||
+    analysis.kind === "dc" ||
+    analysis.kind === "ac"
+  ) {
+    return { index, kind: analysis.kind, analysis };
+  }
+  return undefined;
+}
+
+function executeAnalysisStep(parsed: ParsedNetlist, step: AnalysisPlanStep): AnalysisResult {
+  const analysis = step.analysis;
+  if (analysis.kind === "op") {
+    return dcOp(parsed.circuit, parsed.dcOpOptions());
+  }
+  if (analysis.kind === "dc") {
+    return dcSweep(
+      parsed.circuit,
+      analysis.sourceName,
+      analysis.start,
+      analysis.stop,
+      analysis.step,
+    );
+  }
+  if (analysis.kind === "ac") {
+    return acSweep(
+      parsed.circuit,
+      analysis.startHz,
+      analysis.stopHz,
+      executableAcPointsPerDecade(analysis),
+    );
+  }
+  if (analysis.kind === "tran") {
+    return transient(
+      parsed.circuit,
+      analysis.timeStep,
+      analysis.stopTime,
+      parsed.transientMethod(analysis) ?? "euler",
+    );
+  }
+  throw new NetlistParseError(`analysis card at index ${step.index} is not executable`);
+}
+
+function executableAcPointsPerDecade(analysis: AcAnalysis): number {
+  if (analysis.mode === "dec" || analysis.mode === "log") {
+    return analysis.points;
+  }
+  throw new NetlistParseError(
+    `.ac mode ${JSON.stringify(analysis.mode)} is not executable; supported modes are "dec" and "log"`,
+  );
 }
 
 function parseModelCard(fields: readonly string[]): ModelCard {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -10,8 +10,10 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   NetlistParseError,
+  buildAnalysisPlan,
   parseNetlist,
   parseValue,
+  runNetlist,
 } from "../src/index.js";
 
 describe("parseNetlist", () => {
@@ -35,6 +37,53 @@ R2 mid 0 1k
 
     const result = dcOp(parsed.circuit);
     expect(result.voltage("mid")).toBeCloseTo(5.0, 9);
+  });
+
+  it("builds and runs core analysis plans", () => {
+    const deck = `
+V1 in 0 DC 1 AC 1
+R1 in out 1k
+R2 out 0 1k
+C1 out 0 1u IC=0
+.options method=trap
+.op
+.dc V1 0 1 0.5
+.ac dec 1 1k 1k
+.tran 1m 1m
+.end
+`;
+    const parsed = parseNetlist(deck);
+
+    const plan = parsed.analysisPlan();
+    expect(plan).toEqual(buildAnalysisPlan(parsed));
+    expect(plan.map((step) => [step.index, step.kind])).toEqual([
+      [1, "op"],
+      [2, "dc"],
+      [3, "ac"],
+      [4, "tran"],
+    ]);
+
+    const results = parsed.runAnalysisPlan();
+    expect(results.map((result) => result.kind)).toEqual(["op", "dc", "ac", "tran"]);
+    expect((results[0].result as { voltage(node: string): number | undefined }).voltage("out"))
+      .toBeCloseTo(0.5, 9);
+    const dcPoints = results[1].result as readonly {
+      result: { voltage(node: string): number | undefined };
+    }[];
+    expect(dcPoints).toHaveLength(3);
+    expect(dcPoints.at(-1)?.result.voltage("out")).toBeCloseTo(0.5, 9);
+    const acPoints = results[2].result as readonly {
+      voltage(node: string): { real: number; imag: number } | undefined;
+    }[];
+    expect(acPoints).toHaveLength(1);
+    expect(acPoints[0].voltage("out")?.real ?? 0.0).toBeGreaterThan(0.0);
+    const transientPoints = results[3].result as readonly {
+      voltage(node: string): number | undefined;
+    }[];
+    expect(transientPoints).toHaveLength(1);
+    expect(transientPoints[0].voltage("out")).toBeGreaterThan(0.0);
+
+    expect(runNetlist(deck)).toHaveLength(4);
   });
 
   it("parses reactive elements, VCCS, source waveforms, and analysis cards", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -15,14 +15,13 @@ downstream tools to compare.
 
 ## Current PR Slice
 
-1. Distortion and pole-zero named-corner parity in Python and TypeScript.
+1. Netlist-to-analysis-plan execution for `.op`, `.dc`, `.ac`, and `.tran`.
    - Status: in progress.
-   - Rust already exposes `distortion_from_transient_corners`,
-     `CornerDistortionResult`, `format_corner_distortion_table`,
-     `pole_zero_corners`, `CornerPoleZeroResult`, `PoleZeroTopology`, and
-     `format_corner_pole_zero_table`.
-   - Python and TypeScript need matching result shapes, named-corner wrappers,
-     named-corner table helpers, changelog entries, and parity tests.
+   - Python, Rust, and TypeScript should expose matching plan builders and
+     execution helpers that run parsed `.op`, `.dc`, `.ac dec` / `.ac log`, and
+     `.tran` cards against the parsed circuit in deck order.
+   - The slice deliberately leaves `.measure`, `.save`, `.probe`, `.control`,
+     and non-log AC sweep execution to later backlog items.
 
 ## Completed Slices
 
@@ -50,6 +49,15 @@ downstream tools to compare.
    - Python and TypeScript now expose matching result shapes, named-corner
      Fourier wrappers, named-corner table helpers, changelog entries, and parity
      tests.
+
+4. Distortion and pole-zero named-corner parity in Python and TypeScript.
+   - Status: completed in PR 5417.
+   - Rust already exposes `distortion_from_transient_corners`,
+     `CornerDistortionResult`, `format_corner_distortion_table`,
+     `pole_zero_corners`, `CornerPoleZeroResult`, `PoleZeroTopology`, and
+     `format_corner_pole_zero_table`.
+   - Python and TypeScript now expose matching result shapes, named-corner
+     wrappers, named-corner table helpers, changelog entries, and parity tests.
 
 ## Backlog
 
@@ -110,11 +118,10 @@ downstream tools to compare.
 
 ## Suggested PR Queue
 
-1. Distortion/pole-zero corner audit and parity closure.
-2. Netlist-to-analysis-plan execution for `.op`, `.dc`, `.ac`, and `.tran`.
-3. `.measure`, `.save`, and `.probe` output selection.
-4. Sparse solver productionization and convergence diagnostics.
-5. Device model audit fixtures and model-card alias compatibility.
-6. Mixed-signal hardware VM bridge.
-7. Verilog-A/custom-model foothold.
-8. Compatibility corpus and release readiness.
+1. Netlist-to-analysis-plan execution for `.op`, `.dc`, `.ac`, and `.tran`.
+2. `.measure`, `.save`, and `.probe` output selection.
+3. Sparse solver productionization and convergence diagnostics.
+4. Device model audit fixtures and model-card alias compatibility.
+5. Mixed-signal hardware VM bridge.
+6. Verilog-A/custom-model foothold.
+7. Compatibility corpus and release readiness.


### PR DESCRIPTION
## Summary
- add cross-language analysis-plan builders and runners for parsed SPICE .op, .dc, .ac dec/log, and .tran cards
- expose Python, Rust, and TypeScript helpers plus ParsedNetlist convenience methods
- update parser tests, docs, changelogs, and the full-SPICE implementation plan after PR #5417 landed

## Validation
- Python: ruff check src tests
- Python: pytest tests/test_spice_netlist_parser.py -q
- TypeScript: npm run build
- TypeScript: npm test
- Rust: cargo fmt --check
- Rust: cargo test