### PR TITLE
Add smart-home activation control room tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -70,6 +70,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation operator queue planning:
   `smart_home.list_integration_activation_operator_queue` and
   `smart_home.get_integration_activation_operator_queue_summary`.
+- Added D18D handlers for D23A activation control-room panel planning:
+  `smart_home.list_integration_activation_control_room` and
+  `smart_home.get_integration_activation_control_room_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -58,6 +58,7 @@ Chief of Staff job/session/agent
   -> activation-forecast list and summary reads for next-action wave planning
   -> activation-playbook list and summary reads for operator-ready planning steps
   -> activation-operator queue list and summary reads for actionable work
+  -> activation-control-room list and summary reads for grouped operator panels
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -125,6 +126,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_playbook_summary`
 - `smart_home.list_integration_activation_operator_queue`
 - `smart_home.get_integration_activation_operator_queue_summary`
+- `smart_home.list_integration_activation_control_room`
+- `smart_home.get_integration_activation_control_room_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,45 +36,47 @@ use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_briefing_items_from_readouts,
     activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
-    activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
-    activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
-    activation_health_from_candidates, activation_maintenance_from_candidates,
-    activation_operator_tasks_from_playbook_steps, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
-    activation_readouts_from_candidates, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates,
-    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
-    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
-    entries_requiring_primitive, find_entry, first_party_catalog,
-    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
-    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
-    readiness_gap_inventory_from_reports, readiness_report_for_plan,
-    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
-    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
-    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
-    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
-    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
-    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
-    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
-    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
-    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
-    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
-    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
-    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
-    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
-    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
-    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    activation_control_room_panels_from_operator_tasks, activation_dashboard_cards_from_readouts,
+    activation_decisions_from_candidates, activation_dependency_graph_from_reports,
+    activation_dossiers_from_candidates, activation_evidence_from_candidates,
+    activation_forecasts_from_timeline_milestones, activation_health_from_candidates,
+    activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
+    describe_primitive_family, ecosystem_platform_coverage,
+    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
+    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
+    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
+    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
+    readiness_report_for_plan, readiness_reports_at_or_before_priority,
+    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
+    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
+    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
+    IntegrationActivationActionKind, IntegrationActivationActionSummary,
+    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
+    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
+    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
+    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationControlRoomPanel,
+    IntegrationActivationControlRoomSummary, IntegrationActivationDashboardCard,
+    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
+    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
+    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
+    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
+    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
+    IntegrationActivationForecastSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
+    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -265,6 +267,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
     "smart_home.list_integration_activation_operator_queue";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_operator_queue_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID: &str =
+    "smart_home.list_integration_activation_control_room";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_control_room_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -570,6 +576,18 @@ impl SmartHomeToolBridge {
                     let query = integration_activation_operator_queue_query(&arguments)?;
                     Ok(
                         get_integration_activation_operator_queue_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID => {
+                    let query = integration_activation_control_room_query(&arguments)?;
+                    Ok(list_integration_activation_control_room_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_control_room_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_control_room_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -1926,6 +1944,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation operator queue summary",
             "Return compact D23A activation operator queue counts for actionable work, blockers, review work, activation, and monitor tasks.",
             integration_activation_operator_queue_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID,
+            "List smart-home integration activation control room panels",
+            "List D23A activation control-room panels that group operator queue tasks by recommended planning view, attention state, blockers, review work, and activation readiness.",
+            integration_activation_control_room_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_control_room", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_control_room",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation control room summary",
+            "Return compact D23A activation control-room panel counts for attention, blockers, review work, activation work, and the next recommended view.",
+            integration_activation_control_room_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4622,6 +4674,17 @@ struct IntegrationActivationOperatorQueueQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationControlRoomQuery {
+    operator_queue: IntegrationActivationOperatorQueueQuery,
+    recommended_view: Option<IntegrationActivationPlaybookView>,
+    requires_attention: Option<bool>,
+    has_blockers: Option<bool>,
+    has_review_work: Option<bool>,
+    has_activation_work: Option<bool>,
+    panel_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -4971,6 +5034,29 @@ fn integration_activation_operator_queue_query(
         actionable: optional_bool(arguments, "actionable")?,
         include_monitor: optional_bool(arguments, "include_monitor")?.unwrap_or(false),
         task_limit: optional_u64(arguments, "task_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_control_room_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationControlRoomQuery, ToolCallError> {
+    let recommended_view = optional_string(arguments, "control_room_view")?
+        .or(optional_string(arguments, "panel_view")?)
+        .map(|label| parse_activation_playbook_view(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationControlRoomQuery {
+        operator_queue: integration_activation_operator_queue_query(arguments)?,
+        recommended_view,
+        requires_attention: optional_bool(arguments, "panel_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_blockers: optional_bool(arguments, "panel_has_blockers")?
+            .or(optional_bool(arguments, "has_blockers")?),
+        has_review_work: optional_bool(arguments, "panel_has_review_work")?
+            .or(optional_bool(arguments, "has_review_work")?),
+        has_activation_work: optional_bool(arguments, "panel_has_activation_work")?
+            .or(optional_bool(arguments, "has_activation_work")?),
+        panel_limit: optional_u64(arguments, "panel_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5625,6 +5711,35 @@ fn integration_activation_operator_tasks_for_query(
     }
 
     (tasks, catalog_count)
+}
+
+fn integration_activation_control_room_panels_for_query(
+    query: &IntegrationActivationControlRoomQuery,
+) -> (Vec<IntegrationActivationControlRoomPanel>, usize) {
+    let (tasks, catalog_count) =
+        integration_activation_operator_tasks_for_query(&query.operator_queue);
+    let mut panels = activation_control_room_panels_from_operator_tasks(tasks);
+
+    if let Some(view) = query.recommended_view {
+        panels.retain(|panel| panel.recommended_view == view);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        panels.retain(|panel| panel.requires_attention() == requires_attention);
+    }
+    if let Some(has_blockers) = query.has_blockers {
+        panels.retain(|panel| panel.has_blockers() == has_blockers);
+    }
+    if let Some(has_review_work) = query.has_review_work {
+        panels.retain(|panel| panel.has_review_work() == has_review_work);
+    }
+    if let Some(has_activation_work) = query.has_activation_work {
+        panels.retain(|panel| panel.has_activation_work() == has_activation_work);
+    }
+    if let Some(limit) = query.panel_limit {
+        panels.truncate(limit);
+    }
+
+    (panels, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -7329,6 +7444,88 @@ fn get_integration_activation_operator_queue_summary_output_handler_output(
                 summary
                     .next_task_kind
                     .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_control_room_output_handler_output(
+    query: IntegrationActivationControlRoomQuery,
+) -> ToolHandlerOutput {
+    let (panels, catalog_count) = integration_activation_control_room_panels_for_query(&query);
+    let summary = IntegrationActivationControlRoomSummary::from_panels(panels.iter());
+    let count = panels.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_control_room",
+            JsonValue::Array(
+                panels
+                    .iter()
+                    .map(activation_control_room_panel_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_control_room_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_control_room"),
+            ),
+            ("panels", integer(count as i64)),
+            (
+                "panels_requiring_attention",
+                integer(summary.panels_requiring_attention as i64),
+            ),
+            ("total_tasks", integer(summary.total_tasks as i64)),
+            (
+                "next_recommended_view",
+                summary
+                    .next_recommended_view
+                    .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_control_room_summary_output_handler_output(
+    query: IntegrationActivationControlRoomQuery,
+) -> ToolHandlerOutput {
+    let (panels, _) = integration_activation_control_room_panels_for_query(&query);
+    let summary = IntegrationActivationControlRoomSummary::from_panels(panels.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_control_room_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_control_room_summary"),
+            ),
+            ("total_panels", integer(summary.total_panels as i64)),
+            (
+                "panels_requiring_attention",
+                integer(summary.panels_requiring_attention as i64),
+            ),
+            ("total_tasks", integer(summary.total_tasks as i64)),
+            (
+                "next_recommended_view",
+                summary
+                    .next_recommended_view
+                    .map(|view| string(view.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -13802,6 +13999,237 @@ fn integration_activation_operator_queue_summary_json(
     ])
 }
 
+fn activation_control_room_panel_json(panel: &IntegrationActivationControlRoomPanel) -> JsonValue {
+    object([
+        ("sequence", integer(panel.sequence as i64)),
+        ("recommended_view", string(panel.recommended_view.as_str())),
+        ("priority", integer(panel.priority as i64)),
+        (
+            "task_sequences",
+            JsonValue::Array(
+                panel
+                    .task_sequences
+                    .iter()
+                    .map(|sequence| integer(*sequence as i64))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                panel
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(panel.integration_count() as i64),
+        ),
+        ("task_count", integer(panel.task_count as i64)),
+        (
+            "operator_summary",
+            integration_activation_operator_queue_summary_json(&panel.operator_summary),
+        ),
+        (
+            "has_operator_work",
+            JsonValue::Bool(panel.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(panel.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(panel.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(panel.has_blockers())),
+        ("has_review_work", JsonValue::Bool(panel.has_review_work())),
+        (
+            "requires_attention",
+            JsonValue::Bool(panel.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_control_room_summary_json(
+    summary: &IntegrationActivationControlRoomSummary,
+) -> JsonValue {
+    object([
+        ("total_panels", integer(summary.total_panels as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "panels_requiring_attention",
+            integer(summary.panels_requiring_attention as i64),
+        ),
+        (
+            "panels_with_operator_work",
+            integer(summary.panels_with_operator_work as i64),
+        ),
+        (
+            "panels_with_actionable_work",
+            integer(summary.panels_with_actionable_work as i64),
+        ),
+        (
+            "panels_with_activation_work",
+            integer(summary.panels_with_activation_work as i64),
+        ),
+        (
+            "panels_with_blockers",
+            integer(summary.panels_with_blockers as i64),
+        ),
+        (
+            "panels_with_review_work",
+            integer(summary.panels_with_review_work as i64),
+        ),
+        (
+            "constraint_panels",
+            integer(summary.constraint_panels as i64),
+        ),
+        (
+            "dependency_panels",
+            integer(summary.dependency_panels as i64),
+        ),
+        ("approval_panels", integer(summary.approval_panels as i64)),
+        ("review_panels", integer(summary.review_panels as i64)),
+        ("risk_panels", integer(summary.risk_panels as i64)),
+        ("action_panels", integer(summary.action_panels as i64)),
+        ("dashboard_panels", integer(summary.dashboard_panels as i64)),
+        ("total_tasks", integer(summary.total_tasks as i64)),
+        (
+            "operator_required_tasks",
+            integer(summary.operator_required_tasks as i64),
+        ),
+        ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+        (
+            "activation_ready_tasks",
+            integer(summary.activation_ready_tasks as i64),
+        ),
+        ("blocked_tasks", integer(summary.blocked_tasks as i64)),
+        (
+            "review_required_tasks",
+            integer(summary.review_required_tasks as i64),
+        ),
+        ("monitor_tasks", integer(summary.monitor_tasks as i64)),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_panel_sequence",
+            summary
+                .next_panel_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_panel_priority",
+            summary
+                .next_panel_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_panel_sequence",
+            summary
+                .first_blocked_panel_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_panel_sequence",
+            summary
+                .first_review_panel_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_panel_sequence",
+            summary
+                .first_activation_panel_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_panel_sequence",
+            summary
+                .first_actionable_panel_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_panel_priority",
+            summary
+                .first_blocked_panel_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_panel_priority",
+            summary
+                .first_review_panel_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_panel_priority",
+            summary
+                .first_activation_panel_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_panel_priority",
+            summary
+                .first_actionable_panel_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(summary.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -17579,6 +18007,37 @@ fn integration_activation_operator_queue_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_control_room_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_operator_queue_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("control_room_view", JsonSchema::String));
+        properties.push(SchemaProperty::new("panel_view", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "panel_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "panel_has_blockers",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "panel_has_review_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "panel_has_activation_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("panel_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -17723,7 +18182,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 99);
+        assert_eq!(definitions.len(), 101);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -17988,9 +18447,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            91
+            93
         );
         assert_eq!(
             export
@@ -18182,6 +18647,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -18436,11 +18909,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(99))
+            Some(&integer(101))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(91))
+            Some(&integer(93))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -21178,6 +21651,141 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_control_room_request = request(
+            "call-list-integration-activation-control-room",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("panel_requires_attention", JsonValue::Bool(true)),
+                ("panel_limit", integer(3)),
+            ]),
+            5_033,
+        );
+        let list_activation_control_room_trace =
+            tool_runtime.invoke_with_events(&list_activation_control_room_request);
+        assert!(list_activation_control_room_trace.result.ok);
+        assert_eq!(
+            list_activation_control_room_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_control_room_output = list_activation_control_room_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_control_room_count =
+            integer_value(field(list_activation_control_room_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_control_room_count));
+        let activation_control_room_summary =
+            field(list_activation_control_room_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_control_room_summary, "total_panels"),
+            Some(&integer(activation_control_room_count))
+        );
+        assert!(
+            integer_value(field(activation_control_room_summary, "total_tasks").unwrap()).unwrap()
+                >= activation_control_room_count
+        );
+        assert_eq!(
+            field(activation_control_room_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_control_room_panel = array_item(
+            field(
+                list_activation_control_room_output,
+                "activation_control_room",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_control_room_panel, "sequence").is_some());
+        assert!(field(activation_control_room_panel, "recommended_view").is_some());
+        assert!(field(activation_control_room_panel, "task_sequences").is_some());
+        assert!(field(activation_control_room_panel, "operator_summary").is_some());
+        assert_eq!(
+            field(activation_control_room_panel, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_control_room_summary_request = request(
+            "call-integration-activation-control-room-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("control_room_view", string("constraints")),
+                ("panel_has_blockers", JsonValue::Bool(true)),
+            ]),
+            5_034,
+        );
+        let activation_control_room_summary_trace =
+            tool_runtime.invoke_with_events(&activation_control_room_summary_request);
+        assert!(activation_control_room_summary_trace.result.ok);
+        assert_eq!(
+            activation_control_room_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_control_room_summary_output = activation_control_room_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_control_room_rollup =
+            field(activation_control_room_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_control_room_rollup, "constraint_panels").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_control_room_rollup, "next_recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_control_room_rollup, "next_task_kind"),
+            Some(&string("resolve_constraints"))
+        );
+        assert_eq!(
+            field(activation_control_room_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -22949,6 +23557,14 @@ mod tests {
             activation_operator_queue_summary_request,
             activation_operator_queue_summary_trace,
         );
+        journal.record_trace(
+            list_activation_control_room_request,
+            list_activation_control_room_trace,
+        );
+        journal.record_trace(
+            activation_control_room_summary_request,
+            activation_control_room_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -23022,9 +23638,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 99);
-        assert_eq!(journal_summary.completed_count, 99);
-        assert_eq!(journal.audit_records().len(), 99);
+        assert_eq!(journal_summary.invocation_count, 101);
+        assert_eq!(journal_summary.completed_count, 101);
+        assert_eq!(journal.audit_records().len(), 101);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -91,6 +91,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_operator_queue_summary` tool
   descriptors for read-only actionable human/operator work derived from
   playbook steps.
+- `smart_home.list_integration_activation_control_room` and
+  `smart_home.get_integration_activation_control_room_summary` tool
+  descriptors for read-only grouped operator-view panels derived from the
+  activation operator queue.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -93,6 +93,8 @@ Current scope:
   steps derived from forecast next actions
 - D18D integration activation-operator queue descriptors for actionable
   human/operator work derived from playbook steps
+- D18D integration activation-control-room descriptors for grouped
+  operator-view panels derived from the activation operator queue
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1497,6 +1497,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationPlaybookSummary,
     ListIntegrationActivationOperatorQueue,
     GetIntegrationActivationOperatorQueueSummary,
+    ListIntegrationActivationControlRoom,
+    GetIntegrationActivationControlRoomSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1694,6 +1696,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationOperatorQueueSummary => {
                 read_tool("smart_home.get_integration_activation_operator_queue_summary")
+            }
+            Self::ListIntegrationActivationControlRoom => {
+                read_tool("smart_home.list_integration_activation_control_room")
+            }
+            Self::GetIntegrationActivationControlRoomSummary => {
+                read_tool("smart_home.get_integration_activation_control_room_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2374,6 +2382,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationPlaybookSummary,
         SmartHomeTool::ListIntegrationActivationOperatorQueue,
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
+        SmartHomeTool::ListIntegrationActivationControlRoom,
+        SmartHomeTool::GetIntegrationActivationControlRoomSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3216,7 +3226,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 99);
+        assert_eq!(catalog.len(), 101);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3619,6 +3629,14 @@ mod tests {
             == "smart_home.get_integration_activation_operator_queue_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_control_room"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_control_room_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3626,15 +3644,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 99);
-        assert_eq!(summary.read_tools, 91);
+        assert_eq!(summary.total_tools, 101);
+        assert_eq!(summary.read_tools, 93);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 91);
+        assert_eq!(summary.read_only_tier_tools, 93);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 99);
+        assert_eq!(summary.total_required_capabilities, 101);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -78,6 +78,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationOperatorTask` and
   `IntegrationActivationOperatorTaskSummary` for turning playbook steps into
   actionable human/operator queue rows.
+- `IntegrationActivationControlRoomPanel` and
+  `IntegrationActivationControlRoomSummary` for grouping operator queue work by
+  recommended planning view.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -77,6 +77,8 @@ runtime and Chief of Staff tools a typed catalog for:
   planning views and operator-readiness flags
 - activation operator tasks that turn playbook steps into actionable
   human/operator queue rows
+- activation control-room panels that group operator tasks by recommended
+  planning view for compact attention, blocker, review, and activation rollups
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -2242,6 +2242,57 @@ pub struct IntegrationActivationOperatorTaskSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationControlRoomPanel {
+    pub sequence: usize,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub priority: u8,
+    pub task_sequences: Vec<usize>,
+    pub integration_ids: Vec<IntegrationId>,
+    pub task_count: usize,
+    pub operator_summary: IntegrationActivationOperatorTaskSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationControlRoomSummary {
+    pub total_panels: usize,
+    pub unique_integrations: usize,
+    pub panels_requiring_attention: usize,
+    pub panels_with_operator_work: usize,
+    pub panels_with_actionable_work: usize,
+    pub panels_with_activation_work: usize,
+    pub panels_with_blockers: usize,
+    pub panels_with_review_work: usize,
+    pub constraint_panels: usize,
+    pub dependency_panels: usize,
+    pub approval_panels: usize,
+    pub review_panels: usize,
+    pub risk_panels: usize,
+    pub action_panels: usize,
+    pub dashboard_panels: usize,
+    pub total_tasks: usize,
+    pub operator_required_tasks: usize,
+    pub actionable_tasks: usize,
+    pub activation_ready_tasks: usize,
+    pub blocked_tasks: usize,
+    pub review_required_tasks: usize,
+    pub monitor_tasks: usize,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_panel_sequence: Option<usize>,
+    pub next_panel_priority: Option<u8>,
+    pub first_blocked_panel_sequence: Option<usize>,
+    pub first_review_panel_sequence: Option<usize>,
+    pub first_activation_panel_sequence: Option<usize>,
+    pub first_actionable_panel_sequence: Option<usize>,
+    pub first_blocked_panel_priority: Option<u8>,
+    pub first_review_panel_priority: Option<u8>,
+    pub first_activation_panel_priority: Option<u8>,
+    pub first_actionable_panel_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -4719,6 +4770,244 @@ impl IntegrationActivationOperatorTaskSummary {
             || self.has_blockers()
             || self.has_review_work()
             || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationControlRoomPanel {
+    fn from_tasks(
+        sequence: usize,
+        recommended_view: IntegrationActivationPlaybookView,
+        tasks: Vec<IntegrationActivationOperatorTask>,
+    ) -> Self {
+        let operator_summary = IntegrationActivationOperatorTaskSummary::from_tasks(tasks.iter());
+        let mut task_sequences = tasks.iter().map(|task| task.sequence).collect::<Vec<_>>();
+        task_sequences.sort_unstable();
+
+        let mut integration_ids = tasks
+            .iter()
+            .flat_map(|task| task.integration_ids.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        integration_ids.sort();
+
+        let priority = tasks
+            .iter()
+            .map(|task| task.priority)
+            .min()
+            .unwrap_or(u8::MAX);
+
+        Self {
+            sequence,
+            recommended_view,
+            priority,
+            task_sequences,
+            integration_ids,
+            task_count: operator_summary.total_tasks,
+            operator_summary,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.operator_summary.has_operator_work()
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.operator_summary.has_actionable_work()
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.operator_summary.has_activation_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.operator_summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.operator_summary.has_review_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.operator_summary.requires_attention()
+    }
+}
+
+impl IntegrationActivationControlRoomSummary {
+    pub fn from_panels<'a>(
+        panels: impl IntoIterator<Item = &'a IntegrationActivationControlRoomPanel>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_panels: 0,
+            unique_integrations: 0,
+            panels_requiring_attention: 0,
+            panels_with_operator_work: 0,
+            panels_with_actionable_work: 0,
+            panels_with_activation_work: 0,
+            panels_with_blockers: 0,
+            panels_with_review_work: 0,
+            constraint_panels: 0,
+            dependency_panels: 0,
+            approval_panels: 0,
+            review_panels: 0,
+            risk_panels: 0,
+            action_panels: 0,
+            dashboard_panels: 0,
+            total_tasks: 0,
+            operator_required_tasks: 0,
+            actionable_tasks: 0,
+            activation_ready_tasks: 0,
+            blocked_tasks: 0,
+            review_required_tasks: 0,
+            monitor_tasks: 0,
+            next_recommended_view: None,
+            next_task_kind: None,
+            next_panel_sequence: None,
+            next_panel_priority: None,
+            first_blocked_panel_sequence: None,
+            first_review_panel_sequence: None,
+            first_activation_panel_sequence: None,
+            first_actionable_panel_sequence: None,
+            first_blocked_panel_priority: None,
+            first_review_panel_priority: None,
+            first_activation_panel_priority: None,
+            first_actionable_panel_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for panel in panels {
+            summary.total_panels += 1;
+            for integration_id in &panel.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match panel.recommended_view {
+                IntegrationActivationPlaybookView::ConstraintQueue => {
+                    summary.constraint_panels += 1
+                }
+                IntegrationActivationPlaybookView::DependencyGraph => {
+                    summary.dependency_panels += 1
+                }
+                IntegrationActivationPlaybookView::ApprovalPackets => summary.approval_panels += 1,
+                IntegrationActivationPlaybookView::ReviewQueue => summary.review_panels += 1,
+                IntegrationActivationPlaybookView::RiskRegister => summary.risk_panels += 1,
+                IntegrationActivationPlaybookView::ActivationActions => summary.action_panels += 1,
+                IntegrationActivationPlaybookView::StatusDashboard => summary.dashboard_panels += 1,
+            }
+
+            if summary.next_recommended_view.is_none()
+                && panel.operator_summary.next_task_kind.is_some()
+            {
+                summary.next_recommended_view = Some(panel.recommended_view);
+                summary.next_task_kind = panel.operator_summary.next_task_kind;
+                summary.next_panel_sequence = Some(panel.sequence);
+                summary.next_panel_priority = Some(panel.priority);
+            }
+
+            if panel.requires_attention() {
+                summary.panels_requiring_attention += 1;
+            }
+            if panel.has_operator_work() {
+                summary.panels_with_operator_work += 1;
+            }
+            if panel.has_actionable_work() {
+                summary.panels_with_actionable_work += 1;
+                summary.first_actionable_panel_sequence = summary
+                    .first_actionable_panel_sequence
+                    .or(Some(panel.sequence));
+                summary.first_actionable_panel_priority = min_optional_priority(
+                    summary.first_actionable_panel_priority,
+                    Some(panel.priority),
+                );
+            }
+            if panel.has_activation_work() {
+                summary.panels_with_activation_work += 1;
+                summary.first_activation_panel_sequence = summary
+                    .first_activation_panel_sequence
+                    .or(Some(panel.sequence));
+                summary.first_activation_panel_priority = min_optional_priority(
+                    summary.first_activation_panel_priority,
+                    Some(panel.priority),
+                );
+            }
+            if panel.has_blockers() {
+                summary.panels_with_blockers += 1;
+                summary.first_blocked_panel_sequence = summary
+                    .first_blocked_panel_sequence
+                    .or(Some(panel.sequence));
+                summary.first_blocked_panel_priority = min_optional_priority(
+                    summary.first_blocked_panel_priority,
+                    Some(panel.priority),
+                );
+            }
+            if panel.has_review_work() {
+                summary.panels_with_review_work += 1;
+                summary.first_review_panel_sequence =
+                    summary.first_review_panel_sequence.or(Some(panel.sequence));
+                summary.first_review_panel_priority = min_optional_priority(
+                    summary.first_review_panel_priority,
+                    Some(panel.priority),
+                );
+            }
+
+            summary.total_tasks += panel.operator_summary.total_tasks;
+            summary.operator_required_tasks += panel.operator_summary.operator_required_tasks;
+            summary.actionable_tasks += panel.operator_summary.actionable_tasks;
+            summary.activation_ready_tasks += panel.operator_summary.activation_ready_tasks;
+            summary.blocked_tasks += panel.operator_summary.blocked_tasks;
+            summary.review_required_tasks += panel.operator_summary.review_required_tasks;
+            summary.monitor_tasks += panel.operator_summary.monitor_tasks;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(panel.operator_summary.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.panels_with_blockers > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.panels_with_review_work > 0 || summary.panels_with_operator_work > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.panels_with_activation_work > 0 || summary.panels_with_actionable_work > 0
+        {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_panels == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.panels_with_operator_work > 0
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.panels_with_actionable_work > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.panels_with_activation_work > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.panels_with_blockers > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.panels_with_review_work > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.panels_requiring_attention > 0 || self.overall_status.requires_attention()
     }
 }
 
@@ -8875,6 +9164,102 @@ pub fn activation_operator_tasks_at_or_before_priority(
     ))
 }
 
+pub fn activation_control_room_panels_from_operator_tasks(
+    mut tasks: Vec<IntegrationActivationOperatorTask>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    tasks.sort_by(compare_activation_operator_tasks);
+    let mut tasks_by_view: BTreeMap<
+        IntegrationActivationPlaybookView,
+        Vec<IntegrationActivationOperatorTask>,
+    > = BTreeMap::new();
+    for task in tasks {
+        tasks_by_view
+            .entry(task.recommended_view)
+            .or_default()
+            .push(task);
+    }
+
+    let mut panels = tasks_by_view
+        .into_iter()
+        .map(|(view, tasks)| IntegrationActivationControlRoomPanel::from_tasks(0, view, tasks))
+        .collect::<Vec<_>>();
+    panels.sort_by(compare_activation_control_room_panels);
+    for (index, panel) in panels.iter_mut().enumerate() {
+        panel.sequence = index + 1;
+    }
+    panels
+}
+
+pub fn activation_control_room_panels_from_playbook_steps(
+    steps: Vec<IntegrationActivationPlaybookStep>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(
+        activation_operator_tasks_from_playbook_steps(steps),
+    )
+}
+
+pub fn activation_control_room_panels_from_forecasts(
+    forecasts: Vec<IntegrationActivationForecastItem>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(activation_operator_tasks_from_forecasts(
+        forecasts,
+    ))
+}
+
+pub fn activation_control_room_panels_from_timeline_milestones(
+    milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(
+        activation_operator_tasks_from_timeline_milestones(milestones),
+    )
+}
+
+pub fn activation_control_room_panels_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(
+        activation_operator_tasks_from_dashboard_cards(cards),
+    )
+}
+
+pub fn activation_control_room_panels_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(activation_operator_tasks_from_readouts(
+        readouts,
+    ))
+}
+
+pub fn activation_control_room_panels_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(activation_operator_tasks_from_candidates(
+        catalog,
+        candidates,
+        enabled_integrations,
+    ))
+}
+
+pub fn activation_control_room_panels_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationControlRoomPanel> {
+    activation_control_room_panels_from_operator_tasks(
+        activation_operator_tasks_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -10269,6 +10654,22 @@ fn compare_activation_operator_tasks(
         .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
         .then_with(|| left.task_kind.cmp(&right.task_kind))
         .then_with(|| left.recommended_view.cmp(&right.recommended_view))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_control_room_panels(
+    left: &IntegrationActivationControlRoomPanel,
+    right: &IntegrationActivationControlRoomPanel,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.has_actionable_work().cmp(&left.has_actionable_work()))
+        .then_with(|| left.recommended_view.cmp(&right.recommended_view))
+        .then_with(|| right.task_count.cmp(&left.task_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -12677,6 +13078,132 @@ mod tests {
         assert!(catalog_tasks
             .iter()
             .any(IntegrationActivationOperatorTask::requires_attention));
+    }
+
+    #[test]
+    fn activation_control_room_panels_group_operator_work_by_view() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let panels = activation_control_room_panels_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(panels.len(), 3);
+        assert_eq!(panels[0].sequence, 1);
+        assert_eq!(
+            panels[0].recommended_view,
+            IntegrationActivationPlaybookView::ConstraintQueue
+        );
+        assert_eq!(panels[0].priority, 1);
+        assert_eq!(panels[0].task_count, 1);
+        assert_eq!(panels[0].operator_summary.blocked_tasks, 1);
+        assert!(panels[0].has_blockers());
+        assert!(panels[0].requires_attention());
+        assert_eq!(
+            panels[0].operator_summary.next_task_kind,
+            Some(IntegrationActivationOperatorTaskKind::ResolveConstraints)
+        );
+        assert!(panels.iter().any(|panel| {
+            panel.recommended_view == IntegrationActivationPlaybookView::DependencyGraph
+                && panel.has_blockers()
+        }));
+        assert!(panels.iter().any(|panel| {
+            panel.recommended_view == IntegrationActivationPlaybookView::ActivationActions
+                && panel.has_activation_work()
+        }));
+
+        let summary = IntegrationActivationControlRoomSummary::from_panels(panels.iter());
+        assert_eq!(summary.total_panels, 3);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.total_tasks, 3);
+        assert_eq!(summary.constraint_panels, 1);
+        assert_eq!(summary.dependency_panels, 1);
+        assert_eq!(summary.action_panels, 1);
+        assert!(summary.panels_requiring_attention >= 2);
+        assert!(summary.panels_with_blockers >= 2);
+        assert_eq!(summary.panels_with_activation_work, 1);
+        assert_eq!(
+            summary.next_recommended_view,
+            Some(IntegrationActivationPlaybookView::ConstraintQueue)
+        );
+        assert_eq!(
+            summary.next_task_kind,
+            Some(IntegrationActivationOperatorTaskKind::ResolveConstraints)
+        );
+        assert_eq!(summary.next_panel_sequence, Some(1));
+        assert_eq!(summary.first_actionable_panel_sequence, Some(1));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_operator_work());
+        assert!(summary.has_actionable_work());
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_panels = activation_control_room_panels_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_panels
+            .iter()
+            .any(IntegrationActivationControlRoomPanel::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation control-room panels and summaries derived from operator queue tasks in `smart-home-integration-catalog`
- expose read-only D18D descriptors for listing control-room panels and fetching summary state in `smart-home-core`
- wire Chief smart-home tool handlers, schema, JSON output, runtime coverage, and docs for the control-room surface

## Validation
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`, `smart-home-integration-catalog`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, `smart-home-local-http`, `smart-home-discovery`, and `chief-of-staff-smart-home-tools`
