### PR TITLE
Enrich ARIA widget browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -2273,6 +2273,9 @@ pub struct BrowserAriaCollection {
     pub checked_item_count: usize,
     pub current_item_count: usize,
     pub disabled_item_count: usize,
+    pub item_roles: Vec<String>,
+    pub selection_mode: String,
+    pub active_descendant_matches_item: bool,
     pub items: Vec<BrowserAriaCollectionItem>,
 }
 
@@ -2317,6 +2320,12 @@ pub struct BrowserAriaRange {
     pub aria_required: Option<String>,
     pub tabindex: Option<String>,
     pub text_value: Option<String>,
+    pub value_attribute_names: Vec<String>,
+    pub value_attribute_count: usize,
+    pub range_value_complete: bool,
+    pub focusable: bool,
+    pub range_blocked: bool,
+    pub range_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2336,6 +2345,11 @@ pub struct BrowserAriaLiveRegion {
     pub aria_relevant: Vec<String>,
     pub aria_hidden: bool,
     pub update_kind: String,
+    pub live_attribute_names: Vec<String>,
+    pub live_attribute_count: usize,
+    pub assertive_update: bool,
+    pub live_region_blocked: bool,
+    pub live_region_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17012,6 +17026,18 @@ fn browser_aria_collection_element(
         .iter()
         .filter(|item| item.aria_disabled.as_deref() == Some("true"))
         .count();
+    let aria_multiselectable = browser_aria_state(element, "aria-multiselectable");
+    let aria_activedescendant = browser_aria_idref(element, "aria-activedescendant");
+    let item_roles = browser_aria_collection_item_roles(&items);
+    let selection_mode = browser_aria_collection_selection_mode(
+        aria_multiselectable.as_deref(),
+        selected_item_count,
+        checked_item_count,
+        current_item_count,
+    );
+    let active_descendant_matches_item = aria_activedescendant
+        .as_deref()
+        .is_some_and(|id| items.iter().any(|item| item.id.as_deref() == Some(id)));
 
     Some(BrowserAriaCollection {
         element: element.name.clone(),
@@ -17023,17 +17049,49 @@ fn browser_aria_collection_element(
         aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
         aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
         aria_orientation: browser_aria_state(element, "aria-orientation"),
-        aria_multiselectable: browser_aria_state(element, "aria-multiselectable"),
-        aria_activedescendant: browser_aria_idref(element, "aria-activedescendant"),
+        aria_multiselectable,
+        aria_activedescendant,
         aria_owns: browser_aria_idrefs(element, "aria-owns"),
         item_count: items.len(),
         selected_item_count,
         checked_item_count,
         current_item_count,
         disabled_item_count,
+        item_roles,
+        selection_mode,
+        active_descendant_matches_item,
         role,
         items,
     })
+}
+
+fn browser_aria_collection_item_roles(items: &[BrowserAriaCollectionItem]) -> Vec<String> {
+    let mut roles = Vec::new();
+    for item in items {
+        if !roles.contains(&item.role) {
+            roles.push(item.role.clone());
+        }
+    }
+    roles
+}
+
+fn browser_aria_collection_selection_mode(
+    aria_multiselectable: Option<&str>,
+    selected_item_count: usize,
+    checked_item_count: usize,
+    current_item_count: usize,
+) -> String {
+    if aria_multiselectable.is_some_and(|value| value.eq_ignore_ascii_case("true"))
+        || selected_item_count > 1
+        || checked_item_count > 1
+    {
+        "multiple"
+    } else if selected_item_count + checked_item_count + current_item_count > 0 {
+        "single"
+    } else {
+        "none"
+    }
+    .to_string()
 }
 
 fn browser_authored_collection_role(element: &Element) -> Option<String> {
@@ -17124,6 +17182,16 @@ fn browser_aria_range_element(
 ) -> Option<BrowserAriaRange> {
     let role = browser_authored_range_role(element)?;
     let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    let aria_valuenow = browser_aria_state(element, "aria-valuenow");
+    let aria_valuemin = browser_aria_state(element, "aria-valuemin");
+    let aria_valuemax = browser_aria_state(element, "aria-valuemax");
+    let aria_valuetext = browser_aria_state(element, "aria-valuetext");
+    let aria_disabled = browser_aria_state(element, "aria-disabled");
+    let aria_readonly = browser_aria_state(element, "aria-readonly");
+    let value_attribute_names =
+        browser_aria_range_value_attribute_names(element, aria_valuetext.is_some());
+    let range_block_reasons =
+        browser_aria_range_block_reasons(aria_disabled.as_deref(), aria_readonly.as_deref());
     Some(BrowserAriaRange {
         element: element.name.clone(),
         id: element.attribute("id").map(ToOwned::to_owned),
@@ -17133,19 +17201,57 @@ fn browser_aria_range_element(
         aria_label: browser_aria_label(element),
         aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
         aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
-        aria_valuenow: browser_aria_state(element, "aria-valuenow"),
-        aria_valuemin: browser_aria_state(element, "aria-valuemin"),
-        aria_valuemax: browser_aria_state(element, "aria-valuemax"),
-        aria_valuetext: browser_aria_state(element, "aria-valuetext"),
+        aria_valuenow: aria_valuenow.clone(),
+        aria_valuemin: aria_valuemin.clone(),
+        aria_valuemax: aria_valuemax.clone(),
+        aria_valuetext,
         aria_orientation: browser_aria_state(element, "aria-orientation"),
-        aria_disabled: browser_aria_state(element, "aria-disabled"),
-        aria_readonly: browser_aria_state(element, "aria-readonly"),
+        aria_disabled,
+        aria_readonly,
         aria_required: browser_aria_state(element, "aria-required"),
         tabindex: element.attribute("tabindex").map(ToOwned::to_owned),
         text_value: (!text.is_empty()).then(|| text.clone()),
+        value_attribute_count: value_attribute_names.len(),
+        value_attribute_names,
+        range_value_complete: aria_valuenow.is_some()
+            && aria_valuemin.is_some()
+            && aria_valuemax.is_some(),
+        focusable: element.attribute("tabindex").is_some(),
+        range_blocked: !range_block_reasons.is_empty(),
+        range_block_reasons,
         role,
         text,
     })
+}
+
+fn browser_aria_range_value_attribute_names(
+    element: &Element,
+    has_aria_valuetext: bool,
+) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in ["aria-valuemin", "aria-valuemax", "aria-valuenow"] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    if has_aria_valuetext {
+        attributes.push("aria-valuetext".to_string());
+    }
+    attributes
+}
+
+fn browser_aria_range_block_reasons(
+    aria_disabled: Option<&str>,
+    aria_readonly: Option<&str>,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if aria_disabled.is_some_and(|value| value.eq_ignore_ascii_case("true")) {
+        reasons.push("aria-disabled".to_string());
+    }
+    if aria_readonly.is_some_and(|value| value.eq_ignore_ascii_case("true")) {
+        reasons.push("aria-readonly".to_string());
+    }
+    reasons
 }
 
 fn browser_authored_range_role(element: &Element) -> Option<String> {
@@ -17164,6 +17270,14 @@ fn browser_aria_live_region_element(
     let role = browser_aria_live_region_role(element)?;
     let aria_live = browser_aria_state(element, "aria-live");
     let text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    let aria_busy = browser_aria_state(element, "aria-busy");
+    let aria_atomic = browser_aria_state(element, "aria-atomic");
+    let aria_relevant = browser_aria_tokens(element, "aria-relevant");
+    let aria_hidden = browser_aria_hidden(element);
+    let update_kind = browser_aria_live_update_kind(&role, aria_live.as_deref());
+    let live_attribute_names = browser_aria_live_attribute_names(element, aria_hidden);
+    let live_region_block_reasons =
+        browser_aria_live_region_block_reasons(aria_hidden, &update_kind);
     Some(BrowserAriaLiveRegion {
         element: element.name.clone(),
         id: element.attribute("id").map(ToOwned::to_owned),
@@ -17174,14 +17288,43 @@ fn browser_aria_live_region_element(
         aria_labelledby: browser_aria_idrefs(element, "aria-labelledby"),
         aria_describedby: browser_aria_idrefs(element, "aria-describedby"),
         aria_live: aria_live.clone(),
-        aria_busy: browser_aria_state(element, "aria-busy"),
-        aria_atomic: browser_aria_state(element, "aria-atomic"),
-        aria_relevant: browser_aria_tokens(element, "aria-relevant"),
-        aria_hidden: browser_aria_hidden(element),
-        update_kind: browser_aria_live_update_kind(&role, aria_live.as_deref()),
+        aria_busy,
+        aria_atomic,
+        aria_relevant,
+        aria_hidden,
+        assertive_update: update_kind == "assertive",
+        live_attribute_count: live_attribute_names.len(),
+        live_attribute_names,
+        live_region_blocked: !live_region_block_reasons.is_empty(),
+        live_region_block_reasons,
+        update_kind,
         role,
         text,
     })
+}
+
+fn browser_aria_live_attribute_names(element: &Element, aria_hidden: bool) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in ["aria-live", "aria-busy", "aria-atomic", "aria-relevant"] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    if aria_hidden {
+        attributes.push("aria-hidden".to_string());
+    }
+    attributes
+}
+
+fn browser_aria_live_region_block_reasons(aria_hidden: bool, update_kind: &str) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if aria_hidden {
+        reasons.push("aria-hidden".to_string());
+    }
+    if update_kind == "off" {
+        reasons.push("live-off".to_string());
+    }
+    reasons
 }
 
 fn browser_aria_live_region_role(element: &Element) -> Option<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1964,6 +1964,12 @@ struct ExpectedAriaCollection {
     #[serde(default)]
     disabled_item_count: usize,
     #[serde(default)]
+    item_roles: Vec<String>,
+    #[serde(default)]
+    selection_mode: String,
+    #[serde(default)]
+    active_descendant_matches_item: bool,
+    #[serde(default)]
     items: Vec<ExpectedAriaCollectionItem>,
 }
 
@@ -2037,6 +2043,18 @@ struct ExpectedAriaRange {
     tabindex: Option<String>,
     #[serde(default)]
     text_value: Option<String>,
+    #[serde(default)]
+    value_attribute_names: Vec<String>,
+    #[serde(default)]
+    value_attribute_count: usize,
+    #[serde(default)]
+    range_value_complete: bool,
+    #[serde(default)]
+    focusable: bool,
+    #[serde(default)]
+    range_blocked: bool,
+    #[serde(default)]
+    range_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2067,6 +2085,16 @@ struct ExpectedAriaLiveRegion {
     #[serde(default)]
     aria_hidden: bool,
     update_kind: String,
+    #[serde(default)]
+    live_attribute_names: Vec<String>,
+    #[serde(default)]
+    live_attribute_count: usize,
+    #[serde(default)]
+    assertive_update: bool,
+    #[serde(default)]
+    live_region_blocked: bool,
+    #[serde(default)]
+    live_region_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4372,6 +4400,42 @@ fn browser_aria_collection_descriptor_metadata_tracks_grouped_composites() {
 }
 
 #[test]
+fn browser_aria_collection_descriptors_track_selection_model_and_active_descendant() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <div id=menu role=menu aria-activedescendant=item-two>
+              <button id=item-one role=menuitem>One</button>
+              <button id=item-two role=menuitemcheckbox aria-checked=mixed>Two</button>
+            </div>
+            <div id=list role=listbox aria-multiselectable=true>
+              <div id=alpha role=option aria-selected=true>Alpha</div>
+              <div id=beta role=option aria-selected=true aria-disabled=true>Beta</div>
+            </div>
+        </body>"#,
+    )
+    .expect("ARIA collection descriptor fixture should parse");
+
+    let menu = actual
+        .aria_collections
+        .iter()
+        .find(|collection| collection.id.as_deref() == Some("menu"))
+        .expect("menu collection should be present");
+    assert_eq!(menu.item_roles, vec!["menuitem", "menuitemcheckbox"]);
+    assert_eq!(menu.selection_mode, "single");
+    assert!(menu.active_descendant_matches_item);
+
+    let list = actual
+        .aria_collections
+        .iter()
+        .find(|collection| collection.id.as_deref() == Some("list"))
+        .expect("listbox collection should be present");
+    assert_eq!(list.item_roles, vec!["option"]);
+    assert_eq!(list.selection_mode, "multiple");
+    assert!(!list.active_descendant_matches_item);
+    assert_eq!(list.disabled_item_count, 1);
+}
+
+#[test]
 fn browser_aria_range_descriptor_metadata_tracks_value_widgets() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -4388,6 +4452,54 @@ fn browser_aria_range_descriptor_metadata_tracks_value_widgets() {
     assert_eq!(
         actual.aria_ranges, expected.aria_ranges,
         "ARIA range descriptors should preserve value bounds, value text, orientation, and value widget states",
+    );
+}
+
+#[test]
+fn browser_aria_range_descriptors_track_value_completeness_focus_and_blockers() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <div id=volume role=slider aria-valuemin=0 aria-valuemax=10 aria-valuenow=7 aria-valuetext="7 of 10" tabindex=0></div>
+            <div id=scroll role=scrollbar aria-valuemin=0 aria-valuemax=100 aria-disabled=true aria-readonly=true>Scroll</div>
+        </body>"#,
+    )
+    .expect("ARIA range descriptor fixture should parse");
+
+    let volume = actual
+        .aria_ranges
+        .iter()
+        .find(|range| range.id.as_deref() == Some("volume"))
+        .expect("volume range should be present");
+    assert_eq!(
+        volume.value_attribute_names,
+        vec![
+            "aria-valuemin",
+            "aria-valuemax",
+            "aria-valuenow",
+            "aria-valuetext",
+        ]
+    );
+    assert_eq!(volume.value_attribute_count, 4);
+    assert!(volume.range_value_complete);
+    assert!(volume.focusable);
+    assert!(!volume.range_blocked);
+
+    let scroll = actual
+        .aria_ranges
+        .iter()
+        .find(|range| range.id.as_deref() == Some("scroll"))
+        .expect("scrollbar range should be present");
+    assert_eq!(
+        scroll.value_attribute_names,
+        vec!["aria-valuemin", "aria-valuemax"]
+    );
+    assert_eq!(scroll.value_attribute_count, 2);
+    assert!(!scroll.range_value_complete);
+    assert!(!scroll.focusable);
+    assert!(scroll.range_blocked);
+    assert_eq!(
+        scroll.range_block_reasons,
+        vec!["aria-disabled", "aria-readonly"]
     );
 }
 
@@ -4409,6 +4521,50 @@ fn browser_aria_live_region_descriptor_metadata_tracks_update_semantics() {
         actual.aria_live_regions, expected.aria_live_regions,
         "ARIA live-region descriptors should preserve live politeness, busy/atomic/relevant flags, and implicit update semantics",
     );
+}
+
+#[test]
+fn browser_aria_live_region_descriptors_track_attributes_assertive_and_blockers() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <div id=alert role=alert aria-busy=true>Error</div>
+            <div id=clock role=timer aria-live=off>12:00</div>
+            <p id=hidden role=status aria-hidden=true aria-atomic=true>Muted</p>
+        </body>"#,
+    )
+    .expect("ARIA live-region descriptor fixture should parse");
+
+    let alert = actual
+        .aria_live_regions
+        .iter()
+        .find(|region| region.id.as_deref() == Some("alert"))
+        .expect("alert live region should be present");
+    assert_eq!(alert.live_attribute_names, vec!["aria-busy"]);
+    assert_eq!(alert.live_attribute_count, 1);
+    assert!(alert.assertive_update);
+    assert!(!alert.live_region_blocked);
+
+    let clock = actual
+        .aria_live_regions
+        .iter()
+        .find(|region| region.id.as_deref() == Some("clock"))
+        .expect("timer live region should be present");
+    assert_eq!(clock.live_attribute_names, vec!["aria-live"]);
+    assert!(!clock.assertive_update);
+    assert!(clock.live_region_blocked);
+    assert_eq!(clock.live_region_block_reasons, vec!["live-off"]);
+
+    let hidden = actual
+        .aria_live_regions
+        .iter()
+        .find(|region| region.id.as_deref() == Some("hidden"))
+        .expect("hidden live region should be present");
+    assert_eq!(
+        hidden.live_attribute_names,
+        vec!["aria-atomic", "aria-hidden"]
+    );
+    assert!(hidden.live_region_blocked);
+    assert_eq!(hidden.live_region_block_reasons, vec!["aria-hidden"]);
 }
 
 #[test]
@@ -13171,6 +13327,9 @@ impl ExpectedAriaCollection {
             checked_item_count: self.checked_item_count,
             current_item_count: self.current_item_count,
             disabled_item_count: self.disabled_item_count,
+            item_roles: self.item_roles,
+            selection_mode: self.selection_mode,
+            active_descendant_matches_item: self.active_descendant_matches_item,
             items: self
                 .items
                 .into_iter()
@@ -13225,6 +13384,12 @@ impl ExpectedAriaRange {
             aria_required: self.aria_required,
             tabindex: self.tabindex,
             text_value: self.text_value,
+            value_attribute_names: self.value_attribute_names,
+            value_attribute_count: self.value_attribute_count,
+            range_value_complete: self.range_value_complete,
+            focusable: self.focusable,
+            range_blocked: self.range_blocked,
+            range_block_reasons: self.range_block_reasons,
         }
     }
 }
@@ -13263,6 +13428,11 @@ impl ExpectedAriaLiveRegion {
             aria_relevant: self.aria_relevant,
             aria_hidden: self.aria_hidden,
             update_kind: self.update_kind,
+            live_attribute_names: self.live_attribute_names,
+            live_attribute_count: self.live_attribute_count,
+            assertive_update: self.assertive_update,
+            live_region_blocked: self.live_region_blocked,
+            live_region_block_reasons: self.live_region_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1605,7 +1605,7 @@
           { "element": "div", "id": "action", "role": "block", "text": "Inline action", "popover": "manual" }
         ],
         "aria_live_regions": [
-          { "element": "section", "id": "panel", "role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "update_kind": "polite" }
+          { "element": "section", "id": "panel", "role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "accessible_description": "Choose options", "aria_labelledby": ["panel-title"], "aria_describedby": ["panel-help"], "aria_live": "polite", "aria_busy": "true", "update_kind": "polite", "live_attribute_names": ["aria-live", "aria-busy"], "live_attribute_count": 2 }
         ],
         "links": [],
         "images": [],
@@ -1809,6 +1809,9 @@
             "item_count": 2,
             "selected_item_count": 1,
             "disabled_item_count": 1,
+            "item_roles": ["tab"],
+            "selection_mode": "single",
+            "active_descendant_matches_item": true,
             "items": [
               { "element": "button", "id": "tab-home", "role": "tab", "text": "Home", "accessible_name": "Home", "aria_selected": "true", "aria_controls": ["panel-home"] },
               { "element": "button", "id": "tab-settings", "role": "tab", "text": "Settings", "accessible_name": "Settings", "aria_selected": "false", "aria_disabled": "true", "aria_controls": ["panel-settings"] }
@@ -1849,10 +1852,10 @@
           { "level": 2, "text": "Settings" }
         ],
         "aria_ranges": [
-          { "element": "div", "id": "volume", "role": "slider", "text": "", "accessible_name": "Settings", "accessible_description": "Loud", "aria_labelledby": ["range-title"], "aria_describedby": ["volume-help"], "aria_valuenow": "7", "aria_valuemin": "0", "aria_valuemax": "10", "aria_valuetext": "7 of 10", "aria_orientation": "vertical", "tabindex": "0" },
-          { "element": "div", "id": "stepper", "role": "spinbutton", "text": "", "accessible_name": "Retries", "aria_label": "Retries", "aria_valuenow": "2", "aria_valuemin": "1", "aria_valuemax": "5", "aria_required": "true", "tabindex": "0" },
-          { "element": "div", "id": "load", "role": "progressbar", "text": "Loading", "accessible_name": "Load progress", "aria_label": "Load progress", "aria_valuenow": "40", "aria_valuemin": "0", "aria_valuemax": "100", "text_value": "Loading" },
-          { "element": "div", "id": "scroll", "role": "scrollbar", "text": "Scroll", "accessible_name": "Timeline", "aria_label": "Timeline", "aria_valuenow": "120", "aria_valuemin": "0", "aria_valuemax": "300", "aria_disabled": "true", "aria_readonly": "true", "text_value": "Scroll" }
+          { "element": "div", "id": "volume", "role": "slider", "text": "", "accessible_name": "Settings", "accessible_description": "Loud", "aria_labelledby": ["range-title"], "aria_describedby": ["volume-help"], "aria_valuenow": "7", "aria_valuemin": "0", "aria_valuemax": "10", "aria_valuetext": "7 of 10", "aria_orientation": "vertical", "tabindex": "0", "value_attribute_names": ["aria-valuemin", "aria-valuemax", "aria-valuenow", "aria-valuetext"], "value_attribute_count": 4, "range_value_complete": true, "focusable": true },
+          { "element": "div", "id": "stepper", "role": "spinbutton", "text": "", "accessible_name": "Retries", "aria_label": "Retries", "aria_valuenow": "2", "aria_valuemin": "1", "aria_valuemax": "5", "aria_required": "true", "tabindex": "0", "value_attribute_names": ["aria-valuemin", "aria-valuemax", "aria-valuenow"], "value_attribute_count": 3, "range_value_complete": true, "focusable": true },
+          { "element": "div", "id": "load", "role": "progressbar", "text": "Loading", "accessible_name": "Load progress", "aria_label": "Load progress", "aria_valuenow": "40", "aria_valuemin": "0", "aria_valuemax": "100", "text_value": "Loading", "value_attribute_names": ["aria-valuemin", "aria-valuemax", "aria-valuenow"], "value_attribute_count": 3, "range_value_complete": true },
+          { "element": "div", "id": "scroll", "role": "scrollbar", "text": "Scroll", "accessible_name": "Timeline", "aria_label": "Timeline", "aria_valuenow": "120", "aria_valuemin": "0", "aria_valuemax": "300", "aria_disabled": "true", "aria_readonly": "true", "text_value": "Scroll", "value_attribute_names": ["aria-valuemin", "aria-valuemax", "aria-valuenow"], "value_attribute_count": 3, "range_value_complete": true, "range_blocked": true, "range_block_reasons": ["aria-disabled", "aria-readonly"] }
         ],
         "links": [],
         "images": [],
@@ -1892,13 +1895,13 @@
           { "level": 2, "text": "Updates" }
         ],
         "aria_live_regions": [
-          { "element": "div", "id": "toast", "role": "status", "text": "Saved", "accessible_name": "Updates", "accessible_description": "Sync status", "aria_labelledby": ["live-title"], "aria_describedby": ["status-help"], "aria_atomic": "true", "aria_relevant": ["additions", "text"], "update_kind": "polite" },
-          { "element": "div", "id": "alert", "role": "alert", "text": "Network down", "accessible_name": "Error alert", "aria_label": "Error alert", "aria_busy": "true", "update_kind": "assertive" },
-          { "element": "div", "id": "feed", "role": "log", "text": "First Second", "accessible_name": "First Second", "aria_live": "polite", "aria_relevant": ["additions"], "update_kind": "polite" },
-          { "element": "div", "id": "ticker", "role": "marquee", "text": "Stocks", "accessible_name": "Ticker", "aria_label": "Ticker", "update_kind": "off" },
-          { "element": "div", "id": "clock", "role": "timer", "text": "12:00", "accessible_name": "12:00", "aria_live": "off", "update_kind": "off" },
-          { "element": "div", "id": "custom", "role": "region", "text": "Custom", "accessible_name": "Notifications", "aria_label": "Notifications", "aria_live": "assertive", "aria_busy": "false", "aria_atomic": "false", "aria_relevant": ["removals", "all"], "update_kind": "assertive" },
-          { "element": "p", "id": "hidden", "role": "status", "text": "Muted", "accessible_name": "Muted", "aria_hidden": true, "update_kind": "polite" }
+          { "element": "div", "id": "toast", "role": "status", "text": "Saved", "accessible_name": "Updates", "accessible_description": "Sync status", "aria_labelledby": ["live-title"], "aria_describedby": ["status-help"], "aria_atomic": "true", "aria_relevant": ["additions", "text"], "update_kind": "polite", "live_attribute_names": ["aria-atomic", "aria-relevant"], "live_attribute_count": 2 },
+          { "element": "div", "id": "alert", "role": "alert", "text": "Network down", "accessible_name": "Error alert", "aria_label": "Error alert", "aria_busy": "true", "update_kind": "assertive", "live_attribute_names": ["aria-busy"], "live_attribute_count": 1, "assertive_update": true },
+          { "element": "div", "id": "feed", "role": "log", "text": "First Second", "accessible_name": "First Second", "aria_live": "polite", "aria_relevant": ["additions"], "update_kind": "polite", "live_attribute_names": ["aria-live", "aria-relevant"], "live_attribute_count": 2 },
+          { "element": "div", "id": "ticker", "role": "marquee", "text": "Stocks", "accessible_name": "Ticker", "aria_label": "Ticker", "update_kind": "off", "live_region_blocked": true, "live_region_block_reasons": ["live-off"] },
+          { "element": "div", "id": "clock", "role": "timer", "text": "12:00", "accessible_name": "12:00", "aria_live": "off", "update_kind": "off", "live_attribute_names": ["aria-live"], "live_attribute_count": 1, "live_region_blocked": true, "live_region_block_reasons": ["live-off"] },
+          { "element": "div", "id": "custom", "role": "region", "text": "Custom", "accessible_name": "Notifications", "aria_label": "Notifications", "aria_live": "assertive", "aria_busy": "false", "aria_atomic": "false", "aria_relevant": ["removals", "all"], "update_kind": "assertive", "live_attribute_names": ["aria-live", "aria-busy", "aria-atomic", "aria-relevant"], "live_attribute_count": 4, "assertive_update": true },
+          { "element": "p", "id": "hidden", "role": "status", "text": "Muted", "accessible_name": "Muted", "aria_hidden": true, "update_kind": "polite", "live_attribute_names": ["aria-hidden"], "live_attribute_count": 1, "live_region_blocked": true, "live_region_block_reasons": ["aria-hidden"] }
         ],
         "links": [],
         "images": [],


### PR DESCRIPTION
## Summary
- add derived ARIA collection item-role, selection-model, and active-descendant matching hints
- add ARIA range value-attribute, completeness, focus, and blocking hints
- add ARIA live-region attribute, assertive-update, and blocked-update hints

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser