### PR TITLE
Add smart-home activation response tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -100,6 +100,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation escalation cases:
   `smart_home.list_integration_activation_escalations` and
   `smart_home.get_integration_activation_escalation_summary`.
+- Added D18D handlers for D23A activation response planning:
+  `smart_home.list_integration_activation_responses` and
+  `smart_home.get_integration_activation_response_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -68,6 +68,7 @@ Chief of Staff job/session/agent
   -> activation-sentinel list and summary reads for compact alert rollups
   -> activation-audit list and summary reads for source-linked audit trails
   -> activation-escalation list and summary reads for Chief-facing cases
+  -> activation-response list and summary reads for owner-lane next actions
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -155,6 +156,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_audit_summary`
 - `smart_home.list_integration_activation_escalations`
 - `smart_home.get_integration_activation_escalation_summary`
+- `smart_home.list_integration_activation_responses`
+- `smart_home.get_integration_activation_response_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -47,9 +47,10 @@ use smart_home_integration_catalog::{
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
     activation_plan_for_entry, activation_plans_at_or_before_priority,
     activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runbook_entries_from_playbook_steps, activation_runway_from_candidates,
-    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
+    activation_response_items_from_escalation_cases, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
+    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
+    activation_timeline_milestones_from_dashboard_cards,
     activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
@@ -93,6 +94,8 @@ use smart_home_integration_catalog::{
     IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
+    IntegrationActivationResponseItem, IntegrationActivationResponseKind,
+    IntegrationActivationResponseOwnerLane, IntegrationActivationResponseSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
     IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunbookEntry, IntegrationActivationRunbookPhase,
@@ -327,6 +330,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ESCALATIONS_TOOL_ID: &str =
     "smart_home.list_integration_activation_escalations";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_escalation_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID: &str =
+    "smart_home.list_integration_activation_responses";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_response_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -737,6 +744,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_escalation_query(&arguments)?;
                     Ok(get_integration_activation_escalation_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID => {
+                    let query = integration_activation_response_query(&arguments)?;
+                    Ok(list_integration_activation_responses_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_response_query(&arguments)?;
+                    Ok(get_integration_activation_response_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2405,6 +2422,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation escalation summary",
             "Return compact D23A activation escalation counts by blocker, dependency, policy risk, review, verification, and audit case.",
             integration_activation_escalation_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID,
+            "List smart-home integration activation responses",
+            "List Chief-facing D23A activation response items derived from escalation cases with owner lanes and next actions.",
+            integration_activation_response_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_responses", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_responses",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation response summary",
+            "Return compact D23A activation response counts by owner lane, next action, blocker, dependency, policy, review, verification, and audit follow-up work.",
+            integration_activation_response_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5235,6 +5286,17 @@ struct IntegrationActivationEscalationQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationResponseQuery {
+    escalation: IntegrationActivationEscalationQuery,
+    response_kind: Option<IntegrationActivationResponseKind>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    ready_to_verify: Option<bool>,
+    response_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5862,6 +5924,29 @@ fn integration_activation_escalation_query(
         escalation_limit: optional_u64(arguments, "escalation_limit")?
             .or(optional_u64(arguments, "case_limit")?)
             .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_response_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationResponseQuery, ToolCallError> {
+    let response_kind = optional_string(arguments, "response_kind")?
+        .or(optional_string(arguments, "response")?)
+        .map(|label| parse_activation_response_kind(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "owner_lane")?
+        .or(optional_string(arguments, "response_owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationResponseQuery {
+        escalation: integration_activation_escalation_query(arguments)?,
+        response_kind,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "response_requires_attention")?,
+        blocked: optional_bool(arguments, "response_blocked")?,
+        ready_to_verify: optional_bool(arguments, "response_ready_to_verify")?,
+        response_limit: optional_u64(arguments, "response_limit")?.map(|value| value as usize),
     })
 }
 
@@ -6909,6 +6994,35 @@ fn integration_activation_escalation_cases_for_query(
     }
 
     (cases, catalog_count)
+}
+
+fn integration_activation_response_items_for_query(
+    query: &IntegrationActivationResponseQuery,
+) -> (Vec<IntegrationActivationResponseItem>, usize) {
+    let (cases, catalog_count) =
+        integration_activation_escalation_cases_for_query(&query.escalation);
+    let mut responses = activation_response_items_from_escalation_cases(&cases);
+
+    if let Some(response_kind) = query.response_kind {
+        responses.retain(|response| response.response_kind == response_kind);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        responses.retain(|response| response.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        responses.retain(|response| response.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        responses.retain(|response| response.blocked() == blocked);
+    }
+    if let Some(ready_to_verify) = query.ready_to_verify {
+        responses.retain(|response| response.ready_to_verify() == ready_to_verify);
+    }
+    if let Some(limit) = query.response_limit {
+        responses.truncate(limit);
+    }
+
+    (responses, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -9442,6 +9556,92 @@ fn get_integration_activation_escalation_summary_output_handler_output(
             (
                 "cases_ready_to_verify",
                 integer(summary.cases_ready_to_verify as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_responses_output_handler_output(
+    query: IntegrationActivationResponseQuery,
+) -> ToolHandlerOutput {
+    let (responses, catalog_count) = integration_activation_response_items_for_query(&query);
+    let summary = IntegrationActivationResponseSummary::from_responses(responses.iter());
+    let count = responses.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_responses",
+            JsonValue::Array(
+                responses
+                    .iter()
+                    .map(activation_response_item_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_response_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_responses")),
+            ("responses", integer(count as i64)),
+            (
+                "responses_requiring_attention",
+                integer(summary.responses_requiring_attention as i64),
+            ),
+            (
+                "blocked_responses",
+                integer(summary.blocked_responses as i64),
+            ),
+            (
+                "responses_ready_to_verify",
+                integer(summary.responses_ready_to_verify as i64),
+            ),
+            (
+                "next_response_kind",
+                summary
+                    .next_response_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_response_summary_output_handler_output(
+    query: IntegrationActivationResponseQuery,
+) -> ToolHandlerOutput {
+    let (responses, _) = integration_activation_response_items_for_query(&query);
+    let summary = IntegrationActivationResponseSummary::from_responses(responses.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_response_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_response_summary"),
+            ),
+            ("total_responses", integer(summary.total_responses as i64)),
+            (
+                "responses_requiring_attention",
+                integer(summary.responses_requiring_attention as i64),
+            ),
+            (
+                "blocked_responses",
+                integer(summary.blocked_responses as i64),
+            ),
+            (
+                "responses_ready_to_verify",
+                integer(summary.responses_ready_to_verify as i64),
             ),
         ]),
     )
@@ -18581,6 +18781,221 @@ fn integration_activation_escalation_summary_json(
     ])
 }
 
+fn activation_response_item_json(response: &IntegrationActivationResponseItem) -> JsonValue {
+    object([
+        ("sequence", integer(response.sequence as i64)),
+        ("response_kind", string(response.response_kind.as_str())),
+        ("owner_lane", string(response.owner_lane.as_str())),
+        (
+            "source_case_sequence",
+            integer(response.source_case_sequence as i64),
+        ),
+        (
+            "source_case_kind",
+            string(response.source_case_kind.as_str()),
+        ),
+        ("source_id", string(&response.source_id)),
+        ("title", string(&response.title)),
+        ("summary", string(&response.summary)),
+        ("priority", integer(response.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                response
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(response.integration_count() as i64),
+        ),
+        (
+            "recommended_view",
+            string(response.recommended_view.as_str()),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(response.required_tier)),
+        ),
+        (
+            "policy_surface",
+            response
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(response.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(response.has_policy_risk()),
+        ),
+        (
+            "ready_to_verify",
+            JsonValue::Bool(response.ready_to_verify()),
+        ),
+        ("blocked", JsonValue::Bool(response.blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(response.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_response_summary_json(
+    summary: &IntegrationActivationResponseSummary,
+) -> JsonValue {
+    object([
+        ("total_responses", integer(summary.total_responses as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "responses_requiring_attention",
+            integer(summary.responses_requiring_attention as i64),
+        ),
+        (
+            "resolve_blocker_responses",
+            integer(summary.resolve_blocker_responses as i64),
+        ),
+        (
+            "enable_dependency_responses",
+            integer(summary.enable_dependency_responses as i64),
+        ),
+        (
+            "review_policy_responses",
+            integer(summary.review_policy_responses as i64),
+        ),
+        (
+            "queue_review_responses",
+            integer(summary.queue_review_responses as i64),
+        ),
+        (
+            "verify_activation_responses",
+            integer(summary.verify_activation_responses as i64),
+        ),
+        (
+            "audit_follow_up_responses",
+            integer(summary.audit_follow_up_responses as i64),
+        ),
+        (
+            "platform_owner_responses",
+            integer(summary.platform_owner_responses as i64),
+        ),
+        (
+            "integration_owner_responses",
+            integer(summary.integration_owner_responses as i64),
+        ),
+        (
+            "security_owner_responses",
+            integer(summary.security_owner_responses as i64),
+        ),
+        (
+            "reviewer_owner_responses",
+            integer(summary.reviewer_owner_responses as i64),
+        ),
+        (
+            "verification_owner_responses",
+            integer(summary.verification_owner_responses as i64),
+        ),
+        (
+            "audit_owner_responses",
+            integer(summary.audit_owner_responses as i64),
+        ),
+        (
+            "responses_with_dependency_work",
+            integer(summary.responses_with_dependency_work as i64),
+        ),
+        (
+            "responses_with_policy_risk",
+            integer(summary.responses_with_policy_risk as i64),
+        ),
+        (
+            "responses_ready_to_verify",
+            integer(summary.responses_ready_to_verify as i64),
+        ),
+        (
+            "blocked_responses",
+            integer(summary.blocked_responses as i64),
+        ),
+        (
+            "responses_with_policy_surface",
+            integer(summary.responses_with_policy_surface as i64),
+        ),
+        (
+            "next_response_kind",
+            summary
+                .next_response_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_response_sequence",
+            summary
+                .next_response_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_response_priority",
+            summary
+                .next_response_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(summary.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(summary.has_policy_risk()),
+        ),
+        (
+            "ready_to_verify",
+            JsonValue::Bool(summary.ready_to_verify()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -21465,6 +21880,50 @@ fn parse_activation_escalation_case_kind(
     }
 }
 
+fn parse_activation_response_kind(
+    label: &str,
+) -> Result<IntegrationActivationResponseKind, ToolCallError> {
+    match label {
+        "resolve_blocker" | "blocker" | "blockers" => {
+            Ok(IntegrationActivationResponseKind::ResolveBlocker)
+        }
+        "enable_dependency" | "dependency" | "dependencies" => {
+            Ok(IntegrationActivationResponseKind::EnableDependency)
+        }
+        "review_policy" | "policy" | "policy_risk" | "risk" => {
+            Ok(IntegrationActivationResponseKind::ReviewPolicy)
+        }
+        "queue_review" | "review" | "reviewer" => {
+            Ok(IntegrationActivationResponseKind::QueueReview)
+        }
+        "verify_activation" | "verification" | "verify" => {
+            Ok(IntegrationActivationResponseKind::VerifyActivation)
+        }
+        "audit_follow_up" | "audit" | "follow_up" => {
+            Ok(IntegrationActivationResponseKind::AuditFollowUp)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation response kind `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_response_owner_lane(
+    label: &str,
+) -> Result<IntegrationActivationResponseOwnerLane, ToolCallError> {
+    match label {
+        "platform" => Ok(IntegrationActivationResponseOwnerLane::Platform),
+        "integration" | "integrations" => Ok(IntegrationActivationResponseOwnerLane::Integration),
+        "security" | "policy" => Ok(IntegrationActivationResponseOwnerLane::Security),
+        "reviewer" | "review" => Ok(IntegrationActivationResponseOwnerLane::Reviewer),
+        "verification" | "verify" => Ok(IntegrationActivationResponseOwnerLane::Verification),
+        "audit" => Ok(IntegrationActivationResponseOwnerLane::Audit),
+        _ => Err(validation_error(format!(
+            "unknown activation response owner lane `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -22989,6 +23448,35 @@ fn integration_activation_escalation_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_response_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_escalation_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("response_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("response", JsonSchema::String));
+        properties.push(SchemaProperty::new("owner_lane", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "response_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "response_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("response_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "response_ready_to_verify",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("response_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -23133,7 +23621,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 119);
+        assert_eq!(definitions.len(), 121);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -23462,9 +23950,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ESCALATION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            111
+            113
         );
         assert_eq!(
             export
@@ -23489,6 +23983,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -23942,11 +24444,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(119))
+            Some(&integer(121))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(111))
+            Some(&integer(113))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -28040,6 +28542,157 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_responses_request = request(
+            "call-list-integration-activation-responses",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("response_kind", string("resolve_blocker")),
+                ("response_requires_attention", JsonValue::Bool(true)),
+                ("response_blocked", JsonValue::Bool(true)),
+                ("response_limit", integer(3)),
+            ]),
+            5_045,
+        );
+        let list_activation_responses_trace =
+            tool_runtime.invoke_with_events(&list_activation_responses_request);
+        assert!(list_activation_responses_trace.result.ok);
+        assert_eq!(
+            list_activation_responses_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_responses_output = list_activation_responses_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_response_count =
+            integer_value(field(list_activation_responses_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_response_count));
+        let activation_response_summary =
+            field(list_activation_responses_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_response_summary, "total_responses"),
+            Some(&integer(activation_response_count))
+        );
+        assert_eq!(
+            field(activation_response_summary, "next_response_kind"),
+            Some(&string("resolve_blocker"))
+        );
+        assert_eq!(
+            field(activation_response_summary, "next_owner_lane"),
+            Some(&string("platform"))
+        );
+        assert_eq!(
+            field(activation_response_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_response_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_response = array_item(
+            field(list_activation_responses_output, "activation_responses").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_response, "response_kind"),
+            Some(&string("resolve_blocker"))
+        );
+        assert_eq!(
+            field(activation_response, "owner_lane"),
+            Some(&string("platform"))
+        );
+        assert_eq!(
+            field(activation_response, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_response, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_response_summary_request = request(
+            "call-integration-activation-response-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("response_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_046,
+        );
+        let activation_response_summary_trace =
+            tool_runtime.invoke_with_events(&activation_response_summary_request);
+        assert!(activation_response_summary_trace.result.ok);
+        assert_eq!(
+            activation_response_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_response_summary_output = activation_response_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_response_rollup =
+            field(activation_response_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_response_rollup, "total_responses").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_response_rollup, "blocked_responses").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_response_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_response_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -29888,6 +30541,14 @@ mod tests {
             activation_escalation_summary_request,
             activation_escalation_summary_trace,
         );
+        journal.record_trace(
+            list_activation_responses_request,
+            list_activation_responses_trace,
+        );
+        journal.record_trace(
+            activation_response_summary_request,
+            activation_response_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -29961,9 +30622,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 119);
-        assert_eq!(journal_summary.completed_count, 119);
-        assert_eq!(journal.audit_records().len(), 119);
+        assert_eq!(journal_summary.invocation_count, 121);
+        assert_eq!(journal_summary.completed_count, 121);
+        assert_eq!(journal.audit_records().len(), 121);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -132,6 +132,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_escalation_summary` tool descriptors
   for read-only Chief-facing activation escalation cases derived from sentinel
   alerts, verification checkpoints, and audit records.
+- `smart_home.list_integration_activation_responses` and
+  `smart_home.get_integration_activation_response_summary` tool descriptors for
+  read-only owner-lane activation response planning derived from escalation
+  cases.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -115,6 +115,8 @@ Current scope:
 - D18D integration activation-escalation descriptors for Chief-facing
   blocker, dependency, policy-risk, review, verification, and audit cases
   derived from sentinel, verification, and audit rollups
+- D18D integration activation-response descriptors for owner-lane next actions
+  derived from Chief-facing escalation cases
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1517,6 +1517,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationAuditSummary,
     ListIntegrationActivationEscalations,
     GetIntegrationActivationEscalationSummary,
+    ListIntegrationActivationResponses,
+    GetIntegrationActivationResponseSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1774,6 +1776,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationEscalationSummary => {
                 read_tool("smart_home.get_integration_activation_escalation_summary")
+            }
+            Self::ListIntegrationActivationResponses => {
+                read_tool("smart_home.list_integration_activation_responses")
+            }
+            Self::GetIntegrationActivationResponseSummary => {
+                read_tool("smart_home.get_integration_activation_response_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2474,6 +2482,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationAuditSummary,
         SmartHomeTool::ListIntegrationActivationEscalations,
         SmartHomeTool::GetIntegrationActivationEscalationSummary,
+        SmartHomeTool::ListIntegrationActivationResponses,
+        SmartHomeTool::GetIntegrationActivationResponseSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3316,7 +3326,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 119);
+        assert_eq!(catalog.len(), 121);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3799,6 +3809,14 @@ mod tests {
             == "smart_home.get_integration_activation_escalation_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_responses"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_response_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3806,15 +3824,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 119);
-        assert_eq!(summary.read_tools, 111);
+        assert_eq!(summary.total_tools, 121);
+        assert_eq!(summary.read_tools, 113);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 111);
+        assert_eq!(summary.read_only_tier_tools, 113);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 119);
+        assert_eq!(summary.total_required_capabilities, 121);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -106,6 +106,9 @@ All notable changes to this package will be documented in this file.
   `IntegrationActivationEscalationSummary` for packaging sentinel alerts,
   verification checkpoints, and audit records into Chief-facing escalation
   queues.
+- `IntegrationActivationResponseItem` and
+  `IntegrationActivationResponseSummary` for turning escalation cases into
+  owner-lane next actions for response planning.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -96,6 +96,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation escalation cases that package sentinel alerts, verification
   checkpoints, and audit records into Chief-facing blocker, dependency,
   policy-risk, review, verification, and audit cases
+- activation response items that turn escalation cases into owner-lane next
+  actions for blocker, dependency, policy, review, verification, and audit
+  follow-up work
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1393,6 +1393,74 @@ impl IntegrationActivationEscalationCaseKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationResponseKind {
+    ResolveBlocker,
+    EnableDependency,
+    ReviewPolicy,
+    QueueReview,
+    VerifyActivation,
+    AuditFollowUp,
+}
+
+impl IntegrationActivationResponseKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ResolveBlocker => "resolve_blocker",
+            Self::EnableDependency => "enable_dependency",
+            Self::ReviewPolicy => "review_policy",
+            Self::QueueReview => "queue_review",
+            Self::VerifyActivation => "verify_activation",
+            Self::AuditFollowUp => "audit_follow_up",
+        }
+    }
+
+    pub fn from_case_kind(case_kind: IntegrationActivationEscalationCaseKind) -> Self {
+        match case_kind {
+            IntegrationActivationEscalationCaseKind::Blocker => Self::ResolveBlocker,
+            IntegrationActivationEscalationCaseKind::Dependency => Self::EnableDependency,
+            IntegrationActivationEscalationCaseKind::PolicyRisk => Self::ReviewPolicy,
+            IntegrationActivationEscalationCaseKind::Review => Self::QueueReview,
+            IntegrationActivationEscalationCaseKind::Verification => Self::VerifyActivation,
+            IntegrationActivationEscalationCaseKind::Audit => Self::AuditFollowUp,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationResponseOwnerLane {
+    Platform,
+    Integration,
+    Security,
+    Reviewer,
+    Verification,
+    Audit,
+}
+
+impl IntegrationActivationResponseOwnerLane {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::Integration => "integration",
+            Self::Security => "security",
+            Self::Reviewer => "reviewer",
+            Self::Verification => "verification",
+            Self::Audit => "audit",
+        }
+    }
+
+    pub fn from_response_kind(response_kind: IntegrationActivationResponseKind) -> Self {
+        match response_kind {
+            IntegrationActivationResponseKind::ResolveBlocker => Self::Platform,
+            IntegrationActivationResponseKind::EnableDependency => Self::Integration,
+            IntegrationActivationResponseKind::ReviewPolicy => Self::Security,
+            IntegrationActivationResponseKind::QueueReview => Self::Reviewer,
+            IntegrationActivationResponseKind::VerifyActivation => Self::Verification,
+            IntegrationActivationResponseKind::AuditFollowUp => Self::Audit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3111,6 +3179,60 @@ pub struct IntegrationActivationEscalationSummary {
     pub first_policy_risk_priority: Option<u8>,
     pub first_review_priority: Option<u8>,
     pub first_verification_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationResponseItem {
+    pub sequence: usize,
+    pub response_kind: IntegrationActivationResponseKind,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_case_sequence: usize,
+    pub source_case_kind: IntegrationActivationEscalationCaseKind,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_ready: bool,
+    pub blocked: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationResponseSummary {
+    pub total_responses: usize,
+    pub unique_integrations: usize,
+    pub responses_requiring_attention: usize,
+    pub resolve_blocker_responses: usize,
+    pub enable_dependency_responses: usize,
+    pub review_policy_responses: usize,
+    pub queue_review_responses: usize,
+    pub verify_activation_responses: usize,
+    pub audit_follow_up_responses: usize,
+    pub platform_owner_responses: usize,
+    pub integration_owner_responses: usize,
+    pub security_owner_responses: usize,
+    pub reviewer_owner_responses: usize,
+    pub verification_owner_responses: usize,
+    pub audit_owner_responses: usize,
+    pub responses_with_dependency_work: usize,
+    pub responses_with_policy_risk: usize,
+    pub responses_ready_to_verify: usize,
+    pub blocked_responses: usize,
+    pub responses_with_policy_surface: usize,
+    pub next_response_kind: Option<IntegrationActivationResponseKind>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_response_sequence: Option<usize>,
+    pub next_response_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -8586,6 +8708,225 @@ impl IntegrationActivationEscalationSummary {
     }
 }
 
+impl IntegrationActivationResponseItem {
+    fn from_escalation_case(case: &IntegrationActivationEscalationCase) -> Self {
+        let response_kind = IntegrationActivationResponseKind::from_case_kind(case.case_kind);
+        let owner_lane = IntegrationActivationResponseOwnerLane::from_response_kind(response_kind);
+
+        Self {
+            sequence: 0,
+            response_kind,
+            owner_lane,
+            source_case_sequence: case.sequence,
+            source_case_kind: case.case_kind,
+            source_id: case.source_id.clone(),
+            title: format!("{}: {}", response_kind.as_str(), case.title),
+            summary: case.summary.clone(),
+            priority: case.priority,
+            integration_ids: case.integration_ids.clone(),
+            recommended_view: case.recommended_view,
+            required_tier: case.required_tier,
+            policy_surface: case.policy_surface,
+            dependency_work: case.has_dependency_work(),
+            policy_risk: case.has_policy_risk(),
+            verification_ready: case.ready_to_verify(),
+            blocked: case.blocked(),
+            requires_attention: case.requires_attention() || case.ready_to_verify(),
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.verification_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationResponseSummary {
+    pub fn from_responses<'a>(
+        responses: impl IntoIterator<Item = &'a IntegrationActivationResponseItem>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_responses: 0,
+            unique_integrations: 0,
+            responses_requiring_attention: 0,
+            resolve_blocker_responses: 0,
+            enable_dependency_responses: 0,
+            review_policy_responses: 0,
+            queue_review_responses: 0,
+            verify_activation_responses: 0,
+            audit_follow_up_responses: 0,
+            platform_owner_responses: 0,
+            integration_owner_responses: 0,
+            security_owner_responses: 0,
+            reviewer_owner_responses: 0,
+            verification_owner_responses: 0,
+            audit_owner_responses: 0,
+            responses_with_dependency_work: 0,
+            responses_with_policy_risk: 0,
+            responses_ready_to_verify: 0,
+            blocked_responses: 0,
+            responses_with_policy_surface: 0,
+            next_response_kind: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_response_sequence: None,
+            next_response_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for response in responses {
+            summary.total_responses += 1;
+            for integration_id in &response.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_response_kind.is_none()
+                && (response.requires_attention() || response.ready_to_verify())
+            {
+                summary.next_response_kind = Some(response.response_kind);
+                summary.next_owner_lane = Some(response.owner_lane);
+                summary.next_recommended_view = Some(response.recommended_view);
+                summary.next_response_sequence = Some(response.sequence);
+                summary.next_response_priority = Some(response.priority);
+            }
+
+            match response.response_kind {
+                IntegrationActivationResponseKind::ResolveBlocker => {
+                    summary.resolve_blocker_responses += 1;
+                }
+                IntegrationActivationResponseKind::EnableDependency => {
+                    summary.enable_dependency_responses += 1;
+                }
+                IntegrationActivationResponseKind::ReviewPolicy => {
+                    summary.review_policy_responses += 1;
+                }
+                IntegrationActivationResponseKind::QueueReview => {
+                    summary.queue_review_responses += 1;
+                }
+                IntegrationActivationResponseKind::VerifyActivation => {
+                    summary.verify_activation_responses += 1;
+                }
+                IntegrationActivationResponseKind::AuditFollowUp => {
+                    summary.audit_follow_up_responses += 1;
+                }
+            }
+
+            match response.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_responses += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_responses += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_responses += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_responses += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_responses += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_responses += 1;
+                }
+            }
+
+            if response.requires_attention() {
+                summary.responses_requiring_attention += 1;
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(response.priority),
+                );
+            }
+            if response.has_dependency_work() {
+                summary.responses_with_dependency_work += 1;
+            }
+            if response.has_policy_risk() {
+                summary.responses_with_policy_risk += 1;
+            }
+            if response.ready_to_verify() {
+                summary.responses_ready_to_verify += 1;
+            }
+            if response.blocked() {
+                summary.blocked_responses += 1;
+            }
+            if response.has_policy_surface() {
+                summary.responses_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(response.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_responses > 0
+            || summary.resolve_blocker_responses > 0
+            || summary.enable_dependency_responses > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.responses_requiring_attention > 0
+            || summary.review_policy_responses > 0
+            || summary.queue_review_responses > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.responses_ready_to_verify > 0 || summary.verify_activation_responses > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_responses == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.resolve_blocker_responses > 0 || self.blocked_responses > 0
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.enable_dependency_responses > 0 || self.responses_with_dependency_work > 0
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.review_policy_responses > 0 || self.responses_with_policy_risk > 0
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.responses_ready_to_verify > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.responses_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -13614,6 +13955,39 @@ pub fn activation_escalation_cases_at_or_before_priority(
     activation_escalation_cases_from_rollups(&alerts, &checkpoints, &audit_records)
 }
 
+pub fn activation_response_items_from_escalation_cases(
+    cases: &[IntegrationActivationEscalationCase],
+) -> Vec<IntegrationActivationResponseItem> {
+    let mut responses: Vec<_> = cases
+        .iter()
+        .filter(|case| case.requires_attention() || case.ready_to_verify())
+        .map(IntegrationActivationResponseItem::from_escalation_case)
+        .collect();
+
+    responses.sort_by(compare_activation_response_items);
+    for (index, response) in responses.iter_mut().enumerate() {
+        response.sequence = index + 1;
+    }
+    responses
+}
+
+pub fn activation_response_items_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationResponseItem> {
+    let cases = activation_escalation_cases_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_response_items_from_escalation_cases(&cases)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -15214,6 +15588,23 @@ fn compare_activation_escalation_cases(
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
         .then_with(|| left.case_kind.cmp(&right.case_kind))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_response_items(
+    left: &IntegrationActivationResponseItem,
+    right: &IntegrationActivationResponseItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
+        .then_with(|| left.response_kind.cmp(&right.response_kind))
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
         .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
 }
@@ -18690,6 +19081,42 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let response_items = activation_response_items_from_escalation_cases(&escalation_cases);
+        assert!(!response_items.is_empty());
+        assert!(response_items
+            .iter()
+            .any(|response| response.response_kind
+                == IntegrationActivationResponseKind::ResolveBlocker));
+        assert!(response_items.iter().any(|response| response.response_kind
+            == IntegrationActivationResponseKind::EnableDependency));
+        assert!(response_items.iter().any(|response| response.response_kind
+            == IntegrationActivationResponseKind::VerifyActivation));
+        assert!(response_items
+            .iter()
+            .any(IntegrationActivationResponseItem::requires_attention));
+        assert!(response_items
+            .iter()
+            .any(IntegrationActivationResponseItem::blocked));
+
+        let response_summary =
+            IntegrationActivationResponseSummary::from_responses(response_items.iter());
+        assert_eq!(response_summary.total_responses, response_items.len());
+        assert!(response_summary.has_blockers());
+        assert!(response_summary.has_dependency_work());
+        assert!(response_summary.requires_attention());
+        assert_eq!(
+            response_summary.next_response_kind,
+            Some(IntegrationActivationResponseKind::ResolveBlocker)
+        );
+        assert_eq!(
+            response_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            response_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -18750,6 +19177,16 @@ mod tests {
         assert!(catalog_escalation_cases
             .iter()
             .any(IntegrationActivationEscalationCase::requires_attention));
+        let catalog_response_items = activation_response_items_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_response_items
+            .iter()
+            .any(IntegrationActivationResponseItem::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add catalog activation response items and summaries that turn escalation cases into owner-lane next actions
- expose D18D/core read tools for listing activation responses and response summaries
- extend Chief bridge end-to-end coverage and package docs for the response surface

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
