### PR TITLE
fix(closurec): CLOC12.97 — close gap-094 (array trailing-hole comma, CORRECTNESS)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.101.0] - 2026-06-12
+
+### Fixed
+- **CLOSES gap-094 (CORRECTNESS)** — the array trailing-comma drop
+  (gap-046) no longer corrupts arrays with a trailing HOLE. `[1,,]` is
+  `[1, <hole>]` (length 2); the old rule dropped the comma before `]`
+  to `[1,]` (length 1), silently shrinking the array. The drop is now
+  guarded so it only fires when the comma follows a REAL element —
+  the token before it must be neither a structural `,` (a preceding
+  hole) nor a structural `[` (a leading hole):
+
+      [1,,]    -> [1,,]    (kept — length 2)
+      [,]      -> [,]      (kept)
+      [,,]     -> [,,]     (kept)
+      [1,2,,]  -> [1,2,,]  (kept)
+      [1,2,]   -> [1,2]    (still drops — real element)
+      [[1],]   -> [[1]]    (still drops)
+      [f(),]   -> [f()]    (still drops)
+
+  `minify_array_hole_trail` enforced. A stale gap-046 test that
+  asserted the buggy `[1,,]` -> `[1,]` (and noted the rule was
+  "technically WRONG") was corrected; +1 dedicated test.
+
 ## [0.100.0] - 2026-06-12
 
 ### Changed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.100.0"
+version = "0.101.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -2461,8 +2461,24 @@ pub fn whitespace_only_minify(
         // appears IMMEDIATELY before `]` — i.e. as the
         // trailing-comma-after-last-element form. Inner
         // elisions have a non-`]` token next.
+        //
+        // gap-094 (CORRECTNESS): a trailing comma is droppable
+        // ONLY when it follows a REAL element. When it follows a
+        // HOLE — a preceding `,` (`[1,,]`) or the opening `[`
+        // (`[,]`) — the comma is load-bearing: `[1,,]` has length
+        // 2 (element + one trailing hole), and dropping the last
+        // comma yields `[1,]` (length 1), silently changing the
+        // array. So we additionally require the token BEFORE the
+        // comma to be a value-producing element, i.e. NOT a `,`
+        // and NOT a `[`. (Both checks route through
+        // `is_structural_punct` so a string/regex literal whose
+        // CONTENT is `,`/`[` is treated as a real element, not a
+        // hole marker.)
         if val == ","
             && kept.get(idx + 1).map(|t| t.value.as_str()) == Some("]")
+            && idx > 0
+            && !is_structural_punct(kept[idx - 1], ",")
+            && !is_structural_punct(kept[idx - 1], "[")
         {
             idx += 1;
             continue;
@@ -6252,19 +6268,28 @@ mod tests {
         assert_eq!(minify("var a=[1,2,3];"), "var a=[1,2,3];");
     }
 
-    /// **Elision-with-trailing** ambiguity: `[1,,]` —
-    /// elision `[1,,]` is `[1, undefined]` (length 2).
-    /// Hmm — actually the second `,` IS trailing. After
-    /// our rule drops it: `[1,]`. But `[1,]` is length 1,
-    /// not 2. So our rule is technically WRONG for this
-    /// case. However: upstream Closure under
-    /// WHITESPACE_ONLY produces `[1,]` for the source
-    /// `[1,,]` too (verified via JAR probe — they accept
-    /// this lossy normalisation for whitespace_only).
-    /// Confirmed via probe `[1,,];` → `[1,];`.
+    /// gap-094 (CORRECTNESS, was a wrong gap-046 assertion): `[1,,]`
+    /// is `[1, <hole>]` (length 2). The comma before `]` follows a
+    /// HOLE (the preceding `,`), so it is load-bearing and must be
+    /// KEPT — dropping it to `[1,]` (length 1) silently changes the
+    /// array. A fresh JAR probe confirms upstream keeps `[1,,]`
+    /// verbatim. (The original test asserted the buggy `[1,]` and even
+    /// noted the rule was "technically WRONG" — gap-094 fixes it.)
     #[test]
     fn gap046_elision_with_trailing_normalised() {
-        assert_eq!(minify("var a=[1,,];"), "var a=[1,];");
+        assert_eq!(minify("var a=[1,,];"), "var a=[1,,];");
+    }
+
+    /// gap-094: a trailing comma after a REAL element still drops
+    /// (`[1,2,]` → `[1,2]`, `[[1],]` → `[[1]]`, `[f(),]` → `[f()]`),
+    /// while every hole form is preserved (`[,]`, `[,,]`, `[1,2,,]`).
+    #[test]
+    fn gap094_hole_vs_real_trailing_comma() {
+        assert_eq!(minify("var x=[,];"), "var x=[,];");
+        assert_eq!(minify("var x=[,,];"), "var x=[,,];");
+        assert_eq!(minify("var x=[1,2,,];"), "var x=[1,2,,];");
+        assert_eq!(minify("var x=[[1],];"), "var x=[[1]];");
+        assert_eq!(minify("var x=[f(),];"), "var x=[f()];");
     }
 
     /// **Non-regression**: function-call trailing comma

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.100.0
+Version: 0.101.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -95,12 +95,11 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     ("num_member_method", "gap-093: number literal .member paren-wrap"),
     ("num_member_prop",   "gap-093: number .prop (closurec emits invalid 1.x)"),
     ("num_float_method",  "gap-093: float literal .member paren-wrap"),
-    // gap-094 (CLOC14.41) — CORRECTNESS: a trailing ELISION comma in an
-    // array literal is load-bearing — `[1,,]` has length 2 (element +
-    // one hole). closurec drops it to `[1,]` (length 1), changing the
-    // array. The trailing-comma-drop pass (gap-046) must NOT fire when
-    // the comma follows a hole.
-    ("array_hole_trail", "gap-094: array trailing-hole comma dropped (length change)"),
+    // gap-094 RESOLVED in CLOC12.97 — the gap-046 array trailing-comma
+    // drop is now guarded so it only fires when the comma follows a
+    // REAL element (not a hole: a preceding `,` or `[`). `[1,,]`
+    // (length 2) is preserved; `[1,2,]` -> `[1,2]` still drops.
+    // `minify_array_hole_trail` enforced.
     // gap-095 (CLOC14.41): a chained `new new A` is wrapped by upstream
     // to `new (new A)` (disambiguates the inner NewExpression as the
     // callee). closurec leaves `new new A` (valid, but not byte-id).

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -706,9 +706,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-094 — array trailing-hole comma dropped (CORRECTNESS, WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.41). `minify_array_hole_trail` ignored. **CORRECTNESS — changes the array's length.**
-- **Input:** `var x=[1,,];` → **Upstream:** `var x=[1,,];` (closurec emits `[1,]`).
+- **Status:** RESOLVED in CLOC12.97. `minify_array_hole_trail` enforced.
+- **Input:** `var x=[1,,];` → **Upstream:** `var x=[1,,];` (closurec emitted `[1,]`).
 - **What it needs:** the array trailing-comma-drop pass (gap-046) treats the final comma in `[1,,]` as a redundant trailing comma and drops it, yielding `[1,]`. But `[1,,]` is an array of length 2 (one element + one hole) whereas `[1,]` is length 1 — the comma after a HOLE (an empty elision slot) is load-bearing. The gap-046 drop must be guarded: only drop a trailing comma when it follows a real element, never when it follows another comma (a hole).
+- **CLOC12.97 resolution:** Guarded the gap-046 drop with two extra conditions on the token BEFORE the comma — it must be neither a structural `,` (a preceding hole, as in `[1,,]`) nor a structural `[` (a leading hole, as in `[,]`). Both checks route through `is_structural_punct`, so a string/regex literal whose CONTENT is `,`/`[` is treated as a real element. Real-element trailing commas still drop (`[1,2,]` → `[1,2]`, `[[1],]` → `[[1]]`, `[f(),]` → `[f()]`), while every hole form is preserved (`[1,,]`, `[,]`, `[,,]`, `[1,2,,]`). JAR-verified across all forms. A stale gap-046 unit test that asserted the buggy `[1,,]` → `[1,]` (and even noted the rule was "technically WRONG") was corrected to the kept form; +1 dedicated `gap094_hole_vs_real_trailing_comma` test.
 
 ### gap-095 — chained new paren-wrap (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## CLOC12.97 — close gap-094 (array trailing-hole comma) — **CORRECTNESS**

The array trailing-comma drop (gap-046) was **corrupting arrays whose last slot is a hole**. `[1,,]` is `[1, <hole>]` (length 2); the rule dropped the comma before `]` to `[1,]` (length 1), silently shrinking the array.

### Fix
The drop now fires **only when the comma follows a real element** — the token before it must be neither a structural `,` (a preceding hole, `[1,,]`) nor a structural `[` (a leading hole, `[,]`). Both checks route through `is_structural_punct`, so a string/regex literal whose content is `,`/`[` counts as a real element.

```
[1,,]   → [1,,]     [,]    → [,]      [,,] → [,,]     [1,2,,] → [1,2,,]   (holes preserved)
[1,2,]  → [1,2]     [[1],] → [[1]]    [f(),] → [f()]                     (real-element commas still drop)
```

`minify_array_hole_trail` enforced. A stale gap-046 test that asserted the buggy `[1,,]`→`[1,]` (and even noted the rule was "technically WRONG") was corrected; +1 dedicated `gap094_*` test. Full `cargo test` green (529 lib + walk-test); v0.100.0 → 0.101.0; spec RESOLVED; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)