### PR TITLE
fix(closurec): CLOC12.102 — close gap-099 (computed-member object paren elision)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.106.0] - 2026-06-12
+
+### Fixed
+- **CLOSES gap-099** — grouping parens around the OBJECT of a
+  computed-member `[…]` access are now elided when the object is a
+  simple reference:
+
+      a=(b)[c]    -> a=b[c]      a=(b.c)[d]  -> a=b.c[d]
+      a=(b)[c][d] -> a=b[c][d]   (a)[b]=c    -> a[b]=c
+
+  This is the `[index]` sibling of gap-065 (callee `(f)(x)` -> `f(x)`)
+  and gap-057 (`.member` `(a).b` -> `a.b`); `[` binds tighter than any
+  operator a grouping paren could protect around a bare reference. The
+  new pass mirrors gap-065's guards exactly — GROUPING (not a call/index
+  paren), SIMPLE REFERENCE inside (identifier + `.IDENT` chain, no
+  operators/commas/computed members), and a `[` FOLLOWER — only the
+  follower differs. Non-trivial operands keep their parens (`(a+b)[c]`,
+  `(b||c)[d]`), and a call paren is never grouping (`f(b)[c]` stays).
+  Distinct from gap-087, which elided parens INSIDE the index
+  (`a[(b)]` -> `a[b]`); gap-099 is the object side.
+
+  Behaviour change: `(a)[")"]` now minifies to `a[")"]` (was left as
+  `(a)[")"]` before gap-099 — the parens were previously kept because
+  gap-057 only handled `.member`). JAR-verified. The stale gap-057
+  `string_content_not_bracket` test (which asserted the pre-gap-099
+  form, while still verifying the string `")"` isn't mistaken for a
+  bracket) was updated and renamed to `gap099_string_content_not_bracket`.
+  +4 new `gap099_*` unit tests. The `computed_member_paren` /
+  `computed_member_chain` byte-identity fixtures leave the ignore list.
+
 ## [0.105.0] - 2026-06-12
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.105.0"
+version = "0.106.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.105.0",
+  "version": "0.106.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -1493,6 +1493,87 @@ pub fn whitespace_only_minify(
         }
     }
 
+    // ---- gap-099: computed-member object paren elision ---------
+    // `(b)[c]` → `b[c]`. The `[index]` sibling of gap-065 (callee)
+    // and gap-057 (`.member`): upstream strips the grouping parens
+    // around the OBJECT of a computed-member `[…]` access when the
+    // object is a *simple reference* — a plain identifier plus
+    // zero-or-more `.IDENT` accessors. `[` binds tighter than any
+    // operator a grouping paren could be protecting around a bare
+    // reference, so removal is meaning-preserving:
+    //
+    //   `(b)[c]`     →  `b[c]`
+    //   `(b.c)[d]`   →  `b.c[d]`
+    //   `(a)[b]=c`   →  `a[b]=c`
+    //
+    // The guards mirror gap-065 exactly; only the FOLLOWER differs:
+    //
+    //   1. GROUPING, NOT CALL/INDEX: the `(` must be a grouping
+    //      paren (prev token is punct other than `)`/`]`/`?.`, or
+    //      start of stream) — never a call/index paren. `f(a)[b]`
+    //      keeps its parens (the `(a)` is f's call).
+    //   2. SIMPLE REFERENCE: the inner is a plain identifier plus a
+    //      `.IDENT` chain. NO operators/commas/computed members —
+    //      `(a+b)[c]` and `(b||c)[d]` keep their parens (the scan
+    //      stops at the first non-`.IDENT` token; if that isn't the
+    //      matching `)`, nothing is dropped).
+    //   3. COMPUTED INDEX FOLLOWS: the token after `)` must be a
+    //      real `[` index bracket.
+    //
+    // Distinct from gap-087, which elided parens INSIDE the index
+    // (`a[(b)]` → `a[b]`); gap-099 is the object side. All bracket
+    // checks route through `is_structural_punct`.
+    {
+        let mut drops: Vec<usize> = Vec::new();
+        let mut i = 0;
+        while i + 2 < kept.len() {
+            if is_structural_punct(&kept[i], "(")
+                && is_plain_identifier(&kept[i + 1])
+            {
+                let grouping = match i.checked_sub(1).and_then(|k| kept.get(k)) {
+                    None => true,
+                    Some(p) => {
+                        is_punct(p)
+                            && !is_structural_punct(p, ")")
+                            && !is_structural_punct(p, "]")
+                            && !is_structural_punct(p, "?.")
+                    }
+                };
+                if grouping {
+                    // Consume the `.IDENT` member chain.
+                    let mut p = i + 1;
+                    while p + 2 < kept.len()
+                        && is_structural_punct(&kept[p + 1], ".")
+                        && is_plain_identifier(&kept[p + 2])
+                    {
+                        p += 2;
+                    }
+                    // Expect the matching `)` immediately, then a
+                    // computed-index `[`.
+                    let close_ok = kept
+                        .get(p + 1)
+                        .map(|t| is_structural_punct(t, ")"))
+                        .unwrap_or(false);
+                    let index_follows = kept
+                        .get(p + 2)
+                        .map(|t| is_structural_punct(t, "["))
+                        .unwrap_or(false);
+                    if close_ok && index_follows {
+                        drops.push(i); // open `(`
+                        drops.push(p + 1); // close `)`
+                        i = p + 2;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+        }
+        drops.sort_unstable();
+        for &drop_idx in drops.iter().rev() {
+            kept.remove(drop_idx);
+        }
+    }
+
     // ---- gap-066: redundant parens after `extends` ------------
     // `class A extends(B){}` → `class A extends B{}`. After the
     // `extends` keyword a parenthesized simple reference is
@@ -5729,6 +5810,41 @@ mod tests {
         assert_eq!(minify("f(g)(x);"), "f(g)(x);");
     }
 
+    // ---- gap-099: computed-member object paren elision ----
+
+    /// gap-099: grouping parens around a computed-member OBJECT are
+    /// dropped — `(b)[c]` → `b[c]`, `(b.c)[d]` → `b.c[d]`, including
+    /// deep chains and assignment targets.
+    #[test]
+    fn gap099_computed_member_paren_stripped() {
+        assert_eq!(minify("a=(b)[c];"), "a=b[c];");
+        assert_eq!(minify("a=(b.c)[d];"), "a=b.c[d];");
+        assert_eq!(minify("a=(b.c.d)[e];"), "a=b.c.d[e];");
+        assert_eq!(minify("(a)[b]=c;"), "a[b]=c;");
+    }
+
+    /// Trailing accessors ride along after the unwrap.
+    #[test]
+    fn gap099_computed_member_then_chain() {
+        assert_eq!(minify("a=(b)[c][d];"), "a=b[c][d];");
+        assert_eq!(minify("a=(b)[c].d;"), "a=b[c].d;");
+    }
+
+    /// **Non-regression**: a non-trivial operand keeps its parens —
+    /// `(a+b)[c]` and `(b||c)[d]` are NOT simple references.
+    #[test]
+    fn gap099_operator_operand_keeps_parens() {
+        assert_eq!(minify("x=(a+b)[c];"), "x=(a+b)[c];");
+        assert_eq!(minify("a=(b||c)[d];"), "a=(b||c)[d];");
+    }
+
+    /// **Non-regression**: a CALL paren is never treated as grouping —
+    /// `f(b)[c]` keeps `(b)` (it is f's call), not stripped to `fb[c]`.
+    #[test]
+    fn gap099_call_paren_not_stripped() {
+        assert_eq!(minify("a=f(b)[c];"), "a=f(b)[c];");
+    }
+
     // ---- gap-066: redundant parens after `extends` -------
 
     /// gap-066: `class A extends(B){}` → `class A extends B{}`.
@@ -6438,11 +6554,15 @@ mod tests {
         assert_eq!(minify("var x=(a+b).c;"), "var x=(a+b).c;");
     }
 
-    /// gap-057 safety: a string-literal whose content is `)` must
-    /// not corrupt the depth scan (structural-punct guard).
+    /// gap-099 + structural-punct safety: `(a)["\")\""]` — the grouping
+    /// parens around the computed-member object `a` are now stripped by
+    /// gap-099 (`(a)[…]` → `a[…]`), while the string literal `")"` is
+    /// preserved INTACT — its content must not be mistaken for a
+    /// structural bracket by the depth scan. (Before gap-099 this stayed
+    /// `(a)[")"]`; upstream JAR confirms `a[")"]`.)
     #[test]
-    fn gap057_string_content_not_bracket() {
-        assert_eq!(minify("var x=(a)[\")\"];"), "var x=(a)[\")\"];");
+    fn gap099_string_content_not_bracket() {
+        assert_eq!(minify("var x=(a)[\")\"];"), "var x=a[\")\"];");
     }
 
     // ---- gap-046: trailing array comma drop --------------

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.105.0
+Version: 0.106.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -85,13 +85,11 @@ const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
 ///
 /// Format: fixture name (without the `minify_` prefix) → reason.
 const IGNORE_FIXTURES: &[(&str, &str)] = &[
-    // gap-099 (CLOC14.43): paren elision around a COMPUTED-MEMBER object.
-    // `(b)[c]` -> `b[c]`, `(b.c)[d]` -> `b.c[d]` — the `[index]` analog
-    // of gap-057 (which only did `(a).b` -> `a.b` for `.member`). Only a
-    // SAFE operand (identifier / member-reference chain) is unwrapped;
-    // `(a+b)[c]` and `(b||c)[d]` keep their parens.
-    ("computed_member_paren", "gap-099: (b)[c] -> b[c]"),
-    ("computed_member_chain", "gap-099: (b.c)[d] -> b.c[d]"),
+    // gap-099 RESOLVED in CLOC12.102 — paren elision around a
+    // COMPUTED-MEMBER object: `(b)[c]` -> `b[c]`, `(b.c)[d]` -> `b.c[d]`.
+    // The `[index]` sibling of gap-065/gap-057; only a safe simple
+    // reference is unwrapped (`(a+b)[c]`, `(b||c)[d]`, `f(b)[c]` keep
+    // their parens).
     // gap-100 (CLOC14.43): paren elision around a FUNCTION/CLASS
     // EXPRESSION that is NOT at statement position. `a=(function(){})()`
     // -> `a=function(){}()`, `a=(class{})()` -> `a=class{}()`. The

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -741,9 +741,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-099 — computed-member object paren elision (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.43). `minify_computed_member_paren` / `minify_computed_member_chain` ignored.
+- **Status:** RESOLVED in CLOC12.102. `minify_computed_member_paren` / `minify_computed_member_chain` enforced.
 - **Input:** `a=(b)[c];` → **Upstream:** `a=b[c];` (also `a=(b.c)[d];` → `a=b.c[d];`, `a=(b)[c][d];` → `a=b[c][d];`, `(a)[b]=c;` → `a[b]=c;`).
 - **What it needs:** the `[index]` analog of gap-057 (`(a).b` → `a.b`). When a parenthesised expression is the OBJECT of a computed-member `[…]` access and the inner expression is a SAFE operand (a bare identifier or a member-reference chain), the parens are pure grouping and upstream drops them. Reuse gap-057's safe-operand predicate (`is_safe_unary_paren_operand` / the member-reference-chain check) but trigger on a following `[` instead of `.`. Must NOT strip when the inner expression is non-trivial: `(a+b)[c]` and `(b||c)[d]` keep their parens (binary/logical operands bind looser than member access). Distinct from gap-087, which elided parens INSIDE the index (`a[(b)]` → `a[b]`); gap-099 is the object side.
+- **CLOC12.102 resolution:** Implemented as a dedicated pass right after gap-065, copying gap-065's structure verbatim and changing only the FOLLOWER check from a call `(`/template to a `[` index. Guards: GROUPING (prev token is punct other than `)`/`]`/`?.`, or start of stream — never a call/index paren, so `f(b)[c]` is left alone), SIMPLE REFERENCE inside (a `is_plain_identifier` head + zero-or-more `.IDENT` accessors; the scan stops at the first non-`.IDENT` token so `(a+b)[c]`/`(b||c)[d]` never match), and a structural `[` follower. JAR-verified across 13 forms. A stale gap-057 test (`string_content_not_bracket`) asserted the PRE-gap-099 form `(a)[")"]` (kept because gap-057 only handled `.member`); since gap-099 now correctly strips it to `a[")"]` (JAR-confirmed) while still preserving the string `")"` intact, the test was updated + renamed to `gap099_string_content_not_bracket`. +4 new `gap099_*` tests.
 
 ### gap-100 — function/class-expression paren elision in expression position (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## Summary

Closes **gap-099** — grouping parens around the OBJECT of a computed-member `[…]` access are now elided when the object is a simple reference.

| input | before | after / upstream |
|---|---|---|
| `a=(b)[c]` | `a=(b)[c]` | `a=b[c]` |
| `a=(b.c)[d]` | `a=(b.c)[d]` | `a=b.c[d]` |
| `(a)[b]=c` | `(a)[b]=c` | `a[b]=c` |

## Mechanism

The `[index]` sibling of gap-065 (callee `(f)(x)`→`f(x)`) and gap-057 (`.member` `(a).b`→`a.b`). `[` binds tighter than any operator a grouping paren could protect around a bare reference, so removal is meaning-preserving. The new pass copies gap-065's structure verbatim and changes only the **follower** — a `[` index instead of a call `(`/template. Guards: **grouping** (not a call/index paren — `f(b)[c]` keeps its paren), **simple reference** inside (identifier + `.IDENT` chain; the scan stops at the first non-`.IDENT` token so `(a+b)[c]`/`(b||c)[d]` keep their parens), and a `[` follower.

Distinct from gap-087, which elided parens *inside* the index (`a[(b)]`→`a[b]`); gap-099 is the object side.

## Behaviour change (noted)
`(a)[")"]` now minifies to `a[")"]` (kept before gap-099, since gap-057 only handled `.member`). JAR-verified. The stale gap-057 `string_content_not_bracket` test was updated + renamed to `gap099_string_content_not_bracket` — it still verifies the string `")"` isn't mistaken for a structural bracket, just with the parens now correctly dropped.

## Tests
+4 `gap099_*` unit tests; **555 lib tests + walk-test + help-markdown golden all green**. JAR-verified across 13 forms (chains, assignment targets, kept-operand cases, call-paren non-regression). The `computed_member_paren` / `computed_member_chain` fixtures leave the ignore list. v0.106.0; spec RESOLVED.

## Security
Read-only token scan + removals — bounds-checked indexing, the chain scan advances each iteration (terminates), all bracket checks route through `is_structural_punct` (a string `")"`/`"["` can't be mistaken for a delimiter), no `unsafe`, no recursion, no new input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)