### PR TITLE
Add smart-home activation audit tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -82,6 +82,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation sentinel alerts:
   `smart_home.list_integration_activation_sentinel` and
   `smart_home.get_integration_activation_sentinel_summary`.
+- Added D18D handlers for D23A activation audit trails:
+  `smart_home.list_integration_activation_audit` and
+  `smart_home.get_integration_activation_audit_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -62,6 +62,7 @@ Chief of Staff job/session/agent
   -> activation-command-center list and summary reads for operating-lane rollups
   -> activation-watchtower list and summary reads for escalation signal rollups
   -> activation-sentinel list and summary reads for compact alert rollups
+  -> activation-audit list and summary reads for source-linked audit trails
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -137,6 +138,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_watchtower_summary`
 - `smart_home.list_integration_activation_sentinel`
 - `smart_home.get_integration_activation_sentinel_summary`
+- `smart_home.list_integration_activation_audit`
+- `smart_home.get_integration_activation_audit_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -34,8 +34,8 @@ use smart_home_discovery::{
 };
 use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
-    activation_approval_packets_from_candidates, activation_briefing_items_from_readouts,
-    activation_candidates_at_or_before_priority,
+    activation_approval_packets_from_candidates, activation_audit_records_from_rollups,
+    activation_briefing_items_from_readouts, activation_candidates_at_or_before_priority,
     activation_command_center_sections_from_control_room_panels,
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
@@ -59,28 +59,29 @@ use smart_home_integration_catalog::{
     ImplementationStatus, IntegrationActivationAction, IntegrationActivationActionKind,
     IntegrationActivationActionSummary, IntegrationActivationAgendaStage,
     IntegrationActivationAgendaSummary, IntegrationActivationApprovalPacket,
-    IntegrationActivationApprovalSummary, IntegrationActivationBriefingItem,
-    IntegrationActivationBriefingItemKind, IntegrationActivationBriefingSummary,
-    IntegrationActivationCandidate, IntegrationActivationCandidateRecommendation,
-    IntegrationActivationCandidateSummary, IntegrationActivationCommandCenterSection,
-    IntegrationActivationCommandCenterSectionKind, IntegrationActivationCommandCenterSummary,
-    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
-    IntegrationActivationConstraintSummary, IntegrationActivationControlRoomPanel,
-    IntegrationActivationControlRoomSummary, IntegrationActivationDashboardCard,
-    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
-    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
-    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
-    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
-    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
-    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
-    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
-    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
-    IntegrationActivationForecastSummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
-    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
-    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationApprovalSummary, IntegrationActivationAuditRecord,
+    IntegrationActivationAuditRecordKind, IntegrationActivationAuditSummary,
+    IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
+    IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
+    IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
+    IntegrationActivationCommandCenterSection, IntegrationActivationCommandCenterSectionKind,
+    IntegrationActivationCommandCenterSummary, IntegrationActivationConstraint,
+    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
+    IntegrationActivationControlRoomPanel, IntegrationActivationControlRoomSummary,
+    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
+    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
+    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
+    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
+    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
+    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
+    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
+    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -290,6 +291,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_SENTINEL_TOOL_ID: &str =
     "smart_home.list_integration_activation_sentinel";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_sentinel_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID: &str =
+    "smart_home.list_integration_activation_audit";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_audit_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -640,6 +645,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID => {
                     let query = integration_activation_sentinel_query(&arguments)?;
                     Ok(get_integration_activation_sentinel_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID => {
+                    let query = integration_activation_audit_query(&arguments)?;
+                    Ok(list_integration_activation_audit_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_audit_query(&arguments)?;
+                    Ok(get_integration_activation_audit_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2119,6 +2134,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation sentinel summary",
             "Return compact D23A activation sentinel alert counts for blockers, dependencies, policy risk, review work, ready work, and observation lanes.",
             integration_activation_sentinel_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID,
+            "List smart-home integration activation audit records",
+            "List D23A activation audit records that connect sentinel alerts to watchtower signals, decisions, evidence, risks, dependency blockers, and readiness gaps.",
+            integration_activation_audit_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_audit", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_audit", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation audit summary",
+            "Return compact D23A activation audit counts by sentinel, watchtower, decision, evidence, risk, dependency, and readiness-gap source.",
+            integration_activation_audit_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4865,6 +4909,16 @@ struct IntegrationActivationSentinelQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationAuditQuery {
+    sentinel: IntegrationActivationSentinelQuery,
+    record_kind: Option<IntegrationActivationAuditRecordKind>,
+    requires_attention: Option<bool>,
+    has_dependency_link: Option<bool>,
+    has_policy_surface: Option<bool>,
+    audit_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5312,6 +5366,25 @@ fn integration_activation_sentinel_query(
         has_activation_work: optional_bool(arguments, "alert_has_activation_work")?
             .or(optional_bool(arguments, "has_activation_work")?),
         alert_limit: optional_u64(arguments, "alert_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_audit_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationAuditQuery, ToolCallError> {
+    let record_kind = optional_string(arguments, "audit_record")?
+        .or(optional_string(arguments, "record_kind")?)
+        .map(|label| parse_activation_audit_record_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationAuditQuery {
+        sentinel: integration_activation_sentinel_query(arguments)?,
+        record_kind,
+        requires_attention: optional_bool(arguments, "record_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_dependency_link: optional_bool(arguments, "has_dependency_link")?,
+        has_policy_surface: optional_bool(arguments, "has_policy_surface")?,
+        audit_limit: optional_u64(arguments, "audit_limit")?.map(|value| value as usize),
     })
 }
 
@@ -6101,6 +6174,63 @@ fn integration_activation_sentinel_alerts_for_query(
     }
 
     (alerts, catalog_count)
+}
+
+fn integration_activation_audit_records_for_query(
+    query: &IntegrationActivationAuditQuery,
+) -> (Vec<IntegrationActivationAuditRecord>, usize) {
+    let catalog = first_party_catalog();
+    let (alerts, catalog_count) = integration_activation_sentinel_alerts_for_query(&query.sentinel);
+    let (signals, _) =
+        integration_activation_watchtower_signals_for_query(&query.sentinel.watchtower);
+    let (risks, _) = integration_activation_risk_for_query(&query.sentinel.risk);
+    let (graph, _) = integration_activation_dependency_graph_for_query(&query.sentinel.dependency);
+    let (mut gap_inventory, _) =
+        integration_readiness_gap_inventory_for_query(&query.sentinel.gaps.readiness);
+    if let Some(limit) = query.sentinel.gaps.limit_per_kind {
+        gap_inventory.primitive_gaps.truncate(limit);
+        gap_inventory.capability_gaps.truncate(limit);
+        gap_inventory.dependency_gaps.truncate(limit);
+    }
+    let (candidates, _) =
+        integration_activation_candidates_for_query(&query.sentinel.risk.candidates);
+    let enabled_integrations = &query
+        .sentinel
+        .risk
+        .candidates
+        .readiness
+        .enabled_integrations;
+    let decisions =
+        activation_decisions_from_candidates(&catalog, candidates.iter(), enabled_integrations);
+    let evidence =
+        activation_evidence_from_candidates(&catalog, candidates.iter(), enabled_integrations);
+    let mut records = activation_audit_records_from_rollups(
+        &alerts,
+        &signals,
+        &decisions,
+        &evidence,
+        &risks,
+        &graph,
+        &gap_inventory,
+    );
+
+    if let Some(kind) = query.record_kind {
+        records.retain(|record| record.record_kind == kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention() == requires_attention);
+    }
+    if let Some(has_dependency_link) = query.has_dependency_link {
+        records.retain(|record| record.has_dependency_link() == has_dependency_link);
+    }
+    if let Some(has_policy_surface) = query.has_policy_surface {
+        records.retain(|record| record.has_policy_surface() == has_policy_surface);
+    }
+    if let Some(limit) = query.audit_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -8127,6 +8257,80 @@ fn get_integration_activation_sentinel_summary_output_handler_output(
             (
                 "total_unique_gaps",
                 integer(summary.total_unique_gaps as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_audit_output_handler_output(
+    query: IntegrationActivationAuditQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_audit_records_for_query(&query);
+    let summary = IntegrationActivationAuditSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_audit",
+            JsonValue::Array(records.iter().map(activation_audit_record_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_audit_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_audit")),
+            ("records", integer(count as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            (
+                "dependency_records",
+                integer(summary.dependency_records as i64),
+            ),
+            (
+                "readiness_gap_records",
+                integer(summary.readiness_gap_records as i64),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_audit_summary_output_handler_output(
+    query: IntegrationActivationAuditQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_audit_records_for_query(&query);
+    let summary = IntegrationActivationAuditSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_audit_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_audit_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            (
+                "dependency_records",
+                integer(summary.dependency_records as i64),
+            ),
+            (
+                "readiness_gap_records",
+                integer(summary.readiness_gap_records as i64),
             ),
         ]),
     )
@@ -15550,6 +15754,195 @@ fn integration_activation_sentinel_summary_json(
     ])
 }
 
+fn activation_audit_record_json(record: &IntegrationActivationAuditRecord) -> JsonValue {
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        ("record_kind", string(record.record_kind.as_str())),
+        ("record_id", string(&record.record_id)),
+        ("title", string(&record.title)),
+        ("summary", string(&record.summary)),
+        ("priority", integer(record.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                record
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(record.integration_count() as i64),
+        ),
+        (
+            "sentinel_alert_kind",
+            record
+                .sentinel_alert_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "watchtower_signal_kind",
+            record
+                .watchtower_signal_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "decision_status",
+            record
+                .decision_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "evidence_kind",
+            record
+                .evidence_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "evidence_status",
+            record
+                .evidence_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "risk_kind",
+            record
+                .risk_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependency_integration_id",
+            record
+                .dependency_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependent_integration_id",
+            record
+                .dependent_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "readiness_gap_kind",
+            record
+                .readiness_gap_kind
+                .as_ref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(record.required_tier)),
+        ),
+        (
+            "policy_surface",
+            record
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_link",
+            JsonValue::Bool(record.has_dependency_link()),
+        ),
+        (
+            "has_policy_surface",
+            JsonValue::Bool(record.has_policy_surface()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_audit_summary_json(
+    summary: &IntegrationActivationAuditSummary,
+) -> JsonValue {
+    object([
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("sentinel_records", integer(summary.sentinel_records as i64)),
+        (
+            "watchtower_records",
+            integer(summary.watchtower_records as i64),
+        ),
+        ("decision_records", integer(summary.decision_records as i64)),
+        ("evidence_records", integer(summary.evidence_records as i64)),
+        ("risk_records", integer(summary.risk_records as i64)),
+        (
+            "dependency_records",
+            integer(summary.dependency_records as i64),
+        ),
+        (
+            "readiness_gap_records",
+            integer(summary.readiness_gap_records as i64),
+        ),
+        (
+            "records_with_policy_surface",
+            integer(summary.records_with_policy_surface as i64),
+        ),
+        (
+            "records_with_dependency_link",
+            integer(summary.records_with_dependency_link as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_readiness_gap_priority",
+            summary
+                .first_readiness_gap_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(summary.has_dependency_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -18292,6 +18685,28 @@ fn parse_activation_sentinel_alert_kind(
     }
 }
 
+fn parse_activation_audit_record_kind(
+    label: &str,
+) -> Result<IntegrationActivationAuditRecordKind, ToolCallError> {
+    match label {
+        "sentinel" | "alert" | "alerts" => Ok(IntegrationActivationAuditRecordKind::Sentinel),
+        "watchtower" | "signal" | "signals" => Ok(IntegrationActivationAuditRecordKind::Watchtower),
+        "decision" | "decisions" | "approval" | "approvals" => {
+            Ok(IntegrationActivationAuditRecordKind::Decision)
+        }
+        "evidence" | "proof" | "support" => Ok(IntegrationActivationAuditRecordKind::Evidence),
+        "risk" | "risks" | "policy_risk" => Ok(IntegrationActivationAuditRecordKind::Risk),
+        "dependency" | "dependencies" | "dependency_blocker" => {
+            Ok(IntegrationActivationAuditRecordKind::Dependency)
+        }
+        "readiness_gap" | "gap" | "gaps" | "primitive_gap" | "capability_gap"
+        | "dependency_gap" => Ok(IntegrationActivationAuditRecordKind::ReadinessGap),
+        _ => Err(validation_error(format!(
+            "unknown activation audit record `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -19546,6 +19961,33 @@ fn integration_activation_sentinel_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_audit_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_sentinel_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("audit_record", JsonSchema::String));
+        properties.push(SchemaProperty::new("record_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "record_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_dependency_link",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_policy_surface",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("audit_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -19690,7 +20132,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 107);
+        assert_eq!(definitions.len(), 109);
         assert!(export.ok());
         assert!(export
             .tool_ids()
@@ -19979,9 +20421,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_SENTINEL_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            99
+            101
         );
         assert_eq!(
             export
@@ -20435,11 +20883,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(107))
+            Some(&integer(109))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(99))
+            Some(&integer(101))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -23719,6 +24167,128 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_audit_request = request(
+            "call-list-integration-activation-audit",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("record_requires_attention", JsonValue::Bool(true)),
+                ("audit_limit", integer(4)),
+            ]),
+            5_041,
+        );
+        let list_activation_audit_trace =
+            tool_runtime.invoke_with_events(&list_activation_audit_request);
+        assert!(list_activation_audit_trace.result.ok);
+        assert_eq!(
+            list_activation_audit_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_audit_output =
+            list_activation_audit_trace.result.output.as_ref().unwrap();
+        let activation_audit_count =
+            integer_value(field(list_activation_audit_output, "count").unwrap()).unwrap();
+        assert!((1..=4).contains(&activation_audit_count));
+        let activation_audit_summary = field(list_activation_audit_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_audit_summary, "total_records"),
+            Some(&integer(activation_audit_count))
+        );
+        assert!(
+            integer_value(field(activation_audit_summary, "records_requiring_attention").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_audit_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_audit_record = array_item(
+            field(list_activation_audit_output, "activation_audit").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_audit_record, "sequence").is_some());
+        assert!(field(activation_audit_record, "record_kind").is_some());
+        assert!(field(activation_audit_record, "record_id").is_some());
+        assert!(field(activation_audit_record, "integration_ids").is_some());
+        assert!(field(activation_audit_record, "required_tier").is_some());
+        assert_eq!(
+            field(activation_audit_record, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_audit_summary_request = request(
+            "call-integration-activation-audit-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("audit_record", string("readiness_gap")),
+                ("record_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_042,
+        );
+        let activation_audit_summary_trace =
+            tool_runtime.invoke_with_events(&activation_audit_summary_request);
+        assert!(activation_audit_summary_trace.result.ok);
+        assert_eq!(
+            activation_audit_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_audit_summary_output = activation_audit_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_audit_rollup = field(activation_audit_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_audit_rollup, "readiness_gap_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_audit_rollup, "has_dependency_work"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_audit_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -25522,6 +26092,11 @@ mod tests {
             activation_sentinel_summary_request,
             activation_sentinel_summary_trace,
         );
+        journal.record_trace(list_activation_audit_request, list_activation_audit_trace);
+        journal.record_trace(
+            activation_audit_summary_request,
+            activation_audit_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -25595,9 +26170,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 107);
-        assert_eq!(journal_summary.completed_count, 107);
-        assert_eq!(journal.audit_records().len(), 107);
+        assert_eq!(journal_summary.invocation_count, 109);
+        assert_eq!(journal_summary.completed_count, 109);
+        assert_eq!(journal.audit_records().len(), 109);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -108,6 +108,10 @@ All notable changes to this package will be documented in this file.
   for read-only blocker, dependency, policy-risk, review, ready, and
   observation alert rollups derived from activation watchtower, risk,
   dependency, and readiness-gap rollups.
+- `smart_home.list_integration_activation_audit` and
+  `smart_home.get_integration_activation_audit_summary` tool descriptors for
+  read-only activation audit trails that connect sentinel alerts to
+  watchtower, decision, evidence, risk, dependency, and readiness-gap sources.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -101,6 +101,9 @@ Current scope:
   ready, action, and observation signal rollups
 - D18D integration activation-sentinel descriptors for compact blocker,
   dependency, policy-risk, review, ready, and observation alert rollups
+- D18D integration activation-audit descriptors for read-only audit trails
+  connecting sentinel alerts to watchtower, decision, evidence, risk,
+  dependency, and readiness-gap sources
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1505,6 +1505,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationWatchtowerSummary,
     ListIntegrationActivationSentinel,
     GetIntegrationActivationSentinelSummary,
+    ListIntegrationActivationAudit,
+    GetIntegrationActivationAuditSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1726,6 +1728,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationSentinelSummary => {
                 read_tool("smart_home.get_integration_activation_sentinel_summary")
+            }
+            Self::ListIntegrationActivationAudit => {
+                read_tool("smart_home.list_integration_activation_audit")
+            }
+            Self::GetIntegrationActivationAuditSummary => {
+                read_tool("smart_home.get_integration_activation_audit_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2414,6 +2422,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationWatchtowerSummary,
         SmartHomeTool::ListIntegrationActivationSentinel,
         SmartHomeTool::GetIntegrationActivationSentinelSummary,
+        SmartHomeTool::ListIntegrationActivationAudit,
+        SmartHomeTool::GetIntegrationActivationAuditSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3256,7 +3266,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 107);
+        assert_eq!(catalog.len(), 109);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3691,6 +3701,14 @@ mod tests {
             == "smart_home.get_integration_activation_sentinel_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_audit"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_audit_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3698,15 +3716,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 107);
-        assert_eq!(summary.read_tools, 99);
+        assert_eq!(summary.total_tools, 109);
+        assert_eq!(summary.read_tools, 101);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 99);
+        assert_eq!(summary.read_only_tier_tools, 101);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 107);
+        assert_eq!(summary.total_required_capabilities, 109);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -91,6 +91,9 @@ All notable changes to this package will be documented in this file.
   `IntegrationActivationSentinelSummary` for combining watchtower, risk,
   dependency, and readiness-gap rollups into blocker, dependency, policy-risk,
   review, ready, and observation alert lanes.
+- `IntegrationActivationAuditRecord` and `IntegrationActivationAuditSummary`
+  for connecting sentinel alerts to watchtower signals, decisions, evidence,
+  policy risk, dependency blockers, and readiness gaps in one audit trail.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -86,6 +86,8 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation sentinel alerts that combine watchtower, risk, dependency, and
   readiness-gap rollups into blocker, dependency, policy-risk, review, ready,
   and observation lanes
+- activation audit records that connect sentinel alerts to watchtower signals,
+  decisions, evidence, policy risk, dependency blockers, and readiness gaps
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1244,6 +1244,31 @@ impl IntegrationActivationSentinelAlertKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationAuditRecordKind {
+    Sentinel,
+    Watchtower,
+    Decision,
+    Evidence,
+    Risk,
+    Dependency,
+    ReadinessGap,
+}
+
+impl IntegrationActivationAuditRecordKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sentinel => "sentinel",
+            Self::Watchtower => "watchtower",
+            Self::Decision => "decision",
+            Self::Evidence => "evidence",
+            Self::Risk => "risk",
+            Self::Dependency => "dependency",
+            Self::ReadinessGap => "readiness_gap",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationDecisionStatus {
     ReadyToApprove,
     BlockedOnPrerequisites,
@@ -2532,6 +2557,50 @@ pub struct IntegrationActivationSentinelSummary {
     pub first_policy_risk_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
     pub first_ready_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationAuditRecord {
+    pub sequence: usize,
+    pub record_kind: IntegrationActivationAuditRecordKind,
+    pub record_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub sentinel_alert_kind: Option<IntegrationActivationSentinelAlertKind>,
+    pub watchtower_signal_kind: Option<IntegrationActivationWatchtowerSignalKind>,
+    pub decision_status: Option<IntegrationActivationDecisionStatus>,
+    pub evidence_kind: Option<IntegrationActivationEvidenceKind>,
+    pub evidence_status: Option<IntegrationActivationEvidenceStatus>,
+    pub risk_kind: Option<IntegrationActivationRiskKind>,
+    pub dependency_integration_id: Option<IntegrationId>,
+    pub dependent_integration_id: Option<IntegrationId>,
+    pub readiness_gap_kind: Option<String>,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationAuditSummary {
+    pub total_records: usize,
+    pub unique_integrations: usize,
+    pub records_requiring_attention: usize,
+    pub sentinel_records: usize,
+    pub watchtower_records: usize,
+    pub decision_records: usize,
+    pub evidence_records: usize,
+    pub risk_records: usize,
+    pub dependency_records: usize,
+    pub readiness_gap_records: usize,
+    pub records_with_policy_surface: usize,
+    pub records_with_dependency_link: usize,
+    pub first_attention_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_readiness_gap_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -6046,6 +6115,369 @@ impl IntegrationActivationSentinelSummary {
 
     pub fn requires_attention(&self) -> bool {
         self.alerts_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationAuditRecord {
+    fn new(
+        record_kind: IntegrationActivationAuditRecordKind,
+        record_id: String,
+        title: String,
+        summary: String,
+        priority: u8,
+        mut integration_ids: Vec<IntegrationId>,
+        required_tier: PrivilegeTier,
+        policy_surface: Option<IntegrationPolicySurface>,
+        requires_attention: bool,
+    ) -> Self {
+        integration_ids.sort();
+        integration_ids.dedup();
+
+        Self {
+            sequence: 0,
+            record_kind,
+            record_id,
+            title,
+            summary,
+            priority,
+            integration_ids,
+            sentinel_alert_kind: None,
+            watchtower_signal_kind: None,
+            decision_status: None,
+            evidence_kind: None,
+            evidence_status: None,
+            risk_kind: None,
+            dependency_integration_id: None,
+            dependent_integration_id: None,
+            readiness_gap_kind: None,
+            required_tier,
+            policy_surface,
+            requires_attention,
+        }
+    }
+
+    fn from_sentinel_alert(alert: &IntegrationActivationSentinelAlert) -> Self {
+        let required_tier = alert
+            .watchtower_summary
+            .highest_policy_tier
+            .max(alert.risk_summary.highest_policy_tier)
+            .max(alert.dependency_summary.highest_policy_tier);
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Sentinel,
+            format!("sentinel:{}", alert.alert_kind.as_str()),
+            format!("Activation sentinel {} alert", alert.alert_kind.as_str()),
+            format!(
+                "{} integrations, {} dependency edges, {} readiness gaps",
+                alert.integration_count(),
+                alert.dependency_summary.total_edges,
+                alert.gap_inventory.total_unique_gaps()
+            ),
+            alert.priority,
+            alert.integration_ids.clone(),
+            required_tier,
+            None,
+            alert.requires_attention(),
+        );
+        record.sentinel_alert_kind = Some(alert.alert_kind);
+        record
+    }
+
+    fn from_watchtower_signal(signal: &IntegrationActivationWatchtowerSignal) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Watchtower,
+            format!("watchtower:{}", signal.signal_kind.as_str()),
+            format!(
+                "Activation watchtower {} signal",
+                signal.signal_kind.as_str()
+            ),
+            format!(
+                "{} command-center sections across {} integrations",
+                signal.section_count,
+                signal.integration_count()
+            ),
+            signal.priority,
+            signal.integration_ids.clone(),
+            signal.command_center_summary.highest_policy_tier,
+            None,
+            signal.requires_attention(),
+        );
+        record.watchtower_signal_kind = Some(signal.signal_kind);
+        record
+    }
+
+    fn from_decision(decision: &IntegrationActivationDecisionItem) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Decision,
+            format!("decision:{}", decision.requested_integration_id().as_str()),
+            format!("Activation decision for {}", decision.display_name()),
+            format!(
+                "{} with {} actions and {} constraints",
+                decision.decision_status.as_str(),
+                decision.packet.action_summary.total_actions,
+                decision.packet.constraint_summary.total_constraints
+            ),
+            decision.priority(),
+            vec![decision.requested_integration_id().clone()],
+            decision.required_tier(),
+            decision.packet.review.policy_surfaces.first().copied(),
+            decision.requires_attention(),
+        );
+        record.decision_status = Some(decision.decision_status);
+        record
+    }
+
+    fn from_evidence(evidence: &IntegrationActivationEvidenceItem) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Evidence,
+            format!(
+                "evidence:{}:{}",
+                evidence.requested_integration_id.as_str(),
+                evidence.detail_id
+            ),
+            format!("Activation evidence for {}", evidence.display_name),
+            format!(
+                "{} evidence {}",
+                evidence.kind.as_str(),
+                evidence.status.as_str()
+            ),
+            evidence.priority,
+            vec![evidence.requested_integration_id.clone()],
+            evidence.required_tier,
+            evidence.policy_surface,
+            evidence.requires_attention(),
+        );
+        record.decision_status = Some(evidence.decision_status);
+        record.evidence_kind = Some(evidence.kind);
+        record.evidence_status = Some(evidence.status);
+        record.dependency_integration_id = evidence.dependency_integration_id.clone();
+        record
+    }
+
+    fn from_risk(risk: &IntegrationActivationRiskItem) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Risk,
+            format!("risk:{}", risk.risk_id),
+            risk.display_name.clone(),
+            format!(
+                "{} integrations require {} review",
+                risk.integration_count(),
+                privilege_tier_label_for_catalog(risk.required_tier)
+            ),
+            risk.highest_priority,
+            risk.integration_ids.clone(),
+            risk.required_tier,
+            risk.policy_surface,
+            risk.requires_attention(),
+        );
+        record.risk_kind = Some(risk.kind);
+        record
+    }
+
+    fn from_dependency_edge(edge: &IntegrationActivationDependencyEdge) -> Self {
+        let dependency_name = edge
+            .dependency_display_name
+            .as_deref()
+            .unwrap_or(edge.dependency_integration_id.as_str());
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::Dependency,
+            format!(
+                "dependency:{}:{}",
+                edge.dependency_integration_id.as_str(),
+                edge.dependent_integration_id.as_str()
+            ),
+            format!("Activation dependency for {}", edge.dependent_display_name),
+            format!(
+                "{} depends on {} ({})",
+                edge.dependent_display_name,
+                dependency_name,
+                if edge.satisfied {
+                    "satisfied"
+                } else {
+                    "blocked"
+                }
+            ),
+            edge.dependent_priority,
+            vec![
+                edge.dependency_integration_id.clone(),
+                edge.dependent_integration_id.clone(),
+            ],
+            PrivilegeTier::ReadOnly,
+            None,
+            edge.blocks_activation,
+        );
+        record.dependency_integration_id = Some(edge.dependency_integration_id.clone());
+        record.dependent_integration_id = Some(edge.dependent_integration_id.clone());
+        record
+    }
+
+    fn from_primitive_gap(gap: &IntegrationReadinessPrimitiveGap) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::ReadinessGap,
+            format!("readiness_gap:primitive:{}", gap.primitive.as_str()),
+            format!("Missing {} primitive", gap.primitive.as_str()),
+            format!(
+                "{} integrations are blocked by this primitive gap",
+                gap.blocked_report_count
+            ),
+            gap.highest_priority,
+            gap.integration_ids.clone(),
+            PrivilegeTier::ReadOnly,
+            None,
+            true,
+        );
+        record.readiness_gap_kind = Some("primitive".to_string());
+        record
+    }
+
+    fn from_capability_gap(gap: &IntegrationReadinessCapabilityGap) -> Self {
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::ReadinessGap,
+            format!("readiness_gap:capability:{}", gap.capability_id.as_str()),
+            format!("Missing {} capability", gap.capability_id.as_str()),
+            format!(
+                "{} integrations are blocked by this capability gap",
+                gap.blocked_report_count
+            ),
+            gap.highest_priority,
+            gap.integration_ids.clone(),
+            PrivilegeTier::ReadOnly,
+            None,
+            true,
+        );
+        record.readiness_gap_kind = Some("capability".to_string());
+        record
+    }
+
+    fn from_dependency_gap(gap: &IntegrationReadinessDependencyGap) -> Self {
+        let mut integration_ids = gap.requested_integration_ids.clone();
+        integration_ids.push(gap.integration_id.clone());
+        let mut record = Self::new(
+            IntegrationActivationAuditRecordKind::ReadinessGap,
+            format!("readiness_gap:dependency:{}", gap.integration_id.as_str()),
+            format!("Missing {} dependency", gap.integration_id.as_str()),
+            format!(
+                "{} integrations are blocked by this dependency gap",
+                gap.blocked_report_count
+            ),
+            gap.highest_priority,
+            integration_ids,
+            PrivilegeTier::ReadOnly,
+            None,
+            true,
+        );
+        record.dependency_integration_id = Some(gap.integration_id.clone());
+        record.readiness_gap_kind = Some("dependency".to_string());
+        record
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_link(&self) -> bool {
+        self.dependency_integration_id.is_some() || self.dependent_integration_id.is_some()
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationAuditSummary {
+    pub fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationAuditRecord>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            sentinel_records: 0,
+            watchtower_records: 0,
+            decision_records: 0,
+            evidence_records: 0,
+            risk_records: 0,
+            dependency_records: 0,
+            readiness_gap_records: 0,
+            records_with_policy_surface: 0,
+            records_with_dependency_link: 0,
+            first_attention_priority: None,
+            first_dependency_priority: None,
+            first_readiness_gap_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for record in records {
+            summary.total_records += 1;
+            for integration_id in &record.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            match record.record_kind {
+                IntegrationActivationAuditRecordKind::Sentinel => summary.sentinel_records += 1,
+                IntegrationActivationAuditRecordKind::Watchtower => summary.watchtower_records += 1,
+                IntegrationActivationAuditRecordKind::Decision => summary.decision_records += 1,
+                IntegrationActivationAuditRecordKind::Evidence => summary.evidence_records += 1,
+                IntegrationActivationAuditRecordKind::Risk => summary.risk_records += 1,
+                IntegrationActivationAuditRecordKind::Dependency => {
+                    summary.dependency_records += 1;
+                    if record.requires_attention() {
+                        summary.first_dependency_priority = min_optional_priority(
+                            summary.first_dependency_priority,
+                            Some(record.priority),
+                        );
+                    }
+                }
+                IntegrationActivationAuditRecordKind::ReadinessGap => {
+                    summary.readiness_gap_records += 1;
+                    summary.first_readiness_gap_priority = min_optional_priority(
+                        summary.first_readiness_gap_priority,
+                        Some(record.priority),
+                    );
+                }
+            }
+            if record.requires_attention() {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(record.priority));
+            }
+            if record.has_policy_surface() {
+                summary.records_with_policy_surface += 1;
+            }
+            if record.has_dependency_link() {
+                summary.records_with_dependency_link += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(record.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status =
+            if summary.readiness_gap_records > 0 || summary.first_dependency_priority.is_some() {
+                IntegrationActivationHealthStatus::Blocked
+            } else if summary.records_requiring_attention > 0 {
+                IntegrationActivationHealthStatus::NeedsReview
+            } else if summary.total_records > 0 {
+                IntegrationActivationHealthStatus::Ready
+            } else {
+                IntegrationActivationHealthStatus::Empty
+            };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_records == 0
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_records > 0 || self.readiness_gap_records > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0 || self.overall_status.requires_attention()
     }
 }
 
@@ -10708,6 +11140,113 @@ pub fn activation_sentinel_alerts_at_or_before_priority(
     activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory)
 }
 
+pub fn activation_audit_records_from_rollups(
+    alerts: &[IntegrationActivationSentinelAlert],
+    signals: &[IntegrationActivationWatchtowerSignal],
+    decisions: &[IntegrationActivationDecisionItem],
+    evidence: &[IntegrationActivationEvidenceItem],
+    risks: &[IntegrationActivationRiskItem],
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) -> Vec<IntegrationActivationAuditRecord> {
+    let mut records = Vec::new();
+    records.extend(
+        alerts
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_sentinel_alert),
+    );
+    records.extend(
+        signals
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_watchtower_signal),
+    );
+    records.extend(
+        decisions
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_decision),
+    );
+    records.extend(
+        evidence
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_evidence),
+    );
+    records.extend(
+        risks
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_risk),
+    );
+    records.extend(
+        graph
+            .edges
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_dependency_edge),
+    );
+    records.extend(
+        gap_inventory
+            .primitive_gaps
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_primitive_gap),
+    );
+    records.extend(
+        gap_inventory
+            .capability_gaps
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_capability_gap),
+    );
+    records.extend(
+        gap_inventory
+            .dependency_gaps
+            .iter()
+            .map(IntegrationActivationAuditRecord::from_dependency_gap),
+    );
+
+    records.sort_by(compare_activation_audit_records);
+    for (index, record) in records.iter_mut().enumerate() {
+        record.sequence = index + 1;
+    }
+    records
+}
+
+pub fn activation_audit_records_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationAuditRecord> {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let candidates = activation_candidates_from_reports(reports.iter());
+    let risks = activation_risk_from_candidates(catalog, candidates.iter());
+    let signals = activation_watchtower_signals_from_candidates(
+        catalog,
+        candidates.clone(),
+        enabled_integrations,
+    );
+    let graph =
+        activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations);
+    let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+    let alerts = activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory);
+    let decisions =
+        activation_decisions_from_candidates(catalog, candidates.iter(), enabled_integrations);
+    let evidence = activation_evidence_from_decisions(decisions.iter());
+
+    activation_audit_records_from_rollups(
+        &alerts,
+        &signals,
+        &decisions,
+        &evidence,
+        &risks,
+        &graph,
+        &gap_inventory,
+    )
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -12166,6 +12705,18 @@ fn compare_activation_sentinel_alerts(
         .then_with(|| right.has_review_work().cmp(&left.has_review_work()))
         .then_with(|| right.has_activation_work().cmp(&left.has_activation_work()))
         .then_with(|| left.alert_kind.cmp(&right.alert_kind))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_audit_records(
+    left: &IntegrationActivationAuditRecord,
+    right: &IntegrationActivationAuditRecord,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| left.record_kind.cmp(&right.record_kind))
+        .then_with(|| left.record_id.cmp(&right.record_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -15248,6 +15799,126 @@ mod tests {
         assert!(catalog_alerts
             .iter()
             .any(IntegrationActivationSentinelAlert::requires_attention));
+    }
+
+    #[test]
+    fn activation_audit_records_join_sentinel_attention_to_evidence() {
+        let reports = vec![
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+                display_name: "Review Ready Bridge".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 1,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HumanApproval,
+                local_only: true,
+                cloud_required: false,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+                display_name: "Blocked Review Camera".to_string(),
+                activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                    IntegrationId::trusted("mqtt"),
+                ),
+                priority: 2,
+                missing_primitives: vec![PrimitiveFamily::CameraMedia],
+                missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+                missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HighRisk,
+                local_only: false,
+                cloud_required: true,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("read_only_probe"),
+                display_name: "Read-only Probe".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 3,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: false,
+                highest_policy_tier: PrivilegeTier::ReadOnly,
+                local_only: true,
+                cloud_required: false,
+            },
+        ];
+        let candidates = activation_candidates_from_reports(reports.iter());
+        let risks = activation_risk_from_candidates(&[], candidates.iter());
+        let sections =
+            activation_command_center_sections_from_candidates(&[], candidates.clone(), &[]);
+        let signals = activation_watchtower_signals_from_command_center_sections(sections);
+        let graph = activation_dependency_graph_from_reports(&[], reports.iter(), &[]);
+        let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+        let alerts =
+            activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory);
+        let decisions = activation_decisions_from_candidates(&[], candidates.iter(), &[]);
+        let evidence = activation_evidence_from_decisions(decisions.iter());
+        let records = activation_audit_records_from_rollups(
+            &alerts,
+            &signals,
+            &decisions,
+            &evidence,
+            &risks,
+            &graph,
+            &gap_inventory,
+        );
+
+        assert!(records.iter().all(|record| record.sequence > 0));
+        assert!(records
+            .iter()
+            .any(|record| record.record_kind == IntegrationActivationAuditRecordKind::Sentinel));
+        assert!(records
+            .iter()
+            .any(|record| record.record_kind == IntegrationActivationAuditRecordKind::Evidence));
+        assert!(records
+            .iter()
+            .any(|record| record.record_kind == IntegrationActivationAuditRecordKind::Risk));
+        assert!(records
+            .iter()
+            .any(|record| record.record_kind == IntegrationActivationAuditRecordKind::Dependency));
+        assert!(records.iter().any(|record| {
+            record.record_kind == IntegrationActivationAuditRecordKind::ReadinessGap
+                && record.readiness_gap_kind.as_deref() == Some("primitive")
+        }));
+        assert!(records
+            .iter()
+            .any(IntegrationActivationAuditRecord::requires_attention));
+
+        let summary = IntegrationActivationAuditSummary::from_records(records.iter());
+        assert_eq!(summary.total_records, records.len());
+        assert!(summary.sentinel_records >= alerts.len());
+        assert!(summary.evidence_records >= evidence.len());
+        assert!(summary.records_requiring_attention > 0);
+        assert!(summary.has_dependency_work());
+        assert!(summary.requires_attention());
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_records = activation_audit_records_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_records
+            .iter()
+            .any(IntegrationActivationAuditRecord::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable activation audit records and summaries that connect sentinel alerts to watchtower, decision, evidence, risk, dependency, and readiness-gap sources
- expose read-only D18D activation audit list/summary tool descriptors and Chief handlers
- document the activation audit surface across the catalog, core, and Chief tool crates

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools