### PR TITLE
feat(lang-matrix): LM-J expression languages — Twig/Nib/Oct/ALGOL on real java

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog — `lang-aot`
 
+## 0.61.0 — 2026-06-11 — Expression languages join the JVM column (LANG-MATRIX LM-J)
+
+`lang_matrix.rs` opens the **JVM** column on **real `java`** for the four expression
+languages — Twig / Nib / Oct / ALGOL 60. New `Backend::Jvm` runner: source →
+`compile_source_to_jvm_class` → the W16 wrapper-launcher (inject a
+`main([Ljava/lang/String;)V` that invokes the entry `main()I` and
+`System.out.println`s its `int`) → real `java` → parse the printed integer. Gated on
+`java`, skipping gracefully when absent (mirrors the LLVM column's `clang` gate).
+
+**Backend fix found by running on real `java`:** `concretize_scalar_any_for_jvm`
+retyped a scalar function's return type and instruction hints to `i32` but left its
+**parameter** types `i64`. Nib's `double(x)` therefore emitted the inconsistent method
+signature `(J)I` with an `int`-computing body, which real `java` rejects with
+`VerifyError: Expecting to find integer on stack` (the laxer in-repo `jvm-simulator`
+used by `jvm_emit.rs` never caught it). The pass now concretizes parameter types too —
+a reusable correctness fix, not a Nib-specific hack, and safe because lisp/`any`-param
+functions are already skipped by the `uses_lisp` guard.
+
+Verified by RUNNING on real `java` (OpenJDK 21): Twig→42, Nib→42, Oct→0,
+ALGOL `17 mod 5`→2. **20 proven matrix cells** (was 16). `jvm_emit` (simulator floor),
+`conformance` (McCarthy W16) and `wasm_emit` suites all still green. JVM column now green
+for the expression languages; BASIC pends an `env.BasicRuntime` host class (its
+`print_i64` → `invokestatic env/BasicRuntime.println(J)V`), Brainfuck the tape ops.
+
 ## 0.60.0 — 2026-06-11 — Dartmouth BASIC joins the WASM column (LANG-MATRIX LM-W BASIC)
 
 `lang_matrix.rs` greens **Dartmouth BASIC on WASM** (the `DartmouthBasic` program now

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -130,9 +130,11 @@ ALGOL 60 (exit code) and Dartmouth BASIC (stdout, via a generic `__print_i64`
 runtime); Brainfuck is deferred. The **WASM** column (in-process `wasm-runtime`) is
 green for Twig / Nib / Oct / ALGOL 60 (exit code) and Dartmouth BASIC (stdout — a tiny
 `PrintHost` resolves the `env.__print_i64` import and captures the printed value);
-Brainfuck (tape ops) is the only WASM follow-up. The JVM/CLR columns
-follow per the matrix spec; the VM/JIT columns are McCarthy-specialized and need
-op-coverage work.
+Brainfuck (tape ops) is the only WASM follow-up. The **JVM** column runs on **real
+`java`** (the W16 wrapper-launcher pattern) and is green for the expression languages
+Twig / Nib / Oct / ALGOL 60; BASIC pends an `env.BasicRuntime` host class and Brainfuck
+the tape ops. The CLR column follows per the matrix spec; the VM/JIT columns are
+McCarthy-specialized and need op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -575,6 +575,22 @@ fn concretize_scalar_any_for_jvm(module: &mut IIRModule) {
         if to_i32(&func.return_type) {
             func.return_type = "i32".to_string();
         }
+        // Concretize the **parameters** too, not just the return type and the
+        // instruction hints. A scalar helper such as Nib's `double(x: u8)` widens
+        // its parameter to `i64`; if we retype the body to `i32` but leave the
+        // parameter `i64`, the emitted method's signature is the inconsistent
+        // `(J)I` and its body does `iadd`/`ireturn` on a `long` parameter — which
+        // a real `java` rejects with `VerifyError: Expecting to find integer on
+        // stack`. (The in-repo `jvm-simulator` is laxer and didn't catch it, so
+        // this only surfaced once a parameterized scalar program ran on real
+        // `java` in the LANG-MATRIX JVM column.) The lisp/`any`-param functions
+        // were already skipped by the `uses_lisp` guard above, so every parameter
+        // reaching here is a concrete scalar — safe to bring down to `i32`.
+        for (_, ty) in &mut func.params {
+            if to_i32(ty) {
+                *ty = "i32".to_string();
+            }
+        }
         for instr in &mut func.instructions {
             if to_i32(&instr.type_hint) {
                 instr.type_hint = "i32".to_string();

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -21,8 +21,14 @@
 //!   (exit code from `main`'s wasm result) and Dartmouth BASIC (stdout — a `PrintHost`
 //!   resolves the `env.__print_i64` import and captures the printed value). Brainfuck
 //!   pends the tape ops — its own follow-up.
+//! * **JVM** (Phase J) — source → `JvmClassFile` (`iir-to-jvm-class-file`) → real
+//!   `java`. The W16 wrapper-launcher pattern: a `main([Ljava/lang/String;)V` launcher
+//!   invokes the entry method `main()I` and `System.out.println`s its `int` result,
+//!   which the harness parses. Green for the expression languages Twig / Nib / Oct /
+//!   ALGOL 60. Dartmouth BASIC pends an `env.BasicRuntime` host class (its `print_i64`
+//!   lowers to `invokestatic env/BasicRuntime.println(J)V`); Brainfuck the tape ops.
 //!
-//! Later slices add the JVM / CLR columns (also general code generators) and the
+//! Later slices add the CLR column (also a general code generator) and the
 //! Deferred items — Brainfuck-on-LLVM/WASM, and the McCarthy-specialized VM and JIT
 //! (op-coverage work). See `code/specs/LANG-PLATFORM-MATRIX.md`.
 //!
@@ -48,6 +54,10 @@ enum Backend {
     Llvm,
     /// Source → wasm bytes (`iir-to-wasm`) → in-process `wasm-runtime` (Phase W).
     Wasm,
+    /// Source → `JvmClassFile` (`iir-to-jvm-class-file`) → real `java` (Phase J).
+    /// The W16 wrapper-launcher pattern: a `main([Ljava/lang/String;)V` launcher is
+    /// injected to invoke the entry method and `System.out.println` its `int` result.
+    Jvm,
 }
 
 /// The known, backend-independent observable result of a conformance program.
@@ -68,14 +78,14 @@ struct Prog {
     backends: &'static [Backend],
 }
 
-use Backend::{Llvm, NativeAot, Wasm};
+use Backend::{Jvm, Llvm, NativeAot, Wasm};
 
 /// The cross-language battery. Each program is deliberately tiny but exercises real
 /// computation (arithmetic, calls, comparisons, loops, I/O) — not just constants —
 /// so a backend that merely emits a literal would not pass.
 const PROGRAMS: &[Prog] = &[
     // Twig — the original AOT language; a bare expression is the whole program.
-    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm] },
+    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm, Jvm] },
     // Nib — typed functions: define `double`, call it, return the result. Greened on
     // WASM in LM-W Nib by completing the i64 materialization: `nib_ty_str` and the
     // un-annotated-literal fallback now emit `i64` (not `u8`), so the const argument
@@ -85,7 +95,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "nib",
         src: "fn double(x: u8) -> u8 { return x + x; } fn main() -> u8 { return double(21); }",
         expect: Expect::Exit(42),
-        backends: &[NativeAot, Llvm, Wasm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm],
     },
     // Oct — `let` + `if` + comparison; `main` is void so the process exits 0.
     Prog {
@@ -93,7 +103,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "oct",
         src: "fn main() { let x: u8 = 1; if x == 1 { let y: u8 = 2; } else { let z: u8 = 3; } }",
         expect: Expect::Exit(0),
-        backends: &[NativeAot, Llvm, Wasm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm],
     },
     // ALGOL 60 — a begin/end block with real integer arithmetic (`17 mod 5` = 2).
     Prog {
@@ -101,7 +111,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "alg",
         src: "begin integer result; result := 17 mod 5 end",
         expect: Expect::Exit(2),
-        backends: &[NativeAot, Llvm, Wasm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // (LLVM column pending: `iir-to-llvm` lacks the tape ops `alloc_bytes`/`load_byte`/
@@ -384,6 +394,140 @@ fn run_wasm(p: &Prog) -> Option<(Option<i32>, String)> {
     Some((code, stdout))
 }
 
+/// Is a usable `java` present? Gates the JVM column (skip when absent), exactly as
+/// `clang_ok` gates LLVM and the W16 suite gates its external backends.
+fn java_ok() -> bool {
+    Command::new("java")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// JVM runner: source → `JvmClassFile` (`iir-to-jvm-class-file`) → real `java`, the
+/// W16 wrapper-launcher strategy generalized from McCarthy to any language whose
+/// entry method returns an `int` (the expression languages).
+///
+/// `compile_source_to_jvm_class` emits a class `Main` whose entry method is
+/// `main()I` — but a class run by `java` needs a `main([Ljava/lang/String;)V`
+/// entry point. So, exactly as the McCarthy W16 conformance runner does, we append
+/// the constant-pool entries for `System.out`, `PrintStream.println(I)V` and a
+/// self-reference to `Main.main()I`, then inject a launcher method:
+///
+/// ```text
+///   getstatic  System.out          // : PrintStream
+///   invokestatic Main.main()I      // : int  (the program's result)
+///   invokevirtual println(I)V      // print it
+///   return
+/// ```
+///
+/// (Two methods named `main` with different descriptors is legal — the JVM keys
+/// methods on name **and** descriptor.) The harness then parses the printed integer
+/// as the program's result. `None` when `java` is absent or any step fails (skip).
+///
+/// Security/termination: the program is a fixed literal (no untrusted input); the
+/// emitted class is written into a fresh `tempfile::tempdir()` (random, `0700`,
+/// auto-removed) so the executed `Main.class` cannot be substituted in the
+/// write→run window (CWE-377/367); the class name is the constant `"Main"`, never
+/// interpolated from input; and each program terminates by construction.
+fn run_jvm(p: &Prog) -> Option<(Option<i32>, String)> {
+    use iir_to_jvm_class_file::serialize_jvm_class_file;
+    use jvm_class_file::{
+        JvmCodeAttribute, JvmConstantPoolEntry, JvmMethodAttribute, JvmMethodInfo, ACC_PUBLIC,
+        ACC_STATIC,
+    };
+    if !java_ok() {
+        return None;
+    }
+    fn cp_append(cp: &mut Vec<Option<JvmConstantPoolEntry>>, e: JvmConstantPoolEntry) -> u16 {
+        cp.push(Some(e));
+        (cp.len() - 1) as u16
+    }
+    let mut class = lang_aot::compile_source_to_jvm_class(p.lang, p.src, "Main").ok()?;
+    let (out_fieldref, println_ref, entry_ref) = {
+        let cp = &mut class.constant_pool;
+        let sys_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("java/lang/System".into()));
+        let sys_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: sys_utf8 });
+        let out_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("out".into()));
+        let ps_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("Ljava/io/PrintStream;".into()));
+        let out_nat = cp_append(
+            cp,
+            JvmConstantPoolEntry::NameAndType { name_index: out_utf8, descriptor_index: ps_desc },
+        );
+        let out_fieldref = cp_append(
+            cp,
+            JvmConstantPoolEntry::Fieldref { class_index: sys_class, name_and_type_index: out_nat },
+        );
+        let ps_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("java/io/PrintStream".into()));
+        let ps_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: ps_utf8 });
+        let pln_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("println".into()));
+        let pln_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("(I)V".into()));
+        let pln_nat = cp_append(
+            cp,
+            JvmConstantPoolEntry::NameAndType { name_index: pln_utf8, descriptor_index: pln_desc },
+        );
+        let println_ref = cp_append(
+            cp,
+            JvmConstantPoolEntry::Methodref { class_index: ps_class, name_and_type_index: pln_nat },
+        );
+        let main_utf8 = cp_append(cp, JvmConstantPoolEntry::Utf8("Main".into()));
+        let main_class = cp_append(cp, JvmConstantPoolEntry::Class { name_index: main_utf8 });
+        let ent_name = cp_append(cp, JvmConstantPoolEntry::Utf8("main".into()));
+        let ent_desc = cp_append(cp, JvmConstantPoolEntry::Utf8("()I".into()));
+        let ent_nat = cp_append(
+            cp,
+            JvmConstantPoolEntry::NameAndType { name_index: ent_name, descriptor_index: ent_desc },
+        );
+        let entry_ref = cp_append(
+            cp,
+            JvmConstantPoolEntry::Methodref { class_index: main_class, name_and_type_index: ent_nat },
+        );
+        let _ = cp_append(cp, JvmConstantPoolEntry::Utf8("([Ljava/lang/String;)V".into()));
+        (out_fieldref, println_ref, entry_ref)
+    };
+    let [out_hi, out_lo] = out_fieldref.to_be_bytes();
+    let [ent_hi, ent_lo] = entry_ref.to_be_bytes();
+    let [pln_hi, pln_lo] = println_ref.to_be_bytes();
+    let main_code = vec![
+        0xB2, out_hi, out_lo, // getstatic System.out
+        0xB8, ent_hi, ent_lo, // invokestatic Main.main()I
+        0xB6, pln_hi, pln_lo, // invokevirtual println(I)V
+        0xB1, // return
+    ];
+    class.methods.push(JvmMethodInfo {
+        access_flags: ACC_PUBLIC | ACC_STATIC,
+        name: "main".into(),
+        descriptor: "([Ljava/lang/String;)V".into(),
+        attributes: vec![JvmMethodAttribute::Code(JvmCodeAttribute {
+            name: "Code".into(),
+            max_stack: 2,
+            max_locals: 1,
+            code: main_code,
+            nested_attributes: vec![],
+        })],
+    });
+    let bytes = serialize_jvm_class_file(&class);
+    let dir = tempfile::tempdir().ok()?;
+    std::fs::write(dir.path().join("Main.class"), &bytes).ok()?;
+    // NB: we deliberately do **not** pass `-Xverify:none`. The expression languages'
+    // scalar bytecode is well-formed, so full bytecode verification is a *stronger*
+    // check — and, crucially, verification rejects malformed bytecode cleanly (a
+    // `VerifyError` → non-zero exit, captured below) instead of letting the JVM
+    // execute it and SIGSEGV-crash with an `hs_err_pid*.log` dump. (The McCarthy W16
+    // runner disables verification only because its `Object[]`-cons bytecode is laxer
+    // than the verifier allows; the scalar path here doesn't need that escape hatch.)
+    let out = Command::new("java")
+        .arg("-cp")
+        .arg(dir.path())
+        .arg("Main")
+        .output()
+        .ok()?;
+    // The launcher printed the entry method's `int` result; parse it as the
+    // program's value (matching the exit-code convention of the other columns).
+    let code = String::from_utf8_lossy(&out.stdout).trim().parse::<i32>().ok();
+    Some((code, String::new()))
+}
+
 /// Dispatch a program to a backend runner. `None` = the backend's toolchain is
 /// unavailable on this host (skip, like the W16 external-tool backends).
 fn run(backend: Backend, p: &Prog) -> Option<(Option<i32>, String)> {
@@ -391,6 +535,7 @@ fn run(backend: Backend, p: &Prog) -> Option<(Option<i32>, String)> {
         Backend::NativeAot => run_native(p),
         Backend::Llvm => run_llvm(p),
         Backend::Wasm => run_wasm(p),
+        Backend::Jvm => run_jvm(p),
     }
 }
 
@@ -462,5 +607,15 @@ fn proven_columns_do_not_silently_skip() {
             "in-process wasm-runtime failed to run {:?}",
             p.lang
         );
+    }
+    // JVM: when `java` is present every JVM-tagged program must run.
+    if java_ok() {
+        for p in PROGRAMS.iter().filter(|p| p.backends.contains(&Jvm)) {
+            assert!(
+                run_jvm(p).is_some(),
+                "java present but JVM failed to run {:?}",
+                p.lang
+            );
+        }
     }
 }

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -101,12 +101,12 @@ achievable code-gen columns land first).
 
 | Language        | VM | JIT | native-AOT | LLVM | WASM | JVM | CLR |
 |-----------------|----|-----|-----------|------|------|-----|-----|
-| Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ◑   | ◑   |
-| Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
-| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ☐   | ☐   |
+| Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ◑   |
+| Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
+| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ⏸  | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
-| Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
-| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ☐   | ☐   |
+| Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
+| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
 
 **native-AOT is uniformly ✅ as of LM0** — all six languages compile to a host
 executable and run with the expected result (`lang-aot/tests/lang_matrix.rs`:
@@ -114,9 +114,9 @@ Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2, Brainfuck→stdout `A`, BASI
 The VM/JIT columns are op-coverage work (see above); the code-gen columns
 (LLVM/WASM/JVM/CLR) are conformance + I/O wiring.
 
-(`◑` = partial today: Twig is proven at *scalar* level on LLVM/WASM/JVM/CLR; the
-slice promotes it to a full feature battery. The starting state is re-verified per
-slice — the loop trusts running, not this table.)
+(`◑` = partial today: Twig is proven at *scalar* level on CLR; the slice promotes it
+to a full feature battery. The starting state is re-verified per slice — the loop
+trusts running, not this table.)
 
 ## Worklist (one PR per item; slice further if large)
 
@@ -185,8 +185,24 @@ BASIC); only Brainfuck is deferred.
 
 ### Phase J — JVM for every language
 
-- ☐ **LM-J** — each language on `iir-to-jvm-class-file` + real `java` (the W16
-  wrapper-launcher pattern). I/O via `System.out`.
+- ✅ **LM-J expression languages (Twig / Nib / Oct / ALGOL on real `java`).** Added a
+  `Backend::Jvm` runner to `lang_matrix.rs`: source → `compile_source_to_jvm_class` →
+  the W16 wrapper-launcher (inject a `main([Ljava/lang/String;)V` that invokes the
+  entry `main()I` and `System.out.println`s its `int`) → real `java` → parse the
+  printed integer. Gated on `java`, skips gracefully when absent (like the LLVM
+  column on `clang`). Fixed a real backend-glue bug found **by running on real
+  `java`**: `concretize_scalar_any_for_jvm` retyped a scalar function's return + body
+  to `i32` but left its **parameters** `i64`, so Nib's `double(x)` emitted the
+  inconsistent `(J)I` and `java` rejected it with `VerifyError: Expecting to find
+  integer on stack` (the laxer in-repo `jvm-simulator` didn't catch it). Now the pass
+  concretizes parameter types too. Verified by RUNNING: Twig→42, Nib→42, Oct→0,
+  ALGOL `17 mod 5`→2 on real `java` (20 proven matrix cells); jvm_emit + conformance
+  suites still green.
+- ☐ **LM-J BASIC (on JVM).** BASIC's `print_i64` lowers to `invokestatic
+  env/BasicRuntime.println(J)V`; running it on real `java` needs that `env.BasicRuntime`
+  host class on the classpath (the JVM analogue of the wasm `PrintHost` / LLVM print
+  runtime). Provide it, then capture/assert `System.out`.
+- ⏸ **LM-J Brainfuck (on JVM) — DEFERRED.** Same tape-op gap as Brainfuck on LLVM/WASM.
 
 ### Phase C — CLR for every language
 


### PR DESCRIPTION
## LANG-PLATFORM-MATRIX · Phase J · LM-J (expression languages)

Opens the **JVM** column on **real `java`** for the four expression languages — Twig / Nib / Oct / ALGOL 60 — mirroring how the LLVM and WASM columns landed the expression languages first.

### What & why
New `Backend::Jvm` runner in `lang_matrix.rs` — the W16 wrapper-launcher pattern, generalized from McCarthy to any language whose entry method returns an `int`:

```
source → compile_source_to_jvm_class → inject a main([Ljava/lang/String;)V launcher
  (getstatic System.out; invokestatic Main.main()I; invokevirtual println(I)V; return)
  → real java → parse the printed integer
```

Gated on `java`, skipping gracefully when absent (mirrors the LLVM column's `clang` gate). **Full bytecode verification left ON** (no `-Xverify:none`): the scalar bytecode is well-formed, so verification is a *stronger* check and rejects any malformed bytecode cleanly instead of letting the JVM execute it and SIGSEGV-crash.

### Backend fix found BY RUNNING on real `java`
`concretize_scalar_any_for_jvm` (in `src/lib.rs`) retyped a scalar function's return type and instruction hints to `i32` but left its **parameter** types `i64`. Nib's `double(x)` therefore emitted the inconsistent signature `(J)I` with an `int`-computing body, which real `java` rejects with `VerifyError: Expecting to find integer on stack` — the laxer in-repo `jvm-simulator` never caught it. The pass now concretizes parameter types too. **Reusable correctness fix, not a Nib-specific hack**, and safe because lisp/`any`-param functions are already skipped by the `uses_lisp` guard.

### Verified by RUNNING (OpenJDK 21)
- Twig→42 · Nib→42 · Oct→0 · ALGOL `17 mod 5`→2 on real `java`.
- **20 proven matrix cells** (was 16); both `lang_matrix` tests pass.
- `jvm_emit` (simulator floor, 2), `conformance` (McCarthy W16, 1), `wasm_emit` (18) all still green — the concretize change caused no regression.
- Clippy clean on the changed files. (Pre-existing, unrelated: the `iir-to-beam` min/max clippy lint and a `cil_emit.rs` clr-simulator API drift on origin/main — neither touched by this diff.)

### Matrix after this PR
| | native-AOT | LLVM | WASM | JVM |
|---|---|---|---|---|
| Twig / Nib / Oct / ALGOL 60 | ✅ | ✅ | ✅ | ✅ ← this PR |
| Dartmouth BASIC | ✅ | ✅ | ✅ | ☐ (needs `env.BasicRuntime` host class) |
| Brainfuck | ✅ | ⏸ | ⏸ | ⏸ (tape ops) |

### Changes
- `tests/lang_matrix.rs` — `Backend::Jvm` + `java_ok` + `run_jvm` (launcher injection, tempdir, stdout parse); `Jvm` added to the four expression languages; JVM floor block.
- `src/lib.rs` — `concretize_scalar_any_for_jvm` now concretizes parameter types.
- `LANG-PLATFORM-MATRIX.md` — JVM cells ticked; LM-J worklist item ✅; BASIC/Brainfuck JVM follow-ups noted.
- `CHANGELOG.md`, `README.md` — updated; `lang-aot` 0.60.0 → 0.61.0.

### Security
Reviewed by a security sub-agent: **PASSED**. No `unsafe`, no untrusted input (programs are compile-time literals), no shell (args passed as a vector), class name is the constant `"Main"` (no bytecode/constant-pool injection), output written to a random-0700 `tempfile::tempdir()` held in scope (no write→exec TOCTOU), full JVM verification enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)