### PR TITLE
feat(closurec): CLOC12.78 — close gap-069 (new ( emit-adjacency space)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.82.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-069** — a `new` keyword followed by a KEPT grouping
+  paren (compound callee) now gets a separating space, matching
+  upstream Closure: `new(a+b)` → `new (a+b)`, `new(a,b)` →
+  `new (a,b)`. `minify_new_paren_space` is now enforced.
+
+### Added — gap-069 `new (` emit-adjacency space
+
+A two-token look-behind helper, `new_paren_needs_space(kept, idx)`,
+consulted at the main emit site (NOT in `needs_separator`, which
+sees only the adjacent pair). Distinguishing the genuine
+NewExpression keyword `new` from a PROPERTY named `new` (`o.new(f)`
+— a method call) requires the token *before* `new`: the JavaScript
+lexer is context-free and types `new` identically in both, so only
+a preceding `.`/`?.` member accessor tells them apart. The helper
+fires only when (a) `kept[idx]` is a structural `(`, (b)
+`kept[idx-1]` is the word-like `new` keyword, and (c) `kept[idx-2]`
+(if any) is not a `.`/`?.` accessor. The companion `new(f)()`
+simple-reference form never reaches here — gap-068's pre-pass has
+already elided those parens to `new f`. 3 new gap069_* unit tests
++ the `minify_new_paren_space` byte-identity fixture.
+
 ## [0.81.0] - 2026-06-11
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.81.0"
+version = "0.82.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1692,7 +1692,7 @@ pub fn whitespace_only_minify(
 
         // Emit the token (with separator if needed).
         if let Some(prev) = prev_emitted_tok {
-            if needs_separator(prev, tok) {
+            if needs_separator(prev, tok) || new_paren_needs_space(&kept, idx) {
                 out.push(' ');
             }
         }
@@ -2456,6 +2456,60 @@ fn needs_separator(a: &lexer::token::Token, b: &lexer::token::Token) -> bool {
         }
     }
     false
+}
+
+/// gap-069: decide whether the token at `kept[idx]` — known to be
+/// the one about to be emitted — needs a single leading space
+/// because it is a `(` GROUPING paren immediately following the
+/// `new` KEYWORD. Upstream Closure emits `new (a+b)` (with a
+/// space), not `new(a+b)`.
+///
+/// Why this lives HERE (a two-token look-behind) and not in
+/// `needs_separator` (which sees only the adjacent pair):
+/// distinguishing the genuine NewExpression keyword `new` from a
+/// PROPERTY named `new` requires the token *before* `new`. The
+/// JavaScript lexer is context-free, so it types `new` identically
+/// in `new X` and `o.new(f)` — only the preceding `.`/`?.` member
+/// accessor tells them apart:
+///
+///   `new(a+b)`   → kept[..] = … new ( …      → SPACE  (NewExpr)
+///   `o.new(f)`   → kept[..] = … . new ( …     → NO SPACE (method call)
+///   `a.b(x)`     → kept[..] = … b ( …         → rule doesn't fire
+///
+/// The companion case `new(f)()` (simple-reference callee) never
+/// reaches here: gap-068's pre-pass has already ELIDED the parens
+/// (`new f`) before the emit loop runs, so no `new (` survives.
+///
+/// GUARDS (all required, fail-closed):
+///   - `kept[idx]` is a *structural* `(` (not a one-char string
+///     `"("` whose `.value` merely equals `(`).
+///   - `kept[idx-1]` is word-like AND its value is exactly `new`
+///     (so a string literal `"new"` can never trigger it; `new`
+///     is reserved, so no identifier can collide either).
+///   - `kept[idx-2]`, if present, is NOT a `.`/`?.` member
+///     accessor — i.e. `new` is a real unary keyword, not a
+///     property. When `new` is the very first token (idx < 2)
+///     there is no accessor, so it is unambiguously a NewExpression.
+fn new_paren_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bool {
+    if idx == 0 {
+        return false; // need a `new` token before the `(`
+    }
+    let open = kept[idx];
+    let prev = kept[idx - 1];
+    if !is_structural_punct(open, "(") {
+        return false;
+    }
+    if !(is_word_like(prev) && prev.value == "new") {
+        return false;
+    }
+    // Property guard: reject `o.new(` / `o?.new(` (method call).
+    if idx >= 2 {
+        let before_new = kept[idx - 2];
+        if is_structural_punct(before_new, ".") || is_structural_punct(before_new, "?.") {
+            return false;
+        }
+    }
+    true
 }
 
 /// True iff a token is "word-like" — its value would merge with
@@ -3925,6 +3979,36 @@ mod tests {
         assert_eq!(minify("o.new(f);"), "o.new(f);");
     }
 
+    // ---- gap-069: `new (` emit-adjacency separating space ----
+
+    /// gap-069: a `new` keyword followed by a KEPT grouping paren
+    /// (compound callee) gets a separating space — `new(a+b)` →
+    /// `new (a+b)`, matching upstream Closure.
+    #[test]
+    fn gap069_new_paren_gets_space() {
+        assert_eq!(minify("new(a+b);"), "new (a+b);");
+        assert_eq!(minify("new(a,b);"), "new (a,b);");
+    }
+
+    /// gap-069 SAFETY: a PROPERTY named `new` (`o.new(f)`) is a
+    /// method call, NOT a NewExpression — the preceding `.`
+    /// accessor must suppress the space. (Also covered by
+    /// gap068_new_property_not_stripped; this asserts the space
+    /// specifically does not creep in for a compound argument.)
+    #[test]
+    fn gap069_property_new_no_space() {
+        assert_eq!(minify("o.new(a+b);"), "o.new(a+b);");
+        assert_eq!(minify("o?.new(a+b);"), "o?.new(a+b);");
+    }
+
+    /// gap-069 boundary: `new X()` (simple identifier callee) does
+    /// NOT trigger the space — `new` is followed by the IDENT `X`,
+    /// not a `(` — and gap-050 still drops the empty `()`.
+    #[test]
+    fn gap069_new_ident_unaffected() {
+        assert_eq!(minify("new X();"), "new X;");
+    }
+
     // ---- gap-067: labeled single-statement block flatten ----
 
     /// gap-067: `label:{break label}` → `label:break label;` —
@@ -4465,19 +4549,22 @@ mod tests {
         );
     }
 
-    /// **Non-regression**: `new` keyword followed by a
-    /// non-identifier (e.g. `new (expr)`) is NOT
-    /// targeted by this peephole — kept[idx-1] isn't a
-    /// simple identifier.
+    /// **Non-regression (gap-050) + gap-069**: `new` keyword
+    /// followed by a non-identifier (e.g. `new (expr)`) is NOT
+    /// targeted by the gap-050 empty-paren peephole — kept[idx-1]
+    /// isn't a simple identifier, so the trailing constructor
+    /// `()` survives. Since CLOC12.78, the `new (` adjacency also
+    /// carries the gap-069 separating space.
     #[test]
     fn gap050_new_with_paren_expr_unchanged() {
         // `new (Foo||Bar)()` — paren expression for
         // constructor selection. The empty `()` after the
-        // paren-close is NOT what we target (idx-1 is `)`,
-        // not an identifier).
+        // paren-close is NOT what gap-050 targets (idx-1 is `)`,
+        // not an identifier), so it is preserved. gap-069 keeps
+        // the `new (` space (the grouping parens are kept).
         assert_eq!(
             minify("var x=new (Foo||Bar)();"),
-            "var x=new(Foo||Bar)();"
+            "var x=new (Foo||Bar)();"
         );
     }
 

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.81.0
+Version: 0.82.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,10 +90,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-069 (CLOC14.35): `new` directly followed by a `(`
-    // grouping paren needs a separating space — `new(a+b)` →
-    // `new (a+b)` (emit-adjacency, both keep the parens).
-    ("new_paren_space", "gap-069: `new(` needs a space → `new (`"),
     // gap-070/071/072 (CLOC14.35): prefix-operator OPERAND paren
     // elision — strip redundant parens around a simple-reference
     // operand. `typeof`/`void` already do this; `delete`,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -535,9 +535,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-069 — `new(` emit-adjacency space
 
-- **Status:** OPEN — discovered by CLOC14.35. `minify_new_paren_space` ignored.
+- **Status:** RESOLVED in CLOC12.78. `minify_new_paren_space` enforced.
 - **Input:** `new(a+b);` → **Upstream:** `new (a+b);` (also `new(a,b)` → `new (a,b)`)
-- **What it needs:** When the `new` keyword is directly followed by a `(` GROUPING paren (a parenthesized callee expression that gap-068 keeps), the re-stitcher must insert a single space: `new (…)`. Both forms keep the parens; this is purely an emit-adjacency rule (`needs_separator`-style) for `new` + `(`. (Noted as the gap-069 candidate during CLOC12.76.)
+- **What it needed:** When the `new` keyword is directly followed by a `(` GROUPING paren (a parenthesized callee expression that gap-068 keeps), the re-stitcher inserts a single space: `new (…)`. Both forms keep the parens; this is an emit-adjacency rule for `new` + `(`. (Noted as the gap-069 candidate during CLOC12.76.)
+- **CLOC12.78 resolution:** A two-token look-behind, `new_paren_needs_space(kept, idx)`, consulted at the main emit site (NOT in `needs_separator`, which sees only the adjacent pair). Distinguishing the genuine NewExpression keyword `new` from a PROPERTY named `new` (`o.new(f)` — a method call) requires the token *before* `new`: the JS lexer is context-free and types `new` identically in both, so only a preceding `.`/`?.` member accessor tells them apart. The helper fires only when (a) `kept[idx]` is a structural `(`, (b) `kept[idx-1]` is the word-like `new` keyword, and (c) `kept[idx-2]` (if any) is not a `.`/`?.` accessor. The companion `new(f)()` simple-reference form never reaches here — gap-068's pre-pass has already elided those parens to `new f`. 3 unit tests + the byte-identity fixture.
 
 ### gap-070 / gap-071 / gap-072 — prefix-operator operand paren elision
 


### PR DESCRIPTION
## CLOC12.78 — closes gap-069

Upstream Closure emits a separating space between the `new` keyword and a **kept** grouping paren (a compound parenthesised callee):

| input | closurec (before) | upstream / closurec (now) |
|---|---|---|
| `new(a+b);` | `new(a+b);` | `new (a+b);` |
| `new(a,b);` | `new(a,b);` | `new (a,b);` |

Discovered as a hard gap by CLOC14.35; flagged as the gap-069 candidate back in CLOC12.76.

### Implementation
A two-token look-behind helper `new_paren_needs_space(kept, idx)`, consulted at the **main emit site** — NOT in `needs_separator`, which is a pure `(prev, cur)` function and can't see two tokens back.

Distinguishing the genuine NewExpression keyword `new` from a **property** named `new` (`o.new(f)` — a method call) requires the token *before* `new`: the JS lexer is context-free and types `new` identically in both, so only a preceding `.`/`?.` member accessor tells them apart. The helper fires only when:
- `kept[idx]` is a structural `(` (not a one-char string `"("`),
- `kept[idx-1]` is the word-like `new` keyword (not a string `"new"`),
- `kept[idx-2]` (if any) is **not** a `.`/`?.` accessor.

The companion `new(f)()` simple-reference form never reaches here — gap-068's pre-pass already elided those parens to `new f`.

**Why not `needs_separator`:** an initial attempt there wrongly spaced `o.new(f)` → `o.new (f)`; four existing unit tests (gap050/gap059/gap061/gap068) caught it. Moving the decision to the emit loop with the `kept[idx-2]` property guard fixes it cleanly.

### Tests / bookkeeping
- 3 new `gap069_*` unit tests (space added, property-guard `.`/`?.`, simple-ident unaffected); `gap050_new_with_paren_expr_unchanged` updated to the new `new (Foo||Bar)()` expectation.
- `minify_new_paren_space` removed from `IGNORE_FIXTURES` (now enforced byte-identical).
- version `0.81.0` → `0.82.0` (Cargo.toml, cli.spec.json, help-markdown golden regenerated).
- `code/specs/CLOC12-gaps.md`: gap-069 marked RESOLVED; CHANGELOG updated.

All 460 lib tests + every integration suite (incl. the byte-identity harness) green. Security review PASS (index-safety + property-guard verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)