### PR TITLE
Add smart-home activation watchtower tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -76,6 +76,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation command-center operating lanes:
   `smart_home.list_integration_activation_command_center` and
   `smart_home.get_integration_activation_command_center_summary`.
+- Added D18D handlers for D23A activation watchtower signals:
+  `smart_home.list_integration_activation_watchtower` and
+  `smart_home.get_integration_activation_watchtower_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -60,6 +60,7 @@ Chief of Staff job/session/agent
   -> activation-operator queue list and summary reads for actionable work
   -> activation-control-room list and summary reads for grouped operator panels
   -> activation-command-center list and summary reads for operating-lane rollups
+  -> activation-watchtower list and summary reads for escalation signal rollups
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -131,6 +132,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_control_room_summary`
 - `smart_home.list_integration_activation_command_center`
 - `smart_home.get_integration_activation_command_center_summary`
+- `smart_home.list_integration_activation_watchtower`
+- `smart_home.get_integration_activation_watchtower_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -46,7 +46,8 @@ use smart_home_integration_catalog::{
     activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
     activation_readouts_from_candidates, activation_reviews_from_candidates,
     activation_risk_from_candidates, activation_runway_from_candidates,
-    activation_timeline_milestones_from_dashboard_cards, describe_primitive_family,
+    activation_timeline_milestones_from_dashboard_cards,
+    activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog,
     policy_surface_inventory_at_or_before_priority, primitive_backlog_at_or_before_priority,
@@ -86,13 +87,15 @@ use smart_home_integration_catalog::{
     IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
     IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
-    IntegrationActivationTimelineSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
-    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
-    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
-    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
-    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
-    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationActivationTimelineSummary, IntegrationActivationWatchtowerSignal,
+    IntegrationActivationWatchtowerSignalKind, IntegrationActivationWatchtowerSummary,
+    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
+    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
+    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
+    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
+    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
+    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
+    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -278,6 +281,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMMAND_CENTER_TOOL_ID: &str =
     "smart_home.list_integration_activation_command_center";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_command_center_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID: &str =
+    "smart_home.list_integration_activation_watchtower";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_watchtower_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -610,6 +617,14 @@ impl SmartHomeToolBridge {
                             query,
                         ),
                     )
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID => {
+                    let query = integration_activation_watchtower_query(&arguments)?;
+                    Ok(list_integration_activation_watchtower_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_watchtower_query(&arguments)?;
+                    Ok(get_integration_activation_watchtower_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2031,6 +2046,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation command center summary",
             "Return compact D23A activation command-center section counts for blocker, review, activation, actionable, and monitoring operating lanes.",
             integration_activation_command_center_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID,
+            "List smart-home integration activation watchtower signals",
+            "List D23A activation watchtower signals that roll command-center sections into escalation, review, ready, action, and observation lanes.",
+            integration_activation_watchtower_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_watchtower", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_watchtower", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation watchtower summary",
+            "Return compact D23A activation watchtower counts for escalation, review, ready, action, and observation signals.",
+            integration_activation_watchtower_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4749,6 +4793,18 @@ struct IntegrationActivationCommandCenterQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationWatchtowerQuery {
+    command_center: IntegrationActivationCommandCenterQuery,
+    signal_kind: Option<IntegrationActivationWatchtowerSignalKind>,
+    requires_attention: Option<bool>,
+    has_blockers: Option<bool>,
+    has_review_work: Option<bool>,
+    has_activation_work: Option<bool>,
+    needs_escalation: Option<bool>,
+    signal_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5144,6 +5200,30 @@ fn integration_activation_command_center_query(
         has_activation_work: optional_bool(arguments, "section_has_activation_work")?
             .or(optional_bool(arguments, "has_activation_work")?),
         section_limit: optional_u64(arguments, "section_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_watchtower_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationWatchtowerQuery, ToolCallError> {
+    let signal_kind = optional_string(arguments, "watchtower_signal")?
+        .or(optional_string(arguments, "signal_kind")?)
+        .map(|label| parse_activation_watchtower_signal_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationWatchtowerQuery {
+        command_center: integration_activation_command_center_query(arguments)?,
+        signal_kind,
+        requires_attention: optional_bool(arguments, "signal_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_blockers: optional_bool(arguments, "signal_has_blockers")?
+            .or(optional_bool(arguments, "has_blockers")?),
+        has_review_work: optional_bool(arguments, "signal_has_review_work")?
+            .or(optional_bool(arguments, "has_review_work")?),
+        has_activation_work: optional_bool(arguments, "signal_has_activation_work")?
+            .or(optional_bool(arguments, "has_activation_work")?),
+        needs_escalation: optional_bool(arguments, "needs_escalation")?,
+        signal_limit: optional_u64(arguments, "signal_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5856,6 +5936,38 @@ fn integration_activation_command_center_sections_for_query(
     }
 
     (sections, catalog_count)
+}
+
+fn integration_activation_watchtower_signals_for_query(
+    query: &IntegrationActivationWatchtowerQuery,
+) -> (Vec<IntegrationActivationWatchtowerSignal>, usize) {
+    let (sections, catalog_count) =
+        integration_activation_command_center_sections_for_query(&query.command_center);
+    let mut signals = activation_watchtower_signals_from_command_center_sections(sections);
+
+    if let Some(signal_kind) = query.signal_kind {
+        signals.retain(|signal| signal.signal_kind == signal_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        signals.retain(|signal| signal.requires_attention() == requires_attention);
+    }
+    if let Some(has_blockers) = query.has_blockers {
+        signals.retain(|signal| signal.has_blockers() == has_blockers);
+    }
+    if let Some(has_review_work) = query.has_review_work {
+        signals.retain(|signal| signal.has_review_work() == has_review_work);
+    }
+    if let Some(has_activation_work) = query.has_activation_work {
+        signals.retain(|signal| signal.has_activation_work() == has_activation_work);
+    }
+    if let Some(needs_escalation) = query.needs_escalation {
+        signals.retain(|signal| signal.needs_escalation() == needs_escalation);
+    }
+    if let Some(limit) = query.signal_limit {
+        signals.truncate(limit);
+    }
+
+    (signals, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -7726,6 +7838,92 @@ fn get_integration_activation_command_center_summary_output_handler_output(
                 "next_section_kind",
                 summary
                     .next_section_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_watchtower_output_handler_output(
+    query: IntegrationActivationWatchtowerQuery,
+) -> ToolHandlerOutput {
+    let (signals, catalog_count) = integration_activation_watchtower_signals_for_query(&query);
+    let summary = IntegrationActivationWatchtowerSummary::from_signals(signals.iter());
+    let count = signals.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_watchtower",
+            JsonValue::Array(
+                signals
+                    .iter()
+                    .map(activation_watchtower_signal_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_watchtower_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_watchtower"),
+            ),
+            ("signals", integer(count as i64)),
+            (
+                "signals_requiring_attention",
+                integer(summary.signals_requiring_attention as i64),
+            ),
+            ("total_sections", integer(summary.total_sections as i64)),
+            ("total_panels", integer(summary.total_panels as i64)),
+            (
+                "next_signal_kind",
+                summary
+                    .next_signal_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_watchtower_summary_output_handler_output(
+    query: IntegrationActivationWatchtowerQuery,
+) -> ToolHandlerOutput {
+    let (signals, _) = integration_activation_watchtower_signals_for_query(&query);
+    let summary = IntegrationActivationWatchtowerSummary::from_signals(signals.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_watchtower_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_watchtower_summary"),
+            ),
+            ("total_signals", integer(summary.total_signals as i64)),
+            (
+                "signals_requiring_attention",
+                integer(summary.signals_requiring_attention as i64),
+            ),
+            (
+                "escalation_signals",
+                integer(summary.escalation_signals as i64),
+            ),
+            (
+                "next_signal_kind",
+                summary
+                    .next_signal_kind
                     .map(|kind| string(kind.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
@@ -14686,6 +14884,279 @@ fn integration_activation_command_center_summary_json(
     ])
 }
 
+fn activation_watchtower_signal_json(signal: &IntegrationActivationWatchtowerSignal) -> JsonValue {
+    object([
+        ("sequence", integer(signal.sequence as i64)),
+        ("signal_kind", string(signal.signal_kind.as_str())),
+        ("priority", integer(signal.priority as i64)),
+        (
+            "section_sequences",
+            JsonValue::Array(
+                signal
+                    .section_sequences
+                    .iter()
+                    .map(|sequence| integer(*sequence as i64))
+                    .collect(),
+            ),
+        ),
+        (
+            "section_kinds",
+            JsonValue::Array(
+                signal
+                    .section_kinds
+                    .iter()
+                    .map(|kind| string(kind.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "recommended_views",
+            JsonValue::Array(
+                signal
+                    .recommended_views
+                    .iter()
+                    .map(|view| string(view.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                signal
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(signal.integration_count() as i64),
+        ),
+        ("section_count", integer(signal.section_count as i64)),
+        (
+            "command_center_summary",
+            integration_activation_command_center_summary_json(&signal.command_center_summary),
+        ),
+        (
+            "has_operator_work",
+            JsonValue::Bool(signal.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(signal.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(signal.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(signal.has_blockers())),
+        ("has_review_work", JsonValue::Bool(signal.has_review_work())),
+        (
+            "requires_attention",
+            JsonValue::Bool(signal.requires_attention()),
+        ),
+        (
+            "needs_escalation",
+            JsonValue::Bool(signal.needs_escalation()),
+        ),
+    ])
+}
+
+fn integration_activation_watchtower_summary_json(
+    summary: &IntegrationActivationWatchtowerSummary,
+) -> JsonValue {
+    object([
+        ("total_signals", integer(summary.total_signals as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "signals_requiring_attention",
+            integer(summary.signals_requiring_attention as i64),
+        ),
+        (
+            "signals_with_operator_work",
+            integer(summary.signals_with_operator_work as i64),
+        ),
+        (
+            "signals_with_actionable_work",
+            integer(summary.signals_with_actionable_work as i64),
+        ),
+        (
+            "signals_with_activation_work",
+            integer(summary.signals_with_activation_work as i64),
+        ),
+        (
+            "signals_with_blockers",
+            integer(summary.signals_with_blockers as i64),
+        ),
+        (
+            "signals_with_review_work",
+            integer(summary.signals_with_review_work as i64),
+        ),
+        (
+            "escalation_signals",
+            integer(summary.escalation_signals as i64),
+        ),
+        ("review_signals", integer(summary.review_signals as i64)),
+        ("ready_signals", integer(summary.ready_signals as i64)),
+        ("action_signals", integer(summary.action_signals as i64)),
+        (
+            "observation_signals",
+            integer(summary.observation_signals as i64),
+        ),
+        ("total_sections", integer(summary.total_sections as i64)),
+        ("total_panels", integer(summary.total_panels as i64)),
+        ("total_tasks", integer(summary.total_tasks as i64)),
+        (
+            "operator_required_tasks",
+            integer(summary.operator_required_tasks as i64),
+        ),
+        ("actionable_tasks", integer(summary.actionable_tasks as i64)),
+        (
+            "activation_ready_tasks",
+            integer(summary.activation_ready_tasks as i64),
+        ),
+        ("blocked_tasks", integer(summary.blocked_tasks as i64)),
+        (
+            "review_required_tasks",
+            integer(summary.review_required_tasks as i64),
+        ),
+        ("monitor_tasks", integer(summary.monitor_tasks as i64)),
+        (
+            "next_signal_kind",
+            summary
+                .next_signal_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_section_kind",
+            summary
+                .next_section_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_signal_sequence",
+            summary
+                .next_signal_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_signal_priority",
+            summary
+                .next_signal_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_escalation_signal_sequence",
+            summary
+                .first_escalation_signal_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_signal_sequence",
+            summary
+                .first_review_signal_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_signal_sequence",
+            summary
+                .first_ready_signal_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_signal_sequence",
+            summary
+                .first_action_signal_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_escalation_signal_priority",
+            summary
+                .first_escalation_signal_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_signal_priority",
+            summary
+                .first_review_signal_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_signal_priority",
+            summary
+                .first_ready_signal_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_action_signal_priority",
+            summary
+                .first_action_signal_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_actionable_work",
+            JsonValue::Bool(summary.has_actionable_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+        (
+            "needs_escalation",
+            JsonValue::Bool(summary.needs_escalation()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -17375,6 +17846,31 @@ fn parse_activation_command_center_section_kind(
     }
 }
 
+fn parse_activation_watchtower_signal_kind(
+    label: &str,
+) -> Result<IntegrationActivationWatchtowerSignalKind, ToolCallError> {
+    match label {
+        "escalation" | "escalate" | "blocker" | "blockers" | "constraint" | "constraints" => {
+            Ok(IntegrationActivationWatchtowerSignalKind::Escalation)
+        }
+        "review" | "reviews" | "approval" | "approvals" | "human_review" => {
+            Ok(IntegrationActivationWatchtowerSignalKind::Review)
+        }
+        "ready" | "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationWatchtowerSignalKind::Ready)
+        }
+        "action" | "actionable" | "actions" | "operator_action" => {
+            Ok(IntegrationActivationWatchtowerSignalKind::Action)
+        }
+        "observation" | "observe" | "monitoring" | "monitor" | "status" => {
+            Ok(IntegrationActivationWatchtowerSignalKind::Observation)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation watchtower signal `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -18553,6 +19049,38 @@ fn integration_activation_command_center_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_watchtower_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_command_center_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("watchtower_signal", JsonSchema::String));
+        properties.push(SchemaProperty::new("signal_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "signal_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "signal_has_blockers",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "signal_has_review_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "signal_has_activation_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("needs_escalation", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("signal_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -18697,7 +19225,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 103);
+        assert_eq!(definitions.len(), 105);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -18974,9 +19502,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_COMMAND_CENTER_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            95
+            97
         );
         assert_eq!(
             export
@@ -19430,11 +19964,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(103))
+            Some(&integer(105))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(95))
+            Some(&integer(97))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -22448,6 +22982,143 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_watchtower_request = request(
+            "call-list-integration-activation-watchtower",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("signal_requires_attention", JsonValue::Bool(true)),
+                ("signal_limit", integer(3)),
+            ]),
+            5_037,
+        );
+        let list_activation_watchtower_trace =
+            tool_runtime.invoke_with_events(&list_activation_watchtower_request);
+        assert!(list_activation_watchtower_trace.result.ok);
+        assert_eq!(
+            list_activation_watchtower_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_watchtower_output = list_activation_watchtower_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_watchtower_count =
+            integer_value(field(list_activation_watchtower_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_watchtower_count));
+        let activation_watchtower_summary =
+            field(list_activation_watchtower_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_watchtower_summary, "total_signals"),
+            Some(&integer(activation_watchtower_count))
+        );
+        assert!(
+            integer_value(field(activation_watchtower_summary, "total_sections").unwrap()).unwrap()
+                >= activation_watchtower_count
+        );
+        assert_eq!(
+            field(activation_watchtower_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_watchtower_signal = array_item(
+            field(list_activation_watchtower_output, "activation_watchtower").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_watchtower_signal, "sequence").is_some());
+        assert!(field(activation_watchtower_signal, "signal_kind").is_some());
+        assert!(field(activation_watchtower_signal, "section_sequences").is_some());
+        assert!(field(activation_watchtower_signal, "recommended_views").is_some());
+        assert!(field(activation_watchtower_signal, "command_center_summary").is_some());
+        assert_eq!(
+            field(activation_watchtower_signal, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_watchtower_summary_request = request(
+            "call-integration-activation-watchtower-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("watchtower_signal", string("escalation")),
+                ("signal_has_blockers", JsonValue::Bool(true)),
+                ("needs_escalation", JsonValue::Bool(true)),
+            ]),
+            5_038,
+        );
+        let activation_watchtower_summary_trace =
+            tool_runtime.invoke_with_events(&activation_watchtower_summary_request);
+        assert!(activation_watchtower_summary_trace.result.ok);
+        assert_eq!(
+            activation_watchtower_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_watchtower_summary_output = activation_watchtower_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_watchtower_rollup =
+            field(activation_watchtower_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_watchtower_rollup, "escalation_signals").unwrap(),)
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_watchtower_rollup, "next_signal_kind"),
+            Some(&string("escalation"))
+        );
+        assert_eq!(
+            field(activation_watchtower_rollup, "next_section_kind"),
+            Some(&string("blockers"))
+        );
+        assert_eq!(
+            field(activation_watchtower_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_watchtower_rollup, "needs_escalation"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -24235,6 +24906,14 @@ mod tests {
             activation_command_center_summary_request,
             activation_command_center_summary_trace,
         );
+        journal.record_trace(
+            list_activation_watchtower_request,
+            list_activation_watchtower_trace,
+        );
+        journal.record_trace(
+            activation_watchtower_summary_request,
+            activation_watchtower_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -24308,9 +24987,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 103);
-        assert_eq!(journal_summary.completed_count, 103);
-        assert_eq!(journal.audit_records().len(), 103);
+        assert_eq!(journal_summary.invocation_count, 105);
+        assert_eq!(journal_summary.completed_count, 105);
+        assert_eq!(journal.audit_records().len(), 105);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -99,6 +99,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_command_center_summary` tool
   descriptors for read-only grouped operating-lane planning derived from
   activation control-room panels.
+- `smart_home.list_integration_activation_watchtower` and
+  `smart_home.get_integration_activation_watchtower_summary` tool descriptors
+  for read-only escalation, review, ready, action, and observation signal
+  rollups derived from activation command-center sections.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -97,6 +97,8 @@ Current scope:
   operator-view panels derived from the activation operator queue
 - D18D integration activation-command-center descriptors for grouped
   operating-lane sections derived from control-room panels
+- D18D integration activation-watchtower descriptors for escalation, review,
+  ready, action, and observation signal rollups
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1501,6 +1501,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationControlRoomSummary,
     ListIntegrationActivationCommandCenter,
     GetIntegrationActivationCommandCenterSummary,
+    ListIntegrationActivationWatchtower,
+    GetIntegrationActivationWatchtowerSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1710,6 +1712,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationCommandCenterSummary => {
                 read_tool("smart_home.get_integration_activation_command_center_summary")
+            }
+            Self::ListIntegrationActivationWatchtower => {
+                read_tool("smart_home.list_integration_activation_watchtower")
+            }
+            Self::GetIntegrationActivationWatchtowerSummary => {
+                read_tool("smart_home.get_integration_activation_watchtower_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2394,6 +2402,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationControlRoomSummary,
         SmartHomeTool::ListIntegrationActivationCommandCenter,
         SmartHomeTool::GetIntegrationActivationCommandCenterSummary,
+        SmartHomeTool::ListIntegrationActivationWatchtower,
+        SmartHomeTool::GetIntegrationActivationWatchtowerSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3236,7 +3246,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 103);
+        assert_eq!(catalog.len(), 105);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3655,6 +3665,14 @@ mod tests {
             == "smart_home.get_integration_activation_command_center_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_watchtower"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_watchtower_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3662,15 +3680,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 103);
-        assert_eq!(summary.read_tools, 95);
+        assert_eq!(summary.total_tools, 105);
+        assert_eq!(summary.read_tools, 97);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 95);
+        assert_eq!(summary.read_only_tier_tools, 97);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 103);
+        assert_eq!(summary.total_required_capabilities, 105);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -84,6 +84,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationCommandCenterSection` and
   `IntegrationActivationCommandCenterSummary` for grouping control-room panels
   into blocker, review, activation, actionable, and monitoring operating lanes.
+- `IntegrationActivationWatchtowerSignal` and
+  `IntegrationActivationWatchtowerSummary` for rolling command-center sections
+  into escalation, review, ready, action, and observation signal lanes.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -81,6 +81,8 @@ runtime and Chief of Staff tools a typed catalog for:
   planning view for compact attention, blocker, review, and activation rollups
 - activation command-center sections that group control-room panels into
   blocker, review, activation, actionable, and monitoring operating lanes
+- activation watchtower signals that roll command-center sections into
+  escalation, review, ready, action, and observation signal lanes
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1186,6 +1186,41 @@ impl IntegrationActivationCommandCenterSectionKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationWatchtowerSignalKind {
+    Escalation,
+    Review,
+    Ready,
+    Action,
+    Observation,
+}
+
+impl IntegrationActivationWatchtowerSignalKind {
+    pub fn from_section(section: &IntegrationActivationCommandCenterSection) -> Self {
+        if section.has_blockers() {
+            Self::Escalation
+        } else if section.has_activation_work() {
+            Self::Ready
+        } else if section.has_review_work() {
+            Self::Review
+        } else if section.has_actionable_work() {
+            Self::Action
+        } else {
+            Self::Observation
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Escalation => "escalation",
+            Self::Review => "review",
+            Self::Ready => "ready",
+            Self::Action => "action",
+            Self::Observation => "observation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2376,6 +2411,61 @@ pub struct IntegrationActivationCommandCenterSummary {
     pub first_review_section_priority: Option<u8>,
     pub first_activation_section_priority: Option<u8>,
     pub first_actionable_section_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationWatchtowerSignal {
+    pub sequence: usize,
+    pub signal_kind: IntegrationActivationWatchtowerSignalKind,
+    pub priority: u8,
+    pub section_sequences: Vec<usize>,
+    pub section_kinds: Vec<IntegrationActivationCommandCenterSectionKind>,
+    pub recommended_views: Vec<IntegrationActivationPlaybookView>,
+    pub integration_ids: Vec<IntegrationId>,
+    pub section_count: usize,
+    pub command_center_summary: IntegrationActivationCommandCenterSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationWatchtowerSummary {
+    pub total_signals: usize,
+    pub unique_integrations: usize,
+    pub signals_requiring_attention: usize,
+    pub signals_with_operator_work: usize,
+    pub signals_with_actionable_work: usize,
+    pub signals_with_activation_work: usize,
+    pub signals_with_blockers: usize,
+    pub signals_with_review_work: usize,
+    pub escalation_signals: usize,
+    pub review_signals: usize,
+    pub ready_signals: usize,
+    pub action_signals: usize,
+    pub observation_signals: usize,
+    pub total_sections: usize,
+    pub total_panels: usize,
+    pub total_tasks: usize,
+    pub operator_required_tasks: usize,
+    pub actionable_tasks: usize,
+    pub activation_ready_tasks: usize,
+    pub blocked_tasks: usize,
+    pub review_required_tasks: usize,
+    pub monitor_tasks: usize,
+    pub next_signal_kind: Option<IntegrationActivationWatchtowerSignalKind>,
+    pub next_section_kind: Option<IntegrationActivationCommandCenterSectionKind>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_signal_sequence: Option<usize>,
+    pub next_signal_priority: Option<u8>,
+    pub first_escalation_signal_sequence: Option<usize>,
+    pub first_review_signal_sequence: Option<usize>,
+    pub first_ready_signal_sequence: Option<usize>,
+    pub first_action_signal_sequence: Option<usize>,
+    pub first_escalation_signal_priority: Option<u8>,
+    pub first_review_signal_priority: Option<u8>,
+    pub first_ready_signal_priority: Option<u8>,
+    pub first_action_signal_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -5354,6 +5444,288 @@ impl IntegrationActivationCommandCenterSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.sections_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationWatchtowerSignal {
+    fn from_sections(
+        sequence: usize,
+        signal_kind: IntegrationActivationWatchtowerSignalKind,
+        sections: Vec<IntegrationActivationCommandCenterSection>,
+    ) -> Self {
+        let command_center_summary =
+            IntegrationActivationCommandCenterSummary::from_sections(sections.iter());
+        let mut section_sequences = sections
+            .iter()
+            .map(|section| section.sequence)
+            .collect::<Vec<_>>();
+        section_sequences.sort_unstable();
+
+        let mut section_kinds = sections
+            .iter()
+            .map(|section| section.section_kind)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        section_kinds.sort();
+
+        let mut recommended_views = sections
+            .iter()
+            .flat_map(|section| section.recommended_views.iter().copied())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        recommended_views.sort();
+
+        let mut integration_ids = sections
+            .iter()
+            .flat_map(|section| section.integration_ids.iter().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        integration_ids.sort();
+
+        let priority = sections
+            .iter()
+            .map(|section| section.priority)
+            .min()
+            .unwrap_or(u8::MAX);
+
+        Self {
+            sequence,
+            signal_kind,
+            priority,
+            section_sequences,
+            section_kinds,
+            recommended_views,
+            integration_ids,
+            section_count: command_center_summary.total_sections,
+            command_center_summary,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.command_center_summary.has_operator_work()
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.command_center_summary.has_actionable_work()
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.command_center_summary.has_activation_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.command_center_summary.has_blockers()
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.command_center_summary.has_review_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.command_center_summary.requires_attention()
+    }
+
+    pub fn needs_escalation(&self) -> bool {
+        self.signal_kind == IntegrationActivationWatchtowerSignalKind::Escalation
+            || self.has_blockers()
+    }
+}
+
+impl IntegrationActivationWatchtowerSummary {
+    pub fn from_signals<'a>(
+        signals: impl IntoIterator<Item = &'a IntegrationActivationWatchtowerSignal>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_signals: 0,
+            unique_integrations: 0,
+            signals_requiring_attention: 0,
+            signals_with_operator_work: 0,
+            signals_with_actionable_work: 0,
+            signals_with_activation_work: 0,
+            signals_with_blockers: 0,
+            signals_with_review_work: 0,
+            escalation_signals: 0,
+            review_signals: 0,
+            ready_signals: 0,
+            action_signals: 0,
+            observation_signals: 0,
+            total_sections: 0,
+            total_panels: 0,
+            total_tasks: 0,
+            operator_required_tasks: 0,
+            actionable_tasks: 0,
+            activation_ready_tasks: 0,
+            blocked_tasks: 0,
+            review_required_tasks: 0,
+            monitor_tasks: 0,
+            next_signal_kind: None,
+            next_section_kind: None,
+            next_recommended_view: None,
+            next_task_kind: None,
+            next_signal_sequence: None,
+            next_signal_priority: None,
+            first_escalation_signal_sequence: None,
+            first_review_signal_sequence: None,
+            first_ready_signal_sequence: None,
+            first_action_signal_sequence: None,
+            first_escalation_signal_priority: None,
+            first_review_signal_priority: None,
+            first_ready_signal_priority: None,
+            first_action_signal_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for signal in signals {
+            summary.total_signals += 1;
+            for integration_id in &signal.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match signal.signal_kind {
+                IntegrationActivationWatchtowerSignalKind::Escalation => {
+                    summary.escalation_signals += 1;
+                    summary.first_escalation_signal_sequence = summary
+                        .first_escalation_signal_sequence
+                        .or(Some(signal.sequence));
+                    summary.first_escalation_signal_priority = min_optional_priority(
+                        summary.first_escalation_signal_priority,
+                        Some(signal.priority),
+                    );
+                }
+                IntegrationActivationWatchtowerSignalKind::Review => {
+                    summary.review_signals += 1;
+                    summary.first_review_signal_sequence = summary
+                        .first_review_signal_sequence
+                        .or(Some(signal.sequence));
+                    summary.first_review_signal_priority = min_optional_priority(
+                        summary.first_review_signal_priority,
+                        Some(signal.priority),
+                    );
+                }
+                IntegrationActivationWatchtowerSignalKind::Ready => {
+                    summary.ready_signals += 1;
+                    summary.first_ready_signal_sequence = summary
+                        .first_ready_signal_sequence
+                        .or(Some(signal.sequence));
+                    summary.first_ready_signal_priority = min_optional_priority(
+                        summary.first_ready_signal_priority,
+                        Some(signal.priority),
+                    );
+                }
+                IntegrationActivationWatchtowerSignalKind::Action => {
+                    summary.action_signals += 1;
+                    summary.first_action_signal_sequence = summary
+                        .first_action_signal_sequence
+                        .or(Some(signal.sequence));
+                    summary.first_action_signal_priority = min_optional_priority(
+                        summary.first_action_signal_priority,
+                        Some(signal.priority),
+                    );
+                }
+                IntegrationActivationWatchtowerSignalKind::Observation => {
+                    summary.observation_signals += 1;
+                }
+            }
+
+            if summary.next_signal_kind.is_none()
+                && signal.command_center_summary.next_task_kind.is_some()
+            {
+                summary.next_signal_kind = Some(signal.signal_kind);
+                summary.next_section_kind = signal.command_center_summary.next_section_kind;
+                summary.next_recommended_view = signal.command_center_summary.next_recommended_view;
+                summary.next_task_kind = signal.command_center_summary.next_task_kind;
+                summary.next_signal_sequence = Some(signal.sequence);
+                summary.next_signal_priority = Some(signal.priority);
+            }
+
+            if signal.requires_attention() {
+                summary.signals_requiring_attention += 1;
+            }
+            if signal.has_operator_work() {
+                summary.signals_with_operator_work += 1;
+            }
+            if signal.has_actionable_work() {
+                summary.signals_with_actionable_work += 1;
+            }
+            if signal.has_activation_work() {
+                summary.signals_with_activation_work += 1;
+            }
+            if signal.has_blockers() {
+                summary.signals_with_blockers += 1;
+            }
+            if signal.has_review_work() {
+                summary.signals_with_review_work += 1;
+            }
+
+            summary.total_sections += signal.command_center_summary.total_sections;
+            summary.total_panels += signal.command_center_summary.total_panels;
+            summary.total_tasks += signal.command_center_summary.total_tasks;
+            summary.operator_required_tasks +=
+                signal.command_center_summary.operator_required_tasks;
+            summary.actionable_tasks += signal.command_center_summary.actionable_tasks;
+            summary.activation_ready_tasks += signal.command_center_summary.activation_ready_tasks;
+            summary.blocked_tasks += signal.command_center_summary.blocked_tasks;
+            summary.review_required_tasks += signal.command_center_summary.review_required_tasks;
+            summary.monitor_tasks += signal.command_center_summary.monitor_tasks;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(signal.command_center_summary.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.signals_with_blockers > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.signals_with_review_work > 0 || summary.signals_with_operator_work > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.signals_with_activation_work > 0
+            || summary.signals_with_actionable_work > 0
+        {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_signals == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.signals_with_operator_work > 0
+    }
+
+    pub fn has_actionable_work(&self) -> bool {
+        self.signals_with_actionable_work > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.signals_with_activation_work > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.signals_with_blockers > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.signals_with_review_work > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.signals_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+
+    pub fn needs_escalation(&self) -> bool {
+        self.escalation_signals > 0 || self.has_blockers()
     }
 }
 
@@ -9712,6 +10084,124 @@ pub fn activation_command_center_sections_at_or_before_priority(
     )
 }
 
+pub fn activation_watchtower_signals_from_command_center_sections(
+    mut sections: Vec<IntegrationActivationCommandCenterSection>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    sections.sort_by(compare_activation_command_center_sections);
+    let mut sections_by_signal: BTreeMap<
+        IntegrationActivationWatchtowerSignalKind,
+        Vec<IntegrationActivationCommandCenterSection>,
+    > = BTreeMap::new();
+    for section in sections {
+        sections_by_signal
+            .entry(IntegrationActivationWatchtowerSignalKind::from_section(
+                &section,
+            ))
+            .or_default()
+            .push(section);
+    }
+
+    let mut signals = sections_by_signal
+        .into_iter()
+        .map(|(signal_kind, sections)| {
+            IntegrationActivationWatchtowerSignal::from_sections(0, signal_kind, sections)
+        })
+        .collect::<Vec<_>>();
+    signals.sort_by(compare_activation_watchtower_signals);
+    for (index, signal) in signals.iter_mut().enumerate() {
+        signal.sequence = index + 1;
+    }
+    signals
+}
+
+pub fn activation_watchtower_signals_from_control_room_panels(
+    panels: Vec<IntegrationActivationControlRoomPanel>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_control_room_panels(panels),
+    )
+}
+
+pub fn activation_watchtower_signals_from_operator_tasks(
+    tasks: Vec<IntegrationActivationOperatorTask>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_operator_tasks(tasks),
+    )
+}
+
+pub fn activation_watchtower_signals_from_playbook_steps(
+    steps: Vec<IntegrationActivationPlaybookStep>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_playbook_steps(steps),
+    )
+}
+
+pub fn activation_watchtower_signals_from_forecasts(
+    forecasts: Vec<IntegrationActivationForecastItem>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_forecasts(forecasts),
+    )
+}
+
+pub fn activation_watchtower_signals_from_timeline_milestones(
+    milestones: Vec<IntegrationActivationTimelineMilestone>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_timeline_milestones(milestones),
+    )
+}
+
+pub fn activation_watchtower_signals_from_dashboard_cards(
+    cards: Vec<IntegrationActivationDashboardCard>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_dashboard_cards(cards),
+    )
+}
+
+pub fn activation_watchtower_signals_from_readouts<'a>(
+    readouts: impl IntoIterator<Item = &'a IntegrationActivationReadoutStage>,
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_readouts(readouts),
+    )
+}
+
+pub fn activation_watchtower_signals_from_candidates(
+    catalog: &[IntegrationCatalogEntry],
+    candidates: Vec<IntegrationActivationCandidate>,
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_from_candidates(
+            catalog,
+            candidates,
+            enabled_integrations,
+        ),
+    )
+}
+
+pub fn activation_watchtower_signals_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationWatchtowerSignal> {
+    activation_watchtower_signals_from_command_center_sections(
+        activation_command_center_sections_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -11138,6 +11628,22 @@ fn compare_activation_command_center_sections(
         .then_with(|| right.has_actionable_work().cmp(&left.has_actionable_work()))
         .then_with(|| left.section_kind.cmp(&right.section_kind))
         .then_with(|| right.panel_count.cmp(&left.panel_count))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_watchtower_signals(
+    left: &IntegrationActivationWatchtowerSignal,
+    right: &IntegrationActivationWatchtowerSignal,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| right.has_actionable_work().cmp(&left.has_actionable_work()))
+        .then_with(|| left.signal_kind.cmp(&right.signal_kind))
+        .then_with(|| right.section_count.cmp(&left.section_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -13800,6 +14306,133 @@ mod tests {
         assert!(catalog_sections
             .iter()
             .any(IntegrationActivationCommandCenterSection::requires_attention));
+    }
+
+    #[test]
+    fn activation_watchtower_signals_roll_up_command_center_attention() {
+        let review_ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+            display_name: "Review Ready Bridge".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 1,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HumanApproval,
+            local_only: true,
+            cloud_required: false,
+        };
+        let blocked_review_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+            display_name: "Blocked Review Camera".to_string(),
+            activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                IntegrationId::trusted("mqtt"),
+            ),
+            priority: 2,
+            missing_primitives: vec![PrimitiveFamily::CameraMedia],
+            missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+            missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+            requires_human_review: true,
+            highest_policy_tier: PrivilegeTier::HighRisk,
+            local_only: false,
+            cloud_required: true,
+        };
+        let ready_report = IntegrationReadinessReport {
+            requested_integration_id: IntegrationId::trusted("read_only_probe"),
+            display_name: "Read-only Probe".to_string(),
+            activation_target: IntegrationActivationTarget::Direct,
+            priority: 3,
+            missing_primitives: Vec::new(),
+            missing_capabilities: Vec::new(),
+            missing_dependencies: Vec::new(),
+            requires_human_review: false,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            local_only: true,
+            cloud_required: false,
+        };
+        let candidates = activation_candidates_from_reports(
+            [review_ready_report, blocked_review_report, ready_report].iter(),
+        );
+        let sections = activation_command_center_sections_from_candidates(&[], candidates, &[]);
+        let signals = activation_watchtower_signals_from_command_center_sections(sections);
+
+        assert_eq!(signals.len(), 2);
+        assert_eq!(signals[0].sequence, 1);
+        assert_eq!(
+            signals[0].signal_kind,
+            IntegrationActivationWatchtowerSignalKind::Escalation
+        );
+        assert!(signals[0].has_blockers());
+        assert!(signals[0].requires_attention());
+        assert!(signals[0].needs_escalation());
+        assert!(signals[0]
+            .section_kinds
+            .contains(&IntegrationActivationCommandCenterSectionKind::Blockers));
+        assert!(!signals[0].section_sequences.is_empty());
+        assert!(!signals[0].recommended_views.is_empty());
+        assert!(signals.iter().any(|signal| {
+            signal.signal_kind == IntegrationActivationWatchtowerSignalKind::Ready
+                && signal.has_activation_work()
+        }));
+
+        let summary = IntegrationActivationWatchtowerSummary::from_signals(signals.iter());
+        assert_eq!(summary.total_signals, 2);
+        assert_eq!(summary.unique_integrations, 3);
+        assert_eq!(summary.total_sections, 2);
+        assert_eq!(summary.total_panels, 3);
+        assert_eq!(summary.escalation_signals, 1);
+        assert_eq!(summary.ready_signals, 1);
+        assert_eq!(summary.signals_with_blockers, 1);
+        assert_eq!(summary.signals_with_activation_work, 1);
+        assert_eq!(
+            summary.next_signal_kind,
+            Some(IntegrationActivationWatchtowerSignalKind::Escalation)
+        );
+        assert_eq!(
+            summary.next_section_kind,
+            Some(IntegrationActivationCommandCenterSectionKind::Blockers)
+        );
+        assert_eq!(
+            summary.next_task_kind,
+            Some(IntegrationActivationOperatorTaskKind::ResolveConstraints)
+        );
+        assert_eq!(summary.next_signal_sequence, Some(1));
+        assert_eq!(summary.first_escalation_signal_sequence, Some(1));
+        assert_eq!(summary.first_ready_signal_sequence, Some(2));
+        assert_eq!(summary.highest_policy_tier, PrivilegeTier::HighRisk);
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+        assert!(summary.has_operator_work());
+        assert!(summary.has_actionable_work());
+        assert!(summary.has_activation_work());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(summary.needs_escalation());
+        assert!(!summary.is_empty());
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_signals = activation_watchtower_signals_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_signals
+            .iter()
+            .any(IntegrationActivationWatchtowerSignal::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add D23A activation watchtower signals and summaries derived from command-center sections
- expose two read-only smart-home core descriptors for watchtower list and summary tools
- wire Chief D18D schema, parsing, JSON handlers, runtime coverage, and docs for the new watchtower tools

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools