### PR TITLE
feat(closurec): CLOC12.79 — close gap-070 (delete member-chain paren elision) + property-guard fix

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.83.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-070** — `delete`/`typeof`/`void` followed by a
+  parenthesised MEMBER-REFERENCE CHAIN now drops the redundant
+  grouping parens: `delete(a.b)` → `delete a.b`, `delete(a[b])` →
+  `delete a[b]`, `typeof(a.b)` → `typeof a.b`. `minify_delete_paren_elide`
+  is now enforced.
+
+### Fixed
+- **Correctness (property guard)** — `o.delete(a)` (a Map/Set
+  `.delete()` method call) previously mis-emitted as the INVALID
+  `o.delete a` because the unary-operand paren-elision pass lacked
+  a property guard. The keyword is now skipped when preceded by a
+  `.`/`?.` member accessor, so `o.delete(a)`, `o.typeof(x)`, and
+  `o?.delete(a)` keep their call parens.
+
+### Added — gap-070 member-chain operand elision
+
+The gap-054 unary-keyword paren-elision pre-pass (previously
+single-token only) was generalised. The operand validator
+`is_safe_unary_operand` now accepts either a single safe token
+(identifier / number / string — the original gap-054 case) OR a
+member-reference chain: an identifier base followed by any run of
+`.name` / `?.name` / `[…]` accessors with no top-level operator,
+call, or comma. Both shapes bind tighter than a prefix unary
+operator and are self-delimiting, so `OP(REF)` ≡ `OP REF`.
+Operands with a top-level binary operator (`delete(a+b)`) are
+left alone. The matching close paren is located by a structural
+depth scan instead of the old fixed `i+3` offset. 4 new gap070_*
+unit tests + the `minify_delete_paren_elide` byte-identity fixture.
+
 ## [0.82.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.82.0"
+version = "0.83.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -317,39 +317,95 @@ pub fn whitespace_only_minify(
         }
     }
 
-    // gap-054: paren elision around unary operand.
-    // Pattern: `void ( SINGLE )` / `typeof ( SINGLE )` /
-    // `delete ( SINGLE )` where SINGLE is exactly one
-    // token of a "safe" kind (numeric literal, string
-    // literal, or simple identifier). Drop both parens.
+    // gap-054 + gap-070: paren elision around a unary-keyword
+    // operand. Pattern: `void (E)` / `typeof (E)` / `delete (E)`
+    // where `E` is a "safe" operand whose grouping parens are
+    // redundant. Drop both parens.
     //
-    // Multi-token contents (`void(a+b)`, `delete(o.x)`)
-    // are left alone — upstream is more aggressive on
-    // `delete(o.x)`, deferred.
+    // Two shapes of safe operand are recognised:
+    //
+    //   (gap-054) a SINGLE safe token — a numeric literal, a
+    //     string literal, or a simple identifier:
+    //       typeof(x)   -> typeof x        delete(a) -> delete a
+    //       typeof(1)   -> typeof 1        void(0)   -> void 0
+    //
+    //   (gap-070) a MEMBER-REFERENCE CHAIN — an identifier base
+    //     followed by any run of `.name` / `?.name` / `[…]`
+    //     accessors, with NO top-level operators, calls, or
+    //     commas:
+    //       delete(a.b)    -> delete a.b      delete(a[b]) -> delete a[b]
+    //       typeof(a.b.c)  -> typeof a.b.c    void(a.b)    -> void a.b
+    //
+    // Both shapes are higher-precedence than the prefix unary
+    // operator and self-delimiting, so the grouping parens carry
+    // no meaning — `OP(REF)` and `OP REF` parse identically, and
+    // whatever follows the close paren re-associates the same way
+    // (member access binds tighter than the unary op). Operands
+    // that contain a top-level binary operator (`void(a+b)`,
+    // `delete(a-1)`) are LEFT ALONE: there `OP(a+b)` ≠ `OP a+b`.
+    //
+    // PROPERTY GUARD (gap-070 correctness fix): the keyword must
+    // be the genuine unary OPERATOR, not a PROPERTY of the same
+    // name. `o.delete(a)` is a method call (Map/Set#delete), NOT
+    // a `delete` expression — stripping its call parens would
+    // corrupt it into the invalid `o.delete a`. A property is
+    // preceded by a `.`/`?.` accessor; the operator is at the
+    // statement start or preceded by anything else. (Before this
+    // guard, `o.delete(a)` mis-emitted as `o.delete a`.)
     {
         let mut drops: Vec<usize> = Vec::new();
         let mut i = 0;
-        while i + 3 < kept.len() {
-            let is_unary_kw = matches!(
-                kept[i].value.as_str(),
-                "void" | "typeof" | "delete"
-            );
+        while i + 1 < kept.len() {
+            // The keyword must be a real word-like token (never a
+            // string literal `"delete"` whose `.value` matches).
+            let is_unary_kw = is_word_like(kept[i])
+                && matches!(
+                    kept[i].value.as_str(),
+                    "void" | "typeof" | "delete"
+                );
+            // Property guard: skip `o.delete(`, `o?.typeof(`, …
+            let is_property = i >= 1
+                && (is_structural_punct(kept[i - 1], ".")
+                    || is_structural_punct(kept[i - 1], "?."));
             if is_unary_kw
-                && kept[i + 1].value == "("
-                && kept[i + 3].value == ")"
+                && !is_property
+                && is_structural_punct(kept[i + 1], "(")
             {
-                let operand = kept[i + 2].value.as_str();
-                let is_safe = !operand.is_empty()
-                    && (operand.starts_with(|c: char| {
-                        c.is_ascii_alphabetic() || c == '_' || c == '$'
-                    }) || operand.starts_with(|c: char| c.is_ascii_digit())
-                        || operand.starts_with('"')
-                        || operand.starts_with('\''));
-                if is_safe {
-                    drops.push(i + 1);
-                    drops.push(i + 3);
-                    i += 4;
-                    continue;
+                let open = i + 1;
+                // Find the matching close paren (structural depth
+                // scan — string/regex literals whose content holds
+                // a bracket char never perturb the count).
+                let mut depth: i32 = 1;
+                let mut close: Option<usize> = None;
+                let mut j = open + 1;
+                while j < kept.len() {
+                    let t = kept[j];
+                    if is_structural_punct(t, "(")
+                        || is_structural_punct(t, "[")
+                        || is_structural_punct(t, "{")
+                    {
+                        depth += 1;
+                    } else if is_structural_punct(t, ")") {
+                        depth -= 1;
+                        if depth == 0 {
+                            close = Some(j);
+                            break;
+                        }
+                    } else if is_structural_punct(t, "]")
+                        || is_structural_punct(t, "}")
+                    {
+                        depth -= 1;
+                    }
+                    j += 1;
+                }
+                if let Some(close) = close {
+                    let span = &kept[open + 1..close];
+                    if is_safe_unary_operand(span) {
+                        drops.push(open);
+                        drops.push(close);
+                        i = close + 1;
+                        continue;
+                    }
                 }
             }
             i += 1;
@@ -2512,6 +2568,101 @@ fn new_paren_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bool {
     true
 }
 
+/// gap-054 + gap-070: True iff `span` (the tokens BETWEEN a unary
+/// keyword's grouping parens, exclusive of the parens) is a "safe"
+/// operand whose parens are pure grouping and can be dropped.
+///
+/// Two accepted shapes (see the call site for the full rationale):
+///
+///   1. A SINGLE safe token — an identifier, a numeric literal, or
+///      a string literal. (gap-054, the original case.)
+///   2. A MEMBER-REFERENCE CHAIN — an identifier base followed by
+///      any run of `.name` / `?.name` / `[…]` accessors and nothing
+///      else at the top level. (gap-070.)
+///
+/// Both are self-delimiting and bind tighter than a prefix unary
+/// operator, so `OP(span)` ≡ `OP span`. Anything with a top-level
+/// binary operator, comma, or call `(` is rejected — there the
+/// parens change meaning.
+fn is_safe_unary_operand(span: &[&lexer::token::Token]) -> bool {
+    if span.is_empty() {
+        return false;
+    }
+    // Shape 1: a single safe token (identifier / number / string).
+    if span.len() == 1 {
+        let t = span[0];
+        if is_string_literal(t) {
+            return true;
+        }
+        let v = t.value.as_str();
+        return !v.is_empty()
+            && v.starts_with(|c: char| {
+                c.is_ascii_alphabetic()
+                    || c == '_'
+                    || c == '$'
+                    || c.is_ascii_digit()
+            });
+    }
+    // Shape 2: a member-reference chain. The base must be a plain
+    // word-like identifier/keyword token (`a`, `this`) — never a
+    // string, number, or operator. (A number base like `1` is
+    // rejected: `1.toString` would re-lex the `.` as part of the
+    // number.)
+    let base = span[0];
+    if is_string_literal(base) || !is_word_like(base) {
+        return false;
+    }
+    if !base
+        .value
+        .starts_with(|c: char| c.is_ascii_alphabetic() || c == '_' || c == '$')
+    {
+        return false;
+    }
+    // Walk the accessors after the base.
+    let mut k = 1;
+    while k < span.len() {
+        let t = span[k];
+        if is_structural_punct(t, ".") || is_structural_punct(t, "?.") {
+            // A `.`/`?.` must be followed by a property name — a
+            // word-like identifier or keyword (`a.if` is legal).
+            let Some(name) = span.get(k + 1) else {
+                return false;
+            };
+            if is_string_literal(name) || !is_word_like(name) {
+                return false;
+            }
+            k += 2;
+        } else if is_structural_punct(t, "[") {
+            // Balanced computed-member subscript `[ … ]`. The
+            // contents are a complete sub-expression; we only
+            // require the brackets balance and are non-empty.
+            let mut depth: i32 = 1;
+            let mut j = k + 1;
+            while j < span.len() {
+                let u = span[j];
+                if is_structural_punct(u, "[") {
+                    depth += 1;
+                } else if is_structural_punct(u, "]") {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                j += 1;
+            }
+            if depth != 0 || j == k + 1 {
+                return false; // unbalanced or empty `[]`
+            }
+            k = j + 1;
+        } else {
+            // Top-level operator, call `(`, comma, etc. → not a
+            // pure reference chain; the parens are meaningful.
+            return false;
+        }
+    }
+    true
+}
+
 /// True iff a token is "word-like" — its value would merge with
 /// an adjacent word-like value if no separator were inserted.
 ///
@@ -4007,6 +4158,48 @@ mod tests {
     #[test]
     fn gap069_new_ident_unaffected() {
         assert_eq!(minify("new X();"), "new X;");
+    }
+
+    // ---- gap-070: unary-keyword operand member-chain paren elision ----
+
+    /// gap-070: `delete`/`typeof`/`void` followed by a parenthesised
+    /// MEMBER-REFERENCE CHAIN drops the redundant parens.
+    #[test]
+    fn gap070_member_chain_paren_elided() {
+        assert_eq!(minify("delete(a.b);"), "delete a.b;");
+        assert_eq!(minify("delete(a.b.c);"), "delete a.b.c;");
+        assert_eq!(minify("delete(a[b]);"), "delete a[b];");
+        assert_eq!(minify("typeof(a.b);"), "typeof a.b;");
+        assert_eq!(minify("void(a.b);"), "void a.b;");
+    }
+
+    /// gap-070 SAFETY (correctness fix): a PROPERTY named
+    /// `delete`/`typeof`/`void` is a method call, NOT a unary
+    /// operator — its call parens must be preserved. Before the
+    /// property guard, `o.delete(a)` mis-emitted as the invalid
+    /// `o.delete a`.
+    #[test]
+    fn gap070_property_keyword_not_elided() {
+        assert_eq!(minify("o.delete(a);"), "o.delete(a);");
+        assert_eq!(minify("o.typeof(x);"), "o.typeof(x);");
+        assert_eq!(minify("o?.delete(a);"), "o?.delete(a);");
+    }
+
+    /// gap-070 boundary: an operand containing a top-level binary
+    /// operator is NOT a pure reference chain — `delete(a+b)` must
+    /// keep its parens (`delete a+b` ≠ `delete(a+b)`).
+    #[test]
+    fn gap070_operator_operand_kept() {
+        assert_eq!(minify("delete(a+b);"), "delete(a+b);");
+        assert_eq!(minify("typeof(a||b);"), "typeof(a||b);");
+    }
+
+    /// gap-054 non-regression: the single-token cases still elide.
+    #[test]
+    fn gap070_single_token_still_elided() {
+        assert_eq!(minify("delete(a);"), "delete a;");
+        assert_eq!(minify("typeof(x);"), "typeof x;");
+        assert_eq!(minify("void(0);"), "void 0;");
     }
 
     // ---- gap-067: labeled single-statement block flatten ----

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.82.0
+Version: 0.83.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-070/071/072 (CLOC14.35): prefix-operator OPERAND paren
-    // elision — strip redundant parens around a simple-reference
-    // operand. `typeof`/`void` already do this; `delete`,
-    // `instanceof`, `await` do not yet.
-    ("delete_paren_elide", "gap-070: delete operand paren elision"),
+    // gap-071/072 (CLOC14.35): prefix/binary-operator OPERAND
+    // paren elision — strip redundant parens around a simple-
+    // reference operand. `typeof`/`void`/`delete` (gap-070, closed
+    // in CLOC12.79) do this; `instanceof`, `await` do not yet.
     ("instanceof_paren",   "gap-071: instanceof operand paren elision"),
     ("await_paren_elide",  "gap-072: await operand paren elision"),
     // gap-073 (CLOC14.35): a `get`/`set` accessor before a

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -540,11 +540,19 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **What it needed:** When the `new` keyword is directly followed by a `(` GROUPING paren (a parenthesized callee expression that gap-068 keeps), the re-stitcher inserts a single space: `new (…)`. Both forms keep the parens; this is an emit-adjacency rule for `new` + `(`. (Noted as the gap-069 candidate during CLOC12.76.)
 - **CLOC12.78 resolution:** A two-token look-behind, `new_paren_needs_space(kept, idx)`, consulted at the main emit site (NOT in `needs_separator`, which sees only the adjacent pair). Distinguishing the genuine NewExpression keyword `new` from a PROPERTY named `new` (`o.new(f)` — a method call) requires the token *before* `new`: the JS lexer is context-free and types `new` identically in both, so only a preceding `.`/`?.` member accessor tells them apart. The helper fires only when (a) `kept[idx]` is a structural `(`, (b) `kept[idx-1]` is the word-like `new` keyword, and (c) `kept[idx-2]` (if any) is not a `.`/`?.` accessor. The companion `new(f)()` simple-reference form never reaches here — gap-068's pre-pass has already elided those parens to `new f`. 3 unit tests + the byte-identity fixture.
 
-### gap-070 / gap-071 / gap-072 — prefix-operator operand paren elision
+### gap-070 — `delete` operand member-chain paren elision
 
-- **Status:** OPEN — discovered by CLOC14.35. `minify_delete_paren_elide` / `minify_instanceof_paren` / `minify_await_paren_elide` ignored.
-- **Inputs:** `delete(a.b)` → `delete a.b`; `a instanceof(B)` → `a instanceof B`; `await(x)` → `await x`.
-- **What it needs:** Strip the redundant grouping parens around the OPERAND of these prefix/binary-RHS operators when the operand is a simple reference (identifier or member chain), exactly as `typeof`/`void` already do (those round-trip correctly). The operator keyword + a keyword-space + the bare operand re-lex correctly. Same simple-reference / precedence caveat as gap-054/065.
+- **Status:** RESOLVED in CLOC12.79. `minify_delete_paren_elide` enforced.
+- **Input:** `delete(a.b)` → `delete a.b` (also `delete(a.b.c)`, `delete(a[b])`).
+- **What it needed:** Strip the redundant grouping parens around the OPERAND of the `delete` prefix operator when the operand is a member-reference chain — exactly the shape `typeof`/`void` already handled for single tokens.
+- **CLOC12.79 resolution:** The existing gap-054 pre-pass (which handled `void`/`typeof`/`delete` for a single safe token) was generalised. The operand check now accepts a **member-reference chain** — an identifier base followed by any run of `.name` / `?.name` / `[…]` accessors with no top-level operator, call, or comma — via the new `is_safe_unary_operand` helper. Both shapes are higher-precedence than the unary operator and self-delimiting, so the parens are pure grouping (`OP(REF)` ≡ `OP REF`). The matching close paren is found by a structural depth scan rather than the old fixed `i+3` offset.
+- **Correctness fix bundled in:** the pre-pass previously lacked a PROPERTY GUARD, so `o.delete(a)` (a Map/Set `.delete()` method call) mis-emitted as the **invalid** `o.delete a`. A `.`/`?.` look-behind now skips property-named keywords (`o.delete(`, `o.typeof(`, …). The same generalisation also closes `typeof(a.b)` / `void(a.b)` against the JAR. 4 unit tests + the byte-identity fixture.
+
+### gap-071 / gap-072 — instanceof / await operand paren elision
+
+- **Status:** OPEN — discovered by CLOC14.35. `minify_instanceof_paren` / `minify_await_paren_elide` ignored.
+- **Inputs:** `a instanceof(B)` → `a instanceof B`; `await(x)` → `await x`.
+- **What it needs:** Same simple-reference operand paren elision as gap-070, but for the binary-RHS `instanceof` operator and the `await` unary operator. Deferred to follow-up PRs (different anchor positions — `instanceof` has a left operand; `await` is async-context-only).
 
 ### gap-073 — `get`/`set` before a computed key needs a space
 


### PR DESCRIPTION
## CLOC12.79 — closes gap-070

Upstream Closure strips redundant grouping parens around a `delete`/`typeof`/`void` operand when the operand is a **member-reference chain**:

| input | closurec (before) | upstream / closurec (now) |
|---|---|---|
| `delete(a.b);` | `delete(a.b);` | `delete a.b;` |
| `delete(a.b.c);` | `delete(a.b.c);` | `delete a.b.c;` |
| `delete(a[b]);` | `delete(a[b]);` | `delete a[b];` |
| `typeof(a.b);` | `typeof(a.b);` | `typeof a.b;` |
| `void(a.b);` | `void(a.b);` | `void a.b;` |

closurec already handled the single-token case (gap-054: `typeof(x)` → `typeof x`) but deferred multi-token member chains. CLOC14.35 captured `delete(a.b)` as the gap-070 fixture.

### 🐞 Correctness fix bundled in
While extending this area I found a **pre-existing bug**: the pass lacked a property guard, so `o.delete(a)` (a Map/Set `.delete()` method call) mis-emitted as the **invalid** `o.delete a`. Verified against the JAR (v20240317): the JAR keeps `o.delete(a)`. Now fixed — a `.`/`?.` look-behind skips property-named keywords (`o.delete(`, `o.typeof(`, `o?.delete(`).

### Implementation
Generalised the gap-054 pre-pass:
- New operand validator `is_safe_unary_operand(span)` accepts **either** a single safe token (identifier/number/string — the original gap-054 case) **or** a member-reference chain: an identifier base followed by any run of `.name` / `?.name` / `[…]` accessors, with **no** top-level operator, call, or comma. Both shapes bind tighter than a prefix unary operator and are self-delimiting, so `OP(REF)` ≡ `OP REF`. Operator operands (`delete(a+b)`) are left alone.
- The matching close paren is now found by a structural depth scan (`is_structural_punct`-gated, so bracket chars inside string/regex content can't corrupt the count) instead of the old fixed `i+3` offset.

### Tests / bookkeeping
- 4 new `gap070_*` unit tests: member chain elided, property guard, operator-operand kept, single-token non-regression.
- `minify_delete_paren_elide` removed from `IGNORE_FIXTURES` (now enforced); gap-071/072 (instanceof/await) split out as still-open.
- version `0.82.0` → `0.83.0` (Cargo.toml, cli.spec.json, help-markdown golden regenerated).
- `code/specs/CLOC12-gaps.md`: gap-070 marked RESOLVED; CHANGELOG updated.

464 unit tests + every integration suite (incl. the byte-identity harness) green. Security review PASS (panic-free index/slice safety, property guard, no over-stripping all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)