### PR TITLE
Add smart-home activation execution tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -40,7 +40,8 @@ use smart_home_integration_catalog::{
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_evidence_from_candidates, activation_forecasts_from_timeline_milestones,
+    activation_evidence_from_candidates, activation_execution_packets_from_handoff_packages,
+    activation_forecasts_from_timeline_milestones,
     activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
     activation_plan_for_entry, activation_plans_at_or_before_priority,
@@ -76,15 +77,16 @@ use smart_home_integration_catalog::{
     IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
     IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
     IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
-    IntegrationActivationEvidenceSummary, IntegrationActivationForecastAction,
-    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
-    IntegrationActivationHandoffPackage, IntegrationActivationHandoffStatus,
-    IntegrationActivationHandoffSummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
-    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
-    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationEvidenceSummary, IntegrationActivationExecutionPacket,
+    IntegrationActivationExecutionStatus, IntegrationActivationExecutionSummary,
+    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
+    IntegrationActivationForecastSummary, IntegrationActivationHandoffPackage,
+    IntegrationActivationHandoffStatus, IntegrationActivationHandoffSummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
+    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -284,6 +286,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_HANDOFF_TOOL_ID: &str =
     "smart_home.list_integration_activation_handoff";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_handoff_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID: &str =
+    "smart_home.list_integration_activation_execution";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_execution_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
     "smart_home.list_integration_activation_operator_queue";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
@@ -624,6 +630,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID => {
                     let query = integration_activation_handoff_query(&arguments)?;
                     Ok(get_integration_activation_handoff_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID => {
+                    let query = integration_activation_execution_query(&arguments)?;
+                    Ok(list_integration_activation_execution_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_execution_query(&arguments)?;
+                    Ok(get_integration_activation_execution_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID => {
                     let query = integration_activation_operator_queue_query(&arguments)?;
@@ -2065,6 +2081,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation handoff summary",
             "Return compact D23A activation handoff counts for ready packages, blockers, review work, dependency gaps, audit attention, and the next execution-transfer step.",
             integration_activation_handoff_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID,
+            "List smart-home integration activation execution packets",
+            "List read-only D23A activation execution packets that join handoff packages to operator queue tasks, including executable, approval, dependency, and blocker state.",
+            integration_activation_execution_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_execution", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_execution",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation execution summary",
+            "Return compact D23A activation execution counts for executable packets, approvals, operator work, dependency blockers, and attention state.",
+            integration_activation_execution_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -4968,6 +5018,22 @@ struct IntegrationActivationHandoffQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationExecutionQuery {
+    handoff: IntegrationActivationHandoffQuery,
+    task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    execution_status: Option<IntegrationActivationExecutionStatus>,
+    executable: Option<bool>,
+    operator_required: Option<bool>,
+    approval_required: Option<bool>,
+    dependency_ready: Option<bool>,
+    blocked: Option<bool>,
+    review_required: Option<bool>,
+    requires_attention: Option<bool>,
+    include_monitor: bool,
+    execution_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationOperatorQueueQuery {
     playbook: IntegrationActivationPlaybookQuery,
     task_kind: Option<IntegrationActivationOperatorTaskKind>,
@@ -5422,6 +5488,44 @@ fn integration_activation_handoff_query(
             .or(optional_bool(arguments, "requires_attention")?),
         include_monitor,
         handoff_limit: optional_u64(arguments, "handoff_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_execution_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationExecutionQuery, ToolCallError> {
+    let include_monitor = optional_bool(arguments, "include_monitor")?.unwrap_or(false);
+    let mut handoff = integration_activation_handoff_query(arguments)?;
+    handoff.include_monitor = include_monitor;
+    handoff.runbook.include_monitor = include_monitor;
+    let task_kind = optional_string(arguments, "execution_task_kind")?
+        .or(optional_string(arguments, "operator_task_kind")?)
+        .or(optional_string(arguments, "task_kind")?)
+        .map(|label| parse_activation_operator_task_kind(&label))
+        .transpose()?;
+    let execution_status = optional_string(arguments, "execution_status")?
+        .or(optional_string(arguments, "execution_state")?)
+        .map(|label| parse_activation_execution_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationExecutionQuery {
+        handoff,
+        task_kind,
+        execution_status,
+        executable: optional_bool(arguments, "executable")?
+            .or(optional_bool(arguments, "can_execute")?),
+        operator_required: optional_bool(arguments, "execution_operator_required")?
+            .or(optional_bool(arguments, "operator_required")?),
+        approval_required: optional_bool(arguments, "approval_required")?,
+        dependency_ready: optional_bool(arguments, "dependency_ready")?,
+        blocked: optional_bool(arguments, "execution_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        review_required: optional_bool(arguments, "execution_review_required")?
+            .or(optional_bool(arguments, "review_required")?),
+        requires_attention: optional_bool(arguments, "execution_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        include_monitor,
+        execution_limit: optional_u64(arguments, "execution_limit")?.map(|value| value as usize),
     })
 }
 
@@ -6261,6 +6365,53 @@ fn integration_activation_handoff_packages_for_query(
     }
 
     (packages, catalog_count)
+}
+
+fn integration_activation_execution_packets_for_query(
+    query: &IntegrationActivationExecutionQuery,
+) -> (Vec<IntegrationActivationExecutionPacket>, usize) {
+    let (packages, catalog_count) =
+        integration_activation_handoff_packages_for_query(&query.handoff);
+    let (steps, _) =
+        integration_activation_playbook_steps_for_query(&query.handoff.runbook.playbook);
+    let tasks = activation_operator_tasks_from_playbook_steps(steps);
+    let mut packets = activation_execution_packets_from_handoff_packages(packages, tasks);
+
+    if !query.include_monitor {
+        packets.retain(|packet| !packet.monitor_only());
+    }
+    if let Some(kind) = query.task_kind {
+        packets.retain(|packet| packet.task_kind == Some(kind));
+    }
+    if let Some(execution_status) = query.execution_status {
+        packets.retain(|packet| packet.execution_status == execution_status);
+    }
+    if let Some(executable) = query.executable {
+        packets.retain(|packet| packet.executable() == executable);
+    }
+    if let Some(operator_required) = query.operator_required {
+        packets.retain(|packet| packet.operator_required() == operator_required);
+    }
+    if let Some(approval_required) = query.approval_required {
+        packets.retain(|packet| packet.approval_required() == approval_required);
+    }
+    if let Some(dependency_ready) = query.dependency_ready {
+        packets.retain(|packet| packet.dependency_ready() == dependency_ready);
+    }
+    if let Some(blocked) = query.blocked {
+        packets.retain(|packet| packet.blocked() == blocked);
+    }
+    if let Some(review_required) = query.review_required {
+        packets.retain(|packet| packet.review_required() == review_required);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        packets.retain(|packet| packet.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.execution_limit {
+        packets.truncate(limit);
+    }
+
+    (packets, catalog_count)
 }
 
 fn integration_activation_operator_tasks_for_query(
@@ -8275,6 +8426,93 @@ fn get_integration_activation_handoff_summary_output_handler_output(
                 "next_handoff_status",
                 summary
                     .next_handoff_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_execution_output_handler_output(
+    query: IntegrationActivationExecutionQuery,
+) -> ToolHandlerOutput {
+    let (packets, catalog_count) = integration_activation_execution_packets_for_query(&query);
+    let summary = IntegrationActivationExecutionSummary::from_packets(packets.iter());
+    let count = packets.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_execution",
+            JsonValue::Array(
+                packets
+                    .iter()
+                    .map(activation_execution_packet_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_execution_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_execution")),
+            ("execution_packets", integer(count as i64)),
+            (
+                "executable_packets",
+                integer(summary.executable_packets as i64),
+            ),
+            (
+                "approval_required_packets",
+                integer(summary.approval_required_packets as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
+            (
+                "next_execution_status",
+                summary
+                    .next_execution_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_execution_summary_output_handler_output(
+    query: IntegrationActivationExecutionQuery,
+) -> ToolHandlerOutput {
+    let (packets, _) = integration_activation_execution_packets_for_query(&query);
+    let summary = IntegrationActivationExecutionSummary::from_packets(packets.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_execution_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_execution_summary"),
+            ),
+            ("total_packets", integer(summary.total_packets as i64)),
+            (
+                "executable_packets",
+                integer(summary.executable_packets as i64),
+            ),
+            (
+                "approval_required_packets",
+                integer(summary.approval_required_packets as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
+            (
+                "next_execution_status",
+                summary
+                    .next_execution_status
                     .map(|status| string(status.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
@@ -15580,6 +15818,343 @@ fn integration_activation_handoff_summary_json(
     ])
 }
 
+fn activation_execution_packet_json(packet: &IntegrationActivationExecutionPacket) -> JsonValue {
+    object([
+        ("sequence", integer(packet.sequence as i64)),
+        ("handoff_sequence", integer(packet.handoff_sequence as i64)),
+        ("runbook_sequence", integer(packet.runbook_sequence as i64)),
+        (
+            "operator_task_sequence",
+            packet
+                .operator_task_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("priority", integer(packet.priority as i64)),
+        ("execution_status", string(packet.execution_status.as_str())),
+        ("handoff_status", string(packet.handoff_status.as_str())),
+        ("phase", string(packet.phase.as_str())),
+        (
+            "task_kind",
+            packet
+                .task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("playbook_action", string(packet.playbook_action.as_str())),
+        ("recommended_view", string(packet.recommended_view.as_str())),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                packet
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(packet.integration_count() as i64),
+        ),
+        (
+            "risk_ids",
+            JsonValue::Array(
+                packet
+                    .risk_ids
+                    .iter()
+                    .map(|risk_id| string(risk_id))
+                    .collect(),
+            ),
+        ),
+        ("risk_count", integer(packet.risk_count as i64)),
+        (
+            "dependency_integration_ids",
+            JsonValue::Array(
+                packet
+                    .dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocking_dependency_integration_ids",
+            JsonValue::Array(
+                packet
+                    .blocking_dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_edge_count",
+            integer(packet.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(packet.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "readiness_gap_count",
+            integer(packet.readiness_gap_count as i64),
+        ),
+        (
+            "audit_record_count",
+            integer(packet.audit_record_count as i64),
+        ),
+        (
+            "attention_audit_record_count",
+            integer(packet.attention_audit_record_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(packet.highest_policy_tier)),
+        ),
+        (
+            "operator_required",
+            JsonValue::Bool(packet.operator_required()),
+        ),
+        ("activation_ready", JsonValue::Bool(packet.activation_ready)),
+        (
+            "ready_for_handoff",
+            JsonValue::Bool(packet.ready_for_handoff),
+        ),
+        (
+            "approval_required",
+            JsonValue::Bool(packet.approval_required()),
+        ),
+        (
+            "dependency_ready",
+            JsonValue::Bool(packet.dependency_ready()),
+        ),
+        ("executable", JsonValue::Bool(packet.executable())),
+        ("blocked", JsonValue::Bool(packet.blocked())),
+        ("review_required", JsonValue::Bool(packet.review_required())),
+        ("monitor_only", JsonValue::Bool(packet.monitor_only())),
+        (
+            "requires_attention",
+            JsonValue::Bool(packet.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_execution_summary_json(
+    summary: &IntegrationActivationExecutionSummary,
+) -> JsonValue {
+    object([
+        ("total_packets", integer(summary.total_packets as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "executable_packets",
+            integer(summary.executable_packets as i64),
+        ),
+        (
+            "operator_required_packets",
+            integer(summary.operator_required_packets as i64),
+        ),
+        (
+            "approval_required_packets",
+            integer(summary.approval_required_packets as i64),
+        ),
+        ("blocked_packets", integer(summary.blocked_packets as i64)),
+        (
+            "dependency_ready_packets",
+            integer(summary.dependency_ready_packets as i64),
+        ),
+        (
+            "dependency_blocked_packets",
+            integer(summary.dependency_blocked_packets as i64),
+        ),
+        ("monitor_packets", integer(summary.monitor_packets as i64)),
+        (
+            "activation_ready_packets",
+            integer(summary.activation_ready_packets as i64),
+        ),
+        (
+            "packets_requiring_attention",
+            integer(summary.packets_requiring_attention as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "total_readiness_gaps",
+            integer(summary.total_readiness_gaps as i64),
+        ),
+        (
+            "total_audit_records",
+            integer(summary.total_audit_records as i64),
+        ),
+        (
+            "attention_audit_records",
+            integer(summary.attention_audit_records as i64),
+        ),
+        (
+            "next_execution_status",
+            summary
+                .next_execution_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_phase",
+            summary
+                .next_phase
+                .map(|phase| string(phase.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_packet_sequence",
+            summary
+                .next_packet_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_packet_priority",
+            summary
+                .next_packet_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_executable_sequence",
+            summary
+                .first_executable_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_sequence",
+            summary
+                .first_operator_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_sequence",
+            summary
+                .first_approval_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_blocked_sequence",
+            summary
+                .first_dependency_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_executable_priority",
+            summary
+                .first_executable_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_operator_priority",
+            summary
+                .first_operator_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_approval_priority",
+            summary
+                .first_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_blocked_priority",
+            summary
+                .first_dependency_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "ready_to_execute",
+            JsonValue::Bool(summary.ready_to_execute()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_approval_work",
+            JsonValue::Bool(summary.has_approval_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_operator_task_json(task: &IntegrationActivationOperatorTask) -> JsonValue {
     object([
         ("sequence", integer(task.sequence as i64)),
@@ -19666,6 +20241,29 @@ fn parse_activation_handoff_status(
     }
 }
 
+fn parse_activation_execution_status(
+    label: &str,
+) -> Result<IntegrationActivationExecutionStatus, ToolCallError> {
+    match label {
+        "executable" | "ready" | "ready_to_execute" | "can_execute" => {
+            Ok(IntegrationActivationExecutionStatus::Executable)
+        }
+        "operator_required" | "operator" | "human_action" | "human_required" => {
+            Ok(IntegrationActivationExecutionStatus::OperatorRequired)
+        }
+        "needs_approval" | "approval" | "approval_required" | "requires_approval" => {
+            Ok(IntegrationActivationExecutionStatus::NeedsApproval)
+        }
+        "blocked" | "blocker" | "blockers" => Ok(IntegrationActivationExecutionStatus::Blocked),
+        "monitoring" | "monitor" | "monitor_only" | "watching" => {
+            Ok(IntegrationActivationExecutionStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation execution status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_operator_task_kind(
     label: &str,
 ) -> Result<IntegrationActivationOperatorTaskKind, ToolCallError> {
@@ -20969,6 +21567,53 @@ fn integration_activation_handoff_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_execution_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_handoff_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new(
+            "execution_task_kind",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "operator_task_kind",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("task_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("execution_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("execution_state", JsonSchema::String));
+        properties.push(SchemaProperty::new("executable", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("can_execute", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "execution_operator_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "approval_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("dependency_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "execution_blocked",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "execution_review_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "execution_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("execution_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_operator_queue_query_schema() -> JsonSchema {
     let mut schema = integration_activation_playbook_query_schema();
     if let JsonSchema::Object {
@@ -21306,7 +21951,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 113);
+        assert_eq!(definitions.len(), 115);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -21583,6 +22228,12 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -21619,7 +22270,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            105
+            107
         );
         assert_eq!(
             export
@@ -21819,6 +22470,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_HANDOFF_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(
@@ -22089,11 +22748,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(113))
+            Some(&integer(115))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(105))
+            Some(&integer(107))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -24954,6 +25613,139 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_execution_request = request(
+            "call-list-integration-activation-execution",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("execution_status", string("blocked")),
+                ("execution_limit", integer(3)),
+            ]),
+            5_533,
+        );
+        let list_activation_execution_trace =
+            tool_runtime.invoke_with_events(&list_activation_execution_request);
+        assert!(list_activation_execution_trace.result.ok);
+        assert_eq!(
+            list_activation_execution_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_execution_output = list_activation_execution_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_execution_count =
+            integer_value(field(list_activation_execution_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_execution_count));
+        let activation_execution_summary =
+            field(list_activation_execution_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_execution_summary, "total_packets"),
+            Some(&integer(activation_execution_count))
+        );
+        assert_eq!(
+            field(activation_execution_summary, "next_execution_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_execution_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_execution_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_execution_packet = array_item(
+            field(list_activation_execution_output, "activation_execution").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_execution_packet, "execution_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_execution_packet, "executable"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert_eq!(
+            field(activation_execution_packet, "dependency_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let activation_execution_summary_request = request(
+            "call-integration-activation-execution-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("execution_status", string("blocked")),
+            ]),
+            5_534,
+        );
+        let activation_execution_summary_trace =
+            tool_runtime.invoke_with_events(&activation_execution_summary_request);
+        assert!(activation_execution_summary_trace.result.ok);
+        assert_eq!(
+            activation_execution_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_execution_summary_output = activation_execution_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_execution_rollup =
+            field(activation_execution_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_execution_rollup, "blocked_packets").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_execution_rollup, "next_execution_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_execution_rollup, "ready_to_execute"),
+            Some(&JsonValue::Bool(false))
+        );
+
         let list_activation_operator_queue_request = request(
             "call-list-integration-activation-operator-queue",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
@@ -27545,6 +28337,14 @@ mod tests {
             activation_handoff_summary_trace,
         );
         journal.record_trace(
+            list_activation_execution_request,
+            list_activation_execution_trace,
+        );
+        journal.record_trace(
+            activation_execution_summary_request,
+            activation_execution_summary_trace,
+        );
+        journal.record_trace(
             list_activation_operator_queue_request,
             list_activation_operator_queue_trace,
         );
@@ -27662,9 +28462,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 113);
-        assert_eq!(journal_summary.completed_count, 113);
-        assert_eq!(journal.audit_records().len(), 113);
+        assert_eq!(journal_summary.invocation_count, 115);
+        assert_eq!(journal_summary.completed_count, 115);
+        assert_eq!(journal.audit_records().len(), 115);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1499,6 +1499,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationRunbookSummary,
     ListIntegrationActivationHandoff,
     GetIntegrationActivationHandoffSummary,
+    ListIntegrationActivationExecution,
+    GetIntegrationActivationExecutionSummary,
     ListIntegrationActivationOperatorQueue,
     GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationControlRoom,
@@ -1714,6 +1716,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationHandoffSummary => {
                 read_tool("smart_home.get_integration_activation_handoff_summary")
+            }
+            Self::ListIntegrationActivationExecution => {
+                read_tool("smart_home.list_integration_activation_execution")
+            }
+            Self::GetIntegrationActivationExecutionSummary => {
+                read_tool("smart_home.get_integration_activation_execution_summary")
             }
             Self::ListIntegrationActivationOperatorQueue => {
                 read_tool("smart_home.list_integration_activation_operator_queue")
@@ -2432,6 +2440,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationRunbookSummary,
         SmartHomeTool::ListIntegrationActivationHandoff,
         SmartHomeTool::GetIntegrationActivationHandoffSummary,
+        SmartHomeTool::ListIntegrationActivationExecution,
+        SmartHomeTool::GetIntegrationActivationExecutionSummary,
         SmartHomeTool::ListIntegrationActivationOperatorQueue,
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationControlRoom,
@@ -3286,7 +3296,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 113);
+        assert_eq!(catalog.len(), 115);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3698,6 +3708,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_execution"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_execution_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_activation_operator_queue"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -3752,15 +3770,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 113);
-        assert_eq!(summary.read_tools, 105);
+        assert_eq!(summary.total_tools, 115);
+        assert_eq!(summary.read_tools, 107);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 105);
+        assert_eq!(summary.read_only_tier_tools, 107);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 113);
+        assert_eq!(summary.total_required_capabilities, 115);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1174,6 +1174,34 @@ impl IntegrationActivationHandoffStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationExecutionStatus {
+    Executable,
+    OperatorRequired,
+    NeedsApproval,
+    Blocked,
+    Monitoring,
+}
+
+impl IntegrationActivationExecutionStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Executable => "executable",
+            Self::OperatorRequired => "operator_required",
+            Self::NeedsApproval => "needs_approval",
+            Self::Blocked => "blocked",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::OperatorRequired | Self::NeedsApproval | Self::Blocked
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationOperatorTaskKind {
     ResolveConstraints,
     EnableDependencies,
@@ -2496,6 +2524,85 @@ pub struct IntegrationActivationHandoffSummary {
     pub first_ready_priority: Option<u8>,
     pub first_blocked_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationExecutionPacket {
+    pub sequence: usize,
+    pub handoff_sequence: usize,
+    pub runbook_sequence: usize,
+    pub operator_task_sequence: Option<usize>,
+    pub priority: u8,
+    pub execution_status: IntegrationActivationExecutionStatus,
+    pub handoff_status: IntegrationActivationHandoffStatus,
+    pub phase: IntegrationActivationRunbookPhase,
+    pub task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub risk_ids: Vec<String>,
+    pub dependency_integration_ids: Vec<IntegrationId>,
+    pub blocking_dependency_integration_ids: Vec<IntegrationId>,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub readiness_gap_count: usize,
+    pub audit_record_count: usize,
+    pub attention_audit_record_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_required: bool,
+    pub activation_ready: bool,
+    pub ready_for_handoff: bool,
+    pub approval_required: bool,
+    pub dependency_ready: bool,
+    pub executable: bool,
+    pub blocked: bool,
+    pub review_required: bool,
+    pub monitor_only: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationExecutionSummary {
+    pub total_packets: usize,
+    pub unique_integrations: usize,
+    pub executable_packets: usize,
+    pub operator_required_packets: usize,
+    pub approval_required_packets: usize,
+    pub blocked_packets: usize,
+    pub dependency_ready_packets: usize,
+    pub dependency_blocked_packets: usize,
+    pub monitor_packets: usize,
+    pub activation_ready_packets: usize,
+    pub packets_requiring_attention: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_readiness_gaps: usize,
+    pub total_audit_records: usize,
+    pub attention_audit_records: usize,
+    pub next_execution_status: Option<IntegrationActivationExecutionStatus>,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_phase: Option<IntegrationActivationRunbookPhase>,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_packet_sequence: Option<usize>,
+    pub next_packet_priority: Option<u8>,
+    pub first_executable_sequence: Option<usize>,
+    pub first_operator_sequence: Option<usize>,
+    pub first_approval_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_dependency_blocked_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_executable_priority: Option<u8>,
+    pub first_operator_priority: Option<u8>,
+    pub first_approval_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_dependency_blocked_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -5687,6 +5794,315 @@ impl IntegrationActivationHandoffSummary {
             || self.operator_required_packages > 0
             || self.has_blockers()
             || self.has_review_work()
+            || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationExecutionPacket {
+    fn from_handoff_package(
+        package: IntegrationActivationHandoffPackage,
+        task: Option<&IntegrationActivationOperatorTask>,
+    ) -> Self {
+        let task_blocked = task
+            .map(IntegrationActivationOperatorTask::blocked)
+            .unwrap_or(false);
+        let task_review_required = task
+            .map(IntegrationActivationOperatorTask::review_required)
+            .unwrap_or(false);
+        let task_operator_required = task
+            .map(IntegrationActivationOperatorTask::operator_required)
+            .unwrap_or(false);
+        let task_activation_ready = task
+            .map(IntegrationActivationOperatorTask::activation_ready)
+            .unwrap_or(true);
+        let task_monitor_only = task
+            .map(IntegrationActivationOperatorTask::monitor_only)
+            .unwrap_or(false);
+
+        let dependency_ready = !package.has_dependency_blockers() && !package.has_readiness_gaps();
+        let highest_policy_tier = task
+            .map(|task| package.highest_policy_tier.max(task.highest_policy_tier))
+            .unwrap_or(package.highest_policy_tier);
+        let activation_ready = package.activation_ready() && task_activation_ready;
+        let ready_for_handoff = package.ready_for_handoff();
+        let review_required = package.review_required() || task_review_required;
+        let approval_required =
+            review_required || highest_policy_tier >= PrivilegeTier::HumanApproval;
+        let blocked = package.blocked() || task_blocked || !dependency_ready;
+        let monitor_only = package.monitor_only() || task_monitor_only;
+        let operator_required = package.operator_required()
+            || task_operator_required
+            || (review_required && !monitor_only)
+            || (blocked && !monitor_only);
+        let executable = ready_for_handoff
+            && activation_ready
+            && dependency_ready
+            && !approval_required
+            && !blocked
+            && !monitor_only;
+        let execution_status = if monitor_only {
+            IntegrationActivationExecutionStatus::Monitoring
+        } else if blocked {
+            IntegrationActivationExecutionStatus::Blocked
+        } else if approval_required {
+            IntegrationActivationExecutionStatus::NeedsApproval
+        } else if operator_required && !executable {
+            IntegrationActivationExecutionStatus::OperatorRequired
+        } else {
+            IntegrationActivationExecutionStatus::Executable
+        };
+        let requires_attention = execution_status.requires_attention()
+            || package.requires_attention()
+            || task
+                .map(IntegrationActivationOperatorTask::requires_attention)
+                .unwrap_or(false);
+
+        Self {
+            sequence: package.sequence,
+            handoff_sequence: package.sequence,
+            runbook_sequence: package.runbook_sequence,
+            operator_task_sequence: task.map(|task| task.sequence),
+            priority: package.priority,
+            execution_status,
+            handoff_status: package.handoff_status,
+            phase: package.phase,
+            task_kind: task.map(|task| task.task_kind),
+            playbook_action: package.playbook_action,
+            recommended_view: package.recommended_view,
+            integration_ids: package.integration_ids,
+            integration_count: package.integration_count,
+            risk_ids: package.risk_ids,
+            dependency_integration_ids: package.dependency_integration_ids,
+            blocking_dependency_integration_ids: package.blocking_dependency_integration_ids,
+            risk_count: package.risk_count,
+            dependency_edge_count: package.dependency_edge_count,
+            blocking_dependency_edge_count: package.blocking_dependency_edge_count,
+            readiness_gap_count: package.readiness_gap_count,
+            audit_record_count: package.audit_record_count,
+            attention_audit_record_count: package.attention_audit_record_count,
+            highest_policy_tier,
+            operator_required,
+            activation_ready,
+            ready_for_handoff,
+            approval_required,
+            dependency_ready,
+            executable,
+            blocked,
+            review_required,
+            monitor_only,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn executable(&self) -> bool {
+        self.executable
+    }
+
+    pub fn operator_required(&self) -> bool {
+        self.operator_required
+    }
+
+    pub fn approval_required(&self) -> bool {
+        self.approval_required
+    }
+
+    pub fn dependency_ready(&self) -> bool {
+        self.dependency_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn review_required(&self) -> bool {
+        self.review_required
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationExecutionSummary {
+    pub fn from_packets<'a>(
+        packets: impl IntoIterator<Item = &'a IntegrationActivationExecutionPacket>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_packets: 0,
+            unique_integrations: 0,
+            executable_packets: 0,
+            operator_required_packets: 0,
+            approval_required_packets: 0,
+            blocked_packets: 0,
+            dependency_ready_packets: 0,
+            dependency_blocked_packets: 0,
+            monitor_packets: 0,
+            activation_ready_packets: 0,
+            packets_requiring_attention: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_readiness_gaps: 0,
+            total_audit_records: 0,
+            attention_audit_records: 0,
+            next_execution_status: None,
+            next_task_kind: None,
+            next_phase: None,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_packet_sequence: None,
+            next_packet_priority: None,
+            first_executable_sequence: None,
+            first_operator_sequence: None,
+            first_approval_sequence: None,
+            first_blocked_sequence: None,
+            first_dependency_blocked_sequence: None,
+            first_attention_sequence: None,
+            first_executable_priority: None,
+            first_operator_priority: None,
+            first_approval_priority: None,
+            first_blocked_priority: None,
+            first_dependency_blocked_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for packet in packets {
+            summary.total_packets += 1;
+            for integration_id in &packet.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_execution_status.is_none() && !packet.monitor_only() {
+                summary.next_execution_status = Some(packet.execution_status);
+                summary.next_task_kind = packet.task_kind;
+                summary.next_phase = Some(packet.phase);
+                summary.next_playbook_action = Some(packet.playbook_action);
+                summary.next_recommended_view = Some(packet.recommended_view);
+                summary.next_packet_sequence = Some(packet.sequence);
+                summary.next_packet_priority = Some(packet.priority);
+            }
+
+            if packet.executable() {
+                summary.executable_packets += 1;
+                summary.first_executable_sequence =
+                    summary.first_executable_sequence.or(Some(packet.sequence));
+                summary.first_executable_priority =
+                    min_optional_priority(summary.first_executable_priority, Some(packet.priority));
+            }
+            if packet.operator_required() {
+                summary.operator_required_packets += 1;
+                summary.first_operator_sequence =
+                    summary.first_operator_sequence.or(Some(packet.sequence));
+                summary.first_operator_priority =
+                    min_optional_priority(summary.first_operator_priority, Some(packet.priority));
+            }
+            if packet.approval_required() {
+                summary.approval_required_packets += 1;
+                summary.first_approval_sequence =
+                    summary.first_approval_sequence.or(Some(packet.sequence));
+                summary.first_approval_priority =
+                    min_optional_priority(summary.first_approval_priority, Some(packet.priority));
+            }
+            if packet.blocked() {
+                summary.blocked_packets += 1;
+                summary.first_blocked_sequence =
+                    summary.first_blocked_sequence.or(Some(packet.sequence));
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, Some(packet.priority));
+            }
+            if packet.dependency_ready() {
+                summary.dependency_ready_packets += 1;
+            } else {
+                summary.dependency_blocked_packets += 1;
+                summary.first_dependency_blocked_sequence = summary
+                    .first_dependency_blocked_sequence
+                    .or(Some(packet.sequence));
+                summary.first_dependency_blocked_priority = min_optional_priority(
+                    summary.first_dependency_blocked_priority,
+                    Some(packet.priority),
+                );
+            }
+            if packet.monitor_only() {
+                summary.monitor_packets += 1;
+            }
+            if packet.activation_ready {
+                summary.activation_ready_packets += 1;
+            }
+            if packet.requires_attention() {
+                summary.packets_requiring_attention += 1;
+                summary.first_attention_sequence =
+                    summary.first_attention_sequence.or(Some(packet.sequence));
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(packet.priority));
+            }
+
+            summary.total_risks += packet.risk_count;
+            summary.total_dependency_edges += packet.dependency_edge_count;
+            summary.blocking_dependency_edges += packet.blocking_dependency_edge_count;
+            summary.total_readiness_gaps += packet.readiness_gap_count;
+            summary.total_audit_records += packet.audit_record_count;
+            summary.attention_audit_records += packet.attention_audit_record_count;
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(packet.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_packets > 0
+            || summary.dependency_blocked_packets > 0
+            || summary.blocking_dependency_edges > 0
+            || summary.total_readiness_gaps > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.approval_required_packets > 0
+            || summary.operator_required_packets > 0
+            || summary.packets_requiring_attention > 0
+            || summary.total_risks > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.executable_packets > 0 || summary.activation_ready_packets > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_packets == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_packets > 0
+            || self.dependency_blocked_packets > 0
+            || self.blocking_dependency_edges > 0
+            || self.total_readiness_gaps > 0
+    }
+
+    pub fn has_approval_work(&self) -> bool {
+        self.approval_required_packets > 0
+            || self.operator_required_packets > 0
+            || self.attention_audit_records > 0
+    }
+
+    pub fn ready_to_execute(&self) -> bool {
+        self.executable_packets > 0 && !self.has_blockers() && !self.has_approval_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.packets_requiring_attention > 0
+            || self.has_blockers()
+            || self.has_approval_work()
             || self.overall_status.requires_attention()
     }
 }
@@ -11612,6 +12028,54 @@ pub fn activation_operator_tasks_at_or_before_priority(
     ))
 }
 
+pub fn activation_execution_packets_from_handoff_packages(
+    packages: Vec<IntegrationActivationHandoffPackage>,
+    tasks: Vec<IntegrationActivationOperatorTask>,
+) -> Vec<IntegrationActivationExecutionPacket> {
+    let tasks_by_playbook_sequence = tasks
+        .iter()
+        .map(|task| (task.playbook_sequence, task))
+        .collect::<BTreeMap<_, _>>();
+    let mut packets = packages
+        .into_iter()
+        .map(|package| {
+            let task = tasks_by_playbook_sequence
+                .get(&package.runbook_sequence)
+                .copied();
+            IntegrationActivationExecutionPacket::from_handoff_package(package, task)
+        })
+        .collect::<Vec<_>>();
+    packets.sort_by(compare_activation_execution_packets);
+    for (index, packet) in packets.iter_mut().enumerate() {
+        packet.sequence = index + 1;
+    }
+    packets
+}
+
+pub fn activation_execution_packets_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationExecutionPacket> {
+    let packages = activation_handoff_packages_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let tasks = activation_operator_tasks_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_execution_packets_from_handoff_packages(packages, tasks)
+}
+
 pub fn activation_control_room_panels_from_operator_tasks(
     mut tasks: Vec<IntegrationActivationOperatorTask>,
 ) -> Vec<IntegrationActivationControlRoomPanel> {
@@ -13631,6 +14095,16 @@ fn activation_handoff_status_sort_key(status: IntegrationActivationHandoffStatus
     }
 }
 
+fn activation_execution_status_sort_key(status: IntegrationActivationExecutionStatus) -> u8 {
+    match status {
+        IntegrationActivationExecutionStatus::Blocked => 0,
+        IntegrationActivationExecutionStatus::NeedsApproval => 1,
+        IntegrationActivationExecutionStatus::OperatorRequired => 2,
+        IntegrationActivationExecutionStatus::Executable => 3,
+        IntegrationActivationExecutionStatus::Monitoring => 4,
+    }
+}
+
 fn compare_activation_handoff_packages(
     left: &IntegrationActivationHandoffPackage,
     right: &IntegrationActivationHandoffPackage,
@@ -13651,6 +14125,28 @@ fn compare_activation_handoff_packages(
                 .cmp(&left.blocking_dependency_edge_count)
         })
         .then_with(|| right.readiness_gap_count.cmp(&left.readiness_gap_count))
+        .then_with(|| right.risk_count.cmp(&left.risk_count))
+        .then_with(|| left.phase.cmp(&right.phase))
+        .then_with(|| left.runbook_sequence.cmp(&right.runbook_sequence))
+}
+
+fn compare_activation_execution_packets(
+    left: &IntegrationActivationExecutionPacket,
+    right: &IntegrationActivationExecutionPacket,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| {
+            activation_execution_status_sort_key(left.execution_status).cmp(
+                &activation_execution_status_sort_key(right.execution_status),
+            )
+        })
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.approval_required().cmp(&left.approval_required()))
+        .then_with(|| right.operator_required().cmp(&left.operator_required()))
+        .then_with(|| right.executable().cmp(&left.executable()))
+        .then_with(|| right.dependency_ready().cmp(&left.dependency_ready()))
         .then_with(|| right.risk_count.cmp(&left.risk_count))
         .then_with(|| left.phase.cmp(&right.phase))
         .then_with(|| left.runbook_sequence.cmp(&right.runbook_sequence))
@@ -17014,6 +17510,7 @@ mod tests {
             &gap_inventory,
         );
 
+        let tasks = activation_operator_tasks_from_playbook_steps(steps.clone());
         let entries = activation_runbook_entries_from_playbook_steps(steps, &audit_records);
 
         assert!(entries.iter().all(|entry| entry.sequence > 0));
@@ -17092,6 +17589,50 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let execution =
+            activation_execution_packets_from_handoff_packages(handoff.clone(), tasks.clone());
+        assert_eq!(execution.len(), handoff.len());
+        assert!(execution
+            .iter()
+            .any(IntegrationActivationExecutionPacket::requires_attention));
+        assert!(
+            execution
+                .iter()
+                .any(|packet| packet.execution_status
+                    == IntegrationActivationExecutionStatus::Blocked)
+        );
+        assert!(execution
+            .iter()
+            .any(|packet| packet.execution_status
+                == IntegrationActivationExecutionStatus::NeedsApproval));
+
+        let blocked_execution = execution
+            .iter()
+            .find(|packet| {
+                packet
+                    .integration_ids
+                    .contains(&IntegrationId::trusted("blocked_review_camera"))
+            })
+            .unwrap();
+        assert_eq!(
+            blocked_execution.execution_status,
+            IntegrationActivationExecutionStatus::Blocked
+        );
+        assert!(blocked_execution.blocked());
+        assert!(!blocked_execution.dependency_ready());
+        assert!(!blocked_execution.executable());
+
+        let execution_summary =
+            IntegrationActivationExecutionSummary::from_packets(execution.iter());
+        assert_eq!(execution_summary.total_packets, execution.len());
+        assert!(execution_summary.has_blockers());
+        assert!(execution_summary.has_approval_work());
+        assert!(execution_summary.requires_attention());
+        assert_eq!(
+            execution_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -17121,6 +17662,16 @@ mod tests {
         assert!(catalog_handoff_entries
             .iter()
             .any(IntegrationActivationHandoffPackage::requires_attention));
+        let catalog_execution_packets = activation_execution_packets_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_execution_packets
+            .iter()
+            .any(IntegrationActivationExecutionPacket::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog-level activation execution packets that join handoff packages with operator queue tasks
- expose read-only Chief tools for listing execution packets and summarizing executable, approval, dependency, and blocker state
- register the new execution tools in the shared smart-home tool catalog

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Generated code/packages/rust/Cargo.lock was removed before push.