### PR TITLE
Enrich data/global browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1547,6 +1547,9 @@ pub struct BrowserDataAttributeDescriptor {
     pub slot_name: Option<String>,
     pub part: Vec<String>,
     pub data_attributes: Vec<BrowserDataAttribute>,
+    pub data_attribute_names: Vec<String>,
+    pub data_attribute_count: usize,
+    pub json_data_attribute_names: Vec<String>,
     pub text: String,
 }
 
@@ -1569,6 +1572,11 @@ pub struct BrowserGlobalStateDescriptor {
     pub draggable_state: Option<String>,
     pub spellcheck: Option<String>,
     pub translate: Option<String>,
+    pub global_attribute_names: Vec<String>,
+    pub global_attribute_count: usize,
+    pub focus_navigation_hint: bool,
+    pub global_state_blocked: bool,
+    pub global_state_block_reasons: Vec<String>,
     pub text: String,
 }
 
@@ -17354,6 +17362,8 @@ fn browser_data_attribute_descriptor(element: &Element) -> Option<BrowserDataAtt
         return None;
     }
 
+    let data_attribute_names = browser_data_attribute_names(&data_attributes);
+    let json_data_attribute_names = browser_json_data_attribute_names(&data_attributes);
     let custom_element_name = browser_custom_element_name(element);
     let custom_element_is = browser_custom_element_is(element);
     let custom_element = custom_element_name.is_some() || custom_element_is.is_some();
@@ -17371,7 +17381,10 @@ fn browser_data_attribute_descriptor(element: &Element) -> Option<BrowserDataAtt
         slot: browser_slot_assignment(element),
         slot_name: browser_slot_name(element),
         part: browser_part_tokens(element),
+        data_attribute_count: data_attributes.len(),
         data_attributes,
+        data_attribute_names,
+        json_data_attribute_names,
         text: visible_text_for_nodes(&element.children),
     })
 }
@@ -17396,10 +17409,15 @@ fn browser_global_state_descriptor(element: &Element) -> Option<BrowserGlobalSta
     }
 
     let accesskey = browser_accesskey(element);
-    let has_global_state = browser_hidden(element)
-        || browser_inert(element)
+    let hidden = browser_hidden(element);
+    let inert = browser_inert(element);
+    let autofocus = browser_autofocus(element);
+    let global_attribute_names = browser_global_attribute_names(element);
+    let global_state_block_reasons = browser_global_state_block_reasons(hidden, inert);
+    let has_global_state = hidden
+        || inert
         || !accesskey.is_empty()
-        || browser_autofocus(element)
+        || autofocus
         || element.attribute("contenteditable").is_some()
         || element.attribute("draggable").is_some()
         || element.attribute("spellcheck").is_some()
@@ -17419,17 +17437,24 @@ fn browser_global_state_descriptor(element: &Element) -> Option<BrowserGlobalSta
         title: element.attribute("title").map(ToOwned::to_owned),
         lang: element.attribute("lang").map(ToOwned::to_owned),
         dir: element.attribute("dir").map(ToOwned::to_owned),
-        hidden: browser_hidden(element),
-        inert: browser_inert(element),
+        hidden,
+        inert,
         tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
+        focus_navigation_hint: element.attribute("tabindex").is_some()
+            || !accesskey.is_empty()
+            || autofocus,
         accesskey,
-        autofocus: browser_autofocus(element),
+        autofocus,
         contenteditable: element.attribute("contenteditable").map(ToOwned::to_owned),
         editing_mode: browser_editing_mode(element),
         draggable: element.attribute("draggable").map(ToOwned::to_owned),
         draggable_state: browser_draggable_state(element),
         spellcheck: browser_spellcheck_state(element),
         translate: browser_translate_state(element),
+        global_attribute_count: global_attribute_names.len(),
+        global_attribute_names,
+        global_state_blocked: !global_state_block_reasons.is_empty(),
+        global_state_block_reasons,
         text: visible_text_for_nodes(&element.children),
     })
 }
@@ -17546,6 +17571,61 @@ fn browser_data_attributes(element: &Element) -> Vec<BrowserDataAttribute> {
             value: Some(attribute.value.clone()),
         })
         .collect()
+}
+
+fn browser_data_attribute_names(data_attributes: &[BrowserDataAttribute]) -> Vec<String> {
+    data_attributes
+        .iter()
+        .map(|attribute| attribute.name.clone())
+        .collect()
+}
+
+fn browser_json_data_attribute_names(data_attributes: &[BrowserDataAttribute]) -> Vec<String> {
+    data_attributes
+        .iter()
+        .filter(|attribute| {
+            attribute.value.as_deref().is_some_and(|value| {
+                let value = value.trim();
+                (value.starts_with('{') && value.ends_with('}'))
+                    || (value.starts_with('[') && value.ends_with(']'))
+            })
+        })
+        .map(|attribute| attribute.name.clone())
+        .collect()
+}
+
+fn browser_global_attribute_names(element: &Element) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in [
+        "title",
+        "lang",
+        "dir",
+        "hidden",
+        "inert",
+        "tabindex",
+        "accesskey",
+        "autofocus",
+        "contenteditable",
+        "draggable",
+        "spellcheck",
+        "translate",
+    ] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    attributes
+}
+
+fn browser_global_state_block_reasons(hidden: bool, inert: bool) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if hidden {
+        reasons.push("hidden".to_string());
+    }
+    if inert {
+        reasons.push("inert".to_string());
+    }
+    reasons
 }
 
 fn is_browser_custom_element_name(name: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -413,6 +413,12 @@ struct ExpectedDataAttributeDescriptor {
     #[serde(default)]
     data_attributes: Vec<ExpectedDataAttribute>,
     #[serde(default)]
+    data_attribute_names: Vec<String>,
+    #[serde(default)]
+    data_attribute_count: usize,
+    #[serde(default)]
+    json_data_attribute_names: Vec<String>,
+    #[serde(default)]
     text: String,
 }
 
@@ -451,6 +457,16 @@ struct ExpectedGlobalStateDescriptor {
     spellcheck: Option<String>,
     #[serde(default)]
     translate: Option<String>,
+    #[serde(default)]
+    global_attribute_names: Vec<String>,
+    #[serde(default)]
+    global_attribute_count: usize,
+    #[serde(default)]
+    focus_navigation_hint: bool,
+    #[serde(default)]
+    global_state_blocked: bool,
+    #[serde(default)]
+    global_state_block_reasons: Vec<String>,
     #[serde(default)]
     text: String,
 }
@@ -5672,6 +5688,51 @@ fn browser_global_state_descriptor_metadata_tracks_non_form_global_states() {
 }
 
 #[test]
+fn browser_global_state_descriptors_track_attributes_focus_and_blockers() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <section id=panel hidden inert tabindex=-1 accesskey="p ?" autofocus>Panel</section>
+            <div id=editor title="Draft" contenteditable spellcheck=false translate=no draggable=true>Copy</div>
+        </body>"#,
+    )
+    .expect("global state descriptor fixture should parse");
+
+    let panel = actual
+        .global_state_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("panel"))
+        .expect("panel descriptor should be present");
+    assert_eq!(
+        panel.global_attribute_names,
+        vec!["hidden", "inert", "tabindex", "accesskey", "autofocus"]
+    );
+    assert_eq!(panel.global_attribute_count, 5);
+    assert!(panel.focus_navigation_hint);
+    assert!(panel.global_state_blocked);
+    assert_eq!(panel.global_state_block_reasons, vec!["hidden", "inert"]);
+
+    let editor = actual
+        .global_state_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("editor"))
+        .expect("editor descriptor should be present");
+    assert_eq!(
+        editor.global_attribute_names,
+        vec![
+            "title",
+            "contenteditable",
+            "draggable",
+            "spellcheck",
+            "translate",
+        ]
+    );
+    assert_eq!(editor.global_attribute_count, 5);
+    assert!(!editor.focus_navigation_hint);
+    assert!(!editor.global_state_blocked);
+    assert!(editor.global_state_block_reasons.is_empty());
+}
+
+#[test]
 fn browser_accessible_description_metadata_tracks_describedby_text() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -5840,6 +5901,41 @@ fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_element
             .data_attribute_descriptors,
         "data attribute descriptors should preserve custom element, slot, part, and visible-text context for all data-* carriers",
     );
+}
+
+#[test]
+fn browser_data_attribute_descriptors_track_names_counts_and_json_hints() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <div id=card data-controller=dashboard data-options='{"compact":true}' data-empty>Alpha</div>
+            <x-chart data-series='[1,2]' data-state=ready></x-chart>
+        </body>"#,
+    )
+    .expect("data attribute descriptor fixture should parse");
+
+    let card = actual
+        .data_attribute_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("card"))
+        .expect("card descriptor should be present");
+    assert_eq!(
+        card.data_attribute_names,
+        vec!["data-controller", "data-options", "data-empty"]
+    );
+    assert_eq!(card.data_attribute_count, 3);
+    assert_eq!(card.json_data_attribute_names, vec!["data-options"]);
+
+    let chart = actual
+        .data_attribute_descriptors
+        .iter()
+        .find(|descriptor| descriptor.element == "x-chart")
+        .expect("custom chart descriptor should be present");
+    assert_eq!(
+        chart.data_attribute_names,
+        vec!["data-series", "data-state"]
+    );
+    assert_eq!(chart.data_attribute_count, 2);
+    assert_eq!(chart.json_data_attribute_names, vec!["data-series"]);
 }
 
 #[test]
@@ -6749,6 +6845,9 @@ impl ExpectedDataAttributeDescriptor {
                 .into_iter()
                 .map(ExpectedDataAttribute::into_browser_data_attribute)
                 .collect(),
+            data_attribute_names: self.data_attribute_names,
+            data_attribute_count: self.data_attribute_count,
+            json_data_attribute_names: self.json_data_attribute_names,
             text: self.text,
         }
     }
@@ -6774,6 +6873,11 @@ impl ExpectedGlobalStateDescriptor {
             draggable_state: self.draggable_state,
             spellcheck: self.spellcheck,
             translate: self.translate,
+            global_attribute_names: self.global_attribute_names,
+            global_attribute_count: self.global_attribute_count,
+            focus_navigation_hint: self.focus_navigation_hint,
+            global_state_blocked: self.global_state_blocked,
+            global_state_block_reasons: self.global_state_block_reasons,
             text: self.text,
         }
     }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1668,11 +1668,11 @@
           { "element": "details", "id": "more", "disclosure_kind": "details", "text": "More Extra", "text_length": 10, "summary_text": "More", "has_summary": true, "open": true, "accessible_name": "More" }
         ],
         "global_state_descriptors": [
-          { "element": "section", "id": "panel", "inert": true, "text": "Settings Choose options Inline action Editable copy" },
-          { "element": "div", "id": "action", "tabindex": "-1", "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "text": "Inline action" },
-          { "element": "p", "id": "editable", "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes", "text": "Editable copy" },
-          { "element": "dialog", "id": "dialog", "accesskey": ["d", "x"], "text": "Dialog copy" },
-          { "element": "p", "id": "secret", "hidden": true, "draggable": "true", "draggable_state": "true", "text": "Hidden copy" }
+          { "element": "section", "id": "panel", "inert": true, "global_attribute_names": ["inert"], "global_attribute_count": 1, "global_state_blocked": true, "global_state_block_reasons": ["inert"], "text": "Settings Choose options Inline action Editable copy" },
+          { "element": "div", "id": "action", "tabindex": "-1", "focus_navigation_hint": true, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "auto", "draggable_state": "auto", "spellcheck": "false", "translate": "no", "global_attribute_names": ["tabindex", "contenteditable", "draggable", "spellcheck", "translate"], "global_attribute_count": 5, "text": "Inline action" },
+          { "element": "p", "id": "editable", "contenteditable": "", "editing_mode": "richtext", "spellcheck": "true", "translate": "yes", "global_attribute_names": ["contenteditable", "spellcheck", "translate"], "global_attribute_count": 3, "text": "Editable copy" },
+          { "element": "dialog", "id": "dialog", "accesskey": ["d", "x"], "global_attribute_names": ["accesskey"], "global_attribute_count": 1, "focus_navigation_hint": true, "text": "Dialog copy" },
+          { "element": "p", "id": "secret", "hidden": true, "draggable": "true", "draggable_state": "true", "global_attribute_names": ["hidden", "draggable"], "global_attribute_count": 2, "global_state_blocked": true, "global_state_block_reasons": ["hidden"], "text": "Hidden copy" }
         ],
         "forms": [],
         "tables": []
@@ -1701,8 +1701,8 @@
         "links": [],
         "images": [],
         "global_state_descriptors": [
-          { "element": "html", "lang": "en", "dir": "ltr", "hidden": true, "accesskey": ["h", "?"], "spellcheck": "false", "translate": "no", "text": "Ready" },
-          { "element": "body", "id": "app-shell", "classes": ["app", "hydrated"], "title": "App shell", "inert": true, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "true", "draggable_state": "true", "spellcheck": "true", "translate": "yes", "text": "Ready" }
+          { "element": "html", "lang": "en", "dir": "ltr", "hidden": true, "accesskey": ["h", "?"], "focus_navigation_hint": true, "spellcheck": "false", "translate": "no", "global_attribute_names": ["lang", "dir", "hidden", "accesskey", "spellcheck", "translate"], "global_attribute_count": 6, "global_state_blocked": true, "global_state_block_reasons": ["hidden"], "text": "Ready" },
+          { "element": "body", "id": "app-shell", "classes": ["app", "hydrated"], "title": "App shell", "inert": true, "contenteditable": "plaintext-only", "editing_mode": "plaintext", "draggable": "true", "draggable_state": "true", "spellcheck": "true", "translate": "yes", "global_attribute_names": ["title", "inert", "contenteditable", "draggable", "spellcheck", "translate"], "global_attribute_count": 6, "global_state_blocked": true, "global_state_block_reasons": ["inert"], "text": "Ready" }
         ],
         "forms": [],
         "tables": []
@@ -2197,11 +2197,11 @@
           { "element": "slot", "slot_name": "footer", "part": ["footer"], "text": "Fallback footer" }
         ],
         "data_attribute_descriptors": [
-          { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "text": "Untitled Body" },
-          { "element": "product-card", "id": "card", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "data_attributes": [{ "name": "data-controller", "value": "product" }, { "name": "data-state", "value": "ready" }], "text": "Widget Chart fallback Save Fallback footer" },
-          { "element": "span", "slot": "title", "part": ["title"], "data_attributes": [{ "name": "data-field", "value": "name" }], "text": "Widget" },
-          { "element": "canvas", "id": "chart", "part": ["chart"], "data_attributes": [{ "name": "data-renderer", "value": "canvas" }], "text": "Chart fallback" },
-          { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "text": "Save" }
+          { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "data_attribute_names": ["data-template"], "data_attribute_count": 1, "text": "Untitled Body" },
+          { "element": "product-card", "id": "card", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "data_attributes": [{ "name": "data-controller", "value": "product" }, { "name": "data-state", "value": "ready" }], "data_attribute_names": ["data-controller", "data-state"], "data_attribute_count": 2, "text": "Widget Chart fallback Save Fallback footer" },
+          { "element": "span", "slot": "title", "part": ["title"], "data_attributes": [{ "name": "data-field", "value": "name" }], "data_attribute_names": ["data-field"], "data_attribute_count": 1, "text": "Widget" },
+          { "element": "canvas", "id": "chart", "part": ["chart"], "data_attributes": [{ "name": "data-renderer", "value": "canvas" }], "data_attribute_names": ["data-renderer"], "data_attribute_count": 1, "text": "Chart fallback" },
+          { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "data_attribute_names": ["data-action"], "data_attribute_count": 1, "text": "Save" }
         ],
         "forms": [],
         "tables": []


### PR DESCRIPTION
## Summary
- add derived data-* descriptor names, counts, and JSON-like dataset hints
- add global attribute names/counts plus focus and hidden/inert blocking hints
- update browser-readiness fixtures and focused parser tests for the enriched metadata

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser