### PR TITLE
feat(lang-matrix): LM-W — WASM column for the expression languages

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — `lang-aot`
 
+## 0.58.0 — 2026-06-11 — WASM column for the expression languages (LANG-MATRIX LM-W)
+
+`lang_matrix.rs` gains a `Backend::Wasm` runner: source → wasm bytes (`iir-to-wasm`)
+→ the in-process `wasm-runtime`, with `main`'s wasm result read as the exit value
+(in-process, so no host gate — a WASM-tagged program that stops running fails the
+floor test loudly). Verified by RUNNING — the expression languages run on WASM:
+Twig→42, Oct→0, ALGOL `17 mod 5`→2. **14 proven matrix cells** (6 native + 5 LLVM +
+3 WASM).
+
+The other three WASM cells are scoped as follow-ups (gaps found by running): **Nib**
+traps (`type mismatch: expected i64, got I32(21)`) — the const literal still emits
+`i32` while the now-i64 param wants i64 (LLVM tolerated this via param-typed calls;
+`iir-to-wasm` is stricter); **BASIC** needs the `PRINT` env import wired into the
+runtime (`no body for function 0`); **Brainfuck** is deferred — `iir-to-wasm` lacks
+the tape ops (`UnsupportedOp: alloc_bytes`), the same class as Brainfuck-on-LLVM.
+
 ## 0.57.0 — 2026-06-11 — Dartmouth BASIC on LLVM (stdout path) (LANG-MATRIX LM-L BASIC)
 
 Greens **Dartmouth BASIC on LLVM**, the first I/O language in the LLVM column. The

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -127,9 +127,11 @@ non-Lisp languages (Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, ALGOL 60) compil
 host executable and produce the right result (exit code for the expression languages;
 stdout for the I/O languages). The **LLVM** column is green for Twig / Nib / Oct /
 ALGOL 60 (exit code) and Dartmouth BASIC (stdout, via a generic `__print_i64`
-runtime); only Brainfuck pends — `iir-to-llvm` needs the tape ops. The WASM/JVM/CLR
-columns follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and
-need op-coverage work.
+runtime); Brainfuck is deferred. The **WASM** column (in-process `wasm-runtime`) is
+green for the expression languages Twig / Oct / ALGOL 60; Nib (const-literal type),
+BASIC (print import), and Brainfuck (tape ops) are follow-ups. The JVM/CLR columns
+follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
+op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -14,13 +14,16 @@
 //!   Uniformly green: all six languages.
 //! * **LLVM** (Phase L) — source → textual `.ll` (`iir-to-llvm`) → real `clang` → run.
 //!   Green for Twig / Nib / Oct / ALGOL 60 (exit code) and Dartmouth BASIC (stdout —
-//!   the `.ll`'s `@__print_i64` is satisfied by a generic print runtime). Only
-//!   Brainfuck pends: `iir-to-llvm` lacks the tape ops (`alloc_bytes`/`load_byte`/
-//!   `store_byte` + `putchar`), a backend codegen slice.
+//!   the `.ll`'s `@__print_i64` is satisfied by a generic print runtime). Brainfuck
+//!   deferred (the i64-slot-model mismatch — see the spec's Deferred section).
+//! * **WASM** (Phase W) — source → wasm bytes (`iir-to-wasm`) → the in-process
+//!   `wasm-runtime`. Green for the expression languages Twig / Oct / ALGOL 60 (exit
+//!   code from `main`'s wasm result). Nib pends a const-literal type fix, BASIC the
+//!   stdout import, Brainfuck the tape ops — each its own follow-up.
 //!
-//! Later slices add the WASM / JVM / CLR columns (also general code generators) and
-//! tackle the two McCarthy-specialized backends — VM and JIT — which need
-//! arithmetic/comparison op-coverage (see `code/specs/LANG-PLATFORM-MATRIX.md`).
+//! Later slices add the JVM / CLR columns (also general code generators) and the
+//! Deferred items — Brainfuck-on-LLVM/WASM, and the McCarthy-specialized VM and JIT
+//! (op-coverage work). See `code/specs/LANG-PLATFORM-MATRIX.md`.
 //!
 //! ## Two result kinds
 //!
@@ -42,6 +45,8 @@ enum Backend {
     NativeAot,
     /// Source → textual `.ll` (`iir-to-llvm`) → real `clang` → run (Phase L).
     Llvm,
+    /// Source → wasm bytes (`iir-to-wasm`) → in-process `wasm-runtime` (Phase W).
+    Wasm,
 }
 
 /// The known, backend-independent observable result of a conformance program.
@@ -62,19 +67,19 @@ struct Prog {
     backends: &'static [Backend],
 }
 
-use Backend::{Llvm, NativeAot};
+use Backend::{Llvm, NativeAot, Wasm};
 
 /// The cross-language battery. Each program is deliberately tiny but exercises real
 /// computation (arithmetic, calls, comparisons, loops, I/O) — not just constants —
 /// so a backend that merely emits a literal would not pass.
 const PROGRAMS: &[Prog] = &[
     // Twig — the original AOT language; a bare expression is the whole program.
-    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm] },
+    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm] },
     // Nib — typed functions: define `double`, call it, return the result.
     // (LLVM cell greened in LM-L Nib: the Nib frontend now materialises its integer
-    // types to `i64` uniformly — completing its own stated convention — so a
-    // function's signature and its instruction bodies agree and `iir-to-llvm` emits
-    // valid, consistent LLVM.)
+    // types to `i64` uniformly. WASM pends a follow-up: the *const literal* `21` still
+    // emits `i32` while the now-i64 param wants i64 — `iir-to-wasm` is stricter than
+    // LLVM about it, which calls through the param type and tolerates the mismatch.)
     Prog {
         lang: Language::Nib,
         ext: "nib",
@@ -88,7 +93,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "oct",
         src: "fn main() { let x: u8 = 1; if x == 1 { let y: u8 = 2; } else { let z: u8 = 3; } }",
         expect: Expect::Exit(0),
-        backends: &[NativeAot, Llvm],
+        backends: &[NativeAot, Llvm, Wasm],
     },
     // ALGOL 60 — a begin/end block with real integer arithmetic (`17 mod 5` = 2).
     Prog {
@@ -96,7 +101,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "alg",
         src: "begin integer result; result := 17 mod 5 end",
         expect: Expect::Exit(2),
-        backends: &[NativeAot, Llvm],
+        backends: &[NativeAot, Llvm, Wasm],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // (LLVM column pending: `iir-to-llvm` lacks the tape ops `alloc_bytes`/`load_byte`/
@@ -259,12 +264,29 @@ fn run_llvm(p: &Prog) -> Option<(Option<i32>, String)> {
     Some((out.status.code(), stdout))
 }
 
+/// WASM runner: source → wasm bytes (`iir-to-wasm`) → the in-process `wasm-runtime`.
+/// No external tool — the runtime is in-repo, so this always runs (returns `None`
+/// only when the program fails to emit or the runtime can't load it). The exit-code
+/// programs return their value as `main`'s wasm result; the I/O languages (which
+/// route output through a stdout import) get their stdout-capturing variant in a
+/// later slice, so this runner covers the expression languages only.
+fn run_wasm(p: &Prog) -> Option<(Option<i32>, String)> {
+    let bytes = lang_aot::compile_source_to_wasm(p.lang, p.src, "main").ok()?;
+    let rt = wasm_runtime::WasmRuntime::new();
+    let result = rt.load_and_run(&bytes, "main", &[]).ok()?;
+    // `main`'s single i64 result is the program's value (`& 0xFF` matches the exit
+    // convention the native/LLVM columns use for the same programs).
+    let code = result.first().copied().map(|v| (v as i32) & 0xFF);
+    Some((code, String::new()))
+}
+
 /// Dispatch a program to a backend runner. `None` = the backend's toolchain is
 /// unavailable on this host (skip, like the W16 external-tool backends).
 fn run(backend: Backend, p: &Prog) -> Option<(Option<i32>, String)> {
     match backend {
         Backend::NativeAot => run_native(p),
         Backend::Llvm => run_llvm(p),
+        Backend::Wasm => run_wasm(p),
     }
 }
 
@@ -327,5 +349,14 @@ fn proven_columns_do_not_silently_skip() {
                 p.lang
             );
         }
+    }
+    // WASM: the runtime is in-process (always present), so every WASM-tagged program
+    // must run — no host gate.
+    for p in PROGRAMS.iter().filter(|p| p.backends.contains(&Wasm)) {
+        assert!(
+            run_wasm(p).is_some(),
+            "in-process wasm-runtime failed to run {:?}",
+            p.lang
+        );
     }
 }

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -101,12 +101,12 @@ achievable code-gen columns land first).
 
 | Language        | VM | JIT | native-AOT | LLVM | WASM | JVM | CLR |
 |-----------------|----|-----|-----------|------|------|-----|-----|
-| Twig            | ☐  | ☐   | ✅        | ✅   | ◑    | ◑   | ◑   |
+| Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ◑   | ◑   |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ☐    | ☐   | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
-| Oct             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
-| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
+| Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
+| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
 
 **native-AOT is uniformly ✅ as of LM0** — all six languages compile to a host
 executable and run with the expected result (`lang-aot/tests/lang_matrix.rs`:
@@ -158,12 +158,22 @@ slice — the loop trusts running, not this table.)
 The LLVM column is therefore green for **5 / 6** languages (Twig / Nib / Oct / ALGOL /
 BASIC); only Brainfuck is deferred.
 
-### Phase W — WASM for every language  ← NEXT
+### Phase W — WASM for every language
 
-- ☐ **LM-W** — each language on `iir-to-wasm` + `wasm-runtime` (Twig promote to full;
-  Nib/Oct/BF/BASIC/ALGOL new). I/O languages: thread stdout through the wasm runtime.
-  WASM is a general code generator (existing tests already run Twig and ALGOL
-  arithmetic on it), so expect mostly conformance + I/O wiring, like the LLVM column.
+- ✅ **LM-W expression languages (Twig / Oct / ALGOL on WASM).** Added a `Backend::Wasm`
+  runner to `lang_matrix.rs` (source → `iir-to-wasm` → the in-process `wasm-runtime`;
+  `main`'s wasm result is the exit value). Verified by RUNNING: Twig→42, Oct→0,
+  ALGOL `17 mod 5`→2. In-process, so no host gate.
+- ☐ **LM-W Nib (on WASM).** Same root family as the LLVM Nib fix but one layer
+  deeper: after `widen_nib_type`→i64 fixed signatures, the **const literal** `21` still
+  emits `i32` while the now-i64 param expects i64. `iir-to-wasm` traps
+  (`type mismatch: expected i64, got I32(21)`) where LLVM tolerated it (its call site
+  uses the param type). Fix: materialise Nib const-literal integer types to i64 too.
+- ☐ **LM-W BASIC (on WASM).** The in-process `wasm-runtime` reports `no body for
+  function 0` for BASIC — the `PRINT` env import (`__print_i64`-equivalent) isn't
+  provided to the runtime. Wire the print import + capture stdout, then assert `42`.
+- ⏸ **LM-W Brainfuck (on WASM) — DEFERRED.** `iir-to-wasm` lacks the tape ops too
+  (`UnsupportedOp: alloc_bytes`); same deferred class as Brainfuck-on-LLVM.
 
 ### Phase J — JVM for every language
 


### PR DESCRIPTION
## Summary

Phase W of the LANG-PLATFORM-MATRIX campaign — adds the **WASM column**. Mirrors the LLVM column exactly: the general code-gen backend runs the expression languages cleanly, and the I/O / type-mismatch cells are scoped as focused follow-ups.

- Adds a `Backend::Wasm` runner to `lang_matrix.rs`: source → wasm bytes (`iir-to-wasm`) → the **in-process `wasm-runtime`** (`host: None`, a sandboxed interpreter — same pattern as the McCarthy W16 `conformance.rs::run_wasm`). `main`'s wasm result is read as the exit value (`& 0xFF` to match the native/LLVM exit convention). In-process, so no host gate — a WASM-tagged program that stops running fails the floor test loudly.

**Verified by running:** the expression languages run on WASM — Twig→42, Oct→0, ALGOL `17 mod 5`→2. **14 proven matrix cells** (6 native + 5 LLVM + 3 WASM).

## The other three WASM cells (gaps found by running, scoped as follow-ups)

- **Nib** traps: `type mismatch: expected i64, got I32(21)`. Same family as the LLVM Nib fix, one layer deeper — `widen_nib_type`→i64 fixed *signatures*, but the **const literal** `21` still emits `i32` while the now-i64 param wants i64. LLVM tolerated it (its call site uses the param type); `iir-to-wasm` is stricter. Fix: materialise Nib const-literal integer types to i64 too.
- **BASIC**: `no body for function 0` — the `PRINT` env import isn't provided to the in-process runtime. Wire the print import + capture stdout, assert `42`.
- **Brainfuck**: deferred — `iir-to-wasm` also lacks the tape ops (`UnsupportedOp: alloc_bytes`), the same class as Brainfuck-on-LLVM.

All three are recorded in the spec's Phase W worklist.

## Security

Review **PASSED**. Test-only, in-process. The wasm bytes come from compiling **fixed in-repo source** via the repo's own `iir-to-wasm`, run on the in-repo `wasm-runtime` with no host interface (no fs/network/syscall imports) — no attacker-controlled input, same sandbox the McCarthy conformance suite already uses. `run_wasm` is `.ok()?`-based (no panics; safe on empty result vec); `(v as i32) & 0xFF` is a defined truncating cast + pure mask.

## Test plan

- `cargo test --test lang_matrix` → both tests pass: Twig/Oct/ALGOL on WASM agree (14 cells total). The in-process floor asserts every WASM-tagged program runs.
- Clippy clean.

## Versioning / docs

- `lang-aot` 0.57.0 → **0.58.0**
- Spec: WASM cells Twig/Oct/ALGOL ticked ✅; Phase W split into done + the Nib/BASIC/Brainfuck follow-ups; CHANGELOG + README updated.

Next: **LM-W Nib** (const-literal i64), then **LM-W BASIC** (print import), then **Phase J (JVM)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)