### PR TITLE
feat(adj-lang-cli): feed-a-verdict — constraint outcome drives the differential (ADJ constraints E2)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.0] - 2026-06-12 — feed-a-verdict: constraint outcome drives the differential (ADJ constraints E2)
+
+### Added
+
+- **The constraint engine now feeds the differential — one engine, not two.**
+  The CLI runs `solve`/`check`/`optimize` *first*, maps each outcome to a STATUS
+  atom, and injects it as an observed fact into the KB *before* `decide` runs:
+  - `check` Sat/SatReal → `feasible`; Unsat → `infeasible`
+  - `solve` Solved/SolvedRoots → `solved`
+  - `optimize` Optimal → `optimal`; Infeasible → `infeasible`; Unbounded → `unbounded`
+  - Unknown / Unsupported / NoUniqueSolution → **nothing** (the engine never
+    launders an undecided constraint into a verdict).
+- An existing `contributes <lr> from <status> to <verdict>` clause then fires in
+  the differential — composing solver result → verdict through the ordinary
+  contribution + proof machinery, with **no new engine logic and no grammar
+  change**. E.g. an infeasible schedule drives `schedule_broken`; loosening one
+  deadline makes it feasible and the same program drives `schedule_ok` instead.
+- 4 golden tests (infeasible `check` → verdict, feasible → the other verdict,
+  infeasible LP → verdict, inert when no status clause references it).
+
 ## [0.3.7] - 2026-06-11 — decompose→solve golden tests (ADJ constraints track D2)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.3.7"
+version = "0.4.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -33,9 +33,10 @@ use adj_constraint_solver::{
     check, optimize, solve, FeasibilityOutcome, OptimizeOutcome, SolveOutcome,
 };
 use adj_lang::{compile, decide};
-use logic_core::Term;
+use logic_core::{atom, Term};
 use logic_engine::{
-    DerivationOrigin, DifferentialDecision, KnowledgeBase, LRAggregateResult, Provenance, TrustTier,
+    DerivationOrigin, DifferentialDecision, Fact, KnowledgeBase, LRAggregateResult, Provenance,
+    TrustTier,
 };
 
 const SPEC: &str = r#"{
@@ -190,6 +191,47 @@ fn proof_json(hyp: &Term, kb: &KnowledgeBase, result: &LRAggregateResult) -> Str
     format!("[{}]", steps.join(","))
 }
 
+/// Map the constraint-engine outcomes to the STATUS atoms that feed the
+/// differential (ADJ constraints E2 — feed-a-verdict). Each atom, injected as an
+/// observed fact, fires an existing `contributes <lr> from <status> to <verdict>`
+/// clause. Deduplicated and order-stable. An `Unknown` / `Unsupported` /
+/// `NoUniqueSolution` outcome contributes NO status — the engine stays silent
+/// rather than assert a verdict it cannot back (the one-engine invariant: never
+/// launder an undecided constraint into a verdict).
+fn status_facts(
+    solve: &Option<SolveOutcome>,
+    check: &Option<FeasibilityOutcome>,
+    optimize: &Option<OptimizeOutcome>,
+) -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = Vec::new();
+    let mut add = |out: &mut Vec<&'static str>, s: &'static str| {
+        if !out.contains(&s) {
+            out.push(s);
+        }
+    };
+    if let Some(o) = check {
+        match o {
+            FeasibilityOutcome::Sat { .. } | FeasibilityOutcome::SatReal { .. } => {
+                add(&mut out, "feasible")
+            }
+            FeasibilityOutcome::Unsat { .. } => add(&mut out, "infeasible"),
+            FeasibilityOutcome::Unknown { .. } => {}
+        }
+    }
+    if let Some(SolveOutcome::Solved { .. } | SolveOutcome::SolvedRoots { .. }) = solve {
+        add(&mut out, "solved");
+    }
+    if let Some(o) = optimize {
+        match o {
+            OptimizeOutcome::Optimal { .. } => add(&mut out, "optimal"),
+            OptimizeOutcome::Infeasible { .. } => add(&mut out, "infeasible"),
+            OptimizeOutcome::Unbounded => add(&mut out, "unbounded"),
+            OptimizeOutcome::Unknown { .. } => {}
+        }
+    }
+    out
+}
+
 fn main() -> ExitCode {
     let spec = load_spec_from_str(SPEC).expect("internal: invalid CLI spec");
     let parser = Parser::new(spec);
@@ -223,13 +265,38 @@ fn main() -> ExitCode {
         }
     };
 
-    let lowered = match compile(&src) {
+    let mut lowered = match compile(&src) {
         Ok(l) => l,
         Err(e) => {
             println!("{{\"error\":\"{}\"}}", esc(&format!("{:?}", e)));
             return ExitCode::from(1);
         }
     };
+
+    // ---- Constraint engine FIRST, so its verdict can feed the differential
+    // (ADJ constraints E2 — feed-a-verdict). The constraint outcomes are
+    // computed up front; each maps to a STATUS atom (`feasible` / `infeasible`
+    // / `solved` / `optimal` / `unbounded`) that we inject as an observed fact
+    // into the KB *before* `decide` runs. An existing
+    // `contributes <lr> from <status> to <verdict>` clause then fires in the
+    // differential — composing solver result → verdict through the ordinary
+    // contribution machinery, no new engine logic.
+    let solve_outcome =
+        (!lowered.constraints.is_empty()).then(|| solve(&lowered.constraints, &lowered.kb));
+    let check_outcome = lowered
+        .constraints
+        .check
+        .then(|| check(&lowered.constraints, &lowered.kb));
+    let optimize_outcome = lowered
+        .constraints
+        .objective
+        .is_some()
+        .then(|| optimize(&lowered.constraints, &lowered.kb));
+
+    for status in status_facts(&solve_outcome, &check_outcome, &optimize_outcome) {
+        lowered.kb.add_fact(Fact::certain(atom(status)));
+    }
+
     let diff = decide(&lowered);
 
     let mut ranked: Vec<String> = Vec::new();
@@ -274,39 +341,20 @@ fn main() -> ExitCode {
         .map(|q| format!("\"{}\"", esc(&format!("{}", q))))
         .collect();
 
-    // The constraint sublanguage (ADJ constraints): if the program declared a
-    // constraint system, solve it on the CPU and emit the outcome. Absent a
-    // constraint system, the `solve` key is omitted entirely.
-    let solve_section = if lowered.constraints.is_empty() {
-        String::new()
-    } else {
-        format!(
-            ",\"solve\":{}",
-            solve_json(&solve(&lowered.constraints, &lowered.kb))
-        )
+    // Render the constraint sections from the outcomes computed above (the
+    // solvers are not re-run). Absent a constraint system / `check` / objective,
+    // the respective key is omitted entirely.
+    let solve_section = match &solve_outcome {
+        Some(o) => format!(",\"solve\":{}", solve_json(o)),
+        None => String::new(),
     };
-
-    // A `check` requests a feasibility decision (is the constraint set jointly
-    // satisfiable?) — emit a `check` section with the SAT/UNSAT/unknown verdict.
-    let check_section = if lowered.constraints.check {
-        format!(
-            ",\"check\":{}",
-            check_json(&check(&lowered.constraints, &lowered.kb))
-        )
-    } else {
-        String::new()
+    let check_section = match &check_outcome {
+        Some(o) => format!(",\"check\":{}", check_json(o)),
+        None => String::new(),
     };
-
-    // A `minimize`/`maximize` requests a linear-programming optimum — emit an
-    // `optimize` section with the optimal value, achieving assignment, and
-    // binding constraints.
-    let optimize_section = if lowered.constraints.objective.is_some() {
-        format!(
-            ",\"optimize\":{}",
-            optimize_json(&optimize(&lowered.constraints, &lowered.kb))
-        )
-    } else {
-        String::new()
+    let optimize_section = match &optimize_outcome {
+        Some(o) => format!(",\"optimize\":{}", optimize_json(o)),
+        None => String::new(),
     };
 
     println!(

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -384,3 +384,75 @@ fn no_objective_emits_no_optimize_section() {
         "no objective → no optimize key: {s}"
     );
 }
+
+// ---- feed-a-verdict: constraint outcome drives the differential (E2) ----
+
+#[test]
+fn an_infeasible_check_feeds_a_verdict_into_the_differential() {
+    // The schedule is contradictory (design ≥ 28 forces build ≥ 48 > 45). The
+    // `check` returns unsat; the engine injects `infeasible`, which fires
+    // `contributes from infeasible to schedule_broken` in the SAME differential.
+    let (ok, s) = run(
+        "adjcli_feedv_unsat.adj",
+        "prior 0.10 for schedule_ok\n  source \"x\" trust empirical\n\
+         prior 0.10 for schedule_broken\n  source \"x\" trust empirical\n\
+         contributes 1000000 from infeasible to schedule_broken\n  source \"sched\" trust authoritative\n\
+         symbol d : scalar\nsymbol b : scalar\n\
+         constrain d >= 28\nconstrain b >= d + 20\nconstrain b <= 45\ncheck\n\
+         ? schedule_ok\n? schedule_broken\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"unsat\""), "{s}");
+    // The constraint verdict drove the differential to schedule_broken.
+    assert!(s.contains("\"leader\":\"schedule_broken\""), "{s}");
+}
+
+#[test]
+fn a_feasible_check_drives_the_other_verdict() {
+    // Same clauses, looser deadline (design ≥ 25) → feasible → `feasible` fires
+    // `contributes from feasible to schedule_ok`, so schedule_ok leads instead.
+    let (ok, s) = run(
+        "adjcli_feedv_sat.adj",
+        "prior 0.10 for schedule_ok\n  source \"x\" trust empirical\n\
+         prior 0.10 for schedule_broken\n  source \"x\" trust empirical\n\
+         contributes 1000000 from feasible to schedule_ok\n  source \"sched\" trust authoritative\n\
+         contributes 1000000 from infeasible to schedule_broken\n  source \"sched\" trust authoritative\n\
+         symbol d : scalar\nsymbol b : scalar\n\
+         constrain d >= 25\nconstrain b >= d + 20\nconstrain b <= 45\ncheck\n\
+         ? schedule_ok\n? schedule_broken\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"sat\""), "{s}");
+    assert!(s.contains("\"leader\":\"schedule_ok\""), "{s}");
+}
+
+#[test]
+fn an_infeasible_lp_feeds_a_verdict() {
+    // An infeasible `maximize` injects `infeasible` just like `check`.
+    let (ok, s) = run(
+        "adjcli_feedv_lp.adj",
+        "prior 0.10 for plan_ok\n  source \"x\" trust empirical\n\
+         prior 0.10 for plan_overcommitted\n  source \"x\" trust empirical\n\
+         contributes 1000000 from infeasible to plan_overcommitted\n  source \"p\" trust authoritative\n\
+         symbol x : scalar\nconstrain x >= 5\nconstrain x <= 1\nmaximize x\n\
+         ? plan_ok\n? plan_overcommitted\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"infeasible\""), "{s}");
+    assert!(s.contains("\"leader\":\"plan_overcommitted\""), "{s}");
+}
+
+#[test]
+fn no_status_clause_means_constraints_dont_disturb_the_differential() {
+    // A program with constraints but NO `contributes from <status>` clause: the
+    // injected status fact is inert (nothing references it), so the differential
+    // is unchanged — the prior leads.
+    let (ok, s) = run(
+        "adjcli_feedv_inert.adj",
+        "prior 0.30 for acs\n  source \"x\" trust empirical\n\
+         symbol x : scalar\nconstrain x >= 5\nconstrain x <= 1\ncheck\n? acs\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"outcome\":\"unsat\""), "{s}");
+    assert!(s.contains("\"posterior\":0.3"), "prior unchanged: {s}");
+}

--- a/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
+++ b/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
@@ -123,10 +123,16 @@ the **dimensional layer + surface sublanguage + provenance bridge**. Everything 
   catches golden-rulebook bugs ([[project_mycin_prototype]]).
 - **Optimal value** → the objective value + the achieving assignment + the binding constraints (the
   ones tight at the optimum), all cited.
-- **Feed-a-verdict** → `check{…}` result (SAT/UNSAT) becomes a saturating contribution in the
-  differential: feasible ⇒ verdict A, infeasible ⇒ verdict B. One engine; no new verdict logic.
-- A new `DerivationOrigin::FromSolve { … }` lets the proof DAG descend into the solver certificate, so
-  `adj-lang-cli` renders the solution/IIS under the verdict step — auditable without the model.
+- **Feed-a-verdict** ✅ (E2) → the constraint result feeds the differential: feasible ⇒ verdict A,
+  infeasible ⇒ verdict B. One engine; no new verdict logic. **Implemented without a grammar change**:
+  `adj-lang-cli` runs the constraint engine first, maps each outcome to a STATUS atom (`feasible` /
+  `infeasible` / `solved` / `optimal` / `unbounded`; `Unknown`/`Unsupported` → nothing), injects it as
+  an observed fact into the KB *before* `decide`, and an existing
+  `contributes <lr> from <status> to <verdict>` clause fires through the ordinary contribution + proof
+  machinery.
+- **E3 (next):** a new `DerivationOrigin::FromSolve { … }` lets the proof DAG descend into the solver
+  certificate, so `adj-lang-cli` renders the solution/IIS *under* the verdict step — auditable without
+  the model.
 
 ## 6. Reuse map (grounded — verified by source read)
 


### PR DESCRIPTION
## What

Fuses the constraint engine into the differential — **one engine, not two side by side**. A `check` / `solve` / `optimize` outcome now feeds the adjudication differential as the spec's §5 "feed-a-verdict" called for.

## How (no grammar change)

The CLI runs the constraint solvers **first**, maps each outcome to a STATUS atom, and injects it as an observed fact into the KB **before** `decide` runs. An existing `contributes <lr> from <status> to <verdict>` clause then fires through the ordinary contribution + proof machinery — no new engine logic.

| outcome | status atom |
|---|---|
| `check` Sat / SatReal | `feasible` |
| `check` Unsat · `optimize` Infeasible | `infeasible` |
| `solve` Solved / SolvedRoots | `solved` |
| `optimize` Optimal | `optimal` |
| `optimize` Unbounded | `unbounded` |
| Unknown / Unsupported / NoUniqueSolution | **nothing** — never launder an undecided constraint into a verdict |

## End-to-end

```
contributes 1000000 from infeasible to schedule_broken
contributes 1000000 from feasible   to schedule_ok
symbol d   symbol b
constrain d >= 28   constrain b >= d + 20   constrain b <= 45
check
```
`design ≥ 28` forces `build ≥ 48 > 45` → **check unsat → `infeasible` → `schedule_broken` leads at posterior ~1.0**. Loosen one deadline to `d >= 25` and the **same program** → check sat → `feasible` → `schedule_ok` leads. The constraint verdict drives the differential.

## Safety
Equivalent to a user writing `observe <status>` by hand — **no new capability**; the injected atom always mirrors the actual outcome (can't contradict it), and `status_facts` dedups so a status isn't double-counted. Security review **passed**: hardcoded status literals (no `.adj` string reaches `atom()`), exhaustive matches, no new panic path.

## Tests
+4 golden (infeasible `check` → verdict, feasible → the other verdict, infeasible LP → verdict, inert when no status clause references it). Full CLI suite green (26 golden + 4 worked + 5 decompose-run).

Second of three "track E" PRs: E1 (IIS, merged) → **E2 (feed-a-verdict)** → E3 (`FromSolve` proof DAG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)