### PR TITLE
Add smart-home activation remediation tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -103,6 +103,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation response planning:
   `smart_home.list_integration_activation_responses` and
   `smart_home.get_integration_activation_response_summary`.
+- Added D18D handlers for D23A activation remediation work orders:
+  `smart_home.list_integration_activation_remediation` and
+  `smart_home.get_integration_activation_remediation_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -69,6 +69,7 @@ Chief of Staff job/session/agent
   -> activation-audit list and summary reads for source-linked audit trails
   -> activation-escalation list and summary reads for Chief-facing cases
   -> activation-response list and summary reads for owner-lane next actions
+  -> activation-remediation list and summary reads for owner-lane work orders
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -158,6 +159,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_escalation_summary`
 - `smart_home.list_integration_activation_responses`
 - `smart_home.get_integration_activation_response_summary`
+- `smart_home.list_integration_activation_remediation`
+- `smart_home.get_integration_activation_remediation_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -47,10 +47,10 @@ use smart_home_integration_catalog::{
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
     activation_plan_for_entry, activation_plans_at_or_before_priority,
     activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
-    activation_response_items_from_escalation_cases, activation_reviews_from_candidates,
-    activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
-    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
-    activation_timeline_milestones_from_dashboard_cards,
+    activation_remediation_items_from_responses, activation_response_items_from_escalation_cases,
+    activation_reviews_from_candidates, activation_risk_from_candidates,
+    activation_runbook_entries_from_playbook_steps, activation_runway_from_candidates,
+    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
     activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
@@ -94,6 +94,8 @@ use smart_home_integration_catalog::{
     IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
+    IntegrationActivationRemediationItem, IntegrationActivationRemediationKind,
+    IntegrationActivationRemediationStatus, IntegrationActivationRemediationSummary,
     IntegrationActivationResponseItem, IntegrationActivationResponseKind,
     IntegrationActivationResponseOwnerLane, IntegrationActivationResponseSummary,
     IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
@@ -334,6 +336,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RESPONSES_TOOL_ID: &str =
     "smart_home.list_integration_activation_responses";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_response_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID: &str =
+    "smart_home.list_integration_activation_remediation";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_remediation_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -754,6 +760,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_response_query(&arguments)?;
                     Ok(get_integration_activation_response_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID => {
+                    let query = integration_activation_remediation_query(&arguments)?;
+                    Ok(list_integration_activation_remediation_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_remediation_query(&arguments)?;
+                    Ok(get_integration_activation_remediation_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2456,6 +2470,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation response summary",
             "Return compact D23A activation response counts by owner lane, next action, blocker, dependency, policy, review, verification, and audit follow-up work.",
             integration_activation_response_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID,
+            "List smart-home integration activation remediation",
+            "List Chief-facing D23A activation remediation work orders derived from response items with owner lanes and execution status.",
+            integration_activation_remediation_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_remediation", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_remediation",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation remediation summary",
+            "Return compact D23A activation remediation counts by owner lane, remediation kind, status, blocker, dependency, policy, review, verification, and audit follow-up work.",
+            integration_activation_remediation_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5297,6 +5345,18 @@ struct IntegrationActivationResponseQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationRemediationQuery {
+    response: IntegrationActivationResponseQuery,
+    remediation_kind: Option<IntegrationActivationRemediationKind>,
+    status: Option<IntegrationActivationRemediationStatus>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    ready_to_execute: Option<bool>,
+    remediation_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -5947,6 +6007,34 @@ fn integration_activation_response_query(
         blocked: optional_bool(arguments, "response_blocked")?,
         ready_to_verify: optional_bool(arguments, "response_ready_to_verify")?,
         response_limit: optional_u64(arguments, "response_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_remediation_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationRemediationQuery, ToolCallError> {
+    let remediation_kind = optional_string(arguments, "remediation_kind")?
+        .or(optional_string(arguments, "remediation")?)
+        .map(|label| parse_activation_remediation_kind(&label))
+        .transpose()?;
+    let status = optional_string(arguments, "remediation_status")?
+        .or(optional_string(arguments, "status")?)
+        .map(|label| parse_activation_remediation_status(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "remediation_owner_lane")?
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationRemediationQuery {
+        response: integration_activation_response_query(arguments)?,
+        remediation_kind,
+        status,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "remediation_requires_attention")?,
+        blocked: optional_bool(arguments, "remediation_blocked")?,
+        ready_to_execute: optional_bool(arguments, "remediation_ready_to_execute")?,
+        remediation_limit: optional_u64(arguments, "remediation_limit")?
+            .map(|value| value as usize),
     })
 }
 
@@ -7023,6 +7111,38 @@ fn integration_activation_response_items_for_query(
     }
 
     (responses, catalog_count)
+}
+
+fn integration_activation_remediation_items_for_query(
+    query: &IntegrationActivationRemediationQuery,
+) -> (Vec<IntegrationActivationRemediationItem>, usize) {
+    let (responses, catalog_count) =
+        integration_activation_response_items_for_query(&query.response);
+    let mut remediations = activation_remediation_items_from_responses(&responses);
+
+    if let Some(remediation_kind) = query.remediation_kind {
+        remediations.retain(|remediation| remediation.remediation_kind == remediation_kind);
+    }
+    if let Some(status) = query.status {
+        remediations.retain(|remediation| remediation.status == status);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        remediations.retain(|remediation| remediation.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        remediations.retain(|remediation| remediation.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        remediations.retain(|remediation| remediation.blocked() == blocked);
+    }
+    if let Some(ready_to_execute) = query.ready_to_execute {
+        remediations.retain(|remediation| remediation.ready_to_execute() == ready_to_execute);
+    }
+    if let Some(limit) = query.remediation_limit {
+        remediations.truncate(limit);
+    }
+
+    (remediations, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -9642,6 +9762,98 @@ fn get_integration_activation_response_summary_output_handler_output(
             (
                 "responses_ready_to_verify",
                 integer(summary.responses_ready_to_verify as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_remediation_output_handler_output(
+    query: IntegrationActivationRemediationQuery,
+) -> ToolHandlerOutput {
+    let (remediations, catalog_count) = integration_activation_remediation_items_for_query(&query);
+    let summary = IntegrationActivationRemediationSummary::from_remediations(remediations.iter());
+    let count = remediations.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_remediation",
+            JsonValue::Array(
+                remediations
+                    .iter()
+                    .map(activation_remediation_item_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_remediation_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_remediation"),
+            ),
+            ("remediations", integer(count as i64)),
+            (
+                "remediations_requiring_attention",
+                integer(summary.remediations_requiring_attention as i64),
+            ),
+            (
+                "blocked_remediations",
+                integer(summary.blocked_remediations as i64),
+            ),
+            (
+                "ready_to_execute_remediations",
+                integer(summary.ready_to_execute_remediations as i64),
+            ),
+            (
+                "next_remediation_kind",
+                summary
+                    .next_remediation_kind
+                    .map(|kind| string(kind.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_remediation_summary_output_handler_output(
+    query: IntegrationActivationRemediationQuery,
+) -> ToolHandlerOutput {
+    let (remediations, _) = integration_activation_remediation_items_for_query(&query);
+    let summary = IntegrationActivationRemediationSummary::from_remediations(remediations.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_remediation_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_remediation_summary"),
+            ),
+            (
+                "total_remediations",
+                integer(summary.total_remediations as i64),
+            ),
+            (
+                "remediations_requiring_attention",
+                integer(summary.remediations_requiring_attention as i64),
+            ),
+            (
+                "blocked_remediations",
+                integer(summary.blocked_remediations as i64),
+            ),
+            (
+                "ready_to_execute_remediations",
+                integer(summary.ready_to_execute_remediations as i64),
             ),
         ]),
     )
@@ -18996,6 +19208,257 @@ fn integration_activation_response_summary_json(
     ])
 }
 
+fn activation_remediation_item_json(
+    remediation: &IntegrationActivationRemediationItem,
+) -> JsonValue {
+    object([
+        ("sequence", integer(remediation.sequence as i64)),
+        (
+            "remediation_kind",
+            string(remediation.remediation_kind.as_str()),
+        ),
+        ("status", string(remediation.status.as_str())),
+        ("owner_lane", string(remediation.owner_lane.as_str())),
+        (
+            "source_response_sequence",
+            integer(remediation.source_response_sequence as i64),
+        ),
+        (
+            "source_response_kind",
+            string(remediation.source_response_kind.as_str()),
+        ),
+        ("source_id", string(&remediation.source_id)),
+        ("title", string(&remediation.title)),
+        ("summary", string(&remediation.summary)),
+        ("priority", integer(remediation.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                remediation
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(remediation.integration_count() as i64),
+        ),
+        (
+            "recommended_view",
+            string(remediation.recommended_view.as_str()),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(remediation.required_tier)),
+        ),
+        (
+            "policy_surface",
+            remediation
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(remediation.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(remediation.has_policy_risk()),
+        ),
+        (
+            "ready_to_verify",
+            JsonValue::Bool(remediation.ready_to_verify()),
+        ),
+        (
+            "ready_to_execute",
+            JsonValue::Bool(remediation.ready_to_execute()),
+        ),
+        ("blocked", JsonValue::Bool(remediation.blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(remediation.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_remediation_summary_json(
+    summary: &IntegrationActivationRemediationSummary,
+) -> JsonValue {
+    object([
+        (
+            "total_remediations",
+            integer(summary.total_remediations as i64),
+        ),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "remediations_requiring_attention",
+            integer(summary.remediations_requiring_attention as i64),
+        ),
+        (
+            "unblock_platform_remediations",
+            integer(summary.unblock_platform_remediations as i64),
+        ),
+        (
+            "enable_dependency_remediations",
+            integer(summary.enable_dependency_remediations as i64),
+        ),
+        (
+            "review_policy_remediations",
+            integer(summary.review_policy_remediations as i64),
+        ),
+        (
+            "complete_review_remediations",
+            integer(summary.complete_review_remediations as i64),
+        ),
+        (
+            "run_verification_remediations",
+            integer(summary.run_verification_remediations as i64),
+        ),
+        (
+            "record_audit_remediations",
+            integer(summary.record_audit_remediations as i64),
+        ),
+        (
+            "platform_owner_remediations",
+            integer(summary.platform_owner_remediations as i64),
+        ),
+        (
+            "integration_owner_remediations",
+            integer(summary.integration_owner_remediations as i64),
+        ),
+        (
+            "security_owner_remediations",
+            integer(summary.security_owner_remediations as i64),
+        ),
+        (
+            "reviewer_owner_remediations",
+            integer(summary.reviewer_owner_remediations as i64),
+        ),
+        (
+            "verification_owner_remediations",
+            integer(summary.verification_owner_remediations as i64),
+        ),
+        (
+            "audit_owner_remediations",
+            integer(summary.audit_owner_remediations as i64),
+        ),
+        (
+            "blocked_remediations",
+            integer(summary.blocked_remediations as i64),
+        ),
+        (
+            "owner_action_remediations",
+            integer(summary.owner_action_remediations as i64),
+        ),
+        (
+            "ready_to_execute_remediations",
+            integer(summary.ready_to_execute_remediations as i64),
+        ),
+        (
+            "tracking_remediations",
+            integer(summary.tracking_remediations as i64),
+        ),
+        (
+            "remediations_with_dependency_work",
+            integer(summary.remediations_with_dependency_work as i64),
+        ),
+        (
+            "remediations_with_policy_risk",
+            integer(summary.remediations_with_policy_risk as i64),
+        ),
+        (
+            "remediations_ready_to_verify",
+            integer(summary.remediations_ready_to_verify as i64),
+        ),
+        (
+            "remediations_with_policy_surface",
+            integer(summary.remediations_with_policy_surface as i64),
+        ),
+        (
+            "next_remediation_kind",
+            summary
+                .next_remediation_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_status",
+            summary
+                .next_remediation_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_sequence",
+            summary
+                .next_remediation_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_priority",
+            summary
+                .next_remediation_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(summary.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(summary.has_policy_risk()),
+        ),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "ready_to_execute",
+            JsonValue::Bool(summary.ready_to_execute()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -21924,6 +22387,54 @@ fn parse_activation_response_owner_lane(
     }
 }
 
+fn parse_activation_remediation_kind(
+    label: &str,
+) -> Result<IntegrationActivationRemediationKind, ToolCallError> {
+    match label {
+        "unblock_platform" | "unblock" | "resolve_blocker" | "blocker" => {
+            Ok(IntegrationActivationRemediationKind::UnblockPlatform)
+        }
+        "enable_dependency" | "dependency" | "dependencies" => {
+            Ok(IntegrationActivationRemediationKind::EnableDependency)
+        }
+        "review_policy" | "policy" | "policy_risk" | "risk" => {
+            Ok(IntegrationActivationRemediationKind::ReviewPolicy)
+        }
+        "complete_review" | "review" | "queue_review" | "reviewer" => {
+            Ok(IntegrationActivationRemediationKind::CompleteReview)
+        }
+        "run_verification" | "verification" | "verify" | "verify_activation" => {
+            Ok(IntegrationActivationRemediationKind::RunVerification)
+        }
+        "record_audit" | "audit" | "audit_follow_up" | "follow_up" => {
+            Ok(IntegrationActivationRemediationKind::RecordAudit)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation remediation kind `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_remediation_status(
+    label: &str,
+) -> Result<IntegrationActivationRemediationStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" => Ok(IntegrationActivationRemediationStatus::Blocked),
+        "needs_owner_action" | "owner_action" | "needs_action" | "action" => {
+            Ok(IntegrationActivationRemediationStatus::NeedsOwnerAction)
+        }
+        "ready_to_execute" | "ready" | "execute" => {
+            Ok(IntegrationActivationRemediationStatus::ReadyToExecute)
+        }
+        "tracking" | "monitor" | "monitoring" => {
+            Ok(IntegrationActivationRemediationStatus::Tracking)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation remediation status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -23477,6 +23988,45 @@ fn integration_activation_response_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_remediation_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_response_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("remediation_kind", JsonSchema::String));
+        properties.push(SchemaProperty::new("remediation", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "remediation_status",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("status", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "remediation_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "remediation_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "remediation_blocked",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "remediation_ready_to_execute",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "remediation_limit",
+            JsonSchema::Integer,
+        ));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -23621,7 +24171,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 121);
+        assert_eq!(definitions.len(), 123);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -23956,9 +24506,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            113
+            115
         );
         assert_eq!(
             export
@@ -23991,6 +24547,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RESPONSE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -24444,11 +25008,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(121))
+            Some(&integer(123))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(113))
+            Some(&integer(115))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -28693,6 +29257,168 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_remediation_request = request(
+            "call-list-integration-activation-remediation",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("remediation_kind", string("unblock_platform")),
+                ("remediation_status", string("blocked")),
+                ("remediation_requires_attention", JsonValue::Bool(true)),
+                ("remediation_blocked", JsonValue::Bool(true)),
+                ("remediation_limit", integer(3)),
+            ]),
+            5_047,
+        );
+        let list_activation_remediation_trace =
+            tool_runtime.invoke_with_events(&list_activation_remediation_request);
+        assert!(list_activation_remediation_trace.result.ok);
+        assert_eq!(
+            list_activation_remediation_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_remediation_output = list_activation_remediation_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_remediation_count =
+            integer_value(field(list_activation_remediation_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_remediation_count));
+        let activation_remediation_summary =
+            field(list_activation_remediation_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_remediation_summary, "total_remediations"),
+            Some(&integer(activation_remediation_count))
+        );
+        assert_eq!(
+            field(activation_remediation_summary, "next_remediation_kind"),
+            Some(&string("unblock_platform"))
+        );
+        assert_eq!(
+            field(activation_remediation_summary, "next_remediation_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_remediation_summary, "next_owner_lane"),
+            Some(&string("platform"))
+        );
+        assert_eq!(
+            field(activation_remediation_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_remediation_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_remediation = array_item(
+            field(list_activation_remediation_output, "activation_remediation").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_remediation, "remediation_kind"),
+            Some(&string("unblock_platform"))
+        );
+        assert_eq!(
+            field(activation_remediation, "status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_remediation, "owner_lane"),
+            Some(&string("platform"))
+        );
+        assert_eq!(
+            field(activation_remediation, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_remediation, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_remediation_summary_request = request(
+            "call-integration-activation-remediation-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("remediation_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_048,
+        );
+        let activation_remediation_summary_trace =
+            tool_runtime.invoke_with_events(&activation_remediation_summary_request);
+        assert!(activation_remediation_summary_trace.result.ok);
+        assert_eq!(
+            activation_remediation_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_remediation_summary_output = activation_remediation_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_remediation_rollup =
+            field(activation_remediation_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_remediation_rollup, "total_remediations").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_remediation_rollup, "blocked_remediations").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_remediation_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_remediation_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -30549,6 +31275,14 @@ mod tests {
             activation_response_summary_request,
             activation_response_summary_trace,
         );
+        journal.record_trace(
+            list_activation_remediation_request,
+            list_activation_remediation_trace,
+        );
+        journal.record_trace(
+            activation_remediation_summary_request,
+            activation_remediation_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -30622,9 +31356,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 121);
-        assert_eq!(journal_summary.completed_count, 121);
-        assert_eq!(journal.audit_records().len(), 121);
+        assert_eq!(journal_summary.invocation_count, 123);
+        assert_eq!(journal_summary.completed_count, 123);
+        assert_eq!(journal.audit_records().len(), 123);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -136,6 +136,10 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_response_summary` tool descriptors for
   read-only owner-lane activation response planning derived from escalation
   cases.
+- `smart_home.list_integration_activation_remediation` and
+  `smart_home.get_integration_activation_remediation_summary` tool descriptors
+  for read-only owner-lane activation remediation work orders derived from
+  response items.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -117,6 +117,8 @@ Current scope:
   derived from sentinel, verification, and audit rollups
 - D18D integration activation-response descriptors for owner-lane next actions
   derived from Chief-facing escalation cases
+- D18D integration activation-remediation descriptors for owner-lane work
+  orders derived from activation response items
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1519,6 +1519,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationEscalationSummary,
     ListIntegrationActivationResponses,
     GetIntegrationActivationResponseSummary,
+    ListIntegrationActivationRemediation,
+    GetIntegrationActivationRemediationSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1782,6 +1784,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationResponseSummary => {
                 read_tool("smart_home.get_integration_activation_response_summary")
+            }
+            Self::ListIntegrationActivationRemediation => {
+                read_tool("smart_home.list_integration_activation_remediation")
+            }
+            Self::GetIntegrationActivationRemediationSummary => {
+                read_tool("smart_home.get_integration_activation_remediation_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2484,6 +2492,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationEscalationSummary,
         SmartHomeTool::ListIntegrationActivationResponses,
         SmartHomeTool::GetIntegrationActivationResponseSummary,
+        SmartHomeTool::ListIntegrationActivationRemediation,
+        SmartHomeTool::GetIntegrationActivationRemediationSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3326,7 +3336,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 121);
+        assert_eq!(catalog.len(), 123);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3817,6 +3827,14 @@ mod tests {
             == "smart_home.get_integration_activation_response_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_remediation"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_remediation_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3824,15 +3842,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 121);
-        assert_eq!(summary.read_tools, 113);
+        assert_eq!(summary.total_tools, 123);
+        assert_eq!(summary.read_tools, 115);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 113);
+        assert_eq!(summary.read_only_tier_tools, 115);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 121);
+        assert_eq!(summary.total_required_capabilities, 123);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -109,6 +109,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationResponseItem` and
   `IntegrationActivationResponseSummary` for turning escalation cases into
   owner-lane next actions for response planning.
+- `IntegrationActivationRemediationItem` and
+  `IntegrationActivationRemediationSummary` for turning response items into
+  executable owner-lane remediation queues.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -99,6 +99,9 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation response items that turn escalation cases into owner-lane next
   actions for blocker, dependency, policy, review, verification, and audit
   follow-up work
+- activation remediation work orders that assign response items to executable
+  owner-lane queues with blocked, owner-action, ready-to-execute, and tracking
+  status
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1461,6 +1461,73 @@ impl IntegrationActivationResponseOwnerLane {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationRemediationKind {
+    UnblockPlatform,
+    EnableDependency,
+    ReviewPolicy,
+    CompleteReview,
+    RunVerification,
+    RecordAudit,
+}
+
+impl IntegrationActivationRemediationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UnblockPlatform => "unblock_platform",
+            Self::EnableDependency => "enable_dependency",
+            Self::ReviewPolicy => "review_policy",
+            Self::CompleteReview => "complete_review",
+            Self::RunVerification => "run_verification",
+            Self::RecordAudit => "record_audit",
+        }
+    }
+
+    pub fn from_response_kind(response_kind: IntegrationActivationResponseKind) -> Self {
+        match response_kind {
+            IntegrationActivationResponseKind::ResolveBlocker => Self::UnblockPlatform,
+            IntegrationActivationResponseKind::EnableDependency => Self::EnableDependency,
+            IntegrationActivationResponseKind::ReviewPolicy => Self::ReviewPolicy,
+            IntegrationActivationResponseKind::QueueReview => Self::CompleteReview,
+            IntegrationActivationResponseKind::VerifyActivation => Self::RunVerification,
+            IntegrationActivationResponseKind::AuditFollowUp => Self::RecordAudit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationRemediationStatus {
+    Blocked,
+    NeedsOwnerAction,
+    ReadyToExecute,
+    Tracking,
+}
+
+impl IntegrationActivationRemediationStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::NeedsOwnerAction => "needs_owner_action",
+            Self::ReadyToExecute => "ready_to_execute",
+            Self::Tracking => "tracking",
+        }
+    }
+
+    pub fn from_response(response: &IntegrationActivationResponseItem) -> Self {
+        if response.blocked() {
+            Self::Blocked
+        } else if response.ready_to_verify()
+            || response.response_kind == IntegrationActivationResponseKind::VerifyActivation
+        {
+            Self::ReadyToExecute
+        } else if response.requires_attention() {
+            Self::NeedsOwnerAction
+        } else {
+            Self::Tracking
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3233,6 +3300,65 @@ pub struct IntegrationActivationResponseSummary {
     pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
     pub next_response_sequence: Option<usize>,
     pub next_response_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRemediationItem {
+    pub sequence: usize,
+    pub remediation_kind: IntegrationActivationRemediationKind,
+    pub status: IntegrationActivationRemediationStatus,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_response_sequence: usize,
+    pub source_response_kind: IntegrationActivationResponseKind,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_ready: bool,
+    pub blocked: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationRemediationSummary {
+    pub total_remediations: usize,
+    pub unique_integrations: usize,
+    pub remediations_requiring_attention: usize,
+    pub unblock_platform_remediations: usize,
+    pub enable_dependency_remediations: usize,
+    pub review_policy_remediations: usize,
+    pub complete_review_remediations: usize,
+    pub run_verification_remediations: usize,
+    pub record_audit_remediations: usize,
+    pub platform_owner_remediations: usize,
+    pub integration_owner_remediations: usize,
+    pub security_owner_remediations: usize,
+    pub reviewer_owner_remediations: usize,
+    pub verification_owner_remediations: usize,
+    pub audit_owner_remediations: usize,
+    pub blocked_remediations: usize,
+    pub owner_action_remediations: usize,
+    pub ready_to_execute_remediations: usize,
+    pub tracking_remediations: usize,
+    pub remediations_with_dependency_work: usize,
+    pub remediations_with_policy_risk: usize,
+    pub remediations_ready_to_verify: usize,
+    pub remediations_with_policy_surface: usize,
+    pub next_remediation_kind: Option<IntegrationActivationRemediationKind>,
+    pub next_remediation_status: Option<IntegrationActivationRemediationStatus>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_remediation_sequence: Option<usize>,
+    pub next_remediation_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -8927,6 +9053,256 @@ impl IntegrationActivationResponseSummary {
     }
 }
 
+impl IntegrationActivationRemediationItem {
+    fn from_response(response: &IntegrationActivationResponseItem) -> Self {
+        let remediation_kind =
+            IntegrationActivationRemediationKind::from_response_kind(response.response_kind);
+        let status = IntegrationActivationRemediationStatus::from_response(response);
+
+        Self {
+            sequence: 0,
+            remediation_kind,
+            status,
+            owner_lane: response.owner_lane,
+            source_response_sequence: response.sequence,
+            source_response_kind: response.response_kind,
+            source_id: response.source_id.clone(),
+            title: format!("{}: {}", remediation_kind.as_str(), response.title),
+            summary: response.summary.clone(),
+            priority: response.priority,
+            integration_ids: response.integration_ids.clone(),
+            recommended_view: response.recommended_view,
+            required_tier: response.required_tier,
+            policy_surface: response.policy_surface,
+            dependency_work: response.has_dependency_work(),
+            policy_risk: response.has_policy_risk(),
+            verification_ready: response.ready_to_verify(),
+            blocked: response.blocked(),
+            requires_attention: response.requires_attention()
+                || status != IntegrationActivationRemediationStatus::Tracking,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.verification_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked || self.status == IntegrationActivationRemediationStatus::Blocked
+    }
+
+    pub fn ready_to_execute(&self) -> bool {
+        self.status == IntegrationActivationRemediationStatus::ReadyToExecute
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationRemediationSummary {
+    pub fn from_remediations<'a>(
+        remediations: impl IntoIterator<Item = &'a IntegrationActivationRemediationItem>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_remediations: 0,
+            unique_integrations: 0,
+            remediations_requiring_attention: 0,
+            unblock_platform_remediations: 0,
+            enable_dependency_remediations: 0,
+            review_policy_remediations: 0,
+            complete_review_remediations: 0,
+            run_verification_remediations: 0,
+            record_audit_remediations: 0,
+            platform_owner_remediations: 0,
+            integration_owner_remediations: 0,
+            security_owner_remediations: 0,
+            reviewer_owner_remediations: 0,
+            verification_owner_remediations: 0,
+            audit_owner_remediations: 0,
+            blocked_remediations: 0,
+            owner_action_remediations: 0,
+            ready_to_execute_remediations: 0,
+            tracking_remediations: 0,
+            remediations_with_dependency_work: 0,
+            remediations_with_policy_risk: 0,
+            remediations_ready_to_verify: 0,
+            remediations_with_policy_surface: 0,
+            next_remediation_kind: None,
+            next_remediation_status: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_remediation_sequence: None,
+            next_remediation_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for remediation in remediations {
+            summary.total_remediations += 1;
+            for integration_id in &remediation.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_remediation_kind.is_none()
+                && (remediation.requires_attention() || remediation.ready_to_execute())
+            {
+                summary.next_remediation_kind = Some(remediation.remediation_kind);
+                summary.next_remediation_status = Some(remediation.status);
+                summary.next_owner_lane = Some(remediation.owner_lane);
+                summary.next_recommended_view = Some(remediation.recommended_view);
+                summary.next_remediation_sequence = Some(remediation.sequence);
+                summary.next_remediation_priority = Some(remediation.priority);
+            }
+
+            match remediation.remediation_kind {
+                IntegrationActivationRemediationKind::UnblockPlatform => {
+                    summary.unblock_platform_remediations += 1;
+                }
+                IntegrationActivationRemediationKind::EnableDependency => {
+                    summary.enable_dependency_remediations += 1;
+                }
+                IntegrationActivationRemediationKind::ReviewPolicy => {
+                    summary.review_policy_remediations += 1;
+                }
+                IntegrationActivationRemediationKind::CompleteReview => {
+                    summary.complete_review_remediations += 1;
+                }
+                IntegrationActivationRemediationKind::RunVerification => {
+                    summary.run_verification_remediations += 1;
+                }
+                IntegrationActivationRemediationKind::RecordAudit => {
+                    summary.record_audit_remediations += 1;
+                }
+            }
+
+            match remediation.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_remediations += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_remediations += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_remediations += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_remediations += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_remediations += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_remediations += 1;
+                }
+            }
+
+            match remediation.status {
+                IntegrationActivationRemediationStatus::Blocked => {
+                    summary.blocked_remediations += 1;
+                }
+                IntegrationActivationRemediationStatus::NeedsOwnerAction => {
+                    summary.owner_action_remediations += 1;
+                }
+                IntegrationActivationRemediationStatus::ReadyToExecute => {
+                    summary.ready_to_execute_remediations += 1;
+                }
+                IntegrationActivationRemediationStatus::Tracking => {
+                    summary.tracking_remediations += 1;
+                }
+            }
+
+            if remediation.requires_attention() {
+                summary.remediations_requiring_attention += 1;
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(remediation.priority),
+                );
+            }
+            if remediation.has_dependency_work() {
+                summary.remediations_with_dependency_work += 1;
+            }
+            if remediation.has_policy_risk() {
+                summary.remediations_with_policy_risk += 1;
+            }
+            if remediation.ready_to_verify() {
+                summary.remediations_ready_to_verify += 1;
+            }
+            if remediation.has_policy_surface() {
+                summary.remediations_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier =
+                summary.highest_policy_tier.max(remediation.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_remediations > 0
+            || summary.unblock_platform_remediations > 0
+            || summary.enable_dependency_remediations > 0
+        {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.remediations_requiring_attention > 0
+            || summary.review_policy_remediations > 0
+            || summary.complete_review_remediations > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_to_execute_remediations > 0
+            || summary.run_verification_remediations > 0
+        {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_remediations == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.unblock_platform_remediations > 0 || self.blocked_remediations > 0
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.enable_dependency_remediations > 0 || self.remediations_with_dependency_work > 0
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.review_policy_remediations > 0 || self.remediations_with_policy_risk > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.owner_action_remediations > 0
+    }
+
+    pub fn ready_to_execute(&self) -> bool {
+        self.ready_to_execute_remediations > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.remediations_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -13988,6 +14364,38 @@ pub fn activation_response_items_at_or_before_priority(
     activation_response_items_from_escalation_cases(&cases)
 }
 
+pub fn activation_remediation_items_from_responses(
+    responses: &[IntegrationActivationResponseItem],
+) -> Vec<IntegrationActivationRemediationItem> {
+    let mut remediations: Vec<_> = responses
+        .iter()
+        .map(IntegrationActivationRemediationItem::from_response)
+        .collect();
+
+    remediations.sort_by(compare_activation_remediation_items);
+    for (index, remediation) in remediations.iter_mut().enumerate() {
+        remediation.sequence = index + 1;
+    }
+    remediations
+}
+
+pub fn activation_remediation_items_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationRemediationItem> {
+    let responses = activation_response_items_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_remediation_items_from_responses(&responses)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -15604,6 +16012,24 @@ fn compare_activation_response_items(
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
         .then_with(|| left.response_kind.cmp(&right.response_kind))
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_remediation_items(
+    left: &IntegrationActivationRemediationItem,
+    right: &IntegrationActivationRemediationItem,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.status.cmp(&right.status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| right.ready_to_execute().cmp(&left.ready_to_execute()))
+        .then_with(|| left.remediation_kind.cmp(&right.remediation_kind))
         .then_with(|| left.owner_lane.cmp(&right.owner_lane))
         .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
@@ -19117,6 +19543,53 @@ mod tests {
             IntegrationActivationHealthStatus::Blocked
         );
 
+        let remediation_items = activation_remediation_items_from_responses(&response_items);
+        assert!(!remediation_items.is_empty());
+        assert!(remediation_items
+            .iter()
+            .any(|remediation| remediation.remediation_kind
+                == IntegrationActivationRemediationKind::UnblockPlatform));
+        assert!(remediation_items
+            .iter()
+            .any(|remediation| remediation.remediation_kind
+                == IntegrationActivationRemediationKind::EnableDependency));
+        assert!(remediation_items
+            .iter()
+            .any(|remediation| remediation.remediation_kind
+                == IntegrationActivationRemediationKind::RunVerification));
+        assert!(remediation_items
+            .iter()
+            .any(IntegrationActivationRemediationItem::requires_attention));
+        assert!(remediation_items
+            .iter()
+            .any(IntegrationActivationRemediationItem::blocked));
+
+        let remediation_summary =
+            IntegrationActivationRemediationSummary::from_remediations(remediation_items.iter());
+        assert_eq!(
+            remediation_summary.total_remediations,
+            remediation_items.len()
+        );
+        assert!(remediation_summary.has_blockers());
+        assert!(remediation_summary.has_dependency_work());
+        assert!(remediation_summary.requires_attention());
+        assert_eq!(
+            remediation_summary.next_remediation_kind,
+            Some(IntegrationActivationRemediationKind::UnblockPlatform)
+        );
+        assert_eq!(
+            remediation_summary.next_remediation_status,
+            Some(IntegrationActivationRemediationStatus::Blocked)
+        );
+        assert_eq!(
+            remediation_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            remediation_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
         let catalog = first_party_catalog();
         let available_primitives = vec![
             PrimitiveFamily::NormalizedModel,
@@ -19187,6 +19660,16 @@ mod tests {
         assert!(catalog_response_items
             .iter()
             .any(IntegrationActivationResponseItem::requires_attention));
+        let catalog_remediation_items = activation_remediation_items_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_remediation_items
+            .iter()
+            .any(IntegrationActivationRemediationItem::requires_attention));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add activation remediation items and summaries that derive owner-lane work orders from activation response items
- expose D18D read tools for listing activation remediation and reading remediation summaries
- update shared smart-home tool descriptors, Chief bridge handlers, end-to-end coverage, and docs

## Validation
- cargo fmt -p smart-home-integration-catalog -p smart-home-core -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools
- git diff --check