### PR TITLE
Add ARIA description browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -865,6 +865,7 @@ pub struct BrowserDocument {
     pub aria_ranges: Vec<BrowserAriaRange>,
     pub aria_live_regions: Vec<BrowserAriaLiveRegion>,
     pub aria_name_descriptors: Vec<BrowserAriaNameDescriptor>,
+    pub aria_description_descriptors: Vec<BrowserAriaDescriptionDescriptor>,
     pub aria_relation_descriptors: Vec<BrowserAriaRelationDescriptor>,
     pub links: Vec<BrowserLink>,
     pub images: Vec<BrowserImage>,
@@ -1740,6 +1741,26 @@ pub struct BrowserAriaNameDescriptor {
     pub unresolved_label_targets: Vec<String>,
     pub name_blocked: bool,
     pub name_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAriaDescriptionDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub accessible_description: Option<String>,
+    pub aria_description: Option<String>,
+    pub aria_describedby: Vec<String>,
+    pub describedby_text: Vec<String>,
+    pub description_source: String,
+    pub description_attribute_names: Vec<String>,
+    pub description_attribute_count: usize,
+    pub description_target_count: usize,
+    pub unresolved_description_targets: Vec<String>,
+    pub description_blocked: bool,
+    pub description_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -10822,6 +10843,9 @@ fn collect_browser_facts(
         if let Some(aria_name) = browser_aria_name_descriptor(element, id_texts) {
             summary.aria_name_descriptors.push(aria_name);
         }
+        if let Some(aria_description) = browser_aria_description_descriptor(element, id_texts) {
+            summary.aria_description_descriptors.push(aria_description);
+        }
         if let Some(aria_relation) = browser_aria_relation_descriptor(element, id_texts) {
             summary.aria_relation_descriptors.push(aria_relation);
         }
@@ -17844,6 +17868,106 @@ fn browser_aria_name_block_reasons(
     reasons
 }
 
+fn browser_aria_description_descriptor(
+    element: &Element,
+    id_texts: &[(String, String)],
+) -> Option<BrowserAriaDescriptionDescriptor> {
+    let aria_description = browser_aria_description(element);
+    let aria_describedby = browser_aria_idrefs(element, "aria-describedby");
+
+    if aria_description.is_none() && aria_describedby.is_empty() {
+        return None;
+    }
+
+    let role = browser_content_role(&element.name).unwrap_or(element.name.as_str());
+    let describedby_text = browser_idref_texts(&aria_describedby, id_texts);
+    let unresolved_description_targets =
+        browser_unresolved_aria_idrefs(&aria_describedby, id_texts);
+    let description_block_reasons = browser_aria_description_block_reasons(
+        aria_description.as_deref(),
+        &aria_describedby,
+        &describedby_text,
+        &unresolved_description_targets,
+    );
+    let description_attribute_names = browser_aria_description_attribute_names(element);
+    let description_source = browser_aria_description_source(
+        aria_description.as_deref(),
+        &aria_describedby,
+        &describedby_text,
+    );
+
+    Some(BrowserAriaDescriptionDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        role: role.to_string(),
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        accessible_name: browser_accessible_name(element, role, &[], id_texts),
+        accessible_description: browser_accessible_description(element, id_texts),
+        aria_description,
+        aria_describedby,
+        describedby_text,
+        description_source,
+        description_attribute_count: description_attribute_names.len(),
+        description_attribute_names,
+        description_target_count: browser_aria_idrefs(element, "aria-describedby").len(),
+        unresolved_description_targets,
+        description_blocked: !description_block_reasons.is_empty(),
+        description_block_reasons,
+    })
+}
+
+fn browser_aria_description(element: &Element) -> Option<String> {
+    element
+        .attribute("aria-description")
+        .map(collapse_html_whitespace)
+        .filter(|description| !description.is_empty())
+}
+
+fn browser_aria_description_attribute_names(element: &Element) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in ["aria-description", "aria-describedby"] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    attributes
+}
+
+fn browser_aria_description_source(
+    aria_description: Option<&str>,
+    aria_describedby: &[String],
+    describedby_text: &[String],
+) -> String {
+    if !aria_describedby.is_empty() && !describedby_text.is_empty() {
+        "aria-describedby".to_string()
+    } else if aria_description.is_some_and(|description| !description.is_empty()) {
+        "aria-description".to_string()
+    } else if !aria_describedby.is_empty() {
+        "unresolved-aria-describedby".to_string()
+    } else {
+        "none".to_string()
+    }
+}
+
+fn browser_aria_description_block_reasons(
+    aria_description: Option<&str>,
+    aria_describedby: &[String],
+    describedby_text: &[String],
+    unresolved_targets: &[String],
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if !unresolved_targets.is_empty() {
+        reasons.push("unresolved-idref".to_string());
+    }
+    if !aria_describedby.is_empty()
+        && describedby_text.is_empty()
+        && aria_description.is_none_or(|description| description.is_empty())
+    {
+        reasons.push("empty-description".to_string());
+    }
+    reasons
+}
+
 fn browser_slot_assignment(element: &Element) -> Option<String> {
     element.attribute("slot").map(ToOwned::to_owned)
 }
@@ -19591,7 +19715,11 @@ fn browser_accessible_description(
 ) -> Option<String> {
     let describedby = browser_aria_idrefs(element, "aria-describedby");
     let parts = browser_idref_texts(&describedby, id_texts);
-    (!parts.is_empty()).then(|| parts.join(" "))
+    if !parts.is_empty() {
+        Some(parts.join(" "))
+    } else {
+        browser_aria_description(element)
+    }
 }
 
 fn browser_idref_texts(idrefs: &[String], id_texts: &[(String, String)]) -> Vec<String> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,37 +1,37 @@
 use coding_adventures_html_parser::{
     parse_browser_document, BrowserActivationDescriptor, BrowserAnchor,
     BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
-    BrowserAriaLiveRegion, BrowserAriaNameDescriptor, BrowserAriaRange,
-    BrowserAriaRelationDescriptor, BrowserClipboardInteractionDescriptor, BrowserCommandElement,
-    BrowserComponentHydrationTarget, BrowserCompositionInteractionDescriptor,
-    BrowserContextMenuInteractionDescriptor, BrowserDataAttribute, BrowserDataAttributeDescriptor,
-    BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
-    BrowserDocumentMetadata, BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor,
-    BrowserEmbeddedContext, BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor,
-    BrowserFetchPolicyDescriptor, BrowserFocusNavigationDescriptor, BrowserForm,
-    BrowserFormAssociationDescriptor, BrowserFormAutofillDescriptor, BrowserFormButton,
-    BrowserFormChoiceControl, BrowserFormControl, BrowserFormDatalist, BrowserFormFieldset,
-    BrowserFormFileControl, BrowserFormHiddenControl, BrowserFormImageControl, BrowserFormLabel,
-    BrowserFormMeasurement, BrowserFormObject, BrowserFormObjectParam, BrowserFormOutput,
-    BrowserFormPolicyDescriptor, BrowserFormPolicySubmitterDescriptor, BrowserFormResetDescriptor,
-    BrowserFormSelect, BrowserFormSubmissionDescriptor, BrowserFormSubmitter,
-    BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
-    BrowserFormValidationDescriptor, BrowserFullscreenInteractionDescriptor,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInputPlanningDescriptor, BrowserInteractiveElement,
-    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
-    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
-    BrowserScriptModuleGraphDescriptor, BrowserScriptStorageAccessDescriptor,
-    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell, BrowserTemplate,
-    BrowserTextSemantic, BrowserThemeColor,
+    BrowserAriaDescriptionDescriptor, BrowserAriaLiveRegion, BrowserAriaNameDescriptor,
+    BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserClipboardInteractionDescriptor,
+    BrowserCommandElement, BrowserComponentHydrationTarget,
+    BrowserCompositionInteractionDescriptor, BrowserContextMenuInteractionDescriptor,
+    BrowserDataAttribute, BrowserDataAttributeDescriptor, BrowserDatalistOption, BrowserDisclosure,
+    BrowserDisclosureStateDescriptor, BrowserDocument, BrowserDocumentMetadata,
+    BrowserDocumentPolicyDescriptor, BrowserDragDropDescriptor, BrowserEmbeddedContext,
+    BrowserEmbeddedPolicyDescriptor, BrowserEventHandlerDescriptor, BrowserFetchPolicyDescriptor,
+    BrowserFocusNavigationDescriptor, BrowserForm, BrowserFormAssociationDescriptor,
+    BrowserFormAutofillDescriptor, BrowserFormButton, BrowserFormChoiceControl, BrowserFormControl,
+    BrowserFormDatalist, BrowserFormFieldset, BrowserFormFileControl, BrowserFormHiddenControl,
+    BrowserFormImageControl, BrowserFormLabel, BrowserFormMeasurement, BrowserFormObject,
+    BrowserFormObjectParam, BrowserFormOutput, BrowserFormPolicyDescriptor,
+    BrowserFormPolicySubmitterDescriptor, BrowserFormResetDescriptor, BrowserFormSelect,
+    BrowserFormSubmissionDescriptor, BrowserFormSubmitter, BrowserFormSuccessfulControl,
+    BrowserFormTextEntry, BrowserFormValidationControl, BrowserFormValidationDescriptor,
+    BrowserFullscreenInteractionDescriptor, BrowserGlobalStateDescriptor, BrowserHeading,
+    BrowserHttpEquivHint, BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap,
+    BrowserImageMapArea, BrowserImageSource, BrowserInputPlanningDescriptor,
+    BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
+    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
+    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -145,6 +145,8 @@ struct ExpectedBrowserDocument {
     aria_live_regions: Vec<ExpectedAriaLiveRegion>,
     #[serde(default)]
     aria_name_descriptors: Option<Vec<ExpectedAriaNameDescriptor>>,
+    #[serde(default)]
+    aria_description_descriptors: Option<Vec<ExpectedAriaDescriptionDescriptor>>,
     #[serde(default)]
     aria_relation_descriptors: Vec<ExpectedAriaRelationDescriptor>,
     links: Vec<ExpectedLink>,
@@ -538,6 +540,41 @@ struct ExpectedAriaNameDescriptor {
     name_blocked: bool,
     #[serde(default)]
     name_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedAriaDescriptionDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    accessible_description: Option<String>,
+    #[serde(default)]
+    aria_description: Option<String>,
+    #[serde(default)]
+    aria_describedby: Vec<String>,
+    #[serde(default)]
+    describedby_text: Vec<String>,
+    #[serde(default)]
+    description_source: String,
+    #[serde(default)]
+    description_attribute_names: Vec<String>,
+    #[serde(default)]
+    description_attribute_count: usize,
+    #[serde(default)]
+    description_target_count: usize,
+    #[serde(default)]
+    unresolved_description_targets: Vec<String>,
+    #[serde(default)]
+    description_blocked: bool,
+    #[serde(default)]
+    description_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4039,9 +4076,14 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         let actual = parse_browser_document(&case.input)
             .unwrap_or_else(|error| panic!("{} should parse: {error}", case.id));
         let tracks_aria_name_descriptors = case.expected.aria_name_descriptors.is_some();
+        let tracks_aria_description_descriptors =
+            case.expected.aria_description_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
+        }
+        if !tracks_aria_description_descriptors {
+            expected.aria_description_descriptors = actual.aria_description_descriptors.clone();
         }
 
         assert_eq!(
@@ -6098,6 +6140,67 @@ fn browser_aria_name_descriptors_track_unresolved_labelledby_targets() {
 }
 
 #[test]
+fn browser_aria_description_descriptors_track_description_sources_and_resolution() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "aria-description-descriptor-page")
+        .expect("ARIA description fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("ARIA description fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.aria_description_descriptors,
+        case.expected
+            .into_browser_document()
+            .aria_description_descriptors,
+        "ARIA description descriptors should preserve description sources, resolved help text, and unresolved idref diagnostics",
+    );
+}
+
+#[test]
+fn browser_aria_description_descriptors_track_unresolved_describedby_targets() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <button id=save aria-label="Save" aria-describedby="save-help missing">Save</button>
+            <span id=save-help>Persists changes</span>
+        </body>"#,
+    )
+    .expect("ARIA description unresolved-id fixture should parse");
+
+    let description = actual
+        .aria_description_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("save"))
+        .expect("save button description descriptor should be present");
+
+    assert_eq!(description.role, "control");
+    assert_eq!(description.accessible_name.as_deref(), Some("Save"));
+    assert_eq!(
+        description.accessible_description.as_deref(),
+        Some("Persists changes")
+    );
+    assert_eq!(description.aria_describedby, vec!["save-help", "missing"]);
+    assert_eq!(description.describedby_text, vec!["Persists changes"]);
+    assert_eq!(description.description_source, "aria-describedby");
+    assert_eq!(
+        description.description_attribute_names,
+        vec!["aria-describedby"]
+    );
+    assert_eq!(description.description_attribute_count, 1);
+    assert_eq!(description.description_target_count, 2);
+    assert_eq!(description.unresolved_description_targets, vec!["missing"]);
+    assert!(description.description_blocked);
+    assert_eq!(
+        description.description_block_reasons,
+        vec!["unresolved-idref"]
+    );
+}
+
+#[test]
 fn browser_disclosure_descriptor_metadata_tracks_details_and_dialogs() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -6885,6 +6988,12 @@ impl ExpectedBrowserDocument {
                 .unwrap_or_default()
                 .into_iter()
                 .map(ExpectedAriaNameDescriptor::into_browser_aria_name_descriptor)
+                .collect(),
+            aria_description_descriptors: self
+                .aria_description_descriptors
+                .unwrap_or_default()
+                .into_iter()
+                .map(ExpectedAriaDescriptionDescriptor::into_browser_aria_description_descriptor)
                 .collect(),
             aria_relation_descriptors: self
                 .aria_relation_descriptors
@@ -13596,6 +13705,29 @@ impl ExpectedAriaNameDescriptor {
             unresolved_label_targets: self.unresolved_label_targets,
             name_blocked: self.name_blocked,
             name_block_reasons: self.name_block_reasons,
+        }
+    }
+}
+
+impl ExpectedAriaDescriptionDescriptor {
+    fn into_browser_aria_description_descriptor(self) -> BrowserAriaDescriptionDescriptor {
+        BrowserAriaDescriptionDescriptor {
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            accessible_description: self.accessible_description,
+            aria_description: self.aria_description,
+            aria_describedby: self.aria_describedby,
+            describedby_text: self.describedby_text,
+            description_source: self.description_source,
+            description_attribute_names: self.description_attribute_names,
+            description_attribute_count: self.description_attribute_count,
+            description_target_count: self.description_target_count,
+            unresolved_description_targets: self.unresolved_description_targets,
+            description_blocked: self.description_blocked,
+            description_block_reasons: self.description_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -2029,6 +2029,79 @@
       }
     },
     {
+      "id": "aria-description-descriptor-page",
+      "description": "Browser document summaries expose ARIA description sources, resolved describedby text, and unresolved describedby blockers.",
+      "input": "<body><h2 id=dialog-title>Preferences</h2><p id=hint>Choose defaults</p><p id=extra>Extra guidance</p><span id=open aria-label=\"Open preferences\" aria-description=\"Opens the settings panel\">Open</span><div id=panel aria-labelledby=dialog-title aria-describedby=\"hint extra\" aria-description=\"Fallback panel help\">Panel</div><div id=missing-desc aria-label=\"Hidden help\" aria-describedby=\"missing\">Hidden</div></body>",
+      "expected": {
+        "title": null,
+        "base_href": null,
+        "base_target": null,
+        "body_text": "Preferences Choose defaults Extra guidance Open Panel Hidden",
+        "metas": [],
+        "resources": [],
+        "anchors": [
+          { "id": "dialog-title", "name": null, "text": "Preferences" },
+          { "id": "hint", "name": null, "text": "Choose defaults" },
+          { "id": "extra", "name": null, "text": "Extra guidance" },
+          { "id": "open", "name": null, "text": "Open" },
+          { "id": "panel", "name": null, "text": "Panel" },
+          { "id": "missing-desc", "name": null, "text": "Hidden" }
+        ],
+        "headings": [
+          { "level": 2, "text": "Preferences" }
+        ],
+        "aria_description_descriptors": [
+          {
+            "element": "span",
+            "id": "open",
+            "role": "inline",
+            "text": "Open",
+            "accessible_name": "Open preferences",
+            "accessible_description": "Opens the settings panel",
+            "aria_description": "Opens the settings panel",
+            "description_source": "aria-description",
+            "description_attribute_names": ["aria-description"],
+            "description_attribute_count": 1
+          },
+          {
+            "element": "div",
+            "id": "panel",
+            "role": "block",
+            "text": "Panel",
+            "accessible_name": "Preferences",
+            "accessible_description": "Choose defaults Extra guidance",
+            "aria_description": "Fallback panel help",
+            "aria_describedby": ["hint", "extra"],
+            "describedby_text": ["Choose defaults", "Extra guidance"],
+            "description_source": "aria-describedby",
+            "description_attribute_names": ["aria-description", "aria-describedby"],
+            "description_attribute_count": 2,
+            "description_target_count": 2
+          },
+          {
+            "element": "div",
+            "id": "missing-desc",
+            "role": "block",
+            "text": "Hidden",
+            "accessible_name": "Hidden help",
+            "aria_describedby": ["missing"],
+            "description_source": "unresolved-aria-describedby",
+            "description_attribute_names": ["aria-describedby"],
+            "description_attribute_count": 1,
+            "description_target_count": 1,
+            "unresolved_description_targets": ["missing"],
+            "description_blocked": true,
+            "description_block_reasons": ["unresolved-idref", "empty-description"]
+          }
+        ],
+        "links": [],
+        "images": [],
+        "interactive_elements": [],
+        "forms": [],
+        "tables": []
+      }
+    },
+    {
       "id": "loading-hint-descriptor-page",
       "description": "Browser document summaries expose image, frame, and media loading hints as a flat scheduling descriptor inventory.",
       "input": "<base href=\"https://example.test/assets/\"><body><img id=hero src=hero.jpg alt=Hero loading=lazy decoding=async fetchpriority=high><iframe id=frame src=frame.html loading=eager fetchpriority=low title=Frame></iframe><video id=movie src=movie.mp4 preload=metadata></video><audio id=sound src=sound.ogg preload=none></audio></body>",


### PR DESCRIPTION
## Summary
- add ARIA description descriptors for aria-description and aria-describedby sources
- surface resolved describedby text, unresolved description targets, and blocked-description hints
- add fixture-backed and inline tests for description precedence and unresolved idrefs

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser