### PR TITLE
feat(lang-matrix): LM-L Brainfuck — Brainfuck runs on the LLVM backend

### DIFF
--- a/code/packages/rust/iir-to-llvm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-llvm/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this crate are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.0] — 2026-06-12 (LLVM05 — byte-tape ops + Brainfuck I/O; LANG-MATRIX LM-L Brainfuck)
+
+Adds the byte-tape memory ops and character I/O that Brainfuck needs, so the
+LLVM column now covers Brainfuck — the last code-gen gap in that language's row.
+Verified by RUNNING the Brainfuck cell `++++++++[>++++++++<-]>+.` on real `clang`
+in `lang-aot/tests/lang_matrix.rs`: it prints `A`.
+
+**New IIR opcodes** (added to `SUPPORTED_OPS` and `lower_instr`):
+
+- `alloc_bytes dest <- size` → `%dest = call ptr @calloc(i64 size, i64 1)` — a
+  zero-filled tape (Brainfuck cells start at 0). Declared once as
+  `declare ptr @calloc(i64, i64)`. The tape base is a single-assignment value,
+  so it is never a promoted stack slot.
+- `load_byte dest <- base, idx` → `getelementptr i8` + `load i8` + `zext i8…i64`.
+  The 8-bit cell becomes the uniform `i64` register width.
+- `store_byte base, idx, val` (no dest) → `getelementptr i8` + `trunc i64…i8` +
+  `store i8`. The `trunc` is what makes Brainfuck's 8-bit cell wrap-around fall
+  out even though the surrounding arithmetic runs at `i64` width — "byte width
+  only at the tape boundary."
+
+**New `call_builtin`s** (added to `SUPPORTED_BUILTINS`):
+
+- `putchar` (Brainfuck `.`) → `trunc i64…i32` + `call i32 @putchar(i32)`. Maps
+  to libc directly (no host-runtime shim like `print_i64`'s `@__print_i64`).
+- `getchar` (Brainfuck `,`) → `call i32 @getchar()` + `sext i32…i64`. EOF (`-1`)
+  lands as `0xFF` after a subsequent `store_byte` truncation — the conventional
+  Brainfuck behaviour. Declared as `declare i32 @putchar(i32)` / `@getchar()`.
+
+**Bug fix — slot-dest SSA rename.** A variable assigned in 2+ instructions is
+promoted to an `alloca i64` stack slot. Previously a value-producing op wrote
+`%<var> = …` using the variable's name verbatim, so a slot variable that is the
+dest of a real op (rather than only `const`/`mov`) emitted `%v = …` twice — which
+LLVM rejects (*"multiple definition of local value named 'v'"*). Brainfuck's
+`ptr`/`v` (incremented every command) are the first such case. `lower_instr_with_slots`
+now lowers a clone of the instruction with a fresh SSA dest name and stores the
+result into the original variable's slot. `const`/`mov` slot-dests (which emit no
+`%dest =` line) are unaffected.
+
+Six new tests in `tests/test_backend.rs` cover each emit case and the rename
+regression.
+
 ## [0.8.0] — 2026-06-10 (McCarthy W13b — lisp lambda (F7) — LLVM COMPLETE)
 
 Registers the universal exit-coercion runtime helper so the LLVM backend can

--- a/code/packages/rust/iir-to-llvm/Cargo.toml
+++ b/code/packages/rust/iir-to-llvm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-llvm"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
-description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
+description = "IIR → textual LLVM IR backend — emits .ll source for an LLVM target triple.  v0.9.0 (LLVM05, LANG-MATRIX LM-L Brainfuck): adds the byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zero-extend/truncate at the byte boundary), and the `putchar`/`getchar` libc builtins, plus a slot-dest SSA rename so a stack-slot variable assigned 2+ times by a real op no longer emits a duplicate `%name`.  v0.4.0 (LLVM04): adds `call` of user-defined functions (per-arg types resolved via pre-built callee-signature map) and `call_builtin print_i64` → `declare/call @__print_i64(i64)`, completing the LLVM backend's user-callable surface."
 
 [lib]
 name = "iir_to_llvm"

--- a/code/packages/rust/iir-to-llvm/README.md
+++ b/code/packages/rust/iir-to-llvm/README.md
@@ -87,7 +87,26 @@ you actually intend to run `llc` for a non-default architecture.
 | v0.6.0  | `COND` via stack-slot (`alloca`) SSA-merge + `jmp_if` void-cond + empty-block `br` (McCarthy W12b-3). |
 | v0.7.0  | Lisp symbols — `symbol` type → `i64` tagged immediate (McCarthy W13a). |
 | v0.8.0  | Lisp lambda (F7) — declare `lispy_to_exit_code` runtime switch; **LLVM McCarthy-complete F1–F7** (McCarthy W13b). |
+| v0.9.0  | Byte-tape ops `alloc_bytes`→`@calloc`, `load_byte`/`store_byte` (zext/trunc at the byte boundary), `putchar`/`getchar` libc builtins, + slot-dest SSA rename. **Brainfuck runs on LLVM** (LANG-MATRIX LM-L Brainfuck). |
 | (later) | GC, debug info via `!dbg`. |
+
+### Byte-tape memory (v0.9.0)
+
+Brainfuck builds an implicit byte tape; `lower_brainfuck_for_aot` (in `lang-aot`)
+rewrites it into the same `alloc_bytes` / `load_byte` / `store_byte` ops the
+native x86_64 backend already uses (LANG76). This crate's lowering:
+
+| IIR op | LLVM emitted | Notes |
+|--------|--------------|-------|
+| `alloc_bytes d <- n` | `%d = call ptr @calloc(i64 n, i64 1)` | zero-filled tape |
+| `load_byte d <- base, i` | `getelementptr i8` + `load i8` + `zext i8…i64` | cell → word |
+| `store_byte base, i, v` | `getelementptr i8` + `trunc i64…i8` + `store i8` | word → cell (8-bit wrap) |
+| `call_builtin putchar v` | `trunc i64…i32` + `call i32 @putchar(i32)` | libc; Brainfuck `.` |
+| `call_builtin getchar -> d` | `call i32 @getchar()` + `sext i32…i64` | libc; Brainfuck `,` |
+
+Byte width lives **only at the tape boundary** (the `zext`/`trunc`); every register
+in between is a uniform `i64`, which is what lets the i64-only stack-slot model
+consume Brainfuck's reassigned `ptr`/`v` without a width mismatch.
 
 See [`code/specs/iir-to-llvm.md`](../../../specs/iir-to-llvm.md) for the
 full spec and [`code/specs/MULTILANG-BACKEND-PLAN.md`](../../../specs/MULTILANG-BACKEND-PLAN.md)

--- a/code/packages/rust/iir-to-llvm/src/lib.rs
+++ b/code/packages/rust/iir-to-llvm/src/lib.rs
@@ -238,6 +238,12 @@ const SUPPORTED_OPS: &[&str] = &[
     "label", "jmp", "jmp_if_true", "jmp_if_false",
     // LLVM04 — calls
     "call", "call_builtin",
+    // LLVM05 — byte-tape memory (LANG-MATRIX LM-L Brainfuck). `alloc_bytes`
+    // mallocs a zero-filled tape, `load_byte`/`store_byte` index it at byte
+    // width (zero-extend on load, truncate on store). The same op trio the
+    // x86_64 / native AOT backend already supports (LANG76); we add the LLVM
+    // lowering so Brainfuck — which builds an implicit byte tape — compiles.
+    "alloc_bytes", "load_byte", "store_byte",
 ];
 
 /// Builtins the LLVM backend knows how to lower.
@@ -253,7 +259,12 @@ const SUPPORTED_OPS: &[&str] = &[
 /// We pick that name (rather than `@env.__print_i64` etc.) because LLVM
 /// global names commonly use `__` for runtime / launcher symbols, and the
 /// downstream linker resolves the host implementation.
-const SUPPORTED_BUILTINS: &[&str] = &["print_i64"];
+///
+/// LLVM05 (LANG-MATRIX LM-L Brainfuck) adds `putchar` / `getchar` — Brainfuck's
+/// `.` and `,`. These lower directly to the libc `@putchar(i32)` / `@getchar()`
+/// the C standard library already provides, so no host-runtime shim is needed
+/// (unlike `print_i64`); `clang` links libc by default.
+const SUPPORTED_BUILTINS: &[&str] = &["print_i64", "putchar", "getchar"];
 
 /// McCarthy W12b — the **tagged-word lisp** builtins the LLVM backend lowers to
 /// `call`s into the shared C runtime (`twig-aot/runtime/lispy_runtime.c`), the
@@ -411,18 +422,31 @@ pub fn lower_iir_to_llvm(
     // Currently the only supported builtin is `print_i64` (LLVM convention
     // chosen for BASIC's PRINT — see `SUPPORTED_BUILTINS` doc above).
     let mut used_print_i64 = false;
+    // LLVM05 — Brainfuck I/O + tape: libc `putchar`/`getchar` and the
+    // allocator behind `alloc_bytes`. Declared once each, when used.
+    let mut used_putchar = false;
+    let mut used_getchar = false;
+    let mut used_alloc_bytes = false;
     // McCarthy W12b: collect the tagged-word lisp builtins actually used, in
     // first-seen order, so each gets exactly one `declare i64 @__twig_lispy_*`.
     let mut used_lispy: Vec<&'static (&'static str, &'static str, usize)> = Vec::new();
     for f in &module.functions {
         for i in &f.instructions {
+            if i.op == "alloc_bytes" {
+                used_alloc_bytes = true;
+            }
             if i.op == "call_builtin" {
                 if let Some(Operand::Var(name)) = i.srcs.first() {
-                    if name == "print_i64" {
-                        used_print_i64 = true;
-                    } else if let Some(b) = lispy_builtin(name) {
-                        if !used_lispy.iter().any(|(n, _, _)| n == &b.0) {
-                            used_lispy.push(b);
+                    match name.as_str() {
+                        "print_i64" => used_print_i64 = true,
+                        "putchar" => used_putchar = true,
+                        "getchar" => used_getchar = true,
+                        _ => {
+                            if let Some(b) = lispy_builtin(name) {
+                                if !used_lispy.iter().any(|(n, _, _)| n == &b.0) {
+                                    used_lispy.push(b);
+                                }
+                            }
                         }
                     }
                 }
@@ -432,6 +456,21 @@ pub fn lower_iir_to_llvm(
     if used_print_i64 {
         out.push('\n');
         out.push_str("declare void @__print_i64(i64)\n");
+    }
+    // LLVM05 — libc / allocator declarations for the Brainfuck tape & I/O.
+    // `calloc(nmemb, size)` returns a zero-filled buffer (BF cells start at 0);
+    // `putchar`/`getchar` are the libc character I/O the BF `.`/`,` map to.
+    if used_alloc_bytes || used_putchar || used_getchar {
+        out.push('\n');
+        if used_alloc_bytes {
+            out.push_str("declare ptr @calloc(i64, i64)\n");
+        }
+        if used_putchar {
+            out.push_str("declare i32 @putchar(i32)\n");
+        }
+        if used_getchar {
+            out.push_str("declare i32 @getchar()\n");
+        }
     }
     if !used_lispy.is_empty() {
         out.push('\n');
@@ -505,6 +544,16 @@ impl FnState<'_> {
     fn fresh(&mut self, hint: &str) -> String {
         self.counter += 1;
         format!("%__{}{}", hint, self.counter)
+    }
+
+    /// Like [`fresh`](Self::fresh) but without the leading `%` — a *bare* SSA
+    /// name suitable for use as an `IIRInstr::dest` (the lowering helpers add
+    /// the `%` themselves). Used to give a promoted stack-slot's assignment a
+    /// unique SSA name so a variable written more than once does not emit
+    /// `%v = …` twice (LLVM rejects "multiple definition of local value").
+    fn fresh_bare(&mut self, hint: &str) -> String {
+        self.counter += 1;
+        format!("__{}{}", hint, self.counter)
     }
 }
 
@@ -629,16 +678,37 @@ fn lower_instr_with_slots(
     }
 
     // 2. Lower the instruction.
-    lower_instr(instr, state, out)?;
+    //
+    // If `dest` is a slot, rename it to a *fresh* SSA name first. A
+    // value-producing op (`add`/`zext`/`load_byte`/…) emits `%<dest> = …`
+    // using the dest name verbatim; a slot variable is by definition assigned
+    // 2+ times, so reusing its name would emit `%v = …` twice — which LLVM
+    // rejects ("multiple definition of local value named 'v'"). Lowering a
+    // clone with a unique dest name sidesteps that; the post-store below then
+    // writes the produced value into the *original* variable's slot. (`const`
+    // and `mov` slot-dests emit no `%dest = …` line, so they were always fine —
+    // but routing them through the same rename is harmless and keeps the code
+    // uniform.) This is the LANG-MATRIX LM-L-Brainfuck trigger: BF's `ptr`/`v`
+    // are the first slot variables to be the dest of real arithmetic.
+    let slot_dest = instr
+        .dest
+        .as_ref()
+        .filter(|d| state.slots.contains(*d))
+        .cloned();
+    if let Some(orig) = &slot_dest {
+        let fresh = state.fresh_bare("slot");
+        let mut renamed = instr.clone();
+        renamed.dest = Some(fresh.clone());
+        lower_instr(&renamed, state, out)?;
 
-    // 3. Post-store a slot destination.
-    if let Some(dest) = &instr.dest {
-        if state.slots.contains(dest) {
-            if let Some(val) = state.env.get(dest).cloned() {
-                out.push_str(&format!("  store i64 {val}, ptr %{dest}.slot\n"));
-            }
-            state.env.remove(dest); // future reads go through the slot's load.
+        // 3a. Post-store the produced value into the original slot.
+        if let Some(val) = state.env.get(&fresh).cloned() {
+            out.push_str(&format!("  store i64 {val}, ptr %{orig}.slot\n"));
         }
+        state.env.remove(&fresh); // the fresh temp is not referenced again.
+        state.env.remove(orig); // future reads of `orig` go through its slot load.
+    } else {
+        lower_instr(instr, state, out)?;
     }
 
     // 4. Restore the env bindings we overrode for the pre-loads.
@@ -798,11 +868,111 @@ fn lower_instr(
         // is emitted once at the module top by `lower_iir_to_llvm`.
         "call_builtin" => lower_call_builtin(instr, state, out),
 
+        // ── byte-tape memory (LLVM05 — LANG-MATRIX LM-L Brainfuck) ───────
+        "alloc_bytes" => lower_alloc_bytes(instr, state, out),
+        "load_byte" => lower_load_byte(instr, state, out),
+        "store_byte" => lower_store_byte(instr, state, out),
+
         other => Err(IIRLlvmError::UnsupportedOp {
             function: fn_name.into(),
             op: other.into(),
         }),
     }
+}
+
+// ---------------------------------------------------------------------------
+// LLVM05 — byte-tape memory ops (Brainfuck's implicit tape)
+// ---------------------------------------------------------------------------
+
+/// Lower `alloc_bytes dest <- size` — allocate a `size`-byte, zero-filled tape.
+///
+/// ```llvm
+/// %dest = call ptr @calloc(i64 <size>, i64 1)
+/// ```
+///
+/// `calloc` zero-initialises (Brainfuck cells start at 0). `dest` (the tape
+/// base) is bound in `env` as an LLVM `ptr`; it is written exactly once by the
+/// `lower_brainfuck_for_aot` preamble, so it is never a promoted stack slot —
+/// later `load_byte`/`store_byte` read it straight from `env`.
+///
+/// The `size` operand is a compile-time constant from `lower_brainfuck_for_aot`
+/// (30000); we emit it verbatim. A hostile hand-built IIR could pass a huge or
+/// negative literal, but that only makes `calloc` return null at runtime (a
+/// crash on first store, not a compile-time or memory-safety defect in this
+/// emitter), so no extra guard is warranted here — exactly the contract the
+/// native `alloc_bytes` lowering already relies on.
+fn lower_alloc_bytes(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "alloc_bytes", state.fn_name)?.to_string();
+    let size = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    out.push_str(&format!("  %{dest} = call ptr @calloc(i64 {size}, i64 1)\n"));
+    state.env.insert(dest.clone(), format!("%{dest}"));
+    Ok(())
+}
+
+/// Lower `load_byte dest <- base, idx` — read one tape cell, zero-extended.
+///
+/// ```llvm
+/// %p = getelementptr i8, ptr <base>, i64 <idx>
+/// %b = load i8, ptr %p
+/// %dest = zext i8 %b to i64
+/// ```
+///
+/// The 8-bit cell becomes an `i64` register (the uniform BF value width); the
+/// `zext` is the load half of the "byte width only at the tape boundary"
+/// contract. `dest` may be a promoted slot — the slot wrapper stores the
+/// `i64` value we leave in `env[dest]`.
+fn lower_load_byte(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    let dest = require_dest(instr, "load_byte", state.fn_name)?.to_string();
+    let base = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let idx = resolve_operand(instr.srcs.get(1), &state.env, "i64", state.fn_name)?;
+    let p = state.fresh("gep");
+    let b = state.fresh("byte");
+    out.push_str(&format!("  {p} = getelementptr i8, ptr {base}, i64 {idx}\n"));
+    out.push_str(&format!("  {b} = load i8, ptr {p}\n"));
+    out.push_str(&format!("  %{dest} = zext i8 {b} to i64\n"));
+    state.env.insert(dest.clone(), format!("%{dest}"));
+    Ok(())
+}
+
+/// Lower `store_byte base, idx, val` (no dest) — write the low byte of `val`.
+///
+/// ```llvm
+/// %p = getelementptr i8, ptr <base>, i64 <idx>
+/// %t = trunc i64 <val> to i8
+/// store i8 %t, ptr %p
+/// ```
+///
+/// The `trunc` is the store half of the tape-boundary contract; it is exactly
+/// what makes Brainfuck's 8-bit cell wrap-around (`255 + 1 == 0`) fall out
+/// even though the arithmetic ran at `i64` width.
+fn lower_store_byte(
+    instr: &IIRInstr,
+    state: &mut FnState,
+    out: &mut String,
+) -> Result<(), IIRLlvmError> {
+    if instr.dest.is_some() {
+        return Err(IIRLlvmError::InvalidOperand {
+            function: state.fn_name.into(),
+            detail: "store_byte must not have a dest".into(),
+        });
+    }
+    let base = resolve_operand(instr.srcs.first(), &state.env, "i64", state.fn_name)?;
+    let idx = resolve_operand(instr.srcs.get(1), &state.env, "i64", state.fn_name)?;
+    let val = resolve_operand(instr.srcs.get(2), &state.env, "i64", state.fn_name)?;
+    let p = state.fresh("gep");
+    let t = state.fresh("trunc");
+    out.push_str(&format!("  {p} = getelementptr i8, ptr {base}, i64 {idx}\n"));
+    out.push_str(&format!("  {t} = trunc i64 {val} to i8\n"));
+    out.push_str(&format!("  store i8 {t}, ptr {p}\n"));
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1234,6 +1404,36 @@ fn lower_call_builtin(
                 }),
             };
             out.push_str(&format!("  call void @__print_i64(i64 {val})\n"));
+            Ok(())
+        }
+        // ── putchar(v) — Brainfuck `.` (LLVM05) ─────────────────────────
+        //
+        // BF's value register is i64; libc `putchar` takes an `int` (i32), so
+        // truncate to the low 32 bits (the cell already lives in the low 8).
+        // The returned int is discarded.
+        //
+        //   srcs = [Var("putchar"), Var(v: i64)]  →  call i32 @putchar(i32 %t)
+        "putchar" => {
+            let val = resolve_operand(instr.srcs.get(1), &state.env, "i64", state.fn_name)?;
+            let t = state.fresh("pc");
+            out.push_str(&format!("  {t} = trunc i64 {val} to i32\n"));
+            out.push_str(&format!("  call i32 @putchar(i32 {t})\n"));
+            Ok(())
+        }
+        // ── getchar() -> v — Brainfuck `,` (LLVM05) ─────────────────────
+        //
+        // libc `getchar` returns an `int` (the byte, or -1 at EOF). We
+        // sign-extend to the i64 cell register; a subsequent `store_byte`
+        // truncates to the 8-bit cell, so EOF (-1) lands as 0xFF — the
+        // conventional Brainfuck "leave 255 on EOF" behaviour.
+        //
+        //   srcs = [Var("getchar")], dest = v  →  %g = call i32 @getchar()
+        "getchar" => {
+            let dest = require_dest(instr, "getchar", state.fn_name)?.to_string();
+            let g = state.fresh("gc");
+            out.push_str(&format!("  {g} = call i32 @getchar()\n"));
+            out.push_str(&format!("  %{dest} = sext i32 {g} to i64\n"));
+            state.env.insert(dest.clone(), format!("%{dest}"));
             Ok(())
         }
         _ => unreachable!("SUPPORTED_BUILTINS guard above prevents this"),

--- a/code/packages/rust/iir-to-llvm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-llvm/tests/test_backend.rs
@@ -1022,3 +1022,184 @@ fn symbol_typed_const_validates_and_lowers() {
     let ll = lower(&module_with(f));
     assert!(ll.contains("ret i64 2"), "symbol immediate flows as i64; got:\n{ll}");
 }
+
+// ===========================================================================
+// 8. LLVM05 — byte-tape memory + Brainfuck I/O (LANG-MATRIX LM-L Brainfuck)
+// ===========================================================================
+
+/// `alloc_bytes dest <- size` lowers to a zero-filling `@calloc` and declares it.
+#[test]
+fn alloc_bytes_emits_calloc_and_declare() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(30_000)], "i64"),
+            IIRInstr::new("alloc_bytes", Some("t".into()), vec![Operand::Var("n".into())], "i64"),
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("z".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("declare ptr @calloc(i64, i64)"), "calloc declared once; got:\n{ll}");
+    assert!(
+        ll.contains("%t = call ptr @calloc(i64 30000, i64 1)"),
+        "alloc_bytes → zero-filled calloc; got:\n{ll}"
+    );
+}
+
+/// `load_byte`/`store_byte` index the tape at byte width: zero-extend on load,
+/// truncate on store — the "byte width only at the tape boundary" contract.
+#[test]
+fn load_and_store_byte_zext_and_trunc_at_boundary() {
+    // A single-assignment `base` + `idx` keep the snippet slot-free so the
+    // gep/zext/trunc shapes are easy to eyeball.
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(8)], "i64"),
+            IIRInstr::new("alloc_bytes", Some("base".into()), vec![Operand::Var("n".into())], "i64"),
+            IIRInstr::new("const", Some("idx".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("val".into()), vec![Operand::Int(65)], "i64"),
+            IIRInstr::new(
+                "store_byte",
+                None,
+                vec![Operand::Var("base".into()), Operand::Var("idx".into()), Operand::Var("val".into())],
+                "i64",
+            ),
+            IIRInstr::new(
+                "load_byte",
+                Some("got".into()),
+                vec![Operand::Var("base".into()), Operand::Var("idx".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("got".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("getelementptr i8, ptr %base, i64 0"), "byte-indexed gep; got:\n{ll}");
+    assert!(ll.contains("trunc i64 65 to i8"), "store truncates to the cell; got:\n{ll}");
+    assert!(ll.contains("store i8"), "store writes one byte; got:\n{ll}");
+    assert!(ll.contains("load i8, ptr"), "load reads one byte; got:\n{ll}");
+    assert!(ll.contains("zext i8"), "load zero-extends to i64; got:\n{ll}");
+}
+
+/// `store_byte` with a `dest` is rejected — it produces no value.
+#[test]
+fn store_byte_with_dest_is_rejected() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(8)], "i64"),
+            IIRInstr::new("alloc_bytes", Some("base".into()), vec![Operand::Var("n".into())], "i64"),
+            IIRInstr::new("const", Some("idx".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("const", Some("val".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "store_byte",
+                Some("oops".into()),
+                vec![Operand::Var("base".into()), Operand::Var("idx".into()), Operand::Var("val".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret_void", None, vec![], "void"),
+        ],
+    );
+    let err = lower_iir_to_llvm(&module_with(f), &IIRLlvmConfig::default());
+    assert!(err.is_err(), "store_byte must not carry a dest");
+}
+
+/// Brainfuck `.` → libc `putchar`: the i64 cell is truncated to the `int` arg.
+#[test]
+fn putchar_truncs_to_i32_and_declares_libc() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(65)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                None,
+                vec![Operand::Var("putchar".into()), Operand::Var("v".into())],
+                "void",
+            ),
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new("ret", None, vec![Operand::Var("z".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("declare i32 @putchar(i32)"), "putchar declared; got:\n{ll}");
+    assert!(ll.contains("trunc i64 65 to i32"), "cell truncated to int; got:\n{ll}");
+    assert!(ll.contains("call i32 @putchar(i32"), "calls libc putchar; got:\n{ll}");
+}
+
+/// Brainfuck `,` → libc `getchar`: the returned `int` is sign-extended to the
+/// i64 cell register (EOF -1 → 0xFF after a later store_byte truncation).
+#[test]
+fn getchar_calls_libc_and_sexts_to_i64() {
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("v".into()),
+                vec![Operand::Var("getchar".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    assert!(ll.contains("declare i32 @getchar()"), "getchar declared; got:\n{ll}");
+    assert!(ll.contains("call i32 @getchar()"), "calls libc getchar; got:\n{ll}");
+    assert!(ll.contains("sext i32"), "result sign-extended to i64; got:\n{ll}");
+}
+
+/// Regression: a stack-slot variable written by a real op 2+ times must NOT
+/// emit `%v = …` twice (LLVM rejects "multiple definition of local value").
+/// The slot wrapper renames each assignment to a fresh SSA name and stores it
+/// into the slot. Before LM-L-Brainfuck this round-tripped only for `const`/
+/// `mov` slot-dests (which emit no `%v =` line); Brainfuck's `add`-into-slot
+/// was the first real trigger.
+#[test]
+fn slot_var_assigned_twice_by_arith_has_unique_ssa_names() {
+    // `v` is the dest of two `add`s → a 2-assignment slot var.
+    let f = IIRFunction::new(
+        "main",
+        vec![],
+        "i64",
+        vec![
+            IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new("const", Some("k".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "add",
+                Some("v".into()),
+                vec![Operand::Var("v".into()), Operand::Var("k".into())],
+                "i64",
+            ),
+            IIRInstr::new(
+                "add",
+                Some("v".into()),
+                vec![Operand::Var("v".into()), Operand::Var("k".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "i64"),
+        ],
+    );
+    let ll = lower(&module_with(f));
+    // `v` is promoted to a slot…
+    assert!(ll.contains("%v.slot = alloca i64"), "v promoted to a slot; got:\n{ll}");
+    // …and the bare `%v = ` SSA name is never (re)defined.
+    assert!(
+        !ll.contains("%v = "),
+        "slot dest must use fresh SSA names, not a reused %v; got:\n{ll}"
+    );
+    // Each add result is stored back to the slot.
+    assert!(ll.matches("store i64").count() >= 3, "each assignment stores to the slot; got:\n{ll}");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — `lang-aot`
 
+## 0.65.0 — 2026-06-12 — Brainfuck runs on LLVM (LANG-MATRIX LM-L Brainfuck)
+
+`lang_matrix.rs` greens **Brainfuck on the LLVM backend** — the first cell of the
+deferred Brainfuck row, and the last code-gen gap for that language (only the VM/JIT
+columns remain). Verified by RUNNING `++++++++[>++++++++<-]>+.` on real `clang`: it
+prints `A`.
+
+The fix is split across two layers, neither of which touches the McCarthy-critical
+`iir-to-llvm` stack-slot allocator:
+
+- **`lower_brainfuck_for_aot` (this crate) — Step 5: widen narrow hints to `i64`.**
+  The Brainfuck frontend emits `u8` (cells) / `u32` (pointer) `type_hint`s. The
+  AOT/LLVM pass now widens every narrow-integer hint to `i64` so the value model is a
+  uniform machine word. Byte width survives **only at the tape boundary**: `load_byte`
+  zero-extends the 8-bit cell to `i64` and `store_byte` truncates back, so cell
+  wrap-around (`255 + 1 == 0`) stays correct. This is what lets `iir-to-llvm` — which
+  promotes any reassigned variable (BF's `ptr`/`v`/`c`/`k`) to an `alloca i64` slot —
+  consume Brainfuck without a width mismatch (`'%__ld' defined with type 'i64' but
+  expected 'i8'`). It is done in this BF-specific pass, **not the frontend**, so the
+  frontend's `u8`/`u32` hints still reach `vm-core`/`jit-core`, whose `specialise` step
+  keys CIR opcode widths (`add_u8`/`add_u32`) off them — the brainfuck-iir-compiler VM
+  and JIT paths are untouched. Native AOT is unaffected: its byte ops already ignore
+  the hint and its arithmetic runs in 64-bit registers regardless.
+- **`iir-to-llvm` 0.9.0** grew the byte-tape ops (`alloc_bytes`/`load_byte`/`store_byte`)
+  and the `putchar`/`getchar` libc builtins, plus a slot-dest SSA rename (see that
+  crate's changelog).
+
+`tests/lang_matrix.rs` adds `Llvm` to the Brainfuck `Prog`; two new `--lib` tests cover
+the i64 widening (`brainfuck_lowering_widens_narrow_hints_to_i64`,
+`is_narrow_int_hint_classifies_widths`).
+
 ## 0.64.0 — 2026-06-12 — Dartmouth BASIC completes the CLR column (LANG-MATRIX LM-C BASIC)
 
 `lang_matrix.rs` greens **Dartmouth BASIC on the real CoreCLR**, completing the CLR

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.65.0 (LANG-MATRIX LM-L Brainfuck): `lower_brainfuck_for_aot` now widens the Brainfuck frontend's narrow cell/pointer hints (`u8`/`u32`) to `i64` (byte width survives only at the `load_byte`/`store_byte` tape boundary), so Brainfuck runs on the LLVM backend — verified by RUNNING on real `clang` in `tests/lang_matrix.rs`.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -2,7 +2,16 @@
 
 Multi-language AOT driver — compile **Twig, Nib, Brainfuck, Dartmouth
 BASIC, Oct, and McCarthy Lisp** to native executables through the shared
-LANG VM chain.  (McCarthy Lisp is wired as of L3a — scalar programs run
+LANG VM chain.
+
+> **LANG-MATRIX LM-L Brainfuck (v0.65.0):** Brainfuck now also runs on the
+> **LLVM** backend. `lower_brainfuck_for_aot` widens the frontend's narrow cell
+> (`u8`) and pointer (`u32`) hints to `i64` — byte width survives only at the
+> `load_byte`/`store_byte` tape boundary — so `iir-to-llvm`'s i64-only stack-slot
+> model accepts the BF tape. Verified by RUNNING `++++++++[>++++++++<-]>+.` → `A`
+> on real `clang` (`tests/lang_matrix.rs`). The frontend itself is unchanged, so
+> the `vm-core`/`jit-core` Brainfuck paths (which key CIR widths off `u8`/`u32`)
+> keep working.  (McCarthy Lisp is wired as of L3a — scalar programs run
 end-to-end natively; symbol/cons backend support is L3b.)  As of L3b-3a-3c,
 `compile_source_to_wasm` also compiles McCarthy **cons** programs to a runnable
 WasmGC module — `(CAR (CONS 7 9))` → `7` on the in-repo `wasm-runtime` (integer

--- a/code/packages/rust/lang-aot/src/lib.rs
+++ b/code/packages/rust/lang-aot/src/lib.rs
@@ -1465,6 +1465,23 @@ pub fn compile_file_to_macos_executable(
 //    exit code so we always return 0 from main, which the LANG VM AOT
 //    chain requires (the entry-point's return value is the process
 //    exit code).
+// 5. Widen every narrow-integer `type_hint` (`u8`/`u32` — the BF frontend's
+//    cell and pointer widths) to `i64`, so the AOT/LLVM value model is a
+//    uniform machine word. Byte width survives **only at the tape boundary**:
+//    `load_byte` zero-extends the 8-bit cell to `i64` and `store_byte`
+//    truncates back, so cell wrap-around (`255 + 1 == 0`) is still correct.
+//    This is the LANG-MATRIX LM-L-Brainfuck fix: `iir-to-llvm` promotes any
+//    reassigned variable (BF's `ptr`/`v`/`c`/`k`) to an `alloca i64` stack
+//    slot, so a narrow `add i32`/`add i8` reading an `i64` slot-load would be
+//    a type error (`'%__ld' defined with type 'i64' but expected 'i8'`).
+//    Widening here makes every register `i64`, matching the slot model
+//    without touching `iir-to-llvm`'s (McCarthy-critical) slot allocator.
+//    We do it in this BF-specific pass rather than the frontend so the
+//    frontend's `u8`/`u32` hints still reach `vm-core`/`jit-core`, whose
+//    `specialise` step keys CIR opcode widths (`add_u8`/`add_u32`) off them.
+//    Native AOT is unaffected: its byte ops already ignore the hint (they
+//    zero-extend / truncate at the asm level) and its arithmetic runs in
+//    64-bit registers regardless.
 
 fn lower_brainfuck_for_aot(module: &mut IIRModule) {
     use interpreter_ir::instr::{IIRInstr, Operand};
@@ -1546,11 +1563,29 @@ fn lower_brainfuck_for_aot(module: &mut IIRModule) {
                 _ => new_instrs.push(instr),
             }
         }
+        // Step 5 — widen narrow-integer hints to i64 (see the function-level
+        // comment). `void`/`i64`/`u64`/`bool`/floats/lisp refs are left as-is;
+        // only the BF cell/pointer widths (`u8`/`u32`, plus their signed and
+        // 16-bit cousins for completeness) become `i64`.
+        for instr in &mut new_instrs {
+            if is_narrow_int_hint(&instr.type_hint) {
+                instr.type_hint = "i64".to_string();
+            }
+        }
+
         func.instructions = new_instrs;
         // Reflect the step-4 return-type change so downstream type
         // propagation in twig-aot sees i64 instead of void.
         func.return_type = "i64".to_string();
     }
+}
+
+/// True when `hint` is a narrow (< 64-bit) machine integer type that the
+/// Brainfuck-for-AOT pass widens to `i64`. Used by [`lower_brainfuck_for_aot`]
+/// Step 5. We deliberately do **not** widen `u64`/`i64` (already a word),
+/// `void`, `bool`, floats, `any`, `symbol`, or any `ref<…>` lisp type.
+fn is_narrow_int_hint(hint: &str) -> bool {
+    matches!(hint, "i8" | "u8" | "i16" | "u16" | "i32" | "u32")
 }
 
 // ===========================================================================
@@ -1697,6 +1732,55 @@ mod tests {
         let last_two = &ops[ops.len()-2..];
         assert_eq!(last_two, &["const", "ret"],
                    "epilogue must be `const; ret`; got {last_two:?}");
+    }
+
+    /// Step 5: every narrow-integer `type_hint` the BF frontend emits (`u8` for
+    /// cells, `u32` for the pointer) must be widened to `i64` after lowering, so
+    /// the AOT/LLVM value model is a uniform machine word. Byte width survives
+    /// only inside `load_byte`/`store_byte` (the backend zero-extends/truncates).
+    /// `void` stays `void`. This is the LANG-MATRIX LM-L-Brainfuck fix that makes
+    /// `iir-to-llvm`'s i64-only slot model accept Brainfuck.
+    #[test]
+    fn brainfuck_lowering_widens_narrow_hints_to_i64() {
+        // A program that exercises cells (`+`/`-`), the pointer (`>`/`<`),
+        // a loop guard, and output (`.`).
+        let iir = compile_source_to_iir(
+            Language::Brainfuck, "+>+<[->+<].", "bf"
+        ).expect("brainfuck must compile");
+        let main = iir.functions.iter().find(|f| f.name == "main")
+            .expect("BF main must exist");
+
+        for instr in &main.instructions {
+            // No narrow integer hint may survive.
+            assert!(
+                !matches!(instr.type_hint.as_str(),
+                          "u8" | "u32" | "u16" | "i8" | "i16" | "i32"),
+                "instr {:?} kept a narrow hint {:?} — must be widened to i64",
+                instr.op, instr.type_hint,
+            );
+            // Every hint is now either i64 (registers + tape ops) or void
+            // (control flow / store_byte / putchar).
+            assert!(
+                instr.type_hint == "i64" || instr.type_hint == "void",
+                "instr {:?} has unexpected hint {:?}; expected i64 or void",
+                instr.op, instr.type_hint,
+            );
+        }
+        // The tape ops carry the widened i64 hint specifically.
+        let load_byte = main.instructions.iter().find(|i| i.op == "load_byte").unwrap();
+        assert_eq!(load_byte.type_hint, "i64", "load_byte hint widened to i64");
+    }
+
+    /// `is_narrow_int_hint` widens only sub-64-bit machine integers; it leaves
+    /// `i64`/`u64`, `void`, `bool`, floats, and lisp/`any` types alone.
+    #[test]
+    fn is_narrow_int_hint_classifies_widths() {
+        for narrow in ["i8", "u8", "i16", "u16", "i32", "u32"] {
+            assert!(is_narrow_int_hint(narrow), "{narrow} should widen");
+        }
+        for wide in ["i64", "u64", "void", "bool", "f32", "f64", "any", "symbol", "ref<LispyPair>"] {
+            assert!(!is_narrow_int_hint(wide), "{wide} must NOT widen");
+        }
     }
 
     #[test]

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -133,14 +133,19 @@ const PROGRAMS: &[Prog] = &[
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
-    // (LLVM column pending: `iir-to-llvm` lacks the tape ops `alloc_bytes`/`load_byte`/
-    // `store_byte` + `putchar` — a backend codegen slice of its own.)
+    // On LLVM (LM-L Brainfuck), `lower_brainfuck_for_aot` widens the BF cell/ptr
+    // registers to `i64` (byte width survives only at the tape boundary) and
+    // `iir-to-llvm` (v0.9.0) grew the tape ops: `alloc_bytes`→`@calloc`,
+    // `load_byte`→`getelementptr i8`+`load`+`zext`, `store_byte`→`trunc`+`store`,
+    // and `putchar`/`getchar`→ libc. `run_llvm` runs the program and compares the
+    // captured stdout (`A`) — `putchar` writes straight to libc stdout, so no
+    // print-runtime shim is linked (unlike BASIC's `@__print_i64`).
     Prog {
         lang: Language::Brainfuck,
         ext: "bf",
         src: "++++++++[>++++++++<-]>+.",
         expect: Expect::Stdout("A"),
-        backends: &[NativeAot],
+        backends: &[NativeAot, Llvm],
     },
     // Dartmouth BASIC — `PRINT 42` writes `42` to stdout. On LLVM the `.ll` emits
     // `call void @__print_i64(i64 42)`, so `run_llvm` links the generic print runtime

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -103,7 +103,7 @@ achievable code-gen columns land first).
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
-| Brainfuck       | ☐  | ☐   | ✅        | ⏸   | ⏸    | ⏸  | ⏸  |
+| Brainfuck       | ☐  | ☐   | ✅        | ✅   | ⏸    | ⏸  | ⏸  |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
@@ -150,11 +150,23 @@ The VM/JIT columns are op-coverage work (see above); the code-gen columns
   `call void @__print_i64(i64 42)`, so when the `.ll` references `@__print_i64` the
   runner compiles in a generic `__print_i64` C runtime and the harness compares
   **stdout**. Verified by RUNNING: `10 PRINT 42` → stdout `42` on real `clang`.
-- ⏸ **LM-L Brainfuck (on LLVM) — DEFERRED.** See the *Deferred* section below; it
-  needs a deeper `iir-to-llvm` change, so the loop advances past it to the WASM column.
+- ✅ **LM-L Brainfuck (on LLVM).** The first deferred item, tackled via the
+  **frontend-i64** approach (chosen over width-aware slots to avoid touching the
+  McCarthy-critical `iir-to-llvm` slot allocator). The i64 materialisation lives in
+  `lower_brainfuck_for_aot` Step 5 — **not** the BF frontend — because the frontend's
+  `u8`/`u32` hints feed `vm-core`/`jit-core`'s `specialise`, which keys CIR opcode
+  widths (`add_u8`/`add_u32`) off them; widening the frontend would break the BF JIT.
+  So the pass that *already* builds the tape boundary widens every narrow hint to
+  `i64`, and `iir-to-llvm` 0.9.0 grew the tape ops: `alloc_bytes`→`@calloc`,
+  `load_byte` (`getelementptr i8`+`load`+`zext`), `store_byte` (`trunc`+`store`),
+  `putchar`/`getchar`→libc — plus a slot-dest SSA rename (a slot var assigned 2+ times
+  by a real op no longer emits a duplicate `%name`; BF's `ptr`/`v` are the first such
+  case, which is why this only surfaced now). Verified by RUNNING
+  `++++++++[>++++++++<-]>+.` → stdout `A` on real `clang` (`lang_matrix.rs`); the BF
+  `vm-core`/`jit-core` suites stay green (frontend untouched).
 
-The LLVM column is therefore green for **5 / 6** languages (Twig / Nib / Oct / ALGOL /
-BASIC); only Brainfuck is deferred.
+The LLVM column is therefore green for **all 6** languages (Twig / Nib / Oct / ALGOL /
+BASIC / Brainfuck). The LLVM column is **complete**.
 
 ### Phase W — WASM for every language
 
@@ -248,21 +260,22 @@ BASIC); only Brainfuck is deferred.
 
 ## Deferred — deeper backend/frontend work (after the code-gen columns)
 
-These three are **not** "add a conformance test" — each needs a real change to a
-backend/interpreter with risk to currently-green backends, so they are grouped here
-to be tackled deliberately once the achievable code-gen columns (WASM/JVM/CLR) land.
+Each needs a real change to a backend/interpreter with risk to currently-green
+backends, so they are tackled deliberately rather than as a routine conformance slice.
 
-- ⏸ **LM-L Brainfuck (on LLVM).** Two layers: (1) `iir-to-llvm` lacks the tape ops
-  (`alloc_bytes`/`load_byte`/`store_byte` + `putchar`) — straightforward to add
-  (`calloc`/`getelementptr i8`/`load`/`store`/libc `putchar`); but (2) the real wall
-  is that `iir-to-llvm`'s SSA model promotes any 2+-assigned variable to an **`alloca
-  i64` slot**, while Brainfuck's reassigned `v`/`ptr` are narrow (`u8`/`u32`). A
-  slot-loaded `i64` then feeds a `u8` `add` → `'%__ld' defined with type 'i64' but
-  expected 'i8'`. Resolving it needs either **width-aware slots** in `iir-to-llvm`
-  (touches the McCarthy-critical slot model) or making the **Brainfuck frontend**
-  materialise cell/ptr arithmetic as `i64` (byte width only at the tape boundary;
-  touches native + WASM + the simulator). Both are cross-cutting; do as a focused,
-  fully-reverified effort, not a routine slice.
+- ✅ **LM-L Brainfuck (on LLVM).** **Done** (see Phase L). The "real wall" — `iir-to-llvm`
+  promotes any 2+-assigned variable to an `alloca i64` slot, while BF's `v`/`ptr` were
+  narrow (`u8`/`u32`), so a slot-loaded `i64` feeding a `u8` `add` was a type error — was
+  resolved by the **frontend-i64** route, but materialised in `lower_brainfuck_for_aot`
+  (Step 5) rather than the literal frontend, so `vm-core`/`jit-core`'s width-keyed
+  `specialise` stays correct. `iir-to-llvm` 0.9.0 added the tape ops + a slot-dest SSA
+  rename (the duplicate-`%name` bug that the "straightforward" tape ops would have hit).
+- ⏸ **LM-W / LM-J / LM-C Brainfuck (WASM / JVM / CLR).** Now unblocked in principle:
+  the i64-widening in `lower_brainfuck_for_aot` is backend-agnostic, so the remaining
+  Brainfuck cells reduce to giving `iir-to-wasm` / `iir-to-jvm-class-file` /
+  `iir-to-cil-bytecode` the same byte-tape ops (`alloc_bytes`/`load_byte`/`store_byte`)
+  and `putchar`/`getchar` lowerings that `iir-to-llvm` and the native backend already
+  have. One backend-codegen slice each — no frontend or slot-model risk.
 - ⏸ **Phase V — VM op-coverage.** `mccarthy_lisp_vm` is **McCarthy-specialized**, not a
   general interpreter (the LM0 probe: it rejects `add`/`mul`/`cmp_*`/`mod` and the I/O
   ops). Running the other languages on the VM means growing the interpreter with
@@ -281,8 +294,9 @@ BEAM column for the imperative languages). The capstone is a single
 known result — the cross-language analog of McCarthy's W16.
 
 The campaign reaches that end state in two waves: first the **code-generator columns**
-(native ✅, LLVM 5/6, then WASM → JVM → CLR) — these are general over the shared IIR,
-so each cell is mostly a conformance test plus the occasional I/O/type fix; then the
-**Deferred** items (Brainfuck-on-LLVM's slot-model mismatch, the McCarthy-specialized
-VM and JIT) — each a real backend/interpreter change tackled deliberately once the
-straightforward columns are complete.
+(native ✅, **LLVM ✅ — all 6**, WASM/JVM/CLR ✅ for the 5 non-Brainfuck languages) —
+these are general over the shared IIR, so each cell is mostly a conformance test plus
+the occasional I/O/type fix; then the **second-wave** items — Brainfuck on WASM/JVM/CLR
+(now unblocked: the same byte-tape ops `iir-to-llvm` just gained, ported to each managed
+backend) and the McCarthy-specialized VM and JIT — each a real backend/interpreter
+change tackled deliberately. The LLVM column (the priority) is now **complete**.


### PR DESCRIPTION
## Summary

Greens the first deferred Brainfuck cell of the LANG-PLATFORM-MATRIX: **Brainfuck now compiles and runs on the LLVM backend**, verified by RUNNING `++++++++[>++++++++<-]>+.` → stdout `A` on real `clang` (`lang-aot/tests/lang_matrix.rs`). The **LLVM column** (the campaign priority) is now complete for all six languages (Twig / Nib / Oct / ALGOL 60 / BASIC / Brainfuck).

This is the second-wave deferred item the user selected via the **frontend-i64** approach (over width-aware slots, to avoid touching the McCarthy-critical `iir-to-llvm` stack-slot allocator).

## Approach — why the i64 widening lives in `lower_brainfuck_for_aot`, not the frontend

The Brainfuck frontend emits narrow hints: `u8` (cells) / `u32` (pointer). `iir-to-llvm` promotes any reassigned variable (BF's `ptr`/`v`/`c`/`k`) to an `alloca i64` slot, so a slot-loaded `i64` feeding a `u8` `add` was a type error (`'%__ld' defined with type 'i64' but expected 'i8'`).

I initially changed the frontend itself but **reverted** it: the frontend's `u8`/`u32` hints feed `vm-core`/`jit-core`'s `specialise`, which keys CIR opcode widths (`add_u8`/`add_u32`) off them — widening the frontend makes `specialise` emit `add_i64`, which the BF `jit_backend` rejects, breaking the brainfuck-iir-compiler JIT/VM tests. Instead, the i64 materialisation lives in `lower_brainfuck_for_aot` **Step 5** — the BF-specific AOT pass that already builds the tape boundary (rewrites `load_mem`→`load_byte`). Byte width survives **only at the `load_byte`/`store_byte` boundary** (zero-extend on load, truncate on store), so cell wrap-around (`255 + 1 == 0`) stays correct. Native AOT is unaffected (its byte ops ignore the hint; arithmetic runs in 64-bit registers).

## Changes

**`iir-to-llvm` 0.9.0 (LLVM05):**
- `alloc_bytes` → `call ptr @calloc(i64 n, i64 1)` (zero-filled tape)
- `load_byte` → `getelementptr i8` + `load i8` + `zext i8…i64`
- `store_byte` → `getelementptr i8` + `trunc i64…i8` + `store i8`
- `putchar`/`getchar` → libc `@putchar(i32)` / `@getchar()` (Brainfuck `.`/`,`; no host-runtime shim, `clang` links libc)
- **slot-dest SSA rename bug fix:** a stack-slot variable assigned 2+ times by a *real* op (not just `const`/`mov`) previously emitted `%name = …` twice — which LLVM rejects (*"multiple definition of local value"*). Brainfuck's `ptr`/`v` are the first such case. `lower_instr_with_slots` now lowers a clone with a fresh SSA dest and stores into the original slot.

**`lang-aot` 0.65.0:** `lower_brainfuck_for_aot` Step 5 widens narrow int hints (`u8`/`u32`) to `i64`; `lang_matrix.rs` adds `Llvm` to the Brainfuck `Prog`.

**Spec:** `LANG-PLATFORM-MATRIX.md` — Brainfuck LLVM cell ⏸→✅, LLVM column marked complete, Deferred section notes WASM/JVM/CLR Brainfuck are now unblocked (port the same byte-tape ops).

## Security

Reviewed by a security sub-agent → **PASSED, no vulnerabilities**. No new IR-injection surface (new sinks are fixed literals + whitelisted builtins; names interpolated exactly as the pre-existing emitter does); `alloc_bytes` size is a total `i64`→string render (no panic/injection); the slot rename cannot re-enter the slot branch or collide names; no `unsafe`/TOCTOU/temp-file/command-injection.

## Test plan

- **Verified by RUNNING on the real toolchain:** Brainfuck `++++++++[>++++++++<-]>+.` → stdout `A` on real `clang` (host triple), plus all other languages on all proven backends — `lang-aot/tests/lang_matrix.rs` (2 passed).
- `iir-to-llvm` tests: **57 passed** (51 + 6 new — each emit case + the slot-rename regression).
- `lang-aot --lib`: **14 passed** (12 + 2 new — i64 widening + `is_narrow_int_hint`).
- `brainfuck-iir-compiler`: all suites green (frontend untouched → VM/JIT paths unaffected).
- `clippy` clean on the changed files; workspace builds.

**Pre-existing / unrelated (ignored, noted):** `lang-aot/tests/cil_emit.rs` fails to compile on `origin/main` from a clr-simulator API drift (`sim.stack.last().and_then(|v| *v)` returns `Value`, not `i32`) — untouched by this diff; other lang-aot test targets run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)