### PR TITLE
Add smart-home activation command center tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -73,6 +73,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation control-room panel planning:
   `smart_home.list_integration_activation_control_room` and
   `smart_home.get_integration_activation_control_room_summary`.
+- Added D18D handlers for D23A activation command-center operating lanes:
+  `smart_home.list_integration_activation_command_center` and
+  `smart_home.get_integration_activation_command_center_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -59,6 +59,7 @@ Chief of Staff job/session/agent
   -> activation-playbook list and summary reads for operator-ready planning steps
   -> activation-operator queue list and summary reads for actionable work
   -> activation-control-room list and summary reads for grouped operator panels
+  -> activation-command-center list and summary reads for operating-lane rollups
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -128,6 +129,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_operator_queue_summary`
 - `smart_home.list_integration_activation_control_room`
 - `smart_home.get_integration_activation_control_room_summary`
+- `smart_home.list_integration_activation_command_center`
+- `smart_home.get_integration_activation_command_center_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -35,31 +35,34 @@ use smart_home_discovery::{
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_briefing_items_from_readouts,
-    activation_candidates_at_or_before_priority, activation_constraints_from_candidates,
-    activation_control_room_panels_from_operator_tasks, activation_dashboard_cards_from_readouts,
-    activation_decisions_from_candidates, activation_dependency_graph_from_reports,
-    activation_dossiers_from_candidates, activation_evidence_from_candidates,
-    activation_forecasts_from_timeline_milestones, activation_health_from_candidates,
-    activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
-    activation_plan_for_entry, activation_plans_at_or_before_priority,
-    activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runway_from_candidates, activation_timeline_milestones_from_dashboard_cards,
-    describe_primitive_family, ecosystem_platform_coverage,
-    ecosystem_platforms_requiring_primitive, ecosystem_survey_sources, entries_requiring_primitive,
-    find_entry, first_party_catalog, policy_surface_inventory_at_or_before_priority,
-    primitive_backlog_at_or_before_priority, primitive_backlog_with_ecosystem_coverage,
-    primitive_family_descriptors, query_integrations, readiness_gap_inventory_from_reports,
-    readiness_report_for_plan, readiness_reports_at_or_before_priority,
-    survey_sources_requiring_primitive, AuthMode, ConnectivityClass, DiscoveryMechanism,
-    EcosystemPlatformCoverageItem, EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform,
-    EcosystemSurveySource, ImplementationStatus, IntegrationActivationAction,
-    IntegrationActivationActionKind, IntegrationActivationActionSummary,
-    IntegrationActivationAgendaStage, IntegrationActivationAgendaSummary,
-    IntegrationActivationApprovalPacket, IntegrationActivationApprovalSummary,
-    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
-    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
-    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    activation_candidates_at_or_before_priority,
+    activation_command_center_sections_from_control_room_panels,
+    activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
+    activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
+    activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
+    activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
+    activation_health_from_candidates, activation_maintenance_from_candidates,
+    activation_operator_tasks_from_playbook_steps, activation_plan_for_entry,
+    activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
+    activation_readouts_from_candidates, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runway_from_candidates,
+    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
+    ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
+    entries_requiring_primitive, find_entry, first_party_catalog,
+    policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
+    primitive_backlog_with_ecosystem_coverage, primitive_family_descriptors, query_integrations,
+    readiness_gap_inventory_from_reports, readiness_report_for_plan,
+    readiness_reports_at_or_before_priority, survey_sources_requiring_primitive, AuthMode,
+    ConnectivityClass, DiscoveryMechanism, EcosystemPlatformCoverageItem,
+    EcosystemPlatformCoverageSummary, EcosystemSurveyPlatform, EcosystemSurveySource,
+    ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
+    IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
+    IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
+    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
+    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
+    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
+    IntegrationActivationCandidateSummary, IntegrationActivationCommandCenterSection,
+    IntegrationActivationCommandCenterSectionKind, IntegrationActivationCommandCenterSummary,
     IntegrationActivationConstraint, IntegrationActivationConstraintKind,
     IntegrationActivationConstraintSummary, IntegrationActivationControlRoomPanel,
     IntegrationActivationControlRoomSummary, IntegrationActivationDashboardCard,
@@ -271,6 +274,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CONTROL_ROOM_TOOL_ID: &str =
     "smart_home.list_integration_activation_control_room";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_control_room_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID: &str =
+    "smart_home.list_integration_activation_command_center";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_command_center_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -588,6 +595,18 @@ impl SmartHomeToolBridge {
                     let query = integration_activation_control_room_query(&arguments)?;
                     Ok(
                         get_integration_activation_control_room_summary_output_handler_output(
+                            query,
+                        ),
+                    )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID => {
+                    let query = integration_activation_command_center_query(&arguments)?;
+                    Ok(list_integration_activation_command_center_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_command_center_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_command_center_summary_output_handler_output(
                             query,
                         ),
                     )
@@ -1978,6 +1997,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation control room summary",
             "Return compact D23A activation control-room panel counts for attention, blockers, review work, activation work, and the next recommended view.",
             integration_activation_control_room_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID,
+            "List smart-home integration activation command center sections",
+            "List D23A activation command-center sections that group control-room panels into blocker, review, activation, actionable, and monitoring operating lanes.",
+            integration_activation_command_center_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_command_center", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_command_center",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation command center summary",
+            "Return compact D23A activation command-center section counts for blocker, review, activation, actionable, and monitoring operating lanes.",
+            integration_activation_command_center_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4685,6 +4738,17 @@ struct IntegrationActivationControlRoomQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationCommandCenterQuery {
+    control_room: IntegrationActivationControlRoomQuery,
+    section_kind: Option<IntegrationActivationCommandCenterSectionKind>,
+    requires_attention: Option<bool>,
+    has_blockers: Option<bool>,
+    has_review_work: Option<bool>,
+    has_activation_work: Option<bool>,
+    section_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5057,6 +5121,29 @@ fn integration_activation_control_room_query(
         has_activation_work: optional_bool(arguments, "panel_has_activation_work")?
             .or(optional_bool(arguments, "has_activation_work")?),
         panel_limit: optional_u64(arguments, "panel_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_command_center_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationCommandCenterQuery, ToolCallError> {
+    let section_kind = optional_string(arguments, "command_center_section")?
+        .or(optional_string(arguments, "section_kind")?)
+        .map(|label| parse_activation_command_center_section_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationCommandCenterQuery {
+        control_room: integration_activation_control_room_query(arguments)?,
+        section_kind,
+        requires_attention: optional_bool(arguments, "section_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_blockers: optional_bool(arguments, "section_has_blockers")?
+            .or(optional_bool(arguments, "has_blockers")?),
+        has_review_work: optional_bool(arguments, "section_has_review_work")?
+            .or(optional_bool(arguments, "has_review_work")?),
+        has_activation_work: optional_bool(arguments, "section_has_activation_work")?
+            .or(optional_bool(arguments, "has_activation_work")?),
+        section_limit: optional_u64(arguments, "section_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5740,6 +5827,35 @@ fn integration_activation_control_room_panels_for_query(
     }
 
     (panels, catalog_count)
+}
+
+fn integration_activation_command_center_sections_for_query(
+    query: &IntegrationActivationCommandCenterQuery,
+) -> (Vec<IntegrationActivationCommandCenterSection>, usize) {
+    let (panels, catalog_count) =
+        integration_activation_control_room_panels_for_query(&query.control_room);
+    let mut sections = activation_command_center_sections_from_control_room_panels(panels);
+
+    if let Some(section_kind) = query.section_kind {
+        sections.retain(|section| section.section_kind == section_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        sections.retain(|section| section.requires_attention() == requires_attention);
+    }
+    if let Some(has_blockers) = query.has_blockers {
+        sections.retain(|section| section.has_blockers() == has_blockers);
+    }
+    if let Some(has_review_work) = query.has_review_work {
+        sections.retain(|section| section.has_review_work() == has_review_work);
+    }
+    if let Some(has_activation_work) = query.has_activation_work {
+        sections.retain(|section| section.has_activation_work() == has_activation_work);
+    }
+    if let Some(limit) = query.section_limit {
+        sections.truncate(limit);
+    }
+
+    (sections, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -7526,6 +7642,91 @@ fn get_integration_activation_control_room_summary_output_handler_output(
                 summary
                     .next_recommended_view
                     .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_command_center_output_handler_output(
+    query: IntegrationActivationCommandCenterQuery,
+) -> ToolHandlerOutput {
+    let (sections, catalog_count) =
+        integration_activation_command_center_sections_for_query(&query);
+    let summary = IntegrationActivationCommandCenterSummary::from_sections(sections.iter());
+    let count = sections.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_command_center",
+            JsonValue::Array(
+                sections
+                    .iter()
+                    .map(activation_command_center_section_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_command_center_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_command_center"),
+            ),
+            ("sections", integer(count as i64)),
+            (
+                "sections_requiring_attention",
+                integer(summary.sections_requiring_attention as i64),
+            ),
+            ("total_panels", integer(summary.total_panels as i64)),
+            ("total_tasks", integer(summary.total_tasks as i64)),
+            (
+                "next_section_kind",
+                summary
+                    .next_section_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_command_center_summary_output_handler_output(
+    query: IntegrationActivationCommandCenterQuery,
+) -> ToolHandlerOutput {
+    let (sections, _) = integration_activation_command_center_sections_for_query(&query);
+    let summary = IntegrationActivationCommandCenterSummary::from_sections(sections.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_command_center_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_command_center_summary"),
+            ),
+            ("total_sections", integer(summary.total_sections as i64)),
+            (
+                "sections_requiring_attention",
+                integer(summary.sections_requiring_attention as i64),
+            ),
+            ("total_panels", integer(summary.total_panels as i64)),
+            ("total_tasks", integer(summary.total_tasks as i64)),
+            (
+                "next_section_kind",
+                summary
+                    .next_section_kind
+                    .map(|kind| string(kind.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -14230,6 +14431,261 @@ fn integration_activation_control_room_summary_json(
     ])
 }
 
+fn activation_command_center_section_json(
+    section: &IntegrationActivationCommandCenterSection,
+) -> JsonValue {
+    object([
+        ("sequence", integer(section.sequence as i64)),
+        ("section_kind", string(section.section_kind.as_str())),
+        ("priority", integer(section.priority as i64)),
+        (
+            "panel_sequences",
+            JsonValue::Array(
+                section
+                    .panel_sequences
+                    .iter()
+                    .map(|sequence| integer(*sequence as i64))
+                    .collect(),
+            ),
+        ),
+        (
+            "recommended_views",
+            JsonValue::Array(
+                section
+                    .recommended_views
+                    .iter()
+                    .map(|view| string(view.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                section
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(section.integration_count() as i64),
+        ),
+        ("panel_count", integer(section.panel_count as i64)),
+        (
+            "control_room_summary",
+            integration_activation_control_room_summary_json(&section.control_room_summary),
+        ),
+        (
+            "has_operator_work",
+            JsonValue::Bool(section.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(section.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(section.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(section.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(section.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(section.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_command_center_summary_json(
+    summary: &IntegrationActivationCommandCenterSummary,
+) -> JsonValue {
+    object([
+        ("total_sections", integer(summary.total_sections as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "sections_requiring_attention",
+            integer(summary.sections_requiring_attention as i64),
+        ),
+        (
+            "sections_with_operator_work",
+            integer(summary.sections_with_operator_work as i64),
+        ),
+        (
+            "sections_with_actionable_work",
+            integer(summary.sections_with_actionable_work as i64),
+        ),
+        (
+            "sections_with_activation_work",
+            integer(summary.sections_with_activation_work as i64),
+        ),
+        (
+            "sections_with_blockers",
+            integer(summary.sections_with_blockers as i64),
+        ),
+        (
+            "sections_with_review_work",
+            integer(summary.sections_with_review_work as i64),
+        ),
+        ("blocker_sections", integer(summary.blocker_sections as i64)),
+        ("review_sections", integer(summary.review_sections as i64)),
+        (
+            "activation_sections",
+            integer(summary.activation_sections as i64),
+        ),
+        (
+            "actionable_sections",
+            integer(summary.actionable_sections as i64),
+        ),
+        (
+            "monitoring_sections",
+            integer(summary.monitoring_sections as i64),
+        ),
+        ("total_panels", integer(summary.total_panels as i64)),
+        ("total_tasks", integer(summary.total_tasks as i64)),
+        (
+            "operator_required_tasks",
+            integer(summary.operator_required_tasks as i64),
+        ),
+        ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+        (
+            "activation_ready_tasks",
+            integer(summary.activation_ready_tasks as i64),
+        ),
+        ("blocked_tasks", integer(summary.blocked_tasks as i64)),
+        (
+            "review_required_tasks",
+            integer(summary.review_required_tasks as i64),
+        ),
+        ("monitor_tasks", integer(summary.monitor_tasks as i64)),
+        (
+            "next_section_kind",
+            summary
+                .next_section_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_section_sequence",
+            summary
+                .next_section_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_section_priority",
+            summary
+                .next_section_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_section_sequence",
+            summary
+                .first_blocker_section_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_section_sequence",
+            summary
+                .first_review_section_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_section_sequence",
+            summary
+                .first_activation_section_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_section_sequence",
+            summary
+                .first_actionable_section_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_section_priority",
+            summary
+                .first_blocker_section_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_section_priority",
+            summary
+                .first_review_section_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_section_priority",
+            summary
+                .first_activation_section_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_actionable_section_priority",
+            summary
+                .first_actionable_section_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(summary.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -16894,6 +17350,31 @@ fn parse_activation_operator_task_kind(
     }
 }
 
+fn parse_activation_command_center_section_kind(
+    label: &str,
+) -> Result<IntegrationActivationCommandCenterSectionKind, ToolCallError> {
+    match label {
+        "blockers" | "blocker" | "constraint" | "constraints" => {
+            Ok(IntegrationActivationCommandCenterSectionKind::Blockers)
+        }
+        "review" | "reviews" | "human_review" | "approval" | "approvals" => {
+            Ok(IntegrationActivationCommandCenterSectionKind::Review)
+        }
+        "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationCommandCenterSectionKind::Activation)
+        }
+        "actionable" | "actions" | "operator_action" => {
+            Ok(IntegrationActivationCommandCenterSectionKind::Actionable)
+        }
+        "monitoring" | "monitor" | "dashboard" | "status" => {
+            Ok(IntegrationActivationCommandCenterSectionKind::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation command-center section `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -18038,6 +18519,40 @@ fn integration_activation_control_room_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_command_center_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_control_room_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new(
+            "command_center_section",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("section_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "section_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "section_has_blockers",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "section_has_review_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "section_has_activation_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("section_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -18182,7 +18697,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 101);
+        assert_eq!(definitions.len(), 103);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -18453,9 +18968,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CONTROL_ROOM_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            93
+            95
         );
         assert_eq!(
             export
@@ -18909,11 +19430,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(101))
+            Some(&integer(103))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(93))
+            Some(&integer(95))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -21786,6 +22307,147 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_command_center_request = request(
+            "call-list-integration-activation-command-center",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("section_requires_attention", JsonValue::Bool(true)),
+                ("section_limit", integer(3)),
+            ]),
+            5_035,
+        );
+        let list_activation_command_center_trace =
+            tool_runtime.invoke_with_events(&list_activation_command_center_request);
+        assert!(list_activation_command_center_trace.result.ok);
+        assert_eq!(
+            list_activation_command_center_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_command_center_output = list_activation_command_center_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_command_center_count =
+            integer_value(field(list_activation_command_center_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_command_center_count));
+        let activation_command_center_summary =
+            field(list_activation_command_center_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_command_center_summary, "total_sections"),
+            Some(&integer(activation_command_center_count))
+        );
+        assert!(
+            integer_value(field(activation_command_center_summary, "total_panels").unwrap())
+                .unwrap()
+                >= activation_command_center_count
+        );
+        assert_eq!(
+            field(activation_command_center_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_command_center_section = array_item(
+            field(
+                list_activation_command_center_output,
+                "activation_command_center",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_command_center_section, "sequence").is_some());
+        assert!(field(activation_command_center_section, "section_kind").is_some());
+        assert!(field(activation_command_center_section, "panel_sequences").is_some());
+        assert!(field(activation_command_center_section, "recommended_views").is_some());
+        assert!(field(activation_command_center_section, "control_room_summary").is_some());
+        assert_eq!(
+            field(activation_command_center_section, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_command_center_summary_request = request(
+            "call-integration-activation-command-center-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("command_center_section", string("blockers")),
+                ("section_has_blockers", JsonValue::Bool(true)),
+            ]),
+            5_036,
+        );
+        let activation_command_center_summary_trace =
+            tool_runtime.invoke_with_events(&activation_command_center_summary_request);
+        assert!(activation_command_center_summary_trace.result.ok);
+        assert_eq!(
+            activation_command_center_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_command_center_summary_output = activation_command_center_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_command_center_rollup =
+            field(activation_command_center_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_command_center_rollup, "blocker_sections").unwrap(),)
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_command_center_rollup, "next_section_kind"),
+            Some(&string("blockers"))
+        );
+        assert_eq!(
+            field(activation_command_center_rollup, "next_recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_command_center_rollup, "next_task_kind"),
+            Some(&string("resolve_constraints"))
+        );
+        assert_eq!(
+            field(activation_command_center_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -23565,6 +24227,14 @@ mod tests {
             activation_control_room_summary_request,
             activation_control_room_summary_trace,
         );
+        journal.record_trace(
+            list_activation_command_center_request,
+            list_activation_command_center_trace,
+        );
+        journal.record_trace(
+            activation_command_center_summary_request,
+            activation_command_center_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -23638,9 +24308,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 101);
-        assert_eq!(journal_summary.completed_count, 101);
-        assert_eq!(journal.audit_records().len(), 101);
+        assert_eq!(journal_summary.invocation_count, 103);
+        assert_eq!(journal_summary.completed_count, 103);
+        assert_eq!(journal.audit_records().len(), 103);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -95,6 +95,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_control_room_summary` tool
   descriptors for read-only grouped operator-view panels derived from the
   activation operator queue.
+- `smart_home.list_integration_activation_command_center` and
+  `smart_home.get_integration_activation_command_center_summary` tool
+  descriptors for read-only grouped operating-lane planning derived from
+  activation control-room panels.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -95,6 +95,8 @@ Current scope:
   human/operator work derived from playbook steps
 - D18D integration activation-control-room descriptors for grouped
   operator-view panels derived from the activation operator queue
+- D18D integration activation-command-center descriptors for grouped
+  operating-lane sections derived from control-room panels
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1499,6 +1499,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationControlRoom,
     GetIntegrationActivationControlRoomSummary,
+    ListIntegrationActivationCommandCenter,
+    GetIntegrationActivationCommandCenterSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1702,6 +1704,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationControlRoomSummary => {
                 read_tool("smart_home.get_integration_activation_control_room_summary")
+            }
+            Self::ListIntegrationActivationCommandCenter => {
+                read_tool("smart_home.list_integration_activation_command_center")
+            }
+            Self::GetIntegrationActivationCommandCenterSummary => {
+                read_tool("smart_home.get_integration_activation_command_center_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2384,6 +2392,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationControlRoom,
         SmartHomeTool::GetIntegrationActivationControlRoomSummary,
+        SmartHomeTool::ListIntegrationActivationCommandCenter,
+        SmartHomeTool::GetIntegrationActivationCommandCenterSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3226,7 +3236,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 101);
+        assert_eq!(catalog.len(), 103);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3637,6 +3647,14 @@ mod tests {
             == "smart_home.get_integration_activation_control_room_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_command_center"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_command_center_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3644,15 +3662,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 101);
-        assert_eq!(summary.read_tools, 93);
+        assert_eq!(summary.total_tools, 103);
+        assert_eq!(summary.read_tools, 95);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 93);
+        assert_eq!(summary.read_only_tier_tools, 95);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 101);
+        assert_eq!(summary.total_required_capabilities, 103);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -81,6 +81,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationControlRoomPanel` and
   `IntegrationActivationControlRoomSummary` for grouping operator queue work by
   recommended planning view.
+- `IntegrationActivationCommandCenterSection` and
+  `IntegrationActivationCommandCenterSummary` for grouping control-room panels
+  into blocker, review, activation, actionable, and monitoring operating lanes.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -79,6 +79,8 @@ runtime and Chief of Staff tools a typed catalog for:
   human/operator queue rows
 - activation control-room panels that group operator tasks by recommended
   planning view for compact attention, blocker, review, and activation rollups
+- activation command-center sections that group control-room panels into
+  blocker, review, activation, actionable, and monitoring operating lanes
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1151,6 +1151,41 @@ impl IntegrationActivationOperatorTaskKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationCommandCenterSectionKind {
+    Blockers,
+    Review,
+    Activation,
+    Actionable,
+    Monitoring,
+}
+
+impl IntegrationActivationCommandCenterSectionKind {
+    pub fn from_panel(panel: &IntegrationActivationControlRoomPanel) -> Self {
+        if panel.has_blockers() {
+            Self::Blockers
+        } else if panel.has_activation_work() {
+            Self::Activation
+        } else if panel.has_review_work() {
+            Self::Review
+        } else if panel.has_actionable_work() {
+            Self::Actionable
+        } else {
+            Self::Monitoring
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blockers => "blockers",
+            Self::Review => "review",
+            Self::Activation => "activation",
+            Self::Actionable => "actionable",
+            Self::Monitoring => "monitoring",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2289,6 +2324,58 @@ pub struct IntegrationActivationControlRoomSummary {
     pub first_review_panel_priority: Option<u8>,
     pub first_activation_panel_priority: Option<u8>,
     pub first_actionable_panel_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationCommandCenterSection {
+    pub sequence: usize,
+    pub section_kind: IntegrationActivationCommandCenterSectionKind,
+    pub priority: u8,
+    pub panel_sequences: Vec<usize>,
+    pub recommended_views: Vec<IntegrationActivationPlaybookView>,
+    pub integration_ids: Vec<IntegrationId>,
+    pub panel_count: usize,
+    pub control_room_summary: IntegrationActivationControlRoomSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationCommandCenterSummary {
+    pub total_sections: usize,
+    pub unique_integrations: usize,
+    pub sections_requiring_attention: usize,
+    pub sections_with_operator_work: usize,
+    pub sections_with_actionable_work: usize,
+    pub sections_with_activation_work: usize,
+    pub sections_with_blockers: usize,
+    pub sections_with_review_work: usize,
+    pub blocker_sections: usize,
+    pub review_sections: usize,
+    pub activation_sections: usize,
+    pub actionable_sections: usize,
+    pub monitoring_sections: usize,
+    pub total_panels: usize,
+    pub total_tasks: usize,
+    pub operator_required_tasks: usize,
+    pub actionable_tasks: usize,
+    pub activation_ready_tasks: usize,
+    pub blocked_tasks: usize,
+    pub review_required_tasks: usize,
+    pub monitor_tasks: usize,
+    pub next_section_kind: Option<IntegrationActivationCommandCenterSectionKind>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_section_sequence: Option<usize>,
+    pub next_section_priority: Option<u8>,
+    pub first_blocker_section_sequence: Option<usize>,
+    pub first_review_section_sequence: Option<usize>,
+    pub first_activation_section_sequence: Option<usize>,
+    pub first_actionable_section_sequence: Option<usize>,
+    pub first_blocker_section_priority: Option<u8>,
+    pub first_review_section_priority: Option<u8>,
+    pub first_activation_section_priority: Option<u8>,
+    pub first_actionable_section_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -5008,6 +5095,265 @@ impl IntegrationActivationControlRoomSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.panels_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationCommandCenterSection {
+    fn from_panels(
+        sequence: usize,
+        section_kind: IntegrationActivationCommandCenterSectionKind,
+        panels: Vec<IntegrationActivationControlRoomPanel>,
+    ) -> Self {
+        let control_room_summary =
+            IntegrationActivationControlRoomSummary::from_panels(panels.iter());
+        let mut panel_sequences = panels
+            .iter()
+            .map(|panel| panel.sequence)
+            .collect::<Vec<_>>();
+        panel_sequences.sort_unstable();
+
+        let mut recommended_views = panels
+            .iter()
+            .map(|panel| panel.recommended_view)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        recommended_views.sort();
+
+        let mut integration_ids = panels
+            .iter()
+            .flat_map(|panel| panel.integration_ids.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        integration_ids.sort();
+
+        let priority = panels
+            .iter()
+            .map(|panel| panel.priority)
+            .min()
+            .unwrap_or(u8::MAX);
+
+        Self {
+            sequence,
+            section_kind,
+            priority,
+            panel_sequences,
+            recommended_views,
+            integration_ids,
+            panel_count: control_room_summary.total_panels,
+            control_room_summary,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.control_room_summary.has_operator_work()
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.control_room_summary.has_actionable_work()
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.control_room_summary.has_activation_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.control_room_summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.control_room_summary.has_review_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.control_room_summary.requires_attention()
+    }
+}
+
+impl IntegrationActivationCommandCenterSummary {
+    pub fn from_sections<'a>(
+        sections: impl IntoIterator<Item = &'a IntegrationActivationCommandCenterSection>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_sections: 0,
+            unique_integrations: 0,
+            sections_requiring_attention: 0,
+            sections_with_operator_work: 0,
+            sections_with_actionable_work: 0,
+            sections_with_activation_work: 0,
+            sections_with_blockers: 0,
+            sections_with_review_work: 0,
+            blocker_sections: 0,
+            review_sections: 0,
+            activation_sections: 0,
+            actionable_sections: 0,
+            monitoring_sections: 0,
+            total_panels: 0,
+            total_tasks: 0,
+            operator_required_tasks: 0,
+            actionable_tasks: 0,
+            activation_ready_tasks: 0,
+            blocked_tasks: 0,
+            review_required_tasks: 0,
+            monitor_tasks: 0,
+            next_section_kind: None,
+            next_recommended_view: None,
+            next_task_kind: None,
+            next_section_sequence: None,
+            next_section_priority: None,
+            first_blocker_section_sequence: None,
+            first_review_section_sequence: None,
+            first_activation_section_sequence: None,
+            first_actionable_section_sequence: None,
+            first_blocker_section_priority: None,
+            first_review_section_priority: None,
+            first_activation_section_priority: None,
+            first_actionable_section_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for section in sections {
+            summary.total_sections += 1;
+            for integration_id in &section.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match section.section_kind {
+                IntegrationActivationCommandCenterSectionKind::Blockers => {
+                    summary.blocker_sections += 1
+                }
+                IntegrationActivationCommandCenterSectionKind::Review => {
+                    summary.review_sections += 1
+                }
+                IntegrationActivationCommandCenterSectionKind::Activation => {
+                    summary.activation_sections += 1
+                }
+                IntegrationActivationCommandCenterSectionKind::Actionable => {
+                    summary.actionable_sections += 1
+                }
+                IntegrationActivationCommandCenterSectionKind::Monitoring => {
+                    summary.monitoring_sections += 1
+                }
+            }
+
+            if summary.next_section_kind.is_none()
+                && section.control_room_summary.next_task_kind.is_some()
+            {
+                summary.next_section_kind = Some(section.section_kind);
+                summary.next_recommended_view = section.control_room_summary.next_recommended_view;
+                summary.next_task_kind = section.control_room_summary.next_task_kind;
+                summary.next_section_sequence = Some(section.sequence);
+                summary.next_section_priority = Some(section.priority);
+            }
+
+            if section.requires_attention() {
+                summary.sections_requiring_attention += 1;
+            }
+            if section.has_operator_work() {
+                summary.sections_with_operator_work += 1;
+            }
+            if section.has_actionable_work() {
+                summary.sections_with_actionable_work += 1;
+                summary.first_actionable_section_sequence = summary
+                    .first_actionable_section_sequence
+                    .or(Some(section.sequence));
+                summary.first_actionable_section_priority = min_optional_priority(
+                    summary.first_actionable_section_priority,
+                    Some(section.priority),
+                );
+            }
+            if section.has_activation_work() {
+                summary.sections_with_activation_work += 1;
+                summary.first_activation_section_sequence = summary
+                    .first_activation_section_sequence
+                    .or(Some(section.sequence));
+                summary.first_activation_section_priority = min_optional_priority(
+                    summary.first_activation_section_priority,
+                    Some(section.priority),
+                );
+            }
+            if section.has_blockers() {
+                summary.sections_with_blockers += 1;
+                summary.first_blocker_section_sequence = summary
+                    .first_blocker_section_sequence
+                    .or(Some(section.sequence));
+                summary.first_blocker_section_priority = min_optional_priority(
+                    summary.first_blocker_section_priority,
+                    Some(section.priority),
+                );
+            }
+            if section.has_review_work() {
+                summary.sections_with_review_work += 1;
+                summary.first_review_section_sequence = summary
+                    .first_review_section_sequence
+                    .or(Some(section.sequence));
+                summary.first_review_section_priority = min_optional_priority(
+                    summary.first_review_section_priority,
+                    Some(section.priority),
+                );
+            }
+
+            summary.total_panels += section.control_room_summary.total_panels;
+            summary.total_tasks += section.control_room_summary.total_tasks;
+            summary.operator_required_tasks += section.control_room_summary.operator_required_tasks;
+            summary.actionable_tasks += section.control_room_summary.actionable_tasks;
+            summary.activation_ready_tasks += section.control_room_summary.activation_ready_tasks;
+            summary.blocked_tasks += section.control_room_summary.blocked_tasks;
+            summary.review_required_tasks += section.control_room_summary.review_required_tasks;
+            summary.monitor_tasks += section.control_room_summary.monitor_tasks;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(section.control_room_summary.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.sections_with_blockers > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.sections_with_review_work > 0 || summary.sections_with_operator_work > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.sections_with_activation_work > 0
+            || summary.sections_with_actionable_work > 0
+        {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_sections == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.sections_with_operator_work > 0
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.sections_with_actionable_work > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.sections_with_activation_work > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.sections_with_blockers > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.sections_with_review_work > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.sections_requiring_attention > 0 || self.overall_status.requires_attention()
     }
 }
 
@@ -9260,6 +9606,112 @@ pub fn activation_control_room_panels_at_or_before_priority(
     )
 }
 
+pub fn activation_command_center_sections_from_control_room_panels(
+    mut panels: Vec<IntegrationActivationControlRoomPanel>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    panels.sort_by(compare_activation_control_room_panels);
+    let mut panels_by_section: BTreeMap<
+        IntegrationActivationCommandCenterSectionKind,
+        Vec<IntegrationActivationControlRoomPanel>,
+    > = BTreeMap::new();
+    for panel in panels {
+        panels_by_section
+            .entry(IntegrationActivationCommandCenterSectionKind::from_panel(
+                &panel,
+            ))
+            .or_default()
+            .push(panel);
+    }
+
+    let mut sections = panels_by_section
+        .into_iter()
+        .map(|(section_kind, panels)| {
+            IntegrationActivationCommandCenterSection::from_panels(0, section_kind, panels)
+        })
+        .collect::<Vec<_>>();
+    sections.sort_by(compare_activation_command_center_sections);
+    for (index, section) in sections.iter_mut().enumerate() {
+        section.sequence = index + 1;
+    }
+    sections
+}
+
+pub fn activation_command_center_sections_from_operator_tasks(
+    tasks: Vec<IntegrationActivationOperatorTask>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_operator_tasks(tasks),
+    )
+}
+
+pub fn activation_command_center_sections_from_playbook_steps(
+    steps: Vec<IntegrationActivationPlaybookStep>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_playbook_steps(steps),
+    )
+}
+
+pub fn activation_command_center_sections_from_forecasts(
+    forecasts: Vec<IntegrationActivationForecastItem>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_forecasts(forecasts),
+    )
+}
+
+pub fn activation_command_center_sections_from_timeline_milestones(
+    milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_timeline_milestones(milestones),
+    )
+}
+
+pub fn activation_command_center_sections_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_dashboard_cards(cards),
+    )
+}
+
+pub fn activation_command_center_sections_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_readouts(readouts),
+    )
+}
+
+pub fn activation_command_center_sections_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_from_candidates(catalog, candidates, enabled_integrations),
+    )
+}
+
+pub fn activation_command_center_sections_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationCommandCenterSection> {
+    activation_command_center_sections_from_control_room_panels(
+        activation_control_room_panels_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -10670,6 +11122,22 @@ fn compare_activation_control_room_panels(
         .then_with(|| right.has_actionable_work().cmp(&left.has_actionable_work()))
         .then_with(|| left.recommended_view.cmp(&right.recommended_view))
         .then_with(|| right.task_count.cmp(&left.task_count))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_command_center_sections(
+    left: &IntegrationActivationCommandCenterSection,
+    right: &IntegrationActivationCommandCenterSection,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.has_actionable_work().cmp(&left.has_actionable_work()))
+        .then_with(|| left.section_kind.cmp(&right.section_kind))
+        .then_with(|| right.panel_count.cmp(&left.panel_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -13204,6 +13672,134 @@ mod tests {
         assert!(catalog_panels
             .iter()
             .any(IntegrationActivationControlRoomPanel::requires_attention));
+    }
+
+    #[test]
+    fn activation_command_center_sections_group_control_room_attention() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let sections = activation_command_center_sections_from_candidates(&[], candidates, &[]);
+
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].sequence, 1);
+        assert_eq!(
+            sections[0].section_kind,
+            IntegrationActivationCommandCenterSectionKind::Blockers
+        );
+        assert_eq!(sections[0].priority, 1);
+        assert_eq!(sections[0].panel_count, 2);
+        assert!(sections[0].has_blockers());
+        assert!(sections[0].has_review_work());
+        assert!(sections[0].requires_attention());
+        assert!(sections[0]
+            .recommended_views
+            .contains(&IntegrationActivationPlaybookView::ConstraintQueue));
+        assert!(sections[0]
+            .recommended_views
+            .contains(&IntegrationActivationPlaybookView::DependencyGraph));
+        assert!(sections.iter().any(|section| {
+            section.section_kind == IntegrationActivationCommandCenterSectionKind::Activation
+                && section.has_activation_work()
+        }));
+
+        let summary = IntegrationActivationCommandCenterSummary::from_sections(sections.iter());
+        assert_eq!(summary.total_sections, 2);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.total_panels, 3);
+        assert_eq!(summary.total_tasks, 3);
+        assert_eq!(summary.blocker_sections, 1);
+        assert_eq!(summary.activation_sections, 1);
+        assert_eq!(summary.sections_with_blockers, 1);
+        assert_eq!(summary.sections_with_activation_work, 1);
+        assert_eq!(
+            summary.next_section_kind,
+            Some(IntegrationActivationCommandCenterSectionKind::Blockers)
+        );
+        assert_eq!(
+            summary.next_recommended_view,
+            Some(IntegrationActivationPlaybookView::ConstraintQueue)
+        );
+        assert_eq!(
+            summary.next_task_kind,
+            Some(IntegrationActivationOperatorTaskKind::ResolveConstraints)
+        );
+        assert_eq!(summary.next_section_sequence, Some(1));
+        assert_eq!(summary.first_blocker_section_sequence, Some(1));
+        assert_eq!(summary.first_activation_section_sequence, Some(2));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_operator_work());
+        assert!(summary.has_actionable_work());
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_sections = activation_command_center_sections_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_sections
+            .iter()
+            .any(IntegrationActivationCommandCenterSection::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add D23A activation command-center sections and summaries derived from control-room panels
- expose read-only D18D descriptors in smart-home core for listing command-center sections and summaries
- wire Chief query/schema/JSON handlers, end-to-end runtime coverage, and docs for the new tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools