### PR TITLE
feat(lang-matrix): LM-W BASIC — Dartmouth BASIC on WASM via PrintHost

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — `lang-aot`
 
+## 0.60.0 — 2026-06-11 — Dartmouth BASIC joins the WASM column (LANG-MATRIX LM-W BASIC)
+
+`lang_matrix.rs` greens **Dartmouth BASIC on WASM** (the `DartmouthBasic` program now
+lists `Wasm`), completing the WASM column for every non-Brainfuck language. BASIC's
+`PRINT` lowers to a wasm import `env.__print_i64 : (i64) -> ()` — the wasm sibling of the
+LLVM column's `@__print_i64` C runtime. The `run_wasm` runner now installs a tiny
+`PrintHost` (a test-local `wasm_execution::HostInterface`) that resolves that single
+import to a `PrintFunc` capturing each printed `i64` into a shared buffer; the runner
+joins the captured values as the program's stdout. The expression languages import no
+host functions, so the host is never consulted for them and their behaviour is unchanged
+(`main`'s i64 result is still read as the exit code). Verified by RUNNING: BASIC
+`10 PRINT 42` → stdout `42` on the in-process `wasm-runtime`. New dev-deps `wasm-execution`
++ `wasm-types` (the host-interface + value types, both in-repo — wasm verification stays
+zero-external-dep). WASM column now green for Twig / Nib / Oct / ALGOL 60 / BASIC; only
+Brainfuck (tape ops) remains. **16 proven matrix cells.**
+
 ## 0.59.0 — 2026-06-11 — Nib joins the WASM column (LANG-MATRIX LM-W Nib)
 
 `lang_matrix.rs` greens **Nib on WASM** (the `Nib` program now lists `Wasm`). The fix is

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
@@ -51,6 +51,12 @@ tempfile = "3"
 # the computed result (LANG77 / McCarthy L3b-3a-2). Keeps wasm verification
 # zero-external-dep.
 wasm-runtime = { path = "../wasm-runtime" }
+# The host-interface + value types the runtime resolves imports against. The
+# LANG-MATRIX harness implements a tiny `HostInterface` to satisfy the generic
+# `env.__print_i64` stdout import an I/O language (Dartmouth BASIC) emits, so
+# its `PRINT` output can be captured and asserted (LM-W BASIC).
+wasm-execution = { path = "../wasm-execution" }
+wasm-types = { path = "../wasm-types" }
 # In-repo JVM class-file parser + bytecode simulator — used to RUN the emitted
 # JVM class in tests and assert the computed result (LANG77 / McCarthy W3a),
 # mirroring how wasm-runtime verifies the wasm path. Keeps JVM verification

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -128,8 +128,9 @@ host executable and produce the right result (exit code for the expression langu
 stdout for the I/O languages). The **LLVM** column is green for Twig / Nib / Oct /
 ALGOL 60 (exit code) and Dartmouth BASIC (stdout, via a generic `__print_i64`
 runtime); Brainfuck is deferred. The **WASM** column (in-process `wasm-runtime`) is
-green for Twig / Nib / Oct / ALGOL 60; BASIC (print import) and Brainfuck (tape ops)
-are follow-ups. The JVM/CLR columns
+green for Twig / Nib / Oct / ALGOL 60 (exit code) and Dartmouth BASIC (stdout — a tiny
+`PrintHost` resolves the `env.__print_i64` import and captures the printed value);
+Brainfuck (tape ops) is the only WASM follow-up. The JVM/CLR columns
 follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
 op-coverage work.
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -17,9 +17,10 @@
 //!   the `.ll`'s `@__print_i64` is satisfied by a generic print runtime). Brainfuck
 //!   deferred (the i64-slot-model mismatch — see the spec's Deferred section).
 //! * **WASM** (Phase W) — source → wasm bytes (`iir-to-wasm`) → the in-process
-//!   `wasm-runtime`. Green for the expression languages Twig / Oct / ALGOL 60 (exit
-//!   code from `main`'s wasm result). Nib pends a const-literal type fix, BASIC the
-//!   stdout import, Brainfuck the tape ops — each its own follow-up.
+//!   `wasm-runtime`. Green for the expression languages Twig / Nib / Oct / ALGOL 60
+//!   (exit code from `main`'s wasm result) and Dartmouth BASIC (stdout — a `PrintHost`
+//!   resolves the `env.__print_i64` import and captures the printed value). Brainfuck
+//!   pends the tape ops — its own follow-up.
 //!
 //! Later slices add the JVM / CLR columns (also general code generators) and the
 //! Deferred items — Brainfuck-on-LLVM/WASM, and the McCarthy-specialized VM and JIT
@@ -114,13 +115,15 @@ const PROGRAMS: &[Prog] = &[
     },
     // Dartmouth BASIC — `PRINT 42` writes `42` to stdout. On LLVM the `.ll` emits
     // `call void @__print_i64(i64 42)`, so `run_llvm` links the generic print runtime
-    // and the harness compares stdout (LM-L BASIC).
+    // and the harness compares stdout (LM-L BASIC). On WASM the same `PRINT` lowers to
+    // `call $__print_i64`, imported as `env.__print_i64 : (i64) -> ()`; `run_wasm`'s
+    // `PrintHost` resolves that import and captures the printed value (LM-W BASIC).
     Prog {
         lang: Language::DartmouthBasic,
         ext: "bas",
         src: "10 PRINT 42\n20 END\n",
         expect: Expect::Stdout("42"),
-        backends: &[NativeAot, Llvm],
+        backends: &[NativeAot, Llvm, Wasm],
     },
 ];
 
@@ -263,20 +266,122 @@ fn run_llvm(p: &Prog) -> Option<(Option<i32>, String)> {
     Some((out.status.code(), stdout))
 }
 
-/// WASM runner: source → wasm bytes (`iir-to-wasm`) → the in-process `wasm-runtime`.
+/// The generic stdout primitive an I/O language's wasm emits. Dartmouth BASIC's
+/// `PRINT` lowers to `call $__print_i64`, imported as `env.__print_i64 : (i64) -> ()`
+/// — the wasm sibling of the LLVM column's `@__print_i64` C runtime, the JVM's
+/// `BasicRuntime.println(J)V`, and the CLR's `Console.WriteLine(int64)`. It is *not*
+/// language-specific: any IIR that prints an integer routes through this import.
+///
+/// `PrintFunc` is the host implementation of that import. Each call appends its single
+/// `i64` argument to a shared capture buffer (`Arc<Mutex<Vec<i64>>>`) so the test can
+/// read back exactly what the program printed. The function does no work proportional
+/// to untrusted input — it pushes one integer and returns — so there is no DoS vector.
+struct PrintFunc {
+    captured: std::sync::Arc<std::sync::Mutex<Vec<i64>>>,
+}
+
+impl wasm_execution::HostFunction for PrintFunc {
+    fn func_type(&self) -> &wasm_types::FuncType {
+        // `(i64) -> ()`: one i64 in, nothing out. A `LazyLock` static gives the
+        // `&FuncType` the trait must hand back a stable lifetime.
+        static FT: std::sync::LazyLock<wasm_types::FuncType> =
+            std::sync::LazyLock::new(|| wasm_types::FuncType {
+                params: vec![wasm_types::ValueType::I64],
+                results: vec![],
+            });
+        &FT
+    }
+
+    fn call(
+        &self,
+        args: &[wasm_execution::WasmValue],
+        _memory: Option<&mut wasm_execution::LinearMemory>,
+    ) -> Result<Vec<wasm_execution::WasmValue>, wasm_execution::TrapError> {
+        let value = args
+            .first()
+            .ok_or_else(|| wasm_execution::TrapError::new("__print_i64: missing argument"))?
+            .as_i64()
+            .map_err(|e| wasm_execution::TrapError::new(e.message))?;
+        self.captured
+            .lock()
+            .expect("lang-matrix print buffer poisoned")
+            .push(value);
+        Ok(vec![])
+    }
+}
+
+/// The host interface the matrix runs wasm under: it resolves the single generic
+/// `env.__print_i64` import to a `PrintFunc` writing into the shared buffer, and
+/// resolves nothing else (the expression languages import no host functions, so for
+/// them the host is never consulted and behaviour is identical to `WasmRuntime::new`).
+struct PrintHost {
+    captured: std::sync::Arc<std::sync::Mutex<Vec<i64>>>,
+}
+
+impl wasm_execution::HostInterface for PrintHost {
+    fn resolve_function(
+        &self,
+        module_name: &str,
+        name: &str,
+    ) -> Option<Box<dyn wasm_execution::HostFunction>> {
+        if module_name == "env" && name == "__print_i64" {
+            Some(Box::new(PrintFunc {
+                captured: std::sync::Arc::clone(&self.captured),
+            }))
+        } else {
+            None
+        }
+    }
+
+    fn resolve_global(
+        &self,
+        _module_name: &str,
+        _name: &str,
+    ) -> Option<(wasm_types::GlobalType, wasm_execution::WasmValue)> {
+        None
+    }
+
+    fn resolve_memory(
+        &self,
+        _module_name: &str,
+        _name: &str,
+    ) -> Option<wasm_execution::LinearMemory> {
+        None
+    }
+
+    fn resolve_table(&self, _module_name: &str, _name: &str) -> Option<wasm_execution::Table> {
+        None
+    }
+}
+
+/// WASM runner: source → wasm bytes (`iir-to-wasm`) → the in-process `wasm-runtime`,
+/// run under a `PrintHost` so an I/O language's `env.__print_i64` import resolves.
 /// No external tool — the runtime is in-repo, so this always runs (returns `None`
-/// only when the program fails to emit or the runtime can't load it). The exit-code
-/// programs return their value as `main`'s wasm result; the I/O languages (which
-/// route output through a stdout import) get their stdout-capturing variant in a
-/// later slice, so this runner covers the expression languages only.
+/// only when the program fails to emit or the runtime can't load it). Handles both
+/// result kinds: an expression language returns its value as `main`'s wasm result
+/// (the `code`); an I/O language (Dartmouth BASIC) prints through `env.__print_i64`,
+/// whose arguments the host captured into the buffer, joined as the program's stdout.
 fn run_wasm(p: &Prog) -> Option<(Option<i32>, String)> {
     let bytes = lang_aot::compile_source_to_wasm(p.lang, p.src, "main").ok()?;
-    let rt = wasm_runtime::WasmRuntime::new();
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let host = PrintHost {
+        captured: std::sync::Arc::clone(&captured),
+    };
+    let rt = wasm_runtime::WasmRuntime::with_host(Box::new(host));
     let result = rt.load_and_run(&bytes, "main", &[]).ok()?;
     // `main`'s single i64 result is the program's value (`& 0xFF` matches the exit
     // convention the native/LLVM columns use for the same programs).
     let code = result.first().copied().map(|v| (v as i32) & 0xFF);
-    Some((code, String::new()))
+    // Whatever the program printed through `env.__print_i64`, one integer per call,
+    // joined by newlines — empty for the expression languages (they never print).
+    let stdout = captured
+        .lock()
+        .expect("lang-matrix print buffer poisoned")
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some((code, stdout))
 }
 
 /// Dispatch a program to a backend runner. `None` = the backend's toolchain is

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -103,8 +103,8 @@ achievable code-gen columns land first).
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ◑   | ◑   |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
-| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ☐    | ☐   | ☐   |
-| Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ☐    | ☐   | ☐   |
+| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ☐   | ☐   |
+| Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
 | ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
 
@@ -171,9 +171,15 @@ BASIC); only Brainfuck is deferred.
   WASM backend requires. Verified by RUNNING: Nib on WASM → 42, and still LLVM → 42,
   native → 42 (no regression); nib-iir-compiler (28) + `iir-to-wasm`/`iir-to-llvm`
   suites all green.
-- ☐ **LM-W BASIC (on WASM).** The in-process `wasm-runtime` reports `no body for
-  function 0` for BASIC — the `PRINT` env import (`__print_i64`-equivalent) isn't
-  provided to the runtime. Wire the print import + capture stdout, then assert `42`.
+- ✅ **LM-W BASIC (on WASM).** BASIC's `PRINT` lowers to a wasm import
+  `env.__print_i64 : (i64) -> ()`; the default `WasmRuntime::new()` couldn't resolve it
+  (`no body for function 0`). `run_wasm` now installs a tiny test-local `PrintHost`
+  (`wasm_execution::HostInterface`) that resolves that single import to a `PrintFunc`
+  capturing each printed `i64` into a shared buffer, joined as the program's stdout. The
+  expression languages import nothing, so the host is never consulted for them (behaviour
+  unchanged). New in-repo dev-deps `wasm-execution` + `wasm-types`. Verified by RUNNING:
+  BASIC `10 PRINT 42` → stdout `42`; Twig/Nib/Oct/ALGOL still green (16 proven cells).
+  **WASM column now complete for every language except the deferred Brainfuck.**
 - ⏸ **LM-W Brainfuck (on WASM) — DEFERRED.** `iir-to-wasm` lacks the tape ops too
   (`UnsupportedOp: alloc_bytes`); same deferred class as Brainfuck-on-LLVM.
 


### PR DESCRIPTION
## LANG-PLATFORM-MATRIX · Phase W · LM-W BASIC

Greens the last achievable **WASM** cell: **Dartmouth BASIC on the in-process `wasm-runtime`**. With this, the WASM column is complete for every language except the deferred Brainfuck.

### What & why
BASIC's `PRINT` lowers to a wasm import `env.__print_i64 : (i64) -> ()` — the wasm sibling of the LLVM column's `@__print_i64` C runtime, the JVM's `BasicRuntime.println(J)V`, and the CLR's `Console.WriteLine(int64)`. The default `WasmRuntime::new()` has no host, so it can't resolve the import and traps with `no body for function 0`.

`run_wasm` now installs a tiny **test-local `PrintHost`** (`wasm_execution::HostInterface`) that:
- resolves the single `env.__print_i64` import to a `PrintFunc` capturing each printed `i64` into a shared `Arc<Mutex<Vec<i64>>>`;
- resolves nothing else.

The runner joins the captured values as the program's stdout. The expression languages (Twig/Nib/Oct/ALGOL) import no host functions, so the host is never consulted for them and their behaviour is unchanged — `main`'s i64 result is still read as the exit code.

### Verified by RUNNING
- BASIC `10 PRINT 42` → stdout `42` on the in-process `wasm-runtime`.
- Twig→42 / Nib→42 / Oct→0 / ALGOL `17 mod 5`→2 still green on WASM (no regression).
- **16 proven matrix cells** (was 15); both `lang_matrix` tests pass (`matrix_every_proven_cell_agrees`, `proven_columns_do_not_silently_skip`).
- No clippy hits in `lang_matrix.rs`.

### Matrix after this PR
| | native-AOT | LLVM | WASM |
|---|---|---|---|
| Twig / Nib / Oct / ALGOL 60 | ✅ | ✅ | ✅ |
| Dartmouth BASIC | ✅ | ✅ | ✅ ← this PR |
| Brainfuck | ✅ | ⏸ | ⏸ (tape ops, deferred) |

### Changes
- `tests/lang_matrix.rs` — `PrintHost`/`PrintFunc` host impl; `run_wasm` runs under the host and captures stdout; BASIC's `Prog` gains `Wasm`.
- `Cargo.toml` — new in-repo path dev-deps `wasm-execution` + `wasm-types` (wasm verification stays zero-external-dep); 0.59.0 → 0.60.0.
- `LANG-PLATFORM-MATRIX.md` — matrix table + LM-W BASIC worklist item marked ✅; Brainfuck-WASM marked ⏸.
- `CHANGELOG.md`, `README.md` — updated.

Security review: passed (test-only Rust, no `unsafe`, fixed inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)