### PR TITLE
Add SPICE function call expression resolution

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Deck function-call expression resolution** — `resolve_deck_parameters()`
+  now collects scalar `.func` definitions before `.end` and evaluates scalar
+  function calls in `.param` assignments plus braced or quoted active-line
+  expressions, with stable diagnostics for unknown functions, bad arity, and
+  recursive calls, matching Rust and TypeScript.
+
 - **Deck function definition resolution** — `resolve_deck_functions()` now
   extracts scalar `.func name(args) expression` definitions before `.end`,
   strips braced or quoted expression delimiters, and reports stable diagnostics
@@ -19,8 +25,7 @@
 - **Deck parameter resolution** — `resolve_deck_parameters()` now evaluates
   scalar whitespace-tokenized `.param` assignments, rewrites braced and quoted
   active-line expressions, and reports stable diagnostics for unresolved
-  expressions and still-unsupported `.func` cards, matching Rust and
-  TypeScript.
+  expressions, matching Rust and TypeScript.
 
 - **Deck source resolution** — `resolve_deck_sources()` now expands
   map-provided `.include` files and selected `.lib path section` library

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -116,9 +116,10 @@ provide a source-content map, `.include` directives are expanded in place, and
 diagnostics for missing files, missing sections, unterminated sections, cycles,
 and still-unsupported `.control` blocks.
 `resolve_deck_parameters()` evaluates scalar whitespace-tokenized `.param`
-assignments, preserves parameter order, rewrites braced and quoted active-line
-expressions, and emits stable diagnostics for unresolved expressions and
-still-unsupported `.func` cards.
+assignments, collects scalar `.func` definitions before `.end`, preserves
+parameter order, rewrites braced and quoted active-line expressions, and emits
+stable diagnostics for unresolved expressions, bad function arity, unknown
+functions, and recursive function calls.
 `resolve_deck_initial_conditions()` extracts scalar `.ic` and `.nodeset`
 `V(node)=value` hints before `.end`, keeps non-condition active lines, evaluates
 numeric SPICE suffix/arithmetic expressions, and reports stable diagnostics for

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -328,7 +328,7 @@ _SUPPORTED_ANALYSES = frozenset({"op", "dc", "ac", "tran", "tf"})
 _REQUIRED_ANALYSES = frozenset({"op", "dc", "ac", "tran"})
 _UNSUPPORTED_DECK_CONTROL_DIRECTIVES = frozenset({".include", ".lib", ".control"})
 _UNSUPPORTED_RESOLVED_DIRECTIVES = frozenset({".control"})
-_UNSUPPORTED_PARAMETER_DIRECTIVES = frozenset({".func"})
+_UNSUPPORTED_PARAMETER_DIRECTIVES = frozenset()
 _SPICE_SUFFIX_FACTORS = {
     "t": 1.0e12,
     "g": 1.0e9,
@@ -406,9 +406,10 @@ def resolve_deck_sources(
 
 
 def resolve_deck_parameters(netlist: str) -> DeckParameterSummary:
-    """Evaluate scalar ``.param`` cards and rewrite braced deck expressions."""
+    """Evaluate scalar ``.param`` / ``.func`` cards and rewrite deck expressions."""
 
     state = _DeckParameterState()
+    _collect_parameter_functions(netlist, state)
     active_lines: list[str] = []
     end_line_number: int | None = None
 
@@ -422,6 +423,8 @@ def resolve_deck_parameters(netlist: str) -> DeckParameterSummary:
             break
         if directive == ".param":
             _resolve_param_line(stripped, line_number, state)
+            continue
+        if directive == ".func":
             continue
         if directive in _UNSUPPORTED_PARAMETER_DIRECTIVES:
             _add_parameter_diagnostic(
@@ -688,11 +691,13 @@ class _DeckResolutionState:
 class _DeckParameterState:
     diagnostics: list[DeckParameterDiagnostic]
     parameters: dict[str, DeckParameterValue]
+    functions: dict[str, DeckFunctionDefinition]
     order: list[str]
 
     def __init__(self) -> None:
         self.diagnostics = []
         self.parameters = {}
+        self.functions = {}
         self.order = []
 
     def set_parameter(self, name: str, value: float) -> None:
@@ -703,6 +708,12 @@ class _DeckParameterState:
 
     def parameter_values(self) -> list[DeckParameterValue]:
         return [self.parameters[key] for key in self.order]
+
+    def set_function(self, definition: DeckFunctionDefinition) -> None:
+        self.functions[definition.name.lower()] = definition
+
+    def get_function(self, name: str) -> DeckFunctionDefinition | None:
+        return self.functions.get(name.lower())
 
 
 @dataclass(slots=True)
@@ -919,6 +930,32 @@ def _resolve_param_line(
         state.set_parameter(name, value)
 
 
+def _collect_parameter_functions(netlist: str, state: _DeckParameterState) -> None:
+    function_state = _DeckFunctionState()
+    for line_number, raw_line in enumerate(netlist.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith(("*", ";")):
+            continue
+        directive = _deck_directive(stripped)
+        if directive == ".end":
+            break
+        if directive == ".func":
+            _resolve_function_line(stripped, line_number, function_state)
+
+    for definition in function_state.functions:
+        state.set_function(definition)
+    for diagnostic in function_state.diagnostics:
+        _add_parameter_diagnostic(
+            state,
+            code=diagnostic.code,
+            directive=diagnostic.directive,
+            line_number=diagnostic.line_number,
+            message=diagnostic.message,
+            parameter=diagnostic.function_name,
+            expression=diagnostic.expression,
+        )
+
+
 def _rewrite_parameter_expressions(
     line: str,
     line_number: int,
@@ -976,7 +1013,7 @@ def _evaluate_parameter_expression(
     expression: str,
     state: _DeckParameterState,
 ) -> float:
-    parser = _ParameterExpressionParser(expression, state.parameters)
+    parser = _ParameterExpressionParser(expression, state.parameters, state.functions)
     value = parser.parse()
     if not isfinite(value):
         raise ValueError(f"parameter expression {expression!r} did not evaluate to a finite value")
@@ -988,9 +1025,15 @@ class _ParameterExpressionParser:
         self,
         expression: str,
         parameters: Mapping[str, DeckParameterValue],
+        functions: Mapping[str, DeckFunctionDefinition],
+        local_values: Mapping[str, float] | None = None,
+        call_stack: tuple[str, ...] = (),
     ) -> None:
         self.expression = expression
         self.parameters = parameters
+        self.functions = functions
+        self.local_values = local_values or {}
+        self.call_stack = call_stack
         self.index = 0
 
     def parse(self) -> float:
@@ -1104,13 +1147,55 @@ class _ParameterExpressionParser:
         name = self.expression[start : self.index]
         self._skip_whitespace()
         if self.index < len(self.expression) and self.expression[self.index] == "(":
-            raise ValueError(f"function calls are not supported in parameter expression {name!r}")
+            return self._evaluate_function_call(name, self._parse_call_arguments())
+        local = self.local_values.get(name.lower())
+        if local is not None:
+            return local
         if name.lower() == "pi":
             return pi
         parameter = self.parameters.get(name.lower())
         if parameter is None:
             raise ValueError(f"unknown parameter {name!r}")
         return parameter.value
+
+    def _parse_call_arguments(self) -> list[float]:
+        if not self._match("("):
+            raise ValueError("expected '(' in function call")
+        self._skip_whitespace()
+        if self._match(")"):
+            return []
+        arguments: list[float] = []
+        while True:
+            arguments.append(self._parse_expression())
+            self._skip_whitespace()
+            if self._match(","):
+                continue
+            if self._match(")"):
+                return arguments
+            raise ValueError("missing ')' in function call")
+
+    def _evaluate_function_call(self, name: str, values: Sequence[float]) -> float:
+        definition = self.functions.get(name.lower())
+        if definition is None:
+            raise ValueError(f"unknown function {name!r}")
+        if len(values) != len(definition.arguments):
+            raise ValueError(
+                f"function {name!r} expected {len(definition.arguments)} arguments but got {len(values)}"
+            )
+        key = definition.name.lower()
+        if key in self.call_stack:
+            raise ValueError(f"recursive function call {name!r}")
+        local_values = dict(self.local_values)
+        for argument, value in zip(definition.arguments, values, strict=True):
+            local_values[argument.lower()] = value
+        parser = _ParameterExpressionParser(
+            definition.expression,
+            self.parameters,
+            self.functions,
+            local_values,
+            (*self.call_stack, key),
+        )
+        return parser.parse()
 
     def _skip_whitespace(self) -> None:
         while self.index < len(self.expression) and self.expression[self.index].isspace():

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -225,11 +225,41 @@ Rafter out 0 {total}
     assert summary.diagnostics == ()
 
 
-def test_resolve_deck_parameters_reports_unresolved_and_unsupported_func() -> None:
+def test_resolve_deck_parameters_evaluates_func_calls() -> None:
     summary = resolve_deck_parameters(
         """
-.param GOOD=1k BAD=missing+1
 .func gain(x) {x*2}
+.param BASE=2 SCALE=3 SHIFT=1 TOTAL=blend(base,scale,shift)
+.func blend(a,b,c) 'gain(a)+b+c'
+R1 in out {gain(total)}
+B1 out 0 V='blend(1,2,3)'
+.op
+.end
+"""
+    )
+
+    assert summary.terminated is True
+    assert summary.end_line_number == 8
+    assert summary.active_lines == (
+        "R1 in out 16",
+        "B1 out 0 V=7",
+        ".op",
+    )
+    assert [(param.name, param.value) for param in summary.parameters] == [
+        ("BASE", 2.0),
+        ("SCALE", 3.0),
+        ("SHIFT", 1.0),
+        ("TOTAL", 8.0),
+    ]
+    assert summary.diagnostics == ()
+
+
+def test_resolve_deck_parameters_reports_bad_func_calls() -> None:
+    summary = resolve_deck_parameters(
+        """
+.func one(x) {x+1}
+.func loop(x) {loop(x)}
+.param GOOD=one(1) BAD=unknown(1) ARITY=one(1,2) RECUR=loop(1)
 R1 in out {bad}
 R2 out 0 {good}
 .end
@@ -237,18 +267,23 @@ R2 out 0 {good}
     )
 
     assert summary.active_lines == (
-        ".func gain(x) {x*2}",
         "R1 in out {bad}",
-        "R2 out 0 1000",
+        "R2 out 0 2",
     )
-    assert [(param.name, param.value) for param in summary.parameters] == [("GOOD", 1000.0)]
+    assert [(param.name, param.value) for param in summary.parameters] == [("GOOD", 2.0)]
     assert [diag.code for diag in summary.diagnostics] == [
         "SPICE_DECK_PARAM_EXPRESSION",
-        "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+        "SPICE_DECK_PARAM_EXPRESSION",
+        "SPICE_DECK_PARAM_EXPRESSION",
         "SPICE_DECK_PARAM_UNRESOLVED",
     ]
-    assert summary.diagnostics[0].parameter == "BAD"
-    assert summary.diagnostics[2].expression == "bad"
+    assert [diag.parameter for diag in summary.diagnostics[:3]] == ["BAD", "ARITY", "RECUR"]
+    assert [diag.expression for diag in summary.diagnostics] == [
+        "unknown(1)",
+        "one(1,2)",
+        "loop(1)",
+        "bad",
+    ]
 
 
 def test_resolve_deck_initial_conditions_extracts_ic_and_nodeset_hints() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add scalar `.func` call evaluation to `resolve_deck_parameters`: definitions
+  are collected before `.end`, calls can appear in `.param` assignments and
+  braced or quoted active-line expressions, and unknown functions, bad arity,
+  and recursive calls produce stable diagnostics, matching Python and
+  TypeScript.
 - Add `resolve_deck_functions` for scalar `.func name(args) expression`
   definition extraction before `.end`, braced or quoted expression delimiter
   stripping, and stable diagnostics for malformed signatures, arguments,
@@ -12,8 +17,8 @@
   targets and unresolved values, matching Python and TypeScript.
 - Add `resolve_deck_parameters` for scalar whitespace-tokenized `.param`
   assignment evaluation, braced and quoted active-line expression rewriting,
-  and stable diagnostics for unresolved expressions and still-unsupported
-  `.func` cards, matching Python and TypeScript.
+  and stable diagnostics for unresolved expressions, matching Python and
+  TypeScript.
 - Add `resolve_deck_sources` for map-backed `.include` and selected
   `.lib path section` expansion with stable diagnostics for missing sources,
   missing or unterminated library sections, cycles, and still-unsupported

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -131,9 +131,10 @@ provide a source-content map, `.include` directives are expanded in place, and
 diagnostics for missing files, missing sections, unterminated sections, cycles,
 and still-unsupported `.control` blocks.
 `resolve_deck_parameters` evaluates scalar whitespace-tokenized `.param`
-assignments, preserves parameter order, rewrites braced and quoted active-line
-expressions, and emits stable diagnostics for unresolved expressions and
-still-unsupported `.func` cards.
+assignments, collects scalar `.func` definitions before `.end`, preserves
+parameter order, rewrites braced and quoted active-line expressions, and emits
+stable diagnostics for unresolved expressions, bad function arity, unknown
+functions, and recursive function calls.
 `resolve_deck_initial_conditions` extracts scalar `.ic` and `.nodeset`
 `V(node)=value` hints before `.end`, keeps non-condition active lines, evaluates
 numeric SPICE suffix/arithmetic expressions, and reports stable diagnostics for

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3439,6 +3439,7 @@ pub fn resolve_deck_sources(
 
 pub fn resolve_deck_parameters(netlist: &str) -> DeckParameterSummary {
     let mut state = DeckParameterState::new();
+    collect_parameter_functions(netlist, &mut state);
     let mut active_lines = Vec::new();
     let mut end_line_number = None;
 
@@ -3455,6 +3456,9 @@ pub fn resolve_deck_parameters(netlist: &str) -> DeckParameterSummary {
         }
         if directive.as_deref() == Some(".param") {
             resolve_param_line(stripped, line_number, &mut state);
+            continue;
+        }
+        if directive.as_deref() == Some(".func") {
             continue;
         }
         if let Some(directive) = directive {
@@ -3792,6 +3796,7 @@ impl DeckResolutionState {
 struct DeckParameterState {
     diagnostics: Vec<DeckParameterDiagnostic>,
     parameters: HashMap<String, DeckParameterValue>,
+    functions: HashMap<String, DeckFunctionDefinition>,
     order: Vec<String>,
 }
 
@@ -3800,6 +3805,7 @@ impl DeckParameterState {
         Self {
             diagnostics: Vec::new(),
             parameters: HashMap::new(),
+            functions: HashMap::new(),
             order: Vec::new(),
         }
     }
@@ -3820,6 +3826,15 @@ impl DeckParameterState {
 
     fn get_parameter(&self, name: &str) -> Option<&DeckParameterValue> {
         self.parameters.get(&name.to_ascii_lowercase())
+    }
+
+    fn set_function(&mut self, definition: DeckFunctionDefinition) {
+        self.functions
+            .insert(definition.name.to_ascii_lowercase(), definition);
+    }
+
+    fn get_function(&self, name: &str) -> Option<&DeckFunctionDefinition> {
+        self.functions.get(&name.to_ascii_lowercase())
     }
 
     fn parameter_values(&self) -> Vec<DeckParameterValue> {
@@ -4366,6 +4381,39 @@ fn resolve_param_line(line: &str, line_number: usize, state: &mut DeckParameterS
     }
 }
 
+fn collect_parameter_functions(netlist: &str, state: &mut DeckParameterState) {
+    let mut function_state = DeckFunctionState::new();
+    for (index, raw_line) in netlist.lines().enumerate() {
+        let line_number = index + 1;
+        let stripped = raw_line.trim();
+        if stripped.is_empty() || stripped.starts_with('*') || stripped.starts_with(';') {
+            continue;
+        }
+        let directive = deck_directive(stripped);
+        if directive.as_deref() == Some(".end") {
+            break;
+        }
+        if directive.as_deref() == Some(".func") {
+            resolve_function_line(stripped, line_number, &mut function_state);
+        }
+    }
+
+    for definition in function_state.functions {
+        state.set_function(definition);
+    }
+    for diagnostic in function_state.diagnostics {
+        add_parameter_diagnostic(
+            state,
+            &diagnostic.code,
+            &diagnostic.directive,
+            diagnostic.line_number,
+            &diagnostic.message,
+            diagnostic.function_name,
+            diagnostic.expression,
+        );
+    }
+}
+
 fn rewrite_parameter_expressions(
     line: &str,
     line_number: usize,
@@ -4450,6 +4498,8 @@ fn evaluate_parameter_expression(
 struct ParameterExpressionParser<'a> {
     expression: &'a str,
     state: &'a DeckParameterState,
+    local_values: HashMap<String, f64>,
+    call_stack: Vec<String>,
     index: usize,
 }
 
@@ -4458,6 +4508,23 @@ impl<'a> ParameterExpressionParser<'a> {
         Self {
             expression,
             state,
+            local_values: HashMap::new(),
+            call_stack: Vec::new(),
+            index: 0,
+        }
+    }
+
+    fn new_with_context(
+        expression: &'a str,
+        state: &'a DeckParameterState,
+        local_values: HashMap<String, f64>,
+        call_stack: Vec<String>,
+    ) -> Self {
+        Self {
+            expression,
+            state,
+            local_values,
+            call_stack,
             index: 0,
         }
     }
@@ -4617,20 +4684,74 @@ impl<'a> ParameterExpressionParser<'a> {
         {
             self.advance_char();
         }
-        let name = &self.expression[start..self.index];
+        let name = self.expression[start..self.index].to_string();
         self.skip_whitespace();
         if self.current_char() == Some('(') {
-            return Err(format!(
-                "function calls are not supported in parameter expression {name:?}"
-            ));
+            let values = self.parse_call_arguments()?;
+            return self.evaluate_function_call(&name, &values);
+        }
+        if let Some(value) = self.local_values.get(&name.to_ascii_lowercase()) {
+            return Ok(*value);
         }
         if name.eq_ignore_ascii_case("pi") {
             return Ok(std::f64::consts::PI);
         }
-        let Some(parameter) = self.state.get_parameter(name) else {
+        let Some(parameter) = self.state.get_parameter(&name) else {
             return Err(format!("unknown parameter {name:?}"));
         };
         Ok(parameter.value)
+    }
+
+    fn parse_call_arguments(&mut self) -> Result<Vec<f64>, String> {
+        if !self.match_token("(") {
+            return Err("expected '(' in function call".to_string());
+        }
+        self.skip_whitespace();
+        if self.match_token(")") {
+            return Ok(Vec::new());
+        }
+        let mut values = Vec::new();
+        loop {
+            values.push(self.parse_expression()?);
+            self.skip_whitespace();
+            if self.match_token(",") {
+                continue;
+            }
+            if self.match_token(")") {
+                return Ok(values);
+            }
+            return Err("missing ')' in function call".to_string());
+        }
+    }
+
+    fn evaluate_function_call(&self, name: &str, values: &[f64]) -> Result<f64, String> {
+        let Some(definition) = self.state.get_function(name) else {
+            return Err(format!("unknown function {name:?}"));
+        };
+        if values.len() != definition.arguments.len() {
+            return Err(format!(
+                "function {name:?} expected {} arguments but got {}",
+                definition.arguments.len(),
+                values.len()
+            ));
+        }
+        let key = definition.name.to_ascii_lowercase();
+        if self.call_stack.contains(&key) {
+            return Err(format!("recursive function call {name:?}"));
+        }
+        let mut local_values = self.local_values.clone();
+        for (argument, value) in definition.arguments.iter().zip(values.iter()) {
+            local_values.insert(argument.to_ascii_lowercase(), *value);
+        }
+        let mut call_stack = self.call_stack.clone();
+        call_stack.push(key);
+        ParameterExpressionParser::new_with_context(
+            &definition.expression,
+            self.state,
+            local_values,
+            call_stack,
+        )
+        .parse()
     }
 
     fn skip_whitespace(&mut self) {
@@ -4747,7 +4868,8 @@ fn parse_function_signature(rest: &str) -> Option<(String, Vec<String>, String)>
 }
 
 fn is_unsupported_parameter_directive(directive: &str) -> bool {
-    matches!(directive, ".func")
+    let _ = directive;
+    false
 }
 
 fn is_parameter_name(name: &str) -> bool {

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -319,21 +319,62 @@ Rafter out 0 {total}
 }
 
 #[test]
-fn resolve_deck_parameters_reports_unresolved_and_unsupported_func() {
+fn resolve_deck_parameters_evaluates_func_calls() {
     let summary = resolve_deck_parameters(
         "
-.param GOOD=1k BAD=missing+1
 .func gain(x) {x*2}
+.param BASE=2 SCALE=3 SHIFT=1 TOTAL=blend(base,scale,shift)
+.func blend(a,b,c) 'gain(a)+b+c'
+R1 in out {gain(total)}
+B1 out 0 V='blend(1,2,3)'
+.op
+.end
+",
+    );
+
+    assert!(summary.terminated);
+    assert_eq!(summary.end_line_number, Some(8));
+    assert_eq!(
+        summary.active_lines,
+        vec!["R1 in out 16", "B1 out 0 V=7", ".op"]
+    );
+    assert_eq!(
+        summary
+            .parameters
+            .iter()
+            .map(|parameter| (parameter.name.as_str(), parameter.value))
+            .collect::<Vec<_>>(),
+        vec![
+            ("BASE", 2.0),
+            ("SCALE", 3.0),
+            ("SHIFT", 1.0),
+            ("TOTAL", 8.0)
+        ]
+    );
+    assert!(summary.diagnostics.is_empty());
+}
+
+#[test]
+fn resolve_deck_parameters_reports_bad_func_calls() {
+    let summary = resolve_deck_parameters(
+        "
+.func one(x) {x+1}
+.func loop(x) {loop(x)}
+.param GOOD=one(1) BAD=unknown(1) ARITY=one(1,2) RECUR=loop(1)
 R1 in out {bad}
 R2 out 0 {good}
 .end
 ",
     );
 
-    assert!(summary.terminated);
+    assert_eq!(summary.active_lines, vec!["R1 in out {bad}", "R2 out 0 2"]);
     assert_eq!(
-        summary.active_lines,
-        vec![".func gain(x) {x*2}", "R1 in out {bad}", "R2 out 0 1000"]
+        summary
+            .parameters
+            .iter()
+            .map(|parameter| (parameter.name.as_str(), parameter.value))
+            .collect::<Vec<_>>(),
+        vec![("GOOD", 2.0)]
     );
     assert_eq!(
         summary
@@ -343,8 +384,31 @@ R2 out 0 {good}
             .collect::<Vec<_>>(),
         vec![
             "SPICE_DECK_PARAM_EXPRESSION",
-            "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+            "SPICE_DECK_PARAM_EXPRESSION",
+            "SPICE_DECK_PARAM_EXPRESSION",
             "SPICE_DECK_PARAM_UNRESOLVED"
+        ]
+    );
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .take(3)
+            .map(|diagnostic| diagnostic.parameter.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("BAD"), Some("ARITY"), Some("RECUR")]
+    );
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.expression.as_deref())
+            .collect::<Vec<_>>(),
+        vec![
+            Some("unknown(1)"),
+            Some("one(1,2)"),
+            Some("loop(1)"),
+            Some("bad")
         ]
     );
 }

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add scalar `.func` call evaluation to `resolveDeckParameters`: definitions
+  are collected before `.end`, calls can appear in `.param` assignments and
+  braced or quoted active-line expressions, and unknown functions, bad arity,
+  and recursive calls produce stable diagnostics, matching Python and Rust.
 - Add `resolveDeckFunctions` for scalar `.func name(args) expression`
   definition extraction before `.end`, braced or quoted expression delimiter
   stripping, and stable diagnostics for malformed signatures, arguments,
@@ -12,8 +16,7 @@
   targets and unresolved values, matching Python and Rust.
 - Add `resolveDeckParameters` for scalar whitespace-tokenized `.param`
   assignment evaluation, braced and quoted active-line expression rewriting,
-  and stable diagnostics for unresolved expressions and still-unsupported
-  `.func` cards, matching Python and Rust.
+  and stable diagnostics for unresolved expressions, matching Python and Rust.
 - Add `resolveDeckSources` for map-backed `.include` and selected
   `.lib path section` expansion with stable diagnostics for missing sources,
   missing or unterminated library sections, cycles, and still-unsupported

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -97,9 +97,10 @@ provide a source-content map, `.include` directives are expanded in place, and
 diagnostics for missing files, missing sections, unterminated sections, cycles,
 and still-unsupported `.control` blocks.
 `resolveDeckParameters` evaluates scalar whitespace-tokenized `.param`
-assignments, preserves parameter order, rewrites braced and quoted active-line
-expressions, and emits stable diagnostics for unresolved expressions and
-still-unsupported `.func` cards.
+assignments, collects scalar `.func` definitions before `.end`, preserves
+parameter order, rewrites braced and quoted active-line expressions, and emits
+stable diagnostics for unresolved expressions, bad function arity, unknown
+functions, and recursive function calls.
 `resolveDeckInitialConditions` extracts scalar `.ic` and `.nodeset`
 `V(node)=value` hints before `.end`, keeps non-condition active lines, evaluates
 numeric SPICE suffix/arithmetic expressions, and reports stable diagnostics for

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2664,7 +2664,7 @@ const SUPPORTED_COMPATIBILITY_ANALYSES = new Set(["op", "dc", "ac", "tran", "tf"
 const REQUIRED_COMPATIBILITY_ANALYSES = ["op", "dc", "ac", "tran"];
 const UNSUPPORTED_DECK_CONTROL_DIRECTIVES = new Set([".include", ".lib", ".control"]);
 const UNSUPPORTED_RESOLVED_DIRECTIVES = new Set([".control"]);
-const UNSUPPORTED_PARAMETER_DIRECTIVES = new Set([".func"]);
+const UNSUPPORTED_PARAMETER_DIRECTIVES = new Set<string>();
 
 export function compatibilityCorpus(): readonly CompatibilityDeck[] {
   return COMPATIBILITY_CORPUS;
@@ -2730,6 +2730,7 @@ export function resolveDeckSources(
 
 export function resolveDeckParameters(netlist: string): DeckParameterSummary {
   const state = new DeckParameterState();
+  collectParameterFunctions(netlist, state);
   const activeLines: string[] = [];
   let endLineNumber: number | undefined;
 
@@ -2747,6 +2748,9 @@ export function resolveDeckParameters(netlist: string): DeckParameterSummary {
     }
     if (directive === ".param") {
       resolveParamLine(stripped, lineNumber, state);
+      continue;
+    }
+    if (directive === ".func") {
       continue;
     }
     if (directive !== undefined && UNSUPPORTED_PARAMETER_DIRECTIVES.has(directive)) {
@@ -3230,6 +3234,7 @@ function addResolutionDiagnostic(
 class DeckParameterState {
   readonly diagnostics: DeckParameterDiagnostic[] = [];
   private readonly parametersByName = new Map<string, DeckParameterValue>();
+  private readonly functionsByName = new Map<string, DeckFunctionDefinition>();
   private readonly order: string[] = [];
 
   setParameter(name: string, value: number): void {
@@ -3242,6 +3247,14 @@ class DeckParameterState {
 
   getParameter(name: string): DeckParameterValue | undefined {
     return this.parametersByName.get(name.toLowerCase());
+  }
+
+  setFunction(definition: DeckFunctionDefinition): void {
+    this.functionsByName.set(definition.name.toLowerCase(), definition);
+  }
+
+  getFunction(name: string): DeckFunctionDefinition | undefined {
+    return this.functionsByName.get(name.toLowerCase());
   }
 
   parameterValues(): DeckParameterValue[] {
@@ -3454,6 +3467,39 @@ function resolveParamLine(line: string, lineNumber: number, state: DeckParameter
   }
 }
 
+function collectParameterFunctions(netlist: string, state: DeckParameterState): void {
+  const functionState = new DeckFunctionState();
+  const lines = netlist.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    const lineNumber = index + 1;
+    const stripped = lines[index].trim();
+    if (stripped.length === 0 || stripped.startsWith("*") || stripped.startsWith(";")) {
+      continue;
+    }
+    const directive = deckDirective(stripped);
+    if (directive === ".end") {
+      break;
+    }
+    if (directive === ".func") {
+      resolveFunctionLine(stripped, lineNumber, functionState);
+    }
+  }
+
+  for (const definition of functionState.functions) {
+    state.setFunction(definition);
+  }
+  for (const diagnostic of functionState.diagnostics) {
+    addParameterDiagnostic(state, {
+      code: diagnostic.code,
+      directive: diagnostic.directive,
+      lineNumber: diagnostic.lineNumber,
+      message: diagnostic.message,
+      parameter: diagnostic.functionName,
+      expression: diagnostic.expression,
+    });
+  }
+}
+
 function rewriteParameterExpressions(
   line: string,
   lineNumber: number,
@@ -3521,6 +3567,8 @@ class ParameterExpressionParser {
   constructor(
     private readonly expression: string,
     private readonly state: DeckParameterState,
+    private readonly localValues: ReadonlyMap<string, number> = new Map<string, number>(),
+    private readonly callStack: readonly string[] = [],
   ) {}
 
   parse(): number {
@@ -3676,7 +3724,11 @@ class ParameterExpressionParser {
     const name = this.expression.slice(start, this.index);
     this.skipWhitespace();
     if (this.index < this.expression.length && this.expression[this.index] === "(") {
-      throw new Error(`function calls are not supported in parameter expression ${JSON.stringify(name)}`);
+      return this.evaluateFunctionCall(name, this.parseCallArguments());
+    }
+    const local = this.localValues.get(name.toLowerCase());
+    if (local !== undefined) {
+      return local;
     }
     if (name.toLowerCase() === "pi") {
       return Math.PI;
@@ -3686,6 +3738,52 @@ class ParameterExpressionParser {
       throw new Error(`unknown parameter ${JSON.stringify(name)}`);
     }
     return parameter.value;
+  }
+
+  private parseCallArguments(): number[] {
+    if (!this.match("(")) {
+      throw new Error("expected '(' in function call");
+    }
+    this.skipWhitespace();
+    if (this.match(")")) {
+      return [];
+    }
+    const values: number[] = [];
+    while (true) {
+      values.push(this.parseExpression());
+      this.skipWhitespace();
+      if (this.match(",")) {
+        continue;
+      }
+      if (this.match(")")) {
+        return values;
+      }
+      throw new Error("missing ')' in function call");
+    }
+  }
+
+  private evaluateFunctionCall(name: string, values: readonly number[]): number {
+    const definition = this.state.getFunction(name);
+    if (definition === undefined) {
+      throw new Error(`unknown function ${JSON.stringify(name)}`);
+    }
+    if (values.length !== definition.arguments.length) {
+      throw new Error(
+        `function ${JSON.stringify(name)} expected ${definition.arguments.length} arguments but got ${values.length}`,
+      );
+    }
+    const key = definition.name.toLowerCase();
+    if (this.callStack.includes(key)) {
+      throw new Error(`recursive function call ${JSON.stringify(name)}`);
+    }
+    const localValues = new Map(this.localValues);
+    definition.arguments.forEach((argument, index) => {
+      localValues.set(argument.toLowerCase(), values[index]);
+    });
+    return new ParameterExpressionParser(definition.expression, this.state, localValues, [
+      ...this.callStack,
+      key,
+    ]).parse();
   }
 
   private skipWhitespace(): void {

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -232,30 +232,67 @@ Rafter out 0 {total}
     expect(summary.diagnostics).toStrictEqual([]);
   });
 
-  it("reports unresolved parameters and unsupported functions", () => {
+  it("evaluates scalar .func calls in parameter expressions", () => {
     const summary = resolveDeckParameters(`
-.param GOOD=1k BAD=missing+1
 .func gain(x) {x*2}
+.param BASE=2 SCALE=3 SHIFT=1 TOTAL=blend(base,scale,shift)
+.func blend(a,b,c) 'gain(a)+b+c'
+R1 in out {gain(total)}
+B1 out 0 V='blend(1,2,3)'
+.op
+.end
+`);
+
+    expect(summary.terminated).toBe(true);
+    expect(summary.endLineNumber).toBe(8);
+    expect(summary.activeLines).toStrictEqual([
+      "R1 in out 16",
+      "B1 out 0 V=7",
+      ".op",
+    ]);
+    expect(summary.parameters.map((parameter) => [parameter.name, parameter.value])).toStrictEqual([
+      ["BASE", 2],
+      ["SCALE", 3],
+      ["SHIFT", 1],
+      ["TOTAL", 8],
+    ]);
+    expect(summary.diagnostics).toStrictEqual([]);
+  });
+
+  it("reports bad scalar .func calls in parameter expressions", () => {
+    const summary = resolveDeckParameters(`
+.func one(x) {x+1}
+.func loop(x) {loop(x)}
+.param GOOD=one(1) BAD=unknown(1) ARITY=one(1,2) RECUR=loop(1)
 R1 in out {bad}
 R2 out 0 {good}
 .end
 `);
 
     expect(summary.activeLines).toStrictEqual([
-      ".func gain(x) {x*2}",
       "R1 in out {bad}",
-      "R2 out 0 1000",
+      "R2 out 0 2",
     ]);
     expect(summary.parameters.map((parameter) => [parameter.name, parameter.value])).toStrictEqual([
-      ["GOOD", 1000],
+      ["GOOD", 2],
     ]);
     expect(summary.diagnostics.map((diagnostic) => diagnostic.code)).toStrictEqual([
       "SPICE_DECK_PARAM_EXPRESSION",
-      "SPICE_DECK_UNSUPPORTED_DIRECTIVE",
+      "SPICE_DECK_PARAM_EXPRESSION",
+      "SPICE_DECK_PARAM_EXPRESSION",
       "SPICE_DECK_PARAM_UNRESOLVED",
     ]);
-    expect(summary.diagnostics[0].parameter).toBe("BAD");
-    expect(summary.diagnostics[2].expression).toBe("bad");
+    expect(summary.diagnostics.slice(0, 3).map((diagnostic) => diagnostic.parameter)).toStrictEqual([
+      "BAD",
+      "ARITY",
+      "RECUR",
+    ]);
+    expect(summary.diagnostics.map((diagnostic) => diagnostic.expression)).toStrictEqual([
+      "unknown(1)",
+      "one(1,2)",
+      "loop(1)",
+      "bad",
+    ]);
   });
 
   it("extracts .ic and .nodeset node-voltage hints", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -23,8 +23,8 @@ downstream tools to compare.
      parsed `.func`, `.ic`, and `.nodeset` hints; `.end` boundary detection,
      map-backed `.include` / `.lib` source resolution, scalar `.param`
      evaluation, active-line expression rewriting, function-definition
-     extraction, and initial-condition / nodeset extraction now have shared
-     diagnostic footholds.
+     extraction, scalar function-call evaluation, and initial-condition /
+     nodeset extraction now have shared diagnostic footholds.
    - Expand `.measure`, `.save`, and `.probe` execution toward full SPICE
      compatibility while keeping unsupported control-flow diagnostics explicit.
 
@@ -182,7 +182,7 @@ downstream tools to compare.
       unary signs, `pi`, and common SPICE numeric suffixes.
     - Stable diagnostics cover malformed `.param` cards, invalid parameter
       names, failed expressions, unresolved active-line expressions,
-      unterminated expression delimiters, and still-unsupported `.func` cards.
+      and unterminated expression delimiters.
 
 17. Initial condition/nodeset directive foothold.
     - Status: completed in this initial-condition/nodeset directive slice.
@@ -200,19 +200,31 @@ downstream tools to compare.
       that extract scalar `.func name(args) expression` definitions before
       `.end` while preserving non-function active lines.
     - Function bodies are stored as normalized expression strings with braced
-      or quoted expression delimiters stripped, but function-call evaluation and
-      active-line expansion remain future execution-layer work.
+      or quoted expression delimiters stripped; scalar function-call evaluation
+      and active-line expansion are covered by the follow-up expression slice.
     - Stable diagnostics cover missing definitions, malformed signatures,
       invalid function names, invalid or duplicate arguments, and empty
       expressions.
+
+19. Function-call expression resolution.
+    - Status: completed in this function-call expression slice.
+    - Python, Rust, and TypeScript now let the deck parameter resolver collect
+      scalar `.func` definitions before `.end` and evaluate function calls in
+      `.param` assignments plus braced or quoted active-line expressions.
+    - Function names are case-insensitive, arguments are scalar expressions,
+      local arguments shadow deck parameters inside function bodies, and stable
+      diagnostics cover unknown functions, bad arity, and recursive calls.
+    - The slice deliberately keeps `.ic` / `.nodeset` hints as parsed metadata;
+      execution-layer wiring for initial guesses remains future deck execution
+      work.
 
 ## Backlog
 
 1. Deck execution layer.
    - Convert parsed netlists into runnable analysis plans.
-   - Support richer expression/function surfaces beyond the scalar `.param`
-     and `.func` definition footholds, including function-call evaluation and
-     execution wiring for parsed `.ic` / `.nodeset` hints.
+   - Wire parsed `.ic` / `.nodeset` hints into analysis execution as initial
+     guesses or solver aids now that scalar `.param` and `.func` expression
+     surfaces have shared cross-language resolution.
    - Expand the initial `.measure`, `.save`, and `.probe` support toward full
      SPICE compatibility, including additional measure modes and richer output
      formats.


### PR DESCRIPTION
## Summary
- collect scalar `.func` definitions during deck parameter resolution and evaluate calls in `.param` assignments plus braced/quoted active-line expressions across Python, Rust, and TypeScript
- add stable diagnostics for unknown functions, bad arity, and recursive calls while keeping `.ic`/`.nodeset` execution wiring for a future slice
- update package docs/changelogs and the SPICE full implementation plan

## Verification
- `mise exec -- ruff check code/packages/python/spice-engine/src code/packages/python/spice-engine/tests`
- `PYTHONPATH=code/packages/python/spice-engine/src:code/packages/python/mosfet-models/src:code/packages/python/device-physics/src mise exec -- python -m pytest code/packages/python/spice-engine/tests`
- `cargo fmt --check --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `npm run build` (`code/packages/typescript/spice-engine`)
- `npm test` (`code/packages/typescript/spice-engine`)
- `git diff --check`