### PR TITLE
feat(lang-matrix): LM-C expression languages — Twig/Nib/Oct/ALGOL on real CoreCLR

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.16.0] — 2026-06-12 — integer arithmetic + comparison opcodes (LANG-MATRIX LM-C)
+
+The textual `.il` emitter (`il_text.rs`) grows two op families it previously rejected
+with `UnsupportedOp` — McCarthy only ever emitted a constant return, so arithmetic and
+comparison had never been needed until the LANG-MATRIX campaign ran the expression
+languages (Nib, Oct, ALGOL 60) on the real CLR:
+
+* **Binary integer arithmetic** `add` / `sub` / `mul` / `div` / `mod` → the CIL opcodes
+  `add` / `sub` / `mul` / `div` / `rem` (note `mod` → `rem`, signed remainder). Both
+  operands are loaded and the single opcode emitted; CoreCLR's `div`/`rem` raise on
+  divide-by-zero, matching the other backends' trap behaviour.
+* **Integer comparisons** `cmp_eq` / `cmp_ne` / `cmp_lt` / `cmp_le` / `cmp_gt` / `cmp_ge`
+  → a `0`/`1` `int32`. CIL has only `ceq` / `clt` / `cgt`; the other three relations are
+  the logical negation of one (`<primitive>; ldc.i4.0; ceq`). The result feeds either a
+  `st<dest>` or directly a `brfalse`/`brtrue`.
+
+Verified by RUNNING on real `ilasm` + `dotnet` (via `lang-aot`'s `lang_matrix` CLR
+column): Nib `double(21)`→42, Oct `if x == 1`→0, ALGOL `17 mod 5`→2. New unit tests
+assert the emitted opcodes for every arithmetic + comparison op. No change to existing
+behaviour (49 + 86 prior tests still green).
+
 ## [0.15.0] — 2026-06-11 — textual `.il`: lambda / LABEL / recursion (CLR-real C5)
 
 `emit_il` becomes a **multi-function** emitter — the last McCarthy F-feature:

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -124,6 +124,12 @@ the program artifact whenever any `alloc_closure` instruction appears.
 | Register | `load_reg`, `store_reg` |
 | Coercion | `type_assert` (becomes `nop`) |
 
+As of 0.16.0 the **textual `.il`** emitter (`emit_il`, the `ilasm`/`dotnet` path) also
+covers the integer **arithmetic** (`add`/`sub`/`mul`/`div`/`mod` → `add`/`sub`/`mul`/`div`/`rem`)
+and **comparison** (`cmp_*` → `ceq`/`clt`/`cgt`, negating the other three with `ldc.i4.0; ceq`)
+rows above — previously only the binary codegen path emitted them, which is why running
+the LANG-MATRIX expression languages (Nib/Oct/ALGOL) on the real CLR first surfaced the gap.
+
 ## How CIL synthesis works for derived operations
 
 CIL lacks native opcodes for some logical operations, so we synthesize them

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -619,6 +619,95 @@ fn emit_method(
                     }
                 }
             }
+            // ── Binary integer arithmetic ─────────────────────────────────────
+            //
+            // `dest = <op>(a, b)` with both operands scalar `int32` — the scalar
+            // concretization pass has already lowered every scalar value to i32, so
+            // we load both and emit the single CIL arithmetic opcode.
+            //
+            // | IIR op | CIL  | note                          |
+            // |--------|------|-------------------------------|
+            // | add    | add  | integer addition              |
+            // | sub    | sub  | integer subtraction           |
+            // | mul    | mul  | integer multiplication        |
+            // | div    | div  | signed integer division       |
+            // | mod    | rem  | signed remainder (CIL `rem`)  |
+            //
+            // (CoreCLR's `div`/`rem` raise on divide-by-zero, matching the other
+            // backends' trap-on-zero behaviour — no guard needed here.)
+            "add" | "sub" | "mul" | "div" | "mod" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: format!("{} must have a dest", instr.op),
+                })?;
+                let a = var_src(f, instr, 0, instr.op.as_str())?;
+                let b = var_src(f, instr, 1, instr.op.as_str())?;
+                load_var(il, &regs, a)?;
+                load_var(il, &regs, b)?;
+                let cil = match instr.op.as_str() {
+                    "add" => "add",
+                    "sub" => "sub",
+                    "mul" => "mul",
+                    "div" => "div",
+                    "mod" => "rem",
+                    _ => unreachable!(),
+                };
+                let _ = writeln!(il, "    {cil}");
+                store_var(il, &regs, dest)?;
+            }
+            // ── Integer comparisons → a 0/1 `int32` result ────────────────────
+            //
+            // CIL only has `ceq` / `clt` / `cgt`; the other three relations are the
+            // logical negation of one of those — negate a boolean by `ldc.i4.0; ceq`
+            // (i.e. "== 0"). The 0/1 result feeds either a `st<dest>` or directly a
+            // `brfalse`/`brtrue` (Oct's `if x == 1` does exactly this).
+            //
+            // | IIR op | CIL                | meaning              |
+            // |--------|--------------------|----------------------|
+            // | cmp_eq | ceq                | a == b               |
+            // | cmp_ne | ceq; ldc.i4.0; ceq | !(a == b)            |
+            // | cmp_lt | clt                | a <  b               |
+            // | cmp_gt | cgt                | a >  b               |
+            // | cmp_le | cgt; ldc.i4.0; ceq | !(a >  b)  ⇔  a ≤ b  |
+            // | cmp_ge | clt; ldc.i4.0; ceq | !(a <  b)  ⇔  a ≥ b  |
+            "cmp_eq" | "cmp_ne" | "cmp_lt" | "cmp_le" | "cmp_gt" | "cmp_ge" => {
+                let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
+                    function: f.name.clone(),
+                    detail: format!("{} must have a dest", instr.op),
+                })?;
+                let a = var_src(f, instr, 0, instr.op.as_str())?;
+                let b = var_src(f, instr, 1, instr.op.as_str())?;
+                load_var(il, &regs, a)?;
+                load_var(il, &regs, b)?;
+                match instr.op.as_str() {
+                    "cmp_eq" => {
+                        let _ = writeln!(il, "    ceq");
+                    }
+                    "cmp_lt" => {
+                        let _ = writeln!(il, "    clt");
+                    }
+                    "cmp_gt" => {
+                        let _ = writeln!(il, "    cgt");
+                    }
+                    "cmp_ne" => {
+                        let _ = writeln!(il, "    ceq");
+                        let _ = writeln!(il, "    ldc.i4.0");
+                        let _ = writeln!(il, "    ceq");
+                    }
+                    "cmp_le" => {
+                        let _ = writeln!(il, "    cgt");
+                        let _ = writeln!(il, "    ldc.i4.0");
+                        let _ = writeln!(il, "    ceq");
+                    }
+                    "cmp_ge" => {
+                        let _ = writeln!(il, "    clt");
+                        let _ = writeln!(il, "    ldc.i4.0");
+                        let _ = writeln!(il, "    ceq");
+                    }
+                    _ => unreachable!(),
+                }
+                store_var(il, &regs, dest)?;
+            }
             other => {
                 return Err(IIRClrError::UnsupportedOp {
                     function: f.name.clone(),
@@ -655,6 +744,60 @@ mod tests {
         assert!(il.contains("int32 MccarthyEntry()"), "entry method returns int32");
         assert!(il.contains("ldc.i4 42"), "loads the literal 42; got:\n{il}");
         assert!(il.contains("System.Console]System.Console::WriteLine(int32)"));
+    }
+
+    /// Build a one-function module `c = <op>(a, b); ret c` over two `i32` constants.
+    fn binop_module(op: &str) -> IIRModule {
+        let instrs = vec![
+            IIRInstr::new("const", Some("a".into()), vec![Operand::Int(17)], "i32"),
+            IIRInstr::new("const", Some("b".into()), vec![Operand::Int(5)], "i32"),
+            IIRInstr::new(
+                op,
+                Some("c".into()),
+                vec![Operand::Var("a".into()), Operand::Var("b".into())],
+                "i32",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "test");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    #[test]
+    fn binary_arithmetic_emits_cil_opcodes() {
+        // Each IIR arithmetic op lowers to a single CIL opcode (note `mod` → `rem`).
+        for (op, cil) in
+            [("add", "add"), ("sub", "sub"), ("mul", "mul"), ("div", "div"), ("mod", "rem")]
+        {
+            let il = emit_il(&binop_module(op), &IIRClrConfig::new("Main")).unwrap();
+            assert!(
+                il.lines().any(|l| l.trim() == cil),
+                "op {op:?} must emit a bare `{cil}` instruction; got:\n{il}"
+            );
+        }
+    }
+
+    #[test]
+    fn comparisons_emit_cil_opcodes() {
+        // The three primitive relations are single opcodes.
+        for (op, cil) in [("cmp_eq", "ceq"), ("cmp_lt", "clt"), ("cmp_gt", "cgt")] {
+            let il = emit_il(&binop_module(op), &IIRClrConfig::new("Main")).unwrap();
+            assert!(
+                il.lines().any(|l| l.trim() == cil),
+                "op {op:?} must emit a bare `{cil}` instruction; got:\n{il}"
+            );
+        }
+        // The negated relations build on a primitive then `ldc.i4.0; ceq` (i.e. "== 0").
+        for (op, base) in [("cmp_ne", "ceq"), ("cmp_le", "cgt"), ("cmp_ge", "clt")] {
+            let il = emit_il(&binop_module(op), &IIRClrConfig::new("Main")).unwrap();
+            assert!(il.lines().any(|l| l.trim() == base), "op {op:?} builds on `{base}`; got:\n{il}");
+            assert!(
+                il.contains("ldc.i4.0"),
+                "negated relation {op:?} pushes 0 to invert; got:\n{il}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — `lang-aot`
 
+## 0.63.0 — 2026-06-12 — Expression languages join the CLR column (LANG-MATRIX LM-C)
+
+`lang_matrix.rs` opens the **CLR** column on the **real CoreCLR** for the four
+expression languages — Twig / Nib / Oct / ALGOL 60. New `Backend::Clr` runner: source →
+textual `.il` (`compile_source_to_cil_text`) → real `ilasm` (`-exe`) → real `dotnet` →
+parse the integer the entry `Console.WriteLine`s (the CLR-real path of the McCarthy
+chapter, generalized). Gated on `dotnet` + a locatable `ilasm` (reuses
+`clr_support::find_ilasm`'s NuGet-cache walk); skips gracefully when absent.
+
+Two gaps surfaced **by running** on real `ilasm`/`dotnet`:
+* **CIL backend missing arithmetic + comparisons.** `iir-to-cil-bytecode` rejected
+  `add` (Nib), `cmp_eq` (Oct) and `mod` (ALGOL) — McCarthy only ever emitted a constant.
+  Grown in `iir-to-cil-bytecode` 0.16.0 (CIL `add`/`sub`/`mul`/`div`/`rem` + `ceq`/`clt`/`cgt`).
+* **`concretize_scalar_any_for_cil` parameter bug** (the CLR twin of the JVM fix): the
+  pass retyped a scalar function's return + body to `i32` but left its **parameters**
+  `i64`, so Nib's `double(x)` emitted the inconsistent CIL signature `int32(int64)` that
+  CoreCLR's verifier rejects. The pass now concretizes parameter types too.
+
+Verified by RUNNING on CoreCLR (dotnet 9.0.x): Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2.
+**25 proven matrix cells** (was 21); the `conformance`, `jvm_emit`, `wasm_emit`,
+`iir-to-cil-bytecode` suites all still green. CLR column now green for the expression
+languages; BASIC pends a `Console`-writing `print_i64`, Brainfuck the tape ops.
+
 ## 0.62.0 — 2026-06-12 — Dartmouth BASIC completes the JVM column (LANG-MATRIX LM-J BASIC)
 
 `lang_matrix.rs` greens **Dartmouth BASIC on real `java`**, completing the JVM column

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -134,8 +134,11 @@ Brainfuck (tape ops) is the only WASM follow-up. The **JVM** column runs on **re
 `java`** (the W16 wrapper-launcher pattern) and is green for Twig / Nib / Oct / ALGOL 60
 (exit code) and Dartmouth BASIC (stdout — `run_jvm` compiles an `env.BasicRuntime` host
 class with `javac` and discards the entry result); Brainfuck (tape ops) is the only JVM
-follow-up. The CLR column follows per the matrix spec; the VM/JIT columns are
-McCarthy-specialized and need op-coverage work.
+follow-up. The **CLR** column runs on the **real CoreCLR** (textual `.il` → `ilasm` →
+`dotnet`, the CLR-real path) and is green for the expression languages Twig / Nib / Oct /
+ALGOL 60 (this needed `iir-to-cil-bytecode` to grow integer arithmetic + comparison
+opcodes); BASIC (a `Console`-writing `print_i64`) and Brainfuck (tape ops) are its
+follow-ups. The VM/JIT columns are McCarthy-specialized and need op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -697,6 +697,19 @@ fn concretize_scalar_any_for_cil(module: &mut IIRModule) {
         if to_i32(&func.return_type) {
             func.return_type = "i32".to_string();
         }
+        // Concretize the **parameters** too — the same fix the JVM path needed.
+        // A scalar helper such as Nib's `double(x: u8)` widens its parameter to
+        // `i64`; if the body is retyped to `i32` but the parameter is left `i64`,
+        // the emitted CIL method signature is the inconsistent `int32(int64)` and
+        // its body does `int32` arithmetic on an `int64` argument — CoreCLR's
+        // verifier rejects the mismatch. The lisp/`any`-param functions were
+        // already skipped by the `uses_lisp` guard, so every parameter reaching
+        // here is a concrete scalar — safe to bring down to `i32`.
+        for (_, ty) in &mut func.params {
+            if to_i32(ty) {
+                *ty = "i32".to_string();
+            }
+        }
         for instr in &mut func.instructions {
             if to_i32(&instr.type_hint) {
                 instr.type_hint = "i32".to_string();

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -28,10 +28,16 @@
 //!   while `env.BasicRuntime` — compiled with `javac` onto the classpath — handles the
 //!   output (Dartmouth BASIC, whose `print_i64` lowers to `env/BasicRuntime.println`).
 //!   Green for all five non-Brainfuck languages; Brainfuck pends the tape ops.
+//! * **CLR** (Phase C) — source → textual `.il` (`iir-to-cil-bytecode`) → real `ilasm`
+//!   → real `dotnet`, the CLR-real path. The entry `Console.WriteLine`s its `int`
+//!   result, which the harness parses. Green for the expression languages Twig / Nib /
+//!   Oct / ALGOL 60 (this needed the CIL backend to grow integer arithmetic + the
+//!   comparison opcodes — McCarthy only ever emitted a constant). Dartmouth BASIC pends
+//!   a `Console`-writing `print_i64`; Brainfuck the tape ops.
 //!
-//! Later slices add the CLR column (also a general code generator) and the
-//! Deferred items — Brainfuck-on-LLVM/WASM, and the McCarthy-specialized VM and JIT
-//! (op-coverage work). See `code/specs/LANG-PLATFORM-MATRIX.md`.
+//! The remaining work is the Deferred items — Brainfuck-on-LLVM/WASM/JVM/CLR, and the
+//! McCarthy-specialized VM and JIT (op-coverage work). See
+//! `code/specs/LANG-PLATFORM-MATRIX.md`.
 //!
 //! ## Two result kinds
 //!
@@ -59,6 +65,10 @@ enum Backend {
     /// The W16 wrapper-launcher pattern: a `main([Ljava/lang/String;)V` launcher is
     /// injected to invoke the entry method and `System.out.println` its `int` result.
     Jvm,
+    /// Source → textual `.il` (`iir-to-cil-bytecode`) → real `ilasm` → real `dotnet`
+    /// (Phase C, the CLR-real path). The emitted entry `Console.WriteLine`s its `int`
+    /// result, which the harness parses (mirrors the McCarthy CLR-real chapter).
+    Clr,
 }
 
 /// The known, backend-independent observable result of a conformance program.
@@ -79,14 +89,21 @@ struct Prog {
     backends: &'static [Backend],
 }
 
-use Backend::{Jvm, Llvm, NativeAot, Wasm};
+use Backend::{Clr, Jvm, Llvm, NativeAot, Wasm};
+
+/// The real-CoreCLR helpers (`find_ilasm`, the NuGet-cache assembler search) are
+/// shared with the McCarthy CLR-real chapter; `#[path]`-include the module so we
+/// reuse `find_ilasm` rather than duplicating the cache walk. Only `find_ilasm` is
+/// called from here (the module's own runner is McCarthy-specific dead code).
+#[path = "clr_support/mod.rs"]
+mod clr_support;
 
 /// The cross-language battery. Each program is deliberately tiny but exercises real
 /// computation (arithmetic, calls, comparisons, loops, I/O) — not just constants —
 /// so a backend that merely emits a literal would not pass.
 const PROGRAMS: &[Prog] = &[
     // Twig — the original AOT language; a bare expression is the whole program.
-    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm, Jvm] },
+    Prog { lang: Language::Twig, ext: "twig", src: "42", expect: Expect::Exit(42), backends: &[NativeAot, Llvm, Wasm, Jvm, Clr] },
     // Nib — typed functions: define `double`, call it, return the result. Greened on
     // WASM in LM-W Nib by completing the i64 materialization: `nib_ty_str` and the
     // un-annotated-literal fallback now emit `i64` (not `u8`), so the const argument
@@ -96,7 +113,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "nib",
         src: "fn double(x: u8) -> u8 { return x + x; } fn main() -> u8 { return double(21); }",
         expect: Expect::Exit(42),
-        backends: &[NativeAot, Llvm, Wasm, Jvm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
     // Oct — `let` + `if` + comparison; `main` is void so the process exits 0.
     Prog {
@@ -104,7 +121,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "oct",
         src: "fn main() { let x: u8 = 1; if x == 1 { let y: u8 = 2; } else { let z: u8 = 3; } }",
         expect: Expect::Exit(0),
-        backends: &[NativeAot, Llvm, Wasm, Jvm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
     // ALGOL 60 — a begin/end block with real integer arithmetic (`17 mod 5` = 2).
     Prog {
@@ -112,7 +129,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "alg",
         src: "begin integer result; result := 17 mod 5 end",
         expect: Expect::Exit(2),
-        backends: &[NativeAot, Llvm, Wasm, Jvm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
     // (LLVM column pending: `iir-to-llvm` lacks the tape ops `alloc_bytes`/`load_byte`/
@@ -592,6 +609,67 @@ fn run_jvm(p: &Prog) -> Option<(Option<i32>, String)> {
     }
 }
 
+/// Is `dotnet` present? Together with `find_ilasm` this gates the CLR column.
+fn dotnet_ok() -> bool {
+    Command::new("dotnet")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// CLR runner: source → textual `.il` (`iir-to-cil-bytecode`) → real `ilasm` → real
+/// `dotnet` — the CLR-real path of the McCarthy CLR chapter, generalized to any
+/// language. `compile_source_to_cil_text` emits a `Main` whose entry computes the
+/// program's value and `Console.WriteLine`s it, so (like the McCarthy runner) we
+/// assemble the `.il` to a real PE with `ilasm -exe`, run it on `dotnet`, and parse
+/// the printed integer. Gated on `dotnet` **and** a locatable `ilasm` (the assembler
+/// ships only in a NuGet runtime pack — `clr_support::find_ilasm` walks the cache);
+/// skips gracefully when either is absent.
+///
+/// Security/termination: the program is a fixed literal (no untrusted input); the
+/// `.il`, the assembled `Main.dll` and its `runtimeconfig.json` are written into a
+/// fresh `tempfile::tempdir()` (random, `0700`, auto-removed) whose guard outlives
+/// the run, so the executed assembly cannot be substituted in the assemble→run
+/// window (CWE-377/367); the class name is the constant `"Main"`, never from input;
+/// and each program terminates by construction.
+fn run_clr(p: &Prog) -> Option<(Option<i32>, String)> {
+    if !dotnet_ok() {
+        return None;
+    }
+    let ilasm = clr_support::find_ilasm()?;
+    let il = lang_aot::compile_source_to_cil_text(p.lang, p.src, "Main").ok()?;
+    let dir = tempfile::tempdir().ok()?;
+    let il_path = dir.path().join("Main.il");
+    std::fs::write(&il_path, &il).ok()?;
+    let dll = dir.path().join("Main.dll");
+    let asm = Command::new(&ilasm)
+        .arg("-dll=false")
+        .arg("-exe")
+        .arg(format!("-output={}", dll.display()))
+        .arg(&il_path)
+        .output()
+        .ok()?;
+    if !asm.status.success() || !dll.exists() {
+        return None;
+    }
+    // A `.runtimeconfig.json` is required to launch a framework-dependent assembly
+    // on `dotnet`; pin it to the same net9.0 runtime the McCarthy CLR-real tests use.
+    std::fs::write(
+        dir.path().join("Main.runtimeconfig.json"),
+        r#"{ "runtimeOptions": { "tfm": "net9.0", "framework": { "name": "Microsoft.NETCore.App", "version": "9.0.0" } } }"#,
+    )
+    .ok()?;
+    let out = Command::new("dotnet").arg(&dll).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // The entry `Console.WriteLine`d its `int` result; parse it as the program's
+    // value (matching the exit-code convention of the other columns).
+    let printed = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Some((printed.parse::<i32>().ok(), String::new()))
+}
+
 /// Dispatch a program to a backend runner. `None` = the backend's toolchain is
 /// unavailable on this host (skip, like the W16 external-tool backends).
 fn run(backend: Backend, p: &Prog) -> Option<(Option<i32>, String)> {
@@ -600,6 +678,7 @@ fn run(backend: Backend, p: &Prog) -> Option<(Option<i32>, String)> {
         Backend::Llvm => run_llvm(p),
         Backend::Wasm => run_wasm(p),
         Backend::Jvm => run_jvm(p),
+        Backend::Clr => run_clr(p),
     }
 }
 
@@ -678,6 +757,16 @@ fn proven_columns_do_not_silently_skip() {
             assert!(
                 run_jvm(p).is_some(),
                 "java present but JVM failed to run {:?}",
+                p.lang
+            );
+        }
+    }
+    // CLR: when `dotnet` + `ilasm` are present every CLR-tagged program must run.
+    if dotnet_ok() && clr_support::find_ilasm().is_some() {
+        for p in PROGRAMS.iter().filter(|p| p.backends.contains(&Clr)) {
+            assert!(
+                run_clr(p).is_some(),
+                "dotnet+ilasm present but CLR failed to run {:?}",
                 p.lang
             );
         }

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -101,12 +101,12 @@ achievable code-gen columns land first).
 
 | Language        | VM | JIT | native-AOT | LLVM | WASM | JVM | CLR |
 |-----------------|----|-----|-----------|------|------|-----|-----|
-| Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ◑   |
-| Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
+| Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
+| Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ⏸  | ☐   |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
-| Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
-| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
+| Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
+| ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 
 **native-AOT is uniformly ✅ as of LM0** — all six languages compile to a host
 executable and run with the expected result (`lang-aot/tests/lang_matrix.rs`:
@@ -114,9 +114,7 @@ Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2, Brainfuck→stdout `A`, BASI
 The VM/JIT columns are op-coverage work (see above); the code-gen columns
 (LLVM/WASM/JVM/CLR) are conformance + I/O wiring.
 
-(`◑` = partial today: Twig is proven at *scalar* level on CLR; the slice promotes it
-to a full feature battery. The starting state is re-verified per slice — the loop
-trusts running, not this table.)
+(The starting state is re-verified per slice — the loop trusts running, not this table.)
 
 ## Worklist (one PR per item; slice further if large)
 
@@ -217,8 +215,23 @@ BASIC); only Brainfuck is deferred.
 
 ### Phase C — CLR for every language
 
-- ☐ **LM-C** — each language on `iir-to-cil-bytecode` (textual `.il` → real `ilasm` →
-  real `dotnet`, the CLR-real path) + the `clr-simulator` floor. I/O via `Console`.
+- ✅ **LM-C expression languages (Twig / Nib / Oct / ALGOL on real CoreCLR).** Added a
+  `Backend::Clr` runner to `lang_matrix.rs`: source → textual `.il`
+  (`compile_source_to_cil_text`) → real `ilasm -exe` → real `dotnet` → parse the integer
+  the entry `Console.WriteLine`s (the CLR-real path generalized from McCarthy; reuses
+  `clr_support::find_ilasm`). Gated on `dotnet` + `ilasm`. Two gaps fixed **by running**:
+  (1) `iir-to-cil-bytecode` (0.16.0) grew the integer **arithmetic** (`add`/`sub`/`mul`/
+  `div`/`mod`→`rem`) and **comparison** (`cmp_*`→`ceq`/`clt`/`cgt`) opcodes it had
+  `UnsupportedOp`'d — McCarthy only emitted a constant; (2) `concretize_scalar_any_for_cil`
+  now concretizes **parameter** types too (the CLR twin of the JVM `int32(int64)` verifier
+  fix). Verified by RUNNING on CoreCLR: Twig→42, Nib→42, Oct→0, ALGOL `17 mod 5`→2 (25
+  proven matrix cells); conformance/jvm_emit/wasm_emit/iir-to-cil-bytecode suites green.
+  (The `clr-simulator` floor is intentionally *not* used — its `cil_emit.rs` test is
+  broken on `main` from an API drift; the real-`dotnet` path is the stronger check.)
+- ☐ **LM-C BASIC (on CLR).** BASIC's `print_i64` needs a `Console`-writing lowering on
+  the CIL backend (the CLR analogue of wasm `env.__print_i64` / JVM `env.BasicRuntime`);
+  then capture/assert `Console` output.
+- ⏸ **LM-C Brainfuck (on CLR) — DEFERRED.** Same tape-op gap as Brainfuck elsewhere.
 
 ### Phase A — native AOT completeness
 


### PR DESCRIPTION
## LANG-PLATFORM-MATRIX · Phase C · LM-C (expression languages)

Opens the **CLR** column on the **real CoreCLR** for the four expression languages — Twig / Nib / Oct / ALGOL 60. With this, all four code-gen columns (LLVM / WASM / JVM / CLR) are green for every non-Brainfuck expression language.

### What & why
New `Backend::Clr` runner in `lang_matrix.rs` — the CLR-real path generalized from the McCarthy chapter:

```
source → compile_source_to_cil_text → textual .il → real `ilasm -exe`
       → real `dotnet` → parse the integer the entry Console.WriteLine's
```

Gated on `dotnet` + a locatable `ilasm` (reuses `clr_support::find_ilasm`'s NuGet runtime-pack cache walk via a `#[path]` include); skips gracefully when absent. Output written to a random-0700 `tempfile::tempdir()` held in scope until after the run.

### Two gaps surfaced BY RUNNING on real `ilasm`/`dotnet`
1. **CIL backend missing arithmetic + comparisons.** `iir-to-cil-bytecode` rejected `add` (Nib), `cmp_eq` (Oct) and `mod` (ALGOL) with `UnsupportedOp` — McCarthy only ever emitted a constant. **Grown** (iir-to-cil-bytecode 0.16.0): `add`/`sub`/`mul`/`div`/`mod` → CIL `add`/`sub`/`mul`/`div`/`rem`; `cmp_*` → `ceq`/`clt`/`cgt` (the other three relations negate via `ldc.i4.0; ceq`). New unit tests assert every emitted opcode.
2. **`concretize_scalar_any_for_cil` parameter bug** — the CLR twin of the JVM fix. The pass retyped a scalar function's return + body to `i32` but left its **parameters** `i64`, so Nib's `double(x)` emitted the inconsistent CIL signature `int32(int64)` that CoreCLR's verifier rejects. Now concretizes parameter types too. **Reusable fix, not a language-specific hack.**

### Verified by RUNNING (dotnet 9.0.x)
- Twig→42 · Nib→42 · Oct→0 · ALGOL `17 mod 5`→2 on the real CoreCLR.
- **25 proven matrix cells** (was 21); both `lang_matrix` tests pass.
- `iir-to-cil-bytecode` (49+86+4), `conformance` (1), `jvm_emit` (2), `wasm_emit` (18), lang-aot lib (12) all still green — no regression from the new ops or the concretize fix.
- Clippy clean on changed files. (Pre-existing/unrelated: the `iir-to-beam` min/max lint and the `cil_emit.rs` clr-simulator API drift on `main` — neither touched here. The CLR-simulator floor is intentionally **not** used; the real-`dotnet` path is the stronger check.)

### Matrix after this PR
| | native-AOT | LLVM | WASM | JVM | CLR |
|---|---|---|---|---|---|
| Twig / Nib / Oct / ALGOL 60 | ✅ | ✅ | ✅ | ✅ | ✅ ← this PR |
| Dartmouth BASIC | ✅ | ✅ | ✅ | ✅ | ☐ (Console print) |
| Brainfuck | ✅ | ⏸ | ⏸ | ⏸ | ⏸ (tape ops) |

### Changes
- `iir-to-cil-bytecode/src/il_text.rs` — arithmetic + comparison op arms + unit tests; 0.15.0 → 0.16.0 (CHANGELOG, README).
- `lang-aot/src/lib.rs` — `concretize_scalar_any_for_cil` concretizes parameter types.
- `lang-aot/tests/lang_matrix.rs` — `Backend::Clr` + `run_clr` (CLR-real path, reuses `find_ilasm`); `Clr` added to the four expression languages; CLR floor block.
- `LANG-PLATFORM-MATRIX.md` — CLR cells ✅; LM-C worklist item ✅; BASIC/Brainfuck CLR follow-ups noted.
- `lang-aot` CHANGELOG/README; 0.62.0 → 0.63.0.

### Security
Reviewed by a security sub-agent: **PASSED**. No `unsafe`, no untrusted input (programs are compile-time literals; emitted `.il` is in-repo compiler output), subprocess args vectored with no shell, hardcoded opcode strings (no CIL injection — operand names map to numeric slots, never verbatim), class name constant `"Main"`, output in a random-0700 `tempfile::tempdir()` held in scope (no assemble→exec TOCTOU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)