### PR TITLE
Enrich ARIA relation browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -1714,6 +1714,12 @@ pub struct BrowserAriaRelationDescriptor {
     pub errormessage_text: Vec<String>,
     pub aria_flowto: Vec<String>,
     pub flowto_text: Vec<String>,
+    pub relation_attribute_names: Vec<String>,
+    pub relation_attribute_count: usize,
+    pub relation_target_count: usize,
+    pub unresolved_relation_targets: Vec<String>,
+    pub relation_blocked: bool,
+    pub relation_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -17651,6 +17657,16 @@ fn browser_aria_relation_descriptor(
         return None;
     }
 
+    let relation_attribute_names = browser_aria_relation_attribute_names(element);
+    let unresolved_relation_targets = browser_unresolved_aria_relation_targets(
+        &aria_details,
+        &aria_errormessage,
+        &aria_flowto,
+        id_texts,
+    );
+    let relation_block_reasons = browser_aria_relation_block_reasons(&unresolved_relation_targets);
+    let relation_target_count = aria_details.len() + aria_errormessage.len() + aria_flowto.len();
+
     Some(BrowserAriaRelationDescriptor {
         element: element.name.clone(),
         id: element.attribute("id").map(ToOwned::to_owned),
@@ -17661,7 +17677,50 @@ fn browser_aria_relation_descriptor(
         aria_errormessage,
         flowto_text: browser_idref_texts(&aria_flowto, id_texts),
         aria_flowto,
+        relation_attribute_count: relation_attribute_names.len(),
+        relation_attribute_names,
+        relation_target_count,
+        relation_blocked: !relation_block_reasons.is_empty(),
+        relation_block_reasons,
+        unresolved_relation_targets,
     })
+}
+
+fn browser_aria_relation_attribute_names(element: &Element) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in ["aria-details", "aria-errormessage", "aria-flowto"] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    attributes
+}
+
+fn browser_unresolved_aria_relation_targets(
+    aria_details: &[String],
+    aria_errormessage: &[String],
+    aria_flowto: &[String],
+    id_texts: &[(String, String)],
+) -> Vec<String> {
+    let mut unresolved = Vec::new();
+    for target in aria_details
+        .iter()
+        .chain(aria_errormessage.iter())
+        .chain(aria_flowto.iter())
+    {
+        if !id_texts.iter().any(|(id, _)| id == target) && !unresolved.contains(target) {
+            unresolved.push(target.clone());
+        }
+    }
+    unresolved
+}
+
+fn browser_aria_relation_block_reasons(unresolved_targets: &[String]) -> Vec<String> {
+    if unresolved_targets.is_empty() {
+        Vec::new()
+    } else {
+        vec!["unresolved-idref".to_string()]
+    }
 }
 
 fn browser_slot_assignment(element: &Element) -> Option<String> {
@@ -26461,6 +26520,15 @@ mod tests {
         assert_eq!(relation.errormessage_text, vec!["Required value"]);
         assert_eq!(relation.aria_flowto, vec!["next"]);
         assert_eq!(relation.flowto_text, vec!["Next step"]);
+        assert_eq!(
+            relation.relation_attribute_names,
+            vec!["aria-details", "aria-errormessage", "aria-flowto"]
+        );
+        assert_eq!(relation.relation_attribute_count, 3);
+        assert_eq!(relation.relation_target_count, 4);
+        assert!(relation.unresolved_relation_targets.is_empty());
+        assert!(!relation.relation_blocked);
+        assert!(relation.relation_block_reasons.is_empty());
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -490,6 +490,18 @@ struct ExpectedAriaRelationDescriptor {
     aria_flowto: Vec<String>,
     #[serde(default)]
     flowto_text: Vec<String>,
+    #[serde(default)]
+    relation_attribute_names: Vec<String>,
+    #[serde(default)]
+    relation_attribute_count: usize,
+    #[serde(default)]
+    relation_target_count: usize,
+    #[serde(default)]
+    unresolved_relation_targets: Vec<String>,
+    #[serde(default)]
+    relation_blocked: bool,
+    #[serde(default)]
+    relation_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5939,6 +5951,61 @@ fn browser_aria_state_relation_metadata_tracks_composite_and_live_states() {
         case.expected.into_browser_document().interactive_elements,
         "interactive summaries should preserve ARIA relationship, popup, modal, validation, disabled, required, and live-region states",
     );
+}
+
+#[test]
+fn browser_aria_relation_descriptors_track_targets_and_resolution_state() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-relation-descriptor-page")
+        .expect("ARIA relation fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA relation fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.aria_relation_descriptors,
+        case.expected.into_browser_document().aria_relation_descriptors,
+        "ARIA relation descriptors should preserve relation attributes, target counts, resolved target text, and unresolved-id diagnostics",
+    );
+}
+
+#[test]
+fn browser_aria_relation_descriptors_track_unresolved_idrefs() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <div id=source aria-details="details missing" aria-errormessage=error aria-flowto="next absent">Source</div>
+            <p id=details>Detailed help</p>
+            <p id=error>Required value</p>
+            <p id=next>Next step</p>
+        </body>"#,
+    )
+    .expect("ARIA relation unresolved-id fixture should parse");
+
+    let relation = actual
+        .aria_relation_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("source"))
+        .expect("source relation descriptor should be present");
+
+    assert_eq!(
+        relation.relation_attribute_names,
+        vec!["aria-details", "aria-errormessage", "aria-flowto"]
+    );
+    assert_eq!(relation.relation_attribute_count, 3);
+    assert_eq!(relation.relation_target_count, 5);
+    assert_eq!(relation.details_text, vec!["Detailed help"]);
+    assert_eq!(relation.errormessage_text, vec!["Required value"]);
+    assert_eq!(relation.flowto_text, vec!["Next step"]);
+    assert_eq!(
+        relation.unresolved_relation_targets,
+        vec!["missing", "absent"]
+    );
+    assert!(relation.relation_blocked);
+    assert_eq!(relation.relation_block_reasons, vec!["unresolved-idref"]);
 }
 
 #[test]
@@ -13406,6 +13473,12 @@ impl ExpectedAriaRelationDescriptor {
             errormessage_text: self.errormessage_text,
             aria_flowto: self.aria_flowto,
             flowto_text: self.flowto_text,
+            relation_attribute_names: self.relation_attribute_names,
+            relation_attribute_count: self.relation_attribute_count,
+            relation_target_count: self.relation_target_count,
+            unresolved_relation_targets: self.unresolved_relation_targets,
+            relation_blocked: self.relation_blocked,
+            relation_block_reasons: self.relation_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1947,7 +1947,10 @@
             "aria_errormessage": ["error"],
             "errormessage_text": ["Required value"],
             "aria_flowto": ["next"],
-            "flowto_text": ["Next step"]
+            "flowto_text": ["Next step"],
+            "relation_attribute_names": ["aria-details", "aria-errormessage", "aria-flowto"],
+            "relation_attribute_count": 3,
+            "relation_target_count": 4
           }
         ],
         "links": [],


### PR DESCRIPTION
## Summary
- add derived ARIA relation attribute names/counts and total target counts
- surface unresolved ARIA relation idrefs with blocked relation hints
- add focused relation descriptor tests and fixture expectations

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser