### PR TITLE
Add smart-home activation verification tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -70,6 +70,15 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation runbook planning:
   `smart_home.list_integration_activation_runbook` and
   `smart_home.get_integration_activation_runbook_summary`.
+- Added D18D handlers for D23A activation handoff packages:
+  `smart_home.list_integration_activation_handoff` and
+  `smart_home.get_integration_activation_handoff_summary`.
+- Added D18D handlers for D23A activation execution packets:
+  `smart_home.list_integration_activation_execution` and
+  `smart_home.get_integration_activation_execution_summary`.
+- Added D18D handlers for D23A activation verification checkpoints:
+  `smart_home.list_integration_activation_verification` and
+  `smart_home.get_integration_activation_verification_summary`.
 - Added D18D handlers for D23A activation operator queue planning:
   `smart_home.list_integration_activation_operator_queue` and
   `smart_home.get_integration_activation_operator_queue_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -58,6 +58,9 @@ Chief of Staff job/session/agent
   -> activation-forecast list and summary reads for next-action wave planning
   -> activation-playbook list and summary reads for operator-ready planning steps
   -> activation-runbook list and summary reads for audit-context-rich phases
+  -> activation-handoff list and summary reads for execution-transfer packages
+  -> activation-execution list and summary reads for executable packet state
+  -> activation-verification list and summary reads for post-execution checks
   -> activation-operator queue list and summary reads for actionable work
   -> activation-control-room list and summary reads for grouped operator panels
   -> activation-command-center list and summary reads for operating-lane rollups
@@ -131,6 +134,12 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_playbook_summary`
 - `smart_home.list_integration_activation_runbook`
 - `smart_home.get_integration_activation_runbook_summary`
+- `smart_home.list_integration_activation_handoff`
+- `smart_home.get_integration_activation_handoff_summary`
+- `smart_home.list_integration_activation_execution`
+- `smart_home.get_integration_activation_execution_summary`
+- `smart_home.list_integration_activation_verification`
+- `smart_home.get_integration_activation_verification_summary`
 - `smart_home.list_integration_activation_operator_queue`
 - `smart_home.get_integration_activation_operator_queue_summary`
 - `smart_home.list_integration_activation_control_room`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -49,6 +49,7 @@ use smart_home_integration_catalog::{
     activation_reviews_from_candidates, activation_risk_from_candidates,
     activation_runbook_entries_from_playbook_steps, activation_runway_from_candidates,
     activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
+    activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
     entries_requiring_primitive, find_entry, first_party_catalog,
@@ -96,15 +97,16 @@ use smart_home_integration_catalog::{
     IntegrationActivationRunwaySummary, IntegrationActivationSentinelAlert,
     IntegrationActivationSentinelAlertKind, IntegrationActivationSentinelSummary,
     IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
-    IntegrationActivationTimelineSummary, IntegrationActivationWatchtowerSignal,
-    IntegrationActivationWatchtowerSignalKind, IntegrationActivationWatchtowerSummary,
-    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
-    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
-    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
-    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
-    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
-    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
-    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationActivationTimelineSummary, IntegrationActivationVerificationCheckpoint,
+    IntegrationActivationVerificationStatus, IntegrationActivationVerificationSummary,
+    IntegrationActivationWatchtowerSignal, IntegrationActivationWatchtowerSignalKind,
+    IntegrationActivationWatchtowerSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
+    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
+    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
+    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
+    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
+    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
+    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -290,6 +292,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_EXECUTION_TOOL_ID: &str =
     "smart_home.list_integration_activation_execution";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_execution_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_VERIFICATION_TOOL_ID: &str =
+    "smart_home.list_integration_activation_verification";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_VERIFICATION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_verification_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID: &str =
     "smart_home.list_integration_activation_operator_queue";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_SUMMARY_TOOL_ID: &str =
@@ -640,6 +646,18 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_execution_query(&arguments)?;
                     Ok(get_integration_activation_execution_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_VERIFICATION_TOOL_ID => {
+                    let query = integration_activation_verification_query(&arguments)?;
+                    Ok(list_integration_activation_verification_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_VERIFICATION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_verification_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_verification_summary_output_handler_output(
+                            query,
+                        ),
+                    )
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID => {
                     let query = integration_activation_operator_queue_query(&arguments)?;
@@ -2115,6 +2133,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation execution summary",
             "Return compact D23A activation execution counts for executable packets, approvals, operator work, dependency blockers, and attention state.",
             integration_activation_execution_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_VERIFICATION_TOOL_ID,
+            "List smart-home integration activation verification checkpoints",
+            "List read-only D23A activation verification checkpoints derived from execution packets, audit attention, dependency readiness, and readiness gaps.",
+            integration_activation_verification_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_verification", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_verification",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_VERIFICATION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation verification summary",
+            "Return compact D23A activation verification counts for ready checkpoints, pending operator or approval work, blockers, evidence review, and attention state.",
+            integration_activation_verification_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5034,6 +5086,22 @@ struct IntegrationActivationExecutionQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationVerificationQuery {
+    execution: IntegrationActivationExecutionQuery,
+    verification_status: Option<IntegrationActivationVerificationStatus>,
+    can_verify: Option<bool>,
+    verification_ready: Option<bool>,
+    operator_pending: Option<bool>,
+    approval_pending: Option<bool>,
+    dependency_ready: Option<bool>,
+    blocked: Option<bool>,
+    evidence_review_required: Option<bool>,
+    requires_attention: Option<bool>,
+    include_monitor: bool,
+    verification_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationOperatorQueueQuery {
     playbook: IntegrationActivationPlaybookQuery,
     task_kind: Option<IntegrationActivationOperatorTaskKind>,
@@ -5526,6 +5594,46 @@ fn integration_activation_execution_query(
             .or(optional_bool(arguments, "requires_attention")?),
         include_monitor,
         execution_limit: optional_u64(arguments, "execution_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_verification_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationVerificationQuery, ToolCallError> {
+    let include_monitor = optional_bool(arguments, "include_monitor")?.unwrap_or(false);
+    let mut execution = integration_activation_execution_query(arguments)?;
+    execution.include_monitor = include_monitor;
+    execution.handoff.include_monitor = include_monitor;
+    execution.handoff.runbook.include_monitor = include_monitor;
+    let verification_status = optional_string(arguments, "verification_status")?
+        .or(optional_string(arguments, "verification_state")?)
+        .or(optional_string(arguments, "status")?)
+        .map(|label| parse_activation_verification_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationVerificationQuery {
+        execution,
+        verification_status,
+        can_verify: optional_bool(arguments, "can_verify")?
+            .or(optional_bool(arguments, "ready_to_verify")?),
+        verification_ready: optional_bool(arguments, "verification_ready")?
+            .or(optional_bool(arguments, "closure_ready")?),
+        operator_pending: optional_bool(arguments, "operator_pending")?
+            .or(optional_bool(arguments, "verification_operator_pending")?),
+        approval_pending: optional_bool(arguments, "approval_pending")?
+            .or(optional_bool(arguments, "verification_approval_pending")?),
+        dependency_ready: optional_bool(arguments, "verification_dependency_ready")?
+            .or(optional_bool(arguments, "dependency_ready")?),
+        blocked: optional_bool(arguments, "verification_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        evidence_review_required: optional_bool(arguments, "evidence_review_required")?.or(
+            optional_bool(arguments, "verification_evidence_review_required")?,
+        ),
+        requires_attention: optional_bool(arguments, "verification_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        include_monitor,
+        verification_limit: optional_u64(arguments, "verification_limit")?
+            .map(|value| value as usize),
     })
 }
 
@@ -6412,6 +6520,51 @@ fn integration_activation_execution_packets_for_query(
     }
 
     (packets, catalog_count)
+}
+
+fn integration_activation_verification_checkpoints_for_query(
+    query: &IntegrationActivationVerificationQuery,
+) -> (Vec<IntegrationActivationVerificationCheckpoint>, usize) {
+    let (packets, catalog_count) =
+        integration_activation_execution_packets_for_query(&query.execution);
+    let mut checkpoints = activation_verification_checkpoints_from_execution_packets(packets);
+
+    if !query.include_monitor {
+        checkpoints.retain(|checkpoint| !checkpoint.monitor_only());
+    }
+    if let Some(status) = query.verification_status {
+        checkpoints.retain(|checkpoint| checkpoint.verification_status == status);
+    }
+    if let Some(can_verify) = query.can_verify {
+        checkpoints.retain(|checkpoint| checkpoint.can_verify() == can_verify);
+    }
+    if let Some(verification_ready) = query.verification_ready {
+        checkpoints.retain(|checkpoint| checkpoint.verification_ready() == verification_ready);
+    }
+    if let Some(operator_pending) = query.operator_pending {
+        checkpoints.retain(|checkpoint| checkpoint.operator_pending() == operator_pending);
+    }
+    if let Some(approval_pending) = query.approval_pending {
+        checkpoints.retain(|checkpoint| checkpoint.approval_pending() == approval_pending);
+    }
+    if let Some(dependency_ready) = query.dependency_ready {
+        checkpoints.retain(|checkpoint| checkpoint.dependency_ready() == dependency_ready);
+    }
+    if let Some(blocked) = query.blocked {
+        checkpoints.retain(|checkpoint| checkpoint.blocked() == blocked);
+    }
+    if let Some(evidence_review_required) = query.evidence_review_required {
+        checkpoints
+            .retain(|checkpoint| checkpoint.evidence_review_required() == evidence_review_required);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        checkpoints.retain(|checkpoint| checkpoint.requires_attention() == requires_attention);
+    }
+    if let Some(limit) = query.verification_limit {
+        checkpoints.truncate(limit);
+    }
+
+    (checkpoints, catalog_count)
 }
 
 fn integration_activation_operator_tasks_for_query(
@@ -8513,6 +8666,106 @@ fn get_integration_activation_execution_summary_output_handler_output(
                 "next_execution_status",
                 summary
                     .next_execution_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_verification_output_handler_output(
+    query: IntegrationActivationVerificationQuery,
+) -> ToolHandlerOutput {
+    let (checkpoints, catalog_count) =
+        integration_activation_verification_checkpoints_for_query(&query);
+    let summary = IntegrationActivationVerificationSummary::from_checkpoints(checkpoints.iter());
+    let count = checkpoints.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_verification",
+            JsonValue::Array(
+                checkpoints
+                    .iter()
+                    .map(activation_verification_checkpoint_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_verification_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_verification"),
+            ),
+            ("verification_checkpoints", integer(count as i64)),
+            (
+                "ready_to_verify_checkpoints",
+                integer(summary.ready_to_verify_checkpoints as i64),
+            ),
+            (
+                "pending_approval_checkpoints",
+                integer(summary.pending_approval_checkpoints as i64),
+            ),
+            (
+                "blocked_checkpoints",
+                integer(summary.blocked_checkpoints as i64),
+            ),
+            (
+                "next_verification_status",
+                summary
+                    .next_verification_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_verification_summary_output_handler_output(
+    query: IntegrationActivationVerificationQuery,
+) -> ToolHandlerOutput {
+    let (checkpoints, _) = integration_activation_verification_checkpoints_for_query(&query);
+    let summary = IntegrationActivationVerificationSummary::from_checkpoints(checkpoints.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_verification_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_verification_summary"),
+            ),
+            (
+                "total_checkpoints",
+                integer(summary.total_checkpoints as i64),
+            ),
+            (
+                "ready_to_verify_checkpoints",
+                integer(summary.ready_to_verify_checkpoints as i64),
+            ),
+            (
+                "pending_approval_checkpoints",
+                integer(summary.pending_approval_checkpoints as i64),
+            ),
+            (
+                "blocked_checkpoints",
+                integer(summary.blocked_checkpoints as i64),
+            ),
+            (
+                "next_verification_status",
+                summary
+                    .next_verification_status
                     .map(|status| string(status.as_str()))
                     .unwrap_or(JsonValue::Null),
             ),
@@ -16155,6 +16408,376 @@ fn integration_activation_execution_summary_json(
     ])
 }
 
+fn activation_verification_checkpoint_json(
+    checkpoint: &IntegrationActivationVerificationCheckpoint,
+) -> JsonValue {
+    object([
+        ("sequence", integer(checkpoint.sequence as i64)),
+        (
+            "execution_sequence",
+            integer(checkpoint.execution_sequence as i64),
+        ),
+        (
+            "handoff_sequence",
+            integer(checkpoint.handoff_sequence as i64),
+        ),
+        (
+            "runbook_sequence",
+            integer(checkpoint.runbook_sequence as i64),
+        ),
+        (
+            "operator_task_sequence",
+            checkpoint
+                .operator_task_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("priority", integer(checkpoint.priority as i64)),
+        (
+            "verification_status",
+            string(checkpoint.verification_status.as_str()),
+        ),
+        (
+            "execution_status",
+            string(checkpoint.execution_status.as_str()),
+        ),
+        ("handoff_status", string(checkpoint.handoff_status.as_str())),
+        ("phase", string(checkpoint.phase.as_str())),
+        (
+            "task_kind",
+            checkpoint
+                .task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "playbook_action",
+            string(checkpoint.playbook_action.as_str()),
+        ),
+        (
+            "recommended_view",
+            string(checkpoint.recommended_view.as_str()),
+        ),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                checkpoint
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(checkpoint.integration_count() as i64),
+        ),
+        (
+            "risk_ids",
+            JsonValue::Array(
+                checkpoint
+                    .risk_ids
+                    .iter()
+                    .map(|risk_id| string(risk_id))
+                    .collect(),
+            ),
+        ),
+        ("risk_count", integer(checkpoint.risk_count as i64)),
+        (
+            "dependency_integration_ids",
+            JsonValue::Array(
+                checkpoint
+                    .dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "blocking_dependency_integration_ids",
+            JsonValue::Array(
+                checkpoint
+                    .blocking_dependency_integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "dependency_edge_count",
+            integer(checkpoint.dependency_edge_count as i64),
+        ),
+        (
+            "blocking_dependency_edge_count",
+            integer(checkpoint.blocking_dependency_edge_count as i64),
+        ),
+        (
+            "readiness_gap_count",
+            integer(checkpoint.readiness_gap_count as i64),
+        ),
+        (
+            "audit_record_count",
+            integer(checkpoint.audit_record_count as i64),
+        ),
+        (
+            "attention_audit_record_count",
+            integer(checkpoint.attention_audit_record_count as i64),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(checkpoint.highest_policy_tier)),
+        ),
+        (
+            "operator_pending",
+            JsonValue::Bool(checkpoint.operator_pending()),
+        ),
+        (
+            "approval_pending",
+            JsonValue::Bool(checkpoint.approval_pending()),
+        ),
+        (
+            "dependency_ready",
+            JsonValue::Bool(checkpoint.dependency_ready()),
+        ),
+        ("can_verify", JsonValue::Bool(checkpoint.can_verify())),
+        (
+            "verification_ready",
+            JsonValue::Bool(checkpoint.verification_ready()),
+        ),
+        ("blocked", JsonValue::Bool(checkpoint.blocked())),
+        ("monitor_only", JsonValue::Bool(checkpoint.monitor_only())),
+        (
+            "evidence_review_required",
+            JsonValue::Bool(checkpoint.evidence_review_required()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(checkpoint.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_verification_summary_json(
+    summary: &IntegrationActivationVerificationSummary,
+) -> JsonValue {
+    object([
+        (
+            "total_checkpoints",
+            integer(summary.total_checkpoints as i64),
+        ),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "ready_to_verify_checkpoints",
+            integer(summary.ready_to_verify_checkpoints as i64),
+        ),
+        (
+            "verification_ready_checkpoints",
+            integer(summary.verification_ready_checkpoints as i64),
+        ),
+        (
+            "pending_operator_checkpoints",
+            integer(summary.pending_operator_checkpoints as i64),
+        ),
+        (
+            "pending_approval_checkpoints",
+            integer(summary.pending_approval_checkpoints as i64),
+        ),
+        (
+            "blocked_checkpoints",
+            integer(summary.blocked_checkpoints as i64),
+        ),
+        (
+            "dependency_ready_checkpoints",
+            integer(summary.dependency_ready_checkpoints as i64),
+        ),
+        (
+            "dependency_blocked_checkpoints",
+            integer(summary.dependency_blocked_checkpoints as i64),
+        ),
+        (
+            "monitor_checkpoints",
+            integer(summary.monitor_checkpoints as i64),
+        ),
+        (
+            "evidence_review_checkpoints",
+            integer(summary.evidence_review_checkpoints as i64),
+        ),
+        (
+            "checkpoints_requiring_attention",
+            integer(summary.checkpoints_requiring_attention as i64),
+        ),
+        ("total_risks", integer(summary.total_risks as i64)),
+        (
+            "total_dependency_edges",
+            integer(summary.total_dependency_edges as i64),
+        ),
+        (
+            "blocking_dependency_edges",
+            integer(summary.blocking_dependency_edges as i64),
+        ),
+        (
+            "total_readiness_gaps",
+            integer(summary.total_readiness_gaps as i64),
+        ),
+        (
+            "total_audit_records",
+            integer(summary.total_audit_records as i64),
+        ),
+        (
+            "attention_audit_records",
+            integer(summary.attention_audit_records as i64),
+        ),
+        (
+            "next_verification_status",
+            summary
+                .next_verification_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_execution_status",
+            summary
+                .next_execution_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_task_kind",
+            summary
+                .next_task_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_phase",
+            summary
+                .next_phase
+                .map(|phase| string(phase.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_playbook_action",
+            summary
+                .next_playbook_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_checkpoint_sequence",
+            summary
+                .next_checkpoint_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_checkpoint_priority",
+            summary
+                .next_checkpoint_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_to_verify_sequence",
+            summary
+                .first_ready_to_verify_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_pending_operator_sequence",
+            summary
+                .first_pending_operator_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_pending_approval_sequence",
+            summary
+                .first_pending_approval_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_sequence",
+            summary
+                .first_blocked_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_sequence",
+            summary
+                .first_attention_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_ready_to_verify_priority",
+            summary
+                .first_ready_to_verify_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_pending_operator_priority",
+            summary
+                .first_pending_operator_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_pending_approval_priority",
+            summary
+                .first_pending_approval_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        (
+            "ready_to_verify",
+            JsonValue::Bool(summary.ready_to_verify()),
+        ),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_pending_work",
+            JsonValue::Bool(summary.has_pending_work()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_operator_task_json(task: &IntegrationActivationOperatorTask) -> JsonValue {
     object([
         ("sequence", integer(task.sequence as i64)),
@@ -20264,6 +20887,27 @@ fn parse_activation_execution_status(
     }
 }
 
+fn parse_activation_verification_status(
+    label: &str,
+) -> Result<IntegrationActivationVerificationStatus, ToolCallError> {
+    match label {
+        "ready_to_verify" | "ready" | "verification_ready" | "can_verify" => {
+            Ok(IntegrationActivationVerificationStatus::ReadyToVerify)
+        }
+        "pending_operator" | "operator_pending" | "operator" | "human_action"
+        | "human_required" => Ok(IntegrationActivationVerificationStatus::PendingOperator),
+        "pending_approval" | "needs_approval" | "approval" | "approval_required"
+        | "requires_approval" => Ok(IntegrationActivationVerificationStatus::PendingApproval),
+        "blocked" | "blocker" | "blockers" => Ok(IntegrationActivationVerificationStatus::Blocked),
+        "monitoring" | "monitor" | "monitor_only" | "watching" => {
+            Ok(IntegrationActivationVerificationStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation verification status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_operator_task_kind(
     label: &str,
 ) -> Result<IntegrationActivationOperatorTaskKind, ToolCallError> {
@@ -21614,6 +22258,54 @@ fn integration_activation_execution_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_verification_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_execution_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new(
+            "verification_status",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_state",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("can_verify", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("ready_to_verify", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "verification_ready",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("operator_pending", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("approval_pending", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "verification_dependency_ready",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_blocked",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "evidence_review_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_limit",
+            JsonSchema::Integer,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_operator_queue_query_schema() -> JsonSchema {
     let mut schema = integration_activation_playbook_query_schema();
     if let JsonSchema::Object {
@@ -21951,7 +22643,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 115);
+        assert_eq!(definitions.len(), 117);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -22234,6 +22926,12 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_EXECUTION_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_VERIFICATION_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_VERIFICATION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID));
         assert!(export
             .tool_ids()
@@ -22270,7 +22968,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            107
+            109
         );
         assert_eq!(
             export
@@ -22748,11 +23446,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(115))
+            Some(&integer(117))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(107))
+            Some(&integer(109))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -25746,6 +26444,144 @@ mod tests {
             Some(&JsonValue::Bool(false))
         );
 
+        let list_activation_verification_request = request(
+            "call-list-integration-activation-verification",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_VERIFICATION_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("verification_status", string("blocked")),
+                ("verification_limit", integer(3)),
+            ]),
+            5_535,
+        );
+        let list_activation_verification_trace =
+            tool_runtime.invoke_with_events(&list_activation_verification_request);
+        assert!(list_activation_verification_trace.result.ok);
+        assert_eq!(
+            list_activation_verification_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_verification_output = list_activation_verification_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_verification_count =
+            integer_value(field(list_activation_verification_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_verification_count));
+        let activation_verification_summary =
+            field(list_activation_verification_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_verification_summary, "total_checkpoints"),
+            Some(&integer(activation_verification_count))
+        );
+        assert_eq!(
+            field(activation_verification_summary, "next_verification_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_verification_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_verification_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_verification_checkpoint = array_item(
+            field(
+                list_activation_verification_output,
+                "activation_verification",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_verification_checkpoint, "verification_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_verification_checkpoint, "can_verify"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert_eq!(
+            field(activation_verification_checkpoint, "dependency_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+
+        let activation_verification_summary_request = request(
+            "call-integration-activation-verification-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_VERIFICATION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                ("verification_status", string("blocked")),
+            ]),
+            5_536,
+        );
+        let activation_verification_summary_trace =
+            tool_runtime.invoke_with_events(&activation_verification_summary_request);
+        assert!(activation_verification_summary_trace.result.ok);
+        assert_eq!(
+            activation_verification_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_verification_summary_output = activation_verification_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_verification_rollup =
+            field(activation_verification_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_verification_rollup, "blocked_checkpoints").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_verification_rollup, "next_verification_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_verification_rollup, "ready_to_verify"),
+            Some(&JsonValue::Bool(false))
+        );
+
         let list_activation_operator_queue_request = request(
             "call-list-integration-activation-operator-queue",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_OPERATOR_QUEUE_TOOL_ID,
@@ -28345,6 +29181,14 @@ mod tests {
             activation_execution_summary_trace,
         );
         journal.record_trace(
+            list_activation_verification_request,
+            list_activation_verification_trace,
+        );
+        journal.record_trace(
+            activation_verification_summary_request,
+            activation_verification_summary_trace,
+        );
+        journal.record_trace(
             list_activation_operator_queue_request,
             list_activation_operator_queue_trace,
         );
@@ -28462,9 +29306,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 115);
-        assert_eq!(journal_summary.completed_count, 115);
-        assert_eq!(journal.audit_records().len(), 115);
+        assert_eq!(journal_summary.invocation_count, 117);
+        assert_eq!(journal_summary.completed_count, 117);
+        assert_eq!(journal.audit_records().len(), 117);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -91,6 +91,18 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_runbook_summary` tool descriptors for
   read-only audit-context-rich operator phases derived from activation
   playbook steps.
+- `smart_home.list_integration_activation_handoff` and
+  `smart_home.get_integration_activation_handoff_summary` tool descriptors for
+  read-only execution-transfer handoff packages derived from activation
+  runbooks, risk, dependencies, audit records, and readiness gaps.
+- `smart_home.list_integration_activation_execution` and
+  `smart_home.get_integration_activation_execution_summary` tool descriptors
+  for read-only executable, approval, operator, dependency, and blocker state
+  derived from activation handoff packages.
+- `smart_home.list_integration_activation_verification` and
+  `smart_home.get_integration_activation_verification_summary` tool
+  descriptors for read-only post-execution verification checkpoints derived
+  from activation execution packets.
 - `smart_home.list_integration_activation_operator_queue` and
   `smart_home.get_integration_activation_operator_queue_summary` tool
   descriptors for read-only actionable human/operator work derived from

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -93,6 +93,12 @@ Current scope:
   steps derived from forecast next actions
 - D18D integration activation-runbook descriptors for audit-context-rich
   operator phases derived from activation playbook steps
+- D18D integration activation-handoff descriptors for execution-transfer
+  packages derived from runbooks, risk, dependencies, audit records, and gaps
+- D18D integration activation-execution descriptors for executable, approval,
+  operator, dependency, and blocker state derived from handoff packages
+- D18D integration activation-verification descriptors for post-execution
+  verification checkpoints derived from activation execution packets
 - D18D integration activation-operator queue descriptors for actionable
   human/operator work derived from playbook steps
 - D18D integration activation-control-room descriptors for grouped

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1501,6 +1501,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationHandoffSummary,
     ListIntegrationActivationExecution,
     GetIntegrationActivationExecutionSummary,
+    ListIntegrationActivationVerification,
+    GetIntegrationActivationVerificationSummary,
     ListIntegrationActivationOperatorQueue,
     GetIntegrationActivationOperatorQueueSummary,
     ListIntegrationActivationControlRoom,
@@ -1722,6 +1724,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationExecutionSummary => {
                 read_tool("smart_home.get_integration_activation_execution_summary")
+            }
+            Self::ListIntegrationActivationVerification => {
+                read_tool("smart_home.list_integration_activation_verification")
+            }
+            Self::GetIntegrationActivationVerificationSummary => {
+                read_tool("smart_home.get_integration_activation_verification_summary")
             }
             Self::ListIntegrationActivationOperatorQueue => {
                 read_tool("smart_home.list_integration_activation_operator_queue")
@@ -2442,6 +2450,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationHandoffSummary,
         SmartHomeTool::ListIntegrationActivationExecution,
         SmartHomeTool::GetIntegrationActivationExecutionSummary,
+        SmartHomeTool::ListIntegrationActivationVerification,
+        SmartHomeTool::GetIntegrationActivationVerificationSummary,
         SmartHomeTool::ListIntegrationActivationOperatorQueue,
         SmartHomeTool::GetIntegrationActivationOperatorQueueSummary,
         SmartHomeTool::ListIntegrationActivationControlRoom,
@@ -3296,7 +3306,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 115);
+        assert_eq!(catalog.len(), 117);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3716,6 +3726,14 @@ mod tests {
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
         assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_verification"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_verification_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
             == "smart_home.list_integration_activation_operator_queue"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
@@ -3770,15 +3788,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 115);
-        assert_eq!(summary.read_tools, 107);
+        assert_eq!(summary.total_tools, 117);
+        assert_eq!(summary.read_tools, 109);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 107);
+        assert_eq!(summary.read_only_tier_tools, 109);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 115);
+        assert_eq!(summary.total_required_capabilities, 117);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -78,6 +78,11 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationRunbookEntry` and
   `IntegrationActivationRunbookSummary` for joining playbook steps to audit,
   risk, dependency, and readiness-gap context.
+- `IntegrationActivationHandoffPackage`,
+  `IntegrationActivationExecutionPacket`, and
+  `IntegrationActivationVerificationCheckpoint` rollups for turning activation
+  runbooks into execution-transfer, execution-readiness, and post-execution
+  verification views.
 - `IntegrationActivationOperatorTask` and
   `IntegrationActivationOperatorTaskSummary` for turning playbook steps into
   actionable human/operator queue rows.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -77,6 +77,9 @@ runtime and Chief of Staff tools a typed catalog for:
   planning views and operator-readiness flags
 - activation runbook entries that join playbook steps to audit, risk,
   dependency, and readiness-gap context
+- activation handoff packages, execution packets, and verification checkpoints
+  that carry runbook context through execution-transfer and post-execution
+  readiness checks
 - activation operator tasks that turn playbook steps into actionable
   human/operator queue rows
 - activation control-room panels that group operator tasks by recommended

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1202,6 +1202,34 @@ impl IntegrationActivationExecutionStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationVerificationStatus {
+    ReadyToVerify,
+    PendingOperator,
+    PendingApproval,
+    Blocked,
+    Monitoring,
+}
+
+impl IntegrationActivationVerificationStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadyToVerify => "ready_to_verify",
+            Self::PendingOperator => "pending_operator",
+            Self::PendingApproval => "pending_approval",
+            Self::Blocked => "blocked",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::PendingOperator | Self::PendingApproval | Self::Blocked
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationOperatorTaskKind {
     ResolveConstraints,
     EnableDependencies,
@@ -2603,6 +2631,86 @@ pub struct IntegrationActivationExecutionSummary {
     pub first_approval_priority: Option<u8>,
     pub first_blocked_priority: Option<u8>,
     pub first_dependency_blocked_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationVerificationCheckpoint {
+    pub sequence: usize,
+    pub execution_sequence: usize,
+    pub handoff_sequence: usize,
+    pub runbook_sequence: usize,
+    pub operator_task_sequence: Option<usize>,
+    pub priority: u8,
+    pub verification_status: IntegrationActivationVerificationStatus,
+    pub execution_status: IntegrationActivationExecutionStatus,
+    pub handoff_status: IntegrationActivationHandoffStatus,
+    pub phase: IntegrationActivationRunbookPhase,
+    pub task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub playbook_action: IntegrationActivationForecastAction,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub integration_ids: Vec<IntegrationId>,
+    pub integration_count: usize,
+    pub risk_ids: Vec<String>,
+    pub dependency_integration_ids: Vec<IntegrationId>,
+    pub blocking_dependency_integration_ids: Vec<IntegrationId>,
+    pub risk_count: usize,
+    pub dependency_edge_count: usize,
+    pub blocking_dependency_edge_count: usize,
+    pub readiness_gap_count: usize,
+    pub audit_record_count: usize,
+    pub attention_audit_record_count: usize,
+    pub highest_policy_tier: PrivilegeTier,
+    pub operator_pending: bool,
+    pub approval_pending: bool,
+    pub dependency_ready: bool,
+    pub can_verify: bool,
+    pub verification_ready: bool,
+    pub blocked: bool,
+    pub monitor_only: bool,
+    pub evidence_review_required: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationVerificationSummary {
+    pub total_checkpoints: usize,
+    pub unique_integrations: usize,
+    pub ready_to_verify_checkpoints: usize,
+    pub verification_ready_checkpoints: usize,
+    pub pending_operator_checkpoints: usize,
+    pub pending_approval_checkpoints: usize,
+    pub blocked_checkpoints: usize,
+    pub dependency_ready_checkpoints: usize,
+    pub dependency_blocked_checkpoints: usize,
+    pub monitor_checkpoints: usize,
+    pub evidence_review_checkpoints: usize,
+    pub checkpoints_requiring_attention: usize,
+    pub total_risks: usize,
+    pub total_dependency_edges: usize,
+    pub blocking_dependency_edges: usize,
+    pub total_readiness_gaps: usize,
+    pub total_audit_records: usize,
+    pub attention_audit_records: usize,
+    pub next_verification_status: Option<IntegrationActivationVerificationStatus>,
+    pub next_execution_status: Option<IntegrationActivationExecutionStatus>,
+    pub next_task_kind: Option<IntegrationActivationOperatorTaskKind>,
+    pub next_phase: Option<IntegrationActivationRunbookPhase>,
+    pub next_playbook_action: Option<IntegrationActivationForecastAction>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_checkpoint_sequence: Option<usize>,
+    pub next_checkpoint_priority: Option<u8>,
+    pub first_ready_to_verify_sequence: Option<usize>,
+    pub first_pending_operator_sequence: Option<usize>,
+    pub first_pending_approval_sequence: Option<usize>,
+    pub first_blocked_sequence: Option<usize>,
+    pub first_attention_sequence: Option<usize>,
+    pub first_ready_to_verify_priority: Option<u8>,
+    pub first_pending_operator_priority: Option<u8>,
+    pub first_pending_approval_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -6103,6 +6211,306 @@ impl IntegrationActivationExecutionSummary {
         self.packets_requiring_attention > 0
             || self.has_blockers()
             || self.has_approval_work()
+            || self.overall_status.requires_attention()
+    }
+}
+
+impl IntegrationActivationVerificationCheckpoint {
+    fn from_execution_packet(packet: IntegrationActivationExecutionPacket) -> Self {
+        let verification_status = if packet.monitor_only() {
+            IntegrationActivationVerificationStatus::Monitoring
+        } else if packet.blocked() || !packet.dependency_ready() {
+            IntegrationActivationVerificationStatus::Blocked
+        } else if packet.approval_required() {
+            IntegrationActivationVerificationStatus::PendingApproval
+        } else if packet.operator_required() && !packet.executable() {
+            IntegrationActivationVerificationStatus::PendingOperator
+        } else {
+            IntegrationActivationVerificationStatus::ReadyToVerify
+        };
+        let evidence_review_required =
+            packet.review_required() || packet.attention_audit_record_count > 0;
+        let can_verify =
+            packet.executable() && packet.dependency_ready() && !evidence_review_required;
+        let verification_ready = can_verify && packet.audit_record_count > 0;
+        let requires_attention = verification_status.requires_attention()
+            || evidence_review_required
+            || packet.requires_attention();
+        let operator_pending = packet.operator_required() && !packet.executable();
+        let approval_pending = packet.approval_required();
+        let dependency_ready = packet.dependency_ready();
+        let blocked = packet.blocked();
+        let monitor_only = packet.monitor_only();
+
+        Self {
+            sequence: packet.sequence,
+            execution_sequence: packet.sequence,
+            handoff_sequence: packet.handoff_sequence,
+            runbook_sequence: packet.runbook_sequence,
+            operator_task_sequence: packet.operator_task_sequence,
+            priority: packet.priority,
+            verification_status,
+            execution_status: packet.execution_status,
+            handoff_status: packet.handoff_status,
+            phase: packet.phase,
+            task_kind: packet.task_kind,
+            playbook_action: packet.playbook_action,
+            recommended_view: packet.recommended_view,
+            integration_ids: packet.integration_ids,
+            integration_count: packet.integration_count,
+            risk_ids: packet.risk_ids,
+            dependency_integration_ids: packet.dependency_integration_ids,
+            blocking_dependency_integration_ids: packet.blocking_dependency_integration_ids,
+            risk_count: packet.risk_count,
+            dependency_edge_count: packet.dependency_edge_count,
+            blocking_dependency_edge_count: packet.blocking_dependency_edge_count,
+            readiness_gap_count: packet.readiness_gap_count,
+            audit_record_count: packet.audit_record_count,
+            attention_audit_record_count: packet.attention_audit_record_count,
+            highest_policy_tier: packet.highest_policy_tier,
+            operator_pending,
+            approval_pending,
+            dependency_ready,
+            can_verify,
+            verification_ready,
+            blocked,
+            monitor_only,
+            evidence_review_required,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_count
+    }
+
+    pub fn can_verify(&self) -> bool {
+        self.can_verify
+    }
+
+    pub fn verification_ready(&self) -> bool {
+        self.verification_ready
+    }
+
+    pub fn operator_pending(&self) -> bool {
+        self.operator_pending
+    }
+
+    pub fn approval_pending(&self) -> bool {
+        self.approval_pending
+    }
+
+    pub fn dependency_ready(&self) -> bool {
+        self.dependency_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn monitor_only(&self) -> bool {
+        self.monitor_only
+    }
+
+    pub fn evidence_review_required(&self) -> bool {
+        self.evidence_review_required
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationVerificationSummary {
+    pub fn from_checkpoints<'a>(
+        checkpoints: impl IntoIterator<Item = &'a IntegrationActivationVerificationCheckpoint>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_checkpoints: 0,
+            unique_integrations: 0,
+            ready_to_verify_checkpoints: 0,
+            verification_ready_checkpoints: 0,
+            pending_operator_checkpoints: 0,
+            pending_approval_checkpoints: 0,
+            blocked_checkpoints: 0,
+            dependency_ready_checkpoints: 0,
+            dependency_blocked_checkpoints: 0,
+            monitor_checkpoints: 0,
+            evidence_review_checkpoints: 0,
+            checkpoints_requiring_attention: 0,
+            total_risks: 0,
+            total_dependency_edges: 0,
+            blocking_dependency_edges: 0,
+            total_readiness_gaps: 0,
+            total_audit_records: 0,
+            attention_audit_records: 0,
+            next_verification_status: None,
+            next_execution_status: None,
+            next_task_kind: None,
+            next_phase: None,
+            next_playbook_action: None,
+            next_recommended_view: None,
+            next_checkpoint_sequence: None,
+            next_checkpoint_priority: None,
+            first_ready_to_verify_sequence: None,
+            first_pending_operator_sequence: None,
+            first_pending_approval_sequence: None,
+            first_blocked_sequence: None,
+            first_attention_sequence: None,
+            first_ready_to_verify_priority: None,
+            first_pending_operator_priority: None,
+            first_pending_approval_priority: None,
+            first_blocked_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for checkpoint in checkpoints {
+            summary.total_checkpoints += 1;
+            for integration_id in &checkpoint.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_verification_status.is_none() && !checkpoint.monitor_only() {
+                summary.next_verification_status = Some(checkpoint.verification_status);
+                summary.next_execution_status = Some(checkpoint.execution_status);
+                summary.next_task_kind = checkpoint.task_kind;
+                summary.next_phase = Some(checkpoint.phase);
+                summary.next_playbook_action = Some(checkpoint.playbook_action);
+                summary.next_recommended_view = Some(checkpoint.recommended_view);
+                summary.next_checkpoint_sequence = Some(checkpoint.sequence);
+                summary.next_checkpoint_priority = Some(checkpoint.priority);
+            }
+
+            match checkpoint.verification_status {
+                IntegrationActivationVerificationStatus::ReadyToVerify => {
+                    summary.ready_to_verify_checkpoints += 1;
+                    summary.first_ready_to_verify_sequence = summary
+                        .first_ready_to_verify_sequence
+                        .or(Some(checkpoint.sequence));
+                    summary.first_ready_to_verify_priority = min_optional_priority(
+                        summary.first_ready_to_verify_priority,
+                        Some(checkpoint.priority),
+                    );
+                }
+                IntegrationActivationVerificationStatus::PendingOperator => {
+                    summary.pending_operator_checkpoints += 1;
+                    summary.first_pending_operator_sequence = summary
+                        .first_pending_operator_sequence
+                        .or(Some(checkpoint.sequence));
+                    summary.first_pending_operator_priority = min_optional_priority(
+                        summary.first_pending_operator_priority,
+                        Some(checkpoint.priority),
+                    );
+                }
+                IntegrationActivationVerificationStatus::PendingApproval => {
+                    summary.pending_approval_checkpoints += 1;
+                    summary.first_pending_approval_sequence = summary
+                        .first_pending_approval_sequence
+                        .or(Some(checkpoint.sequence));
+                    summary.first_pending_approval_priority = min_optional_priority(
+                        summary.first_pending_approval_priority,
+                        Some(checkpoint.priority),
+                    );
+                }
+                IntegrationActivationVerificationStatus::Blocked => {
+                    summary.blocked_checkpoints += 1;
+                    summary.first_blocked_sequence =
+                        summary.first_blocked_sequence.or(Some(checkpoint.sequence));
+                    summary.first_blocked_priority = min_optional_priority(
+                        summary.first_blocked_priority,
+                        Some(checkpoint.priority),
+                    );
+                }
+                IntegrationActivationVerificationStatus::Monitoring => {
+                    summary.monitor_checkpoints += 1;
+                }
+            }
+
+            if checkpoint.verification_ready() {
+                summary.verification_ready_checkpoints += 1;
+            }
+            if checkpoint.dependency_ready() {
+                summary.dependency_ready_checkpoints += 1;
+            } else {
+                summary.dependency_blocked_checkpoints += 1;
+            }
+            if checkpoint.evidence_review_required() {
+                summary.evidence_review_checkpoints += 1;
+            }
+            if checkpoint.requires_attention() {
+                summary.checkpoints_requiring_attention += 1;
+                summary.first_attention_sequence = summary
+                    .first_attention_sequence
+                    .or(Some(checkpoint.sequence));
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(checkpoint.priority),
+                );
+            }
+
+            summary.total_risks += checkpoint.risk_count;
+            summary.total_dependency_edges += checkpoint.dependency_edge_count;
+            summary.blocking_dependency_edges += checkpoint.blocking_dependency_edge_count;
+            summary.total_readiness_gaps += checkpoint.readiness_gap_count;
+            summary.total_audit_records += checkpoint.audit_record_count;
+            summary.attention_audit_records += checkpoint.attention_audit_record_count;
+            summary.highest_policy_tier = summary
+                .highest_policy_tier
+                .max(checkpoint.highest_policy_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_checkpoints > 0
+            || summary.dependency_blocked_checkpoints > 0
+            || summary.blocking_dependency_edges > 0
+            || summary.total_readiness_gaps > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.pending_approval_checkpoints > 0
+            || summary.pending_operator_checkpoints > 0
+            || summary.evidence_review_checkpoints > 0
+            || summary.checkpoints_requiring_attention > 0
+            || summary.total_risks > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_to_verify_checkpoints > 0
+            || summary.verification_ready_checkpoints > 0
+        {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_checkpoints == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_checkpoints > 0
+            || self.dependency_blocked_checkpoints > 0
+            || self.blocking_dependency_edges > 0
+            || self.total_readiness_gaps > 0
+    }
+
+    pub fn has_pending_work(&self) -> bool {
+        self.pending_operator_checkpoints > 0
+            || self.pending_approval_checkpoints > 0
+            || self.evidence_review_checkpoints > 0
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.ready_to_verify_checkpoints > 0 && !self.has_blockers() && !self.has_pending_work()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.checkpoints_requiring_attention > 0
+            || self.has_blockers()
+            || self.has_pending_work()
             || self.overall_status.requires_attention()
     }
 }
@@ -12076,6 +12484,38 @@ pub fn activation_execution_packets_at_or_before_priority(
     activation_execution_packets_from_handoff_packages(packages, tasks)
 }
 
+pub fn activation_verification_checkpoints_from_execution_packets(
+    packets: Vec<IntegrationActivationExecutionPacket>,
+) -> Vec<IntegrationActivationVerificationCheckpoint> {
+    let mut checkpoints = packets
+        .into_iter()
+        .map(IntegrationActivationVerificationCheckpoint::from_execution_packet)
+        .collect::<Vec<_>>();
+    checkpoints.sort_by(compare_activation_verification_checkpoints);
+    for (index, checkpoint) in checkpoints.iter_mut().enumerate() {
+        checkpoint.sequence = index + 1;
+    }
+    checkpoints
+}
+
+pub fn activation_verification_checkpoints_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationVerificationCheckpoint> {
+    activation_verification_checkpoints_from_execution_packets(
+        activation_execution_packets_at_or_before_priority(
+            catalog,
+            priority,
+            available_primitives,
+            allowed_capabilities,
+            enabled_integrations,
+        ),
+    )
+}
+
 pub fn activation_control_room_panels_from_operator_tasks(
     mut tasks: Vec<IntegrationActivationOperatorTask>,
 ) -> Vec<IntegrationActivationControlRoomPanel> {
@@ -14105,6 +14545,16 @@ fn activation_execution_status_sort_key(status: IntegrationActivationExecutionSt
     }
 }
 
+fn activation_verification_status_sort_key(status: IntegrationActivationVerificationStatus) -> u8 {
+    match status {
+        IntegrationActivationVerificationStatus::Blocked => 0,
+        IntegrationActivationVerificationStatus::PendingApproval => 1,
+        IntegrationActivationVerificationStatus::PendingOperator => 2,
+        IntegrationActivationVerificationStatus::ReadyToVerify => 3,
+        IntegrationActivationVerificationStatus::Monitoring => 4,
+    }
+}
+
 fn compare_activation_handoff_packages(
     left: &IntegrationActivationHandoffPackage,
     right: &IntegrationActivationHandoffPackage,
@@ -14146,6 +14596,29 @@ fn compare_activation_execution_packets(
         .then_with(|| right.approval_required().cmp(&left.approval_required()))
         .then_with(|| right.operator_required().cmp(&left.operator_required()))
         .then_with(|| right.executable().cmp(&left.executable()))
+        .then_with(|| right.dependency_ready().cmp(&left.dependency_ready()))
+        .then_with(|| right.risk_count.cmp(&left.risk_count))
+        .then_with(|| left.phase.cmp(&right.phase))
+        .then_with(|| left.runbook_sequence.cmp(&right.runbook_sequence))
+}
+
+fn compare_activation_verification_checkpoints(
+    left: &IntegrationActivationVerificationCheckpoint,
+    right: &IntegrationActivationVerificationCheckpoint,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| {
+            activation_verification_status_sort_key(left.verification_status).cmp(
+                &activation_verification_status_sort_key(right.verification_status),
+            )
+        })
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.approval_pending().cmp(&left.approval_pending()))
+        .then_with(|| right.operator_pending().cmp(&left.operator_pending()))
+        .then_with(|| right.can_verify().cmp(&left.can_verify()))
+        .then_with(|| right.verification_ready().cmp(&left.verification_ready()))
         .then_with(|| right.dependency_ready().cmp(&left.dependency_ready()))
         .then_with(|| right.risk_count.cmp(&left.risk_count))
         .then_with(|| left.phase.cmp(&right.phase))
@@ -17633,6 +18106,48 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let verification =
+            activation_verification_checkpoints_from_execution_packets(execution.clone());
+        assert_eq!(verification.len(), execution.len());
+        assert!(verification
+            .iter()
+            .any(IntegrationActivationVerificationCheckpoint::requires_attention));
+        assert!(verification
+            .iter()
+            .any(|checkpoint| checkpoint.verification_status
+                == IntegrationActivationVerificationStatus::Blocked));
+        assert!(verification
+            .iter()
+            .any(|checkpoint| checkpoint.verification_status
+                == IntegrationActivationVerificationStatus::PendingApproval));
+
+        let blocked_verification = verification
+            .iter()
+            .find(|checkpoint| {
+                checkpoint
+                    .integration_ids
+                    .contains(&IntegrationId::trusted("blocked_review_camera"))
+            })
+            .unwrap();
+        assert_eq!(
+            blocked_verification.verification_status,
+            IntegrationActivationVerificationStatus::Blocked
+        );
+        assert!(blocked_verification.blocked());
+        assert!(!blocked_verification.dependency_ready());
+        assert!(!blocked_verification.can_verify());
+
+        let verification_summary =
+            IntegrationActivationVerificationSummary::from_checkpoints(verification.iter());
+        assert_eq!(verification_summary.total_checkpoints, verification.len());
+        assert!(verification_summary.has_blockers());
+        assert!(verification_summary.has_pending_work());
+        assert!(verification_summary.requires_attention());
+        assert_eq!(
+            verification_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -17672,6 +18187,17 @@ mod tests {
         assert!(catalog_execution_packets
             .iter()
             .any(IntegrationActivationExecutionPacket::requires_attention));
+        let catalog_verification_checkpoints =
+            activation_verification_checkpoints_at_or_before_priority(
+                &catalog,
+                2,
+                &available_primitives,
+                &allowed_capabilities,
+                &[],
+            );
+        assert!(catalog_verification_checkpoints
+            .iter()
+            .any(IntegrationActivationVerificationCheckpoint::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation verification checkpoint and summary models in smart-home-integration-catalog derived from execution packets, audit attention, dependency readiness, and readiness gaps
- expose smart_home.list_integration_activation_verification and smart_home.get_integration_activation_verification_summary through chief-of-staff-smart-home-tools
- register shared smart-home-core descriptors and update docs/changelogs for the activation handoff/execution/verification surface

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Note: code/packages/rust/Cargo.lock was generated during validation and removed before push.