### PR TITLE
feat(adj-constraints): live decompose→solve — small model decomposes, engine solves at 0 answer-time calls (ADJ constraints D2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.7] - 2026-06-11 — decompose→solve golden tests (ADJ constraints track D2)
+
+### Added
+
+- `tests/decompose_run.rs` — deterministic golden tests over the **committed**
+  decompositions from the live decompose→solve demonstration
+  (`code/specs/data/adj-constraints-decompose-run/`). A local model
+  (`llama3.1:8b`) turned 4 messy-prose word problems into adj-lang; the engine
+  solved 3/4 to gold (44, 980, unsat) at **0 answer-time model calls**, and
+  reported the 4th (a model mis-transcription) as `unsupported` rather than
+  fabricating a value. The tests re-solve every committed `.adj` with no model in
+  the loop — proving the engine is a pure function of the decomposition. Test +
+  spec-data only; no CLI behavior change.
+
 ## [0.3.6] - 2026-06-11 — grant-allocation LP worked example (ADJ constraints track D)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/tests/decompose_run.rs
+++ b/code/packages/rust/adj-lang-cli/tests/decompose_run.rs
@@ -1,0 +1,77 @@
+//! Deterministic golden tests over the **committed** decompositions from the
+//! live decompose->solve demonstration (ADJ constraints track D2).
+//!
+//! The live run (`code/specs/data/adj-constraints-decompose-run/run.py`) calls a
+//! local model ONCE per case to turn messy prose into an adj-lang program, then
+//! the engine solves it. The model is non-deterministic and Ollama is not in CI,
+//! so the *model* half is not tested here. What IS tested — deterministically,
+//! with no model — is that the **engine is a pure function of the committed
+//! `.adj`**: re-running `adj-lang-cli` on each committed decomposition reproduces
+//! the recorded outcome. This is the load-bearing claim: the model's
+//! non-determinism is fully quarantined to the `.adj`; the answer is the engine's.
+//!
+//! Three of the four recorded decompositions solve to their gold value; the
+//! fourth (`workshop_break_even`) is the honest-failure case — the model wrote an
+//! inequality ("cover cost") where an equality ("break even") was needed, and the
+//! engine reports `unsupported` rather than inventing a number. We assert that
+//! too: the engine never fabricates an answer for a mis-decomposed problem.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A committed decomposition, relative to this crate's manifest:
+/// `code/packages/rust/adj-lang-cli` -> `code/specs/data/adj-constraints-decompose-run/results`.
+fn committed(id: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-constraints-decompose-run/results")
+        .join(format!("{id}.adj"))
+}
+
+/// Run the CLI on a committed `.adj`; return (success, stdout).
+fn solve(id: &str) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(committed(id))
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn relief_allocation_decomposition_solves_to_44() {
+    // The model maximized 4·meals + 3·shelter under the budget + meals cap.
+    let (ok, s) = solve("relief_allocation");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"optimize\":{"), "{s}");
+    assert!(s.contains("\"outcome\":\"optimal\""), "{s}");
+    assert!(s.contains("\"value\":44"), "expected optimum 44: {s}");
+}
+
+#[test]
+fn production_cost_decomposition_solves_to_980() {
+    // The model minimized 5·A + 8·B under the contract minimums.
+    let (ok, s) = solve("production_cost");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"outcome\":\"optimal\""), "{s}");
+    assert!(s.contains("\"value\":980"), "expected optimum 980: {s}");
+}
+
+#[test]
+fn schedule_feasibility_decomposition_is_unsat() {
+    // The model encoded the schedule constraints; the engine proves the
+    // contradiction (design ≥ 28 but design ≤ 25 from the build deadline).
+    let (ok, s) = solve("schedule_feasibility");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"check\":{"), "{s}");
+    assert!(s.contains("\"outcome\":\"unsat\""), "expected unsat: {s}");
+}
+
+#[test]
+fn break_even_misdecomposition_is_unsupported_not_fabricated() {
+    // Honest-failure case: the model wrote an inequality where an equality was
+    // needed. The engine REFUSES to guess — `unsupported`, never a fake value.
+    let (ok, s) = solve("workshop_break_even");
+    assert!(ok, "non-zero exit: {s}");
+    assert!(s.contains("\"outcome\":\"unsupported\""), "{s}");
+    // Crucially: no fabricated solved value.
+    assert!(!s.contains("\"outcome\":\"solved\""), "must not fabricate: {s}");
+}

--- a/code/specs/data/adj-constraints-decompose-run/FINDINGS.md
+++ b/code/specs/data/adj-constraints-decompose-run/FINDINGS.md
@@ -1,0 +1,77 @@
+# FINDINGS — live decompose→solve over the adj-lang constraint sublanguage (D2)
+
+**Model:** `llama3.1:8b` (local, via Ollama, temperature 0, seed 7).
+**Cases:** 4 messy-prose constraint word problems, one per solver path.
+**Recorded run:** `results/` (committed). Reproduce with `python3 run.py`.
+
+## Headline
+
+| metric | value |
+|---|---|
+| engine-solved to gold | **3 / 4** |
+| **answer-time model calls** | **0** |
+| decompose calls (the only model touchpoint) | 4 (one per case) |
+| fabricated wrong answers | **0** |
+
+The architecture holds: the model is called **only to transcribe** prose into
+adj-lang; **every answer is the engine's**, produced by `adj-lang-cli` at zero
+answer-time model calls. On the cases the model transcribed correctly, the engine
+returned the exact optimum / value / verdict, each cited to the constraint that
+determined it.
+
+## Per case
+
+| id | path | model's decomposition (committed `.adj`) | engine | gold | ✓ |
+|---|---|---|---|---|---|
+| `relief_allocation` | maximize | `maximize 4·hot_meals + 3·emergency_shelter` under budget + meals cap | **44** | 44 | ✅ |
+| `production_cost` | minimize | `minimize 5·a + 8·b` under contract minimums | **980** | 980 | ✅ |
+| `schedule_feasibility` | check | introduced a `build_start` intermediate, chained `build_start = design_finish`, `build_finish − build_start ≥ 20` | **unsat** | unsat | ✅ |
+| `workshop_break_even` | solve | wrote `2000 + 15·attendees ≤ 65·attendees` (an inequality) | **unsupported** | 40 | ❌ |
+
+The decompositions are clean and human-legible — e.g. for the schedule the model
+*invented an intermediate variable* (`build_start`) to chain the precedence, and
+the engine then proved the contradiction (design ≥ 28 forces build ≥ 48 > 45).
+
+## The miss is the point
+
+`workshop_break_even` is the **honest-failure** case. "Break even" is an equality
+(`revenue = cost`); the model wrote the inequality `cost ≤ revenue` ("at least
+cover cost"). Solving *for a unique value* under an inequality is ill-posed, so the
+engine returned:
+
+```json
+{ "outcome": "unsupported", "reason": "inequality constraints — feasibility/LP is track C1/C2" }
+```
+
+It did **not** invent a number. This is the whole thesis in one case: a small
+model's mis-transcription is **localized and legible** (you can read the one wrong
+operator in the committed `.adj`), and the engine **never launders a bad
+decomposition into a confident answer**. Contrast a monolithic LLM, which would
+have emitted *some* number with no way to see where it went wrong.
+
+## Why this matters (and what it is not)
+
+- **Intelligence in the framework, not the weights.** An 8B local model — far
+  below a frontier model — is enough, because all it does is map surface forms to
+  a constrained grammar. The reasoning (exact rational LP / feasibility / linear
+  solve) is the CPU engine's. This is the [[project_dumber_models_constrained_envs]]
+  hypothesis made concrete for constraints.
+- **Correctable, not just correct.** Every step is inspectable: the prose, the
+  model's `.adj`, the engine's cited decision. The break-even miss is fixable by
+  editing one operator in the `.adj` — no model retrain, no prompt surgery.
+- **Not a benchmark.** One model, one prompt, four cases — a *demonstration of the
+  architecture*, not a powered model-quality study. The number that matters is
+  **answer-time model calls = 0**, not 3/4. A different/larger local model is a
+  one-arg swap (`python3 run.py qwen2.5:3b`); the engine and the golden tests are
+  unchanged.
+
+## Reproducibility
+
+- The **model** half is non-deterministic and Ollama is not in CI, so it is not
+  asserted in CI. The committed `results/*.adj` capture exactly what `llama3.1:8b`
+  produced on the recorded run.
+- The **engine** half is deterministic and *is* asserted in CI:
+  [`adj-lang-cli/tests/decompose_run.rs`](../../../packages/rust/adj-lang-cli/tests/decompose_run.rs)
+  re-solves every committed `.adj` (44 / 980 / unsat / unsupported) with no model
+  in the loop — proving the engine is a pure function of the decomposition and the
+  model's non-determinism is fully quarantined.

--- a/code/specs/data/adj-constraints-decompose-run/SPEC.md
+++ b/code/specs/data/adj-constraints-decompose-run/SPEC.md
@@ -1,0 +1,88 @@
+# ADJ constraints — live decompose→solve demonstration (track D2)
+
+## The claim
+
+> A **small local model** can do the one job it is good at — turning messy prose
+> into a typed, checkable representation — and a **deterministic CPU engine** does
+> all the reasoning. The model **decomposes**; it never computes the answer. Every
+> answer is produced by `adj-lang-cli` at **zero answer-time model calls**, and is
+> cited back to the constraint that determined it.
+
+This is the constraint-solving analogue of the MYCIN derive-once demonstration:
+the intelligence lives in the *framework* (the grammar that constrains the
+decomposition + the exact solver), not in the weights.
+
+## What this is NOT
+
+- It is **not** a closed-book accuracy benchmark. The model is asked only to
+  *transcribe* a word problem into adj-lang; it is not asked to solve it.
+- It is **not** a CI test. A live model is non-deterministic and Ollama is not
+  available in CI. The reproducible part — that the **engine** solves the
+  committed `.adj` programs correctly — is covered by a deterministic golden test
+  ([`adj-lang-cli/tests/decompose_run.rs`](../../../packages/rust/adj-lang-cli/tests/decompose_run.rs)).
+
+## Protocol
+
+```
+messy prose word problem  (cases/cases.json, with a GOLD answer)
+        │  decompose.py  — ONE model call per case (the only model touchpoint)
+        │     prompt = the adj-lang constraint grammar + vocabulary rules + the prose
+        │     the model emits ONLY an .adj program (symbols/constrain/solve|check|min|max)
+        ▼  results/<id>.adj           ← the model's decomposition (committed)
+        │  adj-lang-cli results/<id>.adj      — the CPU engine SOLVES it
+        ▼  results/<id>.json          ← the engine's decision + provenance (committed)
+        │  score.py — compare the engine's value to the case GOLD
+        ▼  results/summary.json       ← per-case pass/fail + the call accounting
+   answer_time_model_calls == 0  (asserted)
+```
+
+- **Model:** a local Ollama model (default `llama3.1:8b`), temperature 0, called
+  via the zero-dependency `/api/generate` endpoint (urllib only — no SDK).
+- **Decompose-only discipline:** the prompt forbids the model from stating an
+  answer; it must emit only the grammar. If the emitted text fails to compile or
+  uses a non-grammar construct, that is a *decomposition* failure (a framework
+  signal), not a reasoning error — the engine never produces a wrong number.
+- **The engine is the reasoner:** the GOLD answer is checked against
+  `adj-lang-cli`'s output, never against anything the model said.
+
+## Cases (`cases/cases.json`)
+
+Each exercises a different solver path, with a hand-computed GOLD answer:
+
+| id | prose gist | solver path | GOLD |
+|---|---|---|---|
+| `relief_allocation` | split a $12k budget across meals/shelter to maximize relief, meals capped at $8k | `maximize` (LP) | 44 at (meals=8, shelter=4) |
+| `workshop_break_even` | $2000 fixed + $15/attendee, $65/ticket — break-even headcount | `solve for` (linear eq) | 40 |
+| `schedule_feasibility` | design finishes ≥ day 28, build ≥ design+20 and ≤ day 45 — feasible? | `check` (feasibility) | UNSAT (contradiction) |
+| `production_cost` | make ≥100 of A ($5) and ≥60 of B ($8), minimize cost | `minimize` (LP) | 980 |
+
+## Files
+
+- `cases/cases.json` — the prose + gold answers + which engine key carries the answer.
+- `decompose.py` — the model touchpoint (urllib → Ollama, decompose-only prompt).
+- `run.py` — orchestrate decompose → `adj-lang-cli` → score; write `results/`.
+- `results/` — the committed real run: `<id>.adj` (model output), `<id>.json`
+  (engine output), `summary.json` (scores + call accounting).
+- `FINDINGS.md` — what the run showed (honest about decomposition failures).
+- `adj-lang-cli/tests/decompose_run.rs` — deterministic golden test: the engine
+  solves every committed `.adj` to its gold value (no model involved).
+
+## Reproduce
+
+```
+ollama pull llama3.1:8b          # or any local model
+cargo build -p adj-lang-cli
+python3 run.py                   # re-runs the model; overwrites results/
+cargo test -p adj-lang-cli --test decompose_run   # deterministic, no model
+```
+
+## Honest limitations
+
+- One model, one prompt, a handful of cases — a *demonstration*, not a powered
+  study. The point is the **architecture** (decompose-only + exact solver = 0
+  answer-time calls), not a model-quality number.
+- A small model sometimes mis-transcribes a problem (wrong coefficient, a missing
+  constraint). That surfaces as a *failed decomposition* the engine reports
+  honestly (wrong value vs gold, or a compile error) — never a confidently-wrong
+  answer the engine invented. The committed `results/` show exactly which cases
+  the model got right on the recorded run.

--- a/code/specs/data/adj-constraints-decompose-run/cases/cases.json
+++ b/code/specs/data/adj-constraints-decompose-run/cases/cases.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Messy-prose constraint word problems for the live decompose->solve demonstration (ADJ constraints D2). The model decomposes each `prose` into an adj-lang program; the engine solves it. `gold` is the hand-computed answer, checked against the ENGINE output (never against the model). `answer_key` says which engine section carries the answer and how to read it.",
+  "cases": [
+    {
+      "id": "relief_allocation",
+      "prose": "A relief charity has a $12,000 budget this month to split between two programs: hot meals and emergency shelter (count the dollars in thousands). Every $1k put into meals delivers 4 units of relief; every $1k into shelter delivers 3 units. The kitchen can absorb at most $8k of meals funding. They want the split that delivers the most total relief. How many relief units can they deliver, and how should they allocate the budget?",
+      "solver_path": "maximize",
+      "gold": { "optimize_value": 44 },
+      "gold_assignment": { "meals": 8, "shelter": 4 },
+      "notes": "max 4*meals + 3*shelter s.t. meals+shelter<=12, meals<=8, meals>=0, shelter>=0 -> 44 at (8,4)."
+    },
+    {
+      "id": "workshop_break_even",
+      "prose": "Running a one-day workshop costs $2,000 in fixed overhead plus $15 for each attendee (materials and catering). Tickets sell for $65 each. How many attendees does the workshop need so that revenue exactly covers total cost (break even)?",
+      "solver_path": "solve",
+      "gold": { "solve_value": { "var": "attendees", "value": 40 } },
+      "notes": "65*attendees = 2000 + 15*attendees -> 50*attendees = 2000 -> 40."
+    },
+    {
+      "id": "schedule_feasibility",
+      "prose": "A project has two phases. The design phase cannot finish before day 28. The build phase cannot start until design is finished and then takes at least 20 days, and the whole project must be delivered (build finished) by day 45. Treat the day each phase finishes as an unknown. Is this schedule even possible?",
+      "solver_path": "check",
+      "gold": { "check_outcome": "unsat" },
+      "notes": "design_end >= 28 ; build_end >= design_end + 20 ; build_end <= 45 -> design_end <= 25, contradicts design_end >= 28 -> UNSAT."
+    },
+    {
+      "id": "production_cost",
+      "prose": "A small factory must produce at least 100 units of product A and at least 60 units of product B to meet contracts. Product A costs $5 per unit to make and product B costs $8 per unit. The factory wants to meet the contracts at the lowest possible total production cost. What is that minimum cost?",
+      "solver_path": "minimize",
+      "gold": { "optimize_value": 980 },
+      "gold_assignment": { "a": 100, "b": 60 },
+      "notes": "min 5*a + 8*b s.t. a>=100, b>=60 -> 5*100 + 8*60 = 980 at (100,60)."
+    }
+  ]
+}

--- a/code/specs/data/adj-constraints-decompose-run/results/production_cost.adj
+++ b/code/specs/data/adj-constraints-decompose-run/results/production_cost.adj
@@ -1,0 +1,6 @@
+symbol a : scalar
+symbol b : scalar
+constrain 100 <= a
+constrain 60 <= b
+constrain 5 * a + 8 * b >= 0
+minimize 5 * a + 8 * b

--- a/code/specs/data/adj-constraints-decompose-run/results/production_cost.json
+++ b/code/specs/data/adj-constraints-decompose-run/results/production_cost.json
@@ -1,0 +1,29 @@
+{
+  "queries": [],
+  "ranked": [],
+  "decision": {
+    "type": "empty"
+  },
+  "solve": {
+    "outcome": "unsupported",
+    "reason": "inequality constraints \u2014 feasibility/LP is track C1/C2"
+  },
+  "optimize": {
+    "outcome": "optimal",
+    "value": 980,
+    "assignments": [
+      {
+        "name": "a",
+        "value": 100
+      },
+      {
+        "name": "b",
+        "value": 60
+      }
+    ],
+    "binding": [
+      0,
+      1
+    ]
+  }
+}

--- a/code/specs/data/adj-constraints-decompose-run/results/relief_allocation.adj
+++ b/code/specs/data/adj-constraints-decompose-run/results/relief_allocation.adj
@@ -1,0 +1,7 @@
+symbol hot_meals : scalar
+symbol emergency_shelter : scalar
+constrain 12 - hot_meals - emergency_shelter = 0
+constrain 4 * hot_meals + 3 * emergency_shelter >= 0
+constrain hot_meals <= 8
+maximize 4 * hot_meals + 3 * emergency_shelter
+solve for { hot_meals, emergency_shelter }

--- a/code/specs/data/adj-constraints-decompose-run/results/relief_allocation.json
+++ b/code/specs/data/adj-constraints-decompose-run/results/relief_allocation.json
@@ -1,0 +1,29 @@
+{
+  "queries": [],
+  "ranked": [],
+  "decision": {
+    "type": "empty"
+  },
+  "solve": {
+    "outcome": "unsupported",
+    "reason": "inequality constraints \u2014 feasibility/LP is track C1/C2"
+  },
+  "optimize": {
+    "outcome": "optimal",
+    "value": 44,
+    "assignments": [
+      {
+        "name": "emergency_shelter",
+        "value": 4
+      },
+      {
+        "name": "hot_meals",
+        "value": 8
+      }
+    ],
+    "binding": [
+      0,
+      2
+    ]
+  }
+}

--- a/code/specs/data/adj-constraints-decompose-run/results/schedule_feasibility.adj
+++ b/code/specs/data/adj-constraints-decompose-run/results/schedule_feasibility.adj
@@ -1,0 +1,8 @@
+symbol design_finish : scalar
+symbol build_start : scalar
+symbol build_finish : scalar
+constrain design_finish >= 28
+constrain build_start = design_finish
+constrain build_finish - build_start >= 20
+constrain build_finish <= 45
+check

--- a/code/specs/data/adj-constraints-decompose-run/results/schedule_feasibility.json
+++ b/code/specs/data/adj-constraints-decompose-run/results/schedule_feasibility.json
@@ -1,0 +1,20 @@
+{
+  "queries": [],
+  "ranked": [],
+  "decision": {
+    "type": "empty"
+  },
+  "solve": {
+    "outcome": "unsupported",
+    "reason": "inequality constraints \u2014 feasibility/LP is track C1/C2"
+  },
+  "check": {
+    "outcome": "unsat",
+    "core": [
+      0,
+      1,
+      2,
+      3
+    ]
+  }
+}

--- a/code/specs/data/adj-constraints-decompose-run/results/summary.json
+++ b/code/specs/data/adj-constraints-decompose-run/results/summary.json
@@ -1,0 +1,37 @@
+{
+  "model": "llama3.1:8b",
+  "n_cases": 4,
+  "decompose_calls": 4,
+  "answer_time_model_calls": 0,
+  "passed": 3,
+  "cases": [
+    {
+      "id": "relief_allocation",
+      "solver_path": "maximize",
+      "compiled": true,
+      "passed": true,
+      "detail": "value 44 vs 44"
+    },
+    {
+      "id": "workshop_break_even",
+      "solver_path": "solve",
+      "compiled": true,
+      "passed": false,
+      "detail": "expected solved, got unsupported"
+    },
+    {
+      "id": "schedule_feasibility",
+      "solver_path": "check",
+      "compiled": true,
+      "passed": true,
+      "detail": "check unsat vs unsat"
+    },
+    {
+      "id": "production_cost",
+      "solver_path": "minimize",
+      "compiled": true,
+      "passed": true,
+      "detail": "value 980 vs 980"
+    }
+  ]
+}

--- a/code/specs/data/adj-constraints-decompose-run/results/workshop_break_even.adj
+++ b/code/specs/data/adj-constraints-decompose-run/results/workshop_break_even.adj
@@ -1,0 +1,3 @@
+symbol attendees : scalar
+constrain 2000 + 15 * attendees <= 65 * attendees
+solve for { attendees }

--- a/code/specs/data/adj-constraints-decompose-run/results/workshop_break_even.json
+++ b/code/specs/data/adj-constraints-decompose-run/results/workshop_break_even.json
@@ -1,0 +1,11 @@
+{
+  "queries": [],
+  "ranked": [],
+  "decision": {
+    "type": "empty"
+  },
+  "solve": {
+    "outcome": "unsupported",
+    "reason": "inequality constraints \u2014 feasibility/LP is track C1/C2"
+  }
+}

--- a/code/specs/data/adj-constraints-decompose-run/run.py
+++ b/code/specs/data/adj-constraints-decompose-run/run.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Live decompose->solve demonstration for the adj-lang constraint sublanguage
+(ADJ constraints track D2).
+
+The ONE model touchpoint per case decomposes a messy-prose word problem into an
+adj-lang program. The deterministic CPU engine (`adj-lang-cli`) then SOLVES it.
+The model never computes the answer; every answer is the engine's, at zero
+answer-time model calls.
+
+Zero third-party deps: the model is called over Ollama's HTTP `/api/generate`
+endpoint with `urllib` only. Run with `python3 run.py [model]` (default
+`llama3.1:8b`). Re-runs the model and overwrites `results/`.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RESULTS = os.path.join(HERE, "results")
+CASES = os.path.join(HERE, "cases", "cases.json")
+# adj-lang-cli debug binary, relative to this file.
+CLI = os.path.normpath(
+    os.path.join(HERE, "..", "..", "..", "packages", "rust", "target", "debug", "adj-lang-cli")
+)
+OLLAMA = "http://localhost:11434/api/generate"
+# Case ids become filenames and a CLI argument, so constrain them to the
+# lowercase-snake convention the grammar already uses — no `/`, `..`, or leading
+# `-` can reach a path or the subprocess arg vector (defence in depth: cases.json
+# is a committed fixture, but the SPEC invites editing it).
+CID_RE = re.compile(r"^[a-z0-9_]+$")
+
+# The decompose-only system instruction: the adj-lang CONSTRAINT grammar, the
+# decompose-only discipline, and the rule that the model must NOT state an answer.
+GRAMMAR = """\
+You translate a word problem into a tiny constraint language called adj-lang.
+You DO NOT solve it. You DO NOT compute or state any numeric answer. A separate
+deterministic engine solves the program you write. Output ONLY the program.
+
+The language has exactly these statements (one per line):
+
+  symbol <name> : scalar          # declare an unknown (lowercase snake_case name)
+  constrain <expr> <op> <expr>    # an (in)equality the unknowns must satisfy
+  solve for { <name>, <name> }    # ask for the value(s) of the unknown(s)
+  check                           # ask only whether the constraints are satisfiable
+  minimize <expr>                 # find the unknowns minimizing <expr>
+  maximize <expr>                 # find the unknowns maximizing <expr>
+
+  <op>   is one of:  <=  >=  <  >  =  !=
+  <expr> is arithmetic over symbols and numbers: +  -  *  /  and ( ).
+         Always put spaces around operators:  3 * x + 2 * y   (NOT 3*x).
+
+Rules:
+- Declare every unknown with `symbol` before using it.
+- Use ONE of `solve for {...}` / `check` / `minimize <expr>` / `maximize <expr>`,
+  matching what the problem asks ("how many / what value" -> solve for;
+  "is it possible / feasible" -> check; "most / maximize" -> maximize;
+  "least / minimum / cheapest" -> minimize).
+- Encode EVERY limit in the problem as a `constrain` line, including non-negativity
+  (a count or amount that cannot go below zero -> `constrain <name> >= 0`).
+- Do NOT write the answer. Do NOT add comments or prose. Output only the program.
+"""
+
+
+def ollama(model, prompt):
+    """Call Ollama /api/generate, temperature 0, return the response text."""
+    body = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": 0, "seed": 7},
+        }
+    ).encode()
+    req = urllib.request.Request(OLLAMA, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        return json.loads(r.read())["response"]
+
+
+def extract_program(text):
+    """Pull the adj-lang program out of the model's reply: strip ``` fences and
+    keep only lines that start with a known statement keyword."""
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("```") or not line:
+            continue
+        kw = line.split(" ", 1)[0]
+        if kw in ("symbol", "constrain", "solve", "check", "minimize", "maximize"):
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def run_cli(adj_path):
+    """Run adj-lang-cli on a program file; return (ok, parsed_json_or_error)."""
+    out = subprocess.run([CLI, adj_path], capture_output=True, text=True)
+    try:
+        return out.returncode == 0, json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return False, {"error": out.stdout or out.stderr}
+
+
+def score(case, engine):
+    """Compare the ENGINE output to the case GOLD. Returns (passed, detail)."""
+    gold = case["gold"]
+    if "optimize_value" in gold:
+        opt = engine.get("optimize", {})
+        if opt.get("outcome") != "optimal":
+            return False, f"expected optimal, got {opt.get('outcome')}"
+        got = opt.get("value")
+        return abs(got - gold["optimize_value"]) < 1e-6, f"value {got} vs {gold['optimize_value']}"
+    if "solve_value" in gold:
+        sol = engine.get("solve", {})
+        if sol.get("outcome") not in ("solved", "solved_roots"):
+            return False, f"expected solved, got {sol.get('outcome')}"
+        want = gold["solve_value"]
+        for a in sol.get("assignments", []):
+            if abs(a["value"] - want["value"]) < 1e-6:
+                return True, f"{a['name']}={a['value']} matches {want['value']}"
+        return False, f"no assignment == {want['value']} in {sol.get('assignments')}"
+    if "check_outcome" in gold:
+        got = engine.get("check", {}).get("outcome")
+        return got == gold["check_outcome"], f"check {got} vs {gold['check_outcome']}"
+    return False, "unscoreable gold"
+
+
+def main():
+    model = sys.argv[1] if len(sys.argv) > 1 else "llama3.1:8b"
+    cases = json.load(open(CASES))["cases"]
+    os.makedirs(RESULTS, exist_ok=True)
+
+    decompose_calls = 0
+    answer_time_calls = 0  # the engine never calls a model
+    rows = []
+    for case in cases:
+        cid = case["id"]
+        if not CID_RE.match(cid):
+            raise ValueError(f"invalid case id {cid!r}: must match ^[a-z0-9_]+$")
+        prompt = GRAMMAR + "\n\nWORD PROBLEM:\n" + case["prose"] + "\n\nadj-lang program:\n"
+        reply = ollama(model, prompt)
+        decompose_calls += 1
+        program = extract_program(reply)
+        adj_path = os.path.join(RESULTS, cid + ".adj")
+        open(adj_path, "w").write(program)
+
+        ok, engine = run_cli(adj_path)
+        json.dump(engine, open(os.path.join(RESULTS, cid + ".json"), "w"), indent=2)
+        passed, detail = (False, "did not compile") if not ok else score(case, engine)
+        rows.append(
+            {"id": cid, "solver_path": case["solver_path"], "compiled": ok,
+             "passed": passed, "detail": detail}
+        )
+        print(f"[{'PASS' if passed else 'fail'}] {cid:22s} {detail}")
+
+    summary = {
+        "model": model,
+        "n_cases": len(cases),
+        "decompose_calls": decompose_calls,
+        "answer_time_model_calls": answer_time_calls,
+        "passed": sum(r["passed"] for r in rows),
+        "cases": rows,
+    }
+    json.dump(summary, open(os.path.join(RESULTS, "summary.json"), "w"), indent=2)
+    print(
+        f"\n{summary['passed']}/{summary['n_cases']} solved by the engine | "
+        f"decompose calls = {decompose_calls} | answer-time model calls = {answer_time_calls}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The claim

A **small local model** does the one thing it's good at — turning messy prose into a typed, checkable representation — and a **deterministic CPU engine** does all the reasoning. The model **decomposes**; it never computes the answer. Every answer is `adj-lang-cli`'s, at **zero answer-time model calls**, cited to the constraint that determined it. This is the constraint-solving analogue of the MYCIN derive-once demonstration: intelligence in the *framework*, not the weights.

## Recorded run (`llama3.1:8b`, temp 0)

| metric | value |
|---|---|
| engine-solved to gold | **3 / 4** |
| **answer-time model calls** | **0** |
| fabricated wrong answers | **0** |

| case | path | engine | gold | ✓ |
|---|---|---|---|---|
| `relief_allocation` | maximize | **44** | 44 | ✅ |
| `production_cost` | minimize | **980** | 980 | ✅ |
| `schedule_feasibility` | check | **unsat** | unsat | ✅ |
| `workshop_break_even` | solve | **unsupported** | 40 | ❌ |

The decompositions are clean and legible — for the schedule the model even *invented an intermediate variable* (`build_start`) to chain the precedence, and the engine then proved the contradiction.

## The miss is the point

`workshop_break_even` is the **honest-failure** case: the model wrote an inequality (`cost ≤ revenue`) where "break even" needed an equality. Solving *for a unique value* under an inequality is ill-posed, so the engine returned `unsupported` — it did **not** invent a number. A small model's mis-transcription is **localized and legible** (one wrong operator in the committed `.adj`), and the engine never launders a bad decomposition into a confident answer. That's the whole thesis in one case.

## What ships

- `code/specs/data/adj-constraints-decompose-run/` — SPEC.md, `cases/cases.json` (4 prose problems + gold), `run.py` (zero-dep urllib → Ollama, decompose-only), `results/` (the committed real run: per-case `.adj` + engine `.json` + summary), FINDINGS.md.
- `adj-lang-cli/tests/decompose_run.rs` (0.3.6 → 0.3.7) — **deterministic** golden tests that re-solve every committed `.adj` with **no model in the loop**, proving the engine is a pure function of the decomposition. The live-model half is non-deterministic / Ollama-less in CI, so it's not asserted there.

## Not a benchmark
One model, one prompt, four cases — a *demonstration of the architecture*, not a powered model-quality study. The number that matters is **answer-time model calls = 0**, not 3/4. A different local model is a one-arg swap (`python3 run.py qwen2.5:3b`); the engine and golden tests are unchanged.

## Security
Review passed: case ids validated to `^[a-z0-9_]+$` before any path/subprocess use; list-form subprocess (no shell), hardcoded localhost URL, json-only deserialization.

Closes the ADJ-CONSTRAINTS arc end-to-end (A1–A4 · B1 · B2/B2b/B2c/B3 · C1 · C2 · C3 · D1 · D2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)