### PR TITLE
feat(lang-matrix): LM-W Brainfuck — Brainfuck runs on the WASM backend

### DIFF
--- a/code/packages/rust/iir-to-wasm/CHANGELOG.md
+++ b/code/packages/rust/iir-to-wasm/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to this crate are documented here.  The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.0] — 2026-06-12 (LANG-MATRIX LM-W Brainfuck — byte-tape ops on wasm)
+
+Adds the lowering Brainfuck needs to run on the WASM backend — the last code-gen
+gap in Brainfuck's row after LLVM (LM-L). Verified by RUNNING
+`++++++++[>++++++++<-]>+.` on the in-repo `wasm-runtime` in
+`lang-aot/tests/lang_matrix.rs`: it prints `A`.
+
+`lower_brainfuck_for_aot` rewrites Brainfuck's tape into `alloc_bytes` /
+`load_byte` / `store_byte` and widens every cell/pointer register to `i64`. The
+wasm module already has linear memory, `putchar`/`getchar` host imports, and a
+dispatch-loop control flow — what was missing was the byte-tape ops and the
+i64↔i32 conversions the widened value model requires.
+
+### Added
+
+- **`alloc_bytes dest <- size`** → `i64.const 0` (the wasm linear memory *is* the
+  tape and starts at offset 0; `size` only triggers the fixed 1-page memory). The
+  base is bound in the register `dest`.
+- **`load_byte dest <- base, idx`** → `i32.wrap_i64` (narrow the i64 base+idx to
+  the i32 address), `i32.add`, `i32.load8_u`, then `i64.extend_i32_u` to widen the
+  loaded byte back to the i64 cell register. The wasm twin of LLVM's
+  `getelementptr i8 + load + zext`.
+- **`store_byte base, idx, val`** → `i32.wrap_i64` on base+idx (address) and on
+  `val` (the low byte), then `i32.store8`. The `i32.store8`'s implicit `& 0xFF` is
+  what gives Brainfuck's 8-bit cell wrap-around (`255 + 1 == 0`) for free even
+  though the arithmetic ran at i64 width. `store_byte` with a `dest` is rejected.
+- `collect_module_features` now flags `uses_memory` for these ops (so the linear
+  memory is emitted), alongside the existing `load_mem`/`store_mem`.
+- `codegen`: `I64_EQZ` (0x50) constant; `lower` gains `i32.add` / `i32.wrap_i64` /
+  `i64.extend_i32_u` encoders.
+
+### Fixed (the i64-widening ripple)
+
+- **`putchar`/`getchar`**: the `env.putchar`/`env.getchar` imports are `(i32)->()` /
+  `()->i32`, but the Brainfuck cell register is now `i64`. `putchar` now narrows its
+  arg with `i32.wrap_i64`; `getchar` widens its i32 result with `i64.extend_i32_u`.
+- **i64 branch conditions**: `jmp_if_true`/`jmp_if_false` assumed an `i32` condition
+  (`if` / `i32.eqz`). The widened Brainfuck loop guard is an `i64` cell value, so an
+  i64 condition now branches via `i64.eqz` (false-test) / `i64.eqz; i32.eqz`
+  (true-test). Width is chosen per the register's declared type.
+- **i64-declared comparison results**: a wasm comparison always yields `i32`, but
+  `concretize_scalar_any_for_wasm` may declare the result local `i64`. The i32
+  boolean is now widened with `i64.extend_i32_u` when the dest is i64, so the module
+  is well-typed (previously an i32 sat in an i64 local — tolerated only because every
+  consumer happened to use i32 ops; the new `i64.eqz` guard would have tripped on it).
+
+Three new tests in `tests/test_backend.rs` cover the tape ops + memory injection,
+the `store_byte`-with-dest rejection, and the i64-guard / widened-cmp conversions.
+
 ## [0.12.0] — 2026-06-08 (LANG77 / McCarthy L3b-3a-4c — `EQ` / `equal?`)
 
 ### Added

--- a/code/packages/rust/iir-to-wasm/Cargo.toml
+++ b/code/packages/rust/iir-to-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "iir-to-wasm"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
-description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.7.0 (G1): accept cmp_*-prefixed comparison opcodes.  v0.8.0 (G2): whitelist call_builtin print_i64 and route it to the env.__print_i64 host import that io_out uses, so BASIC's PRINT reaches real wasm bytecode."
+description = "IIR → WASM backend — lowers IIRModule to WasmModule.  v0.13.0 (LANG-MATRIX LM-W Brainfuck): adds the byte-tape ops alloc_bytes/load_byte/store_byte over linear memory (with i32.wrap_i64 / i64.extend_i32_u at the byte boundary), i64-aware putchar/getchar, and width-correct i64 branch conditions (i64.eqz) + i64-widened comparison results — so the i64-widened Brainfuck runs on wasm.  v0.7.0 (G1): accept cmp_*-prefixed comparison opcodes.  v0.8.0 (G2): whitelist call_builtin print_i64 and route it to the env.__print_i64 host import that io_out uses, so BASIC's PRINT reaches real wasm bytecode."
 
 [lib]
 name = "iir_to_wasm"

--- a/code/packages/rust/iir-to-wasm/README.md
+++ b/code/packages/rust/iir-to-wasm/README.md
@@ -37,7 +37,15 @@ through a deprecated intermediate.
 - **Function calls**: `call` instructions are lowered to WASM `call`
   opcodes with the correct function index.
 - **Control flow**: dispatch-loop pattern for functions with labels and jumps;
-  plain linear emission for straight-line functions.
+  plain linear emission for straight-line functions. Branch conditions are
+  width-correct: an `i32` guard tests directly / via `i32.eqz`, an `i64` guard
+  (a widened Brainfuck cell) via `i64.eqz` (v0.13.0).
+- **Byte-tape memory (v0.13.0 — Brainfuck)**: `alloc_bytes` (tape base in linear
+  memory), `load_byte` (`i32.load8_u` + `i64.extend_i32_u`), `store_byte`
+  (`i32.wrap_i64` + `i32.store8`), plus the `env.putchar`/`env.getchar` host
+  imports for `.`/`,`. Byte width lives only at the tape boundary; registers in
+  between are uniform `i64`. This is the wasm sibling of the LLVM byte-tape
+  lowering, so **Brainfuck runs on wasm** (LANG-MATRIX LM-W Brainfuck).
 - **All functions exported**: every function in the IIR module is exported by
   name so host runtimes can invoke them.
 
@@ -105,7 +113,7 @@ tests/
 | `ClosureOpcode` | op is `alloc_closure` or `call_closure` — closures require the BEAM backend |
 | `UntypedInstruction` | `type_hint` is `"any"` or `"polymorphic"` |
 | `UnsupportedType` | `type_hint` is `"str"` or starts with `"ref<"` |
-| `UnsupportedOp` | op is `io_in`, `cast`, or `safepoint` (and `call_builtin` with a non-whitelisted name). Note: `alloc`/`field_load`/`field_store`/`is_null` are accepted for `ref<LispyPair>`; `box`/`unbox` are accepted and lower to WasmGC `ref.i31`/`i31.get_s` (LANG77 L3b-3a); `io_out`/`global_*`/`load_mem`/`store_mem` are supported |
+| `UnsupportedOp` | op is `io_in`, `cast`, or `safepoint` (and `call_builtin` with a non-whitelisted name). Note: `alloc`/`field_load`/`field_store`/`is_null` are accepted for `ref<LispyPair>`; `box`/`unbox` are accepted and lower to WasmGC `ref.i31`/`i31.get_s` (LANG77 L3b-3a); `io_out`/`global_*`/`load_mem`/`store_mem` and the byte-tape ops `alloc_bytes`/`load_byte`/`store_byte` (v0.13.0) are supported |
 
 > **LANG35 note**: `alloc_closure` and `call_closure` (LANG34/LANG35 first-class
 > closure opcodes) are BEAM-only.  Using them in a WASM module returns a clear

--- a/code/packages/rust/iir-to-wasm/src/codegen.rs
+++ b/code/packages/rust/iir-to-wasm/src/codegen.rs
@@ -114,6 +114,13 @@ pub const I32_CONST: u8 = 0x41;
 /// `i32.eqz` (0x45) — test if i32 == 0; push i32 result.
 pub const I32_EQZ: u8 = 0x45;
 
+/// `i64.eqz` (0x50) — test if i64 == 0; push **i32** result (1 if zero, else 0).
+///
+/// Used by the control-flow lowering to test an i64 branch condition (the
+/// Brainfuck loop guard is an i64 cell value after `lower_brainfuck_for_aot`
+/// widening) and produce the i32 boolean that `if`/`br_if` require.
+pub const I64_EQZ: u8 = 0x50;
+
 /// `i32.eq` (0x46) — i32 == i32; push i32 (1 or 0).
 pub const I32_EQ: u8 = 0x46;
 

--- a/code/packages/rust/iir-to-wasm/src/lower.rs
+++ b/code/packages/rust/iir-to-wasm/src/lower.rs
@@ -205,6 +205,32 @@ fn encode_i32_store8() -> Vec<u8> {
     vec![0x3Au8, 0x00u8, 0x00u8]
 }
 
+/// Emit `i32.add` (0x6A) — pop two i32, push their sum.
+///
+/// Used by the byte-tape ops (LANG-MATRIX LM-W Brainfuck) to compute the
+/// effective address `base + idx` before an `i32.load8_u` / `i32.store8`.
+fn encode_i32_add() -> Vec<u8> {
+    vec![0x6Au8]
+}
+
+/// Emit `i32.wrap_i64` (0xA7) — truncate an i64 to i32 (drop the high 32 bits).
+///
+/// The Brainfuck value model is uniformly `i64` after `lower_brainfuck_for_aot`
+/// widens it, but wasm linear-memory addresses and `i32.store8` values are i32.
+/// This narrows a tape pointer / cell value to the i32 the memory ops expect;
+/// the low byte (the only part a cell holds) is preserved.
+fn encode_i32_wrap_i64() -> Vec<u8> {
+    vec![0xA7u8]
+}
+
+/// Emit `i64.extend_i32_u` (0xAD) — zero-extend an i32 to i64.
+///
+/// The dual of [`encode_i32_wrap_i64`]: after `i32.load8_u` yields a
+/// zero-extended byte as i32, this widens it back to the i64 cell register.
+fn encode_i64_extend_i32_u() -> Vec<u8> {
+    vec![0xADu8]
+}
+
 fn encode_global_get(idx: u32) -> Vec<u8> {
     use wasm_leb128::encode_unsigned;
     let mut bytes = vec![0x23u8]; // global.get opcode
@@ -705,6 +731,19 @@ fn emit_instr(
         })
     };
 
+    // True when a local slot is an `i64` (vs `i32`). The Brainfuck value model
+    // is uniformly `i64` after `lower_brainfuck_for_aot` widens it, so the
+    // byte-tape ops + `putchar`/`getchar` convert between that i64 and the i32
+    // that wasm linear-memory addresses / `i32.store8` values / the libc
+    // `putchar`/`getchar` imports use. Looking the width up (rather than
+    // assuming i64) keeps the lowering correct for an un-widened i32 caller too.
+    let slot_is_i64 = |slot: u32| -> bool {
+        local_type_hints
+            .get(&slot)
+            .map(|h| matches!(h.as_str(), "i64" | "u64"))
+            .unwrap_or(false)
+    };
+
     let get_label = |label: &str| -> Result<u32, IIRWasmError> {
         label_to_block
             .get(label)
@@ -927,6 +966,19 @@ fn emit_instr(
                 _ => unreachable!(),
             };
             code.push(opcode);
+            // A wasm comparison always yields an `i32` boolean (0/1), regardless
+            // of operand width. If the dest register is an *i64*-declared local
+            // (e.g. a scalar `any` concretised to i64 by `concretize_scalar_any_
+            // for_wasm`), the i32 result must be widened so the stored value
+            // matches the local's declared type — otherwise the module is
+            // ill-typed (an i32 sitting in an i64 local), which the lenient
+            // in-repo runtime tolerated only as long as every consumer used i32
+            // ops. The widened-Brainfuck control flow (`i64.eqz` on an i64 guard,
+            // LANG-MATRIX LM-W) needs the value to actually be i64. The dual fix
+            // lives in the `jmp_if_*` arms.
+            if slot_is_i64(rd) {
+                code.extend(encode_i64_extend_i32_u());
+            }
             code.extend(encode_local_set(rd));
         }
 
@@ -1240,6 +1292,14 @@ fn emit_instr(
                     1 // last block — should not normally conditional-jmp
                 };
                 code.extend(encode_local_get(cond_reg));
+                // `if` tests an i32 != 0. An i64 condition (the Brainfuck loop
+                // guard after `lower_brainfuck_for_aot` widening) must be reduced
+                // to an i32 truth value first: `i64.eqz; i32.eqz` yields 1 iff the
+                // i64 is non-zero.
+                if slot_is_i64(cond_reg) {
+                    code.push(crate::codegen::I64_EQZ);
+                    code.push(I32_EQZ);
+                }
                 // if (empty block type, no result)
                 code.push(crate::codegen::IF);
                 code.push(BLOCK_EMPTY);
@@ -1290,7 +1350,14 @@ fn emit_instr(
                     1 // last block — should not normally conditional-jmp
                 };
                 code.extend(encode_local_get(cond_reg));
-                code.push(I32_EQZ);
+                // "branch if cond == 0" → push the i32 boolean `cond == 0`.
+                // Use the width-correct eqz: `i64.eqz` for an i64 guard (the
+                // widened Brainfuck cell), `i32.eqz` otherwise. Both yield i32.
+                if slot_is_i64(cond_reg) {
+                    code.push(crate::codegen::I64_EQZ);
+                } else {
+                    code.push(I32_EQZ);
+                }
                 code.push(crate::codegen::IF);
                 code.push(BLOCK_EMPTY);
                 code.extend(encode_i32_const(target_idx as i32));
@@ -1710,6 +1777,143 @@ fn emit_instr(
             code.extend(encode_i32_store8());
         }
 
+        // ── alloc_bytes → tape base offset (LANG-MATRIX LM-W Brainfuck) ───────
+        //
+        // `alloc_bytes  dest  <-  size`.  The wasm module's linear memory *is*
+        // the Brainfuck tape and it starts at offset 0, so `dest` (the tape
+        // base) is simply the constant address 0.  The `size` operand only
+        // determines how big the memory must be — that is handled module-wide:
+        // `collect_module_features` flags `uses_memory`, and `lower_iir_to_wasm`
+        // emits a fixed 1-page (64 KiB) memory, comfortably larger than the
+        // 30 000-cell default tape.  `dest` is an `i64` register (the widened
+        // BF value model — see `lower_brainfuck_for_aot` Step 5), so we push an
+        // i64 zero; if some caller declared it i32 we push an i32 zero instead.
+        "alloc_bytes" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "alloc_bytes must have a dest".to_string(),
+            })?;
+            let rd = get_reg(dest)?;
+            if slot_is_i64(rd) {
+                code.extend(encode_i64_const(0));
+            } else {
+                code.extend(encode_i32_const(0));
+            }
+            code.extend(encode_local_set(rd));
+        }
+
+        // ── load_byte → i32.load8_u at base+idx, widened to the cell ─────────
+        //
+        // `load_byte  dest  <-  base, idx`.  Reads one tape cell.  `base` (the
+        // tape, = 0) and `idx` are `i64` registers, but a wasm address is i32,
+        // so we wrap each to i32 and add to form the effective address, then
+        // `i32.load8_u` (which zero-extends the byte to i32).  The result is
+        // widened back to i64 with `i64.extend_i32_u` to match the i64 cell
+        // register `dest`.  This is the wasm twin of the LLVM
+        // `getelementptr i8 + load i8 + zext` lowering — "byte width only at the
+        // tape boundary."  An out-of-bounds index traps at the wasm layer.
+        "load_byte" => {
+            let dest = instr.dest.as_deref().ok_or_else(|| IIRWasmError::InvalidOperand {
+                function: fn_name.to_string(),
+                detail: "load_byte must have a dest".to_string(),
+            })?;
+            let rd = get_reg(dest)?;
+            let base_var = match instr.srcs.first() {
+                Some(Operand::Var(v)) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "load_byte requires Operand::Var(base) as src[0]".to_string(),
+                }),
+            };
+            let idx_var = match instr.srcs.get(1) {
+                Some(Operand::Var(v)) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "load_byte requires Operand::Var(idx) as src[1]".to_string(),
+                }),
+            };
+            let base_slot = get_reg(base_var)?;
+            let idx_slot = get_reg(idx_var)?;
+            // addr = wrap(base) + wrap(idx)
+            code.extend(encode_local_get(base_slot));
+            if slot_is_i64(base_slot) {
+                code.extend(encode_i32_wrap_i64());
+            }
+            code.extend(encode_local_get(idx_slot));
+            if slot_is_i64(idx_slot) {
+                code.extend(encode_i32_wrap_i64());
+            }
+            code.extend(encode_i32_add());
+            code.extend(encode_i32_load8_u());
+            if slot_is_i64(rd) {
+                code.extend(encode_i64_extend_i32_u());
+            }
+            code.extend(encode_local_set(rd));
+        }
+
+        // ── store_byte → i32.store8 of the low byte at base+idx ──────────────
+        //
+        // `store_byte  base, idx, val`  (no dest).  Writes one tape cell.  The
+        // effective address is `wrap(base) + wrap(idx)` (i32); the value is
+        // narrowed with `i32.wrap_i64` and `i32.store8` keeps only its low 8
+        // bits — which is exactly what enforces Brainfuck's 8-bit cell
+        // wrap-around (`255 + 1 == 0`) even though the arithmetic ran at i64
+        // width.  The wasm twin of the LLVM `trunc i64…i8 + store i8`.
+        "store_byte" => {
+            if instr.dest.is_some() {
+                return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_byte must not have a dest".to_string(),
+                });
+            }
+            if instr.srcs.len() < 3 {
+                return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_byte requires 3 srcs: [base, idx, val]".to_string(),
+                });
+            }
+            let base_var = match &instr.srcs[0] {
+                Operand::Var(v) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_byte src[0] must be Operand::Var(base)".to_string(),
+                }),
+            };
+            let idx_var = match &instr.srcs[1] {
+                Operand::Var(v) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_byte src[1] must be Operand::Var(idx)".to_string(),
+                }),
+            };
+            let val_var = match &instr.srcs[2] {
+                Operand::Var(v) => v.as_str(),
+                _ => return Err(IIRWasmError::InvalidOperand {
+                    function: fn_name.to_string(),
+                    detail: "store_byte src[2] must be Operand::Var(val)".to_string(),
+                }),
+            };
+            let base_slot = get_reg(base_var)?;
+            let idx_slot = get_reg(idx_var)?;
+            let val_slot = get_reg(val_var)?;
+            // addr = wrap(base) + wrap(idx) — pushed first (store8 wants [addr, val]).
+            code.extend(encode_local_get(base_slot));
+            if slot_is_i64(base_slot) {
+                code.extend(encode_i32_wrap_i64());
+            }
+            code.extend(encode_local_get(idx_slot));
+            if slot_is_i64(idx_slot) {
+                code.extend(encode_i32_wrap_i64());
+            }
+            code.extend(encode_i32_add());
+            // value (low byte) — narrowed to i32.
+            code.extend(encode_local_get(val_slot));
+            if slot_is_i64(val_slot) {
+                code.extend(encode_i32_wrap_i64());
+            }
+            code.extend(encode_i32_store8());
+        }
+
         // ── call_builtin → call $env.<name> ──────────────────────────────────
         //
         // Dispatch on `srcs[0]` (the builtin name, carried as Var) to the
@@ -1745,7 +1949,13 @@ fn emit_instr(
                         function: fn_name.to_string(),
                         op: "call_builtin \"putchar\": no env.putchar import registered (internal error)".to_string(),
                     })?;
+                    // `env.putchar` takes an i32; the Brainfuck cell register is
+                    // i64 after `lower_brainfuck_for_aot` widening, so narrow it
+                    // (the printable byte lives in the low 8 bits regardless).
                     code.extend(encode_local_get(val_slot));
+                    if slot_is_i64(val_slot) {
+                        code.extend(encode_i32_wrap_i64());
+                    }
                     code.extend(encode_call(fn_idx));
                 }
                 "getchar" => {
@@ -1759,6 +1969,11 @@ fn emit_instr(
                         op: "call_builtin \"getchar\": no env.getchar import registered (internal error)".to_string(),
                     })?;
                     code.extend(encode_call(fn_idx));
+                    // `env.getchar` returns an i32; widen it to the i64 cell
+                    // register `dest` (the widened BF value model).
+                    if slot_is_i64(rd) {
+                        code.extend(encode_i64_extend_i32_u());
+                    }
                     code.extend(encode_local_set(rd));
                 }
                 // G2: `print_i64` reuses the same `env.__print_i64`
@@ -2202,7 +2417,11 @@ fn collect_module_features(module: &IIRModule) -> ModuleFeatures {
                 "io_out" => {
                     uses_io_out = true;
                 }
-                "load_mem" | "store_mem" => {
+                // `load_mem`/`store_mem` are the raw BF-frontend tape ops;
+                // `alloc_bytes`/`load_byte`/`store_byte` are the lowered AOT/LLVM
+                // form `lower_brainfuck_for_aot` rewrites them into. Either shape
+                // means the module needs a linear memory for the tape.
+                "load_mem" | "store_mem" | "alloc_bytes" | "load_byte" | "store_byte" => {
                     uses_memory = true;
                 }
                 "call_builtin" => {

--- a/code/packages/rust/iir-to-wasm/tests/test_backend.rs
+++ b/code/packages/rust/iir-to-wasm/tests/test_backend.rs
@@ -1650,3 +1650,109 @@ fn box_without_dest_is_rejected() {
     );
     assert!(lower_iir_to_wasm(&m, &IIRWasmConfig::default()).is_err());
 }
+
+// ---------------------------------------------------------------------------
+// ── Group N: byte-tape ops + i64 conversions (LANG-MATRIX LM-W Brainfuck) ──
+// ---------------------------------------------------------------------------
+//
+// `lower_brainfuck_for_aot` widens Brainfuck's cell/pointer registers to i64
+// and rewrites the tape into `alloc_bytes` / `load_byte` / `store_byte`. These
+// tests cover the wasm lowering of those ops + the i64↔i32 conversions they and
+// the i64 loop guard need. Opcode bytes asserted: i32.load8_u=0x2D,
+// i32.store8=0x3A, i32.wrap_i64=0xA7, i64.extend_i32_u=0xAD, i64.eqz=0x50.
+
+/// `alloc_bytes`/`load_byte`/`store_byte` lower (the module validates, lowers,
+/// and encodes) and pull in a linear memory + the byte/conversion opcodes.
+#[test]
+fn byte_tape_ops_lower_with_memory_and_conversions() {
+    // A tape round-trip with i64 registers (the widened BF value model):
+    //   const tape_size = 8 (i64)
+    //   alloc_bytes tape <- tape_size       ; base offset 0
+    //   const idx = 0 (i64)
+    //   const val = 65 (i64)
+    //   store_byte tape, idx, val           ; mem[0] = 65
+    //   load_byte got <- tape, idx          ; got = 65 (zero-extended to i64)
+    //   ret got
+    let m = module_one("main", vec![], "i64", vec![
+        IIRInstr::new("const", Some("tape_size".into()), vec![Operand::Int(8)], "i64"),
+        IIRInstr::new("alloc_bytes", Some("tape".into()), vec![Operand::Var("tape_size".into())], "i64"),
+        IIRInstr::new("const", Some("idx".into()), vec![Operand::Int(0)], "i64"),
+        IIRInstr::new("const", Some("val".into()), vec![Operand::Int(65)], "i64"),
+        IIRInstr::new("store_byte", None, vec![
+            Operand::Var("tape".into()), Operand::Var("idx".into()), Operand::Var("val".into()),
+        ], "i64"),
+        IIRInstr::new("load_byte", Some("got".into()), vec![
+            Operand::Var("tape".into()), Operand::Var("idx".into()),
+        ], "i64"),
+        IIRInstr::new("ret", None, vec![Operand::Var("got".into())], "i64"),
+    ]);
+
+    // Validates (no UnsupportedOp for the new ops).
+    let errs = validate_for_wasm(&m);
+    assert!(
+        errs.iter().all(|e| !e.contains("UnsupportedOp")),
+        "byte-tape ops must not be UnsupportedOp; errs: {:?}", errs
+    );
+
+    // Lowers, and the module carries a linear memory for the tape.
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("lowering failed");
+    assert!(!wm.memories.is_empty(), "byte-tape ops must add a linear memory");
+
+    // Encodes; the byte stream carries the memory ops + i64↔i32 conversions.
+    let bytes = encode_module(&wm).expect("encoding failed");
+    assert!(bytes.contains(&0x2Du8), "expected i32.load8_u (0x2D) for load_byte");
+    assert!(bytes.contains(&0x3Au8), "expected i32.store8 (0x3A) for store_byte");
+    assert!(bytes.contains(&0xA7u8), "expected i32.wrap_i64 (0xA7) narrowing an i64 addr/val");
+    assert!(bytes.contains(&0xADu8), "expected i64.extend_i32_u (0xAD) widening the loaded byte");
+}
+
+/// `store_byte` with a dest is rejected — it produces no value.
+#[test]
+fn store_byte_with_dest_is_rejected() {
+    let m = module_one("main", vec![], "i64", vec![
+        IIRInstr::new("const", Some("t".into()), vec![Operand::Int(8)], "i64"),
+        IIRInstr::new("alloc_bytes", Some("tape".into()), vec![Operand::Var("t".into())], "i64"),
+        IIRInstr::new("const", Some("i".into()), vec![Operand::Int(0)], "i64"),
+        IIRInstr::new("const", Some("v".into()), vec![Operand::Int(1)], "i64"),
+        IIRInstr::new("store_byte", Some("oops".into()), vec![
+            Operand::Var("tape".into()), Operand::Var("i".into()), Operand::Var("v".into()),
+        ], "i64"),
+        IIRInstr::new("ret_void", None, vec![], "void"),
+    ]);
+    assert!(
+        lower_iir_to_wasm(&m, &IIRWasmConfig::default()).is_err(),
+        "store_byte must not carry a dest"
+    );
+}
+
+/// An i64 comparison result is widened to i64 (so it matches its i64-declared
+/// local), and an i64 loop guard branches via `i64.eqz` — the dual fix that
+/// keeps the module well-typed once Brainfuck's cells became i64.
+#[test]
+fn i64_condition_uses_i64_eqz_and_widened_cmp() {
+    // c = (a == b)  with i64 operands → i64-declared `c`; then loop on it.
+    //   label L
+    //   c = cmp_eq a, b        ; i32 result widened to i64 (c is i64)
+    //   jmp_if_false c, End     ; i64.eqz (not i32.eqz)
+    //   jmp L
+    //   label End
+    //   ret a
+    let m = module_one("main", vec![("a", "i64"), ("b", "i64")], "i64", vec![
+        IIRInstr::new("label", None, vec![Operand::Var("L".into())], "void"),
+        IIRInstr::new("cmp_eq", Some("c".into()), vec![
+            Operand::Var("a".into()), Operand::Var("b".into()),
+        ], "i64"),
+        IIRInstr::new("jmp_if_false", None, vec![
+            Operand::Var("c".into()), Operand::Var("End".into()),
+        ], "void"),
+        IIRInstr::new("jmp", None, vec![Operand::Var("L".into())], "void"),
+        IIRInstr::new("label", None, vec![Operand::Var("End".into())], "void"),
+        IIRInstr::new("ret", None, vec![Operand::Var("a".into())], "i64"),
+    ]);
+    let wm = lower_iir_to_wasm(&m, &IIRWasmConfig::default()).expect("lowering failed");
+    let bytes = encode_module(&wm).expect("encoding failed");
+    // i64.eqz (0x50) for the i64 guard; i64.extend_i32_u (0xAD) widening the
+    // i32 comparison boolean to the i64-declared `c`.
+    assert!(bytes.contains(&0x50u8), "expected i64.eqz (0x50) for an i64 loop guard");
+    assert!(bytes.contains(&0xADu8), "expected i64.extend_i32_u (0xAD) widening the i64 cmp result");
+}

--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — `lang-aot`
 
+## 0.66.0 — 2026-06-12 — Brainfuck runs on WASM (LANG-MATRIX LM-W Brainfuck)
+
+`lang_matrix.rs` greens **Brainfuck on the WASM backend** — the last code-gen gap in
+Brainfuck's row (only the VM/JIT columns remain). Verified by RUNNING
+`++++++++[>++++++++<-]>+.` on the in-repo `wasm-runtime`: it prints `A`.
+
+The lowering work is in `iir-to-wasm` 0.13.0 (byte-tape ops + i64↔i32 conversions for
+the widened Brainfuck value model — see that crate's changelog). This crate's change is
+in the test harness:
+
+- `run_wasm`'s host (`PrintHost`) now also resolves Brainfuck's I/O imports:
+  `env.putchar : (i32) -> ()` → a new `PutcharFunc` that captures raw output **bytes**
+  (so `.` of cell value 65 yields stdout `A`, not the decimal `65` that `__print_i64`
+  would), and `env.getchar : () -> i32` → a `GetcharFunc` returning EOF (`-1`).
+- `run_wasm` prefers the byte stream when the program wrote any (Brainfuck), else the
+  integer stream joined by newlines (BASIC) — the expression languages print nothing.
+- `tests/lang_matrix.rs` adds `Wasm` to the Brainfuck `Prog`.
+
+No `lang-aot/src` change: `lower_brainfuck_for_aot`'s i64 widening (added in 0.65.0 for
+LLVM) is backend-agnostic and already flowed to the wasm path.
+
 ## 0.65.0 — 2026-06-12 — Brainfuck runs on LLVM (LANG-MATRIX LM-L Brainfuck)
 
 `lang_matrix.rs` greens **Brainfuck on the LLVM backend** — the first cell of the

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.65.0 (LANG-MATRIX LM-L Brainfuck): `lower_brainfuck_for_aot` now widens the Brainfuck frontend's narrow cell/pointer hints (`u8`/`u32`) to `i64` (byte width survives only at the `load_byte`/`store_byte` tape boundary), so Brainfuck runs on the LLVM backend — verified by RUNNING on real `clang` in `tests/lang_matrix.rs`.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.66.0 (LANG-MATRIX LM-W Brainfuck): `tests/lang_matrix.rs` proves Brainfuck on the WASM backend — `run_wasm`'s host now resolves `env.putchar`/`env.getchar` and captures stdout bytes (`.` of 65 → `A`), backed by `iir-to-wasm` 0.13.0's byte-tape ops.  v0.65.0 (LANG-MATRIX LM-L Brainfuck): `lower_brainfuck_for_aot` now widens the Brainfuck frontend's narrow cell/pointer hints (`u8`/`u32`) to `i64` (byte width survives only at the `load_byte`/`store_byte` tape boundary), so Brainfuck runs on the LLVM backend — verified by RUNNING on real `clang` in `tests/lang_matrix.rs`.  v0.13.0 (McCarthy Lisp L3a): adds the `Language::McCarthyLisp` frontend (mccarthy-lisp-iir-compiler) — McCarthy source now produces an IIRModule and scalar programs run on every AOT target (symbol/cons backend support is L3b).  v0.12.0 (Migration Phase 7, FINAL): routed `--emit=riscv32` through the Backend trait over CIR, closing the historical-arch migration."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/README.md
+++ b/code/packages/rust/lang-aot/README.md
@@ -4,12 +4,15 @@ Multi-language AOT driver — compile **Twig, Nib, Brainfuck, Dartmouth
 BASIC, Oct, and McCarthy Lisp** to native executables through the shared
 LANG VM chain.
 
-> **LANG-MATRIX LM-L Brainfuck (v0.65.0):** Brainfuck now also runs on the
-> **LLVM** backend. `lower_brainfuck_for_aot` widens the frontend's narrow cell
-> (`u8`) and pointer (`u32`) hints to `i64` — byte width survives only at the
-> `load_byte`/`store_byte` tape boundary — so `iir-to-llvm`'s i64-only stack-slot
-> model accepts the BF tape. Verified by RUNNING `++++++++[>++++++++<-]>+.` → `A`
-> on real `clang` (`tests/lang_matrix.rs`). The frontend itself is unchanged, so
+> **LANG-MATRIX LM-L/LM-W Brainfuck (v0.65.0 / v0.66.0):** Brainfuck now also runs
+> on the **LLVM** and **WASM** backends. `lower_brainfuck_for_aot` widens the
+> frontend's narrow cell (`u8`) and pointer (`u32`) hints to `i64` — byte width
+> survives only at the `load_byte`/`store_byte` tape boundary — and each backend grew
+> the matching byte-tape ops: `iir-to-llvm` 0.9.0 (`@calloc`/`getelementptr i8`/libc
+> `putchar`) and `iir-to-wasm` 0.13.0 (linear-memory `i32.load8_u`/`i32.store8` with
+> `i32.wrap_i64`/`i64.extend_i32_u`, `env.putchar`/`env.getchar` host imports).
+> Verified by RUNNING `++++++++[>++++++++<-]>+.` → `A` on real `clang` and the in-repo
+> `wasm-runtime` (`tests/lang_matrix.rs`). The frontend itself is unchanged, so
 > the `vm-core`/`jit-core` Brainfuck paths (which key CIR widths off `u8`/`u32`)
 > keep working.  (McCarthy Lisp is wired as of L3a — scalar programs run
 end-to-end natively; symbol/cons backend support is L3b.)  As of L3b-3a-3c,

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -133,19 +133,20 @@ const PROGRAMS: &[Prog] = &[
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr],
     },
     // Brainfuck — build 65 on the tape and `putchar` it: prints `A`.
-    // On LLVM (LM-L Brainfuck), `lower_brainfuck_for_aot` widens the BF cell/ptr
-    // registers to `i64` (byte width survives only at the tape boundary) and
-    // `iir-to-llvm` (v0.9.0) grew the tape ops: `alloc_bytes`→`@calloc`,
-    // `load_byte`→`getelementptr i8`+`load`+`zext`, `store_byte`→`trunc`+`store`,
-    // and `putchar`/`getchar`→ libc. `run_llvm` runs the program and compares the
-    // captured stdout (`A`) — `putchar` writes straight to libc stdout, so no
-    // print-runtime shim is linked (unlike BASIC's `@__print_i64`).
+    // `lower_brainfuck_for_aot` widens the BF cell/ptr registers to `i64` (byte width
+    // survives only at the tape boundary) for every code-gen backend. On LLVM (LM-L)
+    // `iir-to-llvm` (v0.9.0) lowers the tape ops to `@calloc`/`getelementptr i8`+`zext`/
+    // `trunc`+`store` + libc `putchar`/`getchar`. On WASM (LM-W) `iir-to-wasm` (v0.13.0)
+    // lowers them over linear memory: `alloc_bytes`→base offset 0, `load_byte`→
+    // `i32.load8_u`+`i64.extend_i32_u`, `store_byte`→`i32.wrap_i64`+`i32.store8`, and
+    // `putchar`/`getchar`→ the `env.putchar`/`env.getchar` host imports `run_wasm`'s
+    // `PutcharFunc` resolves (capturing raw bytes → stdout `A`, not the decimal `65`).
     Prog {
         lang: Language::Brainfuck,
         ext: "bf",
         src: "++++++++[>++++++++<-]>+.",
         expect: Expect::Stdout("A"),
-        backends: &[NativeAot, Llvm],
+        backends: &[NativeAot, Llvm, Wasm],
     },
     // Dartmouth BASIC — `PRINT 42` writes `42` to stdout. On LLVM the `.ll` emits
     // `call void @__print_i64(i64 42)`, so `run_llvm` links the generic print runtime
@@ -349,12 +350,79 @@ impl wasm_execution::HostFunction for PrintFunc {
     }
 }
 
-/// The host interface the matrix runs wasm under: it resolves the single generic
-/// `env.__print_i64` import to a `PrintFunc` writing into the shared buffer, and
-/// resolves nothing else (the expression languages import no host functions, so for
-/// them the host is never consulted and behaviour is identical to `WasmRuntime::new`).
+/// Brainfuck's `.` lowers to `call $putchar`, imported as `env.putchar : (i32) -> ()`
+/// (the wasm sibling of the LLVM column's libc `@putchar`). `PutcharFunc` is the host
+/// implementation: each call appends the low byte of its i32 argument to a shared byte
+/// buffer, so the test reads back the exact bytes the program wrote — Brainfuck's `.`
+/// of cell value 65 produces the byte `A`, giving stdout `"A"` (NOT the decimal `"65"`
+/// that `__print_i64` would). One byte pushed per call — no DoS vector.
+struct PutcharFunc {
+    bytes: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+impl wasm_execution::HostFunction for PutcharFunc {
+    fn func_type(&self) -> &wasm_types::FuncType {
+        static FT: std::sync::LazyLock<wasm_types::FuncType> =
+            std::sync::LazyLock::new(|| wasm_types::FuncType {
+                params: vec![wasm_types::ValueType::I32],
+                results: vec![],
+            });
+        &FT
+    }
+
+    fn call(
+        &self,
+        args: &[wasm_execution::WasmValue],
+        _memory: Option<&mut wasm_execution::LinearMemory>,
+    ) -> Result<Vec<wasm_execution::WasmValue>, wasm_execution::TrapError> {
+        let value = args
+            .first()
+            .ok_or_else(|| wasm_execution::TrapError::new("putchar: missing argument"))?
+            .as_i32()
+            .map_err(|e| wasm_execution::TrapError::new(e.message))?;
+        self.bytes
+            .lock()
+            .expect("lang-matrix putchar buffer poisoned")
+            .push((value & 0xFF) as u8);
+        Ok(vec![])
+    }
+}
+
+/// Brainfuck's `,` lowers to `call $getchar`, imported as `env.getchar : () -> i32`
+/// (the wasm sibling of libc `@getchar`). This matrix has no stdin, so the host returns
+/// `-1` (EOF) — the conventional Brainfuck "leave 255 on EOF" after the cell store
+/// truncates it. Resolving it keeps the host complete for any BF program that reads
+/// input; the proven cell (`++++++++[>++++++++<-]>+.`) emits no `,`, so it is unused there.
+struct GetcharFunc;
+
+impl wasm_execution::HostFunction for GetcharFunc {
+    fn func_type(&self) -> &wasm_types::FuncType {
+        static FT: std::sync::LazyLock<wasm_types::FuncType> =
+            std::sync::LazyLock::new(|| wasm_types::FuncType {
+                params: vec![],
+                results: vec![wasm_types::ValueType::I32],
+            });
+        &FT
+    }
+
+    fn call(
+        &self,
+        _args: &[wasm_execution::WasmValue],
+        _memory: Option<&mut wasm_execution::LinearMemory>,
+    ) -> Result<Vec<wasm_execution::WasmValue>, wasm_execution::TrapError> {
+        Ok(vec![wasm_execution::WasmValue::I32(-1)])
+    }
+}
+
+/// The host interface the matrix runs wasm under: it resolves the generic
+/// `env.__print_i64` import to a `PrintFunc` (integer capture, for BASIC), and the
+/// Brainfuck I/O imports `env.putchar`/`env.getchar` to a `PutcharFunc` (byte capture)
+/// / `GetcharFunc` (EOF). Everything else resolves to nothing (the expression languages
+/// import no host functions, so the host is never consulted for them and behaviour is
+/// identical to `WasmRuntime::new`).
 struct PrintHost {
     captured: std::sync::Arc<std::sync::Mutex<Vec<i64>>>,
+    bytes: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
 }
 
 impl wasm_execution::HostInterface for PrintHost {
@@ -363,12 +431,15 @@ impl wasm_execution::HostInterface for PrintHost {
         module_name: &str,
         name: &str,
     ) -> Option<Box<dyn wasm_execution::HostFunction>> {
-        if module_name == "env" && name == "__print_i64" {
-            Some(Box::new(PrintFunc {
+        match (module_name, name) {
+            ("env", "__print_i64") => Some(Box::new(PrintFunc {
                 captured: std::sync::Arc::clone(&self.captured),
-            }))
-        } else {
-            None
+            })),
+            ("env", "putchar") => Some(Box::new(PutcharFunc {
+                bytes: std::sync::Arc::clone(&self.bytes),
+            })),
+            ("env", "getchar") => Some(Box::new(GetcharFunc)),
+            _ => None,
         }
     }
 
@@ -401,25 +472,34 @@ impl wasm_execution::HostInterface for PrintHost {
 /// (the `code`); an I/O language (Dartmouth BASIC) prints through `env.__print_i64`,
 /// whose arguments the host captured into the buffer, joined as the program's stdout.
 fn run_wasm(p: &Prog) -> Option<(Option<i32>, String)> {
-    let bytes = lang_aot::compile_source_to_wasm(p.lang, p.src, "main").ok()?;
+    let wasm = lang_aot::compile_source_to_wasm(p.lang, p.src, "main").ok()?;
     let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let byte_buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let host = PrintHost {
         captured: std::sync::Arc::clone(&captured),
+        bytes: std::sync::Arc::clone(&byte_buf),
     };
     let rt = wasm_runtime::WasmRuntime::with_host(Box::new(host));
-    let result = rt.load_and_run(&bytes, "main", &[]).ok()?;
+    let result = rt.load_and_run(&wasm, "main", &[]).ok()?;
     // `main`'s single i64 result is the program's value (`& 0xFF` matches the exit
     // convention the native/LLVM columns use for the same programs).
     let code = result.first().copied().map(|v| (v as i32) & 0xFF);
-    // Whatever the program printed through `env.__print_i64`, one integer per call,
-    // joined by newlines — empty for the expression languages (they never print).
-    let stdout = captured
-        .lock()
-        .expect("lang-matrix print buffer poisoned")
-        .iter()
-        .map(|v| v.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
+    // stdout has two shapes: Brainfuck writes raw bytes via `env.putchar` (so `.` of 65
+    // is the byte `A`); BASIC writes integers via `env.__print_i64` (one per call, joined
+    // by newlines). A program uses one or the other, so prefer the byte stream when the
+    // program wrote any. Expression languages print nothing → empty stdout.
+    let printed_bytes = byte_buf.lock().expect("lang-matrix putchar buffer poisoned");
+    let stdout = if printed_bytes.is_empty() {
+        captured
+            .lock()
+            .expect("lang-matrix print buffer poisoned")
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        String::from_utf8_lossy(&printed_bytes).to_string()
+    };
     Some((code, stdout))
 }
 

--- a/code/specs/LANG-PLATFORM-MATRIX.md
+++ b/code/specs/LANG-PLATFORM-MATRIX.md
@@ -103,7 +103,7 @@ achievable code-gen columns land first).
 |-----------------|----|-----|-----------|------|------|-----|-----|
 | Twig            | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Nib             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
-| Brainfuck       | ☐  | ☐   | ✅        | ✅   | ⏸    | ⏸  | ⏸  |
+| Brainfuck       | ☐  | ☐   | ✅        | ✅   | ✅   | ⏸  | ⏸  |
 | Dartmouth BASIC | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | Oct             | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
 | ALGOL 60        | ☐  | ☐   | ✅        | ✅   | ✅   | ✅  | ✅  |
@@ -190,8 +190,18 @@ BASIC / Brainfuck). The LLVM column is **complete**.
   unchanged). New in-repo dev-deps `wasm-execution` + `wasm-types`. Verified by RUNNING:
   BASIC `10 PRINT 42` → stdout `42`; Twig/Nib/Oct/ALGOL still green (16 proven cells).
   **WASM column now complete for every language except the deferred Brainfuck.**
-- ⏸ **LM-W Brainfuck (on WASM) — DEFERRED.** `iir-to-wasm` lacks the tape ops too
-  (`UnsupportedOp: alloc_bytes`); same deferred class as Brainfuck-on-LLVM.
+- ✅ **LM-W Brainfuck (on WASM).** The LLVM byte-tape pattern ported to wasm.
+  `iir-to-wasm` 0.13.0 grew `alloc_bytes` (tape base 0 in the module's 1-page linear
+  memory), `load_byte` (`i32.load8_u` + `i64.extend_i32_u`), and `store_byte`
+  (`i32.wrap_i64` + `i32.store8`); `run_wasm`'s host resolves the existing
+  `env.putchar`/`env.getchar` imports, with a `PutcharFunc` capturing stdout **bytes**
+  (so `.` of 65 → `A`, not `65`). The i64 widening (shared from LM-L) rippled into wasm
+  control flow: the widened loop guard is i64, so `jmp_if_*` now branches via `i64.eqz`,
+  `putchar`/`getchar` wrap/extend across the i64↔i32 boundary, and an i64-declared
+  comparison result is `i64.extend_i32_u`-widened so the module is well-typed (a latent
+  i32-in-i64-local inconsistency the lenient runtime had tolerated). Verified by RUNNING
+  `++++++++[>++++++++<-]>+.` → stdout `A` on the in-repo `wasm-runtime`; Twig/Nib/Oct/
+  ALGOL/BASIC wasm cells still green. **WASM column now complete for every language.**
 
 ### Phase J — JVM for every language
 
@@ -270,12 +280,16 @@ backends, so they are tackled deliberately rather than as a routine conformance 
   (Step 5) rather than the literal frontend, so `vm-core`/`jit-core`'s width-keyed
   `specialise` stays correct. `iir-to-llvm` 0.9.0 added the tape ops + a slot-dest SSA
   rename (the duplicate-`%name` bug that the "straightforward" tape ops would have hit).
-- ⏸ **LM-W / LM-J / LM-C Brainfuck (WASM / JVM / CLR).** Now unblocked in principle:
-  the i64-widening in `lower_brainfuck_for_aot` is backend-agnostic, so the remaining
-  Brainfuck cells reduce to giving `iir-to-wasm` / `iir-to-jvm-class-file` /
-  `iir-to-cil-bytecode` the same byte-tape ops (`alloc_bytes`/`load_byte`/`store_byte`)
-  and `putchar`/`getchar` lowerings that `iir-to-llvm` and the native backend already
-  have. One backend-codegen slice each — no frontend or slot-model risk.
+- ✅ **LM-W Brainfuck (on WASM).** **Done** (see Phase W). `iir-to-wasm` 0.13.0 grew the
+  byte-tape ops over linear memory; the i64-widening rippled into wasm control flow
+  (i64 loop guard → `i64.eqz`, i64-declared cmp results widened, `putchar`/`getchar`
+  wrap/extend) — all width fixes, no frontend or slot-model change.
+- ⏸ **LM-J / LM-C Brainfuck (JVM / CLR).** Still unblocked in principle: the i64-widening
+  in `lower_brainfuck_for_aot` is backend-agnostic, so the remaining Brainfuck cells
+  reduce to giving `iir-to-jvm-class-file` / `iir-to-cil-bytecode` the same byte-tape ops
+  (`alloc_bytes`/`load_byte`/`store_byte`) and `putchar`/`getchar` lowerings that
+  `iir-to-llvm` / `iir-to-wasm` / the native backend already have — plus the same
+  i64-condition / i64-cmp width handling wasm needed. One backend-codegen slice each.
 - ⏸ **Phase V — VM op-coverage.** `mccarthy_lisp_vm` is **McCarthy-specialized**, not a
   general interpreter (the LM0 probe: it rejects `add`/`mul`/`cmp_*`/`mod` and the I/O
   ops). Running the other languages on the VM means growing the interpreter with
@@ -294,9 +308,10 @@ BEAM column for the imperative languages). The capstone is a single
 known result — the cross-language analog of McCarthy's W16.
 
 The campaign reaches that end state in two waves: first the **code-generator columns**
-(native ✅, **LLVM ✅ — all 6**, WASM/JVM/CLR ✅ for the 5 non-Brainfuck languages) —
-these are general over the shared IIR, so each cell is mostly a conformance test plus
-the occasional I/O/type fix; then the **second-wave** items — Brainfuck on WASM/JVM/CLR
-(now unblocked: the same byte-tape ops `iir-to-llvm` just gained, ported to each managed
-backend) and the McCarthy-specialized VM and JIT — each a real backend/interpreter
-change tackled deliberately. The LLVM column (the priority) is now **complete**.
+(native ✅, **LLVM ✅ — all 6**, **WASM ✅ — all 6**, JVM/CLR ✅ for the 5 non-Brainfuck
+languages) — these are general over the shared IIR, so each cell is mostly a conformance
+test plus the occasional I/O/type fix; then the **second-wave** items — Brainfuck on
+JVM/CLR (the same byte-tape ops + i64 width handling `iir-to-llvm`/`iir-to-wasm` gained,
+ported to each managed backend) and the McCarthy-specialized VM and JIT — each a real
+backend/interpreter change tackled deliberately. The LLVM and WASM columns are now
+**complete**.


### PR DESCRIPTION
## Summary

Greens **Brainfuck on the WASM backend** — the last code-gen gap in Brainfuck's row after LLVM (LM-L). Verified by RUNNING `++++++++[>++++++++<-]>+.` on the in-repo `wasm-runtime` (`lang-aot/tests/lang_matrix.rs`): it prints `A`. The **WASM column is now complete for all six languages** (Twig / Nib / Oct / ALGOL 60 / BASIC / Brainfuck); only the deferred VM/JIT columns remain for Brainfuck.

This is the LM-L byte-tape pattern ported to wasm. `lower_brainfuck_for_aot` (unchanged from LM-L) widens BF's cell/pointer registers to `i64` and rewrites the tape into `alloc_bytes`/`load_byte`/`store_byte` — that already flowed to the wasm path, which is why this needed no frontend or `lang-aot/src` change.

## Changes

**`iir-to-wasm` 0.13.0:**
- `alloc_bytes` → `i64.const 0` (the module's 1-page linear memory **is** the tape, at offset 0; `collect_module_features` now flags `uses_memory` for the byte ops).
- `load_byte` → `i32.wrap_i64`(base)+`i32.wrap_i64`(idx)+`i32.add` → `i32.load8_u` → `i64.extend_i32_u` (widen the byte to the i64 cell register).
- `store_byte` → same address calc + `i32.wrap_i64`(val) + `i32.store8` (the `store8` implicit `& 0xFF` gives BF's 8-bit cell wrap-around for free).
- `codegen`: `I64_EQZ` (0x50) constant + `i32.add`/`i32.wrap_i64`/`i64.extend_i32_u` encoders.

**i64-widening ripple fixes** (the widened value model reaches wasm control flow — these are why this was more than a mechanical port):
- **`putchar`/`getchar`**: the `env.putchar (i32)->()` / `env.getchar ()->i32` imports vs an i64 cell — `putchar` narrows its arg with `i32.wrap_i64`, `getchar` widens its result with `i64.extend_i32_u`.
- **i64 branch conditions**: `jmp_if_*` assumed an i32 guard (`if`/`i32.eqz`); the widened BF loop guard is i64, so it now branches via `i64.eqz` (false) / `i64.eqz; i32.eqz` (true), chosen by the guard register's declared width.
- **i64-declared comparison results**: a wasm comparison always yields i32, but `concretize_scalar_any_for_wasm` may declare the result local i64. The i32 boolean is now `i64.extend_i32_u`-widened when the dest is i64, so the module is well-typed. *Previously an i32 sat in an i64 local* — the lenient in-repo runtime tolerated it only because every consumer used i32 ops; the new `i64.eqz` guard tripped on it. (Surfaced via the Oct cell during testing, then fixed at the root.)

**`lang-aot` 0.66.0 (test harness):** `run_wasm`'s host resolves `env.putchar`/`env.getchar`; a new `PutcharFunc` captures stdout **bytes** (so `.` of cell 65 → `A`, not the decimal `65` that `__print_i64` would), `GetcharFunc` returns EOF. `run_wasm` prefers the byte stream when present. `lang_matrix.rs` adds `Wasm` to the Brainfuck `Prog`.

**Spec:** `LANG-PLATFORM-MATRIX.md` — Brainfuck WASM cell ⏸→✅, WASM column marked complete, Deferred section reduced to Brainfuck-on-JVM/CLR + VM/JIT.

## Security

Reviewed by a security sub-agent → **PASSED, no vulnerabilities**. The wasm runtime bounds-checks every `load8`/`store8`, so an out-of-bounds tape access **traps** (no unchecked host memory access); `i32.wrap_i64` truncation is a BF-semantics concern (tape aliasing within the page), not a host-safety one. No IR injection (new encoders emit fixed opcodes; names → LEB128 local indices; `alloc_bytes` size is ignored). No panics on adversarial IIR (all new arms are length-guarded / fallible). No `unsafe`/TOCTOU/temp-file. Infinite-loop BF is inherent to the language and bounded by the runtime's own step limits, not a new DoS.

## Test plan

- **Verified by RUNNING on the in-process `wasm-runtime`:** Brainfuck → stdout `A`, plus all other languages on all proven backends — `lang-aot/tests/lang_matrix.rs` (2 passed). The floor test (`proven_columns_do_not_silently_skip`) asserts every WASM-tagged cell actually runs.
- `iir-to-wasm` tests: **105 passed** (102 + 3 new — tape ops + memory injection, `store_byte`-with-dest rejection, i64-guard/widened-cmp conversions).
- All other languages' WASM cells (Twig/Nib/Oct/ALGOL/BASIC) still green — the i64-cmp-widening fix keeps them well-typed.
- `clippy` clean on the changed files; rebased onto latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)