### PR TITLE
feat(adj-lang): rulebook + use — the rulebook as a named grammar construct (MYCIN-2026 M2)

### DIFF
--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -35,6 +35,7 @@ statement   = prior_decl
             | define_decl
             | rulebook_decl
             | use_decl
+            | import_decl
             ;
 
 # ----------------------------------------------------------------
@@ -151,6 +152,22 @@ surface_clause = "surface" STRING { COMMA STRING } ;
 rulebook_decl = "rulebook" IDENT LBRACE { statement } RBRACE ;
 
 use_decl      = "use" IDENT ;
+
+# ----------------------------------------------------------------
+# Import (MYCIN-2026 M3 — composition across files). `import "<path>"`
+# parses a sibling `.adj` file and splices its `dictionary` / `define` /
+# `rulebook` declarations (and any bare clauses) into the importing program,
+# so a dictionary and a rulebook can live in separate checked-in files and a
+# case file imports both. Resolution is RELATIVE to the importing file,
+# IDEMPOTENT (a file imported twice is included once, by canonical path),
+# ACYCLIC (a cycle is a clean compile error), and depth/fan-out bounded. The
+# `adj-lang` library stays filesystem-free: the import GRAPH logic lives in
+# `resolve.rs` driven by an injected `ImportProvider`; the CLI supplies the
+# real, sandbox-checked filesystem provider. `import` is an IDENT-matched
+# literal; the path is a STRING.
+# ----------------------------------------------------------------
+
+import_decl   = "import" STRING ;
 
 # ----------------------------------------------------------------
 # Annotations attach a citation / locator / trust tier to the

--- a/code/grammars/adj_lang.grammar
+++ b/code/grammars/adj_lang.grammar
@@ -33,6 +33,8 @@ statement   = prior_decl
             | optimize_decl
             | dictionary_decl
             | define_decl
+            | rulebook_decl
+            | use_decl
             ;
 
 # ----------------------------------------------------------------
@@ -130,6 +132,25 @@ define_kind    = "hypothesis"
                ;
 
 surface_clause = "surface" STRING { COMMA STRING } ;
+
+# ----------------------------------------------------------------
+# Rulebook + use (MYCIN-2026 M2 — the rulebook as a first-class, named,
+# reusable block). A `rulebook <name> { … }` groups the clauses
+# (prior/contributes/interacts/uncertain) that constitute a body of
+# adjudicatable knowledge under one name, so it can be written once,
+# checked in as code, and imported (M3). A `use <dictionary>` inside a
+# rulebook (or at top level) BINDS the controlled vocabulary the rulebook's
+# clauses are checked against: every term the rulebook names must be
+# `define`d in the `use`d dictionary, else a clean compile error. A rulebook
+# with no `use` is unchecked (backward-compatible, like a program with no
+# dictionary). `rulebook`/`use` are IDENT-matched literals — no lexer
+# keywords. The body is `{ statement }` so a rulebook may also carry its own
+# `use` (and nested structure); the lowerer flattens clauses into one KB.
+# ----------------------------------------------------------------
+
+rulebook_decl = "rulebook" IDENT LBRACE { statement } RBRACE ;
+
+use_decl      = "use" IDENT ;
 
 # ----------------------------------------------------------------
 # Annotations attach a citation / locator / trust tier to the

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.5.0] - 2026-06-12 — `import`-aware compile + the filesystem trust boundary (MYCIN-2026 M3)
+
+### Added
+
+- **The CLI now resolves `import`s before compiling.** A program may `import`
+  sibling `.adj` files (dictionary ← rulebook ← case); the CLI walks the graph
+  via `adj_lang::compile_with_imports` and emits the decision over the composed
+  program. Import errors (cycle, bound, missing/unparseable/escaping file)
+  surface as a single `{"error": …}` line.
+- **`FsProvider` — the import trust boundary.** The `adj-lang` library does no
+  I/O; this filesystem-backed `ImportProvider` is the only thing that reads
+  disk, so all path safety lives here: canonical ids are absolute,
+  symlink-resolved real paths (so spellings dedupe and a symlink can't forge a
+  second identity); import literals must be **relative** (absolute refused); the
+  resolved real path must stay within the **sandbox root** (the program file's
+  directory) — `../…` escapes and symlinks pointing outside the root are refused,
+  so `import` cannot read arbitrary host files.
+- 5 e2e tests (3-file decide; diamond no-duplicate; traversal / absolute / cycle
+  all refused without hang).
+
 ## [0.4.1] - 2026-06-12 — `FromSolve` proof: the solver certificate renders under the verdict step (ADJ constraints E3)
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/README.md
+++ b/code/packages/rust/adj-lang-cli/README.md
@@ -23,8 +23,12 @@ the decision **plus a byte-cited proof DAG** as JSON — with **zero model calls
 adj-lang-cli PROGRAM.adj
 ```
 
-`PROGRAM.adj` is typically the CAS rulebook clauses concatenated with a case's
-`observe`/`?` lines. Output (pretty-printed here):
+`PROGRAM.adj` is typically a case file that `import`s its rulebook (which in turn
+`import`s its dictionary) — or, equivalently, the rulebook clauses concatenated
+with the case's `observe`/`?` lines. Any `import "…"` is resolved before
+compiling; imports are relative to the importing file and sandboxed to the
+program file's directory (a `../` escape, an absolute path, or an import cycle is
+refused as a `{"error": …}`). Output (pretty-printed here):
 
 ```json
 {

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -24,6 +24,7 @@
 //! Argument parsing is declarative via `cli-builder`.
 
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use cli_builder::types::ParserOutput;
@@ -32,7 +33,7 @@ use cli_builder::{load_spec_from_str, Parser};
 use adj_constraint_solver::{
     check, optimize, solve, FeasibilityOutcome, OptimizeOutcome, SolveOutcome,
 };
-use adj_lang::{compile, decide};
+use adj_lang::{compile_with_imports, decide, ImportLimits, ImportProvider};
 use logic_core::{atom, Term};
 use logic_engine::{
     DerivationOrigin, DifferentialDecision, Fact, KnowledgeBase, LRAggregateResult, Provenance,
@@ -255,6 +256,60 @@ fn status_certificates(
     out
 }
 
+/// The filesystem-backed [`ImportProvider`] — the **trust boundary** for
+/// `import`. The `adj-lang` library does no I/O; this is the only thing that
+/// touches the disk, so every path-safety check lives here:
+///
+/// - Canonical ids are absolute, symlink-resolved real paths
+///   (`fs::canonicalize`), so two spellings of the same file dedupe and a
+///   symlink cannot smuggle in a second identity.
+/// - Import literals must be **relative** — an absolute literal is refused.
+/// - The resolved real path must stay within `root` (the directory of the
+///   top-level program). A `../…` escape or a symlink pointing outside `root`
+///   is refused — `import` cannot read arbitrary files on the host.
+struct FsProvider {
+    /// The sandbox root: canonicalized directory of the top-level program. No
+    /// import may resolve outside this subtree.
+    root: PathBuf,
+}
+
+impl FsProvider {
+    /// Canonicalize `p` and confirm it lies within the sandbox `root`.
+    fn checked_canonical(&self, p: &Path) -> Result<String, String> {
+        let abs = fs::canonicalize(p).map_err(|e| format!("{}: {e}", p.display()))?;
+        if !abs.starts_with(&self.root) {
+            return Err(format!(
+                "{} escapes the import root {}",
+                abs.display(),
+                self.root.display()
+            ));
+        }
+        Ok(abs.to_string_lossy().into_owned())
+    }
+}
+
+impl ImportProvider for FsProvider {
+    fn resolve(&self, importer: &str, literal: &str) -> Result<String, String> {
+        if Path::new(literal).is_absolute() {
+            return Err(format!("import path must be relative, got {literal:?}"));
+        }
+        // Reject NUL and other obviously hostile bytes before touching the FS.
+        if literal.contains('\0') {
+            return Err("import path contains a NUL byte".to_string());
+        }
+        let importer_dir = Path::new(importer)
+            .parent()
+            .ok_or_else(|| format!("importer {importer:?} has no parent directory"))?;
+        self.checked_canonical(&importer_dir.join(literal))
+    }
+
+    fn load(&self, canonical: &str) -> Result<String, String> {
+        // `canonical` came from `resolve`/the root, already inside `root`; read
+        // it. (Re-checking would re-canonicalize an already-canonical path.)
+        fs::read_to_string(canonical).map_err(|e| format!("{canonical}: {e}"))
+    }
+}
+
 fn main() -> ExitCode {
     let spec = load_spec_from_str(SPEC).expect("internal: invalid CLI spec");
     let parser = Parser::new(spec);
@@ -280,15 +335,30 @@ fn main() -> ExitCode {
         .get("program")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let src = match fs::read_to_string(path) {
-        Ok(s) => s,
+
+    // Resolve the program (and any `import`s) through the filesystem provider.
+    // The sandbox root is the directory of the program file; no `import` may
+    // read outside it. The canonical id of the root file seeds the resolver.
+    let root_id = match fs::canonicalize(path) {
+        Ok(p) => p,
         Err(e) => {
             eprintln!("adj-lang-cli: cannot read {}: {}", path, e);
             return ExitCode::from(2);
         }
     };
-
-    let mut lowered = match compile(&src) {
+    let root_dir = match root_id.parent() {
+        Some(d) => d.to_path_buf(),
+        None => {
+            eprintln!("adj-lang-cli: {} has no parent directory", path);
+            return ExitCode::from(2);
+        }
+    };
+    let provider = FsProvider { root: root_dir };
+    let mut lowered = match compile_with_imports(
+        &root_id.to_string_lossy(),
+        &provider,
+        ImportLimits::default(),
+    ) {
         Ok(l) => l,
         Err(e) => {
             println!("{{\"error\":\"{}\"}}", esc(&format!("{:?}", e)));

--- a/code/packages/rust/adj-lang-cli/tests/import_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/import_e2e.rs
@@ -1,0 +1,138 @@
+//! End-to-end tests for `import` (MYCIN-2026 M3) through the built CLI binary.
+//!
+//! These exercise the real filesystem provider — the `import` trust boundary —
+//! on multi-file `.adj` graphs: a dictionary, a rulebook that imports + `use`s
+//! it, and a case that imports the rulebook. They also confirm the sandbox
+//! rejects path-traversal / absolute / cyclic imports cleanly (no panic, no
+//! infinite loop, no reading outside the program's directory).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A fresh, uniquely-named temp directory under the system temp dir. (Avoids a
+/// dev-dependency on `tempfile`; `line!()` keeps concurrent tests from
+/// colliding.)
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_import_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &PathBuf, name: &str, src: &str) {
+    let p = dir.join(name);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(p, src).unwrap();
+}
+
+fn run(program: &PathBuf) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn three_file_chain_dictionary_rulebook_case_decides() {
+    let dir = scratch("chain");
+    write(
+        &dir,
+        "dictionary.adj",
+        "dictionary meningitis_vocab {\n\
+           define bacterial : hypothesis surface \"bacterial meningitis\"\n\
+           define viral : hypothesis surface \"viral meningitis\"\n\
+           define csf_glucose : finding values [low, normal] surface \"CSF glucose\"\n\
+         }\n",
+    );
+    write(
+        &dir,
+        "rulebook.adj",
+        "import \"dictionary.adj\"\n\
+         rulebook meningitis {\n\
+           use meningitis_vocab\n\
+           prior 0.30 for bacterial\n  source \"Tunkel IDSA 2004\" trust authoritative\n\
+           prior 0.30 for viral\n  source \"Tunkel IDSA 2004\" trust authoritative\n\
+           contributes 5 from csf_glucose(low) to bacterial\n  source \"low CSF glucose favors bacterial\" trust empirical\n\
+         }\n",
+    );
+    write(
+        &dir,
+        "case.adj",
+        "import \"rulebook.adj\"\nobserve csf_glucose(low)\n? bacterial\n? viral\n",
+    );
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // The composed program decides: bacterial leads on low CSF glucose, and the
+    // proof cites the rulebook clause's source — proving the imported rulebook +
+    // dictionary were merged and lowered.
+    assert!(s.contains("\"leader\":\"bacterial\""), "{s}");
+    assert!(
+        s.contains("\"source\":\"low CSF glucose favors bacterial\""),
+        "{s}"
+    );
+    // closed-vocabulary enforcement from the imported dictionary held (no error).
+    assert!(!s.contains("\"error\""), "{s}");
+}
+
+#[test]
+fn diamond_import_does_not_duplicate_the_shared_dictionary() {
+    // case imports two rulebooks, both importing the same dictionary. If the
+    // dictionary's prior were merged twice it would be a DuplicatePrior error.
+    let dir = scratch("diamond");
+    write(
+        &dir,
+        "dict.adj",
+        "dictionary v { define dx : hypothesis }\nprior 0.20 for dx\n  source \"s\" trust empirical\n",
+    );
+    write(&dir, "rb_a.adj", "import \"dict.adj\"\n");
+    write(&dir, "rb_b.adj", "import \"dict.adj\"\n");
+    write(
+        &dir,
+        "case.adj",
+        "import \"rb_a.adj\"\nimport \"rb_b.adj\"\n? dx\n",
+    );
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero (duplicate prior?): {s}");
+    assert!(s.contains("\"hypothesis\":\"dx\""), "{s}");
+    assert!(!s.contains("\"error\""), "{s}");
+}
+
+#[test]
+fn a_traversal_import_is_refused() {
+    // A case in a subdirectory tries to `../`-escape to a sibling of the root.
+    let dir = scratch("traversal");
+    write(&dir, "secret.adj", "prior 0.99 for leaked\n? leaked\n");
+    write(&dir, "sub/case.adj", "import \"../secret.adj\"\n? leaked\n");
+    let (ok, s) = run(&dir.join("sub/case.adj"));
+    assert!(!ok, "traversal import should fail: {s}");
+    assert!(s.contains("escapes the import root"), "{s}");
+}
+
+#[test]
+fn an_absolute_import_is_refused() {
+    let dir = scratch("absolute");
+    write(&dir, "secret.adj", "prior 0.99 for leaked\n? leaked\n");
+    let abs = dir.join("secret.adj");
+    write(
+        &dir,
+        "case.adj",
+        &format!("import \"{}\"\n? leaked\n", abs.display()),
+    );
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(!ok, "absolute import should fail: {s}");
+    assert!(s.contains("must be relative"), "{s}");
+}
+
+#[test]
+fn an_import_cycle_is_refused_without_hanging() {
+    let dir = scratch("cycle");
+    write(&dir, "a.adj", "import \"b.adj\"\n? x\n");
+    write(&dir, "b.adj", "import \"a.adj\"\n? x\n");
+    let (ok, s) = run(&dir.join("a.adj"));
+    assert!(!ok, "cyclic import should fail: {s}");
+    assert!(s.contains("Cycle"), "{s}");
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.10.0] - 2026-06-12 — `rulebook` + `use` (MYCIN-2026 M2)
+
+### Added
+
+- **`rulebook <name> { … }`** — a named, reusable block of clauses
+  (`prior`/`contributes`/`interacts`/`uncertain`), so a body of adjudicatable
+  knowledge can be written once, checked in as code, and (M3) imported. A
+  rulebook is a *container*, not a namespace: its clauses lower into the
+  `KnowledgeBase` exactly as if written at top level (`flatten_clauses`). New
+  AST `Statement::Rulebook { name, statements }`.
+- **`use <dictionary>`** — binds a declared `dictionary` (by name) as the
+  controlled vocabulary the enclosing scope's clauses are checked against. Legal
+  at top level or inside a `rulebook`. New AST `Statement::Use(String)`.
+- **Scoped vocabulary enforcement (M2).** When any `use` appears, enforcement
+  becomes *per-scope*: a top-level `use D` checks the top-level clauses against
+  `D`; a rulebook's own `use D'` checks that rulebook against `D'` (falling back
+  to a top-level `use`). A scope with no `use` is unchecked — a rulebook opts in
+  to checking by `use`-ing a dictionary. A `use` of a dictionary the program
+  never declared is `LowerError::UndefinedDictionary`. When **no** `use` appears
+  anywhere, M1 whole-program enforcement is unchanged (fully backward-compatible).
+- **Rulebooks are flat.** A `rulebook` nested directly in another is a clean
+  `LowerError::NestedRulebook` (nesting has no defined scoping semantics; the
+  refusal also keeps clause-flattening non-recursive, so deeply-nested untrusted
+  source cannot drive unbounded recursion in the lowerer).
+- 8 tests (rulebook lowers like top-level; `use` checks/rejects terms; undefined
+  dictionary; no-`use` rulebook unchecked; top-level `use` scoping; nested
+  rulebook rejected). Grammar regenerated. Next (MYCIN-2026): M3 `import "path"`.
+
 ## [0.9.0] - 2026-06-12 — `dictionary` + `define` (MYCIN-2026 M1)
 
 ### Added

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.11.0] - 2026-06-12 — `import "path"` (MYCIN-2026 M3)
+
+### Added
+
+- **`import "<relative path>"`** — compose a program across files: a dictionary,
+  a rulebook that imports + `use`s it, and a case that imports the rulebook can
+  each be their own checked-in `.adj`. New `Statement::Import(String)`; grammar
+  `import_decl`.
+- **`resolve` module** — the import-graph policy, with **no filesystem I/O** (it
+  drives an injected `ImportProvider`, so the graph logic is unit-testable
+  without a disk and the FS trust boundary lives in the caller):
+  - **relative** — `provider.resolve(importer, literal)` → canonical id.
+  - **idempotent** — a `visited` set keyed by canonical id; a file merges once
+    (diamond imports don't duplicate clauses).
+  - **acyclic** — a DFS stack; re-entering a stacked id is `ImportError::Cycle`
+    (cycle check precedes the idempotency check, so a cycle never masquerades as
+    a harmless repeat). Self-import included.
+  - **bounded** — `ImportLimits { max_depth, max_files }` (default 32 / 256);
+    past either, `DepthExceeded` / `TooManyFiles`. Depth is checked on every
+    descent, so the graph walk can't exceed `max_depth` frames on hostile input.
+  - Merge order is depth-first **post-order** — an imported file's declarations
+    precede the importer's, so a dictionary is in scope by the time the rulebook
+    that `use`s it is merged.
+- **`compile_with_imports(root_id, provider, limits)`** — resolve then lower, with
+  a combined `CompileWithImportsError`. `lower` now rejects a stray unresolved
+  `import` as `LowerError::UnresolvedImport` (never silently dropped).
+- 8 resolver tests (3-file chain, diamond, direct + self cycle, depth + fan-out
+  bounds, unresolvable path, importer-relative). Grammar regenerated. **M3
+  completes the MYCIN-2026 language foundation (M0–M3).**
+
 ## [0.10.0] - 2026-06-12 — `rulebook` + `use` (MYCIN-2026 M2)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -162,6 +162,40 @@ observe csf_glucose(low)
   `use` of an undeclared dictionary is `LowerError::UndefinedDictionary`. With no
   `use` anywhere, the M1 whole-program rule above is unchanged.
 
+### Import — `import "path"` (v0.11, MYCIN-2026)
+
+`import "<relative path>"` composes a program across files, so a dictionary, the
+rulebook that `use`s it, and a case can each be their own checked-in `.adj`:
+
+```adj
+% dictionary.adj
+dictionary meningitis_vocab { define bacterial : hypothesis  define csf_glucose : finding values [low, normal] }
+
+% rulebook.adj
+import "dictionary.adj"
+rulebook meningitis { use meningitis_vocab
+  prior 0.30 for bacterial   source "Tunkel IDSA 2004" trust authoritative
+  contributes 5 from csf_glucose(low) to bacterial  source "…" trust empirical }
+
+% case.adj
+import "rulebook.adj"
+observe csf_glucose(low)
+? bacterial
+```
+
+The import graph is resolved into one program *before* lowering, with four
+guarantees: **relative** to the importing file, **idempotent** (a file imported
+twice — e.g. a diamond — is merged once, by canonical id), **acyclic** (a cycle
+is `ImportError::Cycle`, never a hang), and **bounded** depth + fan-out
+(`ImportLimits`, default 32 / 256 → `DepthExceeded` / `TooManyFiles`).
+
+The library does **no filesystem I/O**: `resolve_imports` drives an injected
+[`ImportProvider`], so the graph policy is unit-testable without a disk and the
+filesystem trust boundary (canonicalization, relative-only, sandbox-root
+containment) lives in the caller — `adj-lang-cli`'s `FsProvider`. Use
+`compile_with_imports(root_id, provider, limits)` for the resolve-then-lower
+path; plain `compile` rejects a stray `import` as `LowerError::UnresolvedImport`.
+
 ### Differential over the `?` queries (v0.4)
 
 A program's `? h` lines are read as the set of **competing hypotheses**.

--- a/code/packages/rust/adj-lang/README.md
+++ b/code/packages/rust/adj-lang/README.md
@@ -124,6 +124,44 @@ value must lie in its declared domain — otherwise `LowerError::UndefinedTerm` 
 against therefore share one closed vocabulary by construction. A program with no
 dictionary is unchecked (backward-compatible).
 
+### Rulebook — `rulebook` / `use` (v0.10, MYCIN-2026)
+
+A **rulebook** is a named, reusable block of the clauses that make up a body of
+adjudicatable knowledge — written once, checked in as code, and (M3) importable.
+A `use` binds the dictionary the rulebook is checked against:
+
+```adj
+dictionary meningitis_vocab {
+  define bacterial : hypothesis
+  define viral     : hypothesis
+  define csf_glucose : finding values [low, normal]
+}
+
+rulebook meningitis {
+  use meningitis_vocab
+  prior 0.30 for bacterial   source "Tunkel IDSA 2004" trust authoritative
+  prior 0.30 for viral       source "Tunkel IDSA 2004" trust authoritative
+  contributes 5 from csf_glucose(low) to bacterial
+    source "low CSF glucose favors bacterial" trust empirical
+}
+
+observe csf_glucose(low)
+? bacterial
+? viral
+```
+
+- `rulebook <name> { … }` groups clauses under one name. The rulebook is a
+  **container, not a namespace**: its clauses lower into the `KnowledgeBase`
+  exactly as if written at top level. The name is for reuse / addressing.
+- `use <dictionary>` (inside a rulebook or at top level) binds a declared
+  dictionary as the vocabulary that scope's clauses are checked against.
+- **Enforcement is scoped by `use`.** When any `use` appears, a top-level
+  `use D` checks the top-level clauses against `D`, and each rulebook is checked
+  against its own `use` (falling back to a top-level one). A scope with no `use`
+  is unchecked — a rulebook opts in to checking by `use`-ing a dictionary. A
+  `use` of an undeclared dictionary is `LowerError::UndefinedDictionary`. With no
+  `use` anywhere, the M1 whole-program rule above is unchanged.
+
 ### Differential over the `?` queries (v0.4)
 
 A program's `? h` lines are read as the set of **competing hypotheses**.

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -35,6 +35,8 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"optimize_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
             ] },
             line_number: 22,
         },
@@ -47,7 +49,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 43,
+            line_number: 45,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -60,7 +62,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 45,
+            line_number: 47,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -68,7 +70,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 55,
+            line_number: 57,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -83,7 +85,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
             ] },
-            line_number: 57,
+            line_number: 59,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -102,7 +104,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 59,
+            line_number: 61,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -119,7 +121,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 61,
+            line_number: 63,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -127,7 +129,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 63,
+            line_number: 65,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -135,7 +137,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 65,
+            line_number: 67,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -145,7 +147,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 79,
+            line_number: 81,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -159,7 +161,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 81,
+            line_number: 83,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -173,7 +175,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 83,
+            line_number: 85,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -187,7 +189,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 85,
+            line_number: 87,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -203,7 +205,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 87,
+            line_number: 89,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -213,7 +215,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 97,
+            line_number: 99,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -223,7 +225,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 99,
+            line_number: 101,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -236,7 +238,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 101,
+            line_number: 103,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -251,12 +253,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 103,
+            line_number: 105,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 105,
+            line_number: 107,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -267,7 +269,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 112,
+            line_number: 114,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -278,7 +280,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 124,
+            line_number: 126,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -289,7 +291,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 126,
+            line_number: 128,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -309,7 +311,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 128,
+            line_number: 130,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -321,7 +323,26 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 132,
+            line_number: 134,
+        },
+        GrammarRule {
+            name: r#"rulebook_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"rulebook"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 151,
+        },
+        GrammarRule {
+            name: r#"use_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"use"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+            ] },
+            line_number: 153,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -330,7 +351,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
             ] },
-            line_number: 140,
+            line_number: 161,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -338,7 +359,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 145,
+            line_number: 166,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -346,7 +367,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 146,
+            line_number: 167,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -354,7 +375,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 168,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -365,7 +386,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 149,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -387,7 +408,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 166,
+            line_number: 187,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -37,6 +37,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
             ] },
             line_number: 22,
         },
@@ -49,7 +50,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 45,
+            line_number: 46,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -62,7 +63,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 47,
+            line_number: 48,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -70,7 +71,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 57,
+            line_number: 58,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -85,7 +86,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
             ] },
-            line_number: 59,
+            line_number: 60,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -104,7 +105,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 61,
+            line_number: 62,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -121,7 +122,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 63,
+            line_number: 64,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -129,7 +130,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 65,
+            line_number: 66,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -137,7 +138,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 67,
+            line_number: 68,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -147,7 +148,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 81,
+            line_number: 82,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -161,7 +162,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 83,
+            line_number: 84,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -175,7 +176,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 85,
+            line_number: 86,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -189,7 +190,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 87,
+            line_number: 88,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -205,7 +206,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 89,
+            line_number: 90,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -215,7 +216,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 99,
+            line_number: 100,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -225,7 +226,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 101,
+            line_number: 102,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -238,7 +239,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 103,
+            line_number: 104,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -253,12 +254,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 105,
+            line_number: 106,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 107,
+            line_number: 108,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -269,7 +270,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 114,
+            line_number: 115,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -280,7 +281,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 126,
+            line_number: 127,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -291,7 +292,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 128,
+            line_number: 129,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -311,7 +312,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] }) },
                 ] },
             ] },
-            line_number: 130,
+            line_number: 131,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -323,7 +324,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 134,
+            line_number: 135,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -334,7 +335,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 151,
+            line_number: 152,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -342,7 +343,15 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 154,
+        },
+        GrammarRule {
+            name: r#"import_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"import"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 170,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -351,7 +360,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"locator_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
             ] },
-            line_number: 161,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -359,7 +368,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 166,
+            line_number: 183,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -367,7 +376,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 167,
+            line_number: 184,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -375,7 +384,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 168,
+            line_number: 185,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -386,7 +395,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 170,
+            line_number: 187,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -408,7 +417,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 187,
+            line_number: 204,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -117,8 +117,10 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "optimize_decl" => adapt_optimize(child),
         "dictionary_decl" => adapt_dictionary(child),
         "define_decl" => adapt_define(child).map(Statement::Define),
+        "rulebook_decl" => adapt_rulebook(child),
+        "use_decl" => adapt_use(child),
         other => Err(AdapterError::UnexpectedRule {
-            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl",
+            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl / rulebook_decl / use_decl",
             actual: other.to_string(),
         }),
     }
@@ -514,6 +516,38 @@ fn adapt_define_kind(node: &GrammarASTNode) -> Result<DefineKind, AdapterError> 
             position: "`hypothesis` or `finding`",
         })
     }
+}
+
+fn adapt_rulebook(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // rulebook_decl = "rulebook" IDENT LBRACE { statement } RBRACE
+    let name = first_name_not(node, "rulebook")
+        .ok_or(AdapterError::MissingChild {
+            rule: "rulebook_decl".into(),
+            position: "rulebook name",
+        })?
+        .to_string();
+    // The body is a sequence of `statement` nodes — adapt each through the
+    // same dispatcher, so a rulebook may hold any clause (and its own `use`).
+    let statements = node
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(adapt_statement(n)),
+            _ => None,
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Statement::Rulebook { name, statements })
+}
+
+fn adapt_use(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // use_decl = "use" IDENT
+    let name = first_name_not(node, "use")
+        .ok_or(AdapterError::MissingChild {
+            rule: "use_decl".into(),
+            position: "dictionary name",
+        })?
+        .to_string();
+    Ok(Statement::Use(name))
 }
 
 /// `relop = GE | LE | GT | LT | EQEQ | EQUALS | NE` — distinguish by the

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -119,8 +119,9 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "define_decl" => adapt_define(child).map(Statement::Define),
         "rulebook_decl" => adapt_rulebook(child),
         "use_decl" => adapt_use(child),
+        "import_decl" => adapt_import(child),
         other => Err(AdapterError::UnexpectedRule {
-            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl / rulebook_decl / use_decl",
+            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl / rulebook_decl / use_decl / import_decl",
             actual: other.to_string(),
         }),
     }
@@ -548,6 +549,24 @@ fn adapt_use(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         })?
         .to_string();
     Ok(Statement::Use(name))
+}
+
+fn adapt_import(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // import_decl = "import" STRING
+    let path = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.type_ == TokenType::String => {
+                Some(unquote_string(&t.value))
+            }
+            _ => None,
+        })
+        .ok_or(AdapterError::MissingChild {
+            rule: "import_decl".into(),
+            position: "import path string",
+        })?;
+    Ok(Statement::Import(path))
 }
 
 /// `relop = GE | LE | GT | LT | EQEQ | EQUALS | NE` — distinguish by the

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -166,6 +166,18 @@ pub enum Statement {
     /// `dictionary <name> { define … }` — a named controlled vocabulary, a
     /// first-class language construct a rulebook `use`s (M2).
     Dictionary { name: String, defines: Vec<Define> },
+    /// `rulebook <name> { … }` — a named, reusable block of clauses (MYCIN-2026
+    /// M2). The clauses lower into the KB exactly as if written at top level;
+    /// the name lets a rulebook be written once and `import`ed (M3). An inner
+    /// `use` binds the dictionary its clauses are vocabulary-checked against.
+    Rulebook {
+        name: String,
+        statements: Vec<Statement>,
+    },
+    /// `use <dictionary>` — bind a `dictionary` (by name) as the controlled
+    /// vocabulary the enclosing scope's clauses are checked against (MYCIN-2026
+    /// M2). Legal at top level or inside a `rulebook`.
+    Use(String),
 }
 
 /// A single dictionary entry (MYCIN-2026).

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -178,6 +178,13 @@ pub enum Statement {
     /// vocabulary the enclosing scope's clauses are checked against (MYCIN-2026
     /// M2). Legal at top level or inside a `rulebook`.
     Use(String),
+    /// `import "<relative path>"` — splice another `.adj` file's declarations
+    /// into this program (MYCIN-2026 M3). The literal string is carried verbatim;
+    /// resolution (relative path, idempotency, cycle + bound checks) happens in
+    /// [`crate::resolve`] before lowering. A program that still contains an
+    /// `Import` at lowering time was compiled without the resolver — a
+    /// [`crate::LowerError::UnresolvedImport`].
+    Import(String),
 }
 
 /// A single dictionary entry (MYCIN-2026).

--- a/code/packages/rust/adj-lang/src/lib.rs
+++ b/code/packages/rust/adj-lang/src/lib.rs
@@ -44,6 +44,7 @@
 pub mod adapter;
 pub mod ast;
 pub mod lower;
+pub mod resolve;
 
 mod _lexer_grammar;
 mod _parser_grammar;
@@ -55,6 +56,7 @@ use parser::grammar_parser::{GrammarParseError, GrammarParser};
 pub use adapter::{adapt_program, AdapterError};
 pub use ast::{Annotation, Define, DefineKind, OptDir, Program, RelOp, Statement, Term as AstTerm};
 pub use lower::{lower, ConstraintSystem, LowerError, LoweredConstraint, LoweredProgram};
+pub use resolve::{resolve_imports, ImportError, ImportLimits, ImportProvider};
 
 /// Result of compilation. Either the typed program produced by the
 /// adapter, or an error from the lexer, parser, adapter, or
@@ -86,6 +88,30 @@ pub fn parse(src: &str) -> Result<Program, CompileError> {
 pub fn compile(src: &str) -> Result<LoweredProgram, CompileError> {
     let program = parse(src)?;
     lower(&program).map_err(CompileError::Lower)
+}
+
+/// Result of compiling a program that may `import` other files: either an
+/// import-graph failure (cycle, bound, missing/unparseable file) from the
+/// [`resolve`] stage, or a lowering failure from the merged program.
+#[derive(Debug)]
+pub enum CompileWithImportsError {
+    Import(ImportError),
+    Lower(LowerError),
+}
+
+/// Import-aware compile: resolve the import graph rooted at `root_id` (driven by
+/// the injected [`ImportProvider`]), then lower the merged program (MYCIN-2026
+/// M3). The library performs **no** filesystem I/O — the provider is the only
+/// thing that reads files, so the caller controls the sandbox. See
+/// [`resolve::resolve_imports`] for the graph guarantees.
+pub fn compile_with_imports(
+    root_id: &str,
+    provider: &dyn ImportProvider,
+    limits: ImportLimits,
+) -> Result<LoweredProgram, CompileWithImportsError> {
+    let program =
+        resolve_imports(root_id, provider, limits).map_err(CompileWithImportsError::Import)?;
+    lower(&program).map_err(CompileWithImportsError::Lower)
 }
 
 /// Run a **differential** over a lowered program's `? h` query lines:

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -119,6 +119,19 @@ pub enum LowerError {
         value: String,
         domain: Vec<String>,
     },
+    /// A `use <name>` (M2) named a dictionary that the program never declared.
+    UndefinedDictionary {
+        name: String,
+    },
+    /// A `rulebook` nested inside another `rulebook` (MYCIN-2026 M2). A rulebook
+    /// is a *flat* container; nested rulebooks have no defined
+    /// vocabulary-scoping semantics, so they are rejected cleanly rather than
+    /// silently mis-scoped. (Also caps `flatten_clauses` recursion at one level,
+    /// closing an unbounded-recursion DoS on untrusted source.)
+    NestedRulebook {
+        outer: String,
+        inner: String,
+    },
 }
 
 /// The result of lowering — a populated KB, any queries to run, and the
@@ -142,7 +155,15 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     let mut constraints = ConstraintSystem::default();
     let mut dictionary: Vec<Define> = Vec::new();
 
-    for stmt in &program.statements {
+    // Flatten rulebooks (MYCIN-2026 M2): a `rulebook <name> { … }` is a named
+    // container whose clauses lower into the KB exactly as if written at top
+    // level — the name is metadata for import/addressing (M3), not a separate
+    // namespace. The flat list drives KB building; the original nested
+    // structure is used afterward to scope vocabulary enforcement per `use`.
+    let mut flat: Vec<&Statement> = Vec::new();
+    flatten_clauses(&program.statements, &mut flat)?;
+
+    for stmt in flat.iter().copied() {
         match stmt {
             Statement::Prior {
                 probability,
@@ -275,17 +296,70 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             // ---- dictionary (MYCIN-2026) ----
             Statement::Define(def) => dictionary.push(def.clone()),
             Statement::Dictionary { defines, .. } => dictionary.extend(defines.iter().cloned()),
+            // ---- rulebook + use (MYCIN-2026 M2) ----
+            // `use` is purely a vocabulary binding (handled in enforcement
+            // below); it adds nothing to the KB. `Rulebook` never reaches here
+            // — `flatten_clauses` expanded it into its inner clauses already.
+            Statement::Use(_) => {}
+            Statement::Rulebook { .. } => {}
         }
     }
 
-    // Compile-time vocabulary enforcement (MYCIN-2026): only when the program
-    // declares a dictionary (≥1 `define`). A program with no dictionary is
-    // unaffected (backward-compatible). When a dictionary IS present, every
-    // hypothesis / finding term used must be defined, and a finding value must
-    // be in its declared domain — the IR the model emits and the rulebook it
-    // compiles against share one closed vocabulary by construction.
-    if !dictionary.is_empty() {
-        enforce_vocabulary(&program.statements, &dictionary)?;
+    // Compile-time vocabulary enforcement (MYCIN-2026 M1 + M2). Two modes:
+    //
+    //   M2 (a `use` appears anywhere): enforcement is SCOPED by `use`. A
+    //   top-level `use D` checks the top-level clauses against dictionary `D`;
+    //   a rulebook's own `use D'` checks that rulebook against `D'` (falling
+    //   back to a top-level `use`). A scope with no `use` is unchecked, and a
+    //   `use` naming an undeclared dictionary is `UndefinedDictionary`. This is
+    //   how a rulebook "written once" binds the vocabulary it reasons in.
+    //
+    //   M1 (no `use` anywhere): a declared dictionary (≥1 `define`) checks the
+    //   WHOLE program against the union of all defines. Backward-compatible —
+    //   programs with neither `use` nor `define` are entirely unchecked.
+    if program_contains_use(&program.statements) {
+        let named_dicts: std::collections::HashMap<&str, &[Define]> = program
+            .statements
+            .iter()
+            .filter_map(|s| match s {
+                Statement::Dictionary { name, defines } => {
+                    Some((name.as_str(), defines.as_slice()))
+                }
+                _ => None,
+            })
+            .collect();
+        let resolve = |name: &str| -> Result<&[Define], LowerError> {
+            named_dicts
+                .get(name)
+                .copied()
+                .ok_or_else(|| LowerError::UndefinedDictionary {
+                    name: name.to_string(),
+                })
+        };
+
+        let top_use = first_use(&program.statements);
+        // Top-level group: every top-level statement that isn't a rulebook.
+        if let Some(d) = top_use {
+            let defs = resolve(d)?;
+            let top_clauses = program
+                .statements
+                .iter()
+                .filter(|s| !matches!(s, Statement::Rulebook { .. }));
+            enforce_vocabulary(top_clauses, defs)?;
+        }
+        // Each rulebook is its own scope (its `use`, else the top-level `use`).
+        for s in &program.statements {
+            if let Statement::Rulebook { statements, .. } = s {
+                if let Some(d) = first_use(statements).or(top_use) {
+                    let defs = resolve(d)?;
+                    let mut clauses: Vec<&Statement> = Vec::new();
+                    flatten_clauses(statements, &mut clauses)?;
+                    enforce_vocabulary(clauses.into_iter(), defs)?;
+                }
+            }
+        }
+    } else if !dictionary.is_empty() {
+        enforce_vocabulary(flat.iter().copied(), &dictionary)?;
     }
 
     Ok(LoweredProgram {
@@ -296,9 +370,75 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     })
 }
 
-/// Verify every hypothesis/finding term used in the program is `define`d and any
-/// finding value is in its declared domain. See [`lower`] for when this runs.
-fn enforce_vocabulary(statements: &[Statement], dictionary: &[Define]) -> Result<(), LowerError> {
+/// Expand `rulebook` blocks into their constituent clause statements, in source
+/// order. A rulebook is a *flat* named container, not a separate namespace — its
+/// clauses lower into the KB as if written at top level (MYCIN-2026 M2).
+///
+/// Rulebooks may NOT nest: a `rulebook` directly inside another is a
+/// [`LowerError::NestedRulebook`]. This keeps the expansion non-recursive (one
+/// level only), so deeply-nested untrusted source cannot drive unbounded
+/// recursion here, and it avoids ambiguous nested-`use` scoping (a nested
+/// rulebook's own `use` would otherwise be silently dropped). The parser still
+/// *parses* nesting; we reject it semantically at this single, well-defined
+/// point.
+fn flatten_clauses<'a>(
+    statements: &'a [Statement],
+    out: &mut Vec<&'a Statement>,
+) -> Result<(), LowerError> {
+    for s in statements {
+        match s {
+            Statement::Rulebook {
+                name: outer,
+                statements: inner,
+            } => {
+                for c in inner {
+                    if let Statement::Rulebook {
+                        name: inner_name, ..
+                    } = c
+                    {
+                        return Err(LowerError::NestedRulebook {
+                            outer: outer.clone(),
+                            inner: inner_name.clone(),
+                        });
+                    }
+                    out.push(c);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    Ok(())
+}
+
+/// Does any statement (at top level or inside a rulebook) `use` a dictionary?
+/// Selects M2 scoped enforcement over M1 whole-program enforcement. Rulebooks
+/// are flat (see [`flatten_clauses`]), so one level of descent suffices.
+fn program_contains_use(statements: &[Statement]) -> bool {
+    statements.iter().any(|s| match s {
+        Statement::Use(_) => true,
+        Statement::Rulebook { statements, .. } => {
+            statements.iter().any(|i| matches!(i, Statement::Use(_)))
+        }
+        _ => false,
+    })
+}
+
+/// The first `use <name>` directly in this statement list (does not descend into
+/// rulebooks — a rulebook's own `use` is found by calling this on its body).
+fn first_use(statements: &[Statement]) -> Option<&str> {
+    statements.iter().find_map(|s| match s {
+        Statement::Use(name) => Some(name.as_str()),
+        _ => None,
+    })
+}
+
+/// Verify every hypothesis/finding term used by `statements` is `define`d in
+/// `dictionary` and any finding value is in its declared domain. See [`lower`]
+/// for the M1 (whole-program) vs M2 (per-`use`-scope) call sites.
+fn enforce_vocabulary<'a>(
+    statements: impl IntoIterator<Item = &'a Statement>,
+    dictionary: &[Define],
+) -> Result<(), LowerError> {
     use std::collections::HashMap;
     let dict: HashMap<&str, &DefineKind> = dictionary
         .iter()
@@ -1006,6 +1146,123 @@ mod tests {
             compile("prior 0.10 for anything\n  source \"x\" trust empirical\n? anything\n")
                 .unwrap();
         assert!(lowered.dictionary.is_empty());
+    }
+
+    // ---- rulebook + use (MYCIN-2026 M2) ----
+
+    #[test]
+    fn a_rulebook_lowers_its_clauses_into_the_kb_like_top_level() {
+        // The `rulebook { … }` wrapper is metadata; its clauses populate the KB
+        // exactly as if written at top level, so the query still decides.
+        let src = "rulebook meningitis {\n\
+                   prior 0.10 for bacterial\n  source \"x\" trust empirical\n\
+                   contributes 3 from csf(low) to bacterial\n  source \"y\" trust empirical\n\
+                   }\n\
+                   observe csf(low)\n? bacterial\n";
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.queries.len(), 1);
+        let d = crate::decide(&lowered);
+        // one contribution fired over the prior → posterior above the 0.10 base.
+        assert!(d.ranked[0].posterior > 0.10, "{d:?}");
+    }
+
+    #[test]
+    fn a_rulebook_that_uses_a_dictionary_is_checked_against_it() {
+        // Every term the rulebook names is defined in the `use`d dictionary.
+        let src = "dictionary vocab {\n\
+                   define bacterial : hypothesis\n\
+                   define csf : finding values [low, normal]\n\
+                   }\n\
+                   rulebook meningitis {\n\
+                   use vocab\n\
+                   prior 0.10 for bacterial\n  source \"x\" trust empirical\n\
+                   contributes 3 from csf(low) to bacterial\n  source \"y\" trust empirical\n\
+                   }\n";
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.dictionary.len(), 2);
+    }
+
+    #[test]
+    fn a_rulebook_naming_an_undefined_term_is_rejected() {
+        // `meningococcal` is not in the `use`d dictionary → clean error, scoped
+        // to the rulebook by its `use`.
+        let src = "dictionary vocab {\n\
+                   define bacterial : hypothesis\n\
+                   define csf : finding values [low, normal]\n\
+                   }\n\
+                   rulebook meningitis {\n\
+                   use vocab\n\
+                   contributes 3 from csf(low) to meningococcal\n  source \"y\" trust empirical\n\
+                   }\n";
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(err, crate::CompileError::Lower(LowerError::UndefinedTerm { ref name, expected: "hypothesis" }) if name == "meningococcal"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn use_of_an_undeclared_dictionary_is_a_clean_error() {
+        let src = "rulebook meningitis {\n\
+                   use nonexistent\n\
+                   prior 0.10 for bacterial\n  source \"x\" trust empirical\n\
+                   }\n";
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(err, crate::CompileError::Lower(LowerError::UndefinedDictionary { ref name }) if name == "nonexistent"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_rulebook_without_use_is_unchecked_even_when_a_dictionary_exists() {
+        // A `use` elsewhere flips the program to M2 scoped mode; a rulebook that
+        // declines to `use` is then unchecked — it may name terms the dictionary
+        // never declared. (Backward-compatible "opt in to checking" semantics.)
+        let src = "dictionary vocab { define bacterial : hypothesis }\n\
+                   rulebook checked { use vocab\n prior 0.10 for bacterial\n  source \"a\" trust empirical\n }\n\
+                   rulebook freeform {\n contributes 2 from whatever(x) to anything\n  source \"b\" trust empirical\n }\n";
+        // Compiles despite `freeform` naming undefined terms, because it has no `use`.
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.dictionary.len(), 1);
+    }
+
+    #[test]
+    fn a_nested_rulebook_is_rejected() {
+        // Rulebooks are flat containers — nesting has no defined scoping
+        // semantics and is refused cleanly (also bounds flatten recursion).
+        let src = "rulebook outer {\n\
+                   rulebook inner {\n\
+                   prior 0.10 for bacterial\n  source \"x\" trust empirical\n\
+                   }\n\
+                   }\n? bacterial\n";
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(err, crate::CompileError::Lower(LowerError::NestedRulebook { ref outer, ref inner }) if outer == "outer" && inner == "inner"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_top_level_use_scopes_the_top_level_clauses() {
+        let src = "dictionary vocab { define bacterial : hypothesis  define csf : finding values [low] }\n\
+                   use vocab\n\
+                   contributes 3 from csf(low) to bacterial\n  source \"y\" trust empirical\n\
+                   observe csf(low)\n? bacterial\n";
+        let lowered = compile(src).unwrap();
+        assert_eq!(lowered.queries.len(), 1);
+    }
+
+    #[test]
+    fn a_top_level_use_rejects_an_undefined_top_level_term() {
+        let src = "dictionary vocab { define bacterial : hypothesis }\n\
+                   use vocab\n\
+                   observe mystery(x)\n? bacterial\n";
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(err, crate::CompileError::Lower(LowerError::UndefinedTerm { ref name, expected: "finding" }) if name == "mystery"),
+            "{err:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -132,6 +132,14 @@ pub enum LowerError {
         outer: String,
         inner: String,
     },
+    /// An `import "<path>"` survived to lowering (MYCIN-2026 M3). Imports must be
+    /// resolved by [`crate::resolve`] *before* `lower` runs — reaching here means
+    /// the caller used `compile` directly on a program that still has imports,
+    /// instead of the import-resolving entry point. Rejected so an `import` is
+    /// never silently dropped.
+    UnresolvedImport {
+        path: String,
+    },
 }
 
 /// The result of lowering — a populated KB, any queries to run, and the
@@ -302,6 +310,12 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             // — `flatten_clauses` expanded it into its inner clauses already.
             Statement::Use(_) => {}
             Statement::Rulebook { .. } => {}
+            // ---- import (MYCIN-2026 M3) ----
+            // Imports are resolved away by `crate::resolve` before lowering; one
+            // reaching here means `compile` was called on an unresolved program.
+            Statement::Import(path) => {
+                return Err(LowerError::UnresolvedImport { path: path.clone() })
+            }
         }
     }
 

--- a/code/packages/rust/adj-lang/src/resolve.rs
+++ b/code/packages/rust/adj-lang/src/resolve.rs
@@ -1,0 +1,384 @@
+//! # Import resolution — composing an Adj-Lang program across files (M3).
+//!
+//! `import "<path>"` lets a `dictionary`, a `rulebook`, and a case live in
+//! separate checked-in `.adj` files: a rulebook file imports its dictionary, a
+//! case file imports the rulebook. This module walks the import graph and
+//! splices every imported file's declarations into one [`Program`], which then
+//! lowers exactly like a single-file program.
+//!
+//! ## Why the library never touches the filesystem
+//!
+//! The import *graph policy* — relative resolution, idempotency, cycle
+//! detection, depth / fan-out bounds — is security-sensitive and must be
+//! unit-testable without a real disk. So this module owns the policy but does no
+//! I/O: it drives an injected [`ImportProvider`]. The `adj-lang-cli` binary
+//! supplies a real, sandbox-checked filesystem provider; tests supply an
+//! in-memory map. The provider is the *only* trust boundary that resolves a
+//! literal import string to a real file, so that is where path-traversal and
+//! symlink defenses live (see the CLI's provider).
+//!
+//! ## The three guarantees, and how each is enforced
+//!
+//! | guarantee     | mechanism                                                  |
+//! |---------------|------------------------------------------------------------|
+//! | relative      | `provider.resolve(importer_id, literal)` → canonical id     |
+//! | idempotent    | a `visited` set keyed by canonical id — a file merges once  |
+//! | acyclic       | a DFS `stack`; re-entering a stacked id is [`ImportError::Cycle`] |
+//! | bounded depth | an explicit depth counter vs [`ImportLimits::max_depth`]    |
+//! | bounded fan   | a file counter vs [`ImportLimits::max_files`]               |
+//!
+//! Because depth is checked on every descent, the recursion that walks the graph
+//! cannot exceed `max_depth` frames regardless of how adversarial the import
+//! graph is — there is no unbounded-recursion path on untrusted input.
+
+use std::collections::HashSet;
+
+use crate::ast::{Program, Statement};
+
+/// Resolves a literal import string (relative to the file doing the importing)
+/// to a *canonical, stable id*, and loads source text for a canonical id. The
+/// canonical id is opaque to this module — it only needs equality (for the
+/// `visited` / cycle sets) and round-tripping through `load`. A filesystem
+/// provider would canonicalize to an absolute real path; an in-memory test
+/// provider can use the map key directly.
+///
+/// **This trait is the trust boundary.** `resolve` is where an implementation
+/// must reject path traversal / escapes outside its sandbox root — this module
+/// treats whatever id `resolve` returns as already-authorized.
+pub trait ImportProvider {
+    /// Resolve `literal` (the verbatim `import "<literal>"` string) against
+    /// `importer` (the canonical id of the importing file) to a canonical id.
+    /// Return `Err(reason)` if the target cannot be resolved or is not allowed
+    /// (e.g. escapes the sandbox root).
+    fn resolve(&self, importer: &str, literal: &str) -> Result<String, String>;
+
+    /// Load the source text for a canonical id produced by [`resolve`].
+    fn load(&self, canonical: &str) -> Result<String, String>;
+}
+
+/// Bounds on the import graph — defenses against a hostile or accidental
+/// fan-out / deep-chain (a "zip-bomb"-shaped import graph). Past either bound,
+/// resolution stops with a clean error rather than exhausting memory or stack.
+#[derive(Debug, Clone, Copy)]
+pub struct ImportLimits {
+    /// Maximum import nesting depth (root = depth 0).
+    pub max_depth: usize,
+    /// Maximum number of *distinct* files merged (including the root).
+    pub max_files: usize,
+}
+
+impl Default for ImportLimits {
+    /// Generous for real rulebooks (a dictionary ← rulebook ← case chain is
+    /// depth 2), tight enough to stop a runaway graph early.
+    fn default() -> Self {
+        ImportLimits {
+            max_depth: 32,
+            max_files: 256,
+        }
+    }
+}
+
+/// What can go wrong while resolving an import graph.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ImportError {
+    /// An import cycle: `path` is the chain of canonical ids from the first
+    /// re-entered file back to itself (e.g. `[a, b, a]`).
+    Cycle { path: Vec<String> },
+    /// Import nesting exceeded [`ImportLimits::max_depth`].
+    DepthExceeded { limit: usize },
+    /// More than [`ImportLimits::max_files`] distinct files were reached.
+    TooManyFiles { limit: usize },
+    /// The provider could not resolve `literal` (relative to `importer`).
+    Resolve {
+        importer: String,
+        literal: String,
+        detail: String,
+    },
+    /// The provider could not load a resolved canonical id.
+    Load { canonical: String, detail: String },
+    /// A file failed to parse. `detail` is the rendered [`crate::CompileError`].
+    Parse { canonical: String, detail: String },
+}
+
+/// Resolve the import graph rooted at `root_id` into a single [`Program`] whose
+/// statements are every reachable file's non-`import` declarations, in
+/// depth-first post-order (an imported file's declarations precede the
+/// declarations of the file that imported it, so a dictionary is in scope by the
+/// time the rulebook that `use`s it is merged). The returned program contains no
+/// `Import` statements and lowers like any single-file program.
+pub fn resolve_imports(
+    root_id: &str,
+    provider: &dyn ImportProvider,
+    limits: ImportLimits,
+) -> Result<Program, ImportError> {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut stack: Vec<String> = Vec::new();
+    let mut statements: Vec<Statement> = Vec::new();
+    visit(
+        root_id,
+        0,
+        provider,
+        &limits,
+        &mut visited,
+        &mut stack,
+        &mut statements,
+    )?;
+    Ok(Program { statements })
+}
+
+/// Depth-first visit of one file. Appends the file's resolved declarations to
+/// `out`. Order of guards matters: the **cycle** check (is this id on the active
+/// DFS stack?) must precede the **idempotency** check (have we fully merged this
+/// id already?) — a file in a cycle is both on the stack *and* in `visited`, and
+/// only the stack check distinguishes "currently being processed" (a cycle) from
+/// "already done" (a harmless repeat import).
+#[allow(clippy::too_many_arguments)]
+fn visit(
+    canonical: &str,
+    depth: usize,
+    provider: &dyn ImportProvider,
+    limits: &ImportLimits,
+    visited: &mut HashSet<String>,
+    stack: &mut Vec<String>,
+    out: &mut Vec<Statement>,
+) -> Result<(), ImportError> {
+    if depth > limits.max_depth {
+        return Err(ImportError::DepthExceeded {
+            limit: limits.max_depth,
+        });
+    }
+    // Cycle BEFORE idempotency (see fn doc).
+    if stack.iter().any(|s| s == canonical) {
+        let mut path = stack.clone();
+        path.push(canonical.to_string());
+        return Err(ImportError::Cycle { path });
+    }
+    // Already fully merged via another path — idempotent no-op.
+    if visited.contains(canonical) {
+        return Ok(());
+    }
+    if visited.len() >= limits.max_files {
+        return Err(ImportError::TooManyFiles {
+            limit: limits.max_files,
+        });
+    }
+    visited.insert(canonical.to_string());
+
+    let src = provider
+        .load(canonical)
+        .map_err(|detail| ImportError::Load {
+            canonical: canonical.to_string(),
+            detail,
+        })?;
+    let program = crate::parse(&src).map_err(|e| ImportError::Parse {
+        canonical: canonical.to_string(),
+        detail: format!("{e:?}"),
+    })?;
+
+    stack.push(canonical.to_string());
+    for stmt in program.statements {
+        match stmt {
+            Statement::Import(literal) => {
+                let child = provider.resolve(canonical, &literal).map_err(|detail| {
+                    ImportError::Resolve {
+                        importer: canonical.to_string(),
+                        literal: literal.clone(),
+                        detail,
+                    }
+                })?;
+                // Post-order: the imported file's declarations are spliced in
+                // *before* the rest of this file's statements.
+                visit(&child, depth + 1, provider, limits, visited, stack, out)?;
+            }
+            other => out.push(other),
+        }
+    }
+    stack.pop();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// An in-memory provider: canonical id == the map key. `resolve` treats the
+    /// literal as the canonical id directly (the test graphs use flat ids), so
+    /// the graph policy is what's under test, not path arithmetic.
+    struct MemProvider {
+        files: HashMap<String, String>,
+        /// If true, `resolve` joins via a trivial "dir/" prefix so we can test
+        /// importer-relative behavior.
+        relative: bool,
+    }
+
+    impl ImportProvider for MemProvider {
+        fn resolve(&self, importer: &str, literal: &str) -> Result<String, String> {
+            let id = if self.relative {
+                // importer "a/b.adj", literal "c.adj" → "a/c.adj"
+                match importer.rfind('/') {
+                    Some(i) => format!("{}/{}", &importer[..i], literal),
+                    None => literal.to_string(),
+                }
+            } else {
+                literal.to_string()
+            };
+            if self.files.contains_key(&id) {
+                Ok(id)
+            } else {
+                Err(format!("no such file: {id}"))
+            }
+        }
+        fn load(&self, canonical: &str) -> Result<String, String> {
+            self.files
+                .get(canonical)
+                .cloned()
+                .ok_or_else(|| format!("no such file: {canonical}"))
+        }
+    }
+
+    fn mem(files: &[(&str, &str)], relative: bool) -> MemProvider {
+        MemProvider {
+            files: files
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            relative,
+        }
+    }
+
+    #[test]
+    fn a_three_file_chain_merges_dictionary_then_rulebook_then_case() {
+        let dict =
+            "dictionary v { define bacterial : hypothesis  define csf : finding values [low] }\n";
+        let rb = "import \"dict.adj\"\n\
+                  rulebook meningitis { use v\n contributes 3 from csf(low) to bacterial\n  source \"x\" trust empirical\n }\n";
+        let case = "import \"rulebook.adj\"\nobserve csf(low)\n? bacterial\n";
+        let provider = mem(
+            &[("dict.adj", dict), ("rulebook.adj", rb), ("case.adj", case)],
+            false,
+        );
+        let program = resolve_imports("case.adj", &provider, ImportLimits::default()).unwrap();
+        // No Import statements survive.
+        assert!(!program
+            .statements
+            .iter()
+            .any(|s| matches!(s, Statement::Import(_))));
+        // The merged program lowers + decides.
+        let lowered = crate::lower(&program).unwrap();
+        assert_eq!(lowered.queries.len(), 1);
+        let d = crate::decide(&lowered);
+        assert!(d.ranked[0].posterior > 0.0);
+    }
+
+    #[test]
+    fn a_diamond_import_includes_the_shared_file_once() {
+        // root imports a and b; both import shared. `shared`'s prior must appear
+        // once (a duplicate prior would be a DuplicatePrior lowering error).
+        let shared = "dictionary v { define dx : hypothesis }\nprior 0.20 for dx\n  source \"s\" trust empirical\n";
+        let a = "import \"shared.adj\"\n";
+        let b = "import \"shared.adj\"\n";
+        let root = "import \"a.adj\"\nimport \"b.adj\"\n? dx\n";
+        let provider = mem(
+            &[
+                ("shared.adj", shared),
+                ("a.adj", a),
+                ("b.adj", b),
+                ("root.adj", root),
+            ],
+            false,
+        );
+        let program = resolve_imports("root.adj", &provider, ImportLimits::default()).unwrap();
+        let priors = program
+            .statements
+            .iter()
+            .filter(|s| matches!(s, Statement::Prior { .. }))
+            .count();
+        assert_eq!(priors, 1, "shared prior should be merged exactly once");
+        crate::lower(&program).unwrap();
+    }
+
+    #[test]
+    fn a_direct_cycle_is_a_clean_error() {
+        let a = "import \"b.adj\"\n";
+        let b = "import \"a.adj\"\n";
+        let provider = mem(&[("a.adj", a), ("b.adj", b)], false);
+        let err = resolve_imports("a.adj", &provider, ImportLimits::default()).unwrap_err();
+        match err {
+            ImportError::Cycle { path } => {
+                assert_eq!(path.first().unwrap(), "a.adj");
+                assert_eq!(path.last().unwrap(), "a.adj");
+            }
+            other => panic!("expected Cycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_self_import_is_a_cycle() {
+        let a = "import \"a.adj\"\n? dx\n";
+        let provider = mem(&[("a.adj", a)], false);
+        let err = resolve_imports("a.adj", &provider, ImportLimits::default()).unwrap_err();
+        assert!(matches!(err, ImportError::Cycle { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn depth_is_bounded() {
+        // a chain a -> b -> c, with max_depth 1, must trip DepthExceeded.
+        let a = "import \"b.adj\"\n";
+        let b = "import \"c.adj\"\n";
+        let c = "prior 0.1 for dx\n  source \"x\" trust empirical\n";
+        let provider = mem(&[("a.adj", a), ("b.adj", b), ("c.adj", c)], false);
+        let limits = ImportLimits {
+            max_depth: 1,
+            max_files: 256,
+        };
+        let err = resolve_imports("a.adj", &provider, limits).unwrap_err();
+        assert!(
+            matches!(err, ImportError::DepthExceeded { limit: 1 }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn fan_out_is_bounded() {
+        // root imports three leaves; max_files 2 (root + 1) must trip.
+        let root = "import \"x.adj\"\nimport \"y.adj\"\nimport \"z.adj\"\n";
+        let leaf = "prior 0.1 for dx\n  source \"s\" trust empirical\n";
+        let provider = mem(
+            &[
+                ("root.adj", root),
+                ("x.adj", leaf),
+                ("y.adj", leaf),
+                ("z.adj", leaf),
+            ],
+            false,
+        );
+        let limits = ImportLimits {
+            max_depth: 32,
+            max_files: 2,
+        };
+        let err = resolve_imports("root.adj", &provider, limits).unwrap_err();
+        assert!(
+            matches!(err, ImportError::TooManyFiles { limit: 2 }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_path_is_reported_not_panicked() {
+        let root = "import \"missing.adj\"\n";
+        let provider = mem(&[("root.adj", root)], false);
+        let err = resolve_imports("root.adj", &provider, ImportLimits::default()).unwrap_err();
+        assert!(matches!(err, ImportError::Resolve { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn imports_resolve_relative_to_the_importing_file() {
+        // root at "pkg/root.adj" imports "lib.adj" → "pkg/lib.adj".
+        let root = "import \"lib.adj\"\n? dx\n";
+        let lib = "dictionary v { define dx : hypothesis }\nprior 0.3 for dx\n  source \"s\" trust empirical\n";
+        let provider = mem(&[("pkg/root.adj", root), ("pkg/lib.adj", lib)], true);
+        let program = resolve_imports("pkg/root.adj", &provider, ImportLimits::default()).unwrap();
+        crate::lower(&program).unwrap();
+    }
+}


### PR DESCRIPTION
## MYCIN-2026 M2 — the rulebook, in the grammar

Second slice of the [MYCIN-2026 rebuild](code/specs/data/mycin-2026/SPEC.md). Per the design decision that *"the rulebook should indeed be at the grammar level — a fundamental part of any adjudicatable knowledge work,"* this lands `rulebook`/`use` in `adj-lang`, building directly on the M1 `dictionary`/`define` vocabulary.

> **Stacked on [#5511](https://github.com/adhithyan15/coding-adventures/pull/5511) (M1).** Base is `adj-lang-dictionary`; this diff is M2-only. Retarget to `main` once M1 merges.

```adj
dictionary meningitis_vocab {
  define bacterial : hypothesis
  define viral     : hypothesis
  define csf_glucose : finding values [low, normal]
}

rulebook meningitis {
  use meningitis_vocab
  prior 0.30 for bacterial   source "Tunkel IDSA 2004" trust authoritative
  prior 0.30 for viral       source "Tunkel IDSA 2004" trust authoritative
  contributes 5 from csf_glucose(low) to bacterial
    source "low CSF glucose favors bacterial" trust empirical
}

observe csf_glucose(low)
? bacterial
? viral
```

### What's in it
- **Grammar**: `rulebook_decl` / `use_decl` rules (`rulebook`/`use` are IDENT-matched literals). Generated parser regenerated canonically (no `cargo fmt` on generated files).
- **AST**: `Statement::Rulebook { name, statements }` + `Statement::Use(String)`.
- **Adapter**: `adapt_rulebook` (re-dispatches each body `statement` through `adapt_statement`) + `adapt_use`.
- **Lower**:
  - `flatten_clauses` expands a rulebook's clauses into the KB **as if written at top level** — a rulebook is a container, not a namespace.
  - **Scoped enforcement** (`program_contains_use`/`first_use`): when any `use` appears, each scope is checked against its bound dictionary; a scope with no `use` is unchecked (opt-in). A `use` of an undeclared dictionary → `LowerError::UndefinedDictionary`. No `use` anywhere → M1 whole-program enforcement, unchanged.

### Security review (2 rounds)
Round 1 flagged a **MEDIUM** (unbounded recursion on nested rulebooks in untrusted `.adj` — stack-exhaustion DoS) and a **LOW** (nested-rulebook `use` silently mis-scoped). **Fix**: rulebooks are now *flat* — a nested rulebook is a clean `LowerError::NestedRulebook`, which makes `flatten_clauses` non-recursive and dissolves the scoping ambiguity. Round 2: **PASSED** (recursion closed, no vocabulary-escape, enforcement still correct).

### Verification
- `cargo test -p adj-lang` → **50 pass** (8 new M2 tests, incl. nested-rulebook rejection + scoped enforcement).
- End-to-end: the CLI on a `rulebook` that `use`s a `dictionary` yields the full differential + proof DAG (bacterial 0.68 vs viral 0.30, each step citing its source/trust).
- `cargo build` across `adj-lang` + `adj-lang-cli` + `adj-constraint-solver` → clean.

### Next in the arc
- **M3**: `import "path"` (relative resolution, idempotent, acyclic, bounded) so a dictionary/rulebook can be `import`ed across files — then **pause for sign-off** before M4–M8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)