### PR TITLE
feat(closurec): CLOC12.87 — close gap-078 (binary symbol-operator right-operand paren elision)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.91.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-078** — the right-operand paren-elision pre-pass
+  (gap-075) now also anchors on the binary comparison / logical /
+  arithmetic / bitwise symbol operators, matching upstream Closure:
+  `a==(b)` → `a==b`, `a||(b)` → `a||b`, `a*(b)` → `a*b`, `a<<(b)` →
+  `a<<b`, … `minify_eq_operand_paren` is now enforced.
+
+### Added — gap-078 binary symbol-operator right-operand elision
+
+Extended the gap-075 pre-pass anchor (`is_sym_unary`, the prefix
+symbols `-`/`+`/`!`/`~`) with an `is_binary_sym` clause covering the
+full binary symbol-operator set — comparison (`==` `!=` `===` `!==`
+`<` `>` `<=` `>=`), logical (`&&` `||` `??`), arithmetic (`*` `/` `%`
+`**`), and bitwise (`&` `|` `^` `<<` `>>` `>>>`) — each
+`is_structural_punct`-gated so a string/regex literal whose CONTENT is
+an operator (e.g. `"=="`) never matches.
+
+The existing `is_safe_unary_paren_operand` operand guard is unchanged
+and remains the single safety gate: it accepts ONLY a self-delimiting
+operand (a single safe token, a member-reference chain, or a leading
+prefix-symbol-unary chain). An atomic operand has no precedence
+interaction with the outer operator, so the strip is sound for *every*
+binary operator.
+
+**Deferred (precedence-aware refinement):** the JAR also strips when
+the parenthesised operand's lowest-precedence operator binds at least
+as tightly as the outer operator (`a==(b+c)` → `a==b+c`, since `+`
+binds tighter than `==`, while `a*(b+c)` KEEPS its parens). That needs
+an operator-precedence table; here `a==(b+c)` conservatively keeps its
+parens (valid, just not yet byte-identical). 4 new `gap078_*` unit
+tests (binary set / member-chain operand / operator-operand-kept /
+literal+call safety) + the enforced byte-identity fixture.
+
 ## [0.90.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.90.0"
+version = "0.91.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -428,20 +428,40 @@ pub fn whitespace_only_minify(
         }
     }
 
-    // gap-075: paren elision around a PREFIX SYMBOL unary operator's
-    // operand. `-(a)` → `-a`, `!(a)` → `!a`, `~(a)` → `~a`, and the
-    // same-sign nesting `-(-a)` → `- -a`, `+(+a)` → `+ +a`.
+    // gap-075 + gap-078: paren elision around a SYMBOL operator's
+    // parenthesised RIGHT operand.
     //
-    // The mirror of gap-070/071 but anchored on the PUNCTUATION
-    // operators `-`/`+`/`!`/`~` (`is_structural_punct`-gated) rather
-    // than a keyword. Unlike the keyword cases there is NO prefix-vs-
-    // binary distinction to make: stripping a grouping paren around a
-    // self-delimiting operand is sound whether the operator is a
-    // prefix unary (`-(a)`) or a binary operator whose RIGHT operand
-    // is parenthesised (`a-(b)` → `a-b`). The operand check
-    // (`is_safe_unary_paren_operand`) rejects anything containing a
-    // top-level binary operator, so `-(a+b)` / `a-(b+c)` keep their
-    // parens.
+    // gap-075 (the prefix-unary symbols `-`/`+`/`!`/`~`):
+    //   `-(a)` → `-a`, `!(a)` → `!a`, `~(a)` → `~a`, and the
+    //   same-sign nesting `-(-a)` → `- -a`, `+(+a)` → `+ +a`.
+    //
+    // gap-078 (the remaining BINARY symbol operators — comparison,
+    // logical, arithmetic, bitwise):
+    //   `a==(b)` → `a==b`, `a||(b)` → `a||b`, `a*(b)` → `a*b`,
+    //   `a<<(b)` → `a<<b`, … (verified against the JAR for the full
+    //   set `== != === !== < > <= >= && || ?? * / % ** & | ^ << >>
+    //   >>>`).
+    //
+    // All are anchored on the PUNCTUATION operator
+    // (`is_structural_punct`-gated, so a string/regex literal whose
+    // CONTENT is e.g. `"=="` never matches) followed by `(`. There is
+    // NO prefix-vs-binary distinction to make: stripping a grouping
+    // paren around a SELF-DELIMITING operand is sound whether the
+    // operator is a prefix unary (`-(a)`) or a binary operator whose
+    // RIGHT operand is parenthesised (`a-(b)` → `a-b`, `a==(b)` →
+    // `a==b`).
+    //
+    // The operand check (`is_safe_unary_paren_operand`) is the single
+    // safety gate: it accepts ONLY a self-delimiting operand (a single
+    // safe token, a member-reference chain, or a leading prefix-symbol
+    // unary chain) and rejects anything containing a top-level binary
+    // operator. An atomic operand has NO precedence interaction with
+    // the outer operator, so the strip is always sound. The fuller,
+    // precedence-aware elision the JAR also does (`a==(b+c)` →
+    // `a==b+c`, since `+` binds tighter than `==`, while `a*(b+c)`
+    // KEEPS its parens) is DEFERRED — it needs an operator-precedence
+    // table; here `a==(b+c)` conservatively keeps its parens (valid,
+    // just not yet byte-identical).
     //
     // SAME-SIGN SAFETY: when the operand begins with the SAME sign
     // (`-(-a)` / `+(+a)`), gluing the two operators would form the
@@ -455,11 +475,38 @@ pub fn whitespace_only_minify(
         let mut drops: Vec<usize> = Vec::new();
         let mut i = 0;
         while i + 1 < kept.len() {
+            // gap-075 prefix-unary symbol anchors.
             let is_sym_unary = is_structural_punct(kept[i], "-")
                 || is_structural_punct(kept[i], "+")
                 || is_structural_punct(kept[i], "!")
                 || is_structural_punct(kept[i], "~");
-            if is_sym_unary && is_structural_punct(kept[i + 1], "(") {
+            // gap-078 binary symbol-operator anchors (comparison /
+            // logical / arithmetic / bitwise). `-`/`+` are already
+            // covered above (they double as additive binary ops).
+            let is_binary_sym = is_structural_punct(kept[i], "==")
+                || is_structural_punct(kept[i], "!=")
+                || is_structural_punct(kept[i], "===")
+                || is_structural_punct(kept[i], "!==")
+                || is_structural_punct(kept[i], "<")
+                || is_structural_punct(kept[i], ">")
+                || is_structural_punct(kept[i], "<=")
+                || is_structural_punct(kept[i], ">=")
+                || is_structural_punct(kept[i], "&&")
+                || is_structural_punct(kept[i], "||")
+                || is_structural_punct(kept[i], "??")
+                || is_structural_punct(kept[i], "*")
+                || is_structural_punct(kept[i], "/")
+                || is_structural_punct(kept[i], "%")
+                || is_structural_punct(kept[i], "**")
+                || is_structural_punct(kept[i], "&")
+                || is_structural_punct(kept[i], "|")
+                || is_structural_punct(kept[i], "^")
+                || is_structural_punct(kept[i], "<<")
+                || is_structural_punct(kept[i], ">>")
+                || is_structural_punct(kept[i], ">>>");
+            if (is_sym_unary || is_binary_sym)
+                && is_structural_punct(kept[i + 1], "(")
+            {
                 let open = i + 1;
                 // Find the matching close paren (structural scan).
                 let mut depth: i32 = 1;
@@ -4762,6 +4809,56 @@ mod tests {
         assert_eq!(minify("var x=-(a+b);"), "var x=-(a+b);");
         assert_eq!(minify("var x=a-(b);"), "var x=a-b;");
         assert_eq!(minify("var x=a-(b+c);"), "var x=a-(b+c);");
+    }
+
+    // ---- gap-078: binary symbol-operator right-operand elision --
+
+    /// gap-078: a binary comparison / logical / arithmetic / bitwise
+    /// symbol operator with a parenthesised ATOMIC right operand
+    /// drops the parens (`a==(b)` → `a==b`, …).
+    #[test]
+    fn gap078_binary_operand_paren_stripped() {
+        assert_eq!(minify("var x=a==(b);"), "var x=a==b;");
+        assert_eq!(minify("var x=a!=(b);"), "var x=a!=b;");
+        assert_eq!(minify("var x=a===(b);"), "var x=a===b;");
+        assert_eq!(minify("var x=a<(b);"), "var x=a<b;");
+        assert_eq!(minify("var x=a||(b);"), "var x=a||b;");
+        assert_eq!(minify("var x=a&&(b);"), "var x=a&&b;");
+        assert_eq!(minify("var x=a??(b);"), "var x=a??b;");
+        assert_eq!(minify("var x=a*(b);"), "var x=a*b;");
+        assert_eq!(minify("var x=a%(b);"), "var x=a%b;");
+        assert_eq!(minify("var x=a<<(b);"), "var x=a<<b;");
+        assert_eq!(minify("var x=a>>>(b);"), "var x=a>>>b;");
+        assert_eq!(minify("var x=a&(b);"), "var x=a&b;");
+    }
+
+    /// gap-078: a member-chain right operand also strips
+    /// (`a==(b.c)` → `a==b.c`).
+    #[test]
+    fn gap078_member_chain_operand_stripped() {
+        assert_eq!(minify("var x=a==(b.c);"), "var x=a==b.c;");
+    }
+
+    /// gap-078 boundary (DEFERRED precedence-aware case): an operand
+    /// containing a top-level binary operator KEEPS its parens — the
+    /// conservative atomic-operand guard does not yet do the full
+    /// precedence analysis the JAR does (`a==(b+c)` → upstream
+    /// `a==b+c`). Output stays valid; just not byte-identical.
+    #[test]
+    fn gap078_operator_operand_kept() {
+        assert_eq!(minify("var x=a==(b+c);"), "var x=a==(b+c);");
+        assert_eq!(minify("var x=a*(b+c);"), "var x=a*(b+c);");
+    }
+
+    /// gap-078 SAFETY: a string/regex literal whose CONTENT is an
+    /// operator must never be treated as the operator token — and a
+    /// CALL paren (`f(a)`) is not a grouping paren.
+    #[test]
+    fn gap078_literal_and_call_safe() {
+        // `"=="` is a string literal, not the `==` operator.
+        assert_eq!(minify("var x=\"==\"+(b);"), "var x=\"==\"+b;");
+        // `f(a)` is a call, never stripped.
+        assert_eq!(minify("var x=a==f(b);"), "var x=a==f(b);");
     }
 
     // ---- gap-073: get/set computed-key separating space ----

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.90.0
+Version: 0.91.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -99,10 +99,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // gap-077 (CLOC14.37): LEFT-operand grouping paren elision —
     // `(a)+b` → `a+b`. The mirror of gap-075's right-operand pass.
     ("left_operand_paren", "gap-077: binary left-operand paren elision"),
-    // gap-078 (CLOC14.37): binary comparison/logical RIGHT-operand
-    // paren elision — `a==(b)` → `a==b`, `a||(b)` → `a||b`. Extends
-    // gap-075 (`-`/`+`) to the remaining binary operators.
-    ("eq_operand_paren", "gap-078: binary comparison/logical right-operand paren elision"),
+    // gap-078 RESOLVED in CLOC12.87 — the right-operand paren-elision
+    // pre-pass (gap-075) now also anchors on the binary comparison /
+    // logical / arithmetic / bitwise symbol operators (`a==(b)` →
+    // `a==b`, `a||(b)` → `a||b`, …), keeping the conservative atomic-
+    // operand guard. `minify_eq_operand_paren` enforced.
     // gap-080 RESOLVED in CLOC12.86 — an `else`-body single-statement
     // block (`if(x)a();else{b()}` → `if(x)a();else b();`) now flattens
     // via a parallel `else`-anchored pre-pass (the `else` keyword

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -597,9 +597,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-078 — binary comparison/logical RIGHT-operand paren elision
 
-- **Status:** OPEN (discovered CLOC14.37). `minify_eq_operand_paren` ignored.
+- **Status:** RESOLVED in CLOC12.87. `minify_eq_operand_paren` enforced.
 - **Input:** `var x=a==(b);` → **Upstream:** `var x=a==b;` (also `a!=(b)` → `a!=b`, `a<(b)` → `a<b`, `a||(b)` → `a||b`, `a&&(b)` → `a&&b`).
-- **What it needs:** gap-075's right-operand pre-pass is anchored only on the SYMBOL set `-`/`+`/`!`/`~`. Upstream applies the same right-operand grouping-paren elision to the remaining binary operators — comparison (`==`/`!=`/`===`/`!==`/`<`/`>`/`<=`/`>=`), logical (`&&`/`||`/`??`), and arithmetic (`*`/`/`/`%`). Extend the anchor set (or generalise to "any binary operator token") while keeping the `is_safe_unary_paren_operand` operand guard so operator operands (`a==(b+c)`) stay parenthesised.
+- **What it needed:** gap-075's right-operand pre-pass is anchored only on the SYMBOL set `-`/`+`/`!`/`~`. Upstream applies the same right-operand grouping-paren elision to the remaining binary operators — comparison (`==`/`!=`/`===`/`!==`/`<`/`>`/`<=`/`>=`), logical (`&&`/`||`/`??`), arithmetic (`*`/`/`/`%`/`**`), and bitwise (`&`/`|`/`^`/`<<`/`>>`/`>>>`).
+- **CLOC12.87 resolution:** Extended the gap-075 pre-pass anchor (`is_sym_unary`) with an `is_binary_sym` clause covering the full comparison / logical / arithmetic / bitwise symbol-operator set, each `is_structural_punct`-gated (so a string/regex literal whose CONTENT is e.g. `"=="` never matches). The existing `is_safe_unary_paren_operand` operand guard is unchanged and is the single safety gate: it accepts ONLY a self-delimiting operand (single safe token / member-reference chain / leading prefix-symbol-unary chain). An atomic operand has NO precedence interaction with the outer operator, so the strip is sound for *every* binary operator. **DEFERRED (separate precedence-aware refinement):** the JAR also strips when the parenthesised operand's lowest-precedence operator binds at least as tightly as the outer operator (`a==(b+c)` → `a==b+c`, since `+` binds tighter than `==`, while `a*(b+c)` KEEPS its parens). That needs an operator-precedence table; here `a==(b+c)` conservatively keeps its parens (valid, just not yet byte-identical). 4 unit tests (binary set / member-chain operand / operator-operand-kept / literal+call safety) + the byte-identity fixture.
 
 ### gap-079 — `if`-body single-statement block flatten
 


### PR DESCRIPTION
## CLOC12.87 — closes gap-078

Upstream Closure strips the redundant grouping parens around the parenthesised RIGHT operand of a binary symbol operator when the operand is atomic:

```
a==(b)  ->  a==b      a||(b)  ->  a||b      a*(b)  ->  a*b
a<<(b)  ->  a<<b      a??(b)  ->  a??b      a&(b)  ->  a&b
```

gap-075 already did this for the prefix-unary symbols `-`/`+`/`!`/`~` (and, since `-`/`+` double as additive binary ops, for `a-(b)` too). gap-078 extends the **same** pre-pass to the rest of the binary symbol-operator set. Closes a gap from the CLOC14.37 exploration round.

### Implementation
Extended the gap-075 anchor (`is_sym_unary`) with an `is_binary_sym` clause covering comparison (`== != === !== < > <= >=`), logical (`&& || ??`), arithmetic (`* / % **`), and bitwise (`& | ^ << >> >>>`), each `is_structural_punct`-gated so a string/regex literal whose CONTENT is an operator (e.g. `"=="`) never matches.

The existing `is_safe_unary_paren_operand` operand guard is **unchanged** and is the single safety gate: it accepts ONLY a self-delimiting operand (single safe token / member-reference chain / leading prefix-symbol-unary chain). An atomic operand has no precedence interaction with the outer operator, so the strip is sound for **every** binary operator.

### Verified against the JAR (v20240317)
The full operator set strips for an atomic right operand; an operator-bearing operand keeps its parens.

### Deferred (precedence-aware refinement)
The JAR also strips when the operand's lowest-precedence operator binds at least as tightly as the outer operator (`a==(b+c)` → `a==b+c`, since `+` binds tighter than `==`, while `a*(b+c)` KEEPS its parens). That needs an operator-precedence table; here `a==(b+c)` conservatively keeps its parens (valid, just not yet byte-identical).

- `src/whitespace_only.rs`: extend gap-075 anchor with `is_binary_sym` + doc
- `tests/diff_minify.rs`: remove gap-078 from IGNORE_FIXTURES (now enforced)
- 4 new `gap078_*` unit tests
- version 0.90.0 → 0.91.0 (Cargo.toml, cli.spec.json, help-markdown golden)
- spec gap-078 RESOLVED; CHANGELOG updated

490 unit tests + all integration suites green (incl. byte-identity harness). Security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)