### PR TITLE
Add SPICE include and library source resolver

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck source resolution** — `resolve_deck_sources()` now expands
+  map-provided `.include` files and selected `.lib path section` library
+  sections with stable diagnostics for missing sources, bad sections, cycles,
+  and still-unsupported `.control` blocks, matching Rust and TypeScript.
+
 - **Deck boundary diagnostics** — `analyze_deck_controls()` now reports the
   active pre-`.end` deck lines and stable unsupported-feature diagnostics for
   `.include`, `.lib`, and `.control` directives, matching Rust and TypeScript.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -110,6 +110,11 @@ provide stable tab-separated summaries for package checks.
 it returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives before future include/library
 resolution and control-block execution are in scope.
+`resolve_deck_sources()` is the first include/library resolution layer: callers
+provide a source-content map, `.include` directives are expanded in place, and
+`.lib path section` selects a named `.lib` / `.endl` section with stable
+diagnostics for missing files, missing sections, unterminated sections, cycles,
+and still-unsupported `.control` blocks.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -6,6 +6,8 @@ from spice_engine.compatibility import (
     CompatibilityOracle,
     DeckControlDiagnostic,
     DeckControlSummary,
+    DeckResolutionDiagnostic,
+    DeckResolutionSummary,
     ReleaseReadinessIssue,
     ReleaseReadinessReport,
     analyze_deck_controls,
@@ -13,6 +15,7 @@ from spice_engine.compatibility import (
     format_compatibility_corpus_table,
     format_release_readiness_report,
     release_readiness_gates,
+    resolve_deck_sources,
 )
 from spice_engine.elements import (
     BJT,
@@ -300,6 +303,8 @@ __all__ = [
     "CurrentSource",
     "DeckControlDiagnostic",
     "DeckControlSummary",
+    "DeckResolutionDiagnostic",
+    "DeckResolutionSummary",
     "DcResult",
     "DcSolverDiagnostics",
     "DcSweepPoint",
@@ -451,6 +456,7 @@ __all__ = [
     "pss_residual_jacobian",
     "pss_residual",
     "release_readiness_gates",
+    "resolve_deck_sources",
     "sens_dc",
     "s_parameters",
     "s_parameters_corners",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import isfinite
 
@@ -59,6 +59,31 @@ class DeckControlSummary:
     terminated: bool
     end_line_number: int | None
     diagnostics: tuple[DeckControlDiagnostic, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DeckResolutionDiagnostic:
+    """A stable diagnostic emitted while resolving deck source directives."""
+
+    code: str
+    directive: str
+    source: str
+    line_number: int
+    message: str
+    severity: str
+    target: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DeckResolutionSummary:
+    """Resolved active deck lines plus source-resolution metadata."""
+
+    active_lines: tuple[str, ...]
+    terminated: bool
+    end_line_number: int | None
+    diagnostics: tuple[DeckResolutionDiagnostic, ...]
+    included_paths: tuple[str, ...]
+    library_sections: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,6 +227,7 @@ R2 out 0 10000
 _SUPPORTED_ANALYSES = frozenset({"op", "dc", "ac", "tran", "tf"})
 _REQUIRED_ANALYSES = frozenset({"op", "dc", "ac", "tran"})
 _UNSUPPORTED_DECK_CONTROL_DIRECTIVES = frozenset({".include", ".lib", ".control"})
+_UNSUPPORTED_RESOLVED_DIRECTIVES = frozenset({".control"})
 
 
 def analyze_deck_controls(netlist: str) -> DeckControlSummary:
@@ -239,6 +265,30 @@ def analyze_deck_controls(netlist: str) -> DeckControlSummary:
         terminated=end_line_number is not None,
         end_line_number=end_line_number,
         diagnostics=tuple(diagnostics),
+    )
+
+
+def resolve_deck_sources(
+    netlist: str,
+    sources: Mapping[str, str],
+) -> DeckResolutionSummary:
+    """Expand ``.include`` and selected ``.lib`` sources from a content map."""
+
+    state = _DeckResolutionState()
+    active_lines, terminated, end_line_number = _resolve_deck_lines(
+        netlist=netlist,
+        source="<deck>",
+        sources=sources,
+        state=state,
+        stack=(),
+    )
+    return DeckResolutionSummary(
+        active_lines=tuple(active_lines),
+        terminated=terminated,
+        end_line_number=end_line_number,
+        diagnostics=tuple(state.diagnostics),
+        included_paths=tuple(state.included_paths),
+        library_sections=tuple(state.library_sections),
     )
 
 
@@ -409,6 +459,299 @@ def _validate_non_empty(
     issues.append(
         ReleaseReadinessIssue(deck_id, field, "field must be documented and non-empty")
     )
+
+
+@dataclass(slots=True)
+class _DeckResolutionState:
+    diagnostics: list[DeckResolutionDiagnostic]
+    included_paths: list[str]
+    library_sections: list[str]
+
+    def __init__(self) -> None:
+        self.diagnostics = []
+        self.included_paths = []
+        self.library_sections = []
+
+
+def _resolve_deck_lines(
+    *,
+    netlist: str,
+    source: str,
+    sources: Mapping[str, str],
+    state: _DeckResolutionState,
+    stack: tuple[str, ...],
+) -> tuple[list[str], bool, int | None]:
+    active_lines: list[str] = []
+    end_line_number: int | None = None
+
+    for line_number, raw_line in enumerate(netlist.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith(("*", ";")):
+            continue
+        directive = _deck_directive(stripped)
+        if directive == ".end":
+            end_line_number = line_number
+            break
+        if directive == ".include":
+            active_lines.extend(
+                _resolve_include(
+                    line=stripped,
+                    source=source,
+                    line_number=line_number,
+                    sources=sources,
+                    state=state,
+                    stack=stack,
+                )
+            )
+            continue
+        if directive == ".lib":
+            active_lines.extend(
+                _resolve_library_section(
+                    line=stripped,
+                    source=source,
+                    line_number=line_number,
+                    sources=sources,
+                    state=state,
+                    stack=stack,
+                )
+            )
+            continue
+        if directive in _UNSUPPORTED_RESOLVED_DIRECTIVES:
+            state.diagnostics.append(
+                DeckResolutionDiagnostic(
+                    code="SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+                    directive=directive,
+                    source=source,
+                    line_number=line_number,
+                    message=(
+                        f"{directive} is not supported by the deck source "
+                        "resolver yet"
+                    ),
+                    severity="error",
+                )
+            )
+        active_lines.append(stripped)
+
+    return active_lines, end_line_number is not None, end_line_number
+
+
+def _resolve_include(
+    *,
+    line: str,
+    source: str,
+    line_number: int,
+    sources: Mapping[str, str],
+    state: _DeckResolutionState,
+    stack: tuple[str, ...],
+) -> list[str]:
+    tokens = _directive_tokens(line)
+    target = _unquote_token(tokens[1]) if len(tokens) >= 2 else None
+    if not target:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_INCLUDE_ARGUMENT",
+            directive=".include",
+            source=source,
+            line_number=line_number,
+            message=".include requires a source path",
+        )
+        return []
+    if target in stack:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_INCLUDE_CYCLE",
+            directive=".include",
+            source=source,
+            line_number=line_number,
+            message=f".include cycle detected for {target}",
+            target=target,
+        )
+        return []
+    content = sources.get(target)
+    if content is None:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_INCLUDE_NOT_FOUND",
+            directive=".include",
+            source=source,
+            line_number=line_number,
+            message=f".include source {target!r} was not provided",
+            target=target,
+        )
+        return []
+
+    state.included_paths.append(target)
+    resolved, _, _ = _resolve_deck_lines(
+        netlist=content,
+        source=target,
+        sources=sources,
+        state=state,
+        stack=(*stack, target),
+    )
+    return resolved
+
+
+def _resolve_library_section(
+    *,
+    line: str,
+    source: str,
+    line_number: int,
+    sources: Mapping[str, str],
+    state: _DeckResolutionState,
+    stack: tuple[str, ...],
+) -> list[str]:
+    tokens = _directive_tokens(line)
+    path = _unquote_token(tokens[1]) if len(tokens) >= 2 else None
+    section = _unquote_token(tokens[2]) if len(tokens) >= 3 else None
+    if not path or not section:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_LIB_ARGUMENT",
+            directive=".lib",
+            source=source,
+            line_number=line_number,
+            message=".lib requires a source path and section name",
+            target=path,
+        )
+        return []
+    content = sources.get(path)
+    target = f"{path}:{section}"
+    if content is None:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_LIB_NOT_FOUND",
+            directive=".lib",
+            source=source,
+            line_number=line_number,
+            message=f".lib source {path!r} was not provided",
+            target=target,
+        )
+        return []
+    if target in stack:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_LIB_CYCLE",
+            directive=".lib",
+            source=source,
+            line_number=line_number,
+            message=f".lib cycle detected for {target}",
+            target=target,
+        )
+        return []
+
+    section_lines = _extract_library_section(
+        content=content,
+        path=path,
+        section=section,
+        call_source=source,
+        call_line_number=line_number,
+        state=state,
+    )
+    if section_lines is None:
+        return []
+
+    state.library_sections.append(target)
+    resolved, _, _ = _resolve_deck_lines(
+        netlist="\n".join(section_lines),
+        source=target,
+        sources=sources,
+        state=state,
+        stack=(*stack, target),
+    )
+    return resolved
+
+
+def _extract_library_section(
+    *,
+    content: str,
+    path: str,
+    section: str,
+    call_source: str,
+    call_line_number: int,
+    state: _DeckResolutionState,
+) -> list[str] | None:
+    in_section = False
+    section_start_line: int | None = None
+    section_lines: list[str] = []
+    wanted = section.lower()
+    target = f"{path}:{section}"
+
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith(("*", ";")):
+            if in_section:
+                section_lines.append(raw_line)
+            continue
+        directive = _deck_directive(stripped)
+        tokens = _directive_tokens(stripped)
+        if not in_section:
+            if (
+                directive == ".lib"
+                and len(tokens) >= 2
+                and _unquote_token(tokens[1]).lower() == wanted
+            ):
+                in_section = True
+                section_start_line = line_number
+            continue
+        if directive in {".endl", ".endlib"}:
+            return section_lines
+        section_lines.append(raw_line)
+
+    if not in_section:
+        _add_resolution_diagnostic(
+            state,
+            code="SPICE_DECK_LIB_SECTION_NOT_FOUND",
+            directive=".lib",
+            source=call_source,
+            line_number=call_line_number,
+            message=f".lib section {section!r} was not found in {path!r}",
+            target=target,
+        )
+        return None
+
+    _add_resolution_diagnostic(
+        state,
+        code="SPICE_DECK_LIB_SECTION_UNTERMINATED",
+        directive=".lib",
+        source=path,
+        line_number=section_start_line or 1,
+        message=f".lib section {section!r} in {path!r} is missing .endl",
+        target=target,
+    )
+    return None
+
+
+def _add_resolution_diagnostic(
+    state: _DeckResolutionState,
+    *,
+    code: str,
+    directive: str,
+    source: str,
+    line_number: int,
+    message: str,
+    target: str | None = None,
+) -> None:
+    state.diagnostics.append(
+        DeckResolutionDiagnostic(
+            code=code,
+            directive=directive,
+            source=source,
+            line_number=line_number,
+            message=message,
+            severity="error",
+            target=target,
+        )
+    )
+
+
+def _directive_tokens(line: str) -> list[str]:
+    return line.split()
+
+
+def _unquote_token(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
 
 
 def _deck_directive(line: str) -> str | None:

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -7,6 +7,7 @@ from spice_engine import (
     format_compatibility_corpus_table,
     format_release_readiness_report,
     release_readiness_gates,
+    resolve_deck_sources,
 )
 
 
@@ -117,3 +118,76 @@ run
         (".control", 4, "error"),
     ]
     assert all(diag.code == "SPICE_DECK_UNSUPPORTED_DIRECTIVE" for diag in summary.diagnostics)
+
+
+def test_resolve_deck_sources_expands_include_and_library_section() -> None:
+    summary = resolve_deck_sources(
+        """
+V1 in 0 DC 1
+.include models.inc
+.lib vendor.lib TT
+.op
+.end
+Rafter out 0 1
+""",
+        {
+            "models.inc": """
+* model include
+.model D1 D
+Rshim in mid 10
+""",
+            "vendor.lib": """
+.lib FF
+Rfast out 0 1
+.endl FF
+.lib TT
+Rtyp mid out 20
+Ctyp out 0 1u
+.endl TT
+""",
+        },
+    )
+
+    assert summary.terminated is True
+    assert summary.end_line_number == 6
+    assert summary.active_lines == (
+        "V1 in 0 DC 1",
+        ".model D1 D",
+        "Rshim in mid 10",
+        "Rtyp mid out 20",
+        "Ctyp out 0 1u",
+        ".op",
+    )
+    assert summary.included_paths == ("models.inc",)
+    assert summary.library_sections == ("vendor.lib:TT",)
+    assert summary.diagnostics == ()
+
+
+def test_resolve_deck_sources_reports_missing_sources_and_cycles() -> None:
+    summary = resolve_deck_sources(
+        """
+.include missing.inc
+.include a.inc
+.lib vendor.lib SS
+.control
+.end
+""",
+        {
+            "a.inc": ".include b.inc\nR1 a b 1\n",
+            "b.inc": ".include a.inc\nR2 b 0 2\n",
+            "vendor.lib": ".lib TT\nRtyp out 0 20\n.endl TT\n",
+        },
+    )
+
+    assert summary.active_lines == ("R2 b 0 2", "R1 a b 1", ".control")
+    assert [diag.code for diag in summary.diagnostics] == [
+        "SPICE_DECK_INCLUDE_NOT_FOUND",
+        "SPICE_DECK_INCLUDE_CYCLE",
+        "SPICE_DECK_LIB_SECTION_NOT_FOUND",
+        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+    ]
+    assert [(diag.source, diag.line_number, diag.target) for diag in summary.diagnostics[:3]] == [
+        ("<deck>", 2, "missing.inc"),
+        ("b.inc", 1, "a.inc"),
+        ("<deck>", 4, "vendor.lib:SS"),
+    ]

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `resolve_deck_sources` for map-backed `.include` and selected
+  `.lib path section` expansion with stable diagnostics for missing sources,
+  missing or unterminated library sections, cycles, and still-unsupported
+  `.control` blocks, matching Python and TypeScript.
 - Add `analyze_deck_controls` for shared deck-control boundary diagnostics:
   active pre-`.end` lines plus stable unsupported-feature diagnostics for
   `.include`, `.lib`, and `.control`, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -125,3 +125,8 @@ provide stable tab-separated summaries for package checks.
 returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives before future include/library
 resolution and control-block execution are in scope.
+`resolve_deck_sources` is the first include/library resolution layer: callers
+provide a source-content map, `.include` directives are expanded in place, and
+`.lib path section` selects a named `.lib` / `.endl` section with stable
+diagnostics for missing files, missing sections, unterminated sections, cycles,
+and still-unsupported `.control` blocks.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3154,6 +3154,27 @@ pub struct DeckControlSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckResolutionDiagnostic {
+    pub code: String,
+    pub directive: String,
+    pub source: String,
+    pub line_number: usize,
+    pub message: String,
+    pub severity: String,
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckResolutionSummary {
+    pub active_lines: Vec<String>,
+    pub terminated: bool,
+    pub end_line_number: Option<usize>,
+    pub diagnostics: Vec<DeckResolutionDiagnostic>,
+    pub included_paths: Vec<String>,
+    pub library_sections: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseReadinessIssue {
     pub deck_id: String,
     pub field: String,
@@ -3313,6 +3334,24 @@ pub fn analyze_deck_controls(netlist: &str) -> DeckControlSummary {
         terminated: end_line_number.is_some(),
         end_line_number,
         diagnostics,
+    }
+}
+
+pub fn resolve_deck_sources(
+    netlist: &str,
+    sources: &HashMap<String, String>,
+) -> DeckResolutionSummary {
+    let mut state = DeckResolutionState::new();
+    let (active_lines, terminated, end_line_number) =
+        resolve_deck_lines(netlist, "<deck>", sources, &mut state, &[]);
+
+    DeckResolutionSummary {
+        active_lines,
+        terminated,
+        end_line_number,
+        diagnostics: state.diagnostics,
+        included_paths: state.included_paths,
+        library_sections: state.library_sections,
     }
 }
 
@@ -3532,6 +3571,319 @@ fn validate_compatibility_non_empty(
         field: field.to_string(),
         message: "field must be documented and non-empty".to_string(),
     });
+}
+
+struct DeckResolutionState {
+    diagnostics: Vec<DeckResolutionDiagnostic>,
+    included_paths: Vec<String>,
+    library_sections: Vec<String>,
+}
+
+impl DeckResolutionState {
+    fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            included_paths: Vec::new(),
+            library_sections: Vec::new(),
+        }
+    }
+}
+
+fn resolve_deck_lines(
+    netlist: &str,
+    source: &str,
+    sources: &HashMap<String, String>,
+    state: &mut DeckResolutionState,
+    stack: &[String],
+) -> (Vec<String>, bool, Option<usize>) {
+    let mut active_lines = Vec::new();
+    let mut end_line_number = None;
+
+    for (index, raw_line) in netlist.lines().enumerate() {
+        let line_number = index + 1;
+        let stripped = raw_line.trim();
+        if stripped.is_empty() || stripped.starts_with('*') || stripped.starts_with(';') {
+            continue;
+        }
+        let directive = deck_directive(stripped);
+        if directive.as_deref() == Some(".end") {
+            end_line_number = Some(line_number);
+            break;
+        }
+        if directive.as_deref() == Some(".include") {
+            active_lines.extend(resolve_include_directive(
+                stripped,
+                source,
+                line_number,
+                sources,
+                state,
+                stack,
+            ));
+            continue;
+        }
+        if directive.as_deref() == Some(".lib") {
+            active_lines.extend(resolve_library_directive(
+                stripped,
+                source,
+                line_number,
+                sources,
+                state,
+                stack,
+            ));
+            continue;
+        }
+        if directive.as_deref() == Some(".control") {
+            state.diagnostics.push(DeckResolutionDiagnostic {
+                code: "SPICE_DECK_UNSUPPORTED_DIRECTIVE".to_string(),
+                directive: ".control".to_string(),
+                source: source.to_string(),
+                line_number,
+                message: ".control is not supported by the deck source resolver yet".to_string(),
+                severity: "error".to_string(),
+                target: None,
+            });
+        }
+        active_lines.push(stripped.to_string());
+    }
+
+    (active_lines, end_line_number.is_some(), end_line_number)
+}
+
+fn resolve_include_directive(
+    line: &str,
+    source: &str,
+    line_number: usize,
+    sources: &HashMap<String, String>,
+    state: &mut DeckResolutionState,
+    stack: &[String],
+) -> Vec<String> {
+    let tokens = directive_tokens(line);
+    let target = tokens.get(1).map(|token| unquote_token(token));
+    let Some(target) = target.filter(|target| !target.is_empty()) else {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_INCLUDE_ARGUMENT",
+            ".include",
+            source,
+            line_number,
+            ".include requires a source path",
+            None,
+        );
+        return Vec::new();
+    };
+    if stack.contains(&target) {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_INCLUDE_CYCLE",
+            ".include",
+            source,
+            line_number,
+            &format!(".include cycle detected for {target}"),
+            Some(target),
+        );
+        return Vec::new();
+    }
+    let Some(content) = sources.get(&target) else {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_INCLUDE_NOT_FOUND",
+            ".include",
+            source,
+            line_number,
+            &format!(".include source {target:?} was not provided"),
+            Some(target),
+        );
+        return Vec::new();
+    };
+
+    state.included_paths.push(target.clone());
+    let mut next_stack = stack.to_vec();
+    next_stack.push(target.clone());
+    let (resolved, _, _) = resolve_deck_lines(content, &target, sources, state, &next_stack);
+    resolved
+}
+
+fn resolve_library_directive(
+    line: &str,
+    source: &str,
+    line_number: usize,
+    sources: &HashMap<String, String>,
+    state: &mut DeckResolutionState,
+    stack: &[String],
+) -> Vec<String> {
+    let tokens = directive_tokens(line);
+    let path = tokens.get(1).map(|token| unquote_token(token));
+    let section = tokens.get(2).map(|token| unquote_token(token));
+    let (Some(path), Some(section)) = (path, section) else {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_LIB_ARGUMENT",
+            ".lib",
+            source,
+            line_number,
+            ".lib requires a source path and section name",
+            None,
+        );
+        return Vec::new();
+    };
+    if path.is_empty() || section.is_empty() {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_LIB_ARGUMENT",
+            ".lib",
+            source,
+            line_number,
+            ".lib requires a source path and section name",
+            Some(path),
+        );
+        return Vec::new();
+    }
+
+    let target = format!("{path}:{section}");
+    let Some(content) = sources.get(&path) else {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_LIB_NOT_FOUND",
+            ".lib",
+            source,
+            line_number,
+            &format!(".lib source {path:?} was not provided"),
+            Some(target),
+        );
+        return Vec::new();
+    };
+    if stack.contains(&target) {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_LIB_CYCLE",
+            ".lib",
+            source,
+            line_number,
+            &format!(".lib cycle detected for {target}"),
+            Some(target),
+        );
+        return Vec::new();
+    }
+
+    let Some(section_lines) =
+        extract_library_section(content, &path, &section, source, line_number, state)
+    else {
+        return Vec::new();
+    };
+    state.library_sections.push(target.clone());
+    let mut next_stack = stack.to_vec();
+    next_stack.push(target.clone());
+    let (resolved, _, _) = resolve_deck_lines(
+        &section_lines.join("\n"),
+        &target,
+        sources,
+        state,
+        &next_stack,
+    );
+    resolved
+}
+
+fn extract_library_section(
+    content: &str,
+    path: &str,
+    section: &str,
+    call_source: &str,
+    call_line_number: usize,
+    state: &mut DeckResolutionState,
+) -> Option<Vec<String>> {
+    let mut in_section = false;
+    let mut section_start_line = None;
+    let mut section_lines = Vec::new();
+    let wanted = section.to_ascii_lowercase();
+    let target = format!("{path}:{section}");
+
+    for (index, raw_line) in content.lines().enumerate() {
+        let line_number = index + 1;
+        let stripped = raw_line.trim();
+        if stripped.is_empty() || stripped.starts_with('*') || stripped.starts_with(';') {
+            if in_section {
+                section_lines.push(raw_line.to_string());
+            }
+            continue;
+        }
+        let directive = deck_directive(stripped);
+        let tokens = directive_tokens(stripped);
+        if !in_section {
+            if directive.as_deref() == Some(".lib")
+                && tokens
+                    .get(1)
+                    .map(|token| unquote_token(token).to_ascii_lowercase() == wanted)
+                    .unwrap_or(false)
+            {
+                in_section = true;
+                section_start_line = Some(line_number);
+            }
+            continue;
+        }
+        if matches!(directive.as_deref(), Some(".endl" | ".endlib")) {
+            return Some(section_lines);
+        }
+        section_lines.push(raw_line.to_string());
+    }
+
+    if !in_section {
+        add_resolution_diagnostic(
+            state,
+            "SPICE_DECK_LIB_SECTION_NOT_FOUND",
+            ".lib",
+            call_source,
+            call_line_number,
+            &format!(".lib section {section:?} was not found in {path:?}"),
+            Some(target),
+        );
+        return None;
+    }
+
+    add_resolution_diagnostic(
+        state,
+        "SPICE_DECK_LIB_SECTION_UNTERMINATED",
+        ".lib",
+        path,
+        section_start_line.unwrap_or(1),
+        &format!(".lib section {section:?} in {path:?} is missing .endl"),
+        Some(target),
+    );
+    None
+}
+
+fn add_resolution_diagnostic(
+    state: &mut DeckResolutionState,
+    code: &str,
+    directive: &str,
+    source: &str,
+    line_number: usize,
+    message: &str,
+    target: Option<String>,
+) {
+    state.diagnostics.push(DeckResolutionDiagnostic {
+        code: code.to_string(),
+        directive: directive.to_string(),
+        source: source.to_string(),
+        line_number,
+        message: message.to_string(),
+        severity: "error".to_string(),
+        target,
+    });
+}
+
+fn directive_tokens(line: &str) -> Vec<&str> {
+    line.split_whitespace().collect()
+}
+
+fn unquote_token(token: &str) -> String {
+    if token.len() >= 2 {
+        let first = token.as_bytes()[0] as char;
+        let last = token.as_bytes()[token.len() - 1] as char;
+        if first == last && (first == '"' || first == '\'') {
+            return token[1..token.len() - 1].to_string();
+        }
+    }
+    token.to_string()
 }
 
 fn deck_directive(line: &str) -> Option<String> {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use spice_engine::{
     analyze_deck_controls, compatibility_corpus, format_compatibility_corpus_table,
-    format_release_readiness_report, release_readiness_gates, CompatibilityDeck,
-    CompatibilityGoldenValue, CompatibilityOracle,
+    format_release_readiness_report, release_readiness_gates, resolve_deck_sources,
+    CompatibilityDeck, CompatibilityGoldenValue, CompatibilityOracle,
 };
 
 #[test]
@@ -161,4 +163,125 @@ run
         .diagnostics
         .iter()
         .all(|diagnostic| diagnostic.code == "SPICE_DECK_UNSUPPORTED_DIRECTIVE"));
+}
+
+#[test]
+fn resolve_deck_sources_expands_include_and_library_section() {
+    let mut sources = HashMap::new();
+    sources.insert(
+        "models.inc".to_string(),
+        "
+* model include
+.model D1 D
+Rshim in mid 10
+"
+        .to_string(),
+    );
+    sources.insert(
+        "vendor.lib".to_string(),
+        "
+.lib FF
+Rfast out 0 1
+.endl FF
+.lib TT
+Rtyp mid out 20
+Ctyp out 0 1u
+.endl TT
+"
+        .to_string(),
+    );
+
+    let summary = resolve_deck_sources(
+        "
+V1 in 0 DC 1
+.include models.inc
+.lib vendor.lib TT
+.op
+.end
+Rafter out 0 1
+",
+        &sources,
+    );
+
+    assert!(summary.terminated);
+    assert_eq!(summary.end_line_number, Some(6));
+    assert_eq!(
+        summary.active_lines,
+        vec![
+            "V1 in 0 DC 1",
+            ".model D1 D",
+            "Rshim in mid 10",
+            "Rtyp mid out 20",
+            "Ctyp out 0 1u",
+            ".op",
+        ]
+    );
+    assert_eq!(summary.included_paths, vec!["models.inc"]);
+    assert_eq!(summary.library_sections, vec!["vendor.lib:TT"]);
+    assert!(summary.diagnostics.is_empty());
+}
+
+#[test]
+fn resolve_deck_sources_reports_missing_sources_and_cycles() {
+    let mut sources = HashMap::new();
+    sources.insert(
+        "a.inc".to_string(),
+        ".include b.inc\nR1 a b 1\n".to_string(),
+    );
+    sources.insert(
+        "b.inc".to_string(),
+        ".include a.inc\nR2 b 0 2\n".to_string(),
+    );
+    sources.insert(
+        "vendor.lib".to_string(),
+        ".lib TT\nRtyp out 0 20\n.endl TT\n".to_string(),
+    );
+
+    let summary = resolve_deck_sources(
+        "
+.include missing.inc
+.include a.inc
+.lib vendor.lib SS
+.control
+.end
+",
+        &sources,
+    );
+
+    assert_eq!(
+        summary.active_lines,
+        vec!["R2 b 0 2", "R1 a b 1", ".control"]
+    );
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "SPICE_DECK_INCLUDE_NOT_FOUND",
+            "SPICE_DECK_INCLUDE_CYCLE",
+            "SPICE_DECK_LIB_SECTION_NOT_FOUND",
+            "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
+        ]
+    );
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .take(3)
+            .map(|diagnostic| {
+                (
+                    diagnostic.source.as_str(),
+                    diagnostic.line_number,
+                    diagnostic.target.as_deref(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("<deck>", 2, Some("missing.inc")),
+            ("b.inc", 1, Some("a.inc")),
+            ("<deck>", 4, Some("vendor.lib:SS")),
+        ]
+    );
 }

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `resolveDeckSources` for map-backed `.include` and selected
+  `.lib path section` expansion with stable diagnostics for missing sources,
+  missing or unterminated library sections, cycles, and still-unsupported
+  `.control` blocks, matching Python and Rust.
 - Add `analyzeDeckControls` for shared deck-control boundary diagnostics:
   active pre-`.end` lines plus stable unsupported-feature diagnostics for
   `.include`, `.lib`, and `.control`, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,3 +91,8 @@ stable tab-separated summaries for package checks.
 returns active lines before `.end` and stable diagnostics for unsupported
 `.include`, `.lib`, and `.control` directives before future include/library
 resolution and control-block execution are in scope.
+`resolveDeckSources` is the first include/library resolution layer: callers
+provide a source-content map, `.include` directives are expanded in place, and
+`.lib path section` selects a named `.lib` / `.endl` section with stable
+diagnostics for missing files, missing sections, unterminated sections, cycles,
+and still-unsupported `.control` blocks.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -420,6 +420,25 @@ export interface DeckControlSummary {
   readonly diagnostics: readonly DeckControlDiagnostic[];
 }
 
+export interface DeckResolutionDiagnostic {
+  readonly code: string;
+  readonly directive: string;
+  readonly source: string;
+  readonly lineNumber: number;
+  readonly message: string;
+  readonly severity: "error" | "warning";
+  readonly target?: string;
+}
+
+export interface DeckResolutionSummary {
+  readonly activeLines: readonly string[];
+  readonly terminated: boolean;
+  readonly endLineNumber?: number;
+  readonly diagnostics: readonly DeckResolutionDiagnostic[];
+  readonly includedPaths: readonly string[];
+  readonly librarySections: readonly string[];
+}
+
 export interface ReleaseReadinessIssue {
   readonly deckId: string;
   readonly field: string;
@@ -2559,6 +2578,7 @@ R2 out 0 10000
 const SUPPORTED_COMPATIBILITY_ANALYSES = new Set(["op", "dc", "ac", "tran", "tf"]);
 const REQUIRED_COMPATIBILITY_ANALYSES = ["op", "dc", "ac", "tran"];
 const UNSUPPORTED_DECK_CONTROL_DIRECTIVES = new Set([".include", ".lib", ".control"]);
+const UNSUPPORTED_RESOLVED_DIRECTIVES = new Set([".control"]);
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2598,6 +2618,27 @@ export function analyzeDeckControls(netlist: string): DeckControlSummary {
     terminated: endLineNumber !== undefined,
     endLineNumber,
     diagnostics,
+  };
+}
+
+export function resolveDeckSources(
+  netlist: string,
+  sources: Readonly<Record<string, string>>,
+): DeckResolutionSummary {
+  const state: DeckResolutionState = {
+    diagnostics: [],
+    includedPaths: [],
+    librarySections: [],
+  };
+  const resolved = resolveDeckLines(netlist, "<deck>", sources, state, []);
+
+  return {
+    activeLines: resolved.activeLines,
+    terminated: resolved.terminated,
+    endLineNumber: resolved.endLineNumber,
+    diagnostics: state.diagnostics,
+    includedPaths: state.includedPaths,
+    librarySections: state.librarySections,
   };
 }
 
@@ -2740,6 +2781,269 @@ export function formatReleaseReadinessReport(report: ReleaseReadinessReport): st
     }
   }
   return lines.join("\n");
+}
+
+interface DeckResolutionState {
+  readonly diagnostics: DeckResolutionDiagnostic[];
+  readonly includedPaths: string[];
+  readonly librarySections: string[];
+}
+
+interface ResolvedDeckLines {
+  readonly activeLines: string[];
+  readonly terminated: boolean;
+  readonly endLineNumber?: number;
+}
+
+function resolveDeckLines(
+  netlist: string,
+  source: string,
+  sources: Readonly<Record<string, string>>,
+  state: DeckResolutionState,
+  stack: readonly string[],
+): ResolvedDeckLines {
+  const activeLines: string[] = [];
+  let endLineNumber: number | undefined;
+
+  const lines = netlist.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const lineNumber = index + 1;
+    const stripped = lines[index].trim();
+    if (stripped.length === 0 || stripped.startsWith("*") || stripped.startsWith(";")) {
+      continue;
+    }
+    const directive = deckDirective(stripped);
+    if (directive === ".end") {
+      endLineNumber = lineNumber;
+      break;
+    }
+    if (directive === ".include") {
+      activeLines.push(
+        ...resolveIncludeDirective(stripped, source, lineNumber, sources, state, stack),
+      );
+      continue;
+    }
+    if (directive === ".lib") {
+      activeLines.push(
+        ...resolveLibraryDirective(stripped, source, lineNumber, sources, state, stack),
+      );
+      continue;
+    }
+    if (directive !== undefined && UNSUPPORTED_RESOLVED_DIRECTIVES.has(directive)) {
+      state.diagnostics.push({
+        code: "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        directive,
+        source,
+        lineNumber,
+        message: `${directive} is not supported by the deck source resolver yet`,
+        severity: "error",
+      });
+    }
+    activeLines.push(stripped);
+  }
+
+  return {
+    activeLines,
+    terminated: endLineNumber !== undefined,
+    endLineNumber,
+  };
+}
+
+function resolveIncludeDirective(
+  line: string,
+  source: string,
+  lineNumber: number,
+  sources: Readonly<Record<string, string>>,
+  state: DeckResolutionState,
+  stack: readonly string[],
+): string[] {
+  const tokens = directiveTokens(line);
+  const target = tokens.length >= 2 ? unquoteToken(tokens[1]) : undefined;
+  if (target === undefined || target.length === 0) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_INCLUDE_ARGUMENT",
+      directive: ".include",
+      source,
+      lineNumber,
+      message: ".include requires a source path",
+    });
+    return [];
+  }
+  if (stack.includes(target)) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_INCLUDE_CYCLE",
+      directive: ".include",
+      source,
+      lineNumber,
+      message: `.include cycle detected for ${target}`,
+      target,
+    });
+    return [];
+  }
+  const content = sources[target];
+  if (content === undefined) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_INCLUDE_NOT_FOUND",
+      directive: ".include",
+      source,
+      lineNumber,
+      message: `.include source ${JSON.stringify(target)} was not provided`,
+      target,
+    });
+    return [];
+  }
+
+  state.includedPaths.push(target);
+  return resolveDeckLines(content, target, sources, state, [...stack, target]).activeLines;
+}
+
+function resolveLibraryDirective(
+  line: string,
+  source: string,
+  lineNumber: number,
+  sources: Readonly<Record<string, string>>,
+  state: DeckResolutionState,
+  stack: readonly string[],
+): string[] {
+  const tokens = directiveTokens(line);
+  const path = tokens.length >= 2 ? unquoteToken(tokens[1]) : undefined;
+  const section = tokens.length >= 3 ? unquoteToken(tokens[2]) : undefined;
+  if (path === undefined || path.length === 0 || section === undefined || section.length === 0) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_LIB_ARGUMENT",
+      directive: ".lib",
+      source,
+      lineNumber,
+      message: ".lib requires a source path and section name",
+      target: path,
+    });
+    return [];
+  }
+
+  const target = `${path}:${section}`;
+  const content = sources[path];
+  if (content === undefined) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_LIB_NOT_FOUND",
+      directive: ".lib",
+      source,
+      lineNumber,
+      message: `.lib source ${JSON.stringify(path)} was not provided`,
+      target,
+    });
+    return [];
+  }
+  if (stack.includes(target)) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_LIB_CYCLE",
+      directive: ".lib",
+      source,
+      lineNumber,
+      message: `.lib cycle detected for ${target}`,
+      target,
+    });
+    return [];
+  }
+
+  const sectionLines = extractLibrarySection(content, path, section, source, lineNumber, state);
+  if (sectionLines === undefined) {
+    return [];
+  }
+
+  state.librarySections.push(target);
+  return resolveDeckLines(sectionLines.join("\n"), target, sources, state, [...stack, target]).activeLines;
+}
+
+function extractLibrarySection(
+  content: string,
+  path: string,
+  section: string,
+  callSource: string,
+  callLineNumber: number,
+  state: DeckResolutionState,
+): string[] | undefined {
+  let inSection = false;
+  let sectionStartLine: number | undefined;
+  const sectionLines: string[] = [];
+  const wanted = section.toLowerCase();
+  const target = `${path}:${section}`;
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index++) {
+    const lineNumber = index + 1;
+    const rawLine = lines[index];
+    const stripped = rawLine.trim();
+    if (stripped.length === 0 || stripped.startsWith("*") || stripped.startsWith(";")) {
+      if (inSection) {
+        sectionLines.push(rawLine);
+      }
+      continue;
+    }
+    const directive = deckDirective(stripped);
+    const tokens = directiveTokens(stripped);
+    if (!inSection) {
+      if (
+        directive === ".lib" &&
+        tokens.length >= 2 &&
+        unquoteToken(tokens[1]).toLowerCase() === wanted
+      ) {
+        inSection = true;
+        sectionStartLine = lineNumber;
+      }
+      continue;
+    }
+    if (directive === ".endl" || directive === ".endlib") {
+      return sectionLines;
+    }
+    sectionLines.push(rawLine);
+  }
+
+  if (!inSection) {
+    addResolutionDiagnostic(state, {
+      code: "SPICE_DECK_LIB_SECTION_NOT_FOUND",
+      directive: ".lib",
+      source: callSource,
+      lineNumber: callLineNumber,
+      message: `.lib section ${JSON.stringify(section)} was not found in ${JSON.stringify(path)}`,
+      target,
+    });
+    return undefined;
+  }
+
+  addResolutionDiagnostic(state, {
+    code: "SPICE_DECK_LIB_SECTION_UNTERMINATED",
+    directive: ".lib",
+    source: path,
+    lineNumber: sectionStartLine ?? 1,
+    message: `.lib section ${JSON.stringify(section)} in ${JSON.stringify(path)} is missing .endl`,
+    target,
+  });
+  return undefined;
+}
+
+function addResolutionDiagnostic(
+  state: DeckResolutionState,
+  diagnostic: Omit<DeckResolutionDiagnostic, "severity"> & { readonly severity?: "error" | "warning" },
+): void {
+  state.diagnostics.push({
+    ...diagnostic,
+    severity: diagnostic.severity ?? "error",
+  });
+}
+
+function directiveTokens(line: string): string[] {
+  return line.split(/\s+/);
+}
+
+function unquoteToken(token: string): string {
+  if (
+    token.length >= 2 &&
+    token[0] === token[token.length - 1] &&
+    (token[0] === "'" || token[0] === '"')
+  ) {
+    return token.slice(1, -1);
+  }
+  return token;
 }
 
 function validateCompatibilityNonEmpty(

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -6,6 +6,7 @@ import {
   formatCompatibilityCorpusTable,
   formatReleaseReadinessReport,
   releaseReadinessGates,
+  resolveDeckSources,
 } from "../src/index.js";
 
 describe("compatibility corpus", () => {
@@ -128,5 +129,76 @@ run
     expect(summary.diagnostics.every((diagnostic) =>
       diagnostic.code === "SPICE_DECK_UNSUPPORTED_DIRECTIVE"
     )).toBe(true);
+  });
+
+  it("expands include files and selected library sections", () => {
+    const summary = resolveDeckSources(`
+V1 in 0 DC 1
+.include models.inc
+.lib vendor.lib TT
+.op
+.end
+Rafter out 0 1
+`, {
+      "models.inc": `
+* model include
+.model D1 D
+Rshim in mid 10
+`,
+      "vendor.lib": `
+.lib FF
+Rfast out 0 1
+.endl FF
+.lib TT
+Rtyp mid out 20
+Ctyp out 0 1u
+.endl TT
+`,
+    });
+
+    expect(summary.terminated).toBe(true);
+    expect(summary.endLineNumber).toBe(6);
+    expect(summary.activeLines).toStrictEqual([
+      "V1 in 0 DC 1",
+      ".model D1 D",
+      "Rshim in mid 10",
+      "Rtyp mid out 20",
+      "Ctyp out 0 1u",
+      ".op",
+    ]);
+    expect(summary.includedPaths).toStrictEqual(["models.inc"]);
+    expect(summary.librarySections).toStrictEqual(["vendor.lib:TT"]);
+    expect(summary.diagnostics).toStrictEqual([]);
+  });
+
+  it("reports missing include and library sources plus include cycles", () => {
+    const summary = resolveDeckSources(`
+.include missing.inc
+.include a.inc
+.lib vendor.lib SS
+.control
+.end
+`, {
+      "a.inc": ".include b.inc\nR1 a b 1\n",
+      "b.inc": ".include a.inc\nR2 b 0 2\n",
+      "vendor.lib": ".lib TT\nRtyp out 0 20\n.endl TT\n",
+    });
+
+    expect(summary.activeLines).toStrictEqual(["R2 b 0 2", "R1 a b 1", ".control"]);
+    expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
+      "SPICE_DECK_INCLUDE_NOT_FOUND",
+      "SPICE_DECK_INCLUDE_CYCLE",
+      "SPICE_DECK_LIB_SECTION_NOT_FOUND",
+      "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+    ]);
+    expect(summary.diagnostics.slice(0, 3).map(({ source, lineNumber, target }) => [
+      source,
+      lineNumber,
+      target,
+    ])).toStrictEqual([
+      ["<deck>", 2, "missing.inc"],
+      ["b.inc", 1, "a.inc"],
+      ["<deck>", 4, "vendor.lib:SS"],
+    ]);
   });
 });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -19,9 +19,9 @@ downstream tools to compare.
    - Status: next.
    - Convert parsed netlists into runnable analysis plans beyond the initial
      `.op`, `.dc`, `.ac`, and `.tran` subset.
-   - Support `.include` and `.lib` resolution, `.param`, `.func`, expressions,
-     `.ic`, and `.nodeset`; `.end` boundary detection now has a shared
-     diagnostic foothold.
+   - Support `.param`, `.func`, expressions, `.ic`, and `.nodeset`; `.end`
+     boundary detection and map-backed `.include` / `.lib` source resolution
+     now have shared diagnostic footholds.
    - Expand `.measure`, `.save`, and `.probe` execution toward full SPICE
      compatibility while keeping unsupported control-flow diagnostics explicit.
 
@@ -158,12 +158,22 @@ downstream tools to compare.
       parser/planner foothold before include/library resolution and control
       block execution are implemented.
 
+15. Include/library source resolution.
+    - Status: completed in this include/library resolution slice.
+    - Python, Rust, and TypeScript now expose matching map-backed deck source
+      resolvers that expand `.include` files into active deck lines before
+      `.end`.
+    - The resolvers also support selected `.lib path section` expansion from
+      named `.lib` / `.endl` library sections.
+    - Stable diagnostics cover missing include files, missing library files,
+      absent or unterminated sections, include/library cycles, and
+      still-unsupported `.control` directives.
+
 ## Backlog
 
 1. Deck execution layer.
    - Convert parsed netlists into runnable analysis plans.
-   - Support `.include` and `.lib` resolution, `.param`, `.func`, expressions,
-     `.ic`, and `.nodeset`.
+   - Support `.param`, `.func`, expressions, `.ic`, and `.nodeset`.
    - Expand the initial `.measure`, `.save`, and `.probe` support toward full
      SPICE compatibility, including additional measure modes and richer output
      formats.


### PR DESCRIPTION
## Summary
- add map-backed deck source resolution across Python, Rust, and TypeScript
- expand `.include` files and selected `.lib path section` library sections before `.end`
- add stable diagnostics for missing sources, missing or unterminated library sections, cycles, and still-unsupported `.control` blocks
- update SPICE package docs, changelogs, and the full implementation plan

## Verification
- `ruff check code/packages/python/spice-engine/src code/packages/python/spice-engine/tests`
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src python -m pytest code/packages/python/spice-engine/tests`
- `cargo fmt --check --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm run build` in `code/packages/typescript/spice-engine`
- `npm test` in `code/packages/typescript/spice-engine`
- `git diff --check`