### PR TITLE
Add browser permissions policy descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1236,6 +1236,8 @@ pub struct BrowserDocumentPolicyDescriptor {
     pub color_scheme: Option<String>,
     pub content_security_policy: Option<String>,
     pub permissions_policy: Option<String>,
+    pub permissions_policy_features: Vec<String>,
+    pub permissions_policy_feature_count: usize,
     pub origin_trials: Vec<String>,
     pub accept_ch: Option<String>,
     pub accept_ch_tokens: Vec<String>,
@@ -2550,7 +2552,10 @@ pub struct BrowserEmbeddedPolicyDescriptor {
     pub sandbox: Vec<String>,
     pub sandbox_token_count: usize,
     pub allow: Option<String>,
+    pub allow_tokens: Vec<String>,
+    pub allow_token_count: usize,
     pub allowfullscreen: bool,
+    pub fullscreen_allowed: bool,
     pub referrerpolicy: Option<String>,
     pub srcdoc: Option<String>,
     pub has_srcdoc: bool,
@@ -11253,6 +11258,10 @@ fn browser_embedded_policy_descriptors(
 fn browser_embedded_policy_descriptor(
     context: &BrowserEmbeddedContext,
 ) -> BrowserEmbeddedPolicyDescriptor {
+    let allow_tokens = browser_allow_policy_features(context.allow.as_deref());
+    let fullscreen_allowed =
+        context.allowfullscreen || allow_tokens.iter().any(|token| token == "fullscreen");
+
     BrowserEmbeddedPolicyDescriptor {
         element: context.element.clone(),
         resource_kind: browser_embedded_resource_kind(&context.element).to_string(),
@@ -11269,7 +11278,10 @@ fn browser_embedded_policy_descriptor(
         sandbox: context.sandbox.clone(),
         sandbox_token_count: context.sandbox.len(),
         allow: context.allow.clone(),
+        allow_token_count: allow_tokens.len(),
+        allow_tokens,
         allowfullscreen: context.allowfullscreen,
+        fullscreen_allowed,
         referrerpolicy: context.referrerpolicy.clone(),
         srcdoc: context.srcdoc.clone(),
         has_srcdoc: context.srcdoc.is_some(),
@@ -11927,6 +11939,8 @@ fn browser_document_policy_descriptor(
     let content_security_policy =
         browser_http_equiv_hint_content(metadata, "content-security-policy");
     let permissions_policy = browser_http_equiv_hint_content(metadata, "permissions-policy");
+    let permissions_policy_features =
+        browser_permissions_policy_features(permissions_policy.as_deref());
     let origin_trials = browser_http_equiv_hint_contents(metadata, "origin-trial");
     let accept_ch = browser_http_equiv_hint_content(metadata, "accept-ch");
     let accept_ch_tokens = accept_ch
@@ -11964,6 +11978,8 @@ fn browser_document_policy_descriptor(
         color_scheme: metadata.color_scheme.clone(),
         content_security_policy,
         permissions_policy,
+        permissions_policy_feature_count: permissions_policy_features.len(),
+        permissions_policy_features,
         origin_trials,
         accept_ch,
         accept_ch_tokens,
@@ -12104,6 +12120,32 @@ fn browser_metadata_list(content: &str) -> Vec<String> {
         .map(trim_browser_metadata_token)
         .filter(|part| !part.is_empty())
         .collect()
+}
+
+fn browser_permissions_policy_features(policy: Option<&str>) -> Vec<String> {
+    policy
+        .into_iter()
+        .flat_map(|policy| policy.split(','))
+        .filter_map(browser_policy_feature)
+        .collect()
+}
+
+fn browser_allow_policy_features(allow: Option<&str>) -> Vec<String> {
+    allow
+        .into_iter()
+        .flat_map(|allow| allow.split(';'))
+        .filter_map(browser_policy_feature)
+        .collect()
+}
+
+fn browser_policy_feature(directive: &str) -> Option<String> {
+    directive
+        .trim()
+        .split(|ch: char| ch == '=' || ch.is_whitespace())
+        .next()
+        .map(str::trim)
+        .filter(|feature| !feature.is_empty())
+        .map(str::to_ascii_lowercase)
 }
 
 fn split_browser_comma_tokens(value: &str) -> Vec<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -501,6 +501,10 @@ struct ExpectedDocumentPolicyDescriptor {
     #[serde(default)]
     permissions_policy: Option<String>,
     #[serde(default)]
+    permissions_policy_features: Vec<String>,
+    #[serde(default)]
+    permissions_policy_feature_count: usize,
+    #[serde(default)]
     origin_trials: Vec<String>,
     #[serde(default)]
     accept_ch: Option<String>,
@@ -2431,7 +2435,13 @@ struct ExpectedEmbeddedPolicyDescriptor {
     #[serde(default)]
     allow: Option<String>,
     #[serde(default)]
+    allow_tokens: Vec<String>,
+    #[serde(default)]
+    allow_token_count: usize,
+    #[serde(default)]
     allowfullscreen: bool,
+    #[serde(default)]
+    fullscreen_allowed: bool,
     #[serde(default)]
     referrerpolicy: Option<String>,
     #[serde(default)]
@@ -4068,6 +4078,69 @@ fn browser_script_module_graph_descriptors_track_flat_import_maps_and_preloads()
         actual.script_module_graph_descriptors, expected.script_module_graph_descriptors,
         "script module graph descriptors should preserve imports, preloads, and blockers",
     );
+}
+
+#[test]
+fn browser_document_policy_descriptors_track_permissions_policy_features() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "document-metadata-policy-page")
+        .expect("document metadata policy fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("document metadata policy fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.document_policy_descriptors, expected.document_policy_descriptors,
+        "document policy descriptors should preserve raw and normalized permissions policy metadata",
+    );
+    assert_eq!(
+        actual.document_policy_descriptors[0].permissions_policy_features,
+        vec!["geolocation".to_string(), "camera".to_string()],
+        "document permissions policy features should be normalized for planner consumption",
+    );
+    assert_eq!(
+        actual.document_policy_descriptors[0].permissions_policy_feature_count, 2,
+        "document permissions policy feature count should match normalized features",
+    );
+}
+
+#[test]
+fn browser_embedded_policy_descriptors_track_allow_policy_features() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "embedded-resource-page")
+        .expect("embedded resource fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("embedded resource fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.embedded_policy_descriptors, expected.embedded_policy_descriptors,
+        "embedded policy descriptors should preserve raw and normalized allow policy metadata",
+    );
+
+    let frame = &actual.embedded_policy_descriptors[0];
+    assert_eq!(
+        frame.allow_tokens,
+        vec!["fullscreen".to_string(), "geolocation".to_string()],
+        "iframe allow features should be normalized from semicolon-delimited directives",
+    );
+    assert_eq!(frame.allow_token_count, 2);
+    assert!(frame.fullscreen_allowed);
+
+    let inline = &actual.embedded_policy_descriptors[3];
+    assert_eq!(inline.allow_tokens, vec!["payment".to_string()]);
+    assert_eq!(inline.allow_token_count, 1);
+    assert!(!inline.fullscreen_allowed);
 }
 
 #[test]
@@ -7150,7 +7223,11 @@ fn expected_embedded_policy_descriptor(
         sandbox: context.sandbox.clone(),
         sandbox_token_count: context.sandbox.len(),
         allow: context.allow.clone(),
+        allow_tokens: expected_permission_policy_tokens(context.allow.as_deref()),
+        allow_token_count: expected_permission_policy_tokens(context.allow.as_deref()).len(),
         allowfullscreen: context.allowfullscreen,
+        fullscreen_allowed: context.allowfullscreen
+            || expected_allow_fullscreen_policy(context.allow.as_deref()),
         referrerpolicy: context.referrerpolicy.clone(),
         srcdoc: context.srcdoc.clone(),
         has_srcdoc: context.srcdoc.is_some(),
@@ -11622,6 +11699,8 @@ impl ExpectedDocumentPolicyDescriptor {
             color_scheme: self.color_scheme,
             content_security_policy: self.content_security_policy,
             permissions_policy: self.permissions_policy,
+            permissions_policy_features: self.permissions_policy_features,
+            permissions_policy_feature_count: self.permissions_policy_feature_count,
             origin_trials: self.origin_trials,
             accept_ch: self.accept_ch,
             accept_ch_tokens: self.accept_ch_tokens,
@@ -13380,7 +13459,10 @@ impl ExpectedEmbeddedPolicyDescriptor {
             sandbox: self.sandbox,
             sandbox_token_count: self.sandbox_token_count,
             allow: self.allow,
+            allow_tokens: self.allow_tokens,
+            allow_token_count: self.allow_token_count,
             allowfullscreen: self.allowfullscreen,
+            fullscreen_allowed: self.fullscreen_allowed,
             referrerpolicy: self.referrerpolicy,
             srcdoc: self.srcdoc,
             has_srcdoc: self.has_srcdoc,

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -25,15 +25,15 @@ Global-state descriptor cases pin document/body shell state plus non-form
 inert/hidden, editing, drag, spellcheck, translate, accesskey, autofocus, and
 related focus metadata.
 Document-policy descriptor cases pin charset, viewport, referrer/robots/color
-scheme, CSP/Permissions/Origin-Trial/Accept-CH hints, theme colors, refresh,
-canonical, and manifest metadata.
+scheme, CSP/Permissions/Origin-Trial/Accept-CH hints, normalized permissions
+policy features, theme colors, refresh, canonical, and manifest metadata.
 ARIA descriptor cases pin collection/range/live-region semantics plus details,
 error-message, and flow relationship target text.
 Loading-hint descriptor cases pin scheduling hints across lazy/eager loading,
 decoding, fetch priority, blocking, and media preload metadata.
 Fetch-policy descriptor cases pin integrity, CORS, nonce, referrer policy,
-iframe CSP/sandbox/permissions, fullscreen, credentialless metadata, and
-flattened embedded-policy descriptors.
+iframe CSP/sandbox/permissions, normalized allow features, fullscreen,
+credentialless metadata, and flattened embedded-policy descriptors.
 Resource-endpoint descriptor cases pin refresh redirects plus resolved document
 resources as a flat endpoint inventory for fetch/navigation planning.
 Form-policy descriptor cases pin submission targets, accept/autocomplete/rel

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -547,6 +547,8 @@
             "color_scheme": "light dark",
             "content_security_policy": "default-src 'self'; img-src https:",
             "permissions_policy": "geolocation=(), camera=()",
+            "permissions_policy_features": ["geolocation", "camera"],
+            "permissions_policy_feature_count": 2,
             "origin_trials": ["trial-token"],
             "accept_ch": "Sec-CH-UA-Platform, DPR",
             "accept_ch_tokens": ["Sec-CH-UA-Platform", "DPR"],
@@ -716,10 +718,10 @@
           { "element": "iframe", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "allow": "payment", "srcdoc": "<h1>Inline</h1>", "fallback_text": "" }
         ],
         "embedded_policy_descriptors": [
-          { "element": "iframe", "resource_kind": "document", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "fetchpriority": "high", "csp": "script-src 'self'", "sandbox": ["allow-scripts", "allow-same-origin"], "sandbox_token_count": 2, "allow": "fullscreen; geolocation", "allowfullscreen": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "has_srcdoc": true, "credentialless": true, "fallback_text": "" },
+          { "element": "iframe", "resource_kind": "document", "url": "frame.html", "resolved_url": "https://example.test/media/frame.html", "browsing_context_name": "preview", "title": "Frame", "width": "320", "height": "200", "loading": "lazy", "fetchpriority": "high", "csp": "script-src 'self'", "sandbox": ["allow-scripts", "allow-same-origin"], "sandbox_token_count": 2, "allow": "fullscreen; geolocation", "allow_tokens": ["fullscreen", "geolocation"], "allow_token_count": 2, "allowfullscreen": true, "fullscreen_allowed": true, "referrerpolicy": "no-referrer", "srcdoc": "<p>Fallback</p>", "has_srcdoc": true, "credentialless": true, "fallback_text": "" },
           { "element": "object", "resource_kind": "object", "url": "movie.swf", "resolved_url": "https://example.test/media/movie.swf", "type_hint": "application/x-shockwave-flash", "width": "400", "height": "300", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "" },
           { "element": "embed", "resource_kind": "embed", "url": "legacy.mov", "resolved_url": "https://example.test/media/legacy.mov", "type_hint": "video/quicktime", "width": "160", "height": "120", "sandbox_token_count": 0, "has_srcdoc": false, "fallback_text": "" },
-          { "element": "iframe", "resource_kind": "document", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "sandbox_token_count": 0, "allow": "payment", "srcdoc": "<h1>Inline</h1>", "has_srcdoc": true, "fallback_text": "" }
+          { "element": "iframe", "resource_kind": "document", "url": null, "resolved_url": null, "browsing_context_name": "inline", "title": "Inline", "width": "240", "height": "120", "sandbox_token_count": 0, "allow": "payment", "allow_tokens": ["payment"], "allow_token_count": 1, "srcdoc": "<h1>Inline</h1>", "has_srcdoc": true, "fallback_text": "" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- normalize document Permissions-Policy metadata into feature vectors/counts
- normalize embedded iframe allow policy features and fullscreen allowance hints
- pin the new fields in browser-readiness fixtures and focused tests

## Tests
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_document_policy_descriptors_track_permissions_policy_features
- cargo test -p coding-adventures-html-parser browser_embedded_policy_descriptors_track_allow_policy_features
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser