### PR TITLE
test(adj-lang-cli): grant-allocation LP worked example end-to-end (ADJ constraints D)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.6] - 2026-06-11 — grant-allocation LP worked example (ADJ constraints track D)
+
+### Added
+
+- `grant_allocation.adj` worked example + golden test: an allocation LP
+  (`maximize 3·outreach + 2·training` under a budget + capacity) solved
+  end-to-end through the CLI at **0 model calls** → optimal 26 at (6, 4),
+  binding constraints [0, 1]. Demonstrates the C2 `optimize` path in the
+  worked-examples suite (now 5 examples). Test-only; no CLI behavior change.
+
 ## [0.3.5] - 2026-06-11 — emit LP optima (ADJ constraints track C2)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
+++ b/code/packages/rust/adj-lang-cli/tests/worked_examples.rs
@@ -70,3 +70,18 @@ fn break_even_solves_for_the_unit_price() {
     assert!(s.contains("\"name\":\"p\",\"value\":8"), "{s}");
     assert!(s.contains("\"from_constraints\":[0]"), "{s}");
 }
+
+#[test]
+fn grant_allocation_maximizes_impact_via_lp() {
+    // The allocation LP: max 3·outreach + 2·training s.t. budget ≤ 10,
+    // outreach ≤ 6, both ≥ 0 → optimum 26 at (6, 4), binding the budget and
+    // the outreach cap. The engine solves it end-to-end at 0 model calls.
+    let (ok, s) = run_example("grant_allocation.adj");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"optimize\":{"), "expected an optimize section: {s}");
+    assert!(s.contains("\"outcome\":\"optimal\""), "{s}");
+    assert!(s.contains("\"value\":26"), "expected optimum 26: {s}");
+    assert!(s.contains("\"name\":\"outreach\",\"value\":6"), "{s}");
+    assert!(s.contains("\"name\":\"training\",\"value\":4"), "{s}");
+    assert!(s.contains("\"binding\":[0,1]"), "budget + cap bind: {s}");
+}

--- a/code/specs/data/adj-language-expansion/examples/README.md
+++ b/code/specs/data/adj-language-expansion/examples/README.md
@@ -19,6 +19,7 @@ cargo build -p adj-lang-cli
 | [`debt_to_income.adj`](debt_to_income.adj) | a **computed ratio** (`money / money → dimensionless`) driving a rule | `dti = 0.30 <= 0.43` fires → `mortgage_eligible` ≈ 1.0 |
 | [`proration.adj`](proration.adj) | **`let` arithmetic** (`annual_bonus * months_worked / 12`) feeding a predicate | `prorated = 9000 >= 8000` fires → `senior_tier` ≈ 1.0 |
 | [`break_even.adj`](break_even.adj) | **solving for an unknown** (`p * 1000 = 5000 + 3 * 1000`) | `solve → { p = 8 }`, cited to constraint `[0]` |
+| [`grant_allocation.adj`](grant_allocation.adj) | **linear optimization** — `maximize 3·outreach + 2·training` under a budget + capacity (an LP) | `optimize → optimal 26` at `{ outreach = 6, training = 4 }`, binding constraints `[0, 1]` |
 
 These are covered by golden tests in
 [`adj-lang-cli/tests/worked_examples.rs`](../../../../packages/rust/adj-lang-cli/tests/worked_examples.rs),

--- a/code/specs/data/adj-language-expansion/examples/grant_allocation.adj
+++ b/code/specs/data/adj-language-expansion/examples/grant_allocation.adj
@@ -1,0 +1,32 @@
+% Worked example — grant allocation (maximize impact, an LP).
+%
+% A grant office splits a $10k budget across two programs and wants the
+% allocation that maximizes total impact. Let `outreach` and `training` be the
+% dollars (in $1k units) put into each program:
+%
+%     impact      = 3·outreach + 2·training   (impact units per $1k)
+%     budget:       outreach + training ≤ 10  ($10k total)
+%     capacity:     outreach ≤ 6              (outreach saturates at $6k)
+%     non-negative: outreach ≥ 0, training ≥ 0
+%
+% The model wrote the objective and the constraints; the engine SOLVES the
+% linear program on the CPU (Fourier–Motzkin projection over exact rationals),
+% returns the optimum, an achieving allocation, and the constraints binding at
+% that point — all without the model doing any arithmetic.
+%
+% Optimum at the vertex (outreach = 6, training = 4):
+%     impact = 3·6 + 2·4 = 26
+% binding the budget (6 + 4 = 10) and the outreach cap (6) — constraints 0 and 1.
+%
+% Expected: optimize → optimal, value 26, { outreach = 6, training = 4 },
+%           binding [0, 1].
+
+symbol outreach : scalar
+symbol training : scalar
+
+constrain outreach + training <= 10
+constrain outreach <= 6
+constrain outreach >= 0
+constrain training >= 0
+
+maximize 3 * outreach + 2 * training


### PR DESCRIPTION
## What

Adds a fifth worked adjudication example exercising the **C2 optimization** path end-to-end through the CPU reasoner at **zero answer-time model calls**.

`grant_allocation.adj` — a grant office splits a \$10k budget across two programs to maximize impact:

```
symbol outreach : scalar   symbol training : scalar
constrain outreach + training <= 10    constrain outreach <= 6
constrain outreach >= 0    constrain training >= 0
maximize 3 * outreach + 2 * training
```

The model writes only the objective + constraints; the engine **solves the LP** (Fourier–Motzkin projection over exact rationals) → **optimal 26** at `(outreach=6, training=4)`, **binding constraints [0, 1]** (the budget and the outreach cap). Every number is the engine's, cited to the constraint that bound it.

## How
- New `.adj` example + a golden test in `worked_examples.rs` asserting the full `optimize` JSON section. The worked-examples suite is now **5 examples** (predicate-over-typed-value, computed ratio, `let` arithmetic, solve-for-unknown, and now an LP).
- README table row; CHANGELOG; `adj-lang-cli` 0.3.5 → 0.3.6.

**Test + spec-data + docs only** — no CLI behavior change; the `.adj` runs through the C1/C2 code already merged. Security review passed.

Completes the worked-examples coverage of the ADJ-CONSTRAINTS arc (the model decomposes; the engine does all the math and solving on the CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)