### PR TITLE
Add ARIA name browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -864,6 +864,7 @@ pub struct BrowserDocument {
     pub aria_collections: Vec<BrowserAriaCollection>,
     pub aria_ranges: Vec<BrowserAriaRange>,
     pub aria_live_regions: Vec<BrowserAriaLiveRegion>,
+    pub aria_name_descriptors: Vec<BrowserAriaNameDescriptor>,
     pub aria_relation_descriptors: Vec<BrowserAriaRelationDescriptor>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
@@ -1720,6 +1721,25 @@ pub struct BrowserAriaRelationDescriptor {
     pub unresolved_relation_targets: Vec<String>,
     pub relation_blocked: bool,
     pub relation_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaNameDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub labelledby_text: Vec<String>,
+    pub name_source: String,
+    pub name_attribute_names: Vec<String>,
+    pub name_attribute_count: usize,
+    pub label_target_count: usize,
+    pub unresolved_label_targets: Vec<String>,
+    pub name_blocked: bool,
+    pub name_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -10799,6 +10819,9 @@ fn collect_browser_facts(
         if let Some(aria_live_region) = browser_aria_live_region_element(element, id_texts) {
             summary.aria_live_regions.push(aria_live_region);
         }
+        if let Some(aria_name) = browser_aria_name_descriptor(element, id_texts) {
+            summary.aria_name_descriptors.push(aria_name);
+        }
         if let Some(aria_relation) = browser_aria_relation_descriptor(element, id_texts) {
             summary.aria_relation_descriptors.push(aria_relation);
         }
@@ -17721,6 +17744,104 @@ fn browser_aria_relation_block_reasons(unresolved_targets: &[String]) -> Vec<Str
     } else {
         vec!["unresolved-idref".to_string()]
     }
+}
+
+fn browser_aria_name_descriptor(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaNameDescriptor> {
+    let aria_label = browser_aria_label(element);
+    let aria_labelledby = browser_aria_idrefs(element, "aria-labelledby");
+
+    if aria_label.is_none() && aria_labelledby.is_empty() {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name).unwrap_or(element.name.as_str());
+    let labelledby_text = browser_idref_texts(&aria_labelledby, id_texts);
+    let unresolved_label_targets = browser_unresolved_aria_idrefs(&aria_labelledby, id_texts);
+    let name_block_reasons = browser_aria_name_block_reasons(
+        aria_label.as_deref(),
+        &aria_labelledby,
+        &labelledby_text,
+        &unresolved_label_targets,
+    );
+    let name_attribute_names = browser_aria_name_attribute_names(element);
+    let name_source =
+        browser_aria_name_source(aria_label.as_deref(), &aria_labelledby, &labelledby_text);
+
+    Some(BrowserAriaNameDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        role: role.to_string(),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, role, &[], id_texts),
+        aria_label,
+        aria_labelledby,
+        labelledby_text,
+        name_source,
+        name_attribute_count: name_attribute_names.len(),
+        name_attribute_names,
+        label_target_count: browser_aria_idrefs(element, "aria-labelledby").len(),
+        unresolved_label_targets,
+        name_blocked: !name_block_reasons.is_empty(),
+        name_block_reasons,
+    })
+}
+
+fn browser_aria_name_attribute_names(element: &Element) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in ["aria-label", "aria-labelledby"] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    attributes
+}
+
+fn browser_unresolved_aria_idrefs(idrefs: &[String], id_texts: &[(String, String)]) -> Vec<String> {
+    let mut unresolved = Vec::new();
+    for target in idrefs {
+        if !id_texts.iter().any(|(id, _)| id == target) && !unresolved.contains(target) {
+            unresolved.push(target.clone());
+        }
+    }
+    unresolved
+}
+
+fn browser_aria_name_source(
+    aria_label: Option<&str>,
+    aria_labelledby: &[String],
+    labelledby_text: &[String],
+) -> String {
+    if !aria_labelledby.is_empty() && !labelledby_text.is_empty() {
+        "aria-labelledby".to_string()
+    } else if aria_label.is_some_and(|label| !label.is_empty()) {
+        "aria-label".to_string()
+    } else if !aria_labelledby.is_empty() {
+        "unresolved-aria-labelledby".to_string()
+    } else {
+        "none".to_string()
+    }
+}
+
+fn browser_aria_name_block_reasons(
+    aria_label: Option<&str>,
+    aria_labelledby: &[String],
+    labelledby_text: &[String],
+    unresolved_targets: &[String],
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if !unresolved_targets.is_empty() {
+        reasons.push("unresolved-idref".to_string());
+    }
+    if !aria_labelledby.is_empty()
+        && labelledby_text.is_empty()
+        && aria_label.is_none_or(|label| label.is_empty())
+    {
+        reasons.push("empty-name".to_string());
+    }
+    reasons
 }
 
 fn browser_slot_assignment(element: &Element) -> Option<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,36 +1,37 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserActivationDescriptor, BrowserAnchor,
     BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
-    BrowserAriaLiveRegion, BrowserAriaRange, BrowserAriaRelationDescriptor,
-    BrowserClipboardInteractionDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
-    BrowserCompositionInteractionDescriptor, BrowserContextMenuInteractionDescriptor,
-    BrowserDataAttribute, BrowserDataAttributeDescriptor, BrowserDatalistOption, BrowserDisclosure,
-    BrowserDisclosureStateDescriptor, BrowserDocument, BrowserDocumentMetadata,
-    BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor, BrowserEmbeddedContext,
-    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
-    BrowserFocusNavigationDescriptor, BrowserForm, BrowserFormAssociationDescriptor,
-    BrowserFormAutofillDescriptor, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
-    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
-    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
-    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
-    BrowserFormPolicySubmitterDescriptor, BrowserFormResetDescriptor, BrowserFormSelect,
-    BrowserFormSubmissionDescriptor, BrowserFormSubmitter, BrowserFormSuccessfulControl,
-    BrowserFormTextEntry, BrowserFormValidationControl, BrowserFormValidationDescriptor,
-    BrowserFullscreenInteractionDescriptor, BrowserGlobalStateDescriptor, BrowserHeading,
-    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
-    BrowserImageMapArea, BrowserImageSource, BrowserInputPlanningDescriptor,
-    BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
-    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
-    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
-    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
-    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
-    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
-    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserAriaLiveRegion, BrowserAriaNameDescriptor, BrowserAriaRange,
+    BrowserAriaRelationDescriptor, BrowserClipboardInteractionDescriptor, BrowserCommandElement,
+    BrowserComponentHydrationTarget, BrowserCompositionInteractionDescriptor,
+    BrowserContextMenuInteractionDescriptor, BrowserDataAttribute, BrowserDataAttributeDescriptor,
+    BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
+    BrowserDocumentMetadata, BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor,
+    BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor,
+    BrowserFetchPolicyDescriptor, BrowserFocusNavigationDescriptor, BrowserForm,
+    BrowserFormAssociationDescriptor, BrowserFormAutofillDescriptor, BrowserFormButton,
+    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
+    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
+    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
+    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormResetDescriptor,
+    BrowserFormSelect, BrowserFormSubmissionDescriptor, BrowserFormSubmitter,
+    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
+    BrowserFormValidationDescriptor, BrowserFullscreenInteractionDescriptor,
+    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
+    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
+    BrowserInputPlanningDescriptor, BrowserInteractiveElement,
+    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
+    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
+    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
+    BrowserScriptModuleGraphDescriptor, BrowserScriptStorageAccessDescriptor,
+    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
+    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
+    BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -142,6 +143,8 @@ struct ExpectedBrowserDocument {
     aria_ranges: Vec<ExpectedAriaRange>,
     #[serde(default)]
     aria_live_regions: Vec<ExpectedAriaLiveRegion>,
+    #[serde(default)]
+    aria_name_descriptors: Option<Vec<ExpectedAriaNameDescriptor>>,
     #[serde(default)]
     aria_relation_descriptors: Vec<ExpectedAriaRelationDescriptor>,
     links: Vec<ExpectedLink>,
@@ -502,6 +505,39 @@ struct ExpectedAriaRelationDescriptor {
     relation_blocked: bool,
     #[serde(default)]
     relation_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaNameDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    labelledby_text: Vec<String>,
+    #[serde(default)]
+    name_source: String,
+    #[serde(default)]
+    name_attribute_names: Vec<String>,
+    #[serde(default)]
+    name_attribute_count: usize,
+    #[serde(default)]
+    label_target_count: usize,
+    #[serde(default)]
+    unresolved_label_targets: Vec<String>,
+    #[serde(default)]
+    name_blocked: bool,
+    #[serde(default)]
+    name_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4002,10 +4038,14 @@ fn browser_readiness_cases_extract_browser_document_facts() {
     for case in suite.cases {
         let actual = parse_browser_document(&case.input)
             .unwrap_or_else(|error| panic!("{} should parse: {error}", case.id));
+        let tracks_aria_name_descriptors = case.expected.aria_name_descriptors.is_some();
+        let mut expected = case.expected.into_browser_document();
+        if !tracks_aria_name_descriptors {
+            expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
+        }
 
         assert_eq!(
-            actual,
-            case.expected.into_browser_document(),
+            actual, expected,
             "{} extracted browser facts should match",
             case.id
         );
@@ -6009,6 +6049,55 @@ fn browser_aria_relation_descriptors_track_unresolved_idrefs() {
 }
 
 #[test]
+fn browser_aria_name_descriptors_track_label_sources_and_resolution() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-name-descriptor-page")
+        .expect("ARIA name fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA name fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.aria_name_descriptors,
+        case.expected.into_browser_document().aria_name_descriptors,
+        "ARIA name descriptors should preserve name sources, resolved label text, and unresolved label diagnostics",
+    );
+}
+
+#[test]
+fn browser_aria_name_descriptors_track_unresolved_labelledby_targets() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <button id=save aria-labelledby="save-label missing">Save</button>
+            <span id=save-label>Save changes</span>
+        </body>"#,
+    )
+    .expect("ARIA name unresolved-id fixture should parse");
+
+    let name = actual
+        .aria_name_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("save"))
+        .expect("save button name descriptor should be present");
+
+    assert_eq!(name.role, "control");
+    assert_eq!(name.accessible_name.as_deref(), Some("Save changes"));
+    assert_eq!(name.aria_labelledby, vec!["save-label", "missing"]);
+    assert_eq!(name.labelledby_text, vec!["Save changes"]);
+    assert_eq!(name.name_source, "aria-labelledby");
+    assert_eq!(name.name_attribute_names, vec!["aria-labelledby"]);
+    assert_eq!(name.name_attribute_count, 1);
+    assert_eq!(name.label_target_count, 2);
+    assert_eq!(name.unresolved_label_targets, vec!["missing"]);
+    assert!(name.name_blocked);
+    assert_eq!(name.name_block_reasons, vec!["unresolved-idref"]);
+}
+
+#[test]
 fn browser_disclosure_descriptor_metadata_tracks_details_and_dialogs() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -6790,6 +6879,12 @@ impl ExpectedBrowserDocument {
                 .aria_live_regions
                 .into_iter()
                 .map(ExpectedAriaLiveRegion::into_browser_aria_live_region)
+                .collect(),
+            aria_name_descriptors: self
+                .aria_name_descriptors
+                .unwrap_or_default()
+                .into_iter()
+                .map(ExpectedAriaNameDescriptor::into_browser_aria_name_descriptor)
                 .collect(),
             aria_relation_descriptors: self
                 .aria_relation_descriptors
@@ -13479,6 +13574,28 @@ impl ExpectedAriaRelationDescriptor {
             unresolved_relation_targets: self.unresolved_relation_targets,
             relation_blocked: self.relation_blocked,
             relation_block_reasons: self.relation_block_reasons,
+        }
+    }
+}
+
+impl ExpectedAriaNameDescriptor {
+    fn into_browser_aria_name_descriptor(self) -> BrowserAriaNameDescriptor {
+        BrowserAriaNameDescriptor {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            labelledby_text: self.labelledby_text,
+            name_source: self.name_source,
+            name_attribute_names: self.name_attribute_names,
+            name_attribute_count: self.name_attribute_count,
+            label_target_count: self.label_target_count,
+            unresolved_label_targets: self.unresolved_label_targets,
+            name_blocked: self.name_blocked,
+            name_block_reasons: self.name_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1919,6 +1919,75 @@
       }
     },
     {
+      "id": "aria-name-descriptor-page",
+      "description": "Browser document summaries expose ARIA naming sources, resolved label text, and unresolved labelledby blockers.",
+      "input": "<body><h2 id=dialog-title>Preferences</h2><p id=hint>Choose defaults</p><span id=open aria-label=\"Open preferences\">Open</span><div id=panel aria-labelledby=\"dialog-title hint\" aria-label=\"Fallback panel\">Panel</div><div id=missing-name aria-labelledby=\"missing\">Hidden</div></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Preferences Choose defaults Open Panel Hidden",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "dialog-title", "name": null, "text": "Preferences" },
+          { "id": "hint", "name": null, "text": "Choose defaults" },
+          { "id": "open", "name": null, "text": "Open" },
+          { "id": "panel", "name": null, "text": "Panel" },
+          { "id": "missing-name", "name": null, "text": "Hidden" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Preferences" }
+        ],
+        "aria_name_descriptors": [
+          {
+            "element": "span",
+            "id": "open",
+            "role": "inline",
+            "text": "Open",
+            "accessible_name": "Open preferences",
+            "aria_label": "Open preferences",
+            "name_source": "aria-label",
+            "name_attribute_names": ["aria-label"],
+            "name_attribute_count": 1
+          },
+          {
+            "element": "div",
+            "id": "panel",
+            "role": "block",
+            "text": "Panel",
+            "accessible_name": "Preferences Choose defaults",
+            "aria_label": "Fallback panel",
+            "aria_labelledby": ["dialog-title", "hint"],
+            "labelledby_text": ["Preferences", "Choose defaults"],
+            "name_source": "aria-labelledby",
+            "name_attribute_names": ["aria-label", "aria-labelledby"],
+            "name_attribute_count": 2,
+            "label_target_count": 2
+          },
+          {
+            "element": "div",
+            "id": "missing-name",
+            "role": "block",
+            "text": "Hidden",
+            "aria_labelledby": ["missing"],
+            "name_source": "unresolved-aria-labelledby",
+            "name_attribute_names": ["aria-labelledby"],
+            "name_attribute_count": 1,
+            "label_target_count": 1,
+            "unresolved_label_targets": ["missing"],
+            "name_blocked": true,
+            "name_block_reasons": ["unresolved-idref", "empty-name"]
+          }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "aria-relation-descriptor-page",
       "description": "Browser document summaries expose ARIA details, error-message, and flow relationships with resolved target text.",
       "input": "<body><div id=source aria-details=\"details extra\" aria-errormessage=error aria-flowto=next>Source</div><p id=details>Detailed help</p><p id=extra>Extra notes</p><p id=error>Required value</p><p id=next>Next step</p></body>",


### PR DESCRIPTION
## Summary
- add ARIA name descriptors for aria-label and aria-labelledby naming sources
- surface resolved labelledby text, unresolved label targets, and blocked-name hints
- add fixture-backed and inline tests for naming precedence and unresolved idrefs

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser