### PR TITLE
Add smart-home activation escalation tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -97,6 +97,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation audit trails:
   `smart_home.list_integration_activation_audit` and
   `smart_home.get_integration_activation_audit_summary`.
+- Added D18D handlers for D23A activation escalation cases:
+  `smart_home.list_integration_activation_escalations` and
+  `smart_home.get_integration_activation_escalation_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -67,6 +67,7 @@ Chief of Staff job/session/agent
   -> activation-watchtower list and summary reads for escalation signal rollups
   -> activation-sentinel list and summary reads for compact alert rollups
   -> activation-audit list and summary reads for source-linked audit trails
+  -> activation-escalation list and summary reads for Chief-facing cases
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -152,6 +153,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_sentinel_summary`
 - `smart_home.list_integration_activation_audit`
 - `smart_home.get_integration_activation_audit_summary`
+- `smart_home.list_integration_activation_escalations`
+- `smart_home.get_integration_activation_escalation_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -40,7 +40,8 @@ use smart_home_integration_catalog::{
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
     activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_evidence_from_candidates, activation_execution_packets_from_handoff_packages,
+    activation_escalation_cases_from_rollups, activation_evidence_from_candidates,
+    activation_execution_packets_from_handoff_packages,
     activation_forecasts_from_timeline_milestones,
     activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
@@ -76,18 +77,20 @@ use smart_home_integration_catalog::{
     IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
     IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
     IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
-    IntegrationActivationDossierSummary, IntegrationActivationEvidenceItem,
-    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
-    IntegrationActivationEvidenceSummary, IntegrationActivationExecutionPacket,
-    IntegrationActivationExecutionStatus, IntegrationActivationExecutionSummary,
-    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
-    IntegrationActivationForecastSummary, IntegrationActivationHandoffPackage,
-    IntegrationActivationHandoffStatus, IntegrationActivationHandoffSummary,
-    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
-    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
-    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
-    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
-    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationDossierSummary, IntegrationActivationEscalationCase,
+    IntegrationActivationEscalationCaseKind, IntegrationActivationEscalationSummary,
+    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
+    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
+    IntegrationActivationExecutionPacket, IntegrationActivationExecutionStatus,
+    IntegrationActivationExecutionSummary, IntegrationActivationForecastAction,
+    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
+    IntegrationActivationHandoffPackage, IntegrationActivationHandoffStatus,
+    IntegrationActivationHandoffSummary, IntegrationActivationHealthStage,
+    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
+    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
+    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
+    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
+    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -320,6 +323,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_AUDIT_TOOL_ID: &str =
     "smart_home.list_integration_activation_audit";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_audit_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_escalations";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_escalation_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -722,6 +729,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID => {
                     let query = integration_activation_audit_query(&arguments)?;
                     Ok(get_integration_activation_audit_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID => {
+                    let query = integration_activation_escalation_query(&arguments)?;
+                    Ok(list_integration_activation_escalations_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_escalation_query(&arguments)?;
+                    Ok(get_integration_activation_escalation_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2356,6 +2371,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation audit summary",
             "Return compact D23A activation audit counts by sentinel, watchtower, decision, evidence, risk, dependency, and readiness-gap source.",
             integration_activation_audit_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID,
+            "List smart-home integration activation escalations",
+            "List Chief-facing D23A activation escalation cases derived from sentinel alerts, verification checkpoints, and audit records.",
+            integration_activation_escalation_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_escalations", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_escalations",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation escalation summary",
+            "Return compact D23A activation escalation counts by blocker, dependency, policy risk, review, verification, and audit case.",
+            integration_activation_escalation_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5173,6 +5222,19 @@ struct IntegrationActivationAuditQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationEscalationQuery {
+    audit: IntegrationActivationAuditQuery,
+    verification: IntegrationActivationVerificationQuery,
+    case_kind: Option<IntegrationActivationEscalationCaseKind>,
+    requires_attention: Option<bool>,
+    has_dependency_work: Option<bool>,
+    has_policy_risk: Option<bool>,
+    ready_to_verify: Option<bool>,
+    blocked: Option<bool>,
+    escalation_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5773,6 +5835,33 @@ fn integration_activation_audit_query(
         has_dependency_link: optional_bool(arguments, "has_dependency_link")?,
         has_policy_surface: optional_bool(arguments, "has_policy_surface")?,
         audit_limit: optional_u64(arguments, "audit_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_escalation_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationEscalationQuery, ToolCallError> {
+    let case_kind = optional_string(arguments, "escalation_case")?
+        .or(optional_string(arguments, "case_kind")?)
+        .map(|label| parse_activation_escalation_case_kind(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationEscalationQuery {
+        audit: integration_activation_audit_query(arguments)?,
+        verification: integration_activation_verification_query(arguments)?,
+        case_kind,
+        requires_attention: optional_bool(arguments, "case_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        has_dependency_work: optional_bool(arguments, "case_has_dependency_work")?
+            .or(optional_bool(arguments, "has_dependency_work")?),
+        has_policy_risk: optional_bool(arguments, "case_has_policy_risk")?
+            .or(optional_bool(arguments, "has_policy_risk")?),
+        ready_to_verify: optional_bool(arguments, "ready_to_verify")?
+            .or(optional_bool(arguments, "case_ready_to_verify")?),
+        blocked: optional_bool(arguments, "case_blocked")?.or(optional_bool(arguments, "blocked")?),
+        escalation_limit: optional_u64(arguments, "escalation_limit")?
+            .or(optional_u64(arguments, "case_limit")?)
+            .map(|value| value as usize),
     })
 }
 
@@ -6785,6 +6874,41 @@ fn integration_activation_audit_records_for_query(
     }
 
     (records, catalog_count)
+}
+
+fn integration_activation_escalation_cases_for_query(
+    query: &IntegrationActivationEscalationQuery,
+) -> (Vec<IntegrationActivationEscalationCase>, usize) {
+    let (alerts, catalog_count) =
+        integration_activation_sentinel_alerts_for_query(&query.audit.sentinel);
+    let (checkpoints, _) =
+        integration_activation_verification_checkpoints_for_query(&query.verification);
+    let (audit_records, _) = integration_activation_audit_records_for_query(&query.audit);
+    let mut cases = activation_escalation_cases_from_rollups(&alerts, &checkpoints, &audit_records);
+
+    if let Some(case_kind) = query.case_kind {
+        cases.retain(|case| case.case_kind == case_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        cases.retain(|case| case.requires_attention() == requires_attention);
+    }
+    if let Some(has_dependency_work) = query.has_dependency_work {
+        cases.retain(|case| case.has_dependency_work() == has_dependency_work);
+    }
+    if let Some(has_policy_risk) = query.has_policy_risk {
+        cases.retain(|case| case.has_policy_risk() == has_policy_risk);
+    }
+    if let Some(ready_to_verify) = query.ready_to_verify {
+        cases.retain(|case| case.ready_to_verify() == ready_to_verify);
+    }
+    if let Some(blocked) = query.blocked {
+        cases.retain(|case| case.blocked() == blocked);
+    }
+    if let Some(limit) = query.escalation_limit {
+        cases.truncate(limit);
+    }
+
+    (cases, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -9240,6 +9364,84 @@ fn get_integration_activation_audit_summary_output_handler_output(
             (
                 "readiness_gap_records",
                 integer(summary.readiness_gap_records as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_escalations_output_handler_output(
+    query: IntegrationActivationEscalationQuery,
+) -> ToolHandlerOutput {
+    let (cases, catalog_count) = integration_activation_escalation_cases_for_query(&query);
+    let summary = IntegrationActivationEscalationSummary::from_cases(cases.iter());
+    let count = cases.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_escalations",
+            JsonValue::Array(cases.iter().map(activation_escalation_case_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_escalation_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_escalations"),
+            ),
+            ("cases", integer(count as i64)),
+            (
+                "cases_requiring_attention",
+                integer(summary.cases_requiring_attention as i64),
+            ),
+            ("blocked_cases", integer(summary.blocked_cases as i64)),
+            (
+                "cases_ready_to_verify",
+                integer(summary.cases_ready_to_verify as i64),
+            ),
+            (
+                "next_case_kind",
+                summary
+                    .next_case_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_escalation_summary_output_handler_output(
+    query: IntegrationActivationEscalationQuery,
+) -> ToolHandlerOutput {
+    let (cases, _) = integration_activation_escalation_cases_for_query(&query);
+    let summary = IntegrationActivationEscalationSummary::from_cases(cases.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_escalation_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_escalation_summary"),
+            ),
+            ("total_cases", integer(summary.total_cases as i64)),
+            (
+                "cases_requiring_attention",
+                integer(summary.cases_requiring_attention as i64),
+            ),
+            ("blocked_cases", integer(summary.blocked_cases as i64)),
+            (
+                "cases_ready_to_verify",
+                integer(summary.cases_ready_to_verify as i64),
             ),
         ]),
     )
@@ -18177,6 +18379,208 @@ fn integration_activation_audit_summary_json(
     ])
 }
 
+fn activation_escalation_case_json(case: &IntegrationActivationEscalationCase) -> JsonValue {
+    object([
+        ("sequence", integer(case.sequence as i64)),
+        ("case_kind", string(case.case_kind.as_str())),
+        ("source_id", string(&case.source_id)),
+        ("title", string(&case.title)),
+        ("summary", string(&case.summary)),
+        ("priority", integer(case.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                case.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(case.integration_count() as i64),
+        ),
+        (
+            "sentinel_alert_kind",
+            case.sentinel_alert_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "verification_status",
+            case.verification_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "audit_record_kind",
+            case.audit_record_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        ("recommended_view", string(case.recommended_view.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(case.required_tier)),
+        ),
+        (
+            "policy_surface",
+            case.policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(case.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(case.has_policy_risk())),
+        ("ready_to_verify", JsonValue::Bool(case.ready_to_verify())),
+        ("blocked", JsonValue::Bool(case.blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(case.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_escalation_summary_json(
+    summary: &IntegrationActivationEscalationSummary,
+) -> JsonValue {
+    object([
+        ("total_cases", integer(summary.total_cases as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "cases_requiring_attention",
+            integer(summary.cases_requiring_attention as i64),
+        ),
+        ("blocker_cases", integer(summary.blocker_cases as i64)),
+        ("dependency_cases", integer(summary.dependency_cases as i64)),
+        (
+            "policy_risk_cases",
+            integer(summary.policy_risk_cases as i64),
+        ),
+        ("review_cases", integer(summary.review_cases as i64)),
+        (
+            "verification_cases",
+            integer(summary.verification_cases as i64),
+        ),
+        ("audit_cases", integer(summary.audit_cases as i64)),
+        (
+            "cases_with_dependency_work",
+            integer(summary.cases_with_dependency_work as i64),
+        ),
+        (
+            "cases_with_policy_risk",
+            integer(summary.cases_with_policy_risk as i64),
+        ),
+        (
+            "cases_ready_to_verify",
+            integer(summary.cases_ready_to_verify as i64),
+        ),
+        ("blocked_cases", integer(summary.blocked_cases as i64)),
+        (
+            "cases_with_policy_surface",
+            integer(summary.cases_with_policy_surface as i64),
+        ),
+        (
+            "next_case_kind",
+            summary
+                .next_case_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_case_sequence",
+            summary
+                .next_case_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_case_priority",
+            summary
+                .next_case_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocker_priority",
+            summary
+                .first_blocker_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_dependency_priority",
+            summary
+                .first_dependency_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_policy_risk_priority",
+            summary
+                .first_policy_risk_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_verification_priority",
+            summary
+                .first_verification_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(summary.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(summary.has_policy_risk()),
+        ),
+        (
+            "ready_to_verify",
+            JsonValue::Bool(summary.ready_to_verify()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -21039,6 +21443,28 @@ fn parse_activation_audit_record_kind(
     }
 }
 
+fn parse_activation_escalation_case_kind(
+    label: &str,
+) -> Result<IntegrationActivationEscalationCaseKind, ToolCallError> {
+    match label {
+        "blocker" | "blockers" | "blocked" => Ok(IntegrationActivationEscalationCaseKind::Blocker),
+        "dependency" | "dependencies" | "dependency_work" => {
+            Ok(IntegrationActivationEscalationCaseKind::Dependency)
+        }
+        "policy_risk" | "risk" | "risks" => Ok(IntegrationActivationEscalationCaseKind::PolicyRisk),
+        "review" | "human_review" | "approval" => {
+            Ok(IntegrationActivationEscalationCaseKind::Review)
+        }
+        "verification" | "verify" | "ready_to_verify" => {
+            Ok(IntegrationActivationEscalationCaseKind::Verification)
+        }
+        "audit" | "record" | "records" => Ok(IntegrationActivationEscalationCaseKind::Audit),
+        _ => Err(validation_error(format!(
+            "unknown activation escalation case `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -22499,6 +22925,70 @@ fn integration_activation_audit_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_escalation_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_audit_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("escalation_case", JsonSchema::String));
+        properties.push(SchemaProperty::new("case_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "verification_status",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_state",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("execution_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("execution_state", JsonSchema::String));
+        properties.push(SchemaProperty::new("can_verify", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "verification_ready",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("operator_pending", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("approval_pending", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("dependency_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "verification_blocked",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "evidence_review_required",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "verification_limit",
+            JsonSchema::Integer,
+        ));
+        properties.push(SchemaProperty::new(
+            "case_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "case_has_dependency_work",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "case_has_policy_risk",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("ready_to_verify", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "case_ready_to_verify",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("case_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("escalation_limit", JsonSchema::Integer));
+        properties.push(SchemaProperty::new("case_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -22643,7 +23133,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 117);
+        assert_eq!(definitions.len(), 119);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -22966,9 +23456,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_AUDIT_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            109
+            111
         );
         assert_eq!(
             export
@@ -23446,11 +23942,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(117))
+            Some(&integer(119))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(109))
+            Some(&integer(111))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -27393,6 +27889,157 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_escalations_request = request(
+            "call-list-integration-activation-escalations",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("case_kind", string("blocker")),
+                ("case_requires_attention", JsonValue::Bool(true)),
+                ("case_blocked", JsonValue::Bool(true)),
+                ("escalation_limit", integer(3)),
+            ]),
+            5_043,
+        );
+        let list_activation_escalations_trace =
+            tool_runtime.invoke_with_events(&list_activation_escalations_request);
+        assert!(list_activation_escalations_trace.result.ok);
+        assert_eq!(
+            list_activation_escalations_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_escalations_output = list_activation_escalations_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_escalation_count =
+            integer_value(field(list_activation_escalations_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_escalation_count));
+        let activation_escalation_summary =
+            field(list_activation_escalations_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_escalation_summary, "total_cases"),
+            Some(&integer(activation_escalation_count))
+        );
+        assert_eq!(
+            field(activation_escalation_summary, "next_case_kind"),
+            Some(&string("blocker"))
+        );
+        assert_eq!(
+            field(activation_escalation_summary, "next_recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_escalation_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_escalation_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_escalation = array_item(
+            field(list_activation_escalations_output, "activation_escalations").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_escalation, "case_kind"),
+            Some(&string("blocker"))
+        );
+        assert_eq!(
+            field(activation_escalation, "recommended_view"),
+            Some(&string("constraints"))
+        );
+        assert_eq!(
+            field(activation_escalation, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_escalation, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_escalation_summary_request = request(
+            "call-integration-activation-escalation-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("case_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_044,
+        );
+        let activation_escalation_summary_trace =
+            tool_runtime.invoke_with_events(&activation_escalation_summary_request);
+        assert!(activation_escalation_summary_trace.result.ok);
+        assert_eq!(
+            activation_escalation_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_escalation_summary_output = activation_escalation_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_escalation_rollup =
+            field(activation_escalation_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_escalation_rollup, "total_cases").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_escalation_rollup, "blocked_cases").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_escalation_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_escalation_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -29233,6 +29880,14 @@ mod tests {
             activation_audit_summary_request,
             activation_audit_summary_trace,
         );
+        journal.record_trace(
+            list_activation_escalations_request,
+            list_activation_escalations_trace,
+        );
+        journal.record_trace(
+            activation_escalation_summary_request,
+            activation_escalation_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -29306,9 +29961,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 117);
-        assert_eq!(journal_summary.completed_count, 117);
-        assert_eq!(journal.audit_records().len(), 117);
+        assert_eq!(journal_summary.invocation_count, 119);
+        assert_eq!(journal_summary.completed_count, 119);
+        assert_eq!(journal.audit_records().len(), 119);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -128,6 +128,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_audit_summary` tool descriptors for
   read-only activation audit trails that connect sentinel alerts to
   watchtower, decision, evidence, risk, dependency, and readiness-gap sources.
+- `smart_home.list_integration_activation_escalations` and
+  `smart_home.get_integration_activation_escalation_summary` tool descriptors
+  for read-only Chief-facing activation escalation cases derived from sentinel
+  alerts, verification checkpoints, and audit records.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -112,6 +112,9 @@ Current scope:
 - D18D integration activation-audit descriptors for read-only audit trails
   connecting sentinel alerts to watchtower, decision, evidence, risk,
   dependency, and readiness-gap sources
+- D18D integration activation-escalation descriptors for Chief-facing
+  blocker, dependency, policy-risk, review, verification, and audit cases
+  derived from sentinel, verification, and audit rollups
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1515,6 +1515,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationSentinelSummary,
     ListIntegrationActivationAudit,
     GetIntegrationActivationAuditSummary,
+    ListIntegrationActivationEscalations,
+    GetIntegrationActivationEscalationSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1766,6 +1768,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationAuditSummary => {
                 read_tool("smart_home.get_integration_activation_audit_summary")
+            }
+            Self::ListIntegrationActivationEscalations => {
+                read_tool("smart_home.list_integration_activation_escalations")
+            }
+            Self::GetIntegrationActivationEscalationSummary => {
+                read_tool("smart_home.get_integration_activation_escalation_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2464,6 +2472,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationSentinelSummary,
         SmartHomeTool::ListIntegrationActivationAudit,
         SmartHomeTool::GetIntegrationActivationAuditSummary,
+        SmartHomeTool::ListIntegrationActivationEscalations,
+        SmartHomeTool::GetIntegrationActivationEscalationSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3306,7 +3316,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 117);
+        assert_eq!(catalog.len(), 119);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3781,6 +3791,14 @@ mod tests {
             == "smart_home.get_integration_activation_audit_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_escalations"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_escalation_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3788,15 +3806,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 117);
-        assert_eq!(summary.read_tools, 109);
+        assert_eq!(summary.total_tools, 119);
+        assert_eq!(summary.read_tools, 111);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 109);
+        assert_eq!(summary.read_only_tier_tools, 111);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 117);
+        assert_eq!(summary.total_required_capabilities, 119);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -102,6 +102,10 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationAuditRecord` and `IntegrationActivationAuditSummary`
   for connecting sentinel alerts to watchtower signals, decisions, evidence,
   policy risk, dependency blockers, and readiness gaps in one audit trail.
+- `IntegrationActivationEscalationCase` and
+  `IntegrationActivationEscalationSummary` for packaging sentinel alerts,
+  verification checkpoints, and audit records into Chief-facing escalation
+  queues.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -93,6 +93,9 @@ runtime and Chief of Staff tools a typed catalog for:
   and observation lanes
 - activation audit records that connect sentinel alerts to watchtower signals,
   decisions, evidence, policy risk, dependency blockers, and readiness gaps
+- activation escalation cases that package sentinel alerts, verification
+  checkpoints, and audit records into Chief-facing blocker, dependency,
+  policy-risk, review, verification, and audit cases
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1360,6 +1360,39 @@ impl IntegrationActivationSentinelAlertKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationEscalationCaseKind {
+    Blocker,
+    Dependency,
+    PolicyRisk,
+    Review,
+    Verification,
+    Audit,
+}
+
+impl IntegrationActivationEscalationCaseKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocker => "blocker",
+            Self::Dependency => "dependency",
+            Self::PolicyRisk => "policy_risk",
+            Self::Review => "review",
+            Self::Verification => "verification",
+            Self::Audit => "audit",
+        }
+    }
+
+    pub fn recommended_view(self) -> IntegrationActivationPlaybookView {
+        match self {
+            Self::Blocker => IntegrationActivationPlaybookView::ConstraintQueue,
+            Self::Dependency => IntegrationActivationPlaybookView::DependencyGraph,
+            Self::PolicyRisk => IntegrationActivationPlaybookView::RiskRegister,
+            Self::Review => IntegrationActivationPlaybookView::ReviewQueue,
+            Self::Verification | Self::Audit => IntegrationActivationPlaybookView::StatusDashboard,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3027,6 +3060,58 @@ pub struct IntegrationActivationAuditSummary {
     pub first_attention_priority: Option<u8>,
     pub first_dependency_priority: Option<u8>,
     pub first_readiness_gap_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationEscalationCase {
+    pub sequence: usize,
+    pub case_kind: IntegrationActivationEscalationCaseKind,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub sentinel_alert_kind: Option<IntegrationActivationSentinelAlertKind>,
+    pub verification_status: Option<IntegrationActivationVerificationStatus>,
+    pub audit_record_kind: Option<IntegrationActivationAuditRecordKind>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_ready: bool,
+    pub blocked: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationEscalationSummary {
+    pub total_cases: usize,
+    pub unique_integrations: usize,
+    pub cases_requiring_attention: usize,
+    pub blocker_cases: usize,
+    pub dependency_cases: usize,
+    pub policy_risk_cases: usize,
+    pub review_cases: usize,
+    pub verification_cases: usize,
+    pub audit_cases: usize,
+    pub cases_with_dependency_work: usize,
+    pub cases_with_policy_risk: usize,
+    pub cases_ready_to_verify: usize,
+    pub blocked_cases: usize,
+    pub cases_with_policy_surface: usize,
+    pub next_case_kind: Option<IntegrationActivationEscalationCaseKind>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_case_sequence: Option<usize>,
+    pub next_case_priority: Option<u8>,
+    pub first_blocker_priority: Option<u8>,
+    pub first_dependency_priority: Option<u8>,
+    pub first_policy_risk_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
+    pub first_verification_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -8164,6 +8249,343 @@ impl IntegrationActivationAuditSummary {
     }
 }
 
+impl IntegrationActivationEscalationCase {
+    fn new(
+        case_kind: IntegrationActivationEscalationCaseKind,
+        source_id: String,
+        title: String,
+        summary: String,
+        priority: u8,
+        mut integration_ids: Vec<IntegrationId>,
+        required_tier: PrivilegeTier,
+        policy_surface: Option<IntegrationPolicySurface>,
+        requires_attention: bool,
+    ) -> Self {
+        integration_ids.sort();
+        integration_ids.dedup();
+
+        Self {
+            sequence: 0,
+            case_kind,
+            source_id,
+            title,
+            summary,
+            priority,
+            integration_ids,
+            sentinel_alert_kind: None,
+            verification_status: None,
+            audit_record_kind: None,
+            recommended_view: case_kind.recommended_view(),
+            required_tier,
+            policy_surface,
+            dependency_work: false,
+            policy_risk: false,
+            verification_ready: false,
+            blocked: false,
+            requires_attention,
+        }
+    }
+
+    fn from_sentinel_alert(alert: &IntegrationActivationSentinelAlert) -> Self {
+        let case_kind = match alert.alert_kind {
+            IntegrationActivationSentinelAlertKind::Blocker => {
+                IntegrationActivationEscalationCaseKind::Blocker
+            }
+            IntegrationActivationSentinelAlertKind::Dependency => {
+                IntegrationActivationEscalationCaseKind::Dependency
+            }
+            IntegrationActivationSentinelAlertKind::PolicyRisk => {
+                IntegrationActivationEscalationCaseKind::PolicyRisk
+            }
+            IntegrationActivationSentinelAlertKind::Review => {
+                IntegrationActivationEscalationCaseKind::Review
+            }
+            IntegrationActivationSentinelAlertKind::Ready
+            | IntegrationActivationSentinelAlertKind::Observation => {
+                IntegrationActivationEscalationCaseKind::Audit
+            }
+        };
+        let required_tier = alert
+            .watchtower_summary
+            .highest_policy_tier
+            .max(alert.risk_summary.highest_policy_tier)
+            .max(alert.dependency_summary.highest_policy_tier);
+        let mut case = Self::new(
+            case_kind,
+            format!("sentinel:{}", alert.alert_kind.as_str()),
+            format!("Escalate {} activation alert", alert.alert_kind.as_str()),
+            format!(
+                "{} integrations, {} blocking dependencies, {} readiness gaps",
+                alert.integration_count(),
+                alert.dependency_summary.blocking_edges,
+                alert.gap_inventory.total_unique_gaps()
+            ),
+            alert.priority,
+            alert.integration_ids.clone(),
+            required_tier,
+            None,
+            alert.requires_attention(),
+        );
+        case.sentinel_alert_kind = Some(alert.alert_kind);
+        case.dependency_work = alert.has_dependency_work();
+        case.policy_risk = alert.has_policy_risk();
+        case.blocked =
+            alert.has_blockers() || alert.has_blocking_dependencies() || alert.has_gaps();
+        case
+    }
+
+    fn from_verification_checkpoint(
+        checkpoint: &IntegrationActivationVerificationCheckpoint,
+    ) -> Self {
+        let mut case = Self::new(
+            IntegrationActivationEscalationCaseKind::Verification,
+            format!("verification:{}", checkpoint.sequence),
+            format!(
+                "Verify activation checkpoint {}",
+                checkpoint.verification_status.as_str()
+            ),
+            format!(
+                "{} integrations, {} audit records, {} readiness gaps",
+                checkpoint.integration_count(),
+                checkpoint.audit_record_count,
+                checkpoint.readiness_gap_count
+            ),
+            checkpoint.priority,
+            checkpoint.integration_ids.clone(),
+            checkpoint.highest_policy_tier,
+            None,
+            checkpoint.requires_attention() || checkpoint.can_verify(),
+        );
+        case.verification_status = Some(checkpoint.verification_status);
+        case.recommended_view = checkpoint.recommended_view;
+        case.dependency_work =
+            !checkpoint.dependency_ready() || checkpoint.blocking_dependency_edge_count > 0;
+        case.policy_risk = checkpoint.risk_count > 0;
+        case.verification_ready = checkpoint.verification_ready() || checkpoint.can_verify();
+        case.blocked = checkpoint.blocked() || !checkpoint.dependency_ready();
+        case
+    }
+
+    fn from_audit_record(record: &IntegrationActivationAuditRecord) -> Self {
+        let case_kind = match record.record_kind {
+            IntegrationActivationAuditRecordKind::Risk => {
+                IntegrationActivationEscalationCaseKind::PolicyRisk
+            }
+            IntegrationActivationAuditRecordKind::Dependency
+            | IntegrationActivationAuditRecordKind::ReadinessGap => {
+                IntegrationActivationEscalationCaseKind::Dependency
+            }
+            IntegrationActivationAuditRecordKind::Decision
+            | IntegrationActivationAuditRecordKind::Evidence => {
+                IntegrationActivationEscalationCaseKind::Review
+            }
+            IntegrationActivationAuditRecordKind::Sentinel
+            | IntegrationActivationAuditRecordKind::Watchtower => {
+                IntegrationActivationEscalationCaseKind::Audit
+            }
+        };
+        let mut case = Self::new(
+            case_kind,
+            format!("audit:{}", record.record_id),
+            record.title.clone(),
+            record.summary.clone(),
+            record.priority,
+            record.integration_ids.clone(),
+            record.required_tier,
+            record.policy_surface,
+            record.requires_attention(),
+        );
+        case.audit_record_kind = Some(record.record_kind);
+        case.sentinel_alert_kind = record.sentinel_alert_kind;
+        case.dependency_work = record.has_dependency_link()
+            || record.record_kind == IntegrationActivationAuditRecordKind::Dependency
+            || record.record_kind == IntegrationActivationAuditRecordKind::ReadinessGap;
+        case.policy_risk = record.risk_kind.is_some() || record.policy_surface.is_some();
+        case.blocked = record.record_kind == IntegrationActivationAuditRecordKind::ReadinessGap
+            || (record.record_kind == IntegrationActivationAuditRecordKind::Dependency
+                && record.requires_attention());
+        case
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.verification_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationEscalationSummary {
+    pub fn from_cases<'a>(
+        cases: impl IntoIterator<Item = &'a IntegrationActivationEscalationCase>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_cases: 0,
+            unique_integrations: 0,
+            cases_requiring_attention: 0,
+            blocker_cases: 0,
+            dependency_cases: 0,
+            policy_risk_cases: 0,
+            review_cases: 0,
+            verification_cases: 0,
+            audit_cases: 0,
+            cases_with_dependency_work: 0,
+            cases_with_policy_risk: 0,
+            cases_ready_to_verify: 0,
+            blocked_cases: 0,
+            cases_with_policy_surface: 0,
+            next_case_kind: None,
+            next_recommended_view: None,
+            next_case_sequence: None,
+            next_case_priority: None,
+            first_blocker_priority: None,
+            first_dependency_priority: None,
+            first_policy_risk_priority: None,
+            first_review_priority: None,
+            first_verification_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for case in cases {
+            summary.total_cases += 1;
+            for integration_id in &case.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_case_kind.is_none()
+                && (case.requires_attention() || case.ready_to_verify())
+            {
+                summary.next_case_kind = Some(case.case_kind);
+                summary.next_recommended_view = Some(case.recommended_view);
+                summary.next_case_sequence = Some(case.sequence);
+                summary.next_case_priority = Some(case.priority);
+            }
+
+            match case.case_kind {
+                IntegrationActivationEscalationCaseKind::Blocker => {
+                    summary.blocker_cases += 1;
+                    summary.first_blocker_priority =
+                        min_optional_priority(summary.first_blocker_priority, Some(case.priority));
+                }
+                IntegrationActivationEscalationCaseKind::Dependency => {
+                    summary.dependency_cases += 1;
+                    summary.first_dependency_priority = min_optional_priority(
+                        summary.first_dependency_priority,
+                        Some(case.priority),
+                    );
+                }
+                IntegrationActivationEscalationCaseKind::PolicyRisk => {
+                    summary.policy_risk_cases += 1;
+                    summary.first_policy_risk_priority = min_optional_priority(
+                        summary.first_policy_risk_priority,
+                        Some(case.priority),
+                    );
+                }
+                IntegrationActivationEscalationCaseKind::Review => {
+                    summary.review_cases += 1;
+                    summary.first_review_priority =
+                        min_optional_priority(summary.first_review_priority, Some(case.priority));
+                }
+                IntegrationActivationEscalationCaseKind::Verification => {
+                    summary.verification_cases += 1;
+                    summary.first_verification_priority = min_optional_priority(
+                        summary.first_verification_priority,
+                        Some(case.priority),
+                    );
+                }
+                IntegrationActivationEscalationCaseKind::Audit => {
+                    summary.audit_cases += 1;
+                }
+            }
+
+            if case.requires_attention() {
+                summary.cases_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(case.priority));
+            }
+            if case.has_dependency_work() {
+                summary.cases_with_dependency_work += 1;
+            }
+            if case.has_policy_risk() {
+                summary.cases_with_policy_risk += 1;
+            }
+            if case.ready_to_verify() {
+                summary.cases_ready_to_verify += 1;
+            }
+            if case.blocked() {
+                summary.blocked_cases += 1;
+            }
+            if case.has_policy_surface() {
+                summary.cases_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(case.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_cases > 0 || summary.blocker_cases > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.cases_requiring_attention > 0
+            || summary.review_cases > 0
+            || summary.policy_risk_cases > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.cases_ready_to_verify > 0 || summary.verification_cases > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_cases == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocker_cases > 0 || self.blocked_cases > 0
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_cases > 0 || self.cases_with_dependency_work > 0
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk_cases > 0 || self.cases_with_policy_risk > 0
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.cases_ready_to_verify > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.cases_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -13129,6 +13551,69 @@ pub fn activation_audit_records_at_or_before_priority(
     )
 }
 
+pub fn activation_escalation_cases_from_rollups(
+    alerts: &[IntegrationActivationSentinelAlert],
+    checkpoints: &[IntegrationActivationVerificationCheckpoint],
+    audit_records: &[IntegrationActivationAuditRecord],
+) -> Vec<IntegrationActivationEscalationCase> {
+    let mut cases = Vec::new();
+    cases.extend(
+        alerts
+            .iter()
+            .filter(|alert| alert.requires_attention())
+            .map(IntegrationActivationEscalationCase::from_sentinel_alert),
+    );
+    cases.extend(
+        checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.requires_attention() || checkpoint.can_verify())
+            .map(IntegrationActivationEscalationCase::from_verification_checkpoint),
+    );
+    cases.extend(
+        audit_records
+            .iter()
+            .filter(|record| record.requires_attention())
+            .map(IntegrationActivationEscalationCase::from_audit_record),
+    );
+
+    cases.sort_by(compare_activation_escalation_cases);
+    for (index, case) in cases.iter_mut().enumerate() {
+        case.sequence = index + 1;
+    }
+    cases
+}
+
+pub fn activation_escalation_cases_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationEscalationCase> {
+    let alerts = activation_sentinel_alerts_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let checkpoints = activation_verification_checkpoints_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let audit_records = activation_audit_records_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_escalation_cases_from_rollups(&alerts, &checkpoints, &audit_records)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -14714,6 +15199,22 @@ fn compare_activation_audit_records(
         .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
         .then_with(|| left.record_kind.cmp(&right.record_kind))
         .then_with(|| left.record_id.cmp(&right.record_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_escalation_cases(
+    left: &IntegrationActivationEscalationCase,
+    right: &IntegrationActivationEscalationCase,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
+        .then_with(|| left.case_kind.cmp(&right.case_kind))
+        .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
 
@@ -18148,6 +18649,47 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let escalation_cases =
+            activation_escalation_cases_from_rollups(&alerts, &verification, &audit_records);
+        assert!(!escalation_cases.is_empty());
+        assert!(escalation_cases
+            .iter()
+            .any(|case| case.case_kind == IntegrationActivationEscalationCaseKind::Blocker));
+        assert!(escalation_cases
+            .iter()
+            .any(|case| case.case_kind == IntegrationActivationEscalationCaseKind::Dependency));
+        assert!(escalation_cases
+            .iter()
+            .any(|case| case.case_kind == IntegrationActivationEscalationCaseKind::Verification));
+        assert!(escalation_cases
+            .iter()
+            .any(IntegrationActivationEscalationCase::requires_attention));
+        assert!(escalation_cases
+            .iter()
+            .any(IntegrationActivationEscalationCase::has_dependency_work));
+        assert!(escalation_cases
+            .iter()
+            .any(IntegrationActivationEscalationCase::blocked));
+
+        let escalation_summary =
+            IntegrationActivationEscalationSummary::from_cases(escalation_cases.iter());
+        assert_eq!(escalation_summary.total_cases, escalation_cases.len());
+        assert!(escalation_summary.has_blockers());
+        assert!(escalation_summary.has_dependency_work());
+        assert!(escalation_summary.requires_attention());
+        assert_eq!(
+            escalation_summary.next_case_kind,
+            Some(IntegrationActivationEscalationCaseKind::Blocker)
+        );
+        assert_eq!(
+            escalation_summary.next_recommended_view,
+            Some(IntegrationActivationPlaybookView::ConstraintQueue)
+        );
+        assert_eq!(
+            escalation_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -18198,6 +18740,16 @@ mod tests {
         assert!(catalog_verification_checkpoints
             .iter()
             .any(IntegrationActivationVerificationCheckpoint::requires_attention));
+        let catalog_escalation_cases = activation_escalation_cases_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_escalation_cases
+            .iter()
+            .any(IntegrationActivationEscalationCase::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation escalation cases and summaries to the smart-home integration catalog
- expose two read-only smart_home activation escalation descriptors in smart-home-core
- wire Chief-of-Staff D18D list/summary handlers with schema, JSON output, docs, and end-to-end runtime coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Cargo.lock generated during validation was removed before commit.