### PR TITLE
feat(lang-matrix): LM-C BASIC — Dartmouth BASIC on real CoreCLR via Console.WriteLine

### DIFF
--- a/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
+++ b/code/packages/rust/iir-to-cil-bytecode/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — iir-to-cil-bytecode
 
+## [0.17.0] — 2026-06-12 — `print_i64` → `Console.WriteLine` + I/O launcher (LANG-MATRIX LM-C BASIC)
+
+The textual `.il` emitter gains the **`print_i64`** I/O primitive that Dartmouth
+BASIC's `PRINT` lowers to — previously `UnsupportedOp`. It has **no dest** (it's a side
+effect), so it's handled before the dest lookup: the value is loaded and handed to
+`call void [System.Console]System.Console::WriteLine(int32)` (the CLR analogue of the
+wasm `env.__print_i64` import / JVM `env.BasicRuntime.println(J)V`).
+
+The `Run()` launcher is now **I/O-aware**: an expression program still
+`Console.WriteLine`s the entry method's `int` result, but a program that calls
+`print_i64` has already written its own output as a side effect, so the launcher merely
+runs the entry and **discards** its (unused) `int32` return with `pop` — no double-print.
+
+Verified by RUNNING on real `ilasm` + `dotnet` (via `lang-aot`'s `lang_matrix` CLR
+column): BASIC `10 PRINT 42` → `Console` `42` (exactly once). New unit test asserts the
+single `Console.WriteLine` and the launcher `pop`. No change to expression-language
+output (the prior CIL suites + conformance stay green).
+
 ## [0.16.0] — 2026-06-12 — integer arithmetic + comparison opcodes (LANG-MATRIX LM-C)
 
 The textual `.il` emitter (`il_text.rs`) grows two op families it previously rejected

--- a/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
+++ b/code/packages/rust/iir-to-cil-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iir-to-cil-bytecode"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "IIR → CIL bytecode backend — lowers IIRModule to CILProgramArtifact.  v0.7.0 (G4): whitelist call_builtin print_i64 and lower it to call env.BasicRuntime::PrintI64(int64), mirroring iir-to-wasm v0.8.0 (env.__print_i64) and iir-to-jvm-class-file v0.7.0 (env/BasicRuntime.println(J)V).  Together they let BASIC's PRINT reach real wasm, JVM, and CLR bytecode."
 

--- a/code/packages/rust/iir-to-cil-bytecode/README.md
+++ b/code/packages/rust/iir-to-cil-bytecode/README.md
@@ -130,6 +130,11 @@ and **comparison** (`cmp_*` → `ceq`/`clt`/`cgt`, negating the other three with
 rows above — previously only the binary codegen path emitted them, which is why running
 the LANG-MATRIX expression languages (Nib/Oct/ALGOL) on the real CLR first surfaced the gap.
 
+As of 0.17.0 it also emits the **`print_i64`** I/O primitive (Dartmouth BASIC's `PRINT`)
+as `call void [System.Console]System.Console::WriteLine(int32)`; for a program that
+prints, the `Run()` launcher discards the entry method's result (`pop`) instead of
+`Console.WriteLine`-ing it, so the program prints exactly once.
+
 ## How CIL synthesis works for derived operations
 
 CIL lacks native opcodes for some logical operations, so we synthesize them

--- a/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
+++ b/code/packages/rust/iir-to-cil-bytecode/src/il_text.rs
@@ -265,16 +265,32 @@ pub fn emit_il(module: &IIRModule, config: &IIRClrConfig) -> Result<String, IIRC
         emit_method(&mut il, module, f, asm)?;
     }
 
-    // Launcher: `Console.WriteLine(MccarthyEntry())` so the result is observable by
-    // running the assembly (matches how the BEAM/JVM e2e runners read a printout).
+    // Launcher. For an **expression** program the result is the program — so we
+    // `Console.WriteLine(MccarthyEntry())` to make it observable by running the
+    // assembly (matches how the BEAM/JVM e2e runners read a printout). For an **I/O**
+    // program (one that calls `print_i64` — Dartmouth BASIC's `PRINT`) the program has
+    // already written its own output as a side effect inside `MccarthyEntry`, so the
+    // launcher merely runs it and **discards** the (unused) `int32` return with `pop`,
+    // rather than printing it a second time. (The entry's CIL return type is always
+    // `int32`, so the `call`/`pop` are well-typed either way.)
+    let prints = module.functions.iter().any(|f| {
+        f.instructions.iter().any(|i| {
+            i.op == "call_builtin"
+                && matches!(i.srcs.first(), Some(Operand::Var(n)) if n == "print_i64")
+        })
+    });
     let _ = writeln!(il, "  .method public static void Run() cil managed {{");
     let _ = writeln!(il, "    .entrypoint");
     let _ = writeln!(il, "    .maxstack 1");
     let _ = writeln!(il, "    call int32 {asm}Program::MccarthyEntry()");
-    let _ = writeln!(
-        il,
-        "    call void [System.Console]System.Console::WriteLine(int32)"
-    );
+    if prints {
+        let _ = writeln!(il, "    pop");
+    } else {
+        let _ = writeln!(
+            il,
+            "    call void [System.Console]System.Console::WriteLine(int32)"
+        );
+    }
     let _ = writeln!(il, "    ret");
     let _ = writeln!(il, "  }}");
     let _ = writeln!(il, "}}");
@@ -572,17 +588,34 @@ fn emit_method(
             }
             // ── McCarthy predicate primitives (call_builtin) ──────────────────
             //
-            // | builtin  | CIL |
-            // |----------|-----|
-            // | `pair?`  | `ld x; isinst object[]; ldnull; ceq; ldc.i4.0; ceq` |
-            // | `not`    | `ld x; ldc.i4.1; xor` |
-            // | `equal?` | `ld a; unbox.any int32; ld b; unbox.any int32; ceq` |
+            // | builtin     | CIL |
+            // |-------------|-----|
+            // | `pair?`     | `ld x; isinst object[]; ldnull; ceq; ldc.i4.0; ceq` |
+            // | `not`       | `ld x; ldc.i4.1; xor` |
+            // | `equal?`    | `ld a; unbox.any int32; ld b; unbox.any int32; ceq` |
+            // | `print_i64` | `ld val; call void Console::WriteLine(int32)`  (no dest) |
             "call_builtin" => {
+                let builtin = var_src(f, instr, 0, "call_builtin")?;
+                // `print_i64` is the I/O primitive Dartmouth BASIC's `PRINT` lowers to.
+                // Unlike the predicate builtins it has **no dest** (it's a side effect),
+                // so handle it before the dest lookup. The value is loaded and handed to
+                // `System.Console.WriteLine(int32)` — the CLR analogue of the wasm
+                // `env.__print_i64` host import / JVM `env.BasicRuntime.println(J)V`.
+                // (Scalar concretization has lowered the value to `int32`, and
+                // `Console.WriteLine` has an `int32` overload, so no `conv.i8` is needed.)
+                if builtin == "print_i64" {
+                    let val = var_src(f, instr, 1, "print_i64")?;
+                    load_var(il, &regs, val)?;
+                    let _ = writeln!(
+                        il,
+                        "    call void [System.Console]System.Console::WriteLine(int32)"
+                    );
+                    continue;
+                }
                 let dest = instr.dest.as_deref().ok_or_else(|| IIRClrError::InvalidOperand {
                     function: f.name.clone(),
                     detail: "call_builtin must have a dest".to_string(),
                 })?;
-                let builtin = var_src(f, instr, 0, "call_builtin")?;
                 match builtin {
                     "pair?" => {
                         let arg = var_src(f, instr, 1, "pair?")?;
@@ -777,6 +810,40 @@ mod tests {
                 "op {op:?} must emit a bare `{cil}` instruction; got:\n{il}"
             );
         }
+    }
+
+    #[test]
+    fn print_i64_emits_console_writeline_and_discards_result() {
+        // A printing program: `print_i64(7); ret 0` — BASIC's `PRINT 7` shape.
+        let instrs = vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "i32"),
+            IIRInstr::new(
+                "call_builtin",
+                None,
+                vec![Operand::Var("print_i64".into()), Operand::Var("v".into())],
+                "void",
+            ),
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i32"),
+            IIRInstr::new("ret", None, vec![Operand::Var("z".into())], "i32"),
+        ];
+        let mut m = IIRModule::new("Main", "test");
+        m.functions.push(IIRFunction::new("main", vec![], "i32", instrs));
+        m.entry_point = Some("main".into());
+        let il = emit_il(&m, &IIRClrConfig::new("Main")).unwrap();
+        // The value is written via Console.WriteLine(int32) inside the entry method…
+        assert!(
+            il.contains("call void [System.Console]System.Console::WriteLine(int32)"),
+            "print_i64 must call Console.WriteLine(int32); got:\n{il}"
+        );
+        // …and the launcher must DISCARD (pop) the entry's result, not re-print it:
+        // for a printing program there is exactly one WriteLine and a `pop`.
+        assert_eq!(
+            il.matches("System.Console::WriteLine(int32)").count(),
+            1,
+            "a printing program prints exactly once (no double-print); got:\n{il}"
+        );
+        let launcher = il.split(".entrypoint").nth(1).expect("a launcher");
+        assert!(launcher.contains("pop"), "launcher discards the entry result; got:\n{il}");
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — `lang-aot`
 
+## 0.64.0 — 2026-06-12 — Dartmouth BASIC completes the CLR column (LANG-MATRIX LM-C BASIC)
+
+`lang_matrix.rs` greens **Dartmouth BASIC on the real CoreCLR**, completing the CLR
+column for every non-Brainfuck language. The CIL backend (`iir-to-cil-bytecode` 0.17.0)
+grew the `print_i64` → `Console.WriteLine(int32)` lowering and an I/O-aware launcher that
+discards (rather than re-prints) the entry result for a printing program. `run_clr` now
+returns the captured `Console` output as well as the parsed integer, so `assert_cell`
+compares the one the program's `Expect` cares about (stdout for BASIC, exit-style int for
+the expression languages). `Clr` is added to BASIC's `Prog`.
+
+Verified by RUNNING on CoreCLR (dotnet 9.0.x): BASIC `10 PRINT 42` → `Console` `42`
+(printed exactly once — no double-print from the launcher). **26 proven matrix cells**
+(was 25); the `conformance`, `jvm_emit`, `wasm_emit` and `iir-to-cil-bytecode` suites all
+still green. CLR column now green for every language except the deferred Brainfuck.
+
 ## 0.63.0 — 2026-06-12 — Expression languages join the CLR column (LANG-MATRIX LM-C)
 
 `lang_matrix.rs` opens the **CLR** column on the **real CoreCLR** for the four

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lang-aot"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -135,10 +135,11 @@ Brainfuck (tape ops) is the only WASM follow-up. The **JVM** column runs on **re
 (exit code) and Dartmouth BASIC (stdout — `run_jvm` compiles an `env.BasicRuntime` host
 class with `javac` and discards the entry result); Brainfuck (tape ops) is the only JVM
 follow-up. The **CLR** column runs on the **real CoreCLR** (textual `.il` → `ilasm` →
-`dotnet`, the CLR-real path) and is green for the expression languages Twig / Nib / Oct /
-ALGOL 60 (this needed `iir-to-cil-bytecode` to grow integer arithmetic + comparison
-opcodes); BASIC (a `Console`-writing `print_i64`) and Brainfuck (tape ops) are its
-follow-ups. The VM/JIT columns are McCarthy-specialized and need op-coverage work.
+`dotnet`, the CLR-real path) and is green for Twig / Nib / Oct / ALGOL 60 (exit code —
+this needed `iir-to-cil-bytecode` to grow integer arithmetic + comparison opcodes) and
+Dartmouth BASIC (stdout — `print_i64` → `Console.WriteLine(int32)` with an I/O-aware
+launcher that discards the entry result); Brainfuck (tape ops) is the only CLR follow-up.
+The VM/JIT columns are McCarthy-specialized and need op-coverage work.
 
 ## Stack position
 

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -29,11 +29,12 @@
 //!   output (Dartmouth BASIC, whose `print_i64` lowers to `env/BasicRuntime.println`).
 //!   Green for all five non-Brainfuck languages; Brainfuck pends the tape ops.
 //! * **CLR** (Phase C) — source → textual `.il` (`iir-to-cil-bytecode`) → real `ilasm`
-//!   → real `dotnet`, the CLR-real path. The entry `Console.WriteLine`s its `int`
-//!   result, which the harness parses. Green for the expression languages Twig / Nib /
-//!   Oct / ALGOL 60 (this needed the CIL backend to grow integer arithmetic + the
-//!   comparison opcodes — McCarthy only ever emitted a constant). Dartmouth BASIC pends
-//!   a `Console`-writing `print_i64`; Brainfuck the tape ops.
+//!   → real `dotnet`, the CLR-real path. An expression program's entry
+//!   `Console.WriteLine`s its `int` result (parsed); Dartmouth BASIC's `PRINT` lowers
+//!   to `Console.WriteLine(int32)` and the launcher discards (not re-prints) the entry
+//!   result, so the harness captures `Console`. Green for Twig / Nib / Oct / ALGOL 60
+//!   (this needed the CIL backend to grow integer arithmetic + the comparison opcodes)
+//!   and Dartmouth BASIC; Brainfuck pends the tape ops.
 //!
 //! The remaining work is the Deferred items — Brainfuck-on-LLVM/WASM/JVM/CLR, and the
 //! McCarthy-specialized VM and JIT (op-coverage work). See
@@ -148,13 +149,15 @@ const PROGRAMS: &[Prog] = &[
     // `PrintHost` resolves that import and captures the printed value (LM-W BASIC). On
     // JVM `print_i64` lowers to `invokestatic env/BasicRuntime.println(J)V`; `run_jvm`
     // compiles that host class with `javac`, discards the entry result, and captures
-    // `System.out` (LM-J BASIC).
+    // `System.out` (LM-J BASIC). On CLR `print_i64` lowers to `Console.WriteLine(int32)`
+    // and the launcher discards (rather than re-prints) the entry result; `run_clr`
+    // captures `Console` (LM-C BASIC).
     Prog {
         lang: Language::DartmouthBasic,
         ext: "bas",
         src: "10 PRINT 42\n20 END\n",
         expect: Expect::Stdout("42"),
-        backends: &[NativeAot, Llvm, Wasm, Jvm],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
 ];
 
@@ -664,10 +667,13 @@ fn run_clr(p: &Prog) -> Option<(Option<i32>, String)> {
     if !out.status.success() {
         return None;
     }
-    // The entry `Console.WriteLine`d its `int` result; parse it as the program's
-    // value (matching the exit-code convention of the other columns).
+    // Whatever the program wrote to `Console`: for an expression language that's the
+    // launcher's `Console.WriteLine` of the entry's `int` result (parsed as the value,
+    // matching the exit-code convention); for an I/O language (Dartmouth BASIC) it's
+    // the `PRINT` output captured directly. Return both — `assert_cell` picks the one
+    // the program's `Expect` cares about.
     let printed = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    Some((printed.parse::<i32>().ok(), String::new()))
+    Some((printed.parse::<i32>().ok(), printed))
 }
 
 /// Dispatch a program to a backend runner. `None` = the backend's toolchain is

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -103,8 +103,8 @@ achievable code-gen columns land first).
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
-| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ⏸  | ☐   |
-| Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ☐   |
+| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ⏸  | ⏸  |
+| Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 
@@ -228,9 +228,17 @@ BASIC); only Brainfuck is deferred.
   proven matrix cells); conformance/jvm_emit/wasm_emit/iir-to-cil-bytecode suites green.
   (The `clr-simulator` floor is intentionally *not* used — its `cil_emit.rs` test is
   broken on `main` from an API drift; the real-`dotnet` path is the stronger check.)
-- ☐ **LM-C BASIC (on CLR).** BASIC's `print_i64` needs a `Console`-writing lowering on
-  the CIL backend (the CLR analogue of wasm `env.__print_i64` / JVM `env.BasicRuntime`);
-  then capture/assert `Console` output.
+- ✅ **LM-C BASIC (on CLR).** Grew the CIL backend (`iir-to-cil-bytecode` 0.17.0) with
+  the `print_i64` → `call void [System.Console]System.Console::WriteLine(int32)` lowering
+  (the CLR analogue of wasm `env.__print_i64` / JVM `env.BasicRuntime.println`) and made
+  the `Run()` launcher I/O-aware: a printing program already wrote its output as a side
+  effect, so the launcher **discards** (`pop`) the entry result instead of
+  `Console.WriteLine`-ing it — no double-print. `run_clr` now returns the captured
+  `Console` output alongside the parsed integer. Verified by RUNNING on CoreCLR: BASIC
+  `10 PRINT 42` → `Console` `42` exactly once (26 proven matrix cells); CIL +
+  conformance/jvm_emit/wasm_emit suites green. **CLR column now green for every language
+  except the deferred Brainfuck — so every code-gen backend (native-AOT, LLVM, WASM, JVM,
+  CLR) is green for all five non-Brainfuck languages.**
 - ⏸ **LM-C Brainfuck (on CLR) — DEFERRED.** Same tape-op gap as Brainfuck elsewhere.
 
 ### Phase A — native AOT completeness


### PR DESCRIPTION
## LANG-PLATFORM-MATRIX · Phase C · LM-C BASIC

Completes the **CLR** column for every non-Brainfuck language: **Dartmouth BASIC now runs on the real CoreCLR**. With this, **every code-gen backend (native-AOT / LLVM / WASM / JVM / CLR) is green for all five non-Brainfuck languages.**

### What & why
**CIL backend** (`iir-to-cil-bytecode` 0.17.0):
- `print_i64` (BASIC's `PRINT`) → `call void [System.Console]System.Console::WriteLine(int32)`. It has **no dest** (a side effect), so it's handled before the dest lookup. The CLR analogue of the wasm `env.__print_i64` import / JVM `env.BasicRuntime.println(J)V`.
- The `Run()` launcher is now **I/O-aware**: an expression program still `Console.WriteLine`s the entry's `int` result, but a printing program has already produced its output, so the launcher **discards** (`pop`) the entry result instead of re-printing it — **no double-print**.

**Harness** (`lang-aot` 0.64.0): `run_clr` now returns the captured `Console` output alongside the parsed integer, so `assert_cell` compares the one the program's `Expect` cares about (stdout for BASIC, exit-style int for the expression languages). `Clr` added to BASIC's `Prog`.

### Verified by RUNNING (dotnet 9.0.x)
- BASIC `10 PRINT 42` → `Console` `42`, **printed exactly once** (the new unit test asserts a single `Console.WriteLine` + the launcher `pop`).
- **26 proven matrix cells** (was 25); both `lang_matrix` tests pass.
- `iir-to-cil-bytecode` (50+86+4), `conformance` (McCarthy CLR, 1), `jvm_emit` (2), `wasm_emit` (18), lang-aot lib (12) all still green — the launcher change is gated on `prints` so McCarthy/expression output is unchanged.
- Clippy clean on changed files.

### Matrix after this PR
| | native-AOT | LLVM | WASM | JVM | CLR |
|---|---|---|---|---|---|
| Twig / Nib / Oct / ALGOL 60 | ✅ | ✅ | ✅ | ✅ | ✅ |
| Dartmouth BASIC | ✅ | ✅ | ✅ | ✅ | ✅ ← this PR |
| Brainfuck | ✅ | ⏸ | ⏸ | ⏸ | ⏸ (tape ops) |

The only remaining work is the **deferred** items: Brainfuck on LLVM/WASM/JVM/CLR (tape-op codegen), and the McCarthy-specialized VM/JIT columns (op-coverage).

### Changes
- `iir-to-cil-bytecode/src/il_text.rs` — `print_i64` arm + I/O-aware launcher + unit test; 0.16.0 → 0.17.0 (CHANGELOG, README).
- `lang-aot/tests/lang_matrix.rs` — `run_clr` returns captured `Console`; `Clr` added to BASIC.
- `LANG-PLATFORM-MATRIX.md` — CLR/BASIC cell ✅; LM-C BASIC worklist item ✅.
- `lang-aot` CHANGELOG/README; 0.63.0 → 0.64.0.

### Security
Reviewed by a security sub-agent: **PASSED**. No `unsafe`, no untrusted input (programs are compile-time literals; emitted `.il` is in-repo compiler output), fixed opcode strings (no CIL injection — operand names resolve to numeric slots, never verbatim), `run_clr` harness unchanged (vectored subprocess args, no shell, random-0700 tempdir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)