### PR TITLE
Add browser form reset descriptors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser-readiness form-reset descriptors now expose resettable controls,
+  resetter controls, default reset values, selection/checked reset state, and
+  form-level `onreset` hooks as a flat browser-planning inventory.
 - Browser-readiness form-submission descriptors now expose successful controls,
   submission values, form action/method/target defaults, and submitter routing
   overrides as a flat browser-planning inventory.

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -845,6 +845,7 @@ pub struct BrowserDocument {
     pub resource_endpoint_descriptors: Vec<BrowserResourceEndpointDescriptor>,
     pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
     pub form_submission_descriptors: Vec<BrowserFormSubmissionDescriptor>,
+    pub form_reset_descriptors: Vec<BrowserFormResetDescriptor>,
     pub form_validation_descriptors: Vec<BrowserFormValidationDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
     pub headings: Vec<BrowserHeading>,
@@ -1332,6 +1333,36 @@ pub struct BrowserFormSubmissionDescriptor {
     pub submitter_target: Option<String>,
     pub effective_submitter_target: Option<String>,
     pub submitter_novalidate: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserFormResetDescriptor {
+    pub form_id: Option<String>,
+    pub form_name: Option<String>,
+    pub form_autocomplete: Option<String>,
+    pub form_event_handlers: Vec<String>,
+    pub form_reset_handlers: Vec<String>,
+    pub form_has_reset_handler: bool,
+    pub element: String,
+    pub id: Option<String>,
+    pub control_type: String,
+    pub name: Option<String>,
+    pub form_owner: Option<String>,
+    pub reset_kind: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub value: Option<String>,
+    pub reset_values: Vec<String>,
+    pub reset_value_count: usize,
+    pub selected_options: Vec<String>,
+    pub option_count: usize,
+    pub checked: bool,
+    pub disabled: bool,
+    pub readonly: bool,
+    pub resettable: bool,
+    pub resetter: bool,
+    pub reset_blocked: bool,
+    pub reset_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2842,6 +2873,7 @@ pub struct BrowserForm {
     pub rel_noopener: bool,
     pub rel_noreferrer: bool,
     pub novalidate: bool,
+    pub event_handlers: Vec<String>,
     pub fieldsets: Vec<BrowserFormFieldset>,
     pub labels: Vec<BrowserFormLabel>,
     pub datalists: Vec<BrowserFormDatalist>,
@@ -3377,6 +3409,7 @@ impl BrowserDocument {
         summary.context_menu_interaction_descriptors =
             browser_context_menu_interaction_descriptors(&summary);
         summary.form_submission_descriptors = browser_form_submission_descriptors(&summary.forms);
+        summary.form_reset_descriptors = browser_form_reset_descriptors(&summary.forms);
         summary.form_validation_descriptors = browser_form_validation_descriptors(&summary.forms);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary
@@ -19721,6 +19754,7 @@ fn browser_form(
         rel_noreferrer: browser_rel_tokens_contain(&rel_tokens, "noreferrer"),
         rel_tokens,
         novalidate,
+        event_handlers: browser_event_handlers(element),
         fieldsets,
         labels: form_labels,
         datalists,
@@ -19870,6 +19904,164 @@ fn browser_form_submission_element(control: &BrowserFormControl) -> String {
         | "search" | "submit" | "tel" | "text" | "time" | "url" | "week" => "input".to_string(),
         other => other.to_string(),
     }
+}
+
+fn browser_form_reset_descriptors(forms: &[BrowserForm]) -> Vec<BrowserFormResetDescriptor> {
+    forms
+        .iter()
+        .flat_map(|form| {
+            form.controls
+                .iter()
+                .filter_map(|control| browser_form_reset_descriptor(form, control))
+        })
+        .collect()
+}
+
+fn browser_form_reset_descriptor(
+    form: &BrowserForm,
+    control: &BrowserFormControl,
+) -> Option<BrowserFormResetDescriptor> {
+    let resettable = browser_form_resettable_control(control);
+    let resetter = browser_form_resetter(control);
+    if !resettable && !resetter {
+        return None;
+    }
+
+    let reset_block_reasons = browser_form_reset_block_reasons(control, resettable, resetter);
+    Some(BrowserFormResetDescriptor {
+        form_id: form.id.clone(),
+        form_name: form.name.clone(),
+        form_autocomplete: form.autocomplete.clone(),
+        form_event_handlers: form.event_handlers.clone(),
+        form_reset_handlers: browser_event_handlers_by_kind(
+            &form.event_handlers,
+            browser_reset_event,
+        ),
+        form_has_reset_handler: !browser_event_handlers_by_kind(
+            &form.event_handlers,
+            browser_reset_event,
+        )
+        .is_empty(),
+        element: browser_form_reset_element(control),
+        id: control.id.clone(),
+        control_type: control.control_type.clone(),
+        name: control.name.clone(),
+        form_owner: control.form_owner.clone(),
+        reset_kind: browser_form_reset_kind(control, resettable, resetter, &reset_block_reasons),
+        text: control.text.clone(),
+        accessible_name: control
+            .accessible_name
+            .clone()
+            .or_else(|| control.alt.clone()),
+        value: control.value.clone(),
+        reset_value_count: browser_form_reset_values(control).len(),
+        reset_values: browser_form_reset_values(control),
+        selected_options: control.selected_options.clone(),
+        option_count: control.option_items.len(),
+        checked: control.checked,
+        disabled: control.disabled,
+        readonly: control.readonly,
+        resettable,
+        resetter,
+        reset_blocked: !reset_block_reasons.is_empty(),
+        reset_block_reasons,
+    })
+}
+
+fn browser_form_reset_kind(
+    control: &BrowserFormControl,
+    resettable: bool,
+    resetter: bool,
+    reset_block_reasons: &[String],
+) -> String {
+    if !reset_block_reasons.is_empty() && resetter {
+        "blocked-resetter".to_string()
+    } else if resetter {
+        "resetter".to_string()
+    } else if matches!(control.control_type.as_str(), "checkbox" | "radio") {
+        "checked-reset-state".to_string()
+    } else if control.control_type == "select" {
+        "selection-reset-state".to_string()
+    } else if control.control_type == "file" {
+        "file-reset-state".to_string()
+    } else if control.control_type == "output" {
+        "output-reset-value".to_string()
+    } else if resettable {
+        "value-reset-state".to_string()
+    } else {
+        "reset-metadata".to_string()
+    }
+}
+
+fn browser_form_resettable_control(control: &BrowserFormControl) -> bool {
+    matches!(
+        control.control_type.as_str(),
+        "checkbox"
+            | "color"
+            | "date"
+            | "datetime-local"
+            | "email"
+            | "file"
+            | "month"
+            | "number"
+            | "password"
+            | "radio"
+            | "range"
+            | "search"
+            | "select"
+            | "tel"
+            | "text"
+            | "textarea"
+            | "time"
+            | "url"
+            | "week"
+            | "output"
+    )
+}
+
+fn browser_form_resetter(control: &BrowserFormControl) -> bool {
+    control.control_type == "reset"
+}
+
+fn browser_form_reset_block_reasons(
+    control: &BrowserFormControl,
+    resettable: bool,
+    resetter: bool,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if control.disabled {
+        reasons.push("disabled".to_string());
+    }
+    if !resettable && !resetter {
+        reasons.push("not-resettable".to_string());
+    }
+    reasons
+}
+
+fn browser_form_reset_values(control: &BrowserFormControl) -> Vec<String> {
+    if !control.selected_options.is_empty() {
+        return control.selected_options.clone();
+    }
+    if let Some(value) = &control.value {
+        return vec![value.clone()];
+    }
+    if !control.text.is_empty() {
+        return vec![control.text.clone()];
+    }
+    Vec::new()
+}
+
+fn browser_form_reset_element(control: &BrowserFormControl) -> String {
+    match control.control_type.as_str() {
+        "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file"
+        | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset"
+        | "search" | "submit" | "tel" | "text" | "time" | "url" | "week" => "input".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn browser_reset_event(handler: &str) -> bool {
+    handler.eq_ignore_ascii_case("onreset")
 }
 
 fn browser_form_validation_descriptors(
@@ -23874,6 +24066,116 @@ mod tests {
         let external = &descriptors[7];
         assert_eq!(external.form_owner.as_deref(), Some("checkout"));
         assert_eq!(external.submission_values, vec!["extra"]);
+    }
+
+    #[test]
+    fn browser_form_reset_descriptors_track_resetters_controls_and_handlers() {
+        let document = parse_browser_document(
+            "<form id=settings name=settings autocomplete=off onreset=restore()>\
+             <label for=title>Title</label><input id=title name=title value=Draft>\
+             <textarea id=body name=body readonly>Copy</textarea>\
+             <input id=enabled name=enabled type=checkbox value=yes checked>\
+             <input id=mode-a name=mode type=radio value=a>\
+             <input id=mode-b name=mode type=radio value=b checked>\
+             <select id=theme name=theme><option value=light selected>Light</option><option value=dark>Dark</option></select>\
+             <input id=upload name=upload type=file>\
+             <output id=preview name=preview>Preview</output>\
+             <button id=reset name=reset type=reset value=clear>Reset</button>\
+             <input id=disabled-reset type=reset value=disabled disabled>\
+             <input id=hidden name=hidden type=hidden value=keep>\
+             <button id=submit>Submit</button>\
+             </form>\
+             <input id=external form=settings name=outside value=outer>",
+        )
+        .expect("form reset descriptor document should parse");
+
+        let descriptors = &document.form_reset_descriptors;
+        let ids: Vec<&str> = descriptors
+            .iter()
+            .filter_map(|descriptor| descriptor.id.as_deref())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "title",
+                "body",
+                "enabled",
+                "mode-a",
+                "mode-b",
+                "theme",
+                "upload",
+                "preview",
+                "reset",
+                "disabled-reset",
+                "external"
+            ]
+        );
+
+        let title = &descriptors[0];
+        assert_eq!(title.form_id.as_deref(), Some("settings"));
+        assert_eq!(title.form_name.as_deref(), Some("settings"));
+        assert_eq!(title.form_autocomplete.as_deref(), Some("off"));
+        assert_eq!(title.form_event_handlers, vec!["onreset"]);
+        assert_eq!(title.form_reset_handlers, vec!["onreset"]);
+        assert!(title.form_has_reset_handler);
+        assert_eq!(title.element, "input");
+        assert_eq!(title.control_type, "text");
+        assert_eq!(title.reset_kind, "value-reset-state");
+        assert_eq!(title.accessible_name.as_deref(), Some("Title"));
+        assert_eq!(title.reset_values, vec!["Draft"]);
+        assert_eq!(title.reset_value_count, 1);
+        assert!(title.resettable);
+        assert!(!title.resetter);
+        assert!(!title.reset_blocked);
+
+        let body = &descriptors[1];
+        assert_eq!(body.element, "textarea");
+        assert_eq!(body.reset_values, vec!["Copy"]);
+        assert!(body.readonly);
+
+        let enabled = &descriptors[2];
+        assert_eq!(enabled.reset_kind, "checked-reset-state");
+        assert!(enabled.checked);
+        assert_eq!(enabled.reset_values, vec!["yes"]);
+
+        let unchecked_radio = &descriptors[3];
+        assert_eq!(unchecked_radio.reset_kind, "checked-reset-state");
+        assert!(!unchecked_radio.checked);
+        assert_eq!(unchecked_radio.reset_values, vec!["a"]);
+
+        let theme = &descriptors[5];
+        assert_eq!(theme.element, "select");
+        assert_eq!(theme.reset_kind, "selection-reset-state");
+        assert_eq!(theme.selected_options, vec!["light"]);
+        assert_eq!(theme.reset_values, vec!["light"]);
+        assert_eq!(theme.option_count, 2);
+
+        let upload = &descriptors[6];
+        assert_eq!(upload.control_type, "file");
+        assert_eq!(upload.reset_kind, "file-reset-state");
+        assert!(upload.reset_values.is_empty());
+
+        let output = &descriptors[7];
+        assert_eq!(output.element, "output");
+        assert_eq!(output.reset_kind, "output-reset-value");
+        assert_eq!(output.reset_values, vec!["Preview"]);
+
+        let reset = &descriptors[8];
+        assert_eq!(reset.reset_kind, "resetter");
+        assert!(reset.resetter);
+        assert!(!reset.resettable);
+        assert_eq!(reset.value.as_deref(), Some("clear"));
+
+        let disabled_reset = &descriptors[9];
+        assert_eq!(disabled_reset.reset_kind, "blocked-resetter");
+        assert!(disabled_reset.resetter);
+        assert!(disabled_reset.disabled);
+        assert!(disabled_reset.reset_blocked);
+        assert_eq!(disabled_reset.reset_block_reasons, vec!["disabled"]);
+
+        let external = &descriptors[10];
+        assert_eq!(external.form_owner.as_deref(), Some("settings"));
+        assert_eq!(external.reset_values, vec!["outer"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -12,9 +12,9 @@ use coding_adventures_html_parser::{
     BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl,
     BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement,
     BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormSelect, BrowserFormSubmissionDescriptor,
-    BrowserFormSubmitter, BrowserFormSuccessfulControl, BrowserFormTextEntry,
-    BrowserFormValidationControl, BrowserFormValidationDescriptor,
+    BrowserFormPolicySubmitterDescriptor, BrowserFormResetDescriptor, BrowserFormSelect,
+    BrowserFormSubmissionDescriptor, BrowserFormSubmitter, BrowserFormSuccessfulControl,
+    BrowserFormTextEntry, BrowserFormValidationControl, BrowserFormValidationDescriptor,
     BrowserFullscreenInteractionDescriptor, BrowserGlobalStateDescriptor, BrowserHeading,
     BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
     BrowserImageMapArea, BrowserImageSource, BrowserInputPlanningDescriptor,
@@ -103,6 +103,8 @@ struct ExpectedBrowserDocument {
     form_policy_descriptors: Vec<ExpectedFormPolicyDescriptor>,
     #[serde(default)]
     form_submission_descriptors: Option<Vec<ExpectedFormSubmissionDescriptor>>,
+    #[serde(default)]
+    form_reset_descriptors: Option<Vec<ExpectedFormResetDescriptor>>,
     #[serde(default)]
     form_validation_descriptors: Option<Vec<ExpectedFormValidationDescriptor>>,
     anchors: Vec<ExpectedAnchor>,
@@ -951,6 +953,59 @@ struct ExpectedFormSubmissionDescriptor {
     effective_submitter_target: Option<String>,
     #[serde(default)]
     submitter_novalidate: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFormResetDescriptor {
+    #[serde(default)]
+    form_id: Option<String>,
+    #[serde(default)]
+    form_name: Option<String>,
+    #[serde(default)]
+    form_autocomplete: Option<String>,
+    #[serde(default)]
+    form_event_handlers: Vec<String>,
+    #[serde(default)]
+    form_reset_handlers: Vec<String>,
+    #[serde(default)]
+    form_has_reset_handler: bool,
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    control_type: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    form_owner: Option<String>,
+    reset_kind: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    reset_values: Vec<String>,
+    #[serde(default)]
+    reset_value_count: usize,
+    #[serde(default)]
+    selected_options: Vec<String>,
+    #[serde(default)]
+    option_count: usize,
+    #[serde(default)]
+    checked: bool,
+    #[serde(default)]
+    disabled: bool,
+    #[serde(default)]
+    readonly: bool,
+    #[serde(default)]
+    resettable: bool,
+    #[serde(default)]
+    resetter: bool,
+    #[serde(default)]
+    reset_blocked: bool,
+    #[serde(default)]
+    reset_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2909,6 +2964,8 @@ struct ExpectedForm {
     #[serde(default)]
     novalidate: bool,
     #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
     fieldsets: Vec<ExpectedFormFieldset>,
     #[serde(default)]
     labels: Vec<ExpectedFormLabel>,
@@ -4349,6 +4406,26 @@ fn browser_form_submission_descriptors_track_flat_successful_controls_and_submit
 }
 
 #[test]
+fn browser_form_reset_descriptors_track_flat_resetters_and_controls() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "form-accessibility-document-page")
+        .expect("form accessibility fixture case should exist");
+
+    let actual =
+        parse_browser_document(&case.input).expect("form reset descriptor fixture should parse");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.form_reset_descriptors, expected.form_reset_descriptors,
+        "form reset descriptors should flatten resettable controls and resetter controls",
+    );
+}
+
+#[test]
 fn browser_form_hidden_descriptor_metadata_tracks_hidden_entries_and_form_owners() {
     let document = parse_browser_document(
         "<form id=session>\
@@ -5621,6 +5698,15 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_form_submission_descriptors(&forms));
+        let form_reset_descriptors = self
+            .form_reset_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedFormResetDescriptor::into_browser_form_reset_descriptor)
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_form_reset_descriptors(&forms));
         let form_validation_descriptors = self
             .form_validation_descriptors
             .map(|descriptors| {
@@ -5850,6 +5936,7 @@ impl ExpectedBrowserDocument {
                 .map(ExpectedFormPolicyDescriptor::into_browser_form_policy_descriptor)
                 .collect(),
             form_submission_descriptors,
+            form_reset_descriptors,
             form_validation_descriptors,
             anchors: self
                 .anchors
@@ -10694,6 +10781,197 @@ impl ExpectedFormSubmissionDescriptor {
     }
 }
 
+impl ExpectedFormResetDescriptor {
+    fn into_browser_form_reset_descriptor(self) -> BrowserFormResetDescriptor {
+        BrowserFormResetDescriptor {
+            form_id: self.form_id,
+            form_name: self.form_name,
+            form_autocomplete: self.form_autocomplete,
+            form_event_handlers: self.form_event_handlers,
+            form_reset_handlers: self.form_reset_handlers,
+            form_has_reset_handler: self.form_has_reset_handler,
+            element: self.element,
+            id: self.id,
+            control_type: self.control_type,
+            name: self.name,
+            form_owner: self.form_owner,
+            reset_kind: self.reset_kind,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            value: self.value,
+            reset_values: self.reset_values,
+            reset_value_count: self.reset_value_count,
+            selected_options: self.selected_options,
+            option_count: self.option_count,
+            checked: self.checked,
+            disabled: self.disabled,
+            readonly: self.readonly,
+            resettable: self.resettable,
+            resetter: self.resetter,
+            reset_blocked: self.reset_blocked,
+            reset_block_reasons: self.reset_block_reasons,
+        }
+    }
+}
+
+fn expected_form_reset_descriptors(forms: &[BrowserForm]) -> Vec<BrowserFormResetDescriptor> {
+    forms
+        .iter()
+        .flat_map(|form| {
+            form.controls
+                .iter()
+                .filter_map(|control| expected_form_reset_descriptor(form, control))
+        })
+        .collect()
+}
+
+fn expected_form_reset_descriptor(
+    form: &BrowserForm,
+    control: &BrowserFormControl,
+) -> Option<BrowserFormResetDescriptor> {
+    let resettable = expected_form_resettable_control(control);
+    let resetter = expected_form_resetter(control);
+    if !resettable && !resetter {
+        return None;
+    }
+
+    let reset_block_reasons = expected_form_reset_block_reasons(control, resettable, resetter);
+    Some(BrowserFormResetDescriptor {
+        form_id: form.id.clone(),
+        form_name: form.name.clone(),
+        form_autocomplete: form.autocomplete.clone(),
+        form_event_handlers: form.event_handlers.clone(),
+        form_reset_handlers: expected_event_handlers_by_kind(
+            &form.event_handlers,
+            expected_reset_event,
+        ),
+        form_has_reset_handler: !expected_event_handlers_by_kind(
+            &form.event_handlers,
+            expected_reset_event,
+        )
+        .is_empty(),
+        element: expected_form_reset_element(control),
+        id: control.id.clone(),
+        control_type: control.control_type.clone(),
+        name: control.name.clone(),
+        form_owner: control.form_owner.clone(),
+        reset_kind: expected_form_reset_kind(control, resettable, resetter, &reset_block_reasons),
+        text: control.text.clone(),
+        accessible_name: control
+            .accessible_name
+            .clone()
+            .or_else(|| control.alt.clone()),
+        value: control.value.clone(),
+        reset_value_count: expected_form_reset_values(control).len(),
+        reset_values: expected_form_reset_values(control),
+        selected_options: control.selected_options.clone(),
+        option_count: control.option_items.len(),
+        checked: control.checked,
+        disabled: control.disabled,
+        readonly: control.readonly,
+        resettable,
+        resetter,
+        reset_blocked: !reset_block_reasons.is_empty(),
+        reset_block_reasons,
+    })
+}
+
+fn expected_form_reset_kind(
+    control: &BrowserFormControl,
+    resettable: bool,
+    resetter: bool,
+    reset_block_reasons: &[String],
+) -> String {
+    if !reset_block_reasons.is_empty() && resetter {
+        "blocked-resetter".to_string()
+    } else if resetter {
+        "resetter".to_string()
+    } else if matches!(control.control_type.as_str(), "checkbox" | "radio") {
+        "checked-reset-state".to_string()
+    } else if control.control_type == "select" {
+        "selection-reset-state".to_string()
+    } else if control.control_type == "file" {
+        "file-reset-state".to_string()
+    } else if control.control_type == "output" {
+        "output-reset-value".to_string()
+    } else if resettable {
+        "value-reset-state".to_string()
+    } else {
+        "reset-metadata".to_string()
+    }
+}
+
+fn expected_form_resettable_control(control: &BrowserFormControl) -> bool {
+    matches!(
+        control.control_type.as_str(),
+        "checkbox"
+            | "color"
+            | "date"
+            | "datetime-local"
+            | "email"
+            | "file"
+            | "month"
+            | "number"
+            | "password"
+            | "radio"
+            | "range"
+            | "search"
+            | "select"
+            | "tel"
+            | "text"
+            | "textarea"
+            | "time"
+            | "url"
+            | "week"
+            | "output"
+    )
+}
+
+fn expected_form_resetter(control: &BrowserFormControl) -> bool {
+    control.control_type == "reset"
+}
+
+fn expected_form_reset_block_reasons(
+    control: &BrowserFormControl,
+    resettable: bool,
+    resetter: bool,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if control.disabled {
+        reasons.push("disabled".to_string());
+    }
+    if !resettable && !resetter {
+        reasons.push("not-resettable".to_string());
+    }
+    reasons
+}
+
+fn expected_form_reset_values(control: &BrowserFormControl) -> Vec<String> {
+    if !control.selected_options.is_empty() {
+        return control.selected_options.clone();
+    }
+    if let Some(value) = &control.value {
+        return vec![value.clone()];
+    }
+    if !control.text.is_empty() {
+        return vec![control.text.clone()];
+    }
+    Vec::new()
+}
+
+fn expected_form_reset_element(control: &BrowserFormControl) -> String {
+    match control.control_type.as_str() {
+        "button" | "checkbox" | "color" | "date" | "datetime-local" | "email" | "file"
+        | "hidden" | "image" | "month" | "number" | "password" | "radio" | "range" | "reset"
+        | "search" | "submit" | "tel" | "text" | "time" | "url" | "week" => "input".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn expected_reset_event(handler: &str) -> bool {
+    handler.eq_ignore_ascii_case("onreset")
+}
+
 fn expected_form_submission_descriptors(
     forms: &[BrowserForm],
 ) -> Vec<BrowserFormSubmissionDescriptor> {
@@ -12063,6 +12341,7 @@ impl ExpectedForm {
             rel_noopener: self.rel_noopener,
             rel_noreferrer: self.rel_noreferrer,
             novalidate: self.novalidate,
+            event_handlers: self.event_handlers,
             fieldsets: self
                 .fieldsets
                 .into_iter()

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -41,6 +41,9 @@ policy tokens, validation bypass state, and submitter overrides.
 Form-submission descriptor cases pin successful controls, submission values,
 form action/method/target defaults, and submitter routing overrides as a flat
 browser-planning inventory.
+Form-reset descriptor cases pin resettable controls, resetter controls, default
+reset values, selection/checked reset state, and form-level `onreset` hooks as a
+flat browser-planning inventory.
 Form-validation descriptor cases pin validation candidates, constraint
 attributes, barred controls, form-level `novalidate`, and submitter-level
 validation bypass hints as a flat browser-planning inventory.


### PR DESCRIPTION
## Summary
- add BrowserFormResetDescriptor and populate BrowserDocument with a flat reset-planning inventory
- expose resettable controls, resetter controls, default reset values, selection/checked reset state, disabled blockers, and form-level onreset hooks
- wire expected browser-readiness fixture derivation and docs for the new descriptor slice

## Tests
- cargo fmt -p coding-adventures-html-parser
- cargo test -p coding-adventures-html-parser browser_form_reset_descriptors
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser