### PR TITLE
feat(closurec): CLOC12.83 — close gap-076 (with-body single-statement block flatten)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.87.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-076** — a `with` statement whose body is a single
+  un-terminated statement now drops its braces, matching upstream
+  Closure: `with(o){a()}` → `with(o)a();`. `minify_with_body_flatten`
+  is now enforced.
+
+### Added — gap-076 with-body single-statement flatten
+
+`with` was added to the gap-074 header-keyword body-flatten pre-pass
+anchor set (`for`/`while`/`with`). A `with(o){…}` statement has the
+same `keyword (…) {body}` shape as a loop, and a `{` immediately
+after the `with(…)` header is unambiguously the with-body — so the
+identical single-statement / property-guard (`o.with(x){…}` left
+alone) / synthetic-`;` machinery applies unchanged. Multi-statement
+bodies (`with(o){a();b()}`) keep their braces. A `with` body that
+already ends in `;` (`with(o){a();}`) is not yet flattened (the
+gap-032 emit-time flatten does not set body-position after a
+`with(…)` header) — deferred. 2 new gap076_* unit tests + the
+`minify_with_body_flatten` byte-identity fixture.
+
 ## [0.86.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.86.0"
+version = "0.87.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.86.0",
+  "version": "0.87.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1240,25 +1240,29 @@ pub fn whitespace_only_minify(
         }
     }
 
-    // ---- gap-074: loop-body single-statement block flatten ------
-    // `for(...){S}` / `while(...){S}` whose body `{S}` is a SINGLE
-    // statement with NO trailing `;` → `for(...)S;`. Loop-body
-    // sibling of gap-067 (which flattens a *labeled* block).
+    // ---- gap-074 + gap-076: header-keyword body flatten ----------
+    // `for(...){S}` / `while(...){S}` / `with(...){S}` whose body
+    // `{S}` is a SINGLE statement with NO trailing `;` →
+    // `for(...)S;`. Sibling of gap-067 (which flattens a *labeled*
+    // block).
     //
-    //   l:for(;;){continue l}  →  l:for(;;)continue l;
-    //   for(;;){break}         →  for(;;)break;
-    //   while(x){g()}          →  while(x)g();
-    //   for(a in o){h(a)}      →  for(a in o)h(a);
+    //   l:for(;;){continue l}  →  l:for(;;)continue l;   (gap-074)
+    //   for(;;){break}         →  for(;;)break;          (gap-074)
+    //   while(x){g()}          →  while(x)g();           (gap-074)
+    //   for(a in o){h(a)}      →  for(a in o)h(a);       (gap-074)
+    //   with(o){a()}           →  with(o)a();            (gap-076)
     //
-    // The `{` immediately following a `for(...)`/`while(...)` header
-    // is UNAMBIGUOUSLY a loop body — never an object literal — so
-    // (unlike gap-067) no completion-keyword guard is needed. The
-    // body is dropped braces + a synthetic `;` terminator.
+    // The `{` immediately following a `for(...)`/`while(...)`/
+    // `with(...)` header is UNAMBIGUOUSLY the statement body — never
+    // an object literal — so (unlike gap-067) no completion-keyword
+    // guard is needed. The body is dropped braces + a synthetic `;`
+    // terminator.
     //
-    // PROVABLY-SAFE minimal slice (matches `minify_loop_body_flatten`):
-    //   - anchor on a `for`/`while` STATEMENT keyword (word-like,
-    //     and NOT a property — `o.while(x){…}` is a method call, so
-    //     a `.`/`?.` look-behind disqualifies it);
+    // PROVABLY-SAFE minimal slice (matches `minify_loop_body_flatten`
+    // and `minify_with_body_flatten`):
+    //   - anchor on a `for`/`while`/`with` STATEMENT keyword
+    //     (word-like, and NOT a property — `o.while(x){…}` is a
+    //     method call, so a `.`/`?.` look-behind disqualifies it);
     //   - the keyword's `(`…`)` header is matched by a structural
     //     depth scan, and the token AFTER `)` must be a `{`;
     //   - the body has NO nested `{` and NO control-flow keyword at
@@ -1273,8 +1277,14 @@ pub fn whitespace_only_minify(
         let mut drops: Vec<usize> = Vec::new();
         let mut i = 0;
         while i + 1 < kept.len() {
+            // gap-076: `with` joins the anchor set. A `with(o){…}`
+            // statement has the same `keyword (…) {body}` shape as a
+            // loop, and a `{` immediately after the `with(…)` header
+            // is unambiguously the with-body — so the identical
+            // single-statement flatten applies (`with(o){a()}` →
+            // `with(o)a();`).
             let is_loop_kw = is_word_like(&kept[i])
-                && matches!(kept[i].value.as_str(), "for" | "while");
+                && matches!(kept[i].value.as_str(), "for" | "while" | "with");
             let is_property = i >= 1
                 && (is_structural_punct(&kept[i - 1], ".")
                     || is_structural_punct(&kept[i - 1], "?."));
@@ -4581,6 +4591,23 @@ mod tests {
     #[test]
     fn gap074_nested_control_flow_kept() {
         assert_eq!(minify("for(;;){if(x)a()}"), "for(;;){if(x)a()};");
+    }
+
+    // ---- gap-076: with-body single-statement block flatten ----
+
+    /// gap-076: a `with` body that is a single un-terminated
+    /// statement drops its braces (`with`-sibling of gap-074).
+    #[test]
+    fn gap076_with_body_flattens() {
+        assert_eq!(minify("with(o){a()}"), "with(o)a();");
+    }
+
+    /// gap-076 boundary: a MULTI-statement `with` body keeps braces;
+    /// a PROPERTY method named `with` (`o.with(x){…}`) is untouched.
+    #[test]
+    fn gap076_with_body_guards() {
+        assert_eq!(minify("with(o){a();b()}"), "with(o){a();b()};");
+        assert_eq!(minify("o.with(x){f()}"), "o.with(x){f()};");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.86.0
+Version: 0.87.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -103,10 +103,10 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // operand machinery as gap-070/071 but anchored on the
     // PUNCTUATION operators `-`/`+`/`!`/`~` rather than a keyword.
     ("unary_minus_paren", "gap-075: prefix-unary symbol operand paren elision"),
-    // gap-076 (CLOC14.36): `with`-body single-statement block
-    // flatten — `with(o){a()}` → `with(o)a();`. The `with`-body
-    // sibling of gap-074 (for/while loop-body flatten).
-    ("with_body_flatten", "gap-076: with-body single-statement block flatten"),
+    // gap-076 RESOLVED in CLOC12.83 — a `with`-body single-statement
+    // block (`with(o){a()}` → `with(o)a();`) now flattens via the
+    // gap-074 pre-pass (`with` added to the anchor keyword set);
+    // `minify_with_body_flatten` enforced.
     // gap-074 RESOLVED in CLOC12.81 — a loop body that is a
     // single-statement block (`for(;;){continue l}` →
     // `for(;;)continue l;`) now flattens; `minify_loop_body_flatten`

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -583,6 +583,7 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-076 — with-body single-statement block flatten
 
-- **Status:** OPEN — discovered by CLOC14.36. `minify_with_body_flatten` ignored.
+- **Status:** RESOLVED in CLOC12.83. `minify_with_body_flatten` enforced.
 - **Input:** `with(o){a()}` → **Upstream:** `with(o)a();`
-- **What it needs:** When a `with` statement's body is a single statement, flatten `with(o){S}` → `with(o)S;`. This is the `with`-body sibling of gap-074 (for/while loop-body flatten) — `with` has the same `keyword (…) {body}` shape, and a `{` immediately after the `with(…)` header is unambiguously the body. Adding `with` to the gap-074 pre-pass anchor set (currently `for`/`while`) should close it, with the same single-statement / synthetic-`;` / property-guard machinery. (`with` is sloppy-mode-only, but valid input the WHITESPACE_ONLY pipeline must round-trip.)
+- **What it needed:** When a `with` statement's body is a single un-terminated statement, flatten `with(o){S}` → `with(o)S;`. The `with`-body sibling of gap-074 (for/while loop-body flatten) — `with` has the same `keyword (…) {body}` shape, and a `{` immediately after the `with(…)` header is unambiguously the body.
+- **CLOC12.83 resolution:** Added `with` to the gap-074 pre-pass anchor keyword set (`for`/`while`/`with`). The identical single-statement / property-guard (`o.with(x){…}` is left alone) / synthetic-`;` machinery applies unchanged; multi-statement bodies (`with(o){a();b()}`) keep their braces. Verified against the JAR. (`with` is sloppy-mode-only, but valid input the WHITESPACE_ONLY pipeline must round-trip.) **Residual:** a `with` body that ALREADY ends in `;` (`with(o){a();}`) is not yet flattened — the gap-032 emit-time flatten sets `body_position_next` after `for`/`while` headers but not after `with(…)`; deferred (the gap-076 fixture is the no-trailing-`;` form). 2 unit tests + the byte-identity fixture.


### PR DESCRIPTION
## CLOC12.83 — closes gap-076

Upstream Closure flattens a `with`-statement body that is a single un-terminated statement, dropping the braces:

| input | upstream / closurec (now) |
|---|---|
| `with(o){a()}` | `with(o)a();` |

The `with`-body sibling of gap-074 (for/while loop-body flatten).

### Implementation
A **one-line** change: `with` joins the gap-074 header-keyword body-flatten pre-pass anchor set (`for`/`while`/`with`). A `with(o){…}` statement has the same `keyword (…) {body}` shape as a loop, and a `{` immediately after the `with(…)` header is unambiguously the with-body — so the identical single-statement / property-guard / synthetic-`;` machinery applies unchanged:
- multi-statement bodies (`with(o){a();b()}`) keep their braces;
- a **property** method named `with` (`o.with(x){f()}`) is left alone by the `.`/`?.`-accessor property guard.

Verified against the JAR (v20240317): `with(o){a()}` → `with(o)a();`, `with(o){a();b()}` keeps braces, `o.with(x){f()}` unchanged.

**Residual (deferred):** a `with` body that already ends in `;` (`with(o){a();}`) is not yet flattened — the gap-032 emit-time flatten sets body-position after for/while headers but not after a `with(…)` header. The gap-076 fixture is the no-trailing-`;` form.

### Tests / bookkeeping
- 2 new `gap076_*` unit tests (flatten / multi-keep-braces + property guard).
- `minify_with_body_flatten` removed from `IGNORE_FIXTURES` (now enforced byte-identical).
- version `0.86.0` → `0.87.0` (Cargo.toml, cli.spec.json, help-markdown golden regenerated).
- `code/specs/CLOC12-gaps.md`: gap-076 marked RESOLVED; CHANGELOG updated.

475 unit tests + every integration suite (incl. the byte-identity harness) green. Security review PASS (shape correctness, guard reuse, no regression, no index hazard all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)