### PR TITLE
Add smart-home activation handoff tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -41,13 +41,13 @@ use smart_home_integration_catalog::{
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
     activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
-    activation_health_from_candidates, activation_maintenance_from_candidates,
-    activation_operator_tasks_from_playbook_steps, activation_plan_for_entry,
-    activation_plans_at_or_before_priority, activation_playbook_steps_from_forecasts,
-    activation_readouts_from_candidates, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
-    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
-    activation_timeline_milestones_from_dashboard_cards,
+    activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
+    activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
+    activation_plan_for_entry, activation_plans_at_or_before_priority,
+    activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runbook_entries_from_playbook_steps, activation_runway_from_candidates,
+    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog,
@@ -78,11 +78,13 @@ use smart_home_integration_catalog::{
     IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
     IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
     IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
-    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationHandoffPackage, IntegrationActivationHandoffStatus,
+    IntegrationActivationHandoffSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
+    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -278,6 +280,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RUNBOOK_TOOL_ID: &str =
     "smart_home.list_integration_activation_runbook";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_runbook_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID: &str =
+    "smart_home.list_integration_activation_handoff";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_handoff_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
     "smart_home.list_integration_activation_operator_queue";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
@@ -608,6 +614,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID => {
                     let query = integration_activation_runbook_query(&arguments)?;
                     Ok(get_integration_activation_runbook_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID => {
+                    let query = integration_activation_handoff_query(&arguments)?;
+                    Ok(list_integration_activation_handoff_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_handoff_query(&arguments)?;
+                    Ok(get_integration_activation_handoff_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID => {
                     let query = integration_activation_operator_queue_query(&arguments)?;
@@ -2020,6 +2036,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation runbook summary",
             "Return compact D23A activation runbook counts across phases, audit context, blockers, review work, activation, and monitoring.",
             integration_activation_runbook_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID,
+            "List smart-home integration activation handoff packages",
+            "List Chief-ready D23A activation handoff packages that consolidate runbook, risk, dependency, audit, and readiness-gap context for execution transfer.",
+            integration_activation_handoff_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_handoff", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_handoff", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation handoff summary",
+            "Return compact D23A activation handoff counts for ready packages, blockers, review work, dependency gaps, audit attention, and the next execution-transfer step.",
+            integration_activation_handoff_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4908,6 +4953,21 @@ struct IntegrationActivationRunbookQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationHandoffQuery {
+    runbook: IntegrationActivationRunbookQuery,
+    risk: IntegrationActivationRiskQuery,
+    dependency: IntegrationActivationDependencyQuery,
+    gaps: IntegrationReadinessGapQuery,
+    handoff_status: Option<IntegrationActivationHandoffStatus>,
+    ready_for_handoff: Option<bool>,
+    blocked: Option<bool>,
+    review_required: Option<bool>,
+    requires_attention: Option<bool>,
+    include_monitor: bool,
+    handoff_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationOperatorQueueQuery {
     playbook: IntegrationActivationPlaybookQuery,
     task_kind: Option<IntegrationActivationOperatorTaskKind>,
@@ -5333,6 +5393,35 @@ fn integration_activation_runbook_query(
             .or(optional_bool(arguments, "activation_ready")?),
         include_monitor: optional_bool(arguments, "include_monitor")?.unwrap_or(false),
         runbook_limit: optional_u64(arguments, "runbook_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_handoff_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationHandoffQuery, ToolCallError> {
+    let include_monitor = optional_bool(arguments, "include_monitor")?.unwrap_or(false);
+    let mut runbook = integration_activation_runbook_query(arguments)?;
+    runbook.include_monitor = include_monitor;
+    let handoff_status = optional_string(arguments, "handoff_status")?
+        .or(optional_string(arguments, "status")?)
+        .map(|label| parse_activation_handoff_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationHandoffQuery {
+        runbook,
+        risk: integration_activation_risk_query(arguments)?,
+        dependency: integration_activation_dependency_query(arguments)?,
+        gaps: integration_readiness_gap_query(arguments)?,
+        handoff_status,
+        ready_for_handoff: optional_bool(arguments, "ready_for_handoff")?,
+        blocked: optional_bool(arguments, "handoff_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        review_required: optional_bool(arguments, "handoff_review_required")?
+            .or(optional_bool(arguments, "review_required")?),
+        requires_attention: optional_bool(arguments, "handoff_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        include_monitor,
+        handoff_limit: optional_u64(arguments, "handoff_limit")?.map(|value| value as usize),
     })
 }
 
@@ -6133,6 +6222,45 @@ fn integration_activation_runbook_entries_for_query(
     }
 
     (entries, catalog_count)
+}
+
+fn integration_activation_handoff_packages_for_query(
+    query: &IntegrationActivationHandoffQuery,
+) -> (Vec<IntegrationActivationHandoffPackage>, usize) {
+    let (entries, catalog_count) = integration_activation_runbook_entries_for_query(&query.runbook);
+    let (risks, _) = integration_activation_risk_for_query(&query.risk);
+    let (graph, _) = integration_activation_dependency_graph_for_query(&query.dependency);
+    let (gap_inventory, _) = integration_readiness_gap_inventory_for_query(&query.gaps.readiness);
+    let mut packages = activation_handoff_packages_from_runbook_entries(
+        entries.iter(),
+        &risks,
+        &graph,
+        &gap_inventory,
+    );
+
+    if !query.include_monitor {
+        packages.retain(|package| !package.monitor_only());
+    }
+    if let Some(handoff_status) = query.handoff_status {
+        packages.retain(|package| package.handoff_status == handoff_status);
+    }
+    if let Some(ready_for_handoff) = query.ready_for_handoff {
+        packages.retain(|package| package.ready_for_handoff() == ready_for_handoff);
+    }
+    if let Some(blocked) = query.blocked {
+        packages.retain(|package| package.blocked() == blocked);
+    }
+    if let Some(review_required) = query.review_required {
+        packages.retain(|package| package.review_required() == review_required);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        packages.retain(|package| package.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.handoff_limit {
+        packages.truncate(limit);
+    }
+
+    (packages, catalog_count)
 }
 
 fn integration_activation_operator_tasks_for_query(
@@ -8067,6 +8195,87 @@ fn get_integration_activation_runbook_summary_output_handler_output(
                 summary
                     .next_phase
                     .map(|phase| string(phase.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_handoff_output_handler_output(
+    query: IntegrationActivationHandoffQuery,
+) -> ToolHandlerOutput {
+    let (packages, catalog_count) = integration_activation_handoff_packages_for_query(&query);
+    let summary = IntegrationActivationHandoffSummary::from_packages(packages.iter());
+    let count = packages.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_handoff",
+            JsonValue::Array(
+                packages
+                    .iter()
+                    .map(activation_handoff_package_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_handoff_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_handoff")),
+            ("activation_handoff_packages", integer(count as i64)),
+            ("ready_packages", integer(summary.ready_packages as i64)),
+            ("blocked_packages", integer(summary.blocked_packages as i64)),
+            (
+                "review_required_packages",
+                integer(summary.review_required_packages as i64),
+            ),
+            (
+                "next_handoff_status",
+                summary
+                    .next_handoff_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_handoff_summary_output_handler_output(
+    query: IntegrationActivationHandoffQuery,
+) -> ToolHandlerOutput {
+    let (packages, _) = integration_activation_handoff_packages_for_query(&query);
+    let summary = IntegrationActivationHandoffSummary::from_packages(packages.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_handoff_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_handoff_summary"),
+            ),
+            ("total_packages", integer(summary.total_packages as i64)),
+            ("ready_packages", integer(summary.ready_packages as i64)),
+            ("blocked_packages", integer(summary.blocked_packages as i64)),
+            (
+                "review_required_packages",
+                integer(summary.review_required_packages as i64),
+            ),
+            (
+                "next_handoff_status",
+                summary
+                    .next_handoff_status
+                    .map(|status| string(status.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
         ]),
@@ -15064,6 +15273,313 @@ fn integration_activation_runbook_summary_json(
     ])
 }
 
+fn activation_handoff_package_json(package: &IntegrationActivationHandoffPackage) -> JsonValue {
+    object([
+        ("sequence", integer(package.sequence as i64)),
+        ("runbook_sequence", integer(package.runbook_sequence as i64)),
+        ("priority", integer(package.priority as i64)),
+        ("handoff_status", string(package.handoff_status.as_str())),
+        ("phase", string(package.phase.as_str())),
+        ("playbook_action", string(package.playbook_action.as_str())),
+        (
+            "recommended_view",
+            string(package.recommended_view.as_str()),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                package
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(package.integration_count() as i64),
+        ),
+        (
+            "risk_ids",
+            JsonValue::Array(
+                package
+                    .risk_ids
+                    .iter()
+                    .map(|risk_id| string(risk_id))
+                    .collect(),
+            ),
+        ),
+        ("risk_count", integer(package.risk_count as i64)),
+        (
+            "dependency_integration_ids",
+            JsonValue::Array(
+                package
+                    .dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocking_dependency_integration_ids",
+            JsonValue::Array(
+                package
+                    .blocking_dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_edge_count",
+            integer(package.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(package.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "primitive_gap_count",
+            integer(package.primitive_gap_count as i64),
+        ),
+        (
+            "capability_gap_count",
+            integer(package.capability_gap_count as i64),
+        ),
+        (
+            "dependency_gap_count",
+            integer(package.dependency_gap_count as i64),
+        ),
+        (
+            "readiness_gap_count",
+            integer(package.readiness_gap_count as i64),
+        ),
+        (
+            "audit_record_count",
+            integer(package.audit_record_count as i64),
+        ),
+        (
+            "attention_audit_record_count",
+            integer(package.attention_audit_record_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(package.highest_policy_tier)),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(package.operator_required()),
+        ),
+        (
+            "activation_ready",
+            JsonValue::Bool(package.activation_ready()),
+        ),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(package.ready_for_handoff()),
+        ),
+        ("blocked", JsonValue::Bool(package.blocked())),
+        (
+            "review_required",
+            JsonValue::Bool(package.review_required()),
+        ),
+        ("monitor_only", JsonValue::Bool(package.monitor_only())),
+        (
+            "has_dependency_blockers",
+            JsonValue::Bool(package.has_dependency_blockers()),
+        ),
+        (
+            "has_readiness_gaps",
+            JsonValue::Bool(package.has_readiness_gaps()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(package.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_handoff_summary_json(
+    summary: &IntegrationActivationHandoffSummary,
+) -> JsonValue {
+    object([
+        ("total_packages", integer(summary.total_packages as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        ("ready_packages", integer(summary.ready_packages as i64)),
+        (
+            "review_required_packages",
+            integer(summary.review_required_packages as i64),
+        ),
+        ("blocked_packages", integer(summary.blocked_packages as i64)),
+        ("monitor_packages", integer(summary.monitor_packages as i64)),
+        (
+            "operator_required_packages",
+            integer(summary.operator_required_packages as i64),
+        ),
+        (
+            "activation_ready_packages",
+            integer(summary.activation_ready_packages as i64),
+        ),
+        (
+            "packages_requiring_attention",
+            integer(summary.packages_requiring_attention as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "total_primitive_gaps",
+            integer(summary.total_primitive_gaps as i64),
+        ),
+        (
+            "total_capability_gaps",
+            integer(summary.total_capability_gaps as i64),
+        ),
+        (
+            "total_dependency_gaps",
+            integer(summary.total_dependency_gaps as i64),
+        ),
+        (
+            "total_readiness_gaps",
+            integer(summary.total_readiness_gaps as i64),
+        ),
+        (
+            "total_audit_records",
+            integer(summary.total_audit_records as i64),
+        ),
+        (
+            "attention_audit_records",
+            integer(summary.attention_audit_records as i64),
+        ),
+        (
+            "next_handoff_status",
+            summary
+                .next_handoff_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_phase",
+            summary
+                .next_phase
+                .map(|phase| string(phase.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_package_sequence",
+            summary
+                .next_package_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_package_priority",
+            summary
+                .next_package_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_sequence",
+            summary
+                .first_ready_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_sequence",
+            summary
+                .first_review_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_priority",
+            summary
+                .first_ready_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(summary.ready_for_handoff()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_review_work",
+            JsonValue::Bool(summary.has_review_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_operator_task_json(task: &IntegrationActivationOperatorTask) -> JsonValue {
     object([
         ("sequence", integer(task.sequence as i64)),
@@ -19130,6 +19646,26 @@ fn parse_activation_runbook_phase(
     }
 }
 
+fn parse_activation_handoff_status(
+    label: &str,
+) -> Result<IntegrationActivationHandoffStatus, ToolCallError> {
+    match label {
+        "ready" | "ready_for_handoff" | "handoff_ready" => {
+            Ok(IntegrationActivationHandoffStatus::Ready)
+        }
+        "needs_review" | "review" | "review_required" | "requires_review" => {
+            Ok(IntegrationActivationHandoffStatus::NeedsReview)
+        }
+        "blocked" | "blocker" | "blockers" => Ok(IntegrationActivationHandoffStatus::Blocked),
+        "monitoring" | "monitor" | "monitor_only" | "watching" => {
+            Ok(IntegrationActivationHandoffStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation handoff status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_operator_task_kind(
     label: &str,
 ) -> Result<IntegrationActivationOperatorTaskKind, ToolCallError> {
@@ -20403,6 +20939,36 @@ fn integration_activation_runbook_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_handoff_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_runbook_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("handoff_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("status", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "ready_for_handoff",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("handoff_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "handoff_review_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "handoff_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("blocking_only", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("limit_per_kind", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("handoff_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_operator_queue_query_schema() -> JsonSchema {
     let mut schema = integration_activation_playbook_query_schema();
     if let JsonSchema::Object {
@@ -20740,7 +21306,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 111);
+        assert_eq!(definitions.len(), 113);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -21011,6 +21577,12 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -21047,7 +21619,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            103
+            105
         );
         assert_eq!(
             export
@@ -21239,6 +21811,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RUNBOOK_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -21509,11 +22089,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(111))
+            Some(&integer(113))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(103))
+            Some(&integer(105))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -24237,6 +24817,143 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_handoff_request = request(
+            "call-list-integration-activation-handoff",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("handoff_status", string("blocked")),
+                ("handoff_limit", integer(3)),
+            ]),
+            5_531,
+        );
+        let list_activation_handoff_trace =
+            tool_runtime.invoke_with_events(&list_activation_handoff_request);
+        assert!(list_activation_handoff_trace.result.ok);
+        assert_eq!(
+            list_activation_handoff_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_handoff_output = list_activation_handoff_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_handoff_count =
+            integer_value(field(list_activation_handoff_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_handoff_count));
+        let activation_handoff_summary = field(list_activation_handoff_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_handoff_summary, "total_packages"),
+            Some(&integer(activation_handoff_count))
+        );
+        assert_eq!(
+            field(activation_handoff_summary, "next_handoff_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_handoff_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_handoff_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_handoff_package = array_item(
+            field(list_activation_handoff_output, "activation_handoff").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_handoff_package, "handoff_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_handoff_package, "ready_for_handoff"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert!(field(activation_handoff_package, "risk_ids").is_some());
+        assert!(field(
+            activation_handoff_package,
+            "blocking_dependency_integration_ids"
+        )
+        .is_some());
+        assert!(
+            integer_value(field(activation_handoff_package, "readiness_gap_count").unwrap())
+                .unwrap()
+                >= 1
+        );
+
+        let activation_handoff_summary_request = request(
+            "call-integration-activation-handoff-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("handoff_status", string("blocked")),
+            ]),
+            5_532,
+        );
+        let activation_handoff_summary_trace =
+            tool_runtime.invoke_with_events(&activation_handoff_summary_request);
+        assert!(activation_handoff_summary_trace.result.ok);
+        assert_eq!(
+            activation_handoff_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_handoff_summary_output = activation_handoff_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_handoff_rollup =
+            field(activation_handoff_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_handoff_rollup, "blocked_packages").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_handoff_rollup, "next_handoff_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_handoff_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_operator_queue_request = request(
             "call-list-integration-activation-operator-queue",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
@@ -26820,6 +27537,14 @@ mod tests {
             activation_runbook_summary_trace,
         );
         journal.record_trace(
+            list_activation_handoff_request,
+            list_activation_handoff_trace,
+        );
+        journal.record_trace(
+            activation_handoff_summary_request,
+            activation_handoff_summary_trace,
+        );
+        journal.record_trace(
             list_activation_operator_queue_request,
             list_activation_operator_queue_trace,
         );
@@ -26937,9 +27662,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 111);
-        assert_eq!(journal_summary.completed_count, 111);
-        assert_eq!(journal.audit_records().len(), 111);
+        assert_eq!(journal_summary.invocation_count, 113);
+        assert_eq!(journal_summary.completed_count, 113);
+        assert_eq!(journal.audit_records().len(), 113);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1497,6 +1497,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationPlaybookSummary,
     ListIntegrationActivationRunbook,
     GetIntegrationActivationRunbookSummary,
+    ListIntegrationActivationHandoff,
+    GetIntegrationActivationHandoffSummary,
     ListIntegrationActivationOperatorQueue,
     GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationControlRoom,
@@ -1706,6 +1708,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationRunbookSummary => {
                 read_tool("smart_home.get_integration_activation_runbook_summary")
+            }
+            Self::ListIntegrationActivationHandoff => {
+                read_tool("smart_home.list_integration_activation_handoff")
+            }
+            Self::GetIntegrationActivationHandoffSummary => {
+                read_tool("smart_home.get_integration_activation_handoff_summary")
             }
             Self::ListIntegrationActivationOperatorQueue => {
                 read_tool("smart_home.list_integration_activation_operator_queue")
@@ -2422,6 +2430,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationPlaybookSummary,
         SmartHomeTool::ListIntegrationActivationRunbook,
         SmartHomeTool::GetIntegrationActivationRunbookSummary,
+        SmartHomeTool::ListIntegrationActivationHandoff,
+        SmartHomeTool::GetIntegrationActivationHandoffSummary,
         SmartHomeTool::ListIntegrationActivationOperatorQueue,
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationControlRoom,
@@ -3276,7 +3286,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 111);
+        assert_eq!(catalog.len(), 113);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3680,6 +3690,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_handoff"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_handoff_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_activation_operator_queue"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -3734,15 +3752,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 111);
-        assert_eq!(summary.read_tools, 103);
+        assert_eq!(summary.total_tools, 113);
+        assert_eq!(summary.read_tools, 105);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 103);
+        assert_eq!(summary.read_only_tier_tools, 105);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 111);
+        assert_eq!(summary.total_required_capabilities, 113);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1151,6 +1151,29 @@ impl IntegrationActivationRunbookPhase {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationHandoffStatus {
+    Ready,
+    NeedsReview,
+    Blocked,
+    Monitoring,
+}
+
+impl IntegrationActivationHandoffStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::NeedsReview => "needs_review",
+            Self::Blocked => "blocked",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::NeedsReview | Self::Blocked)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationOperatorTaskKind {
     ResolveConstraints,
     EnableDependencies,
@@ -2402,6 +2425,77 @@ pub struct IntegrationActivationRunbookSummary {
     pub first_blocked_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
     pub first_monitor_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationHandoffPackage {
+    pub sequence: usize,
+    pub runbook_sequence: usize,
+    pub priority: u8,
+    pub handoff_status: IntegrationActivationHandoffStatus,
+    pub phase: IntegrationActivationRunbookPhase,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub risk_ids: Vec<String>,
+    pub dependency_integration_ids: Vec<IntegrationId>,
+    pub blocking_dependency_integration_ids: Vec<IntegrationId>,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub primitive_gap_count: usize,
+    pub capability_gap_count: usize,
+    pub dependency_gap_count: usize,
+    pub readiness_gap_count: usize,
+    pub audit_record_count: usize,
+    pub attention_audit_record_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_required: bool,
+    pub activation_ready: bool,
+    pub ready_for_handoff: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub monitor_only: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationHandoffSummary {
+    pub total_packages: usize,
+    pub unique_integrations: usize,
+    pub ready_packages: usize,
+    pub review_required_packages: usize,
+    pub blocked_packages: usize,
+    pub monitor_packages: usize,
+    pub operator_required_packages: usize,
+    pub activation_ready_packages: usize,
+    pub packages_requiring_attention: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_primitive_gaps: usize,
+    pub total_capability_gaps: usize,
+    pub total_dependency_gaps: usize,
+    pub total_readiness_gaps: usize,
+    pub total_audit_records: usize,
+    pub attention_audit_records: usize,
+    pub next_handoff_status: Option<IntegrationActivationHandoffStatus>,
+    pub next_phase: Option<IntegrationActivationRunbookPhase>,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_package_sequence: Option<usize>,
+    pub next_package_priority: Option<u8>,
+    pub first_ready_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_review_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_ready_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -5261,6 +5355,338 @@ impl IntegrationActivationRunbookSummary {
             || self.has_blockers()
             || self.has_review_work()
             || self.attention_audit_records > 0
+            || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationHandoffPackage {
+    fn from_runbook_entry(
+        entry: &IntegrationActivationRunbookEntry,
+        risks: &[IntegrationActivationRiskItem],
+        graph: &IntegrationActivationDependencyGraph,
+        gap_inventory: &IntegrationReadinessGapInventory,
+    ) -> Self {
+        let mut risk_ids = BTreeSet::new();
+        let mut highest_policy_tier = entry.highest_policy_tier;
+        for risk in risks {
+            if integration_ids_overlap(&risk.integration_ids, &entry.integration_ids) {
+                risk_ids.insert(risk.risk_id.clone());
+                highest_policy_tier = highest_policy_tier.max(risk.required_tier);
+            }
+        }
+
+        let mut dependency_integration_ids = BTreeSet::new();
+        let mut blocking_dependency_integration_ids = BTreeSet::new();
+        let mut dependency_edge_count = 0;
+        let mut blocking_dependency_edge_count = 0;
+        for edge in &graph.edges {
+            let relates_to_entry =
+                integration_id_in_slice(&entry.integration_ids, &edge.dependency_integration_id)
+                    || integration_id_in_slice(
+                        &entry.integration_ids,
+                        &edge.dependent_integration_id,
+                    );
+            if relates_to_entry {
+                dependency_edge_count += 1;
+                dependency_integration_ids.insert(edge.dependency_integration_id.clone());
+                dependency_integration_ids.insert(edge.dependent_integration_id.clone());
+                if edge.blocks_activation {
+                    blocking_dependency_edge_count += 1;
+                    blocking_dependency_integration_ids
+                        .insert(edge.dependency_integration_id.clone());
+                    blocking_dependency_integration_ids
+                        .insert(edge.dependent_integration_id.clone());
+                }
+            }
+        }
+
+        let primitive_gap_count = gap_inventory
+            .primitive_gaps
+            .iter()
+            .filter(|gap| integration_ids_overlap(&gap.integration_ids, &entry.integration_ids))
+            .count();
+        let capability_gap_count = gap_inventory
+            .capability_gaps
+            .iter()
+            .filter(|gap| integration_ids_overlap(&gap.integration_ids, &entry.integration_ids))
+            .count();
+        let dependency_gap_count = gap_inventory
+            .dependency_gaps
+            .iter()
+            .filter(|gap| {
+                integration_id_in_slice(&entry.integration_ids, &gap.integration_id)
+                    || integration_ids_overlap(
+                        &gap.requested_integration_ids,
+                        &entry.integration_ids,
+                    )
+            })
+            .count();
+        let readiness_gap_count = primitive_gap_count + capability_gap_count + dependency_gap_count;
+
+        let handoff_status = if entry.monitor_only() {
+            IntegrationActivationHandoffStatus::Monitoring
+        } else if entry.blocked() || blocking_dependency_edge_count > 0 || readiness_gap_count > 0 {
+            IntegrationActivationHandoffStatus::Blocked
+        } else if entry.review_required()
+            || !risk_ids.is_empty()
+            || entry.attention_audit_record_count > 0
+        {
+            IntegrationActivationHandoffStatus::NeedsReview
+        } else if entry.activation_ready() {
+            IntegrationActivationHandoffStatus::Ready
+        } else {
+            IntegrationActivationHandoffStatus::NeedsReview
+        };
+
+        let blocked = handoff_status == IntegrationActivationHandoffStatus::Blocked;
+        let review_required = handoff_status == IntegrationActivationHandoffStatus::NeedsReview
+            || entry.review_required();
+        let monitor_only = handoff_status == IntegrationActivationHandoffStatus::Monitoring;
+        let ready_for_handoff = handoff_status == IntegrationActivationHandoffStatus::Ready;
+        let requires_attention = handoff_status.requires_attention() || entry.requires_attention();
+        let operator_required =
+            entry.operator_required() || blocked || review_required || requires_attention;
+        let risk_ids = risk_ids.into_iter().collect::<Vec<_>>();
+        let risk_count = risk_ids.len();
+        let dependency_integration_ids = dependency_integration_ids.into_iter().collect();
+        let blocking_dependency_integration_ids =
+            blocking_dependency_integration_ids.into_iter().collect();
+
+        Self {
+            sequence: entry.sequence,
+            runbook_sequence: entry.sequence,
+            priority: entry.priority,
+            handoff_status,
+            phase: entry.phase,
+            playbook_action: entry.playbook_action,
+            recommended_view: entry.recommended_view,
+            integration_ids: entry.integration_ids.clone(),
+            integration_count: entry.integration_count,
+            risk_ids,
+            dependency_integration_ids,
+            blocking_dependency_integration_ids,
+            risk_count,
+            dependency_edge_count,
+            blocking_dependency_edge_count,
+            primitive_gap_count,
+            capability_gap_count,
+            dependency_gap_count,
+            readiness_gap_count,
+            audit_record_count: entry.audit_record_count,
+            attention_audit_record_count: entry.attention_audit_record_count,
+            highest_policy_tier,
+            operator_required,
+            activation_ready: entry.activation_ready(),
+            ready_for_handoff,
+            blocked,
+            review_required,
+            monitor_only,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn ready_for_handoff(&self) -> bool {
+        self.ready_for_handoff
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn activation_ready(&self) -> bool {
+        self.activation_ready
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    pub fn has_dependency_blockers(&self) -> bool {
+        self.blocking_dependency_edge_count > 0
+            || !self.blocking_dependency_integration_ids.is_empty()
+    }
+
+    pub fn has_readiness_gaps(&self) -> bool {
+        self.readiness_gap_count > 0
+    }
+}
+
+impl IntegrationActivationHandoffSummary {
+    pub fn from_packages<'a>(
+        packages: impl IntoIterator<Item = &'a IntegrationActivationHandoffPackage>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_packages: 0,
+            unique_integrations: 0,
+            ready_packages: 0,
+            review_required_packages: 0,
+            blocked_packages: 0,
+            monitor_packages: 0,
+            operator_required_packages: 0,
+            activation_ready_packages: 0,
+            packages_requiring_attention: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_primitive_gaps: 0,
+            total_capability_gaps: 0,
+            total_dependency_gaps: 0,
+            total_readiness_gaps: 0,
+            total_audit_records: 0,
+            attention_audit_records: 0,
+            next_handoff_status: None,
+            next_phase: None,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_package_sequence: None,
+            next_package_priority: None,
+            first_ready_sequence: None,
+            first_blocked_sequence: None,
+            first_review_sequence: None,
+            first_attention_sequence: None,
+            first_ready_priority: None,
+            first_blocked_priority: None,
+            first_review_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for package in packages {
+            summary.total_packages += 1;
+            for integration_id in &package.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_handoff_status.is_none() && !package.monitor_only() {
+                summary.next_handoff_status = Some(package.handoff_status);
+                summary.next_phase = Some(package.phase);
+                summary.next_playbook_action = Some(package.playbook_action);
+                summary.next_recommended_view = Some(package.recommended_view);
+                summary.next_package_sequence = Some(package.sequence);
+                summary.next_package_priority = Some(package.priority);
+            }
+
+            match package.handoff_status {
+                IntegrationActivationHandoffStatus::Ready => {
+                    summary.ready_packages += 1;
+                    summary.first_ready_sequence =
+                        summary.first_ready_sequence.or(Some(package.sequence));
+                    summary.first_ready_priority =
+                        min_optional_priority(summary.first_ready_priority, Some(package.priority));
+                }
+                IntegrationActivationHandoffStatus::NeedsReview => {
+                    summary.review_required_packages += 1;
+                    summary.first_review_sequence =
+                        summary.first_review_sequence.or(Some(package.sequence));
+                    summary.first_review_priority = min_optional_priority(
+                        summary.first_review_priority,
+                        Some(package.priority),
+                    );
+                }
+                IntegrationActivationHandoffStatus::Blocked => {
+                    summary.blocked_packages += 1;
+                    summary.first_blocked_sequence =
+                        summary.first_blocked_sequence.or(Some(package.sequence));
+                    summary.first_blocked_priority = min_optional_priority(
+                        summary.first_blocked_priority,
+                        Some(package.priority),
+                    );
+                }
+                IntegrationActivationHandoffStatus::Monitoring => {
+                    summary.monitor_packages += 1;
+                }
+            }
+
+            if package.operator_required() {
+                summary.operator_required_packages += 1;
+            }
+            if package.activation_ready() {
+                summary.activation_ready_packages += 1;
+            }
+            if package.requires_attention() {
+                summary.packages_requiring_attention += 1;
+                summary.first_attention_sequence =
+                    summary.first_attention_sequence.or(Some(package.sequence));
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(package.priority));
+            }
+
+            summary.total_risks += package.risk_count;
+            summary.total_dependency_edges += package.dependency_edge_count;
+            summary.blocking_dependency_edges += package.blocking_dependency_edge_count;
+            summary.total_primitive_gaps += package.primitive_gap_count;
+            summary.total_capability_gaps += package.capability_gap_count;
+            summary.total_dependency_gaps += package.dependency_gap_count;
+            summary.total_readiness_gaps += package.readiness_gap_count;
+            summary.total_audit_records += package.audit_record_count;
+            summary.attention_audit_records += package.attention_audit_record_count;
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(package.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_packages > 0
+            || summary.blocking_dependency_edges > 0
+            || summary.total_readiness_gaps > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.review_required_packages > 0
+            || summary.operator_required_packages > 0
+            || summary.packages_requiring_attention > 0
+            || summary.total_risks > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_packages > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_packages == 0
+    }
+
+    pub fn ready_for_handoff(&self) -> bool {
+        self.ready_packages > 0 && !self.has_blockers() && !self.has_review_work()
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_packages > 0
+            || self.blocking_dependency_edges > 0
+            || self.total_readiness_gaps > 0
+    }
+
+    pub fn has_review_work(&self) -> bool {
+        self.review_required_packages > 0
+            || self.total_risks > 0
+            || self.attention_audit_records > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.packages_requiring_attention > 0
+            || self.operator_required_packages > 0
+            || self.has_blockers()
+            || self.has_review_work()
             || self.overall_status.requires_attention()
     }
 }
@@ -10998,11 +11424,18 @@ fn activation_audit_record_matches_integration_ids(
     record: &IntegrationActivationAuditRecord,
     integration_ids: &[IntegrationId],
 ) -> bool {
-    record.integration_ids.iter().any(|record_id| {
-        integration_ids
-            .iter()
-            .any(|integration_id| integration_id == record_id)
-    })
+    integration_ids_overlap(&record.integration_ids, integration_ids)
+}
+
+fn integration_ids_overlap(left: &[IntegrationId], right: &[IntegrationId]) -> bool {
+    left.iter()
+        .any(|left_id| right.iter().any(|right_id| left_id == right_id))
+}
+
+fn integration_id_in_slice(integration_ids: &[IntegrationId], needle: &IntegrationId) -> bool {
+    integration_ids
+        .iter()
+        .any(|integration_id| integration_id == needle)
 }
 
 pub fn activation_runbook_entries_from_playbook_steps(
@@ -11051,6 +11484,59 @@ pub fn activation_runbook_entries_at_or_before_priority(
         enabled_integrations,
     );
     activation_runbook_entries_from_playbook_steps(steps, &audit_records)
+}
+
+pub fn activation_handoff_packages_from_runbook_entries<'a>(
+    entries: impl IntoIterator<Item = &'a IntegrationActivationRunbookEntry>,
+    risks: &[IntegrationActivationRiskItem],
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) -> Vec<IntegrationActivationHandoffPackage> {
+    let mut packages = entries
+        .into_iter()
+        .map(|entry| {
+            IntegrationActivationHandoffPackage::from_runbook_entry(
+                entry,
+                risks,
+                graph,
+                gap_inventory,
+            )
+        })
+        .collect::<Vec<_>>();
+    packages.sort_by(compare_activation_handoff_packages);
+    for (index, package) in packages.iter_mut().enumerate() {
+        package.sequence = index + 1;
+    }
+    packages
+}
+
+pub fn activation_handoff_packages_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationHandoffPackage> {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let candidates = activation_candidates_from_reports(reports.iter());
+    let risks = activation_risk_from_candidates(catalog, candidates.iter());
+    let graph =
+        activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations);
+    let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+    let entries = activation_runbook_entries_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_handoff_packages_from_runbook_entries(entries.iter(), &risks, &graph, &gap_inventory)
 }
 
 pub fn activation_operator_tasks_from_playbook_steps(
@@ -13134,6 +13620,40 @@ fn compare_activation_runbook_entries(
         .then_with(|| left.playbook_action.cmp(&right.playbook_action))
         .then_with(|| right.audit_record_count.cmp(&left.audit_record_count))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn activation_handoff_status_sort_key(status: IntegrationActivationHandoffStatus) -> u8 {
+    match status {
+        IntegrationActivationHandoffStatus::Blocked => 0,
+        IntegrationActivationHandoffStatus::NeedsReview => 1,
+        IntegrationActivationHandoffStatus::Ready => 2,
+        IntegrationActivationHandoffStatus::Monitoring => 3,
+    }
+}
+
+fn compare_activation_handoff_packages(
+    left: &IntegrationActivationHandoffPackage,
+    right: &IntegrationActivationHandoffPackage,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| {
+            activation_handoff_status_sort_key(left.handoff_status)
+                .cmp(&activation_handoff_status_sort_key(right.handoff_status))
+        })
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.review_required().cmp(&left.review_required()))
+        .then_with(|| right.ready_for_handoff().cmp(&left.ready_for_handoff()))
+        .then_with(|| {
+            right
+                .blocking_dependency_edge_count
+                .cmp(&left.blocking_dependency_edge_count)
+        })
+        .then_with(|| right.readiness_gap_count.cmp(&left.readiness_gap_count))
+        .then_with(|| right.risk_count.cmp(&left.risk_count))
+        .then_with(|| left.phase.cmp(&right.phase))
+        .then_with(|| left.runbook_sequence.cmp(&right.runbook_sequence))
 }
 
 fn compare_activation_operator_tasks(
@@ -16533,6 +17053,45 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let handoff = activation_handoff_packages_from_runbook_entries(
+            entries.iter(),
+            &risks,
+            &graph,
+            &gap_inventory,
+        );
+        assert_eq!(handoff.len(), entries.len());
+        assert!(handoff
+            .iter()
+            .any(IntegrationActivationHandoffPackage::requires_attention));
+
+        let blocked_handoff = handoff
+            .iter()
+            .find(|package| {
+                package
+                    .integration_ids
+                    .contains(&IntegrationId::trusted("blocked_review_camera"))
+            })
+            .unwrap();
+        assert_eq!(
+            blocked_handoff.handoff_status,
+            IntegrationActivationHandoffStatus::Blocked
+        );
+        assert!(blocked_handoff.blocked());
+        assert!(blocked_handoff.has_dependency_blockers());
+        assert!(blocked_handoff.has_readiness_gaps());
+        assert!(blocked_handoff.risk_count > 0);
+        assert!(blocked_handoff.readiness_gap_count > 0);
+
+        let handoff_summary = IntegrationActivationHandoffSummary::from_packages(handoff.iter());
+        assert_eq!(handoff_summary.total_packages, handoff.len());
+        assert!(handoff_summary.has_blockers());
+        assert!(handoff_summary.has_review_work());
+        assert!(handoff_summary.requires_attention());
+        assert_eq!(
+            handoff_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -16552,6 +17111,16 @@ mod tests {
         assert!(catalog_entries
             .iter()
             .any(IntegrationActivationRunbookEntry::requires_attention));
+        let catalog_handoff_entries = activation_handoff_packages_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_handoff_entries
+            .iter()
+            .any(IntegrationActivationHandoffPackage::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add reusable smart-home activation handoff packages that join runbook, risk, dependency, audit, and readiness-gap context in the integration catalog.
- Expose Chief D18D read-only tools for listing activation handoff packages and reading their summary rollup.
- Register the new handoff descriptors in smart-home-core and extend Chief end-to-end coverage.

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in code/packages/rust/smart-home-core
- sh BUILD in code/packages/rust/smart-home-integration-catalog
- sh BUILD in code/packages/rust/chief-of-staff-smart-home-tools