### PR TITLE
Add smart-home activation sentinel tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -79,6 +79,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation watchtower signals:
   `smart_home.list_integration_activation_watchtower` and
   `smart_home.get_integration_activation_watchtower_summary`.
+- Added D18D handlers for D23A activation sentinel alerts:
+  `smart_home.list_integration_activation_sentinel` and
+  `smart_home.get_integration_activation_sentinel_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -61,6 +61,7 @@ Chief of Staff job/session/agent
   -> activation-control-room list and summary reads for grouped operator panels
   -> activation-command-center list and summary reads for operating-lane rollups
   -> activation-watchtower list and summary reads for escalation signal rollups
+  -> activation-sentinel list and summary reads for compact alert rollups
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -134,6 +135,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_command_center_summary`
 - `smart_home.list_integration_activation_watchtower`
 - `smart_home.get_integration_activation_watchtower_summary`
+- `smart_home.list_integration_activation_sentinel`
+- `smart_home.get_integration_activation_sentinel_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -46,7 +46,7 @@ use smart_home_integration_catalog::{
     activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
     activation_readouts_from_candidates, activation_reviews_from_candidates,
     activation_risk_from_candidates, activation_runway_from_candidates,
-    activation_timeline_milestones_from_dashboard_cards,
+    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog,
@@ -86,16 +86,17 @@ use smart_home_integration_catalog::{
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
     IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
-    IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
-    IntegrationActivationTimelineSummary, IntegrationActivationWatchtowerSignal,
-    IntegrationActivationWatchtowerSignalKind, IntegrationActivationWatchtowerSummary,
-    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
-    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
-    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
-    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
-    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
-    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
-    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationActivationSentinelAlert, IntegrationActivationSentinelAlertKind,
+    IntegrationActivationSentinelSummary, IntegrationActivationTarget,
+    IntegrationActivationTimelineMilestone, IntegrationActivationTimelineSummary,
+    IntegrationActivationWatchtowerSignal, IntegrationActivationWatchtowerSignalKind,
+    IntegrationActivationWatchtowerSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
+    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
+    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
+    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
+    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
+    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -285,6 +286,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_WATCHTOWER_TOOL_ID: &str =
     "smart_home.list_integration_activation_watchtower";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_watchtower_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID: &str =
+    "smart_home.list_integration_activation_sentinel";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_sentinel_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -625,6 +630,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID => {
                     let query = integration_activation_watchtower_query(&arguments)?;
                     Ok(get_integration_activation_watchtower_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID => {
+                    let query = integration_activation_sentinel_query(&arguments)?;
+                    Ok(list_integration_activation_sentinel_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_sentinel_query(&arguments)?;
+                    Ok(get_integration_activation_sentinel_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2075,6 +2090,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation watchtower summary",
             "Return compact D23A activation watchtower counts for escalation, review, ready, action, and observation signals.",
             integration_activation_watchtower_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID,
+            "List smart-home integration activation sentinel alerts",
+            "List D23A activation sentinel alerts that combine watchtower, risk, dependency, and readiness-gap rollups into blocker, dependency, policy-risk, review, ready, and observation lanes.",
+            integration_activation_sentinel_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_sentinel", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_sentinel", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation sentinel summary",
+            "Return compact D23A activation sentinel alert counts for blockers, dependencies, policy risk, review work, ready work, and observation lanes.",
+            integration_activation_sentinel_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4805,6 +4849,22 @@ struct IntegrationActivationWatchtowerQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationSentinelQuery {
+    watchtower: IntegrationActivationWatchtowerQuery,
+    risk: IntegrationActivationRiskQuery,
+    dependency: IntegrationActivationDependencyQuery,
+    gaps: IntegrationReadinessGapQuery,
+    alert_kind: Option<IntegrationActivationSentinelAlertKind>,
+    requires_attention: Option<bool>,
+    has_blockers: Option<bool>,
+    has_dependency_work: Option<bool>,
+    has_policy_risk: Option<bool>,
+    has_review_work: Option<bool>,
+    has_activation_work: Option<bool>,
+    alert_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5224,6 +5284,34 @@ fn integration_activation_watchtower_query(
             .or(optional_bool(arguments, "has_activation_work")?),
         needs_escalation: optional_bool(arguments, "needs_escalation")?,
         signal_limit: optional_u64(arguments, "signal_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_sentinel_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationSentinelQuery, ToolCallError> {
+    let alert_kind = optional_string(arguments, "sentinel_alert")?
+        .or(optional_string(arguments, "alert_kind")?)
+        .map(|label| parse_activation_sentinel_alert_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationSentinelQuery {
+        watchtower: integration_activation_watchtower_query(arguments)?,
+        risk: integration_activation_risk_query(arguments)?,
+        dependency: integration_activation_dependency_query(arguments)?,
+        gaps: integration_readiness_gap_query(arguments)?,
+        alert_kind,
+        requires_attention: optional_bool(arguments, "alert_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_blockers: optional_bool(arguments, "alert_has_blockers")?
+            .or(optional_bool(arguments, "has_blockers")?),
+        has_dependency_work: optional_bool(arguments, "has_dependency_work")?,
+        has_policy_risk: optional_bool(arguments, "has_policy_risk")?,
+        has_review_work: optional_bool(arguments, "alert_has_review_work")?
+            .or(optional_bool(arguments, "has_review_work")?),
+        has_activation_work: optional_bool(arguments, "alert_has_activation_work")?
+            .or(optional_bool(arguments, "has_activation_work")?),
+        alert_limit: optional_u64(arguments, "alert_limit")?.map(|value| value as usize),
     })
 }
 
@@ -5968,6 +6056,51 @@ fn integration_activation_watchtower_signals_for_query(
     }
 
     (signals, catalog_count)
+}
+
+fn integration_activation_sentinel_alerts_for_query(
+    query: &IntegrationActivationSentinelQuery,
+) -> (Vec<IntegrationActivationSentinelAlert>, usize) {
+    let (signals, catalog_count) =
+        integration_activation_watchtower_signals_for_query(&query.watchtower);
+    let (risks, _) = integration_activation_risk_for_query(&query.risk);
+    let (graph, _) = integration_activation_dependency_graph_for_query(&query.dependency);
+    let (mut gap_inventory, _) =
+        integration_readiness_gap_inventory_for_query(&query.gaps.readiness);
+    if let Some(limit) = query.gaps.limit_per_kind {
+        gap_inventory.primitive_gaps.truncate(limit);
+        gap_inventory.capability_gaps.truncate(limit);
+        gap_inventory.dependency_gaps.truncate(limit);
+    }
+    let mut alerts =
+        activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory);
+
+    if let Some(alert_kind) = query.alert_kind {
+        alerts.retain(|alert| alert.alert_kind == alert_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        alerts.retain(|alert| alert.requires_attention() == requires_attention);
+    }
+    if let Some(has_blockers) = query.has_blockers {
+        alerts.retain(|alert| alert.has_blockers() == has_blockers);
+    }
+    if let Some(has_dependency_work) = query.has_dependency_work {
+        alerts.retain(|alert| alert.has_dependency_work() == has_dependency_work);
+    }
+    if let Some(has_policy_risk) = query.has_policy_risk {
+        alerts.retain(|alert| alert.has_policy_risk() == has_policy_risk);
+    }
+    if let Some(has_review_work) = query.has_review_work {
+        alerts.retain(|alert| alert.has_review_work() == has_review_work);
+    }
+    if let Some(has_activation_work) = query.has_activation_work {
+        alerts.retain(|alert| alert.has_activation_work() == has_activation_work);
+    }
+    if let Some(limit) = query.alert_limit {
+        alerts.truncate(limit);
+    }
+
+    (alerts, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -7926,6 +8059,74 @@ fn get_integration_activation_watchtower_summary_output_handler_output(
                     .next_signal_kind
                     .map(|kind| string(kind.as_str()))
                     .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_sentinel_output_handler_output(
+    query: IntegrationActivationSentinelQuery,
+) -> ToolHandlerOutput {
+    let (alerts, catalog_count) = integration_activation_sentinel_alerts_for_query(&query);
+    let summary = IntegrationActivationSentinelSummary::from_alerts(alerts.iter());
+    let count = alerts.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_sentinel",
+            JsonValue::Array(alerts.iter().map(activation_sentinel_alert_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_sentinel_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_sentinel")),
+            ("alerts", integer(count as i64)),
+            (
+                "alerts_requiring_attention",
+                integer(summary.alerts_requiring_attention as i64),
+            ),
+            ("blocker_alerts", integer(summary.blocker_alerts as i64)),
+            (
+                "total_unique_gaps",
+                integer(summary.total_unique_gaps as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_sentinel_summary_output_handler_output(
+    query: IntegrationActivationSentinelQuery,
+) -> ToolHandlerOutput {
+    let (alerts, _) = integration_activation_sentinel_alerts_for_query(&query);
+    let summary = IntegrationActivationSentinelSummary::from_alerts(alerts.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_sentinel_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_sentinel_summary"),
+            ),
+            ("total_alerts", integer(summary.total_alerts as i64)),
+            (
+                "alerts_requiring_attention",
+                integer(summary.alerts_requiring_attention as i64),
+            ),
+            ("blocker_alerts", integer(summary.blocker_alerts as i64)),
+            (
+                "total_unique_gaps",
+                integer(summary.total_unique_gaps as i64),
             ),
         ]),
     )
@@ -15157,6 +15358,198 @@ fn integration_activation_watchtower_summary_json(
     ])
 }
 
+fn activation_sentinel_alert_json(alert: &IntegrationActivationSentinelAlert) -> JsonValue {
+    object([
+        ("sequence", integer(alert.sequence as i64)),
+        ("alert_kind", string(alert.alert_kind.as_str())),
+        ("priority", integer(alert.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                alert
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(alert.integration_count() as i64),
+        ),
+        (
+            "watchtower_summary",
+            integration_activation_watchtower_summary_json(&alert.watchtower_summary),
+        ),
+        (
+            "risk_summary",
+            integration_activation_risk_summary_json(&alert.risk_summary),
+        ),
+        (
+            "dependency_summary",
+            integration_activation_dependency_summary_json(&alert.dependency_summary),
+        ),
+        (
+            "gap_summary",
+            integration_readiness_gap_summary_json(&alert.gap_inventory),
+        ),
+        ("has_gaps", JsonValue::Bool(alert.has_gaps())),
+        (
+            "has_blocking_dependencies",
+            JsonValue::Bool(alert.has_blocking_dependencies()),
+        ),
+        ("has_blockers", JsonValue::Bool(alert.has_blockers())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(alert.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(alert.has_policy_risk())),
+        ("has_review_work", JsonValue::Bool(alert.has_review_work())),
+        (
+            "has_activation_work",
+            JsonValue::Bool(alert.has_activation_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(alert.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_sentinel_summary_json(
+    summary: &IntegrationActivationSentinelSummary,
+) -> JsonValue {
+    object([
+        ("total_alerts", integer(summary.total_alerts as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "alerts_requiring_attention",
+            integer(summary.alerts_requiring_attention as i64),
+        ),
+        ("blocker_alerts", integer(summary.blocker_alerts as i64)),
+        (
+            "dependency_alerts",
+            integer(summary.dependency_alerts as i64),
+        ),
+        (
+            "policy_risk_alerts",
+            integer(summary.policy_risk_alerts as i64),
+        ),
+        ("review_alerts", integer(summary.review_alerts as i64)),
+        ("ready_alerts", integer(summary.ready_alerts as i64)),
+        (
+            "observation_alerts",
+            integer(summary.observation_alerts as i64),
+        ),
+        ("alerts_with_gaps", integer(summary.alerts_with_gaps as i64)),
+        (
+            "alerts_with_blocking_dependencies",
+            integer(summary.alerts_with_blocking_dependencies as i64),
+        ),
+        (
+            "alerts_with_policy_risk",
+            integer(summary.alerts_with_policy_risk as i64),
+        ),
+        (
+            "alerts_with_review_work",
+            integer(summary.alerts_with_review_work as i64),
+        ),
+        (
+            "alerts_with_activation_work",
+            integer(summary.alerts_with_activation_work as i64),
+        ),
+        (
+            "total_watchtower_signals",
+            integer(summary.total_watchtower_signals as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "total_unique_gaps",
+            integer(summary.total_unique_gaps as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_priority",
+            summary
+                .first_blocker_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_policy_risk_priority",
+            summary
+                .first_policy_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(summary.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(summary.has_policy_risk()),
+        ),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -17871,6 +18264,34 @@ fn parse_activation_watchtower_signal_kind(
     }
 }
 
+fn parse_activation_sentinel_alert_kind(
+    label: &str,
+) -> Result<IntegrationActivationSentinelAlertKind, ToolCallError> {
+    match label {
+        "blocker" | "blockers" | "escalation" | "constraint" | "constraints" => {
+            Ok(IntegrationActivationSentinelAlertKind::Blocker)
+        }
+        "dependency" | "dependencies" | "dependency_work" | "dependency_graph" => {
+            Ok(IntegrationActivationSentinelAlertKind::Dependency)
+        }
+        "policy_risk" | "risk" | "risks" | "policy" | "policy_review" => {
+            Ok(IntegrationActivationSentinelAlertKind::PolicyRisk)
+        }
+        "review" | "reviews" | "approval" | "approvals" | "human_review" => {
+            Ok(IntegrationActivationSentinelAlertKind::Review)
+        }
+        "ready" | "activation" | "activate" | "ready_to_activate" => {
+            Ok(IntegrationActivationSentinelAlertKind::Ready)
+        }
+        "observation" | "observe" | "monitoring" | "monitor" | "status" => {
+            Ok(IntegrationActivationSentinelAlertKind::Observation)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation sentinel alert `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -19081,6 +19502,50 @@ fn integration_activation_watchtower_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_sentinel_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_watchtower_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("sentinel_alert", JsonSchema::String));
+        properties.push(SchemaProperty::new("alert_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "alert_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "alert_has_blockers",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_dependency_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("has_policy_risk", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "alert_has_review_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "alert_has_activation_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("risk_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("required_tier", JsonSchema::String));
+        properties.push(SchemaProperty::new("policy_surface", JsonSchema::String));
+        properties.push(SchemaProperty::new("risk_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("blocking_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("node_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("edge_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("limit_per_kind", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("alert_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -19225,7 +19690,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 105);
+        assert_eq!(definitions.len(), 107);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -19508,9 +19973,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_WATCHTOWER_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            97
+            99
         );
         assert_eq!(
             export
@@ -19964,11 +20435,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(105))
+            Some(&integer(107))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(97))
+            Some(&integer(99))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -23119,6 +23590,135 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_sentinel_request = request(
+            "call-list-integration-activation-sentinel",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("alert_requires_attention", JsonValue::Bool(true)),
+                ("alert_limit", integer(3)),
+            ]),
+            5_039,
+        );
+        let list_activation_sentinel_trace =
+            tool_runtime.invoke_with_events(&list_activation_sentinel_request);
+        assert!(list_activation_sentinel_trace.result.ok);
+        assert_eq!(
+            list_activation_sentinel_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_sentinel_output = list_activation_sentinel_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_sentinel_count =
+            integer_value(field(list_activation_sentinel_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_sentinel_count));
+        let activation_sentinel_summary =
+            field(list_activation_sentinel_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_sentinel_summary, "total_alerts"),
+            Some(&integer(activation_sentinel_count))
+        );
+        assert!(
+            integer_value(field(activation_sentinel_summary, "blocker_alerts").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_sentinel_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_sentinel_alert = array_item(
+            field(list_activation_sentinel_output, "activation_sentinel").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_sentinel_alert, "sequence").is_some());
+        assert!(field(activation_sentinel_alert, "alert_kind").is_some());
+        assert!(field(activation_sentinel_alert, "integration_ids").is_some());
+        assert!(field(activation_sentinel_alert, "watchtower_summary").is_some());
+        assert!(field(activation_sentinel_alert, "risk_summary").is_some());
+        assert!(field(activation_sentinel_alert, "dependency_summary").is_some());
+        assert!(field(activation_sentinel_alert, "gap_summary").is_some());
+        assert_eq!(
+            field(activation_sentinel_alert, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_sentinel_summary_request = request(
+            "call-integration-activation-sentinel-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("sentinel_alert", string("blocker")),
+                ("alert_has_blockers", JsonValue::Bool(true)),
+            ]),
+            5_040,
+        );
+        let activation_sentinel_summary_trace =
+            tool_runtime.invoke_with_events(&activation_sentinel_summary_request);
+        assert!(activation_sentinel_summary_trace.result.ok);
+        assert_eq!(
+            activation_sentinel_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_sentinel_summary_output = activation_sentinel_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_sentinel_rollup =
+            field(activation_sentinel_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_sentinel_rollup, "blocker_alerts").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_sentinel_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_sentinel_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -24914,6 +25514,14 @@ mod tests {
             activation_watchtower_summary_request,
             activation_watchtower_summary_trace,
         );
+        journal.record_trace(
+            list_activation_sentinel_request,
+            list_activation_sentinel_trace,
+        );
+        journal.record_trace(
+            activation_sentinel_summary_request,
+            activation_sentinel_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -24987,9 +25595,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 105);
-        assert_eq!(journal_summary.completed_count, 105);
-        assert_eq!(journal.audit_records().len(), 105);
+        assert_eq!(journal_summary.invocation_count, 107);
+        assert_eq!(journal_summary.completed_count, 107);
+        assert_eq!(journal.audit_records().len(), 107);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -103,6 +103,11 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_watchtower_summary` tool descriptors
   for read-only escalation, review, ready, action, and observation signal
   rollups derived from activation command-center sections.
+- `smart_home.list_integration_activation_sentinel` and
+  `smart_home.get_integration_activation_sentinel_summary` tool descriptors
+  for read-only blocker, dependency, policy-risk, review, ready, and
+  observation alert rollups derived from activation watchtower, risk,
+  dependency, and readiness-gap rollups.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -99,6 +99,8 @@ Current scope:
   operating-lane sections derived from control-room panels
 - D18D integration activation-watchtower descriptors for escalation, review,
   ready, action, and observation signal rollups
+- D18D integration activation-sentinel descriptors for compact blocker,
+  dependency, policy-risk, review, ready, and observation alert rollups
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1503,6 +1503,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationCommandCenterSummary,
     ListIntegrationActivationWatchtower,
     GetIntegrationActivationWatchtowerSummary,
+    ListIntegrationActivationSentinel,
+    GetIntegrationActivationSentinelSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1718,6 +1720,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationWatchtowerSummary => {
                 read_tool("smart_home.get_integration_activation_watchtower_summary")
+            }
+            Self::ListIntegrationActivationSentinel => {
+                read_tool("smart_home.list_integration_activation_sentinel")
+            }
+            Self::GetIntegrationActivationSentinelSummary => {
+                read_tool("smart_home.get_integration_activation_sentinel_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2404,6 +2412,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationCommandCenterSummary,
         SmartHomeTool::ListIntegrationActivationWatchtower,
         SmartHomeTool::GetIntegrationActivationWatchtowerSummary,
+        SmartHomeTool::ListIntegrationActivationSentinel,
+        SmartHomeTool::GetIntegrationActivationSentinelSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3246,7 +3256,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 105);
+        assert_eq!(catalog.len(), 107);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3673,6 +3683,14 @@ mod tests {
             == "smart_home.get_integration_activation_watchtower_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_sentinel"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_sentinel_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3680,15 +3698,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 105);
-        assert_eq!(summary.read_tools, 97);
+        assert_eq!(summary.total_tools, 107);
+        assert_eq!(summary.read_tools, 99);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 97);
+        assert_eq!(summary.read_only_tier_tools, 99);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 105);
+        assert_eq!(summary.total_required_capabilities, 107);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -87,6 +87,10 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationWatchtowerSignal` and
   `IntegrationActivationWatchtowerSummary` for rolling command-center sections
   into escalation, review, ready, action, and observation signal lanes.
+- `IntegrationActivationSentinelAlert` and
+  `IntegrationActivationSentinelSummary` for combining watchtower, risk,
+  dependency, and readiness-gap rollups into blocker, dependency, policy-risk,
+  review, ready, and observation alert lanes.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -83,6 +83,9 @@ runtime and Chief of Staff tools a typed catalog for:
   blocker, review, activation, actionable, and monitoring operating lanes
 - activation watchtower signals that roll command-center sections into
   escalation, review, ready, action, and observation signal lanes
+- activation sentinel alerts that combine watchtower, risk, dependency, and
+  readiness-gap rollups into blocker, dependency, policy-risk, review, ready,
+  and observation lanes
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1221,6 +1221,29 @@ impl IntegrationActivationWatchtowerSignalKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationSentinelAlertKind {
+    Blocker,
+    Dependency,
+    PolicyRisk,
+    Review,
+    Ready,
+    Observation,
+}
+
+impl IntegrationActivationSentinelAlertKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocker => "blocker",
+            Self::Dependency => "dependency",
+            Self::PolicyRisk => "policy_risk",
+            Self::Review => "review",
+            Self::Ready => "ready",
+            Self::Observation => "observation",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2466,6 +2489,49 @@ pub struct IntegrationActivationWatchtowerSummary {
     pub first_review_signal_priority: Option<u8>,
     pub first_ready_signal_priority: Option<u8>,
     pub first_action_signal_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationSentinelAlert {
+    pub sequence: usize,
+    pub alert_kind: IntegrationActivationSentinelAlertKind,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub watchtower_summary: IntegrationActivationWatchtowerSummary,
+    pub risk_summary: IntegrationActivationRiskSummary,
+    pub dependency_summary: IntegrationActivationDependencySummary,
+    pub gap_inventory: IntegrationReadinessGapInventory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationSentinelSummary {
+    pub total_alerts: usize,
+    pub unique_integrations: usize,
+    pub alerts_requiring_attention: usize,
+    pub blocker_alerts: usize,
+    pub dependency_alerts: usize,
+    pub policy_risk_alerts: usize,
+    pub review_alerts: usize,
+    pub ready_alerts: usize,
+    pub observation_alerts: usize,
+    pub alerts_with_gaps: usize,
+    pub alerts_with_blocking_dependencies: usize,
+    pub alerts_with_policy_risk: usize,
+    pub alerts_with_review_work: usize,
+    pub alerts_with_activation_work: usize,
+    pub total_watchtower_signals: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_unique_gaps: usize,
+    pub first_attention_priority: Option<u8>,
+    pub first_blocker_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_policy_risk_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_ready_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -5726,6 +5792,260 @@ impl IntegrationActivationWatchtowerSummary {
 
     pub fn needs_escalation(&self) -> bool {
         self.escalation_signals > 0 || self.has_blockers()
+    }
+}
+
+impl IntegrationActivationSentinelAlert {
+    fn from_rollups(
+        sequence: usize,
+        alert_kind: IntegrationActivationSentinelAlertKind,
+        priority: u8,
+        mut integration_ids: Vec<IntegrationId>,
+        watchtower_summary: IntegrationActivationWatchtowerSummary,
+        risk_summary: IntegrationActivationRiskSummary,
+        dependency_summary: IntegrationActivationDependencySummary,
+        gap_inventory: IntegrationReadinessGapInventory,
+    ) -> Self {
+        integration_ids.sort();
+        integration_ids.dedup();
+
+        Self {
+            sequence,
+            alert_kind,
+            priority,
+            integration_ids,
+            watchtower_summary,
+            risk_summary,
+            dependency_summary,
+            gap_inventory,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_gaps(&self) -> bool {
+        matches!(
+            self.alert_kind,
+            IntegrationActivationSentinelAlertKind::Blocker
+                | IntegrationActivationSentinelAlertKind::Dependency
+        ) && self.gap_inventory.has_gaps()
+    }
+
+    pub fn has_blocking_dependencies(&self) -> bool {
+        matches!(
+            self.alert_kind,
+            IntegrationActivationSentinelAlertKind::Blocker
+                | IntegrationActivationSentinelAlertKind::Dependency
+        ) && self.dependency_summary.has_blocking_dependencies()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.alert_kind == IntegrationActivationSentinelAlertKind::Blocker
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        matches!(
+            self.alert_kind,
+            IntegrationActivationSentinelAlertKind::Blocker
+                | IntegrationActivationSentinelAlertKind::Dependency
+        ) && (self.dependency_summary.has_dependency_edges()
+            || self.gap_inventory.dependency_gap_count() > 0)
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.alert_kind == IntegrationActivationSentinelAlertKind::PolicyRisk
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.alert_kind == IntegrationActivationSentinelAlertKind::Review
+            || (self.alert_kind == IntegrationActivationSentinelAlertKind::PolicyRisk
+                && self.risk_summary.has_review_work())
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.alert_kind == IntegrationActivationSentinelAlertKind::Ready
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        match self.alert_kind {
+            IntegrationActivationSentinelAlertKind::Blocker => true,
+            IntegrationActivationSentinelAlertKind::Dependency => {
+                self.dependency_summary.has_blocking_dependencies() || self.gap_inventory.has_gaps()
+            }
+            IntegrationActivationSentinelAlertKind::PolicyRisk => {
+                self.risk_summary.requires_attention()
+                    || self.risk_summary.highest_policy_tier >= PrivilegeTier::HumanApproval
+            }
+            IntegrationActivationSentinelAlertKind::Review => true,
+            IntegrationActivationSentinelAlertKind::Ready
+            | IntegrationActivationSentinelAlertKind::Observation => false,
+        }
+    }
+}
+
+impl IntegrationActivationSentinelSummary {
+    pub fn from_alerts<'a>(
+        alerts: impl IntoIterator<Item = &'a IntegrationActivationSentinelAlert>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_alerts: 0,
+            unique_integrations: 0,
+            alerts_requiring_attention: 0,
+            blocker_alerts: 0,
+            dependency_alerts: 0,
+            policy_risk_alerts: 0,
+            review_alerts: 0,
+            ready_alerts: 0,
+            observation_alerts: 0,
+            alerts_with_gaps: 0,
+            alerts_with_blocking_dependencies: 0,
+            alerts_with_policy_risk: 0,
+            alerts_with_review_work: 0,
+            alerts_with_activation_work: 0,
+            total_watchtower_signals: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_unique_gaps: 0,
+            first_attention_priority: None,
+            first_blocker_priority: None,
+            first_dependency_priority: None,
+            first_policy_risk_priority: None,
+            first_review_priority: None,
+            first_ready_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for alert in alerts {
+            summary.total_alerts += 1;
+            for integration_id in &alert.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match alert.alert_kind {
+                IntegrationActivationSentinelAlertKind::Blocker => {
+                    summary.blocker_alerts += 1;
+                    summary.first_blocker_priority =
+                        min_optional_priority(summary.first_blocker_priority, Some(alert.priority));
+                }
+                IntegrationActivationSentinelAlertKind::Dependency => {
+                    summary.dependency_alerts += 1;
+                    summary.first_dependency_priority = min_optional_priority(
+                        summary.first_dependency_priority,
+                        Some(alert.priority),
+                    );
+                }
+                IntegrationActivationSentinelAlertKind::PolicyRisk => {
+                    summary.policy_risk_alerts += 1;
+                    summary.first_policy_risk_priority = min_optional_priority(
+                        summary.first_policy_risk_priority,
+                        Some(alert.priority),
+                    );
+                }
+                IntegrationActivationSentinelAlertKind::Review => {
+                    summary.review_alerts += 1;
+                    summary.first_review_priority =
+                        min_optional_priority(summary.first_review_priority, Some(alert.priority));
+                }
+                IntegrationActivationSentinelAlertKind::Ready => {
+                    summary.ready_alerts += 1;
+                    summary.first_ready_priority =
+                        min_optional_priority(summary.first_ready_priority, Some(alert.priority));
+                }
+                IntegrationActivationSentinelAlertKind::Observation => {
+                    summary.observation_alerts += 1;
+                }
+            }
+
+            if alert.requires_attention() {
+                summary.alerts_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(alert.priority));
+            }
+            if alert.has_gaps() {
+                summary.alerts_with_gaps += 1;
+            }
+            if alert.has_blocking_dependencies() {
+                summary.alerts_with_blocking_dependencies += 1;
+            }
+            if alert.has_policy_risk() {
+                summary.alerts_with_policy_risk += 1;
+            }
+            if alert.has_review_work() {
+                summary.alerts_with_review_work += 1;
+            }
+            if alert.has_activation_work() {
+                summary.alerts_with_activation_work += 1;
+            }
+
+            summary.total_watchtower_signals = summary
+                .total_watchtower_signals
+                .max(alert.watchtower_summary.total_signals);
+            summary.total_risks = summary.total_risks.max(alert.risk_summary.total_risks);
+            summary.total_dependency_edges = summary
+                .total_dependency_edges
+                .max(alert.dependency_summary.total_edges);
+            summary.blocking_dependency_edges = summary
+                .blocking_dependency_edges
+                .max(alert.dependency_summary.blocking_edges);
+            summary.total_unique_gaps = summary
+                .total_unique_gaps
+                .max(alert.gap_inventory.total_unique_gaps());
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(alert.watchtower_summary.highest_policy_tier)
+                .max(alert.risk_summary.highest_policy_tier)
+                .max(alert.dependency_summary.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocker_alerts > 0
+            || summary.alerts_with_blocking_dependencies > 0
+            || summary.alerts_with_gaps > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.alerts_requiring_attention > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_alerts > 0 || summary.alerts_with_activation_work > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_alerts == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocker_alerts > 0
+            || self.alerts_with_blocking_dependencies > 0
+            || self.alerts_with_gaps > 0
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_alerts > 0
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk_alerts > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_alerts > 0 || self.alerts_with_review_work > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.ready_alerts > 0 || self.alerts_with_activation_work > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.alerts_requiring_attention > 0 || self.overall_status.requires_attention()
     }
 }
 
@@ -10202,6 +10522,192 @@ pub fn activation_watchtower_signals_at_or_before_priority(
     )
 }
 
+pub fn activation_sentinel_alerts_from_rollups(
+    signals: &[IntegrationActivationWatchtowerSignal],
+    risks: &[IntegrationActivationRiskItem],
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) -> Vec<IntegrationActivationSentinelAlert> {
+    let watchtower_summary = IntegrationActivationWatchtowerSummary::from_signals(signals.iter());
+    let risk_summary = IntegrationActivationRiskSummary::from_risks(risks.iter());
+    let dependency_summary = graph.summary.clone();
+    let integration_ids =
+        integration_ids_for_activation_sentinel_rollups(signals, risks, graph, gap_inventory);
+
+    if watchtower_summary.is_empty()
+        && risk_summary.is_empty()
+        && graph.is_empty()
+        && gap_inventory.is_empty()
+    {
+        return Vec::new();
+    }
+
+    let mut alerts = Vec::new();
+    if watchtower_summary.has_blockers()
+        || risk_summary.has_blockers()
+        || dependency_summary.has_blocking_dependencies()
+        || gap_inventory.has_gaps()
+    {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::Blocker,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::Blocker,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    if dependency_summary.has_dependency_edges() || gap_inventory.dependency_gap_count() > 0 {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::Dependency,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::Dependency,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    if risk_summary.total_risks > 0 {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::PolicyRisk,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::PolicyRisk,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    if watchtower_summary.has_review_work() || risk_summary.has_review_work() {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::Review,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::Review,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    if watchtower_summary.has_activation_work()
+        || risk_summary.has_ready_work()
+        || gap_inventory.all_ready()
+    {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::Ready,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::Ready,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    if alerts.is_empty() {
+        push_activation_sentinel_alert(
+            &mut alerts,
+            IntegrationActivationSentinelAlertKind::Observation,
+            priority_for_activation_sentinel_alert(
+                IntegrationActivationSentinelAlertKind::Observation,
+                &watchtower_summary,
+                &risk_summary,
+                &dependency_summary,
+                graph,
+                gap_inventory,
+                risks,
+            ),
+            &integration_ids,
+            &watchtower_summary,
+            &risk_summary,
+            &dependency_summary,
+            gap_inventory,
+        );
+    }
+
+    alerts.sort_by(compare_activation_sentinel_alerts);
+    for (index, alert) in alerts.iter_mut().enumerate() {
+        alert.sequence = index + 1;
+    }
+    alerts
+}
+
+pub fn activation_sentinel_alerts_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationSentinelAlert> {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let candidates = activation_candidates_from_reports(reports.iter());
+    let risks = activation_risk_from_candidates(catalog, candidates.iter());
+    let signals =
+        activation_watchtower_signals_from_candidates(catalog, candidates, enabled_integrations);
+    let graph =
+        activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations);
+    let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+
+    activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -11645,6 +12151,195 @@ fn compare_activation_watchtower_signals(
         .then_with(|| left.signal_kind.cmp(&right.signal_kind))
         .then_with(|| right.section_count.cmp(&left.section_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_sentinel_alerts(
+    left: &IntegrationActivationSentinelAlert,
+    right: &IntegrationActivationSentinelAlert,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.has_blockers().cmp(&left.has_blockers()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
+        .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
+        .then_with(|| left.alert_kind.cmp(&right.alert_kind))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn push_activation_sentinel_alert(
+    alerts: &mut Vec<IntegrationActivationSentinelAlert>,
+    alert_kind: IntegrationActivationSentinelAlertKind,
+    priority: u8,
+    integration_ids: &[IntegrationId],
+    watchtower_summary: &IntegrationActivationWatchtowerSummary,
+    risk_summary: &IntegrationActivationRiskSummary,
+    dependency_summary: &IntegrationActivationDependencySummary,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) {
+    alerts.push(IntegrationActivationSentinelAlert::from_rollups(
+        0,
+        alert_kind,
+        priority,
+        integration_ids.to_vec(),
+        watchtower_summary.clone(),
+        risk_summary.clone(),
+        dependency_summary.clone(),
+        gap_inventory.clone(),
+    ));
+}
+
+fn integration_ids_for_activation_sentinel_rollups(
+    signals: &[IntegrationActivationWatchtowerSignal],
+    risks: &[IntegrationActivationRiskItem],
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) -> Vec<IntegrationId> {
+    let mut integration_ids = BTreeSet::new();
+    for signal in signals {
+        for integration_id in &signal.integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    for risk in risks {
+        for integration_id in &risk.integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    for node in &graph.nodes {
+        integration_ids.insert(node.integration_id.clone());
+        for integration_id in &node.depends_on_integrations {
+            integration_ids.insert(integration_id.clone());
+        }
+        for integration_id in &node.dependent_integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+        for integration_id in &node.missing_dependencies {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    for edge in &graph.edges {
+        integration_ids.insert(edge.dependency_integration_id.clone());
+        integration_ids.insert(edge.dependent_integration_id.clone());
+    }
+    for gap in &gap_inventory.primitive_gaps {
+        for integration_id in &gap.integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    for gap in &gap_inventory.capability_gaps {
+        for integration_id in &gap.integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    for gap in &gap_inventory.dependency_gaps {
+        integration_ids.insert(gap.integration_id.clone());
+        for integration_id in &gap.requested_integration_ids {
+            integration_ids.insert(integration_id.clone());
+        }
+    }
+    integration_ids.into_iter().collect()
+}
+
+fn priority_for_activation_sentinel_alert(
+    alert_kind: IntegrationActivationSentinelAlertKind,
+    watchtower_summary: &IntegrationActivationWatchtowerSummary,
+    risk_summary: &IntegrationActivationRiskSummary,
+    dependency_summary: &IntegrationActivationDependencySummary,
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+    risks: &[IntegrationActivationRiskItem],
+) -> u8 {
+    let priority = match alert_kind {
+        IntegrationActivationSentinelAlertKind::Blocker => min_optional_priority(
+            min_optional_priority(
+                watchtower_summary.first_escalation_signal_priority,
+                risk_summary.first_blocked_priority,
+            ),
+            min_optional_priority(
+                dependency_summary.first_blocked_priority,
+                first_gap_priority(gap_inventory),
+            ),
+        ),
+        IntegrationActivationSentinelAlertKind::Dependency => min_optional_priority(
+            min_optional_priority(
+                dependency_summary.first_blocked_priority,
+                first_dependency_edge_priority(graph),
+            ),
+            first_dependency_gap_priority(gap_inventory),
+        ),
+        IntegrationActivationSentinelAlertKind::PolicyRisk => {
+            first_risk_priority(risks).or(risk_summary.first_review_priority)
+        }
+        IntegrationActivationSentinelAlertKind::Review => min_optional_priority(
+            watchtower_summary.first_review_signal_priority,
+            risk_summary.first_review_priority,
+        ),
+        IntegrationActivationSentinelAlertKind::Ready => min_optional_priority(
+            watchtower_summary.first_ready_signal_priority,
+            risk_summary.first_ready_priority,
+        ),
+        IntegrationActivationSentinelAlertKind::Observation => min_optional_priority(
+            watchtower_summary.next_signal_priority,
+            min_optional_priority(
+                first_risk_priority(risks),
+                min_optional_priority(
+                    dependency_summary.first_blocked_priority,
+                    first_gap_priority(gap_inventory),
+                ),
+            ),
+        ),
+    };
+
+    priority.unwrap_or(u8::MAX)
+}
+
+fn first_risk_priority(risks: &[IntegrationActivationRiskItem]) -> Option<u8> {
+    risks
+        .iter()
+        .map(|risk| risk.highest_priority)
+        .min()
+        .filter(|priority| *priority < u8::MAX)
+}
+
+fn first_dependency_edge_priority(graph: &IntegrationActivationDependencyGraph) -> Option<u8> {
+    graph.edges.iter().map(|edge| edge.dependent_priority).min()
+}
+
+fn first_gap_priority(gap_inventory: &IntegrationReadinessGapInventory) -> Option<u8> {
+    min_optional_priority(
+        first_primitive_gap_priority(gap_inventory),
+        min_optional_priority(
+            first_capability_gap_priority(gap_inventory),
+            first_dependency_gap_priority(gap_inventory),
+        ),
+    )
+}
+
+fn first_primitive_gap_priority(gap_inventory: &IntegrationReadinessGapInventory) -> Option<u8> {
+    gap_inventory
+        .primitive_gaps
+        .iter()
+        .map(|gap| gap.highest_priority)
+        .min()
+}
+
+fn first_capability_gap_priority(gap_inventory: &IntegrationReadinessGapInventory) -> Option<u8> {
+    gap_inventory
+        .capability_gaps
+        .iter()
+        .map(|gap| gap.highest_priority)
+        .min()
+}
+
+fn first_dependency_gap_priority(gap_inventory: &IntegrationReadinessGapInventory) -> Option<u8> {
+    gap_inventory
+        .dependency_gaps
+        .iter()
+        .map(|gap| gap.highest_priority)
+        .min()
 }
 
 fn compare_activation_dependency_nodes(
@@ -14433,6 +15128,126 @@ mod tests {
         assert!(catalog_signals
             .iter()
             .any(IntegrationActivationWatchtowerSignal::requires_attention));
+    }
+
+    #[test]
+    fn activation_sentinel_alerts_roll_up_activation_attention() {
+        let reports = vec![
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+                display_name: "Review Ready Bridge".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 1,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HumanApproval,
+                local_only: true,
+                cloud_required: false,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+                display_name: "Blocked Review Camera".to_string(),
+                activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                    IntegrationId::trusted("mqtt"),
+                ),
+                priority: 2,
+                missing_primitives: vec![PrimitiveFamily::CameraMedia],
+                missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+                missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HighRisk,
+                local_only: false,
+                cloud_required: true,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("read_only_probe"),
+                display_name: "Read-only Probe".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 3,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: false,
+                highest_policy_tier: PrivilegeTier::ReadOnly,
+                local_only: true,
+                cloud_required: false,
+            },
+        ];
+        let candidates = activation_candidates_from_reports(reports.iter());
+        let risks = activation_risk_from_candidates(&[], candidates.iter());
+        let sections = activation_command_center_sections_from_candidates(&[], candidates, &[]);
+        let signals = activation_watchtower_signals_from_command_center_sections(sections);
+        let graph = activation_dependency_graph_from_reports(&[], reports.iter(), &[]);
+        let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+        let alerts =
+            activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory);
+
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.alert_kind == IntegrationActivationSentinelAlertKind::Blocker));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.alert_kind == IntegrationActivationSentinelAlertKind::Dependency));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.alert_kind == IntegrationActivationSentinelAlertKind::PolicyRisk));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.alert_kind == IntegrationActivationSentinelAlertKind::Review));
+        assert!(alerts
+            .iter()
+            .any(|alert| alert.alert_kind == IntegrationActivationSentinelAlertKind::Ready));
+        assert!(alerts.iter().all(|alert| alert.sequence > 0));
+        assert!(alerts
+            .iter()
+            .any(IntegrationActivationSentinelAlert::has_gaps));
+        assert!(alerts
+            .iter()
+            .any(IntegrationActivationSentinelAlert::has_policy_risk));
+
+        let summary = IntegrationActivationSentinelSummary::from_alerts(alerts.iter());
+        assert_eq!(summary.total_alerts, alerts.len());
+        assert_eq!(summary.unique_integrations, 4);
+        assert_eq!(summary.blocker_alerts, 1);
+        assert_eq!(summary.dependency_alerts, 1);
+        assert_eq!(summary.policy_risk_alerts, 1);
+        assert_eq!(summary.review_alerts, 1);
+        assert_eq!(summary.ready_alerts, 1);
+        assert_eq!(summary.total_watchtower_signals, signals.len());
+        assert_eq!(summary.total_risks, risks.len());
+        assert_eq!(summary.total_unique_gaps, gap_inventory.total_unique_gaps());
+        assert!(summary.requires_attention());
+        assert!(summary.has_blockers());
+        assert!(summary.has_dependency_work());
+        assert!(summary.has_policy_risk());
+        assert!(summary.has_review_work());
+        assert!(summary.has_activation_work());
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_alerts = activation_sentinel_alerts_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_alerts
+            .iter()
+            .any(IntegrationActivationSentinelAlert::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add integration-catalog activation sentinel rollups that combine watchtower readiness gaps, dependency blockers, policy risk, and review/activation work
- expose smart_home.list_integration_activation_sentinel and smart_home.get_integration_activation_sentinel_summary through the core catalog and Chief D18D handlers
- document the new sentinel operator surface and update package changelogs

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools