### PR TITLE
feat(adj-lang-cli): FromSolve — the solver certificate renders under the verdict step (ADJ constraints E3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.4.1] - 2026-06-12 — `FromSolve` proof: the solver certificate renders under the verdict step (ADJ constraints E3)
+
+### Added
+
+- **The verdict's proof now descends into the solver certificate.** When a
+  contribution fired from a constraint STATUS atom (E2 — `feasible` /
+  `infeasible` / `solved` / `optimal` / `unbounded`), its proof step now carries
+  a `"solver": …` field with that constraint's full result — the **IIS `core`**
+  for `infeasible`, the assignment for `solved`, the value + binding constraints
+  for `optimal`, etc. So `schedule_broken`'s proof step reads
+  `…,"solver":{"outcome":"unsat","core":[0,1,2]}` — the verdict, *and* the exact
+  conflicting constraints that forced it, in one auditable tree.
+- Implemented entirely in the CLI renderer (no `logic-engine` change): a single
+  `status_certificates` helper produces the `(status atom, certificate JSON)`
+  pairs that both feed the differential (E2) and annotate the proof (E3); the
+  certificate JSON reuses the existing `check_json`/`solve_json`/`optimize_json`
+  renderers. 4 golden tests (IIS core / solved assignment / optimum under the
+  step; no `solver` field on an ordinary contribution).
+
 ## [0.4.0] - 2026-06-12 — feed-a-verdict: constraint outcome drives the differential (ADJ constraints E2)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -102,7 +102,16 @@ fn prov(p: &Provenance) -> String {
 
 /// Serialize the proof DAG for one hypothesis: walk each step and join its
 /// `clause_id` back to the firing clause's evidence term + cited provenance.
-fn proof_json(hyp: &Term, kb: &KnowledgeBase, result: &LRAggregateResult) -> String {
+/// `certs` maps a constraint STATUS atom to its solver certificate JSON (E3); a
+/// contribution step whose evidence *is* such a status gets the certificate
+/// attached under it as `"solver": …`, so the verdict's proof descends into the
+/// solver's result (the IIS, the assignment, the optimum).
+fn proof_json(
+    hyp: &Term,
+    kb: &KnowledgeBase,
+    result: &LRAggregateResult,
+    certs: &[(&'static str, String)],
+) -> String {
     let prior = kb.prior_for(hyp);
     let contribs = kb.contributions_for(hyp);
     let joints = kb.joint_contributions_for(hyp);
@@ -127,11 +136,20 @@ fn proof_json(hyp: &Term, kb: &KnowledgeBase, result: &LRAggregateResult) -> Str
                     ..
                 } => {
                     if let Some(c) = contribs.iter().find(|c| c.id == *clause_id) {
+                        let ev = format!("{}", c.evidence_term);
+                        // E3: if this contribution fired from a constraint STATUS
+                        // atom, descend into the solver certificate beneath it.
+                        let solver = certs
+                            .iter()
+                            .find(|(k, _)| *k == ev.as_str())
+                            .map(|(_, cert)| format!(",\"solver\":{}", cert))
+                            .unwrap_or_default();
                         steps.push(format!(
-                            "{{\"kind\":\"contribution\",\"evidence\":\"{}\",\"logit\":{},{}}}",
-                            esc(&format!("{}", c.evidence_term)),
+                            "{{\"kind\":\"contribution\",\"evidence\":\"{}\",\"logit\":{},{}{}}}",
+                            esc(&ev),
                             jnum(*logit_delta),
-                            prov(&c.provenance)
+                            prov(&c.provenance),
+                            solver
                         ));
                     }
                 }
@@ -191,41 +209,46 @@ fn proof_json(hyp: &Term, kb: &KnowledgeBase, result: &LRAggregateResult) -> Str
     format!("[{}]", steps.join(","))
 }
 
-/// Map the constraint-engine outcomes to the STATUS atoms that feed the
-/// differential (ADJ constraints E2 — feed-a-verdict). Each atom, injected as an
-/// observed fact, fires an existing `contributes <lr> from <status> to <verdict>`
-/// clause. Deduplicated and order-stable. An `Unknown` / `Unsupported` /
-/// `NoUniqueSolution` outcome contributes NO status — the engine stays silent
-/// rather than assert a verdict it cannot back (the one-engine invariant: never
-/// launder an undecided constraint into a verdict).
-fn status_facts(
+/// Map the constraint-engine outcomes to `(status atom, certificate JSON)` pairs
+/// (ADJ constraints E2 + E3). The status atom, injected as an observed fact,
+/// feeds the differential — it fires an existing
+/// `contributes <lr> from <status> to <verdict>` clause (E2, feed-a-verdict).
+/// The certificate JSON is the solver's full result for that status (the IIS
+/// `core` for `infeasible`, the assignments for `solved`, the value + binding
+/// constraints for `optimal`, …); E3 attaches it *under* the proof step that
+/// fired, so the whole adjudication is one auditable tree.
+///
+/// Deduplicated and order-stable. An `Unknown` / `Unsupported` /
+/// `NoUniqueSolution` outcome yields NOTHING — the engine never launders an
+/// undecided constraint into a verdict (the one-engine invariant).
+fn status_certificates(
     solve: &Option<SolveOutcome>,
     check: &Option<FeasibilityOutcome>,
     optimize: &Option<OptimizeOutcome>,
-) -> Vec<&'static str> {
-    let mut out: Vec<&'static str> = Vec::new();
-    let mut add = |out: &mut Vec<&'static str>, s: &'static str| {
-        if !out.contains(&s) {
-            out.push(s);
+) -> Vec<(&'static str, String)> {
+    let mut out: Vec<(&'static str, String)> = Vec::new();
+    let mut add = |out: &mut Vec<(&'static str, String)>, s: &'static str, cert: String| {
+        if !out.iter().any(|(k, _)| *k == s) {
+            out.push((s, cert));
         }
     };
     if let Some(o) = check {
         match o {
             FeasibilityOutcome::Sat { .. } | FeasibilityOutcome::SatReal { .. } => {
-                add(&mut out, "feasible")
+                add(&mut out, "feasible", check_json(o))
             }
-            FeasibilityOutcome::Unsat { .. } => add(&mut out, "infeasible"),
+            FeasibilityOutcome::Unsat { .. } => add(&mut out, "infeasible", check_json(o)),
             FeasibilityOutcome::Unknown { .. } => {}
         }
     }
-    if let Some(SolveOutcome::Solved { .. } | SolveOutcome::SolvedRoots { .. }) = solve {
-        add(&mut out, "solved");
+    if let Some(o @ (SolveOutcome::Solved { .. } | SolveOutcome::SolvedRoots { .. })) = solve {
+        add(&mut out, "solved", solve_json(o));
     }
     if let Some(o) = optimize {
         match o {
-            OptimizeOutcome::Optimal { .. } => add(&mut out, "optimal"),
-            OptimizeOutcome::Infeasible { .. } => add(&mut out, "infeasible"),
-            OptimizeOutcome::Unbounded => add(&mut out, "unbounded"),
+            OptimizeOutcome::Optimal { .. } => add(&mut out, "optimal", optimize_json(o)),
+            OptimizeOutcome::Infeasible { .. } => add(&mut out, "infeasible", optimize_json(o)),
+            OptimizeOutcome::Unbounded => add(&mut out, "unbounded", optimize_json(o)),
             OptimizeOutcome::Unknown { .. } => {}
         }
     }
@@ -293,15 +316,16 @@ fn main() -> ExitCode {
         .is_some()
         .then(|| optimize(&lowered.constraints, &lowered.kb));
 
-    for status in status_facts(&solve_outcome, &check_outcome, &optimize_outcome) {
-        lowered.kb.add_fact(Fact::certain(atom(status)));
+    let certs = status_certificates(&solve_outcome, &check_outcome, &optimize_outcome);
+    for (status, _) in &certs {
+        lowered.kb.add_fact(Fact::certain(atom(*status)));
     }
 
     let diff = decide(&lowered);
 
     let mut ranked: Vec<String> = Vec::new();
     for r in &diff.ranked {
-        let proof = proof_json(&r.hypothesis, &lowered.kb, &r.result);
+        let proof = proof_json(&r.hypothesis, &lowered.kb, &r.result, &certs);
         ranked.push(format!(
             "{{\"hypothesis\":\"{}\",\"posterior\":{},\"posterior_logit\":{},\"normalized_share\":{},\"proof\":{}}}",
             esc(&format!("{}", r.hypothesis)),

--- a/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
+++ b/code/packages/rust/adj-lang-cli/tests/cli_golden.rs
@@ -456,3 +456,82 @@ fn no_status_clause_means_constraints_dont_disturb_the_differential() {
     assert!(s.contains("\"outcome\":\"unsat\""), "{s}");
     assert!(s.contains("\"posterior\":0.3"), "prior unchanged: {s}");
 }
+
+// ---- FromSolve: the solver certificate renders under the verdict step (E3) ----
+
+#[test]
+fn the_verdict_proof_step_carries_the_iis_core() {
+    // The contribution that fired from `infeasible` now embeds the minimal
+    // infeasibility certificate (IIS core) right under the verdict's proof step,
+    // so the whole adjudication is one auditable tree.
+    let (ok, s) = run(
+        "adjcli_fromsolve_iis.adj",
+        "prior 0.10 for schedule_broken\n  source \"x\" trust empirical\n\
+         contributes 1000000 from infeasible to schedule_broken\n  source \"sched\" trust authoritative\n\
+         symbol d : scalar\nsymbol b : scalar\n\
+         constrain d >= 28\nconstrain b >= d + 20\nconstrain b <= 45\ncheck\n\
+         ? schedule_broken\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    // the proof step embeds the solver cert with the IIS core
+    assert!(
+        s.contains("\"solver\":{"),
+        "expected a solver field on the step: {s}"
+    );
+    assert!(s.contains("\"outcome\":\"unsat\""), "{s}");
+    assert!(
+        s.contains("\"core\":[0,1,2]"),
+        "expected the IIS core under the step: {s}"
+    );
+}
+
+#[test]
+fn the_verdict_proof_step_carries_the_solved_assignment() {
+    // A `solve` that fires a verdict via `solved` embeds the assignment cert.
+    let (ok, s) = run(
+        "adjcli_fromsolve_solved.adj",
+        "prior 0.10 for priced\n  source \"x\" trust empirical\n\
+         contributes 1000000 from solved to priced\n  source \"calc\" trust authoritative\n\
+         symbol p : scalar\nconstrain p * 1000 = 8000\nsolve for { p }\n? priced\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"solver\":{"), "{s}");
+    assert!(
+        s.contains("\"name\":\"p\",\"value\":8"),
+        "expected solved p=8 under the step: {s}"
+    );
+}
+
+#[test]
+fn the_verdict_proof_step_carries_the_optimum() {
+    // An `optimize` that fires a verdict via `optimal` embeds the value + binding.
+    let (ok, s) = run(
+        "adjcli_fromsolve_opt.adj",
+        "prior 0.10 for allocated\n  source \"x\" trust empirical\n\
+         contributes 1000000 from optimal to allocated\n  source \"lp\" trust authoritative\n\
+         symbol x : scalar\nconstrain x <= 5\nconstrain x >= 0\nmaximize x\n? allocated\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(s.contains("\"solver\":{"), "{s}");
+    assert!(s.contains("\"outcome\":\"optimal\""), "{s}");
+    assert!(
+        s.contains("\"value\":5"),
+        "expected optimum 5 under the step: {s}"
+    );
+}
+
+#[test]
+fn a_non_status_contribution_has_no_solver_field() {
+    // An ordinary contribution (not from a constraint status) carries no solver.
+    let (ok, s) = run(
+        "adjcli_fromsolve_none.adj",
+        "prior 0.10 for acs\n  source \"x\" trust empirical\n\
+         contributes 2.5 from symptom(chest_pain) to acs\n  source \"y\" trust empirical\n\
+         observe symptom(chest_pain)\n? acs\n",
+    );
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(
+        !s.contains("\"solver\":"),
+        "no constraint status → no solver field: {s}"
+    );
+}

--- a/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
+++ b/code/specs/data/adj-language-expansion/ADJ-CONSTRAINTS-DESIGN.md
@@ -130,9 +130,13 @@ the **dimensional layer + surface sublanguage + provenance bridge**. Everything 
   an observed fact into the KB *before* `decide`, and an existing
   `contributes <lr> from <status> to <verdict>` clause fires through the ordinary contribution + proof
   machinery.
-- **E3 (next):** a new `DerivationOrigin::FromSolve { … }` lets the proof DAG descend into the solver
-  certificate, so `adj-lang-cli` renders the solution/IIS *under* the verdict step — auditable without
-  the model.
+- **FromSolve / proof descent** ✅ (E3) → the verdict's proof descends into the solver certificate.
+  **Divergence from the original plan:** implemented *without* a new `logic-engine`
+  `DerivationOrigin::FromSolve` — it lives entirely in the `adj-lang-cli` renderer. A contribution step
+  whose evidence is a constraint STATUS atom gets a `"solver": …` field carrying that constraint's full
+  result (the IIS `core`, the assignment, the optimum) via the existing `*_json` renderers. So a
+  verdict's proof step reads `…,"solver":{"outcome":"unsat","core":[0,1,2]}` — the verdict *and* the
+  exact conflicting constraints, in one auditable tree, no engine change.
 
 ## 6. Reuse map (grounded — verified by source read)
 


### PR DESCRIPTION
## What

Completes the constraint→ADJ fusion: **the verdict's proof now descends into the solver certificate**, so the whole adjudication is one auditable tree.

When a contribution fired from a constraint STATUS atom (E2: `feasible`/`infeasible`/`solved`/`optimal`/`unbounded`), its proof step now carries a `"solver": …` field with that constraint's full result:

```jsonc
{ "kind":"contribution", "evidence":"infeasible", "logit":13.8, "source":"sched", …,
  "solver": { "outcome":"unsat", "core":[0,1,2] } }   // ← the minimal IIS, under the verdict step
```

So `schedule_broken`'s proof reads the **verdict and the exact conflicting constraints that forced it**, together — the IIS `core` for `infeasible`, the assignment for `solved`, the value + binding for `optimal`.

## How (no engine change)

Implemented entirely in the CLI renderer — *not* a new `logic-engine` `DerivationOrigin::FromSolve`. A single `status_certificates` helper (renamed from E2's `status_facts`) returns the `(status atom, certificate JSON)` pairs that **both** feed the differential (E2) **and** annotate the proof (E3); the certificate JSON reuses the existing `check_json`/`solve_json`/`optimize_json` renderers. A status-named evidence with no actual constraint outcome gets no `solver` field (no fabrication).

## Tests
+4 golden (IIS core / solved assignment / optimum rendered under the step; ordinary contribution has no `solver` field). Full CLI suite green (30 golden + 4 worked + 5 decompose-run).

## Security
Review **passed**: hardcoded status literals, all cert strings via the existing `esc`/`jnum`-routed renderers, no untrusted concatenation, no panic path, no fabricated certificate.

**This is the last of track E.** Constraints are now fully finished — **standalone** (E1 minimal IIS) and **fused into ADJ** (E2 feed-a-verdict, E3 proof descent). After this merges, the constraint work the user asked to complete is done; MYCIN-2026 rebuild is next, awaiting their scope decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)