### PR TITLE
feat(closurec): CLOC12.96 — close gap-091 (BigInt radix → decimal)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.100.0] - 2026-06-12
+
+### Changed
+- **CLOSES gap-091** — a BigInt RADIX literal is now canonicalised to
+  its shortest decimal form under WHITESPACE_ONLY, matching upstream
+  Closure (mirrors gap-038 for non-BigInt numbers):
+
+      0xFFn   -> 255n
+      0o17n   -> 15n
+      0b101n  -> 5n
+      0x1_FFn -> 511n   (separator + radix combined)
+
+  The BigInt branch of `normalize_number_value` now, after stripping
+  `_` separators (gap-048), parses a `0x`/`0o`/`0b` body into `u128`
+  (`from_str_radix`) and re-emits `{decimal}n`. A decimal BigInt body
+  (no radix prefix) is already shortest and passes through unchanged
+  (`255n` stays `255n`); a magnitude beyond `u128::MAX` (e.g. a 140-bit
+  `0xFF…FFn`) is left verbatim — real bigint arithmetic is a residual.
+  `minify_bigint_hex` / `minify_bigint_bin` are now enforced.
+
+  Three pre-existing gap-038/048 unit tests that asserted the deferred
+  radix-BigInt behaviour (`0xfn` unchanged, `0x1FFFn` unchanged) were
+  updated to the now-correct decimal forms (`15n`, `8191n`).
+
 ## [0.99.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.99.0"
+version = "0.100.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.99.0",
+  "version": "0.100.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -3196,8 +3196,47 @@ fn normalize_number_value(value: &str) -> String {
     //   `9007199254740993n` → NOT normalized to decimal
     //     shortest-form (would need bigint math, deferred)
     if let Some(body) = value.strip_suffix('n') {
+        // First strip any `_` separators (gap-048) — they are pure
+        // lexical sugar regardless of radix.
+        let cleaned_body = if body.contains('_') {
+            body.replace('_', "")
+        } else {
+            body.to_string()
+        };
+        // gap-091: a RADIX BigInt literal (`0xFFn`, `0o17n`, `0b101n`)
+        // is canonicalised to its shortest DECIMAL form (`255n`,
+        // `15n`, `5n`), exactly as gap-038 does for non-BigInt
+        // hex/oct/bin numbers. We parse the radix body into a `u128`
+        // (which covers the common range); a BigInt whose magnitude
+        // exceeds `u128::MAX` would need real bigint arithmetic and is
+        // left verbatim (a residual). A DECIMAL BigInt body has no
+        // radix prefix, so it falls through unchanged (already
+        // shortest — `255n` stays `255n`).
+        let radix_value: Option<u128> = if let Some(rest) = cleaned_body
+            .strip_prefix("0x")
+            .or_else(|| cleaned_body.strip_prefix("0X"))
+        {
+            u128::from_str_radix(rest, 16).ok()
+        } else if let Some(rest) = cleaned_body
+            .strip_prefix("0o")
+            .or_else(|| cleaned_body.strip_prefix("0O"))
+        {
+            u128::from_str_radix(rest, 8).ok()
+        } else if let Some(rest) = cleaned_body
+            .strip_prefix("0b")
+            .or_else(|| cleaned_body.strip_prefix("0B"))
+        {
+            u128::from_str_radix(rest, 2).ok()
+        } else {
+            None
+        };
+        if let Some(n) = radix_value {
+            return format!("{}n", n);
+        }
+        // No radix prefix (decimal BigInt) or out-of-u128 magnitude:
+        // emit the separator-stripped body unchanged.
         if body.contains('_') {
-            return format!("{}n", body.replace('_', ""));
+            return format!("{}n", cleaned_body);
         }
         return value.to_string();
     }
@@ -4940,9 +4979,11 @@ mod tests {
     /// that requires bigint arithmetic — left for a
     /// follow-up gap. Leaving verbatim is safer than
     /// truncating.
+    /// gap-091 (was gap-038's deferred BigInt future): a hex BigInt is
+    /// now decimalised — `0xfn` → `15n`.
     #[test]
     fn gap038_bigint_left_verbatim() {
-        assert_eq!(minify("var x=0xfn;"), "var x=0xfn;");
+        assert_eq!(minify("var x=0xfn;"), "var x=15n;");
     }
 
     /// gap-048: BigInt literal with ES2021 `_` numeric
@@ -4956,14 +4997,14 @@ mod tests {
         );
     }
 
-    /// gap-048: separator stripping also works for hex
-    /// BigInt — the `0x` prefix and digits-pattern are
-    /// preserved; only `_` is removed.
+    /// gap-048 + gap-091: a hex BigInt with a `_` separator is both
+    /// separator-stripped AND decimalised — `0x1_FFFn` → `8191n`
+    /// (0x1FFF = 8191).
     #[test]
     fn gap048_bigint_hex_separator_stripped() {
         assert_eq!(
             minify("var a=0x1_FFFn;"),
-            "var a=0x1FFFn;"
+            "var a=8191n;"
         );
     }
 
@@ -4978,14 +5019,40 @@ mod tests {
         );
     }
 
-    /// **Non-regression**: hex BigInt without separators
-    /// is unchanged (the radix-and-shortest-form
-    /// canonicalization that regular `0xff` → `255`
-    /// gets is still deferred for BigInt — that's
-    /// gap-038's bigint future).
+    /// gap-091: a hex BigInt without separators is decimalised, just
+    /// like regular `0xff` → `255` (gap-038): `0xfn` → `15n`. (Was
+    /// deferred under gap-048; closed by CLOC12.96.)
     #[test]
     fn gap048_bigint_hex_no_separator_unchanged() {
-        assert_eq!(minify("var x=0xfn;"), "var x=0xfn;");
+        assert_eq!(minify("var x=0xfn;"), "var x=15n;");
+    }
+
+    /// gap-091: BigInt radix literals canonicalise to decimal across
+    /// all three radices (hex/oct/bin), case-insensitive prefix.
+    #[test]
+    fn gap091_bigint_radix_to_decimal() {
+        assert_eq!(minify("var x=0xFFn;"), "var x=255n;");
+        assert_eq!(minify("var x=0XFFn;"), "var x=255n;");
+        assert_eq!(minify("var x=0o17n;"), "var x=15n;");
+        assert_eq!(minify("var x=0b101n;"), "var x=5n;");
+        assert_eq!(minify("var x=0n;"), "var x=0n;");
+    }
+
+    /// gap-091 non-regression: a DECIMAL BigInt (no radix prefix) is
+    /// left as-is — it is already shortest. A magnitude beyond u128
+    /// stays verbatim (real bigint arithmetic is a residual).
+    #[test]
+    fn gap091_decimal_and_overflow_bigint_kept() {
+        assert_eq!(minify("var x=255n;"), "var x=255n;");
+        assert_eq!(
+            minify("var x=9007199254740993n;"),
+            "var x=9007199254740993n;"
+        );
+        // 35 hex digits = 140 bits > u128 — left verbatim.
+        assert_eq!(
+            minify("var x=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn;"),
+            "var x=0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn;"
+        );
     }
 
     /// **Non-regression**: separator in regular number

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.99.0
+Version: 0.100.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -96,14 +96,12 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     ("str_codepoint_esc", "gap-090: \\u{...} code-point escape mangled"),
     ("str_hex_esc",       "gap-090: \\xNN hex escape mangled"),
     ("str_null_esc",      "gap-090: \\0 null escape mangled"),
-    // gap-091 (CLOC14.40): a BigInt radix literal is not converted to
-    // decimal — `0xFFn` -> `255n`, `0o17n` -> `15n`, `0b101n` -> `5n`.
-    // gap-038/040 decimalise regular hex/oct/bin; gap-048 strips the
-    // BigInt `_` separator; the radix→decimal BigInt conversion is the
-    // remaining piece (needs bigint arithmetic; u128 covers the common
-    // range).
-    ("bigint_hex", "gap-091: BigInt hex radix -> decimal"),
-    ("bigint_bin", "gap-091: BigInt binary radix -> decimal"),
+    // gap-091 RESOLVED in CLOC12.96 — a BigInt RADIX literal is now
+    // canonicalised to decimal (`0xFFn` -> `255n`, `0o17n` -> `15n`,
+    // `0b101n` -> `5n`) by parsing the radix body to u128 in the BigInt
+    // branch of `normalize_number_value`. Over-u128 magnitudes stay
+    // verbatim (residual). `minify_bigint_hex` / `minify_bigint_bin`
+    // enforced.
     // gap-092 (CLOC14.40): a `/` DIVISION operator in `a/b/c` is mis-
     // lexed as a REGEX literal `/b/`, producing spurious separating
     // spaces (`a /b/ c`). Still valid JS (same grouping) but not byte-

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -687,9 +687,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-091 — BigInt radix literal → decimal (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.40). `minify_bigint_hex` / `minify_bigint_bin` ignored.
+- **Status:** RESOLVED in CLOC12.96. `minify_bigint_hex` / `minify_bigint_bin` enforced.
 - **Input:** `var x=0xFFn;` → **Upstream:** `var x=255n;` (also `0o17n` → `15n`, `0b101n` → `5n`).
 - **What it needs:** the BigInt branch of `normalize_number_value` currently only strips the `_` separator (gap-048). Upstream converts a radix BigInt to its shortest decimal form, exactly as gap-038 does for non-BigInt hex/oct/bin. Extend the BigInt branch to parse the `0x`/`0o`/`0b` body and re-emit `{decimal}n`. Small values fit in u128; very large BigInts would need real bigint arithmetic (residual).
+- **CLOC12.96 resolution:** Extended the BigInt branch of `normalize_number_value`: after stripping `_` separators (gap-048), the body is parsed as a `0x`/`0o`/`0b` radix literal into a `u128` (`from_str_radix`) and re-emitted as `{decimal}n`. A decimal BigInt body has no radix prefix and falls through unchanged (already shortest — `255n` stays `255n`); an over-`u128` magnitude (e.g. a 140-bit `0xFF…FFn`) leaves the literal verbatim (real bigint arithmetic is a residual). JAR-verified across `0xFFn`/`0XFFn`→`255n`, `0o17n`→`15n`, `0b101n`→`5n`, `0x1_FFn`→`511n` (separator+radix), `0n`→`0n`. 2 dedicated unit tests + the two byte-identity fixtures; three pre-existing gap-038/048 tests that asserted the deferred radix-BigInt behavior (`0xfn` unchanged, `0x1FFFn` unchanged) were updated to the now-correct decimal forms.
 
 ### gap-092 — division mis-lexed as regex (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## CLOC12.96 — close gap-091 (BigInt radix → decimal)

Upstream Closure canonicalises a BigInt **radix** literal to its shortest decimal form even under `WHITESPACE_ONLY` (mirroring gap-038 for regular numbers). closurec only stripped the `_` separator.

```
0xFFn   → 255n      0o17n  → 15n
0b101n  → 5n        0x1_FFn → 511n   (separator + radix combined)
```

### Implementation
The BigInt branch of `normalize_number_value` now, after stripping `_` separators (gap-048), parses a `0x`/`0o`/`0b` body into `u128` (`from_str_radix`) and re-emits `{decimal}n`. A decimal BigInt body (no radix prefix) is already shortest and passes through unchanged; an over-`u128` magnitude (e.g. a 140-bit `0xFF…FFn`) is left verbatim — real bigint arithmetic is a residual. All arithmetic via `from_str_radix(...).ok()` → overflow/parse failure falls through to verbatim, never panics.

`minify_bigint_hex` / `minify_bigint_bin` enforced. +2 `gap091_*` unit tests; three stale gap-038/048 tests (which asserted the deferred `0xfn`/`0x1FFFn` unchanged) updated to the now-correct `15n`/`8191n`. Full `cargo test` green (528 lib + walk-test); v0.99.0 → 0.100.0; spec RESOLVED; CHANGELOG updated.

### Note on gap-090 (deferred)
The string-escape correctness bug (gap-090, `\x`/`\u{}`/`\0` lose their backslash) was investigated: it's a **shared grammar-lexer** string-decoding fix needing dedicated careful work (+ emitter re-escaping to match the JAR), not a token-restitcher change. It remains the flagged high-priority item for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)