### PR TITLE
Add browser script module graph descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -839,6 +839,7 @@ pub struct BrowserDocument {
     pub script_execution_descriptors: Vec<BrowserScriptExecutionDescriptor>,
     pub script_storage_access_descriptors: Vec<BrowserScriptStorageAccessDescriptor>,
     pub script_worker_messaging_descriptors: Vec<BrowserScriptWorkerMessagingDescriptor>,
+    pub script_module_graph_descriptors: Vec<BrowserScriptModuleGraphDescriptor>,
     pub stylesheets: Vec<BrowserStylesheet>,
     pub stylesheet_planning_descriptors: Vec<BrowserStylesheetPlanningDescriptor>,
     pub document_policy_descriptors: Vec<BrowserDocumentPolicyDescriptor>,
@@ -1146,6 +1147,30 @@ pub struct BrowserScriptWorkerMessagingDescriptor {
     pub module_worker_hint: bool,
     pub messaging_blocked: bool,
     pub messaging_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserScriptModuleGraphDescriptor {
+    pub script_kind: String,
+    pub module_graph_kind: String,
+    pub src: Option<String>,
+    pub resolved_src: Option<String>,
+    pub type_hint: Option<String>,
+    pub execution_kind: String,
+    pub has_text: bool,
+    pub text_length: usize,
+    pub module_targets: Vec<String>,
+    pub module_target_count: usize,
+    pub external_module_entry: bool,
+    pub inline_module_entry: bool,
+    pub declares_import_map: bool,
+    pub uses_static_imports: bool,
+    pub uses_dynamic_imports: bool,
+    pub has_modulepreload: bool,
+    pub modulepreload_urls: Vec<String>,
+    pub resolved_modulepreload_urls: Vec<String>,
+    pub module_graph_blocked: bool,
+    pub module_graph_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3490,6 +3515,8 @@ impl BrowserDocument {
             browser_script_storage_access_descriptors(&summary.scripts);
         summary.script_worker_messaging_descriptors =
             browser_script_worker_messaging_descriptors(&summary.scripts);
+        summary.script_module_graph_descriptors =
+            browser_script_module_graph_descriptors(&summary.scripts, &summary.resources);
         summary.stylesheet_planning_descriptors =
             browser_stylesheet_planning_descriptors(&summary.stylesheets);
         summary.image_candidate_descriptors = browser_image_candidate_descriptors(&summary.images);
@@ -11621,6 +11648,158 @@ fn browser_script_worker_messaging_kind(
 }
 
 fn browser_script_worker_messaging_block_reasons(script: &BrowserScript) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if script.script_kind == "data" {
+        reasons.push("non-executable-script-type".to_string());
+    }
+    if script.nomodule {
+        reasons.push("nomodule-fallback".to_string());
+    }
+    reasons
+}
+
+fn browser_script_module_graph_descriptors(
+    scripts: &[BrowserScript],
+    resources: &[BrowserResource],
+) -> Vec<BrowserScriptModuleGraphDescriptor> {
+    let modulepreloads: Vec<_> = resources
+        .iter()
+        .filter(|resource| resource.kind == "modulepreload")
+        .collect();
+    scripts
+        .iter()
+        .filter_map(|script| browser_script_module_graph_descriptor(script, &modulepreloads))
+        .collect()
+}
+
+fn browser_script_module_graph_descriptor(
+    script: &BrowserScript,
+    modulepreloads: &[&BrowserResource],
+) -> Option<BrowserScriptModuleGraphDescriptor> {
+    let text = script.text.as_deref().unwrap_or_default();
+    let normalized_text = text.to_ascii_lowercase();
+    let external_module_entry = script.script_kind == "module" && script.src.is_some();
+    let inline_module_entry = script.script_kind == "module" && script.src.is_none();
+    let declares_import_map = script.script_kind == "importmap";
+    let uses_static_imports = browser_script_uses_static_module_imports(&normalized_text);
+    let uses_dynamic_imports = normalized_text.contains("import(");
+    let has_modulepreload = !modulepreloads.is_empty();
+    let module_targets = browser_script_module_graph_targets(
+        external_module_entry,
+        inline_module_entry,
+        declares_import_map,
+        uses_static_imports,
+        uses_dynamic_imports,
+        has_modulepreload,
+    );
+    if module_targets.is_empty() {
+        return None;
+    }
+
+    let modulepreload_urls = modulepreloads
+        .iter()
+        .map(|resource| resource.url.clone())
+        .collect();
+    let resolved_modulepreload_urls = modulepreloads
+        .iter()
+        .filter_map(|resource| resource.resolved_url.clone())
+        .collect();
+    let module_graph_block_reasons = browser_script_module_graph_block_reasons(script);
+    Some(BrowserScriptModuleGraphDescriptor {
+        script_kind: script.script_kind.clone(),
+        module_graph_kind: browser_script_module_graph_kind(
+            external_module_entry,
+            inline_module_entry,
+            declares_import_map,
+            uses_static_imports,
+            uses_dynamic_imports,
+        ),
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        has_text: script.text.is_some(),
+        text_length: text.chars().count(),
+        module_target_count: module_targets.len(),
+        module_targets,
+        external_module_entry,
+        inline_module_entry,
+        declares_import_map,
+        uses_static_imports,
+        uses_dynamic_imports,
+        has_modulepreload,
+        modulepreload_urls,
+        resolved_modulepreload_urls,
+        module_graph_blocked: !module_graph_block_reasons.is_empty(),
+        module_graph_block_reasons,
+    })
+}
+
+fn browser_script_uses_static_module_imports(normalized_text: &str) -> bool {
+    normalized_text.contains("import ")
+        || normalized_text.contains("import{")
+        || normalized_text.contains("export ")
+        || normalized_text.contains(" from '")
+        || normalized_text.contains(" from \"")
+}
+
+fn browser_script_module_graph_targets(
+    external_module_entry: bool,
+    inline_module_entry: bool,
+    declares_import_map: bool,
+    uses_static_imports: bool,
+    uses_dynamic_imports: bool,
+    has_modulepreload: bool,
+) -> Vec<String> {
+    let mut targets = Vec::new();
+    if external_module_entry {
+        targets.push("external-module-entry".to_string());
+    }
+    if inline_module_entry {
+        targets.push("inline-module-entry".to_string());
+    }
+    if declares_import_map {
+        targets.push("importmap".to_string());
+    }
+    if uses_static_imports {
+        targets.push("static-import".to_string());
+    }
+    if uses_dynamic_imports {
+        targets.push("dynamic-import".to_string());
+    }
+    if has_modulepreload {
+        targets.push("modulepreload".to_string());
+    }
+    targets
+}
+
+fn browser_script_module_graph_kind(
+    external_module_entry: bool,
+    inline_module_entry: bool,
+    declares_import_map: bool,
+    uses_static_imports: bool,
+    uses_dynamic_imports: bool,
+) -> String {
+    if declares_import_map {
+        "import-map".to_string()
+    } else if uses_static_imports && uses_dynamic_imports {
+        "mixed-module-imports".to_string()
+    } else if uses_static_imports {
+        "static-module-graph".to_string()
+    } else if uses_dynamic_imports {
+        "dynamic-module-import".to_string()
+    } else if external_module_entry || inline_module_entry {
+        "module-entry".to_string()
+    } else {
+        "module-graph-metadata".to_string()
+    }
+}
+
+fn browser_script_module_graph_block_reasons(script: &BrowserScript) -> Vec<String> {
     let mut reasons = Vec::new();
     if script.script_kind == "data" {
         reasons.push("non-executable-script-type".to_string());
@@ -26655,6 +26834,71 @@ mod tests {
         assert!(legacy.creates_shared_worker);
         assert!(legacy.messaging_blocked);
         assert_eq!(legacy.messaging_block_reasons, vec!["nomodule-fallback"]);
+    }
+
+    #[test]
+    fn browser_script_module_graph_descriptors_track_imports_and_preloads() {
+        let summary = parse_browser_document(
+            "<base href=\"https://example.test/app/index.html\">\
+             <link rel=modulepreload href=chunks/vendor.mjs integrity=sha384-vendor>\
+             <script type=importmap>{\"imports\":{\"app\":\"/app.mjs\"}}</script>\
+             <script type=module src=app.mjs></script>\
+             <script type=module>\
+             import { ready } from './ready.mjs';\
+             export const boot = ready();\
+             import('./lazy.mjs');\
+             </script>\
+             <script nomodule>import('./legacy.js');</script>",
+        )
+        .expect("script module graph descriptor document should parse");
+
+        let descriptors = &summary.script_module_graph_descriptors;
+        assert_eq!(descriptors.len(), 4);
+
+        let importmap = &descriptors[0];
+        assert_eq!(importmap.script_kind, "importmap");
+        assert_eq!(importmap.module_graph_kind, "import-map");
+        assert!(importmap.declares_import_map);
+        assert!(importmap.has_modulepreload);
+        assert_eq!(
+            importmap.modulepreload_urls,
+            vec!["chunks/vendor.mjs".to_string()]
+        );
+        assert_eq!(
+            importmap.resolved_modulepreload_urls,
+            vec!["https://example.test/app/chunks/vendor.mjs".to_string()]
+        );
+
+        let external = &descriptors[1];
+        assert_eq!(external.module_graph_kind, "module-entry");
+        assert!(external.external_module_entry);
+        assert_eq!(external.src.as_deref(), Some("app.mjs"));
+        assert_eq!(
+            external.resolved_src.as_deref(),
+            Some("https://example.test/app/app.mjs")
+        );
+
+        let inline = &descriptors[2];
+        assert_eq!(inline.module_graph_kind, "mixed-module-imports");
+        assert!(inline.inline_module_entry);
+        assert!(inline.uses_static_imports);
+        assert!(inline.uses_dynamic_imports);
+        assert_eq!(
+            inline.module_targets,
+            vec![
+                "inline-module-entry",
+                "static-import",
+                "dynamic-import",
+                "modulepreload"
+            ]
+        );
+
+        let legacy = &descriptors[3];
+        assert_eq!(legacy.script_kind, "classic");
+        assert_eq!(legacy.module_graph_kind, "dynamic-module-import");
+        assert!(legacy.uses_dynamic_imports);
+        assert!(legacy.module_graph_blocked);
+        assert_eq!(legacy.module_graph_block_reasons, vec!["nomodule-fallback"]);
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -25,12 +25,12 @@ use coding_adventures_html_parser::{
     BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
     BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
     BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserScriptExecutionDescriptor, BrowserScriptStorageAccessDescriptor,
-    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
-    BrowserTextSemantic, BrowserThemeColor,
+    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
+    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -94,6 +94,8 @@ struct ExpectedBrowserDocument {
     script_storage_access_descriptors: Option<Vec<ExpectedScriptStorageAccessDescriptor>>,
     #[serde(default)]
     script_worker_messaging_descriptors: Option<Vec<ExpectedScriptWorkerMessagingDescriptor>>,
+    #[serde(default)]
+    script_module_graph_descriptors: Option<Vec<ExpectedScriptModuleGraphDescriptor>>,
     #[serde(default)]
     stylesheets: Vec<ExpectedStylesheet>,
     #[serde(default)]
@@ -1486,6 +1488,48 @@ struct ExpectedScriptWorkerMessagingDescriptor {
     messaging_blocked: bool,
     #[serde(default)]
     messaging_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedScriptModuleGraphDescriptor {
+    script_kind: String,
+    module_graph_kind: String,
+    #[serde(default)]
+    src: Option<String>,
+    #[serde(default)]
+    resolved_src: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    execution_kind: String,
+    #[serde(default)]
+    has_text: bool,
+    #[serde(default)]
+    text_length: usize,
+    #[serde(default)]
+    module_targets: Vec<String>,
+    #[serde(default)]
+    module_target_count: usize,
+    #[serde(default)]
+    external_module_entry: bool,
+    #[serde(default)]
+    inline_module_entry: bool,
+    #[serde(default)]
+    declares_import_map: bool,
+    #[serde(default)]
+    uses_static_imports: bool,
+    #[serde(default)]
+    uses_dynamic_imports: bool,
+    #[serde(default)]
+    has_modulepreload: bool,
+    #[serde(default)]
+    modulepreload_urls: Vec<String>,
+    #[serde(default)]
+    resolved_modulepreload_urls: Vec<String>,
+    #[serde(default)]
+    module_graph_blocked: bool,
+    #[serde(default)]
+    module_graph_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4003,6 +4047,30 @@ fn browser_script_worker_messaging_descriptors_track_flat_worker_and_channel_hin
 }
 
 #[test]
+fn browser_script_module_graph_descriptors_track_flat_import_maps_and_preloads() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "script-module-graph-page")
+        .expect("script module graph fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("script module graph fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.scripts, expected.scripts,
+        "scripts should preserve import maps, module text, and fallback import hints",
+    );
+    assert_eq!(
+        actual.script_module_graph_descriptors, expected.script_module_graph_descriptors,
+        "script module graph descriptors should preserve imports, preloads, and blockers",
+    );
+}
+
+#[test]
 fn browser_resource_priority_metadata_tracks_rel_and_blocking_tokens() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -5952,6 +6020,17 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_script_worker_messaging_descriptors(&scripts));
+        let script_module_graph_descriptors = self
+            .script_module_graph_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(
+                        ExpectedScriptModuleGraphDescriptor::into_browser_script_module_graph_descriptor,
+                    )
+                    .collect()
+            })
+            .unwrap_or_else(|| expected_script_module_graph_descriptors(&scripts, &resources));
         let stylesheet_planning_descriptors = self
             .stylesheet_planning_descriptors
             .map(|descriptors| {
@@ -6247,6 +6326,7 @@ impl ExpectedBrowserDocument {
             script_execution_descriptors,
             script_storage_access_descriptors,
             script_worker_messaging_descriptors,
+            script_module_graph_descriptors,
             stylesheets,
             stylesheet_planning_descriptors,
             document_policy_descriptors: self
@@ -11031,6 +11111,158 @@ fn expected_script_worker_messaging_block_reasons(script: &BrowserScript) -> Vec
     reasons
 }
 
+fn expected_script_module_graph_descriptors(
+    scripts: &[BrowserScript],
+    resources: &[BrowserResource],
+) -> Vec<BrowserScriptModuleGraphDescriptor> {
+    let modulepreloads: Vec<_> = resources
+        .iter()
+        .filter(|resource| resource.kind == "modulepreload")
+        .collect();
+    scripts
+        .iter()
+        .filter_map(|script| expected_script_module_graph_descriptor(script, &modulepreloads))
+        .collect()
+}
+
+fn expected_script_module_graph_descriptor(
+    script: &BrowserScript,
+    modulepreloads: &[&BrowserResource],
+) -> Option<BrowserScriptModuleGraphDescriptor> {
+    let text = script.text.as_deref().unwrap_or_default();
+    let normalized_text = text.to_ascii_lowercase();
+    let external_module_entry = script.script_kind == "module" && script.src.is_some();
+    let inline_module_entry = script.script_kind == "module" && script.src.is_none();
+    let declares_import_map = script.script_kind == "importmap";
+    let uses_static_imports = expected_script_uses_static_module_imports(&normalized_text);
+    let uses_dynamic_imports = normalized_text.contains("import(");
+    let has_modulepreload = !modulepreloads.is_empty();
+    let module_targets = expected_script_module_graph_targets(
+        external_module_entry,
+        inline_module_entry,
+        declares_import_map,
+        uses_static_imports,
+        uses_dynamic_imports,
+        has_modulepreload,
+    );
+    if module_targets.is_empty() {
+        return None;
+    }
+
+    let modulepreload_urls = modulepreloads
+        .iter()
+        .map(|resource| resource.url.clone())
+        .collect();
+    let resolved_modulepreload_urls = modulepreloads
+        .iter()
+        .filter_map(|resource| resource.resolved_url.clone())
+        .collect();
+    let module_graph_block_reasons = expected_script_module_graph_block_reasons(script);
+    Some(BrowserScriptModuleGraphDescriptor {
+        script_kind: script.script_kind.clone(),
+        module_graph_kind: expected_script_module_graph_kind(
+            external_module_entry,
+            inline_module_entry,
+            declares_import_map,
+            uses_static_imports,
+            uses_dynamic_imports,
+        ),
+        src: script.src.clone(),
+        resolved_src: script.resolved_src.clone(),
+        type_hint: script.type_hint.clone(),
+        execution_kind: if script.src.is_some() {
+            "external".to_string()
+        } else {
+            "inline".to_string()
+        },
+        has_text: script.text.is_some(),
+        text_length: text.chars().count(),
+        module_target_count: module_targets.len(),
+        module_targets,
+        external_module_entry,
+        inline_module_entry,
+        declares_import_map,
+        uses_static_imports,
+        uses_dynamic_imports,
+        has_modulepreload,
+        modulepreload_urls,
+        resolved_modulepreload_urls,
+        module_graph_blocked: !module_graph_block_reasons.is_empty(),
+        module_graph_block_reasons,
+    })
+}
+
+fn expected_script_uses_static_module_imports(normalized_text: &str) -> bool {
+    normalized_text.contains("import ")
+        || normalized_text.contains("import{")
+        || normalized_text.contains("export ")
+        || normalized_text.contains(" from '")
+        || normalized_text.contains(" from \"")
+}
+
+fn expected_script_module_graph_targets(
+    external_module_entry: bool,
+    inline_module_entry: bool,
+    declares_import_map: bool,
+    uses_static_imports: bool,
+    uses_dynamic_imports: bool,
+    has_modulepreload: bool,
+) -> Vec<String> {
+    let mut targets = Vec::new();
+    if external_module_entry {
+        targets.push("external-module-entry".to_string());
+    }
+    if inline_module_entry {
+        targets.push("inline-module-entry".to_string());
+    }
+    if declares_import_map {
+        targets.push("importmap".to_string());
+    }
+    if uses_static_imports {
+        targets.push("static-import".to_string());
+    }
+    if uses_dynamic_imports {
+        targets.push("dynamic-import".to_string());
+    }
+    if has_modulepreload {
+        targets.push("modulepreload".to_string());
+    }
+    targets
+}
+
+fn expected_script_module_graph_kind(
+    external_module_entry: bool,
+    inline_module_entry: bool,
+    declares_import_map: bool,
+    uses_static_imports: bool,
+    uses_dynamic_imports: bool,
+) -> String {
+    if declares_import_map {
+        "import-map".to_string()
+    } else if uses_static_imports && uses_dynamic_imports {
+        "mixed-module-imports".to_string()
+    } else if uses_static_imports {
+        "static-module-graph".to_string()
+    } else if uses_dynamic_imports {
+        "dynamic-module-import".to_string()
+    } else if external_module_entry || inline_module_entry {
+        "module-entry".to_string()
+    } else {
+        "module-graph-metadata".to_string()
+    }
+}
+
+fn expected_script_module_graph_block_reasons(script: &BrowserScript) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if script.script_kind == "data" {
+        reasons.push("non-executable-script-type".to_string());
+    }
+    if script.nomodule {
+        reasons.push("nomodule-fallback".to_string());
+    }
+    reasons
+}
+
 fn expected_stylesheet_planning_descriptors(
     stylesheets: &[BrowserStylesheet],
 ) -> Vec<BrowserStylesheetPlanningDescriptor> {
@@ -11238,6 +11470,33 @@ impl ExpectedScriptWorkerMessagingDescriptor {
             module_worker_hint: self.module_worker_hint,
             messaging_blocked: self.messaging_blocked,
             messaging_block_reasons: self.messaging_block_reasons,
+        }
+    }
+}
+
+impl ExpectedScriptModuleGraphDescriptor {
+    fn into_browser_script_module_graph_descriptor(self) -> BrowserScriptModuleGraphDescriptor {
+        BrowserScriptModuleGraphDescriptor {
+            script_kind: self.script_kind,
+            module_graph_kind: self.module_graph_kind,
+            src: self.src,
+            resolved_src: self.resolved_src,
+            type_hint: self.type_hint,
+            execution_kind: self.execution_kind,
+            has_text: self.has_text,
+            text_length: self.text_length,
+            module_targets: self.module_targets,
+            module_target_count: self.module_target_count,
+            external_module_entry: self.external_module_entry,
+            inline_module_entry: self.inline_module_entry,
+            declares_import_map: self.declares_import_map,
+            uses_static_imports: self.uses_static_imports,
+            uses_dynamic_imports: self.uses_dynamic_imports,
+            has_modulepreload: self.has_modulepreload,
+            modulepreload_urls: self.modulepreload_urls,
+            resolved_modulepreload_urls: self.resolved_modulepreload_urls,
+            module_graph_blocked: self.module_graph_blocked,
+            module_graph_block_reasons: self.module_graph_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -39,7 +39,7 @@ resources as a flat endpoint inventory for fetch/navigation planning.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel
 policy tokens, validation bypass state, and submitter overrides.
 Script descriptor cases pin execution, storage access, worker construction,
-worker messaging channels, and fallback blockers.
+worker messaging channels, module graph hints, and fallback blockers.
 Form-association descriptor cases pin form owners, labels, fieldset membership,
 datalist links, and output calculation relationships as a flat browser-planning
 inventory.
@@ -112,6 +112,8 @@ policy, fetch priority, blocking, disabled state, and alternate stylesheets.
 Script storage-access cases pin inline references to Web Storage, cookies,
 IndexedDB, CacheStorage/service workers, StorageManager, storage-event hooks,
 and fallback blockers.
+Script module-graph cases pin import maps, module entrypoints, static/dynamic
+imports, modulepreload hints, and fallback blockers.
 Responsive image cases pin `srcset`/`sizes`, resolved candidate URLs, flattened image candidate
 descriptors, `picture/source` media/type hints, lazy loading, decoding, fetch
 priority, CORS/referrer policy, usemap, and server-side image-map state. Link

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1103,6 +1103,103 @@
       }
     },
     {
+      "id": "script-module-graph-page",
+      "description": "Browser document summaries expose import maps, module graph entrypoints, preload hints, and fallback blockers.",
+      "input": "<base href=\"https://example.test/app/index.html\"><link rel=modulepreload href=chunks/vendor.mjs integrity=sha384-vendor><script type=importmap>{\"imports\":{\"app\":\"/app.mjs\"}}</script><script type=module src=app.mjs></script><script type=module>import { ready } from './ready.mjs'; export const boot = ready(); import('./lazy.mjs');</script><script nomodule>import('./legacy.js');</script>",
+      "expected": {
+        "title": null,
+        "base_href": "https://example.test/app/index.html",
+        "base_target": null,
+        "metadata": {
+          "resource_hints": [
+            { "kind": "modulepreload", "url": "chunks/vendor.mjs", "resolved_url": "https://example.test/app/chunks/vendor.mjs", "rel": "modulepreload", "rel_tokens": ["modulepreload"], "integrity": "sha384-vendor" }
+          ]
+        },
+        "body_text": "",
+        "metas": [],
+        "resources": [
+          { "kind": "modulepreload", "url": "chunks/vendor.mjs", "resolved_url": "https://example.test/app/chunks/vendor.mjs", "rel": "modulepreload", "rel_tokens": ["modulepreload"], "integrity": "sha384-vendor", "async_script": false, "defer_script": false },
+          { "kind": "script", "url": "app.mjs", "resolved_url": "https://example.test/app/app.mjs", "rel": null, "type_hint": "module", "async_script": false, "defer_script": false }
+        ],
+        "scripts": [
+          { "script_kind": "importmap", "type_hint": "importmap", "text": "{\"imports\":{\"app\":\"/app.mjs\"}}" },
+          { "script_kind": "module", "src": "app.mjs", "resolved_src": "https://example.test/app/app.mjs", "type_hint": "module" },
+          { "script_kind": "module", "type_hint": "module", "text": "import { ready } from './ready.mjs'; export const boot = ready(); import('./lazy.mjs');" },
+          { "script_kind": "classic", "nomodule": true, "text": "import('./legacy.js');" }
+        ],
+        "script_module_graph_descriptors": [
+          {
+            "script_kind": "importmap",
+            "module_graph_kind": "import-map",
+            "type_hint": "importmap",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 30,
+            "module_targets": ["importmap", "modulepreload"],
+            "module_target_count": 2,
+            "declares_import_map": true,
+            "has_modulepreload": true,
+            "modulepreload_urls": ["chunks/vendor.mjs"],
+            "resolved_modulepreload_urls": ["https://example.test/app/chunks/vendor.mjs"]
+          },
+          {
+            "script_kind": "module",
+            "module_graph_kind": "module-entry",
+            "src": "app.mjs",
+            "resolved_src": "https://example.test/app/app.mjs",
+            "type_hint": "module",
+            "execution_kind": "external",
+            "module_targets": ["external-module-entry", "modulepreload"],
+            "module_target_count": 2,
+            "external_module_entry": true,
+            "has_modulepreload": true,
+            "modulepreload_urls": ["chunks/vendor.mjs"],
+            "resolved_modulepreload_urls": ["https://example.test/app/chunks/vendor.mjs"]
+          },
+          {
+            "script_kind": "module",
+            "module_graph_kind": "mixed-module-imports",
+            "type_hint": "module",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 87,
+            "module_targets": ["inline-module-entry", "static-import", "dynamic-import", "modulepreload"],
+            "module_target_count": 4,
+            "inline_module_entry": true,
+            "uses_static_imports": true,
+            "uses_dynamic_imports": true,
+            "has_modulepreload": true,
+            "modulepreload_urls": ["chunks/vendor.mjs"],
+            "resolved_modulepreload_urls": ["https://example.test/app/chunks/vendor.mjs"]
+          },
+          {
+            "script_kind": "classic",
+            "module_graph_kind": "dynamic-module-import",
+            "execution_kind": "inline",
+            "has_text": true,
+            "text_length": 22,
+            "module_targets": ["dynamic-import", "modulepreload"],
+            "module_target_count": 2,
+            "uses_dynamic_imports": true,
+            "has_modulepreload": true,
+            "modulepreload_urls": ["chunks/vendor.mjs"],
+            "resolved_modulepreload_urls": ["https://example.test/app/chunks/vendor.mjs"],
+            "module_graph_blocked": true,
+            "module_graph_block_reasons": ["nomodule-fallback"]
+          }
+        ],
+        "fetch_policy_descriptors": [
+          { "element": "link", "url": "chunks/vendor.mjs", "resolved_url": "https://example.test/app/chunks/vendor.mjs", "integrity": "sha384-vendor" }
+        ],
+        "anchors": [],
+        "headings": [],
+        "links": [],
+        "images": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "table-layout-metadata-page",
       "description": "Table summaries expose effective row, column, column hint, cell, and header counts for early layout planning.",
       "input": "<body><table><caption>Prices</caption><colgroup><col span=2 width=80><col width=120><thead><tr><th id=item scope=col abbr=Item>Name<th id=price scope=col>Price<tbody><tr><th scope=row headers=item>Basic<td colspan=2 headers=\"item price\">$1</table>",


### PR DESCRIPTION
## Summary
- add script module graph descriptors to BrowserDocument for import maps, module entrypoints, static/dynamic imports, modulepreload hints, and fallback blockers
- extend browser readiness fixture expectations and harness defaults for module graph descriptors
- add a flat fixture case and README coverage note for the new descriptor family

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_script_module_graph
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser