### PR TITLE
Add template browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -887,6 +887,7 @@ pub struct BrowserDocument {
     pub scroll_interaction_descriptors: Vec<BrowserScrollInteractionDescriptor>,
     pub disclosures: Vec<BrowserDisclosure>,
     pub disclosure_state_descriptors: Vec<BrowserDisclosureStateDescriptor>,
+    pub template_descriptors: Vec<BrowserTemplateDescriptor>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
     pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
     pub global_state_descriptors: Vec<BrowserGlobalStateDescriptor>,
@@ -1418,6 +1419,24 @@ pub struct BrowserTemplate {
     pub shadowrootclonable: bool,
     pub shadowrootserializable: bool,
     pub content_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTemplateDescriptor {
+    pub id: Option<String>,
+    pub template_kind: String,
+    pub shadowrootmode: Option<String>,
+    pub shadowroot_attribute_names: Vec<String>,
+    pub shadowroot_attribute_count: usize,
+    pub declarative_shadow_root: bool,
+    pub shadowroot_mode_valid: bool,
+    pub shadowrootdelegatesfocus: bool,
+    pub shadowrootclonable: bool,
+    pub shadowrootserializable: bool,
+    pub content_text: String,
+    pub content_word_count: usize,
+    pub template_blocked: bool,
+    pub template_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10859,6 +10878,9 @@ fn collect_browser_facts(
             summary.global_state_descriptors.push(descriptor);
         }
         if element.name == "template" {
+            summary
+                .template_descriptors
+                .push(browser_template_descriptor(element));
             summary.templates.push(browser_template(element));
         }
         if browser_item_scope(element) {
@@ -11061,7 +11083,12 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
             "style" => summary
                 .stylesheets
                 .push(browser_style_element(element, summary.base_href.as_deref())),
-            "template" => summary.templates.push(browser_template(element)),
+            "template" => {
+                summary
+                    .template_descriptors
+                    .push(browser_template_descriptor(element));
+                summary.templates.push(browser_template(element));
+            }
             _ => {}
         }
 
@@ -17501,6 +17528,66 @@ fn browser_template(element: &Element) -> BrowserTemplate {
         shadowrootserializable: element.attribute("shadowrootserializable").is_some(),
         content_text: visible_text_for_nodes(&element.children),
     }
+}
+
+fn browser_template_descriptor(element: &Element) -> BrowserTemplateDescriptor {
+    let shadowrootmode = element.attribute("shadowrootmode").map(ToOwned::to_owned);
+    let shadowroot_attribute_names = browser_template_shadowroot_attribute_names(element);
+    let template_block_reasons =
+        browser_template_block_reasons(shadowrootmode.as_deref(), &shadowroot_attribute_names);
+    let content_text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+
+    BrowserTemplateDescriptor {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        template_kind: if shadowrootmode.is_some() {
+            "declarative-shadow-root".to_string()
+        } else {
+            "inert-template".to_string()
+        },
+        shadowrootmode,
+        shadowroot_attribute_count: shadowroot_attribute_names.len(),
+        shadowroot_attribute_names,
+        declarative_shadow_root: element.attribute("shadowrootmode").is_some(),
+        shadowroot_mode_valid: element
+            .attribute("shadowrootmode")
+            .is_some_and(|mode| matches!(mode, "open" | "closed")),
+        shadowrootdelegatesfocus: element.attribute("shadowrootdelegatesfocus").is_some(),
+        shadowrootclonable: element.attribute("shadowrootclonable").is_some(),
+        shadowrootserializable: element.attribute("shadowrootserializable").is_some(),
+        content_word_count: content_text.split_whitespace().count(),
+        content_text,
+        template_blocked: !template_block_reasons.is_empty(),
+        template_block_reasons,
+    }
+}
+
+fn browser_template_shadowroot_attribute_names(element: &Element) -> Vec<String> {
+    let mut attributes = Vec::new();
+    for name in [
+        "shadowrootmode",
+        "shadowrootdelegatesfocus",
+        "shadowrootclonable",
+        "shadowrootserializable",
+    ] {
+        if element.attribute(name).is_some() {
+            attributes.push(name.to_string());
+        }
+    }
+    attributes
+}
+
+fn browser_template_block_reasons(
+    shadowrootmode: Option<&str>,
+    shadowroot_attribute_names: &[String],
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if shadowrootmode.is_some_and(|mode| !matches!(mode, "open" | "closed")) {
+        reasons.push("invalid-shadowrootmode".to_string());
+    }
+    if shadowrootmode.is_none() && !shadowroot_attribute_names.is_empty() {
+        reasons.push("shadowroot-flags-without-mode".to_string());
+    }
+    reasons
 }
 
 fn browser_component_hydration_target(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -31,7 +31,7 @@ use coding_adventures_html_parser::{
     BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
     BrowserSelectionInteractionDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
     BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
-    BrowserTemplate, BrowserTextSemantic, BrowserThemeColor,
+    BrowserTemplate, BrowserTemplateDescriptor, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -187,6 +187,8 @@ struct ExpectedBrowserDocument {
     disclosures: Vec<ExpectedDisclosure>,
     #[serde(default)]
     disclosure_state_descriptors: Option<Vec<ExpectedDisclosureStateDescriptor>>,
+    #[serde(default)]
+    template_descriptors: Option<Vec<ExpectedTemplateDescriptor>>,
     #[serde(default)]
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
     #[serde(default)]
@@ -358,6 +360,38 @@ struct ExpectedTemplate {
     #[serde(default)]
     shadowrootserializable: bool,
     content_text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedTemplateDescriptor {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    template_kind: String,
+    #[serde(default)]
+    shadowrootmode: Option<String>,
+    #[serde(default)]
+    shadowroot_attribute_names: Vec<String>,
+    #[serde(default)]
+    shadowroot_attribute_count: usize,
+    #[serde(default)]
+    declarative_shadow_root: bool,
+    #[serde(default)]
+    shadowroot_mode_valid: bool,
+    #[serde(default)]
+    shadowrootdelegatesfocus: bool,
+    #[serde(default)]
+    shadowrootclonable: bool,
+    #[serde(default)]
+    shadowrootserializable: bool,
+    #[serde(default)]
+    content_text: String,
+    #[serde(default)]
+    content_word_count: usize,
+    #[serde(default)]
+    template_blocked: bool,
+    #[serde(default)]
+    template_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4078,12 +4112,16 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         let tracks_aria_name_descriptors = case.expected.aria_name_descriptors.is_some();
         let tracks_aria_description_descriptors =
             case.expected.aria_description_descriptors.is_some();
+        let tracks_template_descriptors = case.expected.template_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
         }
         if !tracks_aria_description_descriptors {
             expected.aria_description_descriptors = actual.aria_description_descriptors.clone();
+        }
+        if !tracks_template_descriptors {
+            expected.template_descriptors = actual.template_descriptors.clone();
         }
 
         assert_eq!(
@@ -6297,6 +6335,74 @@ fn browser_component_hydration_metadata_tracks_custom_elements_slots_parts_and_d
 }
 
 #[test]
+fn browser_template_descriptors_track_shadowroot_mode_and_flags() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "component-template-page")
+        .expect("component template fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("component template fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.template_descriptors,
+        case.expected.into_browser_document().template_descriptors,
+        "template descriptors should preserve declarative shadow root mode, flags, and content summary",
+    );
+}
+
+#[test]
+fn browser_template_descriptors_track_invalid_shadowroot_modes_and_orphan_flags() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <template id=bad shadowrootmode=sideways shadowrootdelegatesfocus>Bad mode</template>
+            <template id=flags shadowrootserializable>Plain template</template>
+        </body>"#,
+    )
+    .expect("template blocker fixture should parse");
+
+    let bad = actual
+        .template_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("bad"))
+        .expect("bad template descriptor should be present");
+
+    assert_eq!(bad.template_kind, "declarative-shadow-root");
+    assert_eq!(bad.shadowrootmode.as_deref(), Some("sideways"));
+    assert_eq!(
+        bad.shadowroot_attribute_names,
+        vec!["shadowrootmode", "shadowrootdelegatesfocus"]
+    );
+    assert_eq!(bad.shadowroot_attribute_count, 2);
+    assert!(bad.declarative_shadow_root);
+    assert!(!bad.shadowroot_mode_valid);
+    assert!(bad.template_blocked);
+    assert_eq!(bad.template_block_reasons, vec!["invalid-shadowrootmode"]);
+
+    let flags = actual
+        .template_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("flags"))
+        .expect("flags template descriptor should be present");
+
+    assert_eq!(flags.template_kind, "inert-template");
+    assert_eq!(
+        flags.shadowroot_attribute_names,
+        vec!["shadowrootserializable"]
+    );
+    assert!(!flags.declarative_shadow_root);
+    assert!(!flags.shadowroot_mode_valid);
+    assert!(flags.template_blocked);
+    assert_eq!(
+        flags.template_block_reasons,
+        vec!["shadowroot-flags-without-mode"]
+    );
+}
+
+#[test]
 fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_elements() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -7028,6 +7134,12 @@ impl ExpectedBrowserDocument {
             scroll_interaction_descriptors,
             disclosures,
             disclosure_state_descriptors,
+            template_descriptors: self
+                .template_descriptors
+                .unwrap_or_default()
+                .into_iter()
+                .map(ExpectedTemplateDescriptor::into_browser_template_descriptor)
+                .collect(),
             component_hydration_targets: self
                 .component_hydration_targets
                 .into_iter()
@@ -7218,6 +7330,27 @@ impl ExpectedTemplate {
             shadowrootclonable: self.shadowrootclonable,
             shadowrootserializable: self.shadowrootserializable,
             content_text: self.content_text,
+        }
+    }
+}
+
+impl ExpectedTemplateDescriptor {
+    fn into_browser_template_descriptor(self) -> BrowserTemplateDescriptor {
+        BrowserTemplateDescriptor {
+            id: self.id,
+            template_kind: self.template_kind,
+            shadowrootmode: self.shadowrootmode,
+            shadowroot_attribute_names: self.shadowroot_attribute_names,
+            shadowroot_attribute_count: self.shadowroot_attribute_count,
+            declarative_shadow_root: self.declarative_shadow_root,
+            shadowroot_mode_valid: self.shadowroot_mode_valid,
+            shadowrootdelegatesfocus: self.shadowrootdelegatesfocus,
+            shadowrootclonable: self.shadowrootclonable,
+            shadowrootserializable: self.shadowrootserializable,
+            content_text: self.content_text,
+            content_word_count: self.content_word_count,
+            template_blocked: self.template_blocked,
+            template_block_reasons: self.template_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -2333,6 +2333,22 @@
             "content_text": "Untitled Body"
           }
         ],
+        "template_descriptors": [
+          {
+            "id": "card-template",
+            "template_kind": "declarative-shadow-root",
+            "shadowrootmode": "open",
+            "shadowroot_attribute_names": ["shadowrootmode", "shadowrootdelegatesfocus", "shadowrootclonable", "shadowrootserializable"],
+            "shadowroot_attribute_count": 4,
+            "declarative_shadow_root": true,
+            "shadowroot_mode_valid": true,
+            "shadowrootdelegatesfocus": true,
+            "shadowrootclonable": true,
+            "shadowrootserializable": true,
+            "content_text": "Untitled Body",
+            "content_word_count": 2
+          }
+        ],
         "component_hydration_targets": [
           { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "text": "Untitled Body" },
           { "element": "article", "part": ["frame"], "text": "Untitled Body" },


### PR DESCRIPTION
## Summary
- add template descriptors for declarative shadow root mode and flags
- surface template content summaries, shadowroot attribute counts, and blocker hints
- add fixture-backed and inline tests for valid shadow roots and invalid/orphan shadowroot flags

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_template_descriptors
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser