### PR TITLE
feat(closurec): CLOC12.82 — close gap-071 (instanceof right-operand paren elision)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.86.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-071** — the binary `instanceof` operator now drops
+  the redundant grouping parens around a simple-reference RIGHT
+  operand, matching upstream Closure: `a instanceof(B)` →
+  `a instanceof B` (also `a instanceof(b.c)`, `a instanceof(b[c])`).
+  `minify_instanceof_paren` is now enforced.
+
+### Added — gap-071 instanceof operand elision
+
+`instanceof` was added to the gap-054/070 unary-keyword paren-elision
+pre-pass keyword set (`void`/`typeof`/`delete`/`instanceof`). Although
+`instanceof` is a binary operator, the right-operand elision is
+mechanically identical to the prefix-unary cases — the left operand
+sits at `kept[i-1]` and is irrelevant to the right operand's parens.
+`instanceof` binds looser than member access, so `a instanceof(B.c)`
+≡ `a instanceof B.c` and whatever follows the close paren
+re-associates identically. The existing `is_safe_unary_operand`
+check and property guard apply unchanged: operator operands
+(`a instanceof(B||C)`) keep their parens, and `o.instanceof(x)` (a
+property method call) is skipped. 3 new gap071_* unit tests + the
+`minify_instanceof_paren` byte-identity fixture.
+
 ## [0.85.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.85.0"
+version = "0.86.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -358,10 +358,22 @@ pub fn whitespace_only_minify(
         while i + 1 < kept.len() {
             // The keyword must be a real word-like token (never a
             // string literal `"delete"` whose `.value` matches).
+            //
+            // gap-071: `instanceof` joins the set. It is a BINARY
+            // operator (`a instanceof(B)`), but the right-operand
+            // paren elision is mechanically identical to the prefix
+            // unary cases — the left operand sits at `kept[i-1]` and
+            // is irrelevant to whether the RIGHT operand's grouping
+            // parens are redundant. `instanceof` binds looser than
+            // member access, so `a instanceof(B.c)` ≡ `a instanceof
+            // B.c` and whatever follows the close paren re-associates
+            // identically (same as the unary cases). The property
+            // guard below also covers `o.instanceof(x)` — a property
+            // access whose call parens must be preserved.
             let is_unary_kw = is_word_like(kept[i])
                 && matches!(
                     kept[i].value.as_str(),
-                    "void" | "typeof" | "delete"
+                    "void" | "typeof" | "delete" | "instanceof"
                 );
             // Property guard: skip `o.delete(`, `o?.typeof(`, …
             let is_property = i >= 1
@@ -4432,6 +4444,42 @@ mod tests {
         assert_eq!(minify("delete(a);"), "delete a;");
         assert_eq!(minify("typeof(x);"), "typeof x;");
         assert_eq!(minify("void(0);"), "void 0;");
+    }
+
+    // ---- gap-071: instanceof right-operand paren elision ----
+
+    /// gap-071: `instanceof` followed by a parenthesised simple
+    /// reference (single token or member chain) drops the parens.
+    #[test]
+    fn gap071_instanceof_operand_elided() {
+        assert_eq!(minify("var x=a instanceof(B);"), "var x=a instanceof B;");
+        assert_eq!(
+            minify("var x=a instanceof(b.c);"),
+            "var x=a instanceof b.c;"
+        );
+        assert_eq!(
+            minify("var x=a instanceof(b[c]);"),
+            "var x=a instanceof b[c];"
+        );
+    }
+
+    /// gap-071 boundary: an operand containing a top-level binary
+    /// operator keeps its parens — `a instanceof(B||C)` ≠
+    /// `a instanceof B||C`.
+    #[test]
+    fn gap071_operator_operand_kept() {
+        assert_eq!(
+            minify("var x=a instanceof(B||C);"),
+            "var x=a instanceof(B||C);"
+        );
+    }
+
+    /// gap-071 SAFETY: a PROPERTY named `instanceof`
+    /// (`o.instanceof(x)`) is a method call, NOT the operator — its
+    /// call parens must be preserved.
+    #[test]
+    fn gap071_property_instanceof_not_elided() {
+        assert_eq!(minify("o.instanceof(x);"), "o.instanceof(x);");
     }
 
     // ---- gap-073: get/set computed-key separating space ----

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.85.0
+Version: 0.86.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -90,11 +90,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-071/072 (CLOC14.35): prefix/binary-operator OPERAND
-    // paren elision — strip redundant parens around a simple-
-    // reference operand. `typeof`/`void`/`delete` (gap-070, closed
-    // in CLOC12.79) do this; `instanceof`, `await` do not yet.
-    ("instanceof_paren",   "gap-071: instanceof operand paren elision"),
+    // gap-072 (CLOC14.35): `await` OPERAND paren elision — strip
+    // redundant parens around a simple-reference operand.
+    // `typeof`/`void`/`delete` (gap-070, CLOC12.79) and
+    // `instanceof` (gap-071, CLOC12.82) do this; `await` does not
+    // yet (async-context-only anchor — deferred).
     ("await_paren_elide",  "gap-072: await operand paren elision"),
     // gap-074 RESOLVED in CLOC12.81 — a loop body that is a
     // single-statement block (`for(;;){continue l}` →

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -548,11 +548,18 @@ historical context with status `RESOLVED` and a link to the fix PR.
 - **CLOC12.79 resolution:** The existing gap-054 pre-pass (which handled `void`/`typeof`/`delete` for a single safe token) was generalised. The operand check now accepts a **member-reference chain** — an identifier base followed by any run of `.name` / `?.name` / `[…]` accessors with no top-level operator, call, or comma — via the new `is_safe_unary_operand` helper. Both shapes are higher-precedence than the unary operator and self-delimiting, so the parens are pure grouping (`OP(REF)` ≡ `OP REF`). The matching close paren is found by a structural depth scan rather than the old fixed `i+3` offset.
 - **Correctness fix bundled in:** the pre-pass previously lacked a PROPERTY GUARD, so `o.delete(a)` (a Map/Set `.delete()` method call) mis-emitted as the **invalid** `o.delete a`. A `.`/`?.` look-behind now skips property-named keywords (`o.delete(`, `o.typeof(`, …). The same generalisation also closes `typeof(a.b)` / `void(a.b)` against the JAR. 4 unit tests + the byte-identity fixture.
 
-### gap-071 / gap-072 — instanceof / await operand paren elision
+### gap-071 — instanceof right-operand paren elision
 
-- **Status:** OPEN — discovered by CLOC14.35. `minify_instanceof_paren` / `minify_await_paren_elide` ignored.
-- **Inputs:** `a instanceof(B)` → `a instanceof B`; `await(x)` → `await x`.
-- **What it needs:** Same simple-reference operand paren elision as gap-070, but for the binary-RHS `instanceof` operator and the `await` unary operator. Deferred to follow-up PRs (different anchor positions — `instanceof` has a left operand; `await` is async-context-only).
+- **Status:** RESOLVED in CLOC12.82. `minify_instanceof_paren` enforced.
+- **Input:** `a instanceof(B)` → `a instanceof B` (also `a instanceof(b.c)`, `a instanceof(b[c])`).
+- **What it needed:** Strip the redundant grouping parens around the RIGHT operand of the binary `instanceof` operator when the operand is a simple reference (single token or member chain).
+- **CLOC12.82 resolution:** `instanceof` was added to the gap-054/070 unary-keyword paren-elision pre-pass keyword set (`void`/`typeof`/`delete`/`instanceof`). Although `instanceof` is a *binary* operator, the right-operand elision is mechanically identical to the prefix-unary cases — the left operand sits at `kept[i-1]` and is irrelevant to whether the right operand's grouping parens are redundant. `instanceof` binds looser than member access, so `a instanceof(B.c)` ≡ `a instanceof B.c` and whatever follows the close paren re-associates identically. The existing `is_safe_unary_operand` check (single token or member-reference chain) and property guard apply unchanged: operator operands (`a instanceof(B||C)`) keep their parens, and `o.instanceof(x)` (a property method call — `instanceof` reserved word as a property name) is skipped. 3 unit tests + the byte-identity fixture.
+
+### gap-072 — await operand paren elision
+
+- **Status:** OPEN — discovered by CLOC14.35. `minify_await_paren_elide` ignored.
+- **Input:** `await(x)` → `await x`.
+- **What it needs:** Same simple-reference operand paren elision as gap-070/071, but for the `await` unary operator. Deferred: `await` is async-context-only, so a naive keyword-anchored elision could mis-handle a non-async `await` used as a plain identifier (`await` is only reserved inside async functions/modules). Needs an async-context guard before it can be added to the keyword set safely.
 
 ### gap-073 — `get`/`set` before a computed key needs a space
 


### PR DESCRIPTION
## CLOC12.82 — closes gap-071

Upstream Closure strips the redundant grouping parens around the **right** operand of the binary `instanceof` operator when the operand is a simple reference:

| input | upstream / closurec (now) |
|---|---|
| `a instanceof(B);` | `a instanceof B;` |
| `a instanceof(b.c);` | `a instanceof b.c;` |
| `a instanceof(b[c]);` | `a instanceof b[c];` |

### Implementation
A **one-line** addition: `instanceof` joins the gap-054/070 unary-keyword paren-elision pre-pass keyword set (`void`/`typeof`/`delete`/`instanceof`).

Although `instanceof` is a *binary* operator, the right-operand elision is mechanically identical to the prefix-unary cases — the left operand sits at `kept[i-1]` and is irrelevant to whether the right operand's grouping parens are redundant. `instanceof` binds looser than member access, so `a instanceof(B.c)` ≡ `a instanceof B.c` and whatever follows the close paren re-associates identically (same precedence reasoning as gap-070).

The existing machinery applies unchanged:
- `is_safe_unary_operand` (single token **or** member-reference chain) keeps operator operands like `a instanceof(B||C)` parenthesised;
- the property guard skips `o.instanceof(x)` — `instanceof` is a reserved word usable as a property name, so that's a method call whose parens must be preserved.

Verified against the JAR (v20240317): all three elision cases match; `a instanceof(B||C)` keeps parens; `o.instanceof(x)` unchanged.

### Tests / bookkeeping
- 3 new `gap071_*` unit tests (operand elided / operator-operand kept / property guard).
- `minify_instanceof_paren` removed from `IGNORE_FIXTURES` (now enforced byte-identical).
- version `0.85.0` → `0.86.0` (Cargo.toml, cli.spec.json, help-markdown golden regenerated).
- `code/specs/CLOC12-gaps.md`: gap-071 marked RESOLVED; gap-072 (await) split out with an async-context deferral note; CHANGELOG updated.

473 unit tests + every integration suite (incl. the byte-identity harness) green. Security review PASS (precedence soundness, property guard, operator-operand rejection, no regression to void/typeof/delete all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)