### PR TITLE
feat(lang-matrix): LM-W Nib — Nib on WASM by finishing the i64 materialization

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — `lang-aot`
 
+## 0.59.0 — 2026-06-11 — Nib joins the WASM column (LANG-MATRIX LM-W Nib)
+
+`lang_matrix.rs` greens **Nib on WASM** (the `Nib` program now lists `Wasm`). The fix is
+in `nib-iir-compiler` 0.8.0 (it finishes materializing Nib integer types to `i64` — the
+const literals and the un-annotated-literal fallback, which previously stayed `u8` and
+trapped the strict WASM backend). Verified by RUNNING: Nib `double(21)` → 42 on the
+in-process `wasm-runtime`, still → 42 on LLVM and native. WASM column now green for
+Twig / Nib / Oct / ALGOL 60; BASIC (print import) and Brainfuck (tape ops) remain.
+**15 proven matrix cells.**
+
 ## 0.58.0 — 2026-06-11 — WASM column for the expression languages (LANG-MATRIX LM-W)
 
 `lang_matrix.rs` gains a `Backend::Wasm` runner: source → wasm bytes (`iir-to-wasm`)

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -128,8 +128,8 @@ host executable and produce the right result (exit code for the expression langu
 stdout for the I/O languages). The **LLVM** column is green for Twig / Nib / Oct /
 ALGOL 60 (exit code) and Dartmouth BASIC (stdout, via a generic `__print_i64`
 runtime); Brainfuck is deferred. The **WASM** column (in-process `wasm-runtime`) is
-green for the expression languages Twig / Oct / ALGOL 60; Nib (const-literal type),
-BASIC (print import), and Brainfuck (tape ops) are follow-ups. The JVM/CLR columns
+green for Twig / Nib / Oct / ALGOL 60; BASIC (print import) and Brainfuck (tape ops)
+are follow-ups. The JVM/CLR columns
 follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
 op-coverage work.
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -75,17 +75,16 @@ use Backend::{Llvm, NativeAot, Wasm};
 const PROGRAMS: &[Prog] = &[
     // Twig — the original AOT language; a bare expression is the whole program.
     Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm] },
-    // Nib — typed functions: define `double`, call it, return the result.
-    // (LLVM cell greened in LM-L Nib: the Nib frontend now materialises its integer
-    // types to `i64` uniformly. WASM pends a follow-up: the *const literal* `21` still
-    // emits `i32` while the now-i64 param wants i64 — `iir-to-wasm` is stricter than
-    // LLVM about it, which calls through the param type and tolerates the mismatch.)
+    // Nib — typed functions: define `double`, call it, return the result. Greened on
+    // WASM in LM-W Nib by completing the i64 materialization: `nib_ty_str` and the
+    // un-annotated-literal fallback now emit `i64` (not `u8`), so the const argument
+    // `21` matches the `i64` parameter the strict WASM backend expects.
     Prog {
         lang: Language::Nib,
         ext: "nib",
         src: "fn double(x: u8) -> u8 { return x + x; } fn main() -> u8 { return double(21); }",
         expect: Expect::Exit(42),
-        backends: &[NativeAot, Llvm],
+        backends: &[NativeAot, Llvm, Wasm],
     },
     // Oct — `let` + `if` + comparison; `main` is void so the process exits 0.
     Prog {

--- a/code/packages/rust/nib-iir-compiler/CHANGELOG.md
+++ b/code/packages/rust/nib-iir-compiler/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — `nib-iir-compiler`
 
+## 0.8.0 — 2026-06-11 — finish the i64 materialization (const literals + call results) (LANG-MATRIX LM-W Nib)
+
+Completes the integer-type materialization started in 0.7.0. That release fixed
+`widen_nib_type` (function signatures / `let` types) but left **`nib_ty_str`** — which
+types const literals, `ret` values, and call results — emitting the narrow `"u8"`, and
+the const-emit path's *fallback* (for an integer literal the type-checker didn't
+annotate) was hard-coded `"u8"`. So a bare literal argument like `double(21)` emitted a
+`u8` (→ `i32`) const into an `i64` parameter. The LLVM backend tolerated this (its call
+site uses the callee's parameter type), but the **strict WASM backend trapped**:
+`type mismatch: expected i64, got I32(21)`.
+
+Both `nib_ty_str` (`u4`/`u8`/`bcd` → `i64`) and the un-annotated-literal fallback
+(`"u8"` → `"i64"`) now materialise integers as `i64`, so the whole Nib IIR is uniformly
+`i64` for integers — const literals, `let`s, arithmetic, `ret`, calls, and signatures
+all agree. Verified by RUNNING: Nib `double(21)` → 42 on WASM (previously a trap), still
+→ 42 on LLVM and native AOT (no regression); all nib-iir-compiler (28),
+`iir-to-wasm` (46), and `iir-to-llvm` (102) tests green. Narrow semantic width remains a
+deferred backend-masking concern.
+
 ## 0.7.0 — 2026-06-11 — materialise integer types to i64 uniformly (LANG-MATRIX LM-L Nib)
 
 Fixes a type-**inconsistency** in the emitted IIR that a strict backend (`iir-to-llvm`)

--- a/code/packages/rust/nib-iir-compiler/Cargo.toml
+++ b/code/packages/rust/nib-iir-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nib-iir-compiler"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Compile Nib source to InterpreterIR (IIRModule), feeding the LANG-runtime AOT/JIT pipeline.  v0.5.0: marks main function FullyTyped so the JITCore + GenericCirJit chain can run Nib programs JIT-compiled.  v0.6.0: threads real source positions through IIRFunction::source_map for line-based debugger breakpoints."
 

--- a/code/packages/rust/nib-iir-compiler/src/lib.rs
+++ b/code/packages/rust/nib-iir-compiler/src/lib.rs
@@ -550,7 +550,13 @@ impl Compiler {
         // primary is one of: INT_LIT | HEX_LIT | NAME | call_expr | "(" expr ")" | …
         if let Some(value) = parse_literal(node) {
             let v = self.fresh_var();
-            let ty = lookup_node_type(node, types).map(nib_ty_str).unwrap_or("u8");
+            // An integer literal materialises as `i64` (the machine-word convention
+            // used everywhere else in the Nib IIR). When the type-checker annotated
+            // the node, `nib_ty_str` already returns `i64`; the **fallback** for an
+            // un-annotated literal must also be `i64`, not the narrow `"u8"` — else a
+            // bare literal argument (e.g. `double(21)`) is emitted as `i32` and traps
+            // the strict WASM backend when the callee's parameter is `i64`.
+            let ty = lookup_node_type(node, types).map(nib_ty_str).unwrap_or("i64");
             self.emit_to(out, IIRInstr::new(
                 "const",
                 Some(v.clone()),
@@ -930,10 +936,17 @@ fn lookup_node_type<'a>(node: &'a GrammarASTNode, types: &'a HashMap<usize, NibT
 }
 
 fn nib_ty_str(t: &NibType) -> &'static str {
+    // Nib's integer types materialise as `i64` in the IIR — the same machine-word
+    // convention `widen_nib_type` (function signatures / `let`s) uses and the bodies
+    // already use. This function types **const literals, `ret` values, and call
+    // results**; before, those were emitted as the narrow `"u8"` while signatures
+    // were `i64`, so a `const 21 : u8` passed to an `i64` parameter trapped on the
+    // strict WASM backend (`type mismatch: expected i64, got I32(21)`) — LLVM had
+    // tolerated it because its call site uses the param type. Materialising integers
+    // to `i64` here keeps the whole module uniform (consts/lets/arith/ret/calls all
+    // `i64`). Narrow semantic width is a backend-masking concern, deferred.
     match t {
-        NibType::U4   => "u8",   // u4 has no native CIR mnemonic; widen to u8
-        NibType::U8   => "u8",
-        NibType::Bcd  => "u8",   // BCD is byte-encoded
+        NibType::U4 | NibType::U8 | NibType::Bcd => "i64",
         NibType::Bool => "bool",
         NibType::Void => "void",
     }

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -102,7 +102,7 @@ achievable code-gen columns land first).
 | Language        | VM | JIT | native-AOT | LLVM | WASM | JVM | CLR |
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ◑   | ◑   |
-| Nib             | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
+| Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
 | Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ☐    | ☐   | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
@@ -164,11 +164,13 @@ BASIC); only Brainfuck is deferred.
   runner to `lang_matrix.rs` (source → `iir-to-wasm` → the in-process `wasm-runtime`;
   `main`'s wasm result is the exit value). Verified by RUNNING: Twig→42, Oct→0,
   ALGOL `17 mod 5`→2. In-process, so no host gate.
-- ☐ **LM-W Nib (on WASM).** Same root family as the LLVM Nib fix but one layer
-  deeper: after `widen_nib_type`→i64 fixed signatures, the **const literal** `21` still
-  emits `i32` while the now-i64 param expects i64. `iir-to-wasm` traps
-  (`type mismatch: expected i64, got I32(21)`) where LLVM tolerated it (its call site
-  uses the param type). Fix: materialise Nib const-literal integer types to i64 too.
+- ✅ **LM-W Nib (on WASM).** Completed the i64 materialization the LLVM Nib fix
+  started: `nib_ty_str` (const literals / `ret` / call results) **and** the
+  un-annotated-literal fallback now emit `i64`, not the narrow `u8`. So the bare
+  literal argument in `double(21)` is `i64`, matching the `i64` parameter the strict
+  WASM backend requires. Verified by RUNNING: Nib on WASM → 42, and still LLVM → 42,
+  native → 42 (no regression); nib-iir-compiler (28) + `iir-to-wasm`/`iir-to-llvm`
+  suites all green.
 - ☐ **LM-W BASIC (on WASM).** The in-process `wasm-runtime` reports `no body for
   function 0` for BASIC — the `PRINT` env import (`__print_i64`-equivalent) isn't
   provided to the runtime. Wire the print import + capture stdout, then assert `42`.


### PR DESCRIPTION
## Summary

Greens **Nib → WASM**, completing the integer-type materialization the LLVM Nib fix started.

The prior fix (`nib-iir-compiler` 0.7.0) changed `widen_nib_type` so Nib function **signatures** are `i64`, but two other paths still emitted the narrow `u8`:
1. **`nib_ty_str`** — types const literals, `ret` values, and call results.
2. The const-emit **fallback** for an integer literal the type-checker didn't annotate (`unwrap_or("u8")`).

So a bare literal argument like `double(21)` emitted a `u8` (→ `i32`) const into an `i64` parameter. The LLVM backend tolerated this (its call site uses the callee's param type), but the **strict WASM backend trapped**: `type mismatch: expected i64, got I32(21)`.

**Fix:** both `nib_ty_str` (`u4`/`u8`/`bcd` → `i64`) and the un-annotated-literal fallback (`"u8"` → `"i64"`) now materialise integers as `i64`. The whole Nib IIR is now uniformly `i64` for integers — const literals, `let`s, arithmetic, `ret`, calls, and signatures all agree.

**Verified by running:** Nib `double(21)` → **42 on WASM** (previously a trap), and still → 42 on **LLVM** and **native AOT** (no regression). `nib-iir-compiler` (28) + `iir-to-wasm` (46) + `iir-to-llvm` (102) suites all green. **15 proven matrix cells.**

## Security

Review **PASSED**. Compiler-internal type lowering for a toy language with no pointers/arrays/allocation — widening literals to 64-bit has no buffer/index/size to affect, so no memory-safety surface. It increases cross-backend consistency (WASM now agrees with LLVM/native, which already worked in i64 machine words); the prior mismatch was a fail-closed *trap*, not silent unsafe codegen, and the fix removes it by making types uniform.

## Test plan

- `cargo test --test lang_matrix` → Nib on WASM agrees (42); 15 cells total, all agree.
- Full `nib-iir-compiler` / `iir-to-wasm` / `iir-to-llvm` suites green; clippy clean.

## Versioning / docs

- `nib-iir-compiler` 0.7.0 → **0.8.0**; `lang-aot` 0.58.0 → **0.59.0**
- Spec: Nib WASM cell ticked ✅ (WASM column now Twig/Nib/Oct/ALGOL); both CHANGELOGs + README updated.

Next: **LM-W BASIC** (wire the `PRINT` env import into the in-process runtime), then **Phase J (JVM)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)