### PR TITLE
feat(closurec): CLOC12.85 — close gap-079 (if-body single-statement block flatten)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.89.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-079** — an `if` consequent that is a single
+  un-terminated statement block now flattens, matching upstream
+  Closure: `if(x){y()}` → `if(x)y();`. The `if`-sibling of gap-074
+  (for/while loop-body flatten) and gap-076 (with-body flatten).
+  `minify_if_body_flatten` is now enforced.
+
+### Added — gap-079 if-body single-statement block flatten
+
+`if` joins the gap-074 header-keyword body-flatten pre-pass anchor
+set (`for`/`while`/`with`/`if`). A `{` immediately after an `if(…)`
+header is unambiguously the consequent (never an object literal), so
+the identical single-statement / property-guard / synthetic-`;`
+machinery applies unchanged.
+
+**Dangling-else safety came for free.** Stripping the braces around
+an `if` consequent is unsound exactly when the body contains a nested
+un-`else`-d `if` AND the outer `if` has an `else`:
+`if(a){if(b)c()}else d()` must KEEP its braces — flattening to
+`if(a)if(b)c();else d()` would re-bind the `else` to the inner
+`if(b)` (the JAR keeps the braces too, verified). The existing
+no-control-flow-keyword guard (`has_blocking_keyword`, which lists
+`if`) already prevents the brace-drop for any body containing a
+nested `if`, so the dangling-else case can never reach the drop. A
+single non-control consequent (`{y()}`) has no such hazard.
+
+`else`-arm flatten (`else{z()}` → `else z()`) remains the separate
+open gap-080. 4 new `gap079_*` unit tests (flatten / multi-keep /
+dangling-else-kept / else-if-chain) + the enforced byte-identity
+fixture.
+
 ## [0.88.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.88.0"
+version = "0.89.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1315,9 +1315,9 @@ pub fn whitespace_only_minify(
         }
     }
 
-    // ---- gap-074 + gap-076: header-keyword body flatten ----------
-    // `for(...){S}` / `while(...){S}` / `with(...){S}` whose body
-    // `{S}` is a SINGLE statement with NO trailing `;` →
+    // ---- gap-074 + gap-076 + gap-079: header-keyword body flatten -
+    // `for(...){S}` / `while(...){S}` / `with(...){S}` / `if(...){S}`
+    // whose body `{S}` is a SINGLE statement with NO trailing `;` →
     // `for(...)S;`. Sibling of gap-067 (which flattens a *labeled*
     // block).
     //
@@ -1326,22 +1326,37 @@ pub fn whitespace_only_minify(
     //   while(x){g()}          →  while(x)g();           (gap-074)
     //   for(a in o){h(a)}      →  for(a in o)h(a);       (gap-074)
     //   with(o){a()}           →  with(o)a();            (gap-076)
+    //   if(x){y()}             →  if(x)y();              (gap-079)
     //
     // The `{` immediately following a `for(...)`/`while(...)`/
-    // `with(...)` header is UNAMBIGUOUSLY the statement body — never
-    // an object literal — so (unlike gap-067) no completion-keyword
-    // guard is needed. The body is dropped braces + a synthetic `;`
-    // terminator.
+    // `with(...)`/`if(...)` header is UNAMBIGUOUSLY the statement
+    // body — never an object literal — so (unlike gap-067) no
+    // completion-keyword guard is needed. The body is dropped braces
+    // + a synthetic `;` terminator.
     //
-    // PROVABLY-SAFE minimal slice (matches `minify_loop_body_flatten`
-    // and `minify_with_body_flatten`):
-    //   - anchor on a `for`/`while`/`with` STATEMENT keyword
+    // gap-079 (the `if` arm) — DANGLING-ELSE SAFETY. Stripping the
+    // braces around an `if` consequent is unsound exactly when the
+    // body contains a nested un-`else`-d `if` AND the outer `if` has
+    // an `else`:  `if(a){if(b)c()}else d()` must KEEP its braces —
+    // flattening to `if(a)if(b)c();else d()` would re-bind the `else`
+    // to the INNER `if(b)` (the JAR keeps the braces too, verified).
+    // We get this for free: any body containing a nested `if` (or any
+    // other control-flow keyword) sets `has_blocking_keyword` and is
+    // therefore NOT flattened — so the dangling-else case can never
+    // reach the brace-drop. A consequent that is a single non-control
+    // statement (`{y()}`) has no such hazard. `else`-arm flatten
+    // (`else{z()}` → `else z()`) is the separate gap-080.
+    //
+    // PROVABLY-SAFE minimal slice (matches `minify_loop_body_flatten`,
+    // `minify_with_body_flatten`, and `minify_if_body_flatten`):
+    //   - anchor on a `for`/`while`/`with`/`if` STATEMENT keyword
     //     (word-like, and NOT a property — `o.while(x){…}` is a
     //     method call, so a `.`/`?.` look-behind disqualifies it);
     //   - the keyword's `(`…`)` header is matched by a structural
     //     depth scan, and the token AFTER `)` must be a `{`;
     //   - the body has NO nested `{` and NO control-flow keyword at
-    //     depth 1, and EXACTLY ZERO top-level `;` (i.e. a single,
+    //     depth 1 (this is also the dangling-else guard for `if`),
+    //     and EXACTLY ZERO top-level `;` (i.e. a single,
     //     un-terminated statement). Bodies that already end in `;`
     //     are left to the gap-032 emit-time flatten; multi-statement
     //     bodies (`{a();b()}`) and empty bodies (`{}`) are untouched.
@@ -1359,7 +1374,7 @@ pub fn whitespace_only_minify(
             // single-statement flatten applies (`with(o){a()}` →
             // `with(o)a();`).
             let is_loop_kw = is_word_like(&kept[i])
-                && matches!(kept[i].value.as_str(), "for" | "while" | "with");
+                && matches!(kept[i].value.as_str(), "for" | "while" | "with" | "if");
             let is_property = i >= 1
                 && (is_structural_punct(&kept[i - 1], ".")
                     || is_structural_punct(&kept[i - 1], "?."));
@@ -4749,6 +4764,49 @@ mod tests {
     fn gap076_with_body_guards() {
         assert_eq!(minify("with(o){a();b()}"), "with(o){a();b()};");
         assert_eq!(minify("o.with(x){f()}"), "o.with(x){f()};");
+    }
+
+    // ---- gap-079: if-body single-statement block flatten ------
+
+    /// gap-079: an `if` consequent that is a single un-terminated
+    /// statement drops its braces (`if`-sibling of gap-074/076).
+    #[test]
+    fn gap079_if_body_flattens() {
+        assert_eq!(minify("if(x){y()}"), "if(x)y();");
+    }
+
+    /// gap-079 boundary: a MULTI-statement `if` body keeps braces;
+    /// an empty body is untouched.
+    #[test]
+    fn gap079_if_body_guards() {
+        assert_eq!(minify("if(x){a();b()}"), "if(x){a();b()};");
+    }
+
+    /// gap-079 DANGLING-ELSE SAFETY: an `if` whose body contains a
+    /// nested un-`else`-d `if` and is followed by an `else` must KEEP
+    /// its braces — flattening `if(a){if(b)c()}else d()` to
+    /// `if(a)if(b)c();else d()` would re-bind the `else` to the inner
+    /// `if(b)`. The existing no-control-flow-keyword guard prevents
+    /// the brace-drop (the body contains `if`). The decisive property
+    /// is that the braces survive (verified against the JAR, which
+    /// keeps them too — the only diff is an unrelated EOF trailing
+    /// `;` after the bare `else` arm).
+    #[test]
+    fn gap079_dangling_else_kept() {
+        assert_eq!(
+            minify("if(a){if(b)c()}else d()"),
+            "if(a){if(b)c()}else d()"
+        );
+    }
+
+    /// gap-079: an `else if(...)` chain flattens the inner body
+    /// (`else if(c){d()}` → `else if(c)d();`).
+    #[test]
+    fn gap079_else_if_chain_inner_flattens() {
+        assert_eq!(
+            minify("if(a)b();else if(c){d()}"),
+            "if(a)b();else if(c)d();"
+        );
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.88.0
+Version: 0.89.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -103,12 +103,15 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // paren elision — `a==(b)` → `a==b`, `a||(b)` → `a||b`. Extends
     // gap-075 (`-`/`+`) to the remaining binary operators.
     ("eq_operand_paren", "gap-078: binary comparison/logical right-operand paren elision"),
-    // gap-079 (CLOC14.37): `if`-body single-statement flatten —
-    // `if(x){y()}` → `if(x)y();`. The `if` sibling of gap-074/076.
-    ("if_body_flatten", "gap-079: if-body single-statement block flatten"),
     // gap-080 (CLOC14.37): `else`-body single-statement flatten —
     // `if(x)a();else{b()}` → `if(x)a();else b()`.
     ("else_body_flatten", "gap-080: else-body single-statement block flatten"),
+    // gap-079 RESOLVED in CLOC12.85 — an `if`-body single-statement
+    // block (`if(x){y()}` → `if(x)y();`) now flattens via the gap-074
+    // pre-pass (`if` added to the anchor keyword set). The
+    // dangling-else hazard is covered for free by the existing
+    // no-control-flow-keyword guard. `minify_if_body_flatten`
+    // enforced.
     // gap-075 RESOLVED in CLOC12.84 — a prefix-unary SYMBOL operator
     // operand's grouping parens (`-(a)` → `-a`, `!(a)` → `!a`,
     // `~(a)` → `~a`, `-(-a)` → `- -a`) now elide;

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -603,9 +603,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-079 — `if`-body single-statement block flatten
 
-- **Status:** OPEN (discovered CLOC14.37). `minify_if_body_flatten` ignored.
+- **Status:** RESOLVED in CLOC12.85. `minify_if_body_flatten` enforced.
 - **Input:** `if(x){y()}` → **Upstream:** `if(x)y();`
-- **What it needs:** The `if`-statement sibling of gap-074/076 (for/while/with loop-body flatten). When an `if` consequent is a single un-terminated statement block, flatten `if(…){S}` → `if(…)S;`. The anchor differs from gap-074: an `if` may be followed by an `else`, so the flatten must NOT strip braces when doing so would attach a trailing `else` to the wrong `if` (the dangling-else hazard) — guard accordingly, or restrict to the no-`else` form first.
+- **What it needed:** The `if`-statement sibling of gap-074/076 (for/while/with loop-body flatten). When an `if` consequent is a single un-terminated statement block, flatten `if(…){S}` → `if(…)S;`. The anchor differs from gap-074: an `if` may be followed by an `else`, so the flatten must NOT strip braces when doing so would attach a trailing `else` to the wrong `if` (the dangling-else hazard).
+- **CLOC12.85 resolution:** Added `if` to the gap-074 pre-pass anchor keyword set (`for`/`while`/`with`/`if`). A `{` immediately after an `if(…)` header is unambiguously the consequent (never an object literal), so the identical single-statement / property-guard / synthetic-`;` machinery applies. **DANGLING-ELSE SAFETY came for free:** the brace-drop is unsound exactly when the body holds a nested un-`else`-d `if` AND the outer `if` has an `else` (`if(a){if(b)c()}else d()` must keep its braces — flattening would re-bind the `else` to the inner `if(b)`; the JAR keeps the braces too, verified). But ANY body containing a control-flow keyword (including `if`) already sets `has_blocking_keyword` and is therefore never flattened, so the dangling-else case can never reach the drop. A single non-control consequent (`{y()}`) has no such hazard. `else`-arm flatten (`else{z()}` → `else z()`) is the separate gap-080. 4 unit tests (flatten / multi-keep / dangling-else-kept / else-if-chain) + the byte-identity fixture.
 
 ### gap-080 — `else`-body single-statement block flatten
 


### PR DESCRIPTION
## CLOC12.85 — closes gap-079

Upstream Closure flattens an `if` consequent that is a single un-terminated statement, dropping the braces:

```
if(x){y()}  ->  if(x)y();
```

The `if`-sibling of gap-074 (for/while loop-body flatten) and gap-076 (with-body flatten). Closes a gap from the CLOC14.37 exploration round.

### Implementation
`if` joins the gap-074 header-keyword body-flatten pre-pass anchor set (`for`/`while`/`with`/`if`). A `{` immediately after an `if(…)` header is unambiguously the consequent (never an object literal), so the identical single-statement / property-guard / synthetic-`;` machinery applies unchanged — a **one-line** addition.

### Dangling-else safety came for free
Stripping the braces around an `if` consequent is unsound exactly when the body contains a nested un-`else`-d `if` AND the outer `if` has an `else`:

```
if(a){if(b)c()}else d()   // MUST keep its braces
```

Flattening to `if(a)if(b)c();else d()` would re-bind the `else` to the inner `if(b)` (the JAR keeps the braces too, verified). But ANY body containing a control-flow keyword (incl. `if`) already sets `has_blocking_keyword` and is never flattened, so the dangling-else case can never reach the brace-drop.

### Verified against the JAR (v20240317)
- `if(x){y()}` → `if(x)y();`
- `if(x){a();b()}` keeps braces (multi-statement)
- `if(a){if(b)c()}else d()` keeps braces (dangling-else)
- `else if(c){d()}` → `else if(c)d();`

### Deferred
`else`-arm flatten (`else{z()}` → `else z()`) is the separate open gap-080; deeper nested-if flatten is a refinement (closurec partial-flattens the inner, output stays valid).

- `src/whitespace_only.rs`: add `if` to the gap-074 anchor + doc
- `tests/diff_minify.rs`: remove gap-079 from IGNORE_FIXTURES (now enforced)
- 4 new `gap079_*` unit tests
- version 0.88.0 → 0.89.0 (Cargo.toml, cli.spec.json, help-markdown golden)
- spec gap-079 RESOLVED; CHANGELOG updated

482 unit tests + all integration suites green (incl. byte-identity harness). Security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)