### PR TITLE
Add browser script storage access descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — HTML Parser Browser Script Storage Access
+- Browser-readiness summaries now expose script storage-access descriptors for
+  inline references to Web Storage, cookies, IndexedDB, CacheStorage/service
+  workers, StorageManager, storage-event hooks, and fallback blockers such as
+  `nomodule`.
+
 ### Added — HTML Parser DOCTYPE Fragment Contexts
 - Parser-approved initial tokenizer contexts now include seeded DOCTYPE
   continuation states for keyword, name, public/system identifier, bogus, and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -837,6 +837,7 @@ pub struct BrowserDocument {
     pub resources: Vec<BrowserResource>,
     pub scripts: Vec<BrowserScript>,
     pub script_execution_descriptors: Vec<BrowserScriptExecutionDescriptor>,
+    pub script_storage_access_descriptors: Vec<BrowserScriptStorageAccessDescriptor>,
     pub stylesheets: Vec<BrowserStylesheet>,
     pub stylesheet_planning_descriptors: Vec<BrowserStylesheetPlanningDescriptor>,
     pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
@@ -1095,6 +1096,30 @@ pub struct BrowserScriptExecutionDescriptor {
     pub render_blocking: bool,
     pub has_text: bool,
     pub text_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserScriptStorageAccessDescriptor {
+    pub script_kind: String,
+    pub access_kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub type_hint: Option<String>,
+    pub execution_kind: String,
+    pub has_text: bool,
+    pub text_length: usize,
+    pub storage_targets: Vec<String>,
+    pub storage_target_count: usize,
+    pub uses_local_storage: bool,
+    pub uses_session_storage: bool,
+    pub uses_cookies: bool,
+    pub uses_indexed_db: bool,
+    pub uses_cache_storage: bool,
+    pub uses_service_worker: bool,
+    pub uses_storage_manager: bool,
+    pub listens_storage_events: bool,
+    pub storage_blocked: bool,
+    pub storage_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3435,6 +3460,8 @@ impl BrowserDocument {
         );
         summary.script_execution_descriptors =
             browser_script_execution_descriptors(&summary.scripts);
+        summary.script_storage_access_descriptors =
+            browser_script_storage_access_descriptors(&summary.scripts);
         summary.stylesheet_planning_descriptors =
             browser_stylesheet_planning_descriptors(&summary.stylesheets);
         summary.image_candidate_descriptors = browser_image_candidate_descriptors(&summary.images);
@@ -11248,6 +11275,164 @@ fn browser_script_execution_descriptor(script: &BrowserScript) -> BrowserScriptE
         has_text: script.text.is_some(),
         text_length,
     }
+}
+
+fn browser_script_storage_access_descriptors(
+    scripts: &[BrowserScript],
+) -> Vec<BrowserScriptStorageAccessDescriptor> {
+    scripts
+        .iter()
+        .filter_map(browser_script_storage_access_descriptor)
+        .collect()
+}
+
+fn browser_script_storage_access_descriptor(
+    script: &BrowserScript,
+) -> Option<BrowserScriptStorageAccessDescriptor> {
+    let text = script.text.as_deref().unwrap_or_default();
+    let normalized_text = text.to_ascii_lowercase();
+    let uses_local_storage = normalized_text.contains("localstorage");
+    let uses_session_storage = normalized_text.contains("sessionstorage");
+    let uses_cookies =
+        normalized_text.contains("document.cookie") || normalized_text.contains("cookie=");
+    let uses_indexed_db = normalized_text.contains("indexeddb");
+    let uses_cache_storage = normalized_text.contains("caches.")
+        || normalized_text.contains("caches.open")
+        || normalized_text.contains("cachestorage");
+    let uses_service_worker = normalized_text.contains("serviceworker")
+        || normalized_text.contains("service-worker")
+        || normalized_text.contains("navigator.serviceworker");
+    let uses_storage_manager = normalized_text.contains("navigator.storage")
+        || normalized_text.contains(".persist(")
+        || normalized_text.contains(".estimate(");
+    let listens_storage_events = normalized_text.contains("addeventlistener('storage'")
+        || normalized_text.contains("addeventlistener(\"storage\"")
+        || normalized_text.contains("onstorage");
+    let storage_targets = browser_script_storage_targets(
+        uses_local_storage,
+        uses_session_storage,
+        uses_cookies,
+        uses_indexed_db,
+        uses_cache_storage,
+        uses_service_worker,
+        uses_storage_manager,
+        listens_storage_events,
+    );
+    if storage_targets.is_empty() {
+        return None;
+    }
+
+    let storage_block_reasons = browser_script_storage_block_reasons(script);
+    let text_length = text.chars().count();
+    Some(BrowserScriptStorageAccessDescriptor {
+        script_kind: script.script_kind.clone(),
+        access_kind: browser_script_storage_access_kind(
+            uses_local_storage,
+            uses_session_storage,
+            uses_cookies,
+            uses_indexed_db,
+            uses_cache_storage,
+            uses_service_worker,
+            uses_storage_manager,
+            listens_storage_events,
+        ),
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        has_text: script.text.is_some(),
+        text_length,
+        storage_target_count: storage_targets.len(),
+        storage_targets,
+        uses_local_storage,
+        uses_session_storage,
+        uses_cookies,
+        uses_indexed_db,
+        uses_cache_storage,
+        uses_service_worker,
+        uses_storage_manager,
+        listens_storage_events,
+        storage_blocked: !storage_block_reasons.is_empty(),
+        storage_block_reasons,
+    })
+}
+
+fn browser_script_storage_targets(
+    uses_local_storage: bool,
+    uses_session_storage: bool,
+    uses_cookies: bool,
+    uses_indexed_db: bool,
+    uses_cache_storage: bool,
+    uses_service_worker: bool,
+    uses_storage_manager: bool,
+    listens_storage_events: bool,
+) -> Vec<String> {
+    let mut targets = Vec::new();
+    if uses_local_storage {
+        targets.push("localStorage".to_string());
+    }
+    if uses_session_storage {
+        targets.push("sessionStorage".to_string());
+    }
+    if uses_cookies {
+        targets.push("cookies".to_string());
+    }
+    if uses_indexed_db {
+        targets.push("indexedDB".to_string());
+    }
+    if uses_cache_storage {
+        targets.push("CacheStorage".to_string());
+    }
+    if uses_service_worker {
+        targets.push("serviceWorker".to_string());
+    }
+    if uses_storage_manager {
+        targets.push("StorageManager".to_string());
+    }
+    if listens_storage_events {
+        targets.push("storage-event".to_string());
+    }
+    targets
+}
+
+fn browser_script_storage_access_kind(
+    uses_local_storage: bool,
+    uses_session_storage: bool,
+    uses_cookies: bool,
+    uses_indexed_db: bool,
+    uses_cache_storage: bool,
+    uses_service_worker: bool,
+    uses_storage_manager: bool,
+    listens_storage_events: bool,
+) -> String {
+    if uses_service_worker || uses_cache_storage {
+        "worker-cache-storage".to_string()
+    } else if uses_indexed_db {
+        "database-storage".to_string()
+    } else if uses_storage_manager {
+        "storage-manager".to_string()
+    } else if uses_local_storage || uses_session_storage || uses_cookies {
+        "client-key-value-storage".to_string()
+    } else if listens_storage_events {
+        "storage-event-listener".to_string()
+    } else {
+        "storage-metadata".to_string()
+    }
+}
+
+fn browser_script_storage_block_reasons(script: &BrowserScript) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if script.script_kind == "data" {
+        reasons.push("non-executable-script-type".to_string());
+    }
+    if script.nomodule {
+        reasons.push("nomodule-fallback".to_string());
+    }
+    reasons
 }
 
 fn browser_stylesheet_planning_descriptors(
@@ -26143,6 +26328,69 @@ mod tests {
         assert!(legacy.defer_script);
         assert_eq!(legacy.nonce.as_deref(), Some("legacyNonce"));
         assert_eq!(legacy.text_length, "legacy();".chars().count());
+    }
+
+    #[test]
+    fn browser_script_storage_access_descriptors_track_storage_api_hints() {
+        let summary = parse_browser_document(
+            "<script>\
+             localStorage.setItem('theme', 'dark');\
+             sessionStorage.getItem('draft');\
+             document.cookie = 'seen=1';\
+             indexedDB.open('app');\
+             window.addEventListener('storage', syncTabs);\
+             </script>\
+             <script type=module>\
+             navigator.serviceWorker.register('/sw.js');\
+             caches.open('assets');\
+             navigator.storage.persist();\
+             </script>\
+             <script nomodule>localStorage.getItem('legacy');</script>",
+        )
+        .expect("storage access descriptor document should parse");
+
+        let descriptors = &summary.script_storage_access_descriptors;
+        assert_eq!(descriptors.len(), 3);
+
+        let client = &descriptors[0];
+        assert_eq!(client.script_kind, "classic");
+        assert_eq!(client.execution_kind, "inline");
+        assert_eq!(client.access_kind, "database-storage");
+        assert_eq!(
+            client.storage_targets,
+            vec![
+                "localStorage",
+                "sessionStorage",
+                "cookies",
+                "indexedDB",
+                "storage-event",
+            ]
+        );
+        assert_eq!(client.storage_target_count, 5);
+        assert!(client.uses_local_storage);
+        assert!(client.uses_session_storage);
+        assert!(client.uses_cookies);
+        assert!(client.uses_indexed_db);
+        assert!(client.listens_storage_events);
+        assert!(!client.storage_blocked);
+
+        let worker = &descriptors[1];
+        assert_eq!(worker.script_kind, "module");
+        assert_eq!(worker.access_kind, "worker-cache-storage");
+        assert_eq!(
+            worker.storage_targets,
+            vec!["CacheStorage", "serviceWorker", "StorageManager"]
+        );
+        assert!(worker.uses_cache_storage);
+        assert!(worker.uses_service_worker);
+        assert!(worker.uses_storage_manager);
+        assert_eq!(worker.storage_block_reasons, Vec::<String>::new());
+
+        let legacy = &descriptors[2];
+        assert_eq!(legacy.access_kind, "client-key-value-storage");
+        assert!(legacy.uses_local_storage);
+        assert!(legacy.storage_blocked);
+        assert_eq!(legacy.storage_block_reasons, vec!["nomodule-fallback"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -25,10 +25,11 @@ use coding_adventures_html_parser::{
     BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
     BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
     BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserScriptExecutionDescriptor, BrowserScrollInteractionDescriptor, BrowserSectionLandmark,
-    BrowserSelectOption, BrowserSelectionInteractionDescriptor, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserScriptExecutionDescriptor, BrowserScriptStorageAccessDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -88,6 +89,8 @@ struct ExpectedBrowserDocument {
     scripts: Vec<ExpectedScript>,
     #[serde(default)]
     script_execution_descriptors: Option<Vec<ExpectedScriptExecutionDescriptor>>,
+    #[serde(default)]
+    script_storage_access_descriptors: Option<Vec<ExpectedScriptStorageAccessDescriptor>>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
     #[serde(default)]
@@ -1394,6 +1397,48 @@ struct ExpectedScriptExecutionDescriptor {
     has_text: bool,
     #[serde(default)]
     text_length: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedScriptStorageAccessDescriptor {
+    script_kind: String,
+    access_kind: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    execution_kind: String,
+    #[serde(default)]
+    has_text: bool,
+    #[serde(default)]
+    text_length: usize,
+    #[serde(default)]
+    storage_targets: Vec<String>,
+    #[serde(default)]
+    storage_target_count: usize,
+    #[serde(default)]
+    uses_local_storage: bool,
+    #[serde(default)]
+    uses_session_storage: bool,
+    #[serde(default)]
+    uses_cookies: bool,
+    #[serde(default)]
+    uses_indexed_db: bool,
+    #[serde(default)]
+    uses_cache_storage: bool,
+    #[serde(default)]
+    uses_service_worker: bool,
+    #[serde(default)]
+    uses_storage_manager: bool,
+    #[serde(default)]
+    listens_storage_events: bool,
+    #[serde(default)]
+    storage_blocked: bool,
+    #[serde(default)]
+    storage_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3863,6 +3908,30 @@ fn browser_script_style_security_metadata_tracks_nonces_and_fetch_policy() {
 }
 
 #[test]
+fn browser_script_storage_access_descriptors_track_flat_storage_api_hints() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "script-storage-access-page")
+        .expect("script storage access fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("script storage access fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.scripts, expected.scripts,
+        "scripts should preserve storage-relevant inline text and module state",
+    );
+    assert_eq!(
+        actual.script_storage_access_descriptors, expected.script_storage_access_descriptors,
+        "script storage access descriptors should preserve storage API targets and blockers",
+    );
+}
+
+#[test]
 fn browser_resource_priority_metadata_tracks_rel_and_blocking_tokens() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -5790,6 +5859,17 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_script_execution_descriptors(&scripts));
+        let script_storage_access_descriptors = self
+            .script_storage_access_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedScriptStorageAccessDescriptor::into_browser_script_storage_access_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_script_storage_access_descriptors(&scripts));
         let stylesheet_planning_descriptors = self
             .stylesheet_planning_descriptors
             .map(|descriptors| {
@@ -6083,6 +6163,7 @@ impl ExpectedBrowserDocument {
             resources,
             scripts,
             script_execution_descriptors,
+            script_storage_access_descriptors,
             stylesheets,
             stylesheet_planning_descriptors,
             document_policy_descriptors: self
@@ -10542,6 +10623,163 @@ fn expected_script_execution_descriptor(
     }
 }
 
+fn expected_script_storage_access_descriptors(
+    scripts: &[BrowserScript],
+) -> Vec<BrowserScriptStorageAccessDescriptor> {
+    scripts
+        .iter()
+        .filter_map(expected_script_storage_access_descriptor)
+        .collect()
+}
+
+fn expected_script_storage_access_descriptor(
+    script: &BrowserScript,
+) -> Option<BrowserScriptStorageAccessDescriptor> {
+    let text = script.text.as_deref().unwrap_or_default();
+    let normalized_text = text.to_ascii_lowercase();
+    let uses_local_storage = normalized_text.contains("localstorage");
+    let uses_session_storage = normalized_text.contains("sessionstorage");
+    let uses_cookies =
+        normalized_text.contains("document.cookie") || normalized_text.contains("cookie=");
+    let uses_indexed_db = normalized_text.contains("indexeddb");
+    let uses_cache_storage = normalized_text.contains("caches.")
+        || normalized_text.contains("caches.open")
+        || normalized_text.contains("cachestorage");
+    let uses_service_worker = normalized_text.contains("serviceworker")
+        || normalized_text.contains("service-worker")
+        || normalized_text.contains("navigator.serviceworker");
+    let uses_storage_manager = normalized_text.contains("navigator.storage")
+        || normalized_text.contains(".persist(")
+        || normalized_text.contains(".estimate(");
+    let listens_storage_events = normalized_text.contains("addeventlistener('storage'")
+        || normalized_text.contains("addeventlistener(\"storage\"")
+        || normalized_text.contains("onstorage");
+    let storage_targets = expected_script_storage_targets(
+        uses_local_storage,
+        uses_session_storage,
+        uses_cookies,
+        uses_indexed_db,
+        uses_cache_storage,
+        uses_service_worker,
+        uses_storage_manager,
+        listens_storage_events,
+    );
+    if storage_targets.is_empty() {
+        return None;
+    }
+
+    let storage_block_reasons = expected_script_storage_block_reasons(script);
+    Some(BrowserScriptStorageAccessDescriptor {
+        script_kind: script.script_kind.clone(),
+        access_kind: expected_script_storage_access_kind(
+            uses_local_storage,
+            uses_session_storage,
+            uses_cookies,
+            uses_indexed_db,
+            uses_cache_storage,
+            uses_service_worker,
+            uses_storage_manager,
+            listens_storage_events,
+        ),
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        has_text: script.text.is_some(),
+        text_length: text.chars().count(),
+        storage_target_count: storage_targets.len(),
+        storage_targets,
+        uses_local_storage,
+        uses_session_storage,
+        uses_cookies,
+        uses_indexed_db,
+        uses_cache_storage,
+        uses_service_worker,
+        uses_storage_manager,
+        listens_storage_events,
+        storage_blocked: !storage_block_reasons.is_empty(),
+        storage_block_reasons,
+    })
+}
+
+fn expected_script_storage_targets(
+    uses_local_storage: bool,
+    uses_session_storage: bool,
+    uses_cookies: bool,
+    uses_indexed_db: bool,
+    uses_cache_storage: bool,
+    uses_service_worker: bool,
+    uses_storage_manager: bool,
+    listens_storage_events: bool,
+) -> Vec<String> {
+    let mut targets = Vec::new();
+    if uses_local_storage {
+        targets.push("localStorage".to_string());
+    }
+    if uses_session_storage {
+        targets.push("sessionStorage".to_string());
+    }
+    if uses_cookies {
+        targets.push("cookies".to_string());
+    }
+    if uses_indexed_db {
+        targets.push("indexedDB".to_string());
+    }
+    if uses_cache_storage {
+        targets.push("CacheStorage".to_string());
+    }
+    if uses_service_worker {
+        targets.push("serviceWorker".to_string());
+    }
+    if uses_storage_manager {
+        targets.push("StorageManager".to_string());
+    }
+    if listens_storage_events {
+        targets.push("storage-event".to_string());
+    }
+    targets
+}
+
+fn expected_script_storage_access_kind(
+    uses_local_storage: bool,
+    uses_session_storage: bool,
+    uses_cookies: bool,
+    uses_indexed_db: bool,
+    uses_cache_storage: bool,
+    uses_service_worker: bool,
+    uses_storage_manager: bool,
+    listens_storage_events: bool,
+) -> String {
+    if uses_service_worker || uses_cache_storage {
+        "worker-cache-storage".to_string()
+    } else if uses_indexed_db {
+        "database-storage".to_string()
+    } else if uses_storage_manager {
+        "storage-manager".to_string()
+    } else if uses_local_storage || uses_session_storage || uses_cookies {
+        "client-key-value-storage".to_string()
+    } else if listens_storage_events {
+        "storage-event-listener".to_string()
+    } else {
+        "storage-metadata".to_string()
+    }
+}
+
+fn expected_script_storage_block_reasons(script: &BrowserScript) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if script.script_kind == "data" {
+        reasons.push("non-executable-script-type".to_string());
+    }
+    if script.nomodule {
+        reasons.push("nomodule-fallback".to_string());
+    }
+    reasons
+}
+
 fn expected_stylesheet_planning_descriptors(
     stylesheets: &[BrowserStylesheet],
 ) -> Vec<BrowserStylesheetPlanningDescriptor> {
@@ -10692,6 +10930,33 @@ impl ExpectedScriptExecutionDescriptor {
             render_blocking: self.render_blocking,
             has_text: self.has_text,
             text_length: self.text_length,
+        }
+    }
+}
+
+impl ExpectedScriptStorageAccessDescriptor {
+    fn into_browser_script_storage_access_descriptor(self) -> BrowserScriptStorageAccessDescriptor {
+        BrowserScriptStorageAccessDescriptor {
+            script_kind: self.script_kind,
+            access_kind: self.access_kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            type_hint: self.type_hint,
+            execution_kind: self.execution_kind,
+            has_text: self.has_text,
+            text_length: self.text_length,
+            storage_targets: self.storage_targets,
+            storage_target_count: self.storage_target_count,
+            uses_local_storage: self.uses_local_storage,
+            uses_session_storage: self.uses_session_storage,
+            uses_cookies: self.uses_cookies,
+            uses_indexed_db: self.uses_indexed_db,
+            uses_cache_storage: self.uses_cache_storage,
+            uses_service_worker: self.uses_service_worker,
+            uses_storage_manager: self.uses_storage_manager,
+            listens_storage_events: self.listens_storage_events,
+            storage_blocked: self.storage_blocked,
+            storage_block_reasons: self.storage_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -107,6 +107,9 @@ Script/style cases pin module/classic script kind, async/defer/nomodule flags,
 inline script/style text, flattened script execution and stylesheet planning
 descriptors, and loading-policy hints such as integrity, crossorigin, referrer
 policy, fetch priority, blocking, disabled state, and alternate stylesheets.
+Script storage-access cases pin inline references to Web Storage, cookies,
+IndexedDB, CacheStorage/service workers, StorageManager, storage-event hooks,
+and fallback blockers.
 Responsive image cases pin `srcset`/`sizes`, resolved candidate URLs, flattened image candidate
 descriptors, `picture/source` media/type hints, lazy loading, decoding, fetch
 priority, CORS/referrer policy, usemap, and server-side image-map state. Link

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -973,6 +973,71 @@
       }
     },
     {
+      "id": "script-storage-access-page",
+      "description": "Browser document summaries expose inline script storage API targets, broad storage groups, and fallback blockers.",
+      "input": "<script>localStorage.setItem('theme','dark'); sessionStorage.getItem('draft'); document.cookie='seen=1'; indexedDB.open('app'); window.addEventListener('storage', syncTabs);</script><script type=module>navigator.serviceWorker.register('/sw.js'); caches.open('assets'); navigator.storage.persist();</script><script nomodule>localStorage.getItem('legacy');</script>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "",
+        "metas": [],
+        "resources": [],
+        "scripts": [
+          { "script_kind": "classic", "text": "localStorage.setItem('theme','dark'); sessionStorage.getItem('draft'); document.cookie='seen=1'; indexedDB.open('app'); window.addEventListener('storage', syncTabs);" },
+          { "script_kind": "module", "type_hint": "module", "text": "navigator.serviceWorker.register('/sw.js'); caches.open('assets'); navigator.storage.persist();" },
+          { "script_kind": "classic", "nomodule": true, "text": "localStorage.getItem('legacy');" }
+        ],
+        "script_storage_access_descriptors": [
+          {
+            "script_kind": "classic",
+            "access_kind": "database-storage",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 165,
+            "storage_targets": ["localStorage", "sessionStorage", "cookies", "indexedDB", "storage-event"],
+            "storage_target_count": 5,
+            "uses_local_storage": true,
+            "uses_session_storage": true,
+            "uses_cookies": true,
+            "uses_indexed_db": true,
+            "listens_storage_events": true
+          },
+          {
+            "script_kind": "module",
+            "access_kind": "worker-cache-storage",
+            "type_hint": "module",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 95,
+            "storage_targets": ["CacheStorage", "serviceWorker", "StorageManager"],
+            "storage_target_count": 3,
+            "uses_cache_storage": true,
+            "uses_service_worker": true,
+            "uses_storage_manager": true
+          },
+          {
+            "script_kind": "classic",
+            "access_kind": "client-key-value-storage",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 31,
+            "storage_targets": ["localStorage"],
+            "storage_target_count": 1,
+            "uses_local_storage": true,
+            "storage_blocked": true,
+            "storage_block_reasons": ["nomodule-fallback"]
+          }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "table-layout-metadata-page",
       "description": "Table summaries expose effective row, column, column hint, cell, and header counts for early layout planning.",
       "input": "<body><table><caption>Prices</caption><colgroup><col span=2 width=80><col width=120><thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price<tbody><tr><th scope=row headers=item>Basic<td colspan=2 headers=\"item price\">$1</table>",


### PR DESCRIPTION
## Summary
- add browser-readiness script storage-access descriptors for inline storage API usage
- classify Web Storage, cookies, IndexedDB, CacheStorage/service workers, StorageManager, and storage-event hooks
- add fixture coverage plus README/changelog notes for the new descriptor surface

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_schemas.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_case_ids.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_script_storage_access_descriptors
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
