### PR TITLE
feat(closurec): CLOC12.80 — close gap-073 (get/set computed-key separating space)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.84.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-073** — a `get`/`set` accessor in an object literal
+  whose key is COMPUTED gains a separating space before the `[`,
+  matching upstream Closure: `var o={get[k](){return 1}}` →
+  `var o={get [k](){return 1}}` (also `set[k](v){}`).
+  `minify_get_computed_space` is now enforced.
+
+### Added — gap-073 `get`/`set` computed-key space
+
+A two-token look-behind + forward-check helper
+`get_set_computed_needs_space(kept, idx)`, consulted at the main
+emit site (NOT in `needs_separator`, which sees only the adjacent
+pair). `get`/`set` are *contextual* keywords — accessors only
+inside an object/class body, plain identifiers elsewhere — and the
+JS lexer types them identically, so distinguishing a real accessor
+from member access (`o.get[k]`) or variable indexing (`get[k](x)`)
+needs context. The helper fires only when (a) `kept[idx]` is a
+structural `[`, (b) `kept[idx-1]` is the word-like `get`/`set`
+keyword, (c) `kept[idx-2]` is an object-literal property-start
+`{`/`,` (excludes member access and statement-level indexing), and
+(d) the token after the matching `]` is a structural `(` (the
+accessor parameter list). Class-body accessors after a previous
+member (`}`-/`static`-preceded) are deferred. 2 new gap073_* unit
+tests + the `minify_get_computed_space` byte-identity fixture.
+
 ## [0.83.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.83.0"
+version = "0.84.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1748,7 +1748,10 @@ pub fn whitespace_only_minify(
 
         // Emit the token (with separator if needed).
         if let Some(prev) = prev_emitted_tok {
-            if needs_separator(prev, tok) || new_paren_needs_space(&kept, idx) {
+            if needs_separator(prev, tok)
+                || new_paren_needs_space(&kept, idx)
+                || get_set_computed_needs_space(&kept, idx)
+            {
                 out.push(' ');
             }
         }
@@ -2566,6 +2569,82 @@ fn new_paren_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bool {
         }
     }
     true
+}
+
+/// gap-073: decide whether the `[` token at `kept[idx]` needs a
+/// single leading space because it is the COMPUTED KEY of a
+/// `get`/`set` accessor — `{get[k](){…}}` → `{get [k](){…}}`,
+/// matching upstream Closure. Without the space `get[k]` re-reads
+/// as a member access on a variable named `get` rather than a
+/// getter with a computed name.
+///
+/// The hazard mirrors gap-069: `get`/`set` are *contextual*
+/// keywords — accessors only inside an object/class body, plain
+/// identifiers everywhere else. The JS lexer types them
+/// identically, so two tokens of look-behind plus a forward check
+/// are needed to tell a real accessor from member access /
+/// variable indexing:
+///
+///   {get[k](){…}}     → { get [ … ] (   → SPACE    (accessor)
+///   {a:1,set[k](v){}} → , set [ … ] (   → SPACE    (accessor)
+///   o.get[k];         → . get [ … ] ;   → NO SPACE (member access)
+///   get[k](x);        → ^ get [ … ] (   → NO SPACE (var index+call)
+///
+/// GUARDS (all required, fail-closed):
+///   - `kept[idx]` is a structural `[` (not a string `"["`).
+///   - `kept[idx-1]` is a word-like `get` or `set` keyword (so a
+///     string literal `"get"` can never trigger it).
+///   - `kept[idx-2]` is a structural `{` or `,` — an object-literal
+///     property-start position. This is the decisive disambiguator:
+///     it excludes member access (`.`/`?.`) and statement-level
+///     variable indexing (preceded by `;` / start). (Class-body
+///     accessors after a previous member — preceded by `}` /
+///     `static` — are deferred; the object-literal form is the
+///     gap-073 fixture.)
+///   - after the matching `]`, the next token is a structural `(` —
+///     i.e. the accessor's parameter list. This confirms a
+///     method/accessor shape and rejects a bare computed member.
+fn get_set_computed_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bool {
+    if idx < 2 {
+        return false; // need property-start + keyword before `[`
+    }
+    let open = kept[idx];
+    if !is_structural_punct(open, "[") {
+        return false;
+    }
+    let kw = kept[idx - 1];
+    if !(is_word_like(kw) && (kw.value == "get" || kw.value == "set")) {
+        return false;
+    }
+    // Property-start context: an object-literal `{` or `,`.
+    let before_kw = kept[idx - 2];
+    if !(is_structural_punct(before_kw, "{") || is_structural_punct(before_kw, ",")) {
+        return false;
+    }
+    // Find the matching `]` (structural depth scan).
+    let mut depth: i32 = 1;
+    let mut close: Option<usize> = None;
+    let mut j = idx + 1;
+    while j < kept.len() {
+        let t = kept[j];
+        if is_structural_punct(t, "[") {
+            depth += 1;
+        } else if is_structural_punct(t, "]") {
+            depth -= 1;
+            if depth == 0 {
+                close = Some(j);
+                break;
+            }
+        }
+        j += 1;
+    }
+    // The accessor's parameter list `(` must immediately follow.
+    match close {
+        Some(c) => kept
+            .get(c + 1)
+            .is_some_and(|t| is_structural_punct(t, "(")),
+        None => false,
+    }
 }
 
 /// gap-054 + gap-070: True iff `span` (the tokens BETWEEN a unary
@@ -4200,6 +4279,32 @@ mod tests {
         assert_eq!(minify("delete(a);"), "delete a;");
         assert_eq!(minify("typeof(x);"), "typeof x;");
         assert_eq!(minify("void(0);"), "void 0;");
+    }
+
+    // ---- gap-073: get/set computed-key separating space ----
+
+    /// gap-073: a `get`/`set` accessor before a COMPUTED key `[k]`
+    /// in an object literal gets a separating space.
+    #[test]
+    fn gap073_accessor_computed_key_spaced() {
+        assert_eq!(
+            minify("var o={get[k](){return 1}};"),
+            "var o={get [k](){return 1}};"
+        );
+        assert_eq!(minify("var o={set[k](v){}};"), "var o={set [k](v){}};");
+        assert_eq!(
+            minify("var o={a:1,get[k](){return 2}};"),
+            "var o={a:1,get [k](){return 2}};"
+        );
+    }
+
+    /// gap-073 SAFETY: a member access `o.get[k]` or a variable
+    /// index+call `get[k](x)` must NOT gain a space — `get`/`set`
+    /// there are plain identifiers, not accessors.
+    #[test]
+    fn gap073_member_access_not_spaced() {
+        assert_eq!(minify("o.get[k];"), "o.get[k];");
+        assert_eq!(minify("get[k](x);"), "get[k](x);");
     }
 
     // ---- gap-067: labeled single-statement block flatten ----

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.83.0
+Version: 0.84.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -96,10 +96,6 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // in CLOC12.79) do this; `instanceof`, `await` do not yet.
     ("instanceof_paren",   "gap-071: instanceof operand paren elision"),
     ("await_paren_elide",  "gap-072: await operand paren elision"),
-    // gap-073 (CLOC14.35): a `get`/`set` accessor before a
-    // COMPUTED key `[k]` needs a separating space — `get[k]` →
-    // `get [k]` (else it re-lexes as a member access).
-    ("get_computed_space", "gap-073: `get[`/`set[` needs a space → `get [`"),
     // gap-074 (CLOC14.35): a loop body that is a single-statement
     // block flattens — `for(;;){continue l}` → `for(;;)continue
     // l;`. Sibling of gap-067 (labeled-block) in a loop-body

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -556,9 +556,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-073 — `get`/`set` before a computed key needs a space
 
-- **Status:** OPEN — discovered by CLOC14.35. `minify_get_computed_space` ignored.
-- **Input:** `var o={get[k](){return 1}};` → **Upstream:** `var o={get [k](){return 1}};`
-- **What it needs:** When a `get`/`set` accessor keyword is directly followed by a COMPUTED key `[`, the re-stitcher must insert a space — `get [k]` — otherwise `get[k]` re-lexes as a member access on `get` rather than a getter with a computed name. An emit-adjacency (`needs_separator`) rule.
+- **Status:** RESOLVED in CLOC12.80. `minify_get_computed_space` enforced.
+- **Input:** `var o={get[k](){return 1}};` → **Upstream:** `var o={get [k](){return 1}};` (also `set[k](v){}`).
+- **What it needed:** When a `get`/`set` ACCESSOR keyword is directly followed by a COMPUTED key `[`, insert a space — `get [k]` — otherwise `get[k]` re-reads as a member access on a variable named `get` rather than a getter with a computed name.
+- **CLOC12.80 resolution:** A two-token-look-behind + forward-check helper `get_set_computed_needs_space(kept, idx)`, consulted at the main emit site (NOT in `needs_separator`, which sees only the adjacent pair). `get`/`set` are *contextual* keywords (accessors only inside an object/class body, plain identifiers elsewhere) and the JS lexer types them identically, so disambiguating a real accessor from member access (`o.get[k]`) or variable indexing (`get[k](x)`) needs more context. The helper fires only when (a) `kept[idx]` is a structural `[`, (b) `kept[idx-1]` is the word-like `get`/`set` keyword, (c) `kept[idx-2]` is an object-literal property-start `{`/`,` (the decisive guard — excludes `.`/`?.` member access and statement-level indexing), and (d) the token after the matching `]` is a structural `(` (the accessor's parameter list). Verified against the JAR. Class-body accessors after a previous member (`}`-/`static`-preceded) are deferred. 2 unit tests + the byte-identity fixture.
 
 ### gap-074 — loop-body single-statement block flatten
 


### PR DESCRIPTION
## CLOC12.80 — closes gap-073

Upstream Closure inserts a space between a `get`/`set` accessor keyword and its **computed** key in an object literal:

| input | closurec (before) | upstream / closurec (now) |
|---|---|---|
| `var o={get[k](){return 1}};` | `var o={get[k]…};` | `var o={get [k](){return 1}};` |
| `var o={set[k](v){}};` | `var o={set[k]…};` | `var o={set [k](v){}};` |

Without the space, `get[k]` re-reads as a member access on a variable named `get` rather than a getter with a computed name.

### Implementation
`get_set_computed_needs_space(kept, idx)` — a two-token look-behind + forward-check consulted at the **main emit site** (NOT in `needs_separator`, which is a pure `(prev, cur)` function).

`get`/`set` are **contextual** keywords — accessors only inside an object/class body, plain identifiers everywhere else — and the JS lexer types them identically. Disambiguating a real accessor from member access (`o.get[k]`) or variable indexing (`get[k](x)`) requires context, so the helper fires only when:
- `kept[idx]` is a structural `[` (not a string `"["`),
- `kept[idx-1]` is the word-like `get`/`set` keyword (not a string `"get"`),
- `kept[idx-2]` is an object-literal property-start `{` or `,` — the decisive guard, excluding `.`/`?.` member access and statement-level indexing,
- the token after the matching `]` is a structural `(` (the accessor's parameter list).

Verified against the JAR (v20240317): getters/setters get the space; `o.get[k];` and `get[k](x);` keep `get[k]`. Class-body accessors after a previous member (`}`-/`static`-preceded) are deferred — the gap-073 fixture is the object-literal form.

### Tests / bookkeeping
- 2 new `gap073_*` unit tests (accessor spaced / member-access-not-spaced).
- `minify_get_computed_space` removed from `IGNORE_FIXTURES` (now enforced byte-identical).
- version `0.83.0` → `0.84.0` (Cargo.toml, cli.spec.json, help-markdown golden regenerated).
- `code/specs/CLOC12-gaps.md`: gap-073 marked RESOLVED; CHANGELOG updated.

466 unit tests + every integration suite (incl. the byte-identity harness) green. Security review PASS (bounds-safe index/scan, disambiguation, no corruption all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)