### PR TITLE
feat(closurec): CLOC12.94 — close gap-088 (empty-statement elimination)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.98.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-088** — EMPTY-STATEMENT (`;`) elimination under
+  WHITESPACE_ONLY, matching upstream Closure:
+
+      ;;var x=1;          -> var x=1;
+      var x=1;;;          -> var x=1;
+      var a=1;;var b=2;   -> var a=1;var b=2;
+      ;;;                 -> (empty)
+      ;x();               -> x();
+      function f(){;;x();} -> function f(){x()};
+
+  A new FIRST pre-pass drops a `;` whose immediate predecessor is `{`,
+  `;`, or start-of-input — exactly the statement-list positions with no
+  statement before them. `minify_empty_stmt` is now enforced.
+
+  Every other `;` is preserved automatically: a real terminator (`a;` —
+  predecessor is a value) or a control-flow BODY (`while(a);`,
+  `if(a);`, `for(;;);`, `do;while(a);` — predecessor `)`/`do`, not in
+  the droppable set). The one hazard — the second separator in a
+  `for(;;)` header (preceded by the first `;`) — is handled by a
+  bracket stack that marks `for(` parens (detected via the preceding
+  `for` keyword, excluding a `.for(` property call) and refuses to drop
+  a `;` inside a for-header.
+
 ## [0.97.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.97.0"
+version = "0.98.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -184,6 +184,74 @@ pub fn whitespace_only_minify(
         .filter(|t| !is_eof(t))
         .collect();
 
+    // gap-088: EMPTY-STATEMENT elimination. Upstream Closure drops a
+    // `;` that is an EmptyStatement — a `;` in statement-list position
+    // with no statement before it:
+    //   `;;var x=1;`            -> `var x=1;`   (leading)
+    //   `var x=1;;;`            -> `var x=1;`   (trailing — the first
+    //                                          `;` is the real
+    //                                          terminator; the rest are
+    //                                          empty statements)
+    //   `var a=1;;var b=2;`     -> `var a=1;var b=2;`  (between)
+    //   `;;;`                   -> ``           (all empty)
+    //   `function f(){;;x();}`  -> `function f(){x()}`
+    //
+    // A `;` is an empty statement (droppable) exactly when the token
+    // BEFORE it is a `{` (start of a block / program body), another
+    // `;` (a preceding empty statement or terminator), OR nothing (the
+    // `;` is the very first token). In every other position the `;`
+    // either terminates a real statement (`a;` — preceded by a value)
+    // or is the BODY of a control-flow header (`while(a);`, `if(a);`,
+    // `for(;;);`, `do;while(a)` — preceded by `)`/`do`/`else`), and
+    // MUST be kept.
+    //
+    // The ONE hazard is the `for( … )` header, whose `;` SEPARATORS are
+    // not statements: in `for(;;)` the second `;` IS preceded by the
+    // first `;` and would otherwise look droppable. So we track a
+    // bracket stack and refuse to drop a `;` whose innermost enclosing
+    // bracket is a `for(` paren. (`for`'s `(` is detected by the
+    // preceding `for` keyword, excluding a `.for(`/`?.for(` property
+    // call.) Every other `;` inside a `for(...)` header is preceded by
+    // a value and already non-droppable.
+    {
+        // Stack of open brackets; the bool is `true` only for a
+        // `for( … )` header paren.
+        let mut stack: Vec<bool> = Vec::new();
+        let mut drops: Vec<usize> = Vec::new();
+        for i in 0..kept.len() {
+            let t = kept[i];
+            if is_structural_punct(t, ";") {
+                let droppable_pos = i == 0
+                    || is_structural_punct(kept[i - 1], "{")
+                    || is_structural_punct(kept[i - 1], ";");
+                let in_for_header = matches!(stack.last(), Some(true));
+                if droppable_pos && !in_for_header {
+                    drops.push(i);
+                }
+            } else if is_structural_punct(t, "(") {
+                // for-header `(` iff directly preceded by the `for`
+                // keyword (and that `for` is not a `.for` property).
+                let is_for = i > 0
+                    && is_word_like(kept[i - 1])
+                    && kept[i - 1].value == "for"
+                    && !(i >= 2
+                        && (is_structural_punct(kept[i - 2], ".")
+                            || is_structural_punct(kept[i - 2], "?.")));
+                stack.push(is_for);
+            } else if is_structural_punct(t, "[") || is_structural_punct(t, "{") {
+                stack.push(false);
+            } else if is_structural_punct(t, ")")
+                || is_structural_punct(t, "]")
+                || is_structural_punct(t, "}")
+            {
+                stack.pop();
+            }
+        }
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // gap-051: IIFE paren normalisation. Upstream Closure
     // rewrites `(function(){...}())` to `(function(){...})()`
     // — the call's `()` moves OUTSIDE the wrapping parens.
@@ -5597,6 +5665,53 @@ mod tests {
     #[test]
     fn gap081_optional_chain_not_ternary() {
         assert_eq!(minify("var x=(a)?.b;"), "var x=(a)?.b;");
+    }
+
+    // ---- gap-088: empty-statement elimination -----------------
+
+    /// gap-088: a `;` whose predecessor is `{`, `;`, or start-of-input
+    /// is an EmptyStatement and is dropped. Leading, trailing, between,
+    /// sole, and block-internal empties all go; the first `;` after a
+    /// real statement is its terminator and stays.
+    #[test]
+    fn gap088_empty_statements_dropped() {
+        assert_eq!(minify(";;var x=1;"), "var x=1;");
+        assert_eq!(minify("var x=1;;;"), "var x=1;");
+        assert_eq!(minify("var a=1;;var b=2;"), "var a=1;var b=2;");
+        assert_eq!(minify(";;;"), "");
+        assert_eq!(minify(";"), "");
+        assert_eq!(minify(";x();"), "x();");
+        assert_eq!(minify("a;;b;"), "a;b;");
+        assert_eq!(minify("function f(){;;x();}"), "function f(){x()};");
+    }
+
+    /// gap-088 SAFETY — a `;` that is the BODY of a control-flow header
+    /// is NOT an empty statement and must be kept: `while(a);`,
+    /// `if(a);`, `for(;;);`, `do;while(a);`. Each such `;` follows a
+    /// `)`/`do`, never a `{`/`;`/start, so the predecessor test already
+    /// excludes it.
+    #[test]
+    fn gap088_control_flow_body_semicolon_kept() {
+        assert_eq!(minify("while(a);"), "while(a);");
+        assert_eq!(minify("if(a);"), "if(a);");
+        assert_eq!(minify("for(;;);"), "for(;;);");
+        assert_eq!(minify("do;while(a);"), "do;while(a);");
+    }
+
+    /// gap-088 SAFETY — the `for( … )` header separators must survive.
+    /// In `for(;;)` the SECOND `;` is preceded by the first `;`, so the
+    /// predecessor test alone would drop it; the bracket-stack for-guard
+    /// keeps it. A genuine `for` loop is distinguished from a `.for(`
+    /// property call (`a.for(b)` is untouched and never mistaken for a
+    /// for-header).
+    #[test]
+    fn gap088_for_header_separators_kept() {
+        assert_eq!(minify("for(;;)x();"), "for(;;)x();");
+        assert_eq!(
+            minify("for(var i=0;i<3;i++)x();"),
+            "for(var i=0;i<3;i++)x();"
+        );
+        assert_eq!(minify("a.for(b);"), "a.for(b);");
     }
 
     // ---- gap-086: call-argument paren elision -----------------

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.97.0
+Version: 0.98.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -128,10 +128,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // needed (the brackets delimit a single-expression context); array-
     // literal element parens (`[(a,b)]` must keep) are the gap-086
     // comma-guarded family. `minify_index_paren` enforced.
-    // gap-088 (CLOC14.39): EMPTY-STATEMENT (`;`) elimination —
-    // `;;var x=1;;;` → `var x=1;`, `;;;` → ``, `function f(){;;x();}` →
-    // `function f(){x()}`. closurec currently keeps stray semicolons.
-    ("empty_stmt", "gap-088: empty-statement elimination"),
+    // gap-088 RESOLVED in CLOC12.94 — EMPTY-STATEMENT (`;`) elimination
+    // (`;;var x=1;;;` → `var x=1;`, `;;;` → ``, `function f(){;;x();}` →
+    // `function f(){x()}`) now drops a `;` whose predecessor is
+    // `{`/`;`/start-of-input, except inside a `for(...)` header.
+    // `minify_empty_stmt` enforced.
     // gap-089 (CLOC14.39): empty `new` call-paren drop when the callee
     // is a MEMBER expression — `new a.b()` → `new a.b`. gap-050 dropped
     // `new A()` → `new A` for a bare identifier callee; the member-

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -667,9 +667,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-088 — empty-statement elimination (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.39). `minify_empty_stmt` ignored.
+- **Status:** RESOLVED in CLOC12.94. `minify_empty_stmt` enforced.
 - **Input:** `;;var x=1;;;` → **Upstream:** `var x=1;` (also `;;;` → `` empty, `var a=1;;var b=2;` → `var a=1;var b=2;`, `function f(){;;x();;}` → `function f(){x()}`).
 - **What it needs:** drop EMPTY statements — a `;` token that is not the terminator of a real statement (i.e. a `;` immediately following `{`, another `;`, or the start of input, and likewise a trailing run before `}`/EOF). Upstream removes all stray semicolons at statement position. closurec's re-stitcher currently preserves every `;`. Care: a `;` that is the `for(;;)` header separator or a real statement terminator must be kept — the drop only targets semicolons in *statement-list* position with no statement before them.
+- **CLOC12.94 resolution:** Added a FIRST pre-pass (runs on the freshly-built `kept` token list, before every other pass) that drops a `;` whose immediate predecessor is `{`, `;`, or start-of-input — exactly the statement-list positions with no statement before them. Every other `;` is either a real terminator (predecessor is a value) or a control-flow BODY (`while(a);`, `if(a);`, `for(;;);`, `do;while(a);` — predecessor `)`/`do`, not in the droppable set), so those are kept automatically. The single hazard is the `for( … )` header, whose SECOND separator in `for(;;)` is preceded by the first `;`; a bracket stack marks `for(` parens (detected via the preceding `for` keyword, excluding a `.for(` property call) and refuses to drop a `;` whose innermost enclosing bracket is a for-header. JAR-verified across leading/trailing/between/sole/block-internal empties and every must-keep form (`for(;;)x();`, `for(var i=0;i<3;i++)`, `for(;;);`, `while/if/do` bodies, `a.for(b)`, `for(;;){;}` → `for(;;);`). 3 unit tests (drop / control-flow-body-kept / for-header-kept) + the byte-identity fixture.
 
 ### gap-089 — new member-callee empty-paren drop (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## CLOC12.94 — close gap-088 (empty-statement elimination)

Upstream Closure drops `EmptyStatement` `;` tokens even under `WHITESPACE_ONLY`. closurec kept every stray semicolon.

```
;;var x=1;          → var x=1;
var x=1;;;          → var x=1;
var a=1;;var b=2;   → var a=1;var b=2;
;;;                 → (empty)
function f(){;;x();} → function f(){x()};
```

### Implementation
New **first** pre-pass: drops a `;` whose immediate predecessor is `{`, `;`, or start-of-input — exactly the statement-list positions with no statement before them. `minify_empty_stmt` enforced.

Everything else is preserved automatically: real terminators (`a;`) and **control-flow bodies** (`while(a);`, `if(a);`, `for(;;);`, `do;while(a);` — predecessor `)`/`do`, not droppable).

**The one hazard** — the second separator in a `for(;;)` header (preceded by the first `;`) — is handled by a bracket stack that marks `for(` parens (via the preceding `for` keyword, excluding a `.for(` property call) and refuses to drop a `;` inside a for-header. `for(;;){;}`→`for(;;);`; `a.for(b)` is never mistaken for a for-loop.

### Tests
- +3 `gap088_*` unit tests (drop / control-flow-body-kept / for-header-kept)
- Byte-identity fixture `minify_empty_stmt` enforced
- Full `cargo test` green (523 lib + walk-test); v0.97.0 → 0.98.0; spec RESOLVED; CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)