### PR TITLE
Add smart-home activation runbook tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -67,6 +67,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation playbook planning:
   `smart_home.list_integration_activation_playbook` and
   `smart_home.get_integration_activation_playbook_summary`.
+- Added D18D handlers for D23A activation runbook planning:
+  `smart_home.list_integration_activation_runbook` and
+  `smart_home.get_integration_activation_runbook_summary`.
 - Added D18D handlers for D23A activation operator queue planning:
   `smart_home.list_integration_activation_operator_queue` and
   `smart_home.get_integration_activation_operator_queue_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -57,6 +57,7 @@ Chief of Staff job/session/agent
   -> activation-timeline list and summary reads for ordered wave milestones
   -> activation-forecast list and summary reads for next-action wave planning
   -> activation-playbook list and summary reads for operator-ready planning steps
+  -> activation-runbook list and summary reads for audit-context-rich phases
   -> activation-operator queue list and summary reads for actionable work
   -> activation-control-room list and summary reads for grouped operator panels
   -> activation-command-center list and summary reads for operating-lane rollups
@@ -128,6 +129,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_forecast_summary`
 - `smart_home.list_integration_activation_playbook`
 - `smart_home.get_integration_activation_playbook_summary`
+- `smart_home.list_integration_activation_runbook`
+- `smart_home.get_integration_activation_runbook_summary`
 - `smart_home.list_integration_activation_operator_queue`
 - `smart_home.get_integration_activation_operator_queue_summary`
 - `smart_home.list_integration_activation_control_room`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -45,8 +45,9 @@ use smart_home_integration_catalog::{
     activation_operator_tasks_from_playbook_steps, activation_plan_for_entry,
     activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
     activation_readouts_from_candidates, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runway_from_candidates,
-    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
+    activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
+    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
+    activation_timeline_milestones_from_dashboard_cards,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog,
@@ -86,18 +87,20 @@ use smart_home_integration_catalog::{
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
     IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
-    IntegrationActivationRunwayStage, IntegrationActivationRunwaySummary,
-    IntegrationActivationSentinelAlert, IntegrationActivationSentinelAlertKind,
-    IntegrationActivationSentinelSummary, IntegrationActivationTarget,
-    IntegrationActivationTimelineMilestone, IntegrationActivationTimelineSummary,
-    IntegrationActivationWatchtowerSignal, IntegrationActivationWatchtowerSignalKind,
-    IntegrationActivationWatchtowerSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
-    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
-    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
-    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
-    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
-    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationActivationRunbookEntry, IntegrationActivationRunbookPhase,
+    IntegrationActivationRunbookSummary, IntegrationActivationRunwayStage,
+    IntegrationActivationRunwaySummary, IntegrationActivationSentinelAlert,
+    IntegrationActivationSentinelAlertKind, IntegrationActivationSentinelSummary,
+    IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
+    IntegrationActivationTimelineSummary, IntegrationActivationWatchtowerSignal,
+    IntegrationActivationWatchtowerSignalKind, IntegrationActivationWatchtowerSummary,
+    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
+    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
+    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
+    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
+    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
+    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
+    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -271,6 +274,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_PLAYBOOK_TOOL_ID: &str =
     "smart_home.list_integration_activation_playbook";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_playbook_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID: &str =
+    "smart_home.list_integration_activation_runbook";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_runbook_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
     "smart_home.list_integration_activation_operator_queue";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
@@ -591,6 +598,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID => {
                     let query = integration_activation_playbook_query(&arguments)?;
                     Ok(get_integration_activation_playbook_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID => {
+                    let query = integration_activation_runbook_query(&arguments)?;
+                    Ok(list_integration_activation_runbook_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_runbook_query(&arguments)?;
+                    Ok(get_integration_activation_runbook_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID => {
                     let query = integration_activation_operator_queue_query(&arguments)?;
@@ -1974,6 +1991,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation playbook summary",
             "Return compact D23A activation playbook counts for operator work, recommended planning views, blockers, review work, activation, and monitoring.",
             integration_activation_playbook_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID,
+            "List smart-home integration activation runbook",
+            "List Chief-ready D23A activation runbook entries that join playbook steps to audit, risk, dependency, and readiness-gap context.",
+            integration_activation_runbook_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_runbook", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_runbook", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation runbook summary",
+            "Return compact D23A activation runbook counts across phases, audit context, blockers, review work, activation, and monitoring.",
+            integration_activation_runbook_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4848,6 +4894,20 @@ struct IntegrationActivationPlaybookQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationRunbookQuery {
+    playbook: IntegrationActivationPlaybookQuery,
+    audit: IntegrationActivationAuditQuery,
+    phase: Option<IntegrationActivationRunbookPhase>,
+    requires_attention: Option<bool>,
+    has_audit_context: Option<bool>,
+    blocked: Option<bool>,
+    review_required: Option<bool>,
+    activation_ready: Option<bool>,
+    include_monitor: bool,
+    runbook_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationOperatorQueueQuery {
     playbook: IntegrationActivationPlaybookQuery,
     task_kind: Option<IntegrationActivationOperatorTaskKind>,
@@ -5246,6 +5306,33 @@ fn integration_activation_playbook_query(
         recommended_view,
         operator_required: optional_bool(arguments, "operator_required")?,
         playbook_limit: optional_u64(arguments, "playbook_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_runbook_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationRunbookQuery, ToolCallError> {
+    let phase = optional_string(arguments, "runbook_phase")?
+        .or(optional_string(arguments, "phase")?)
+        .map(|label| parse_activation_runbook_phase(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationRunbookQuery {
+        playbook: integration_activation_playbook_query(arguments)?,
+        audit: integration_activation_audit_query(arguments)?,
+        phase,
+        requires_attention: optional_bool(arguments, "runbook_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_audit_context: optional_bool(arguments, "runbook_has_audit_context")?
+            .or(optional_bool(arguments, "has_audit_context")?),
+        blocked: optional_bool(arguments, "runbook_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        review_required: optional_bool(arguments, "runbook_review_required")?
+            .or(optional_bool(arguments, "review_required")?),
+        activation_ready: optional_bool(arguments, "runbook_activation_ready")?
+            .or(optional_bool(arguments, "activation_ready")?),
+        include_monitor: optional_bool(arguments, "include_monitor")?.unwrap_or(false),
+        runbook_limit: optional_u64(arguments, "runbook_limit")?.map(|value| value as usize),
     })
 }
 
@@ -6011,6 +6098,41 @@ fn integration_activation_playbook_steps_for_query(
     }
 
     (steps, catalog_count)
+}
+
+fn integration_activation_runbook_entries_for_query(
+    query: &IntegrationActivationRunbookQuery,
+) -> (Vec<IntegrationActivationRunbookEntry>, usize) {
+    let (steps, catalog_count) = integration_activation_playbook_steps_for_query(&query.playbook);
+    let (audit_records, _) = integration_activation_audit_records_for_query(&query.audit);
+    let mut entries = activation_runbook_entries_from_playbook_steps(steps, &audit_records);
+
+    if !query.include_monitor {
+        entries.retain(|entry| !entry.monitor_only());
+    }
+    if let Some(phase) = query.phase {
+        entries.retain(|entry| entry.phase == phase);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        entries.retain(|entry| entry.requires_attention() == requires_attention);
+    }
+    if let Some(has_audit_context) = query.has_audit_context {
+        entries.retain(|entry| entry.has_audit_context() == has_audit_context);
+    }
+    if let Some(blocked) = query.blocked {
+        entries.retain(|entry| entry.blocked() == blocked);
+    }
+    if let Some(review_required) = query.review_required {
+        entries.retain(|entry| entry.review_required() == review_required);
+    }
+    if let Some(activation_ready) = query.activation_ready {
+        entries.retain(|entry| entry.activation_ready() == activation_ready);
+    }
+    if let Some(limit) = query.runbook_limit {
+        entries.truncate(limit);
+    }
+
+    (entries, catalog_count)
 }
 
 fn integration_activation_operator_tasks_for_query(
@@ -7858,6 +7980,93 @@ fn get_integration_activation_playbook_summary_output_handler_output(
                 summary
                     .next_recommended_view
                     .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_runbook_output_handler_output(
+    query: IntegrationActivationRunbookQuery,
+) -> ToolHandlerOutput {
+    let (entries, catalog_count) = integration_activation_runbook_entries_for_query(&query);
+    let summary = IntegrationActivationRunbookSummary::from_entries(entries.iter());
+    let count = entries.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_runbook",
+            JsonValue::Array(entries.iter().map(activation_runbook_entry_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_runbook_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_runbook")),
+            ("activation_runbook_entries", integer(count as i64)),
+            (
+                "operator_required_entries",
+                integer(summary.operator_required_entries as i64),
+            ),
+            (
+                "attention_audit_records",
+                integer(summary.attention_audit_records as i64),
+            ),
+            (
+                "next_phase",
+                summary
+                    .next_phase
+                    .map(|phase| string(phase.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+            (
+                "next_recommended_view",
+                summary
+                    .next_recommended_view
+                    .map(|view| string(view.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_runbook_summary_output_handler_output(
+    query: IntegrationActivationRunbookQuery,
+) -> ToolHandlerOutput {
+    let (entries, _) = integration_activation_runbook_entries_for_query(&query);
+    let summary = IntegrationActivationRunbookSummary::from_entries(entries.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_runbook_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_runbook_summary"),
+            ),
+            ("total_entries", integer(summary.total_entries as i64)),
+            (
+                "operator_required_entries",
+                integer(summary.operator_required_entries as i64),
+            ),
+            (
+                "attention_audit_records",
+                integer(summary.attention_audit_records as i64),
+            ),
+            (
+                "next_phase",
+                summary
+                    .next_phase
+                    .map(|phase| string(phase.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -14544,6 +14753,317 @@ fn integration_activation_playbook_summary_json(
     ])
 }
 
+fn activation_runbook_entry_json(entry: &IntegrationActivationRunbookEntry) -> JsonValue {
+    object([
+        ("sequence", integer(entry.sequence as i64)),
+        ("playbook_sequence", integer(entry.playbook_sequence as i64)),
+        ("priority", integer(entry.priority as i64)),
+        ("phase", string(entry.phase.as_str())),
+        ("playbook_action", string(entry.playbook_action.as_str())),
+        ("recommended_view", string(entry.recommended_view.as_str())),
+        (
+            "milestone_kind",
+            entry
+                .milestone_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("health_status", string(entry.health_status.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                entry
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(entry.integration_count() as i64),
+        ),
+        ("action_count", integer(entry.action_count as i64)),
+        ("dossier_count", integer(entry.dossier_count as i64)),
+        ("evidence_count", integer(entry.evidence_count as i64)),
+        ("risk_count", integer(entry.risk_count as i64)),
+        (
+            "dependency_edge_count",
+            integer(entry.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(entry.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "audit_record_count",
+            integer(entry.audit_record_count as i64),
+        ),
+        (
+            "attention_audit_record_count",
+            integer(entry.attention_audit_record_count as i64),
+        ),
+        (
+            "risk_audit_record_count",
+            integer(entry.risk_audit_record_count as i64),
+        ),
+        (
+            "dependency_audit_record_count",
+            integer(entry.dependency_audit_record_count as i64),
+        ),
+        (
+            "readiness_gap_record_count",
+            integer(entry.readiness_gap_record_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(entry.highest_policy_tier)),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(entry.operator_required()),
+        ),
+        (
+            "activation_ready",
+            JsonValue::Bool(entry.activation_ready()),
+        ),
+        ("blocked", JsonValue::Bool(entry.blocked())),
+        ("review_required", JsonValue::Bool(entry.review_required())),
+        ("monitor_only", JsonValue::Bool(entry.monitor_only())),
+        (
+            "has_audit_context",
+            JsonValue::Bool(entry.has_audit_context()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(entry.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_runbook_summary_json(
+    summary: &IntegrationActivationRunbookSummary,
+) -> JsonValue {
+    object([
+        ("total_entries", integer(summary.total_entries as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "operator_required_entries",
+            integer(summary.operator_required_entries as i64),
+        ),
+        (
+            "activation_ready_entries",
+            integer(summary.activation_ready_entries as i64),
+        ),
+        ("blocked_entries", integer(summary.blocked_entries as i64)),
+        (
+            "review_required_entries",
+            integer(summary.review_required_entries as i64),
+        ),
+        ("monitor_entries", integer(summary.monitor_entries as i64)),
+        (
+            "clear_blocker_entries",
+            integer(summary.clear_blocker_entries as i64),
+        ),
+        (
+            "dependency_entries",
+            integer(summary.dependency_entries as i64),
+        ),
+        ("approval_entries", integer(summary.approval_entries as i64)),
+        ("review_entries", integer(summary.review_entries as i64)),
+        ("risk_entries", integer(summary.risk_entries as i64)),
+        (
+            "activation_entries",
+            integer(summary.activation_entries as i64),
+        ),
+        (
+            "monitor_phase_entries",
+            integer(summary.monitor_phase_entries as i64),
+        ),
+        ("total_actions", integer(summary.total_actions as i64)),
+        ("total_dossiers", integer(summary.total_dossiers as i64)),
+        ("total_evidence", integer(summary.total_evidence as i64)),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "total_audit_records",
+            integer(summary.total_audit_records as i64),
+        ),
+        (
+            "attention_audit_records",
+            integer(summary.attention_audit_records as i64),
+        ),
+        (
+            "risk_audit_records",
+            integer(summary.risk_audit_records as i64),
+        ),
+        (
+            "dependency_audit_records",
+            integer(summary.dependency_audit_records as i64),
+        ),
+        (
+            "readiness_gap_records",
+            integer(summary.readiness_gap_records as i64),
+        ),
+        (
+            "next_phase",
+            summary
+                .next_phase
+                .map(|phase| string(phase.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_entry_sequence",
+            summary
+                .next_entry_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_entry_priority",
+            summary
+                .next_entry_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_sequence",
+            summary
+                .first_operator_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_sequence",
+            summary
+                .first_activation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_monitor_sequence",
+            summary
+                .first_monitor_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_priority",
+            summary
+                .first_operator_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_activation_priority",
+            summary
+                .first_activation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_monitor_priority",
+            summary
+                .first_monitor_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "has_operator_work",
+            JsonValue::Bool(summary.has_operator_work()),
+        ),
+        (
+            "has_activation_work",
+            JsonValue::Bool(summary.has_activation_work()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "has_audit_context",
+            JsonValue::Bool(summary.has_audit_context()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_operator_task_json(task: &IntegrationActivationOperatorTask) -> JsonValue {
     object([
         ("sequence", integer(task.sequence as i64)),
@@ -18576,6 +19096,40 @@ fn parse_activation_playbook_view(
     }
 }
 
+fn parse_activation_runbook_phase(
+    label: &str,
+) -> Result<IntegrationActivationRunbookPhase, ToolCallError> {
+    match label {
+        "clear_blockers" | "clear_blocker" | "resolve_blockers" | "blockers" | "blocker" => {
+            Ok(IntegrationActivationRunbookPhase::ClearBlockers)
+        }
+        "resolve_dependencies"
+        | "resolve_dependency"
+        | "enable_dependencies"
+        | "enable_dependency"
+        | "dependencies"
+        | "dependency" => Ok(IntegrationActivationRunbookPhase::ResolveDependencies),
+        "prepare_approvals" | "prepare_approval" | "approvals" | "approval"
+        | "ready_to_approve" => Ok(IntegrationActivationRunbookPhase::PrepareApprovals),
+        "complete_reviews" | "complete_review" | "queue_review" | "reviews" | "review"
+        | "human_review" | "policy_review" => {
+            Ok(IntegrationActivationRunbookPhase::CompleteReviews)
+        }
+        "review_risks" | "review_risk" | "risks" | "risk" => {
+            Ok(IntegrationActivationRunbookPhase::ReviewRisks)
+        }
+        "activate" | "activation" | "activate_wave" | "ready_to_activate" => {
+            Ok(IntegrationActivationRunbookPhase::Activate)
+        }
+        "monitor" | "monitor_wave" | "monitoring" | "watch" => {
+            Ok(IntegrationActivationRunbookPhase::Monitor)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation runbook phase `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_operator_task_kind(
     label: &str,
 ) -> Result<IntegrationActivationOperatorTaskKind, ToolCallError> {
@@ -19795,6 +20349,60 @@ fn integration_activation_playbook_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_runbook_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_playbook_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("runbook_phase", JsonSchema::String));
+        properties.push(SchemaProperty::new("phase", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "runbook_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "runbook_has_audit_context",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_audit_context",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("runbook_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "runbook_review_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("review_required", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "runbook_activation_ready",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("include_monitor", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("audit_record", JsonSchema::String));
+        properties.push(SchemaProperty::new("record_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "record_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_dependency_link",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "has_policy_surface",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("audit_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("runbook_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_operator_queue_query_schema() -> JsonSchema {
     let mut schema = integration_activation_playbook_query_schema();
     if let JsonSchema::Object {
@@ -20132,8 +20740,12 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 109);
-        assert!(export.ok());
+        assert_eq!(definitions.len(), 111);
+        assert!(
+            export.ok(),
+            "tool export validation failed: {:?}",
+            export.validation.errors
+        );
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATIONS_TOOL_ID));
@@ -20393,6 +21005,12 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_PLAYBOOK_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -20429,7 +21047,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            101
+            103
         );
         assert_eq!(
             export
@@ -20613,6 +21231,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_TIMELINE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -20883,11 +21509,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(109))
+            Some(&integer(111))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(101))
+            Some(&integer(103))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -23478,6 +24104,139 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_runbook_request = request(
+            "call-list-integration-activation-runbook",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("runbook_phase", string("clear_blockers")),
+                ("runbook_has_audit_context", JsonValue::Bool(true)),
+                ("runbook_limit", integer(3)),
+            ]),
+            5_031,
+        );
+        let list_activation_runbook_trace =
+            tool_runtime.invoke_with_events(&list_activation_runbook_request);
+        assert!(list_activation_runbook_trace.result.ok);
+        assert_eq!(
+            list_activation_runbook_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_runbook_output = list_activation_runbook_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_runbook_count =
+            integer_value(field(list_activation_runbook_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_runbook_count));
+        let activation_runbook_summary = field(list_activation_runbook_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_runbook_summary, "total_entries"),
+            Some(&integer(activation_runbook_count))
+        );
+        assert_eq!(
+            field(activation_runbook_summary, "next_phase"),
+            Some(&string("clear_blockers"))
+        );
+        assert_eq!(
+            field(activation_runbook_summary, "has_audit_context"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(
+            integer_value(field(activation_runbook_summary, "total_audit_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        let activation_runbook_entry = array_item(
+            field(list_activation_runbook_output, "activation_runbook").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_runbook_entry, "sequence").is_some());
+        assert!(field(activation_runbook_entry, "playbook_sequence").is_some());
+        assert_eq!(
+            field(activation_runbook_entry, "phase"),
+            Some(&string("clear_blockers"))
+        );
+        assert!(field(activation_runbook_entry, "audit_record_count").is_some());
+        assert_eq!(
+            field(activation_runbook_entry, "has_audit_context"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_runbook_summary_request = request(
+            "call-integration-activation-runbook-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("runbook_phase", string("clear_blockers")),
+                ("runbook_has_audit_context", JsonValue::Bool(true)),
+            ]),
+            5_032,
+        );
+        let activation_runbook_summary_trace =
+            tool_runtime.invoke_with_events(&activation_runbook_summary_request);
+        assert!(activation_runbook_summary_trace.result.ok);
+        assert_eq!(
+            activation_runbook_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_runbook_summary_output = activation_runbook_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_runbook_rollup =
+            field(activation_runbook_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_runbook_rollup, "clear_blocker_entries").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_runbook_rollup, "next_phase"),
+            Some(&string("clear_blockers"))
+        );
+        assert_eq!(
+            field(activation_runbook_rollup, "has_audit_context"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_operator_queue_request = request(
             "call-list-integration-activation-operator-queue",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
@@ -23504,7 +24263,7 @@ mod tests {
                 ("actionable", JsonValue::Bool(true)),
                 ("task_limit", integer(3)),
             ]),
-            5_031,
+            5_033,
         );
         let list_activation_operator_queue_trace =
             tool_runtime.invoke_with_events(&list_activation_operator_queue_request);
@@ -26053,6 +26812,14 @@ mod tests {
             activation_playbook_summary_trace,
         );
         journal.record_trace(
+            list_activation_runbook_request,
+            list_activation_runbook_trace,
+        );
+        journal.record_trace(
+            activation_runbook_summary_request,
+            activation_runbook_summary_trace,
+        );
+        journal.record_trace(
             list_activation_operator_queue_request,
             list_activation_operator_queue_trace,
         );
@@ -26170,9 +26937,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 109);
-        assert_eq!(journal_summary.completed_count, 109);
-        assert_eq!(journal.audit_records().len(), 109);
+        assert_eq!(journal_summary.invocation_count, 111);
+        assert_eq!(journal_summary.completed_count, 111);
+        assert_eq!(journal.audit_records().len(), 111);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -87,6 +87,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_playbook_summary` tool descriptors
   for read-only operator-ready planning steps derived from activation
   forecasts.
+- `smart_home.list_integration_activation_runbook` and
+  `smart_home.get_integration_activation_runbook_summary` tool descriptors for
+  read-only audit-context-rich operator phases derived from activation
+  playbook steps.
 - `smart_home.list_integration_activation_operator_queue` and
   `smart_home.get_integration_activation_operator_queue_summary` tool
   descriptors for read-only actionable human/operator work derived from

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -91,6 +91,8 @@ Current scope:
   classification derived from activation timeline milestones
 - D18D integration activation-playbook descriptors for operator-ready planning
   steps derived from forecast next actions
+- D18D integration activation-runbook descriptors for audit-context-rich
+  operator phases derived from activation playbook steps
 - D18D integration activation-operator queue descriptors for actionable
   human/operator work derived from playbook steps
 - D18D integration activation-control-room descriptors for grouped

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1495,6 +1495,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationForecastSummary,
     ListIntegrationActivationPlaybook,
     GetIntegrationActivationPlaybookSummary,
+    ListIntegrationActivationRunbook,
+    GetIntegrationActivationRunbookSummary,
     ListIntegrationActivationOperatorQueue,
     GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationControlRoom,
@@ -1698,6 +1700,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationPlaybookSummary => {
                 read_tool("smart_home.get_integration_activation_playbook_summary")
+            }
+            Self::ListIntegrationActivationRunbook => {
+                read_tool("smart_home.list_integration_activation_runbook")
+            }
+            Self::GetIntegrationActivationRunbookSummary => {
+                read_tool("smart_home.get_integration_activation_runbook_summary")
             }
             Self::ListIntegrationActivationOperatorQueue => {
                 read_tool("smart_home.list_integration_activation_operator_queue")
@@ -2412,6 +2420,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationForecastSummary,
         SmartHomeTool::ListIntegrationActivationPlaybook,
         SmartHomeTool::GetIntegrationActivationPlaybookSummary,
+        SmartHomeTool::ListIntegrationActivationRunbook,
+        SmartHomeTool::GetIntegrationActivationRunbookSummary,
         SmartHomeTool::ListIntegrationActivationOperatorQueue,
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationControlRoom,
@@ -3266,7 +3276,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 109);
+        assert_eq!(catalog.len(), 111);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3662,6 +3672,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_runbook"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_runbook_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_activation_operator_queue"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -3716,15 +3734,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 109);
-        assert_eq!(summary.read_tools, 101);
+        assert_eq!(summary.total_tools, 111);
+        assert_eq!(summary.read_tools, 103);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 101);
+        assert_eq!(summary.read_only_tier_tools, 103);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 109);
+        assert_eq!(summary.total_required_capabilities, 111);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -75,6 +75,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationPlaybookStep` and
   `IntegrationActivationPlaybookSummary` for pairing forecast next actions with
   recommended planning views and operator-readiness flags.
+- `IntegrationActivationRunbookEntry` and
+  `IntegrationActivationRunbookSummary` for joining playbook steps to audit,
+  risk, dependency, and readiness-gap context.
 - `IntegrationActivationOperatorTask` and
   `IntegrationActivationOperatorTaskSummary` for turning playbook steps into
   actionable human/operator queue rows.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -75,6 +75,8 @@ runtime and Chief of Staff tools a typed catalog for:
   activation, and monitoring
 - activation playbook steps that pair forecast next actions with recommended
   planning views and operator-readiness flags
+- activation runbook entries that join playbook steps to audit, risk,
+  dependency, and readiness-gap context
 - activation operator tasks that turn playbook steps into actionable
   human/operator queue rows
 - activation control-room panels that group operator tasks by recommended

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1114,6 +1114,43 @@ impl IntegrationActivationPlaybookView {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationRunbookPhase {
+    ClearBlockers,
+    ResolveDependencies,
+    PrepareApprovals,
+    CompleteReviews,
+    ReviewRisks,
+    Activate,
+    Monitor,
+}
+
+impl IntegrationActivationRunbookPhase {
+    pub fn from_playbook_action(action: IntegrationActivationForecastAction) -> Self {
+        match action {
+            IntegrationActivationForecastAction::ResolveBlockers => Self::ClearBlockers,
+            IntegrationActivationForecastAction::EnableDependencies => Self::ResolveDependencies,
+            IntegrationActivationForecastAction::PrepareApproval => Self::PrepareApprovals,
+            IntegrationActivationForecastAction::QueueReview => Self::CompleteReviews,
+            IntegrationActivationForecastAction::ReviewRisk => Self::ReviewRisks,
+            IntegrationActivationForecastAction::ActivateWave => Self::Activate,
+            IntegrationActivationForecastAction::MonitorWave => Self::Monitor,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ClearBlockers => "clear_blockers",
+            Self::ResolveDependencies => "resolve_dependencies",
+            Self::PrepareApprovals => "prepare_approvals",
+            Self::CompleteReviews => "complete_reviews",
+            Self::ReviewRisks => "review_risks",
+            Self::Activate => "activate",
+            Self::Monitor => "monitor",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationOperatorTaskKind {
     ResolveConstraints,
     EnableDependencies,
@@ -2286,6 +2323,86 @@ pub struct IntegrationActivationPlaybookSummary {
     pub first_blocked_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
     pub first_monitor_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRunbookEntry {
+    pub sequence: usize,
+    pub playbook_sequence: usize,
+    pub priority: u8,
+    pub phase: IntegrationActivationRunbookPhase,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub milestone_kind: Option<IntegrationActivationBriefingItemKind>,
+    pub health_status: IntegrationActivationHealthStatus,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub action_count: usize,
+    pub dossier_count: usize,
+    pub evidence_count: usize,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub audit_record_count: usize,
+    pub attention_audit_record_count: usize,
+    pub risk_audit_record_count: usize,
+    pub dependency_audit_record_count: usize,
+    pub readiness_gap_record_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_required: bool,
+    pub activation_ready: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub monitor_only: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRunbookSummary {
+    pub total_entries: usize,
+    pub unique_integrations: usize,
+    pub operator_required_entries: usize,
+    pub activation_ready_entries: usize,
+    pub blocked_entries: usize,
+    pub review_required_entries: usize,
+    pub monitor_entries: usize,
+    pub clear_blocker_entries: usize,
+    pub dependency_entries: usize,
+    pub approval_entries: usize,
+    pub review_entries: usize,
+    pub risk_entries: usize,
+    pub activation_entries: usize,
+    pub monitor_phase_entries: usize,
+    pub total_actions: usize,
+    pub total_dossiers: usize,
+    pub total_evidence: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_audit_records: usize,
+    pub attention_audit_records: usize,
+    pub risk_audit_records: usize,
+    pub dependency_audit_records: usize,
+    pub readiness_gap_records: usize,
+    pub next_phase: Option<IntegrationActivationRunbookPhase>,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_entry_sequence: Option<usize>,
+    pub next_entry_priority: Option<u8>,
+    pub first_operator_sequence: Option<usize>,
+    pub first_activation_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_monitor_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_operator_priority: Option<u8>,
+    pub first_activation_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_monitor_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -4828,6 +4945,322 @@ impl IntegrationActivationPlaybookSummary {
         self.has_operator_work()
             || self.has_blockers()
             || self.has_review_work()
+            || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationRunbookEntry {
+    fn from_playbook_step(
+        step: IntegrationActivationPlaybookStep,
+        audit_records: &[&IntegrationActivationAuditRecord],
+    ) -> Self {
+        let audit_record_count = audit_records.len();
+        let attention_audit_record_count = audit_records
+            .iter()
+            .filter(|record| record.requires_attention())
+            .count();
+        let risk_audit_record_count = audit_records
+            .iter()
+            .filter(|record| record.record_kind == IntegrationActivationAuditRecordKind::Risk)
+            .count();
+        let dependency_audit_record_count = audit_records
+            .iter()
+            .filter(|record| record.record_kind == IntegrationActivationAuditRecordKind::Dependency)
+            .count();
+        let readiness_gap_record_count = audit_records
+            .iter()
+            .filter(|record| {
+                record.record_kind == IntegrationActivationAuditRecordKind::ReadinessGap
+            })
+            .count();
+        let highest_policy_tier = audit_records
+            .iter()
+            .fold(step.highest_policy_tier, |tier, record| {
+                tier.max(record.required_tier)
+            });
+        let dependency_blocking = audit_records.iter().any(|record| {
+            record.record_kind == IntegrationActivationAuditRecordKind::Dependency
+                && record.requires_attention()
+        });
+        let blocked = step.blocked() || dependency_blocking || readiness_gap_record_count > 0;
+        let review_required = step.review_required()
+            || risk_audit_record_count > 0
+            || audit_records.iter().any(|record| {
+                matches!(
+                    record.record_kind,
+                    IntegrationActivationAuditRecordKind::Decision
+                        | IntegrationActivationAuditRecordKind::Evidence
+                ) && record.requires_attention()
+            });
+        let operator_required = step.operator_required()
+            || blocked
+            || review_required
+            || attention_audit_record_count > 0;
+        let requires_attention =
+            step.requires_attention() || operator_required || attention_audit_record_count > 0;
+        let activation_ready = step.activation_ready();
+        let monitor_only = step.monitor_only();
+
+        Self {
+            sequence: step.sequence,
+            playbook_sequence: step.sequence,
+            priority: step.priority,
+            phase: IntegrationActivationRunbookPhase::from_playbook_action(step.playbook_action),
+            playbook_action: step.playbook_action,
+            recommended_view: step.recommended_view,
+            milestone_kind: step.milestone_kind,
+            health_status: step.health_status,
+            integration_ids: step.integration_ids,
+            integration_count: step.integration_count,
+            action_count: step.action_count,
+            dossier_count: step.dossier_count,
+            evidence_count: step.evidence_count,
+            risk_count: step.risk_count,
+            dependency_edge_count: step.dependency_edge_count,
+            blocking_dependency_edge_count: step.blocking_dependency_edge_count,
+            audit_record_count,
+            attention_audit_record_count,
+            risk_audit_record_count,
+            dependency_audit_record_count,
+            readiness_gap_record_count,
+            highest_policy_tier,
+            operator_required,
+            activation_ready,
+            blocked,
+            review_required,
+            monitor_only,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.activation_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+
+    pub fn has_audit_context(&self) -> bool {
+        self.audit_record_count > 0
+    }
+}
+
+impl IntegrationActivationRunbookSummary {
+    pub fn from_entries<'a>(
+        entries: impl IntoIterator<Item = &'a IntegrationActivationRunbookEntry>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_entries: 0,
+            unique_integrations: 0,
+            operator_required_entries: 0,
+            activation_ready_entries: 0,
+            blocked_entries: 0,
+            review_required_entries: 0,
+            monitor_entries: 0,
+            clear_blocker_entries: 0,
+            dependency_entries: 0,
+            approval_entries: 0,
+            review_entries: 0,
+            risk_entries: 0,
+            activation_entries: 0,
+            monitor_phase_entries: 0,
+            total_actions: 0,
+            total_dossiers: 0,
+            total_evidence: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_audit_records: 0,
+            attention_audit_records: 0,
+            risk_audit_records: 0,
+            dependency_audit_records: 0,
+            readiness_gap_records: 0,
+            next_phase: None,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_entry_sequence: None,
+            next_entry_priority: None,
+            first_operator_sequence: None,
+            first_activation_sequence: None,
+            first_blocked_sequence: None,
+            first_review_sequence: None,
+            first_monitor_sequence: None,
+            first_attention_sequence: None,
+            first_operator_priority: None,
+            first_activation_priority: None,
+            first_blocked_priority: None,
+            first_review_priority: None,
+            first_monitor_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for entry in entries {
+            summary.total_entries += 1;
+            for integration_id in &entry.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            match entry.phase {
+                IntegrationActivationRunbookPhase::ClearBlockers => {
+                    summary.clear_blocker_entries += 1
+                }
+                IntegrationActivationRunbookPhase::ResolveDependencies => {
+                    summary.dependency_entries += 1
+                }
+                IntegrationActivationRunbookPhase::PrepareApprovals => {
+                    summary.approval_entries += 1
+                }
+                IntegrationActivationRunbookPhase::CompleteReviews => summary.review_entries += 1,
+                IntegrationActivationRunbookPhase::ReviewRisks => summary.risk_entries += 1,
+                IntegrationActivationRunbookPhase::Activate => summary.activation_entries += 1,
+                IntegrationActivationRunbookPhase::Monitor => summary.monitor_phase_entries += 1,
+            }
+
+            if summary.next_phase.is_none() && !entry.monitor_only() {
+                summary.next_phase = Some(entry.phase);
+                summary.next_playbook_action = Some(entry.playbook_action);
+                summary.next_recommended_view = Some(entry.recommended_view);
+                summary.next_entry_sequence = Some(entry.sequence);
+                summary.next_entry_priority = Some(entry.priority);
+            }
+
+            if entry.operator_required() {
+                summary.operator_required_entries += 1;
+                summary.first_operator_sequence =
+                    summary.first_operator_sequence.or(Some(entry.sequence));
+                summary.first_operator_priority =
+                    min_optional_priority(summary.first_operator_priority, Some(entry.priority));
+            }
+            if entry.activation_ready() {
+                summary.activation_ready_entries += 1;
+                summary.first_activation_sequence =
+                    summary.first_activation_sequence.or(Some(entry.sequence));
+                summary.first_activation_priority =
+                    min_optional_priority(summary.first_activation_priority, Some(entry.priority));
+            }
+            if entry.blocked() {
+                summary.blocked_entries += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(entry.sequence));
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(entry.priority));
+            }
+            if entry.review_required() {
+                summary.review_required_entries += 1;
+                summary.first_review_sequence =
+                    summary.first_review_sequence.or(Some(entry.sequence));
+                summary.first_review_priority =
+                    min_optional_priority(summary.first_review_priority, Some(entry.priority));
+            }
+            if entry.monitor_only() {
+                summary.monitor_entries += 1;
+                summary.first_monitor_sequence =
+                    summary.first_monitor_sequence.or(Some(entry.sequence));
+                summary.first_monitor_priority =
+                    min_optional_priority(summary.first_monitor_priority, Some(entry.priority));
+            }
+            if entry.requires_attention() {
+                summary.first_attention_sequence =
+                    summary.first_attention_sequence.or(Some(entry.sequence));
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(entry.priority));
+            }
+
+            summary.total_actions += entry.action_count;
+            summary.total_dossiers += entry.dossier_count;
+            summary.total_evidence += entry.evidence_count;
+            summary.total_risks += entry.risk_count;
+            summary.total_dependency_edges += entry.dependency_edge_count;
+            summary.blocking_dependency_edges += entry.blocking_dependency_edge_count;
+            summary.total_audit_records += entry.audit_record_count;
+            summary.attention_audit_records += entry.attention_audit_record_count;
+            summary.risk_audit_records += entry.risk_audit_record_count;
+            summary.dependency_audit_records += entry.dependency_audit_record_count;
+            summary.readiness_gap_records += entry.readiness_gap_record_count;
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(entry.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_entries > 0
+            || summary.readiness_gap_records > 0
+            || summary.blocking_dependency_edges > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.review_required_entries > 0
+            || summary.operator_required_entries > 0
+            || summary.attention_audit_records > 0
+            || summary.risk_audit_records > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.activation_ready_entries > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_entries == 0
+    }
+
+    pub fn has_operator_work(&self) -> bool {
+        self.operator_required_entries > 0
+    }
+
+    pub fn has_activation_work(&self) -> bool {
+        self.activation_ready_entries > 0 || self.activation_entries > 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_entries > 0
+            || self.clear_blocker_entries > 0
+            || self.dependency_entries > 0
+            || self.readiness_gap_records > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_entries > 0
+            || self.approval_entries > 0
+            || self.review_entries > 0
+            || self.risk_entries > 0
+            || self.risk_audit_records > 0
+    }
+
+    pub fn has_audit_context(&self) -> bool {
+        self.total_audit_records > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.has_operator_work()
+            || self.has_blockers()
+            || self.has_review_work()
+            || self.attention_audit_records > 0
             || self.overall_status.requires_attention()
     }
 }
@@ -10561,6 +10994,65 @@ pub fn activation_playbook_steps_at_or_before_priority(
     ))
 }
 
+fn activation_audit_record_matches_integration_ids(
+    record: &IntegrationActivationAuditRecord,
+    integration_ids: &[IntegrationId],
+) -> bool {
+    record.integration_ids.iter().any(|record_id| {
+        integration_ids
+            .iter()
+            .any(|integration_id| integration_id == record_id)
+    })
+}
+
+pub fn activation_runbook_entries_from_playbook_steps(
+    mut steps: Vec<IntegrationActivationPlaybookStep>,
+    audit_records: &[IntegrationActivationAuditRecord],
+) -> Vec<IntegrationActivationRunbookEntry> {
+    steps.sort_by(compare_activation_playbook_steps);
+    let mut entries = steps
+        .into_iter()
+        .map(|step| {
+            let matching_audit_records = audit_records
+                .iter()
+                .filter(|record| {
+                    activation_audit_record_matches_integration_ids(record, &step.integration_ids)
+                })
+                .collect::<Vec<_>>();
+            IntegrationActivationRunbookEntry::from_playbook_step(step, &matching_audit_records)
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(compare_activation_runbook_entries);
+    for (index, entry) in entries.iter_mut().enumerate() {
+        entry.sequence = index + 1;
+    }
+    entries
+}
+
+pub fn activation_runbook_entries_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationRunbookEntry> {
+    let steps = activation_playbook_steps_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let audit_records = activation_audit_records_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_runbook_entries_from_playbook_steps(steps, &audit_records)
+}
+
 pub fn activation_operator_tasks_from_playbook_steps(
     mut steps: Vec<IntegrationActivationPlaybookStep>,
 ) -> Vec<IntegrationActivationOperatorTask> {
@@ -12625,6 +13117,22 @@ fn compare_activation_playbook_steps(
         .then_with(|| right.blocked().cmp(&left.blocked()))
         .then_with(|| right.review_required().cmp(&left.review_required()))
         .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_runbook_entries(
+    left: &IntegrationActivationRunbookEntry,
+    right: &IntegrationActivationRunbookEntry,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.review_required().cmp(&left.review_required()))
+        .then_with(|| right.activation_ready().cmp(&left.activation_ready()))
+        .then_with(|| left.phase.cmp(&right.phase))
+        .then_with(|| left.playbook_action.cmp(&right.playbook_action))
+        .then_with(|| right.audit_record_count.cmp(&left.audit_record_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -15919,6 +16427,131 @@ mod tests {
         assert!(catalog_records
             .iter()
             .any(IntegrationActivationAuditRecord::requires_attention));
+    }
+
+    #[test]
+    fn activation_runbook_entries_join_playbook_steps_to_audit_context() {
+        let reports = vec![
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("review_ready_bridge"),
+                display_name: "Review Ready Bridge".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 1,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HumanApproval,
+                local_only: true,
+                cloud_required: false,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("blocked_review_camera"),
+                display_name: "Blocked Review Camera".to_string(),
+                activation_target: IntegrationActivationTarget::DelegatedIntegration(
+                    IntegrationId::trusted("mqtt"),
+                ),
+                priority: 2,
+                missing_primitives: vec![PrimitiveFamily::CameraMedia],
+                missing_capabilities: vec![CapabilityId::trusted("smart_home.command.low_risk")],
+                missing_dependencies: vec![IntegrationId::trusted("mqtt")],
+                requires_human_review: true,
+                highest_policy_tier: PrivilegeTier::HighRisk,
+                local_only: false,
+                cloud_required: true,
+            },
+            IntegrationReadinessReport {
+                requested_integration_id: IntegrationId::trusted("read_only_probe"),
+                display_name: "Read-only Probe".to_string(),
+                activation_target: IntegrationActivationTarget::Direct,
+                priority: 3,
+                missing_primitives: Vec::new(),
+                missing_capabilities: Vec::new(),
+                missing_dependencies: Vec::new(),
+                requires_human_review: false,
+                highest_policy_tier: PrivilegeTier::ReadOnly,
+                local_only: true,
+                cloud_required: false,
+            },
+        ];
+        let candidates = activation_candidates_from_reports(reports.iter());
+        let steps = activation_playbook_steps_from_candidates(&[], candidates.clone(), &[]);
+        let risks = activation_risk_from_candidates(&[], candidates.iter());
+        let signals = activation_watchtower_signals_from_candidates(&[], candidates.clone(), &[]);
+        let graph = activation_dependency_graph_from_reports(&[], reports.iter(), &[]);
+        let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+        let alerts =
+            activation_sentinel_alerts_from_rollups(&signals, &risks, &graph, &gap_inventory);
+        let decisions = activation_decisions_from_candidates(&[], candidates.iter(), &[]);
+        let evidence = activation_evidence_from_decisions(decisions.iter());
+        let audit_records = activation_audit_records_from_rollups(
+            &alerts,
+            &signals,
+            &decisions,
+            &evidence,
+            &risks,
+            &graph,
+            &gap_inventory,
+        );
+
+        let entries = activation_runbook_entries_from_playbook_steps(steps, &audit_records);
+
+        assert!(entries.iter().all(|entry| entry.sequence > 0));
+        assert!(entries
+            .iter()
+            .any(|entry| entry.phase == IntegrationActivationRunbookPhase::ClearBlockers));
+        assert!(entries
+            .iter()
+            .any(IntegrationActivationRunbookEntry::review_required));
+        assert!(entries
+            .iter()
+            .any(IntegrationActivationRunbookEntry::has_audit_context));
+
+        let blocked = entries
+            .iter()
+            .find(|entry| {
+                entry
+                    .integration_ids
+                    .contains(&IntegrationId::trusted("blocked_review_camera"))
+            })
+            .unwrap();
+        assert!(blocked.blocked());
+        assert!(blocked.requires_attention());
+        assert!(blocked.audit_record_count > 0);
+        assert!(blocked.dependency_audit_record_count > 0);
+        assert!(blocked.readiness_gap_record_count > 0);
+
+        let summary = IntegrationActivationRunbookSummary::from_entries(entries.iter());
+        assert_eq!(summary.total_entries, entries.len());
+        assert!(summary.has_audit_context());
+        assert!(summary.has_blockers());
+        assert!(summary.has_review_work());
+        assert!(summary.requires_attention());
+        assert!(summary.total_audit_records >= audit_records.len());
+        assert_eq!(
+            summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let catalog = first_party_catalog();
+        let available_primitives = vec![
+            PrimitiveFamily::NormalizedModel,
+            PrimitiveFamily::DiscoveryIndex,
+            PrimitiveFamily::CommandMapping,
+            PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::Supervision,
+        ];
+        let allowed_capabilities = vec![CapabilityId::trusted("smart_home.read")];
+        let catalog_entries = activation_runbook_entries_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_entries
+            .iter()
+            .any(IntegrationActivationRunbookEntry::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable smart-home integration activation runbook entries and summaries that join playbook phases to audit/risk/dependency/readiness-gap context
- expose runbook list/summary descriptors in smart-home-core and D18D Chief bridge handlers
- document the new runbook surface across catalog, core, and Chief adapter crates

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools