### PR TITLE
Add smart-home activation closure tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -106,6 +106,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation remediation work orders:
   `smart_home.list_integration_activation_remediation` and
   `smart_home.get_integration_activation_remediation_summary`.
+- Added D18D handlers for D23A activation closure gates:
+  `smart_home.list_integration_activation_closure` and
+  `smart_home.get_integration_activation_closure_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -70,6 +70,7 @@ Chief of Staff job/session/agent
   -> activation-escalation list and summary reads for Chief-facing cases
   -> activation-response list and summary reads for owner-lane next actions
   -> activation-remediation list and summary reads for owner-lane work orders
+  -> activation-closure list and summary reads for verification/close gates
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -161,6 +162,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_response_summary`
 - `smart_home.list_integration_activation_remediation`
 - `smart_home.get_integration_activation_remediation_summary`
+- `smart_home.list_integration_activation_closure`
+- `smart_home.get_integration_activation_closure_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -36,6 +36,7 @@ use smart_home_integration_catalog::{
     activation_actions_from_candidates, activation_agenda_from_candidates,
     activation_approval_packets_from_candidates, activation_audit_records_from_rollups,
     activation_briefing_items_from_readouts, activation_candidates_at_or_before_priority,
+    activation_closure_gates_from_remediations,
     activation_command_center_sections_from_control_room_panels,
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
@@ -69,29 +70,30 @@ use smart_home_integration_catalog::{
     IntegrationActivationBriefingItem, IntegrationActivationBriefingItemKind,
     IntegrationActivationBriefingSummary, IntegrationActivationCandidate,
     IntegrationActivationCandidateRecommendation, IntegrationActivationCandidateSummary,
-    IntegrationActivationCommandCenterSection, IntegrationActivationCommandCenterSectionKind,
-    IntegrationActivationCommandCenterSummary, IntegrationActivationConstraint,
-    IntegrationActivationConstraintKind, IntegrationActivationConstraintSummary,
-    IntegrationActivationControlRoomPanel, IntegrationActivationControlRoomSummary,
-    IntegrationActivationDashboardCard, IntegrationActivationDashboardSummary,
-    IntegrationActivationDecisionItem, IntegrationActivationDecisionStatus,
-    IntegrationActivationDecisionSummary, IntegrationActivationDependencyEdge,
-    IntegrationActivationDependencyGraph, IntegrationActivationDependencyNode,
-    IntegrationActivationDependencySummary, IntegrationActivationDossierItem,
-    IntegrationActivationDossierSummary, IntegrationActivationEscalationCase,
-    IntegrationActivationEscalationCaseKind, IntegrationActivationEscalationSummary,
-    IntegrationActivationEvidenceItem, IntegrationActivationEvidenceKind,
-    IntegrationActivationEvidenceStatus, IntegrationActivationEvidenceSummary,
-    IntegrationActivationExecutionPacket, IntegrationActivationExecutionStatus,
-    IntegrationActivationExecutionSummary, IntegrationActivationForecastAction,
-    IntegrationActivationForecastItem, IntegrationActivationForecastSummary,
-    IntegrationActivationHandoffPackage, IntegrationActivationHandoffStatus,
-    IntegrationActivationHandoffSummary, IntegrationActivationHealthStage,
-    IntegrationActivationHealthStatus, IntegrationActivationHealthSummary,
-    IntegrationActivationMaintenanceSummary, IntegrationActivationMaintenanceWindow,
-    IntegrationActivationOperatorTask, IntegrationActivationOperatorTaskKind,
-    IntegrationActivationOperatorTaskSummary, IntegrationActivationPlan,
-    IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
+    IntegrationActivationClosureGate, IntegrationActivationClosureStatus,
+    IntegrationActivationClosureSummary, IntegrationActivationCommandCenterSection,
+    IntegrationActivationCommandCenterSectionKind, IntegrationActivationCommandCenterSummary,
+    IntegrationActivationConstraint, IntegrationActivationConstraintKind,
+    IntegrationActivationConstraintSummary, IntegrationActivationControlRoomPanel,
+    IntegrationActivationControlRoomSummary, IntegrationActivationDashboardCard,
+    IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
+    IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
+    IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
+    IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
+    IntegrationActivationEscalationCase, IntegrationActivationEscalationCaseKind,
+    IntegrationActivationEscalationSummary, IntegrationActivationEvidenceItem,
+    IntegrationActivationEvidenceKind, IntegrationActivationEvidenceStatus,
+    IntegrationActivationEvidenceSummary, IntegrationActivationExecutionPacket,
+    IntegrationActivationExecutionStatus, IntegrationActivationExecutionSummary,
+    IntegrationActivationForecastAction, IntegrationActivationForecastItem,
+    IntegrationActivationForecastSummary, IntegrationActivationHandoffPackage,
+    IntegrationActivationHandoffStatus, IntegrationActivationHandoffSummary,
+    IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
+    IntegrationActivationHealthSummary, IntegrationActivationMaintenanceSummary,
+    IntegrationActivationMaintenanceWindow, IntegrationActivationOperatorTask,
+    IntegrationActivationOperatorTaskKind, IntegrationActivationOperatorTaskSummary,
+    IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
     IntegrationActivationRemediationItem, IntegrationActivationRemediationKind,
@@ -340,6 +342,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_REMEDIATION_TOOL_ID: &str =
     "smart_home.list_integration_activation_remediation";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_remediation_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_closure";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_closure_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -768,6 +774,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_remediation_query(&arguments)?;
                     Ok(get_integration_activation_remediation_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID => {
+                    let query = integration_activation_closure_query(&arguments)?;
+                    Ok(list_integration_activation_closure_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_closure_query(&arguments)?;
+                    Ok(get_integration_activation_closure_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2504,6 +2520,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation remediation summary",
             "Return compact D23A activation remediation counts by owner lane, remediation kind, status, blocker, dependency, policy, review, verification, and audit follow-up work.",
             integration_activation_remediation_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID,
+            "List smart-home integration activation closure",
+            "List Chief-facing D23A activation closure gates derived from remediation work with owner lanes, verification readiness, blockers, and release-close status.",
+            integration_activation_closure_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_closure", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_closure",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation closure summary",
+            "Return compact D23A activation closure-gate counts by closure status, owner lane, blockers, owner action, verification readiness, policy, and dependency work.",
+            integration_activation_closure_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5357,6 +5407,18 @@ struct IntegrationActivationRemediationQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationClosureQuery {
+    remediation: IntegrationActivationRemediationQuery,
+    closure_status: Option<IntegrationActivationClosureStatus>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    ready_for_verification: Option<bool>,
+    closure_ready: Option<bool>,
+    closure_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6035,6 +6097,31 @@ fn integration_activation_remediation_query(
         ready_to_execute: optional_bool(arguments, "remediation_ready_to_execute")?,
         remediation_limit: optional_u64(arguments, "remediation_limit")?
             .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_closure_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationClosureQuery, ToolCallError> {
+    let closure_status = optional_string(arguments, "closure_status")?
+        .or(optional_string(arguments, "closure_state")?)
+        .map(|label| parse_activation_closure_status(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "closure_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationClosureQuery {
+        remediation: integration_activation_remediation_query(arguments)?,
+        closure_status,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "closure_requires_attention")?,
+        blocked: optional_bool(arguments, "closure_blocked")?,
+        ready_for_verification: optional_bool(arguments, "ready_for_verification")?
+            .or(optional_bool(arguments, "closure_ready_for_verification")?),
+        closure_ready: optional_bool(arguments, "closure_ready")?,
+        closure_limit: optional_u64(arguments, "closure_limit")?.map(|value| value as usize),
     })
 }
 
@@ -7143,6 +7230,38 @@ fn integration_activation_remediation_items_for_query(
     }
 
     (remediations, catalog_count)
+}
+
+fn integration_activation_closure_gates_for_query(
+    query: &IntegrationActivationClosureQuery,
+) -> (Vec<IntegrationActivationClosureGate>, usize) {
+    let (remediations, catalog_count) =
+        integration_activation_remediation_items_for_query(&query.remediation);
+    let mut gates = activation_closure_gates_from_remediations(&remediations);
+
+    if let Some(closure_status) = query.closure_status {
+        gates.retain(|gate| gate.closure_status == closure_status);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        gates.retain(|gate| gate.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        gates.retain(|gate| gate.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        gates.retain(|gate| gate.blocked() == blocked);
+    }
+    if let Some(ready_for_verification) = query.ready_for_verification {
+        gates.retain(|gate| gate.ready_to_verify() == ready_for_verification);
+    }
+    if let Some(closure_ready) = query.closure_ready {
+        gates.retain(|gate| gate.closure_ready() == closure_ready);
+    }
+    if let Some(limit) = query.closure_limit {
+        gates.truncate(limit);
+    }
+
+    (gates, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -9854,6 +9973,81 @@ fn get_integration_activation_remediation_summary_output_handler_output(
             (
                 "ready_to_execute_remediations",
                 integer(summary.ready_to_execute_remediations as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_closure_output_handler_output(
+    query: IntegrationActivationClosureQuery,
+) -> ToolHandlerOutput {
+    let (gates, catalog_count) = integration_activation_closure_gates_for_query(&query);
+    let summary = IntegrationActivationClosureSummary::from_gates(gates.iter());
+    let count = gates.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_closure",
+            JsonValue::Array(gates.iter().map(activation_closure_gate_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_closure_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_closure")),
+            ("gates", integer(count as i64)),
+            (
+                "gates_requiring_attention",
+                integer(summary.gates_requiring_attention as i64),
+            ),
+            ("blocked_gates", integer(summary.blocked_gates as i64)),
+            (
+                "ready_for_verification_gates",
+                integer(summary.ready_for_verification_gates as i64),
+            ),
+            (
+                "next_closure_status",
+                summary
+                    .next_closure_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_closure_summary_output_handler_output(
+    query: IntegrationActivationClosureQuery,
+) -> ToolHandlerOutput {
+    let (gates, _) = integration_activation_closure_gates_for_query(&query);
+    let summary = IntegrationActivationClosureSummary::from_gates(gates.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_closure_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_closure_summary"),
+            ),
+            ("total_gates", integer(summary.total_gates as i64)),
+            (
+                "gates_requiring_attention",
+                integer(summary.gates_requiring_attention as i64),
+            ),
+            ("blocked_gates", integer(summary.blocked_gates as i64)),
+            (
+                "ready_for_verification_gates",
+                integer(summary.ready_for_verification_gates as i64),
             ),
         ]),
     )
@@ -19459,6 +19653,205 @@ fn integration_activation_remediation_summary_json(
     ])
 }
 
+fn activation_closure_gate_json(gate: &IntegrationActivationClosureGate) -> JsonValue {
+    object([
+        ("sequence", integer(gate.sequence as i64)),
+        ("closure_status", string(gate.closure_status.as_str())),
+        ("owner_lane", string(gate.owner_lane.as_str())),
+        (
+            "source_remediation_sequence",
+            integer(gate.source_remediation_sequence as i64),
+        ),
+        (
+            "source_remediation_kind",
+            string(gate.source_remediation_kind.as_str()),
+        ),
+        (
+            "source_remediation_status",
+            string(gate.source_remediation_status.as_str()),
+        ),
+        ("source_id", string(&gate.source_id)),
+        ("title", string(&gate.title)),
+        ("summary", string(&gate.summary)),
+        ("priority", integer(gate.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                gate.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(gate.integration_count() as i64),
+        ),
+        ("recommended_view", string(gate.recommended_view.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(gate.required_tier)),
+        ),
+        (
+            "policy_surface",
+            gate.policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(gate.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(gate.has_policy_risk())),
+        ("ready_to_verify", JsonValue::Bool(gate.ready_to_verify())),
+        ("closure_ready", JsonValue::Bool(gate.closure_ready())),
+        ("blocked", JsonValue::Bool(gate.blocked())),
+        (
+            "requires_attention",
+            JsonValue::Bool(gate.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_closure_summary_json(
+    summary: &IntegrationActivationClosureSummary,
+) -> JsonValue {
+    object([
+        ("total_gates", integer(summary.total_gates as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "gates_requiring_attention",
+            integer(summary.gates_requiring_attention as i64),
+        ),
+        ("blocked_gates", integer(summary.blocked_gates as i64)),
+        (
+            "owner_action_gates",
+            integer(summary.owner_action_gates as i64),
+        ),
+        (
+            "ready_for_verification_gates",
+            integer(summary.ready_for_verification_gates as i64),
+        ),
+        (
+            "ready_for_closure_gates",
+            integer(summary.ready_for_closure_gates as i64),
+        ),
+        ("tracking_gates", integer(summary.tracking_gates as i64)),
+        (
+            "platform_owner_gates",
+            integer(summary.platform_owner_gates as i64),
+        ),
+        (
+            "integration_owner_gates",
+            integer(summary.integration_owner_gates as i64),
+        ),
+        (
+            "security_owner_gates",
+            integer(summary.security_owner_gates as i64),
+        ),
+        (
+            "reviewer_owner_gates",
+            integer(summary.reviewer_owner_gates as i64),
+        ),
+        (
+            "verification_owner_gates",
+            integer(summary.verification_owner_gates as i64),
+        ),
+        (
+            "audit_owner_gates",
+            integer(summary.audit_owner_gates as i64),
+        ),
+        (
+            "gates_with_dependency_work",
+            integer(summary.gates_with_dependency_work as i64),
+        ),
+        (
+            "gates_with_policy_risk",
+            integer(summary.gates_with_policy_risk as i64),
+        ),
+        (
+            "gates_ready_to_verify",
+            integer(summary.gates_ready_to_verify as i64),
+        ),
+        (
+            "gates_with_policy_surface",
+            integer(summary.gates_with_policy_surface as i64),
+        ),
+        (
+            "next_closure_status",
+            summary
+                .next_closure_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_remediation_kind",
+            summary
+                .next_remediation_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_gate_sequence",
+            summary
+                .next_gate_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_gate_priority",
+            summary
+                .next_gate_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "ready_for_verification",
+            JsonValue::Bool(summary.ready_for_verification()),
+        ),
+        ("closure_ready", JsonValue::Bool(summary.closure_ready())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -22435,6 +22828,27 @@ fn parse_activation_remediation_status(
     }
 }
 
+fn parse_activation_closure_status(
+    label: &str,
+) -> Result<IntegrationActivationClosureStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" => Ok(IntegrationActivationClosureStatus::Blocked),
+        "owner_action_required" | "owner_action" | "needs_owner_action" | "action_required" => {
+            Ok(IntegrationActivationClosureStatus::OwnerActionRequired)
+        }
+        "ready_for_verification" | "verification" | "verify" | "ready_to_verify" => {
+            Ok(IntegrationActivationClosureStatus::ReadyForVerification)
+        }
+        "ready_for_closure" | "closure_ready" | "ready_to_close" | "close" => {
+            Ok(IntegrationActivationClosureStatus::ReadyForClosure)
+        }
+        "tracking" | "monitor" | "monitoring" => Ok(IntegrationActivationClosureStatus::Tracking),
+        _ => Err(validation_error(format!(
+            "unknown activation closure status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -24027,6 +24441,39 @@ fn integration_activation_remediation_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_closure_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_remediation_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("closure_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("closure_state", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "closure_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "closure_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("closure_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "ready_for_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "closure_ready_for_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("closure_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("closure_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -24171,7 +24618,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 123);
+        assert_eq!(definitions.len(), 125);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -24512,9 +24959,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            115
+            117
         );
         assert_eq!(
             export
@@ -24555,6 +25008,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_REMEDIATION_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -25008,11 +25469,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(123))
+            Some(&integer(125))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(115))
+            Some(&integer(117))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -29419,6 +29880,152 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_closure_request = request(
+            "call-list-integration-activation-closure",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("closure_status", string("blocked")),
+                ("closure_requires_attention", JsonValue::Bool(true)),
+                ("closure_blocked", JsonValue::Bool(true)),
+                ("closure_limit", integer(3)),
+            ]),
+            5_049,
+        );
+        let list_activation_closure_trace =
+            tool_runtime.invoke_with_events(&list_activation_closure_request);
+        assert!(list_activation_closure_trace.result.ok);
+        assert_eq!(
+            list_activation_closure_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_closure_output = list_activation_closure_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_closure_count =
+            integer_value(field(list_activation_closure_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_closure_count));
+        let activation_closure_summary = field(list_activation_closure_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_closure_summary, "total_gates"),
+            Some(&integer(activation_closure_count))
+        );
+        assert_eq!(
+            field(activation_closure_summary, "next_closure_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_closure_summary, "next_owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_closure_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_closure_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_closure = array_item(
+            field(list_activation_closure_output, "activation_closure").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_closure, "closure_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_closure, "owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_closure, "blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_closure, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_closure_summary_request = request(
+            "call-integration-activation-closure-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("closure_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_050,
+        );
+        let activation_closure_summary_trace =
+            tool_runtime.invoke_with_events(&activation_closure_summary_request);
+        assert!(activation_closure_summary_trace.result.ok);
+        assert_eq!(
+            activation_closure_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_closure_summary_output = activation_closure_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_closure_rollup =
+            field(activation_closure_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_closure_rollup, "total_gates").unwrap()).unwrap() >= 1
+        );
+        assert!(
+            integer_value(field(activation_closure_rollup, "blocked_gates").unwrap()).unwrap() >= 1
+        );
+        assert_eq!(
+            field(activation_closure_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_closure_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -31283,6 +31890,14 @@ mod tests {
             activation_remediation_summary_request,
             activation_remediation_summary_trace,
         );
+        journal.record_trace(
+            list_activation_closure_request,
+            list_activation_closure_trace,
+        );
+        journal.record_trace(
+            activation_closure_summary_request,
+            activation_closure_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -31356,9 +31971,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 123);
-        assert_eq!(journal_summary.completed_count, 123);
-        assert_eq!(journal.audit_records().len(), 123);
+        assert_eq!(journal_summary.invocation_count, 125);
+        assert_eq!(journal_summary.completed_count, 125);
+        assert_eq!(journal.audit_records().len(), 125);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -140,6 +140,9 @@ All notable changes to this package will be documented in this file.
   `smart_home.get_integration_activation_remediation_summary` tool descriptors
   for read-only owner-lane activation remediation work orders derived from
   response items.
+- `smart_home.list_integration_activation_closure` and
+  `smart_home.get_integration_activation_closure_summary` tool descriptors for
+  read-only activation closure gates derived from remediation status.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -119,6 +119,8 @@ Current scope:
   derived from Chief-facing escalation cases
 - D18D integration activation-remediation descriptors for owner-lane work
   orders derived from activation response items
+- D18D integration activation-closure descriptors for release-gate views that
+  combine remediation status, owner lanes, blockers, and verification readiness
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1521,6 +1521,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationResponseSummary,
     ListIntegrationActivationRemediation,
     GetIntegrationActivationRemediationSummary,
+    ListIntegrationActivationClosure,
+    GetIntegrationActivationClosureSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1790,6 +1792,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationRemediationSummary => {
                 read_tool("smart_home.get_integration_activation_remediation_summary")
+            }
+            Self::ListIntegrationActivationClosure => {
+                read_tool("smart_home.list_integration_activation_closure")
+            }
+            Self::GetIntegrationActivationClosureSummary => {
+                read_tool("smart_home.get_integration_activation_closure_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2494,6 +2502,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationResponseSummary,
         SmartHomeTool::ListIntegrationActivationRemediation,
         SmartHomeTool::GetIntegrationActivationRemediationSummary,
+        SmartHomeTool::ListIntegrationActivationClosure,
+        SmartHomeTool::GetIntegrationActivationClosureSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3336,7 +3346,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 123);
+        assert_eq!(catalog.len(), 125);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3835,6 +3845,14 @@ mod tests {
             == "smart_home.get_integration_activation_remediation_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_closure"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_closure_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3842,15 +3860,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 123);
-        assert_eq!(summary.read_tools, 115);
+        assert_eq!(summary.total_tools, 125);
+        assert_eq!(summary.read_tools, 117);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 115);
+        assert_eq!(summary.read_only_tier_tools, 117);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 123);
+        assert_eq!(summary.total_required_capabilities, 125);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -112,6 +112,8 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationRemediationItem` and
   `IntegrationActivationRemediationSummary` for turning response items into
   executable owner-lane remediation queues.
+- `IntegrationActivationClosureGate` and `IntegrationActivationClosureSummary`
+  for turning remediation work orders into release closure gates.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -102,6 +102,8 @@ runtime and Chief of Staff tools a typed catalog for:
 - activation remediation work orders that assign response items to executable
   owner-lane queues with blocked, owner-action, ready-to-execute, and tracking
   status
+- activation closure gates that turn remediation work orders into compact
+  blocked, owner-action, verification-ready, ready-to-close, and tracking gates
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1528,6 +1528,41 @@ impl IntegrationActivationRemediationStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationClosureStatus {
+    Blocked,
+    OwnerActionRequired,
+    ReadyForVerification,
+    ReadyForClosure,
+    Tracking,
+}
+
+impl IntegrationActivationClosureStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::OwnerActionRequired => "owner_action_required",
+            Self::ReadyForVerification => "ready_for_verification",
+            Self::ReadyForClosure => "ready_for_closure",
+            Self::Tracking => "tracking",
+        }
+    }
+
+    pub fn from_remediation(remediation: &IntegrationActivationRemediationItem) -> Self {
+        if remediation.blocked() {
+            Self::Blocked
+        } else if remediation.ready_to_execute() || remediation.ready_to_verify() {
+            Self::ReadyForVerification
+        } else if remediation.requires_attention() {
+            Self::OwnerActionRequired
+        } else if remediation.status == IntegrationActivationRemediationStatus::Tracking {
+            Self::ReadyForClosure
+        } else {
+            Self::Tracking
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3359,6 +3394,61 @@ pub struct IntegrationActivationRemediationSummary {
     pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
     pub next_remediation_sequence: Option<usize>,
     pub next_remediation_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationClosureGate {
+    pub sequence: usize,
+    pub closure_status: IntegrationActivationClosureStatus,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_remediation_sequence: usize,
+    pub source_remediation_kind: IntegrationActivationRemediationKind,
+    pub source_remediation_status: IntegrationActivationRemediationStatus,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_ready: bool,
+    pub blocked: bool,
+    pub requires_attention: bool,
+    pub closure_ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationClosureSummary {
+    pub total_gates: usize,
+    pub unique_integrations: usize,
+    pub gates_requiring_attention: usize,
+    pub blocked_gates: usize,
+    pub owner_action_gates: usize,
+    pub ready_for_verification_gates: usize,
+    pub ready_for_closure_gates: usize,
+    pub tracking_gates: usize,
+    pub platform_owner_gates: usize,
+    pub integration_owner_gates: usize,
+    pub security_owner_gates: usize,
+    pub reviewer_owner_gates: usize,
+    pub verification_owner_gates: usize,
+    pub audit_owner_gates: usize,
+    pub gates_with_dependency_work: usize,
+    pub gates_with_policy_risk: usize,
+    pub gates_ready_to_verify: usize,
+    pub gates_with_policy_surface: usize,
+    pub next_closure_status: Option<IntegrationActivationClosureStatus>,
+    pub next_remediation_kind: Option<IntegrationActivationRemediationKind>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_gate_sequence: Option<usize>,
+    pub next_gate_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -9303,6 +9393,220 @@ impl IntegrationActivationRemediationSummary {
     }
 }
 
+impl IntegrationActivationClosureGate {
+    fn from_remediation(remediation: &IntegrationActivationRemediationItem) -> Self {
+        let closure_status = IntegrationActivationClosureStatus::from_remediation(remediation);
+        let closure_ready = closure_status == IntegrationActivationClosureStatus::ReadyForClosure;
+
+        Self {
+            sequence: 0,
+            closure_status,
+            owner_lane: remediation.owner_lane,
+            source_remediation_sequence: remediation.sequence,
+            source_remediation_kind: remediation.remediation_kind,
+            source_remediation_status: remediation.status,
+            source_id: remediation.source_id.clone(),
+            title: format!("{}: {}", closure_status.as_str(), remediation.title),
+            summary: remediation.summary.clone(),
+            priority: remediation.priority,
+            integration_ids: remediation.integration_ids.clone(),
+            recommended_view: remediation.recommended_view,
+            required_tier: remediation.required_tier,
+            policy_surface: remediation.policy_surface,
+            dependency_work: remediation.has_dependency_work(),
+            policy_risk: remediation.has_policy_risk(),
+            verification_ready: remediation.ready_to_verify() || remediation.ready_to_execute(),
+            blocked: remediation.blocked(),
+            requires_attention: remediation.requires_attention()
+                || closure_status.requires_attention(),
+            closure_ready,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn ready_to_verify(&self) -> bool {
+        self.verification_ready
+    }
+
+    pub fn blocked(&self) -> bool {
+        self.blocked || self.closure_status == IntegrationActivationClosureStatus::Blocked
+    }
+
+    pub fn closure_ready(&self) -> bool {
+        self.closure_ready
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationClosureStatus {
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::Blocked | Self::OwnerActionRequired)
+    }
+}
+
+impl IntegrationActivationClosureSummary {
+    pub fn from_gates<'a>(
+        gates: impl IntoIterator<Item = &'a IntegrationActivationClosureGate>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_gates: 0,
+            unique_integrations: 0,
+            gates_requiring_attention: 0,
+            blocked_gates: 0,
+            owner_action_gates: 0,
+            ready_for_verification_gates: 0,
+            ready_for_closure_gates: 0,
+            tracking_gates: 0,
+            platform_owner_gates: 0,
+            integration_owner_gates: 0,
+            security_owner_gates: 0,
+            reviewer_owner_gates: 0,
+            verification_owner_gates: 0,
+            audit_owner_gates: 0,
+            gates_with_dependency_work: 0,
+            gates_with_policy_risk: 0,
+            gates_ready_to_verify: 0,
+            gates_with_policy_surface: 0,
+            next_closure_status: None,
+            next_remediation_kind: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_gate_sequence: None,
+            next_gate_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for gate in gates {
+            summary.total_gates += 1;
+            for integration_id in &gate.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_closure_status.is_none()
+                && (gate.requires_attention() || gate.ready_to_verify() || gate.closure_ready())
+            {
+                summary.next_closure_status = Some(gate.closure_status);
+                summary.next_remediation_kind = Some(gate.source_remediation_kind);
+                summary.next_owner_lane = Some(gate.owner_lane);
+                summary.next_recommended_view = Some(gate.recommended_view);
+                summary.next_gate_sequence = Some(gate.sequence);
+                summary.next_gate_priority = Some(gate.priority);
+            }
+
+            match gate.closure_status {
+                IntegrationActivationClosureStatus::Blocked => summary.blocked_gates += 1,
+                IntegrationActivationClosureStatus::OwnerActionRequired => {
+                    summary.owner_action_gates += 1;
+                }
+                IntegrationActivationClosureStatus::ReadyForVerification => {
+                    summary.ready_for_verification_gates += 1;
+                }
+                IntegrationActivationClosureStatus::ReadyForClosure => {
+                    summary.ready_for_closure_gates += 1;
+                }
+                IntegrationActivationClosureStatus::Tracking => summary.tracking_gates += 1,
+            }
+
+            match gate.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_gates += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_gates += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_gates += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_gates += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_gates += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_gates += 1;
+                }
+            }
+
+            if gate.requires_attention() {
+                summary.gates_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(gate.priority));
+            }
+            if gate.has_dependency_work() {
+                summary.gates_with_dependency_work += 1;
+            }
+            if gate.has_policy_risk() {
+                summary.gates_with_policy_risk += 1;
+            }
+            if gate.ready_to_verify() {
+                summary.gates_ready_to_verify += 1;
+            }
+            if gate.has_policy_surface() {
+                summary.gates_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(gate.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_gates > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.gates_requiring_attention > 0 || summary.owner_action_gates > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_for_verification_gates > 0 || summary.ready_for_closure_gates > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_gates == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_gates > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.owner_action_gates > 0
+    }
+
+    pub fn ready_for_verification(&self) -> bool {
+        self.ready_for_verification_gates > 0
+    }
+
+    pub fn closure_ready(&self) -> bool {
+        self.ready_for_closure_gates > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.gates_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -14396,6 +14700,38 @@ pub fn activation_remediation_items_at_or_before_priority(
     activation_remediation_items_from_responses(&responses)
 }
 
+pub fn activation_closure_gates_from_remediations(
+    remediations: &[IntegrationActivationRemediationItem],
+) -> Vec<IntegrationActivationClosureGate> {
+    let mut gates: Vec<_> = remediations
+        .iter()
+        .map(IntegrationActivationClosureGate::from_remediation)
+        .collect();
+
+    gates.sort_by(compare_activation_closure_gates);
+    for (index, gate) in gates.iter_mut().enumerate() {
+        gate.sequence = index + 1;
+    }
+    gates
+}
+
+pub fn activation_closure_gates_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationClosureGate> {
+    let remediations = activation_remediation_items_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_closure_gates_from_remediations(&remediations)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -16030,6 +16366,28 @@ fn compare_activation_remediation_items(
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| right.ready_to_execute().cmp(&left.ready_to_execute()))
         .then_with(|| left.remediation_kind.cmp(&right.remediation_kind))
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_closure_gates(
+    left: &IntegrationActivationClosureGate,
+    right: &IntegrationActivationClosureGate,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.closure_status.cmp(&right.closure_status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocked().cmp(&left.blocked()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
+        .then_with(|| right.closure_ready().cmp(&left.closure_ready()))
+        .then_with(|| {
+            left.source_remediation_kind
+                .cmp(&right.source_remediation_kind)
+        })
         .then_with(|| left.owner_lane.cmp(&right.owner_lane))
         .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
@@ -19587,6 +19945,40 @@ mod tests {
         );
         assert_eq!(
             remediation_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let closure_gates = activation_closure_gates_from_remediations(&remediation_items);
+        assert_eq!(closure_gates.len(), remediation_items.len());
+        assert!(closure_gates
+            .iter()
+            .any(|gate| gate.closure_status == IntegrationActivationClosureStatus::Blocked));
+        assert!(closure_gates
+            .iter()
+            .any(|gate| gate.closure_status
+                == IntegrationActivationClosureStatus::ReadyForVerification));
+        assert!(closure_gates
+            .iter()
+            .any(IntegrationActivationClosureGate::requires_attention));
+        assert!(closure_gates
+            .iter()
+            .any(IntegrationActivationClosureGate::blocked));
+
+        let closure_summary = IntegrationActivationClosureSummary::from_gates(closure_gates.iter());
+        assert_eq!(closure_summary.total_gates, closure_gates.len());
+        assert!(closure_summary.has_blockers());
+        assert!(closure_summary.ready_for_verification());
+        assert!(closure_summary.requires_attention());
+        assert_eq!(
+            closure_summary.next_closure_status,
+            Some(IntegrationActivationClosureStatus::Blocked)
+        );
+        assert_eq!(
+            closure_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            closure_summary.overall_status,
             IntegrationActivationHealthStatus::Blocked
         );
 


### PR DESCRIPTION
## Summary
- add reusable activation closure gates and summaries derived from remediation rows in `smart-home-integration-catalog`
- expose read-only D18D descriptors for `smart_home.list_integration_activation_closure` and `smart_home.get_integration_activation_closure_summary`
- wire Chief bridge schemas, handlers, JSON output, end-to-end journal coverage, README, and changelog notes for closure verification

## Validation
- `cargo fmt -p smart-home-integration-catalog -p smart-home-core -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-core`
- `cargo test -p smart-home-integration-catalog`
- `cargo test -p hue-core`
- `cargo test -p smart-home-runtime`
- `cargo test -p smart-home-testkit`
- `cargo test -p smart-home-local-http`
- `cargo test -p smart-home-discovery`
- `cargo test -p chief-of-staff-smart-home-tools`
- `cargo test -p smart-home-runtime discover_tool -- --nocapture`
- `sh BUILD` in `smart-home-core`, `smart-home-integration-catalog`, `hue-core`, `smart-home-runtime`, `smart-home-testkit`, `smart-home-local-http`, `smart-home-discovery`, and `chief-of-staff-smart-home-tools`
- `git diff --check`

Generated `code/packages/rust/Cargo.lock` was removed before commit.
