### PR TITLE
feat(closurec): CLOC12.92 — close gap-087 (computed-member index paren elision)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.96.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-087** — a paren wrapping the WHOLE index of a
+  computed-member subscript now elides under WHITESPACE_ONLY, matching
+  upstream Closure:
+
+      a[(b)]      -> a[b]
+      a[(b+c)]    -> a[b+c]
+      a[(b,c)]    -> a[b,c]      (comma operator, single index — safe)
+      a[(b=c)]    -> a[b=c]
+      x()[(b)]    -> x()[b]      (value object ending in `)`)
+      a[b[(c)]]   -> a[b[c]]     (nested subscripts)
+
+  `minify_index_paren` is now enforced. A new subscript-anchored
+  pre-pass fires when a `[` is preceded by a value-producing token (so
+  it is a subscript, not an array literal) and immediately followed by
+  `(`, whose structural-depth-matched `)` is immediately followed by
+  the matching `]`. No comma / atomic guard is needed — the `[ … ]`
+  already delimits a single expression.
+
+  Array-literal element parens are NOT affected: `[(a,b)]` keeps its
+  parens (the value-preceded requirement excludes array-literal `[`),
+  since there a top-level comma is an element separator. That
+  element-paren case is the comma-guarded gap-086 family.
+
 ## [0.95.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.95.0"
+version = "0.96.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -726,6 +726,103 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // gap-087: paren elision inside a COMPUTED-MEMBER index —
+    // `a[(b)]` → `a[b]`, `a[(b+c)]` → `a[b+c]`, `a[(b,c)]` →
+    // `a[b,c]`, `x()[(b)]` → `x()[b]`, `a[b[(c)]]` → `a[b[c]]`.
+    //
+    // A computed-member `[` (the subscript operator) is preceded by
+    // a VALUE-producing token (a word-like name/literal, a string, or
+    // a `)`/`]`/`}` close) — exactly the tokens that make a following
+    // `(` a CALL paren. That is the mirror of the gap-077
+    // `starts_expr` test: here we REQUIRE the `[` to follow a value
+    // (so it is a subscript, not an ARRAY LITERAL `[`). The
+    // distinction matters because inside an array literal a top-level
+    // comma is an ELEMENT separator (`[(a,b)]` must KEEP its parens,
+    // else it becomes the two-element `[a,b]`), whereas inside a
+    // subscript the brackets already delimit a SINGLE expression, so
+    // even a comma operator is safe to expose (`a[(b,c)]` → `a[b,c]`).
+    // Array-literal element parens are the comma-guarded gap-086
+    // family and are handled separately.
+    //
+    // Eligibility: the `[` is immediately followed by `(`, and that
+    // `(`'s matching `)` is immediately followed by the matching `]`
+    // — i.e. the parens wrap the WHOLE index. A partial paren
+    // (`a[(b)+c]`) is already handled by the gap-077 left-operand
+    // pass; a call/group that is not the whole index (`a[(f)(b)]`)
+    // has its `)` followed by `(`, not `]`, so it is left alone. No
+    // comma / atomic-operand guard is needed: any single expression
+    // is safe once the enclosing `[ … ]` is preserved.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 0;
+        while i < kept.len() {
+            // Subscript `[`: preceded by a value-producing token.
+            let is_subscript = i > 0 && {
+                let p = kept[i - 1];
+                is_word_like(p)
+                    || is_string_literal(p)
+                    || is_structural_punct(p, ")")
+                    || is_structural_punct(p, "]")
+                    || is_structural_punct(p, "}")
+            };
+            // Need `[` `(` … directly adjacent.
+            if !(is_subscript
+                && is_structural_punct(kept[i], "[")
+                && i + 1 < kept.len()
+                && is_structural_punct(kept[i + 1], "("))
+            {
+                i += 1;
+                continue;
+            }
+            let open = i + 1; // the `(`
+            // Match the `(` … `)` (structural depth scan, identical to
+            // the gap-077 scan so string/regex bracket content can
+            // never corrupt the depth).
+            let mut depth: i32 = 1;
+            let mut close: Option<usize> = None;
+            let mut j = open + 1;
+            while j < kept.len() {
+                let t = kept[j];
+                if is_structural_punct(t, "(")
+                    || is_structural_punct(t, "[")
+                    || is_structural_punct(t, "{")
+                {
+                    depth += 1;
+                } else if is_structural_punct(t, ")") {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(j);
+                        break;
+                    }
+                } else if is_structural_punct(t, "]")
+                    || is_structural_punct(t, "}")
+                {
+                    depth -= 1;
+                }
+                j += 1;
+            }
+            let Some(close) = close else {
+                i += 1;
+                continue;
+            };
+            // The parens wrap the WHOLE index iff the token after `)`
+            // is the matching `]` of this subscript.
+            if close + 1 < kept.len()
+                && is_structural_punct(kept[close + 1], "]")
+            {
+                drops.push(open);
+                drops.push(close);
+                i = close + 2; // past `… ) ]`
+                continue;
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // gap-055: paren elision around a *whole-arm* sub-
     // expression that follows `?` or `:`. Upstream Closure
     // strips redundant grouping parens around:
@@ -5343,6 +5440,50 @@ mod tests {
     #[test]
     fn gap081_optional_chain_not_ternary() {
         assert_eq!(minify("var x=(a)?.b;"), "var x=(a)?.b;");
+    }
+
+    // ---- gap-087: computed-member index paren elision ---------
+
+    /// gap-087: a paren wrapping the WHOLE index of a computed-member
+    /// subscript elides. The brackets already delimit a single
+    /// expression, so no comma / atomic-operand guard is needed — even
+    /// a comma operator (`a[(b,c)]` → `a[b,c]`) or an assignment
+    /// (`a[(b=c)]` → `a[b=c]`) is safe to expose.
+    #[test]
+    fn gap087_index_paren_stripped() {
+        assert_eq!(minify("a[(b)];"), "a[b];");
+        assert_eq!(minify("a[(b+c)];"), "a[b+c];");
+        assert_eq!(minify("a[(b,c)];"), "a[b,c];");
+        assert_eq!(minify("a[(b=c)];"), "a[b=c];");
+    }
+
+    /// gap-087: the subscripted object may itself end in a `)`/`]`
+    /// (`x()[(b)]` → `x()[b]`), and nested subscripts each strip
+    /// independently (`a[b[(c)]]` → `a[b[c]]`).
+    #[test]
+    fn gap087_index_paren_value_object_and_nested() {
+        assert_eq!(minify("x()[(b)];"), "x()[b];");
+        assert_eq!(minify("a[b[(c)]];"), "a[b[c]];");
+    }
+
+    /// gap-087 SAFETY — must NOT mistake an ARRAY-LITERAL `[` for a
+    /// subscript. An array literal `[` is NOT preceded by a value, and
+    /// inside it a top-level comma is an ELEMENT separator: `[(a,b)]`
+    /// keeps its parens (dropping them would split one element into
+    /// two). Only a value-preceded subscript `[` is eligible.
+    #[test]
+    fn gap087_array_literal_comma_element_kept() {
+        assert_eq!(minify("var x=[(a,b)];"), "var x=[(a,b)];");
+    }
+
+    /// gap-087 SAFETY — the parens must wrap the WHOLE index. A partial
+    /// paren (`a[(b)+c]`) is left to the gap-077 left-operand pass
+    /// (which yields `a[b+c]`), and a non-grouping call inside the
+    /// index (`a[f(b)]`) is untouched by this pass.
+    #[test]
+    fn gap087_partial_and_call_index_safe() {
+        assert_eq!(minify("a[(b)+c];"), "a[b+c];");
+        assert_eq!(minify("a[f(b)];"), "a[f(b)];");
     }
 
     // ---- gap-073: get/set computed-key separating space ----

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.95.0
+Version: 0.96.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -120,11 +120,13 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // else it splits into two args). Mirror of the operand-paren
     // pre-passes, anchored on `(`/`,` inside a call's argument list.
     ("call_arg_paren", "gap-086: call-argument paren elision"),
-    // gap-087 (CLOC14.39): redundant parens inside a COMPUTED MEMBER
-    // index — `a[(b)]` → `a[b]`, `a[(b+c)]` → `a[b+c]`. Unlike a call
-    // argument, the index is a single-expression context so even a
-    // comma operator strips (`a[(b,c)]` → `a[b,c]`).
-    ("index_paren", "gap-087: computed-member index paren elision"),
+    // gap-087 RESOLVED in CLOC12.92 — a paren wrapping the WHOLE index
+    // of a computed-member subscript (`a[(b)]` → `a[b]`, `a[(b+c)]` →
+    // `a[b+c]`, `a[(b,c)]` → `a[b,c]`, `a[b[(c)]]` → `a[b[c]]`) now
+    // elides via a subscript-anchored pre-pass. No comma guard is
+    // needed (the brackets delimit a single-expression context); array-
+    // literal element parens (`[(a,b)]` must keep) are the gap-086
+    // comma-guarded family. `minify_index_paren` enforced.
     // gap-088 (CLOC14.39): EMPTY-STATEMENT (`;`) elimination —
     // `;;var x=1;;;` → `var x=1;`, `;;;` → ``, `function f(){;;x();}` →
     // `function f(){x()}`. closurec currently keeps stray semicolons.

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -659,9 +659,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-087 — computed-member index paren elision (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.39). `minify_index_paren` ignored.
+- **Status:** RESOLVED in CLOC12.92. `minify_index_paren` enforced.
 - **Input:** `a[(b)];` → **Upstream:** `a[b];` (also `a[(b+c)]` → `a[b+c]`, `a[(b,c)]` → `a[b,c]`, `a[(b=c)]` → `a[b=c]`).
 - **What it needs:** strip a redundant grouping paren that wraps the WHOLE index expression inside a computed member `[ … ]` — a `(` directly after `[` whose matching `)` is directly before the matching `]`. Unlike a call argument (gap-086), the index is a SINGLE-expression context, so even a top-level comma operator strips (`a[(b,c)]` → `a[b,c]` — the comma stays a comma operator, not an argument separator). Anchored on the `[`…`]` pair.
+- **CLOC12.92 resolution:** Added a SUBSCRIPT-anchored pre-pass to `whitespace_only.rs` (sibling of the gap-077 left-operand pass). It fires on a `[` that is (a) preceded by a VALUE-producing token (word/literal/string/`)`/`]`/`}` — i.e. a subscript, NOT an array literal) and (b) immediately followed by `(`, when that `(`'s structural-depth-matched `)` is immediately followed by the matching `]`. Both parens are dropped. **No comma / atomic guard** is needed — the enclosing `[ … ]` already delimits a single expression, so any content (comma operator, assignment, …) is safe to expose. The value-preceded requirement is exactly what excludes ARRAY LITERALS, where a top-level comma is an element separator and the parens are load-bearing (`[(a,b)]` kept — that element-paren case belongs to the comma-guarded gap-086 family). Partial parens (`a[(b)+c]`) are left to gap-077 (→ `a[b+c]`); a non-grouping call index (`a[f(b)]`) has no `(` right after `[` and is untouched. 4 unit tests (strip / value-object+nested / array-literal-kept / partial+call-safe) + the byte-identity fixture; JAR-verified across `a[(b)]`, `a[(b+c)]`, `a[(b,c)]`, `a[(b=c)]`, `x()[(b)]`, `a[b[(c)]]`.
 
 ### gap-088 — empty-statement elimination (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## CLOC12.92 — close gap-087 (computed-member index paren elision)

Upstream Closure strips a paren wrapping the **whole index** of a computed-member subscript even under `WHITESPACE_ONLY`. closurec kept it.

```
a[(b)]    → a[b]       a[(b+c)]  → a[b+c]
a[(b,c)]  → a[b,c]     a[(b=c)]  → a[b=c]
x()[(b)]  → x()[b]     a[b[(c)]] → a[b[c]]
```

### Implementation
New subscript-anchored pre-pass (sibling of the gap-077 left-operand pass). Fires when a `[` is **(a)** preceded by a value-producing token (word/literal/string/`)`/`]`/`}` — a subscript, *not* an array literal) and **(b)** immediately followed by `(` whose structural-depth-matched `)` is immediately followed by the matching `]`. Both parens drop.

**No comma / atomic guard needed** — the enclosing `[ … ]` already delimits a single-expression context, so even a comma operator (`a[(b,c)]`→`a[b,c]`) or assignment is safe to expose.

### Why the value-preceded requirement matters
It excludes **array literals**, where a top-level comma is an *element separator*: `[(a,b)]` must keep its parens (else it becomes the two-element `[a,b]`). An array-literal `[` is never preceded by a value, so the pass skips it. That element-paren case is the comma-guarded **gap-086** family. Partial parens (`a[(b)+c]`) are left to gap-077; `a[f(b)]` is untouched.

### Tests
- +4 `gap087_*` unit tests (strip / value-object+nested / array-literal-kept / partial+call-safe)
- Byte-identity fixture `minify_index_paren` enforced (removed from IGNORE)
- Full `cargo test` green (516 lib + walk-test)
- Version 0.95.0 → 0.96.0; spec gap-087 RESOLVED; CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)