### PR TITLE
Add smart-home activation release tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -109,6 +109,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation closure gates:
   `smart_home.list_integration_activation_closure` and
   `smart_home.get_integration_activation_closure_summary`.
+- Added D18D handlers for D23A activation release packets:
+  `smart_home.list_integration_activation_release` and
+  `smart_home.get_integration_activation_release_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -71,6 +71,7 @@ Chief of Staff job/session/agent
   -> activation-response list and summary reads for owner-lane next actions
   -> activation-remediation list and summary reads for owner-lane work orders
   -> activation-closure list and summary reads for verification/close gates
+  -> activation-release list and summary reads for go/no-go release packets
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -164,6 +165,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_remediation_summary`
 - `smart_home.list_integration_activation_closure`
 - `smart_home.get_integration_activation_closure_summary`
+- `smart_home.list_integration_activation_release`
+- `smart_home.get_integration_activation_release_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -48,10 +48,11 @@ use smart_home_integration_catalog::{
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
     activation_plan_for_entry, activation_plans_at_or_before_priority,
     activation_playbook_steps_from_forecasts, activation_readouts_from_candidates,
-    activation_remediation_items_from_responses, activation_response_items_from_escalation_cases,
-    activation_reviews_from_candidates, activation_risk_from_candidates,
-    activation_runbook_entries_from_playbook_steps, activation_runway_from_candidates,
-    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
+    activation_release_packets_from_closure_gates, activation_remediation_items_from_responses,
+    activation_response_items_from_escalation_cases, activation_reviews_from_candidates,
+    activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
+    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
+    activation_timeline_milestones_from_dashboard_cards,
     activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
@@ -96,12 +97,14 @@ use smart_home_integration_catalog::{
     IntegrationActivationPlan, IntegrationActivationPlanSummary, IntegrationActivationPlaybookStep,
     IntegrationActivationPlaybookSummary, IntegrationActivationPlaybookView,
     IntegrationActivationReadoutStage, IntegrationActivationReadoutSummary,
-    IntegrationActivationRemediationItem, IntegrationActivationRemediationKind,
-    IntegrationActivationRemediationStatus, IntegrationActivationRemediationSummary,
-    IntegrationActivationResponseItem, IntegrationActivationResponseKind,
-    IntegrationActivationResponseOwnerLane, IntegrationActivationResponseSummary,
-    IntegrationActivationReviewItem, IntegrationActivationReviewSummary,
-    IntegrationActivationRiskItem, IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
+    IntegrationActivationReleasePacket, IntegrationActivationReleaseStatus,
+    IntegrationActivationReleaseSummary, IntegrationActivationRemediationItem,
+    IntegrationActivationRemediationKind, IntegrationActivationRemediationStatus,
+    IntegrationActivationRemediationSummary, IntegrationActivationResponseItem,
+    IntegrationActivationResponseKind, IntegrationActivationResponseOwnerLane,
+    IntegrationActivationResponseSummary, IntegrationActivationReviewItem,
+    IntegrationActivationReviewSummary, IntegrationActivationRiskItem,
+    IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunbookEntry, IntegrationActivationRunbookPhase,
     IntegrationActivationRunbookSummary, IntegrationActivationRunwayStage,
     IntegrationActivationRunwaySummary, IntegrationActivationSentinelAlert,
@@ -346,6 +349,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_CLOSURE_TOOL_ID: &str =
     "smart_home.list_integration_activation_closure";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_closure_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID: &str =
+    "smart_home.list_integration_activation_release";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_release_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -784,6 +791,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_closure_query(&arguments)?;
                     Ok(get_integration_activation_closure_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID => {
+                    let query = integration_activation_release_query(&arguments)?;
+                    Ok(list_integration_activation_release_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_release_query(&arguments)?;
+                    Ok(get_integration_activation_release_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2554,6 +2571,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation closure summary",
             "Return compact D23A activation closure-gate counts by closure status, owner lane, blockers, owner action, verification readiness, policy, and dependency work.",
             integration_activation_closure_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID,
+            "List smart-home integration activation release",
+            "List Chief-facing D23A activation release packets derived from closure gates with go/no-go status, owner lanes, verification requirements, blockers, and release readiness.",
+            integration_activation_release_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_release", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_release",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation release summary",
+            "Return compact D23A activation release-packet counts by release status, owner lane, blockers, verification requirements, release readiness, policy, and dependency work.",
+            integration_activation_release_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5419,6 +5470,18 @@ struct IntegrationActivationClosureQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationReleaseQuery {
+    closure: IntegrationActivationClosureQuery,
+    release_status: Option<IntegrationActivationReleaseStatus>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    needs_verification: Option<bool>,
+    release_ready: Option<bool>,
+    release_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6122,6 +6185,31 @@ fn integration_activation_closure_query(
             .or(optional_bool(arguments, "closure_ready_for_verification")?),
         closure_ready: optional_bool(arguments, "closure_ready")?,
         closure_limit: optional_u64(arguments, "closure_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_release_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationReleaseQuery, ToolCallError> {
+    let release_status = optional_string(arguments, "release_status")?
+        .or(optional_string(arguments, "release_state")?)
+        .map(|label| parse_activation_release_status(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "release_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationReleaseQuery {
+        closure: integration_activation_closure_query(arguments)?,
+        release_status,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "release_requires_attention")?,
+        blocked: optional_bool(arguments, "release_blocked")?,
+        needs_verification: optional_bool(arguments, "needs_verification")?
+            .or(optional_bool(arguments, "release_needs_verification")?),
+        release_ready: optional_bool(arguments, "release_ready")?,
+        release_limit: optional_u64(arguments, "release_limit")?.map(|value| value as usize),
     })
 }
 
@@ -7262,6 +7350,37 @@ fn integration_activation_closure_gates_for_query(
     }
 
     (gates, catalog_count)
+}
+
+fn integration_activation_release_packets_for_query(
+    query: &IntegrationActivationReleaseQuery,
+) -> (Vec<IntegrationActivationReleasePacket>, usize) {
+    let (gates, catalog_count) = integration_activation_closure_gates_for_query(&query.closure);
+    let mut packets = activation_release_packets_from_closure_gates(&gates);
+
+    if let Some(release_status) = query.release_status {
+        packets.retain(|packet| packet.release_status == release_status);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        packets.retain(|packet| packet.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        packets.retain(|packet| packet.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        packets.retain(|packet| packet.release_blocked() == blocked);
+    }
+    if let Some(needs_verification) = query.needs_verification {
+        packets.retain(|packet| packet.needs_verification() == needs_verification);
+    }
+    if let Some(release_ready) = query.release_ready {
+        packets.retain(|packet| packet.release_ready() == release_ready);
+    }
+    if let Some(limit) = query.release_limit {
+        packets.truncate(limit);
+    }
+
+    (packets, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -10048,6 +10167,89 @@ fn get_integration_activation_closure_summary_output_handler_output(
             (
                 "ready_for_verification_gates",
                 integer(summary.ready_for_verification_gates as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_release_output_handler_output(
+    query: IntegrationActivationReleaseQuery,
+) -> ToolHandlerOutput {
+    let (packets, catalog_count) = integration_activation_release_packets_for_query(&query);
+    let summary = IntegrationActivationReleaseSummary::from_packets(packets.iter());
+    let count = packets.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_release",
+            JsonValue::Array(packets.iter().map(activation_release_packet_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_release_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_release")),
+            ("packets", integer(count as i64)),
+            (
+                "packets_requiring_attention",
+                integer(summary.packets_requiring_attention as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
+            (
+                "verification_required_packets",
+                integer(summary.verification_required_packets as i64),
+            ),
+            (
+                "ready_for_release_packets",
+                integer(summary.ready_for_release_packets as i64),
+            ),
+            (
+                "next_release_status",
+                summary
+                    .next_release_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_release_summary_output_handler_output(
+    query: IntegrationActivationReleaseQuery,
+) -> ToolHandlerOutput {
+    let (packets, _) = integration_activation_release_packets_for_query(&query);
+    let summary = IntegrationActivationReleaseSummary::from_packets(packets.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_release_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_release_summary"),
+            ),
+            ("total_packets", integer(summary.total_packets as i64)),
+            (
+                "packets_requiring_attention",
+                integer(summary.packets_requiring_attention as i64),
+            ),
+            ("blocked_packets", integer(summary.blocked_packets as i64)),
+            (
+                "verification_required_packets",
+                integer(summary.verification_required_packets as i64),
+            ),
+            (
+                "ready_for_release_packets",
+                integer(summary.ready_for_release_packets as i64),
             ),
         ]),
     )
@@ -19852,6 +20054,221 @@ fn integration_activation_closure_summary_json(
     ])
 }
 
+fn activation_release_packet_json(packet: &IntegrationActivationReleasePacket) -> JsonValue {
+    object([
+        ("sequence", integer(packet.sequence as i64)),
+        ("release_status", string(packet.release_status.as_str())),
+        ("owner_lane", string(packet.owner_lane.as_str())),
+        (
+            "source_closure_sequence",
+            integer(packet.source_closure_sequence as i64),
+        ),
+        (
+            "source_closure_status",
+            string(packet.source_closure_status.as_str()),
+        ),
+        (
+            "source_remediation_kind",
+            string(packet.source_remediation_kind.as_str()),
+        ),
+        (
+            "source_remediation_status",
+            string(packet.source_remediation_status.as_str()),
+        ),
+        ("source_id", string(&packet.source_id)),
+        ("title", string(&packet.title)),
+        ("summary", string(&packet.summary)),
+        ("priority", integer(packet.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                packet
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(packet.integration_count() as i64),
+        ),
+        ("recommended_view", string(packet.recommended_view.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(packet.required_tier)),
+        ),
+        (
+            "policy_surface",
+            packet
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(packet.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(packet.has_policy_risk())),
+        (
+            "needs_verification",
+            JsonValue::Bool(packet.needs_verification()),
+        ),
+        ("release_blocked", JsonValue::Bool(packet.release_blocked())),
+        ("release_ready", JsonValue::Bool(packet.release_ready())),
+        (
+            "requires_attention",
+            JsonValue::Bool(packet.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_release_summary_json(
+    summary: &IntegrationActivationReleaseSummary,
+) -> JsonValue {
+    object([
+        ("total_packets", integer(summary.total_packets as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "packets_requiring_attention",
+            integer(summary.packets_requiring_attention as i64),
+        ),
+        ("blocked_packets", integer(summary.blocked_packets as i64)),
+        (
+            "owner_action_packets",
+            integer(summary.owner_action_packets as i64),
+        ),
+        (
+            "verification_required_packets",
+            integer(summary.verification_required_packets as i64),
+        ),
+        (
+            "ready_for_release_packets",
+            integer(summary.ready_for_release_packets as i64),
+        ),
+        (
+            "monitoring_packets",
+            integer(summary.monitoring_packets as i64),
+        ),
+        (
+            "platform_owner_packets",
+            integer(summary.platform_owner_packets as i64),
+        ),
+        (
+            "integration_owner_packets",
+            integer(summary.integration_owner_packets as i64),
+        ),
+        (
+            "security_owner_packets",
+            integer(summary.security_owner_packets as i64),
+        ),
+        (
+            "reviewer_owner_packets",
+            integer(summary.reviewer_owner_packets as i64),
+        ),
+        (
+            "verification_owner_packets",
+            integer(summary.verification_owner_packets as i64),
+        ),
+        (
+            "audit_owner_packets",
+            integer(summary.audit_owner_packets as i64),
+        ),
+        (
+            "packets_with_dependency_work",
+            integer(summary.packets_with_dependency_work as i64),
+        ),
+        (
+            "packets_with_policy_risk",
+            integer(summary.packets_with_policy_risk as i64),
+        ),
+        (
+            "packets_requiring_verification",
+            integer(summary.packets_requiring_verification as i64),
+        ),
+        (
+            "packets_ready_for_release",
+            integer(summary.packets_ready_for_release as i64),
+        ),
+        (
+            "packets_with_policy_surface",
+            integer(summary.packets_with_policy_surface as i64),
+        ),
+        (
+            "next_release_status",
+            summary
+                .next_release_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_closure_status",
+            summary
+                .next_closure_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_packet_sequence",
+            summary
+                .next_packet_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_packet_priority",
+            summary
+                .next_packet_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "needs_verification",
+            JsonValue::Bool(summary.needs_verification()),
+        ),
+        ("release_ready", JsonValue::Bool(summary.release_ready())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -22849,6 +23266,27 @@ fn parse_activation_closure_status(
     }
 }
 
+fn parse_activation_release_status(
+    label: &str,
+) -> Result<IntegrationActivationReleaseStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" => Ok(IntegrationActivationReleaseStatus::Blocked),
+        "owner_action_required" | "owner_action" | "needs_owner_action" | "action_required" => {
+            Ok(IntegrationActivationReleaseStatus::OwnerActionRequired)
+        }
+        "verification_required" | "needs_verification" | "verify" | "verification" => {
+            Ok(IntegrationActivationReleaseStatus::VerificationRequired)
+        }
+        "ready_for_release" | "release_ready" | "ready_to_release" | "release" => {
+            Ok(IntegrationActivationReleaseStatus::ReadyForRelease)
+        }
+        "monitoring" | "monitor" | "tracking" => Ok(IntegrationActivationReleaseStatus::Monitoring),
+        _ => Err(validation_error(format!(
+            "unknown activation release status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -24474,6 +24912,39 @@ fn integration_activation_closure_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_release_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_closure_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("release_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("release_state", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "release_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "release_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("release_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "needs_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "release_needs_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("release_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("release_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -24618,7 +25089,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 125);
+        assert_eq!(definitions.len(), 127);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -24965,9 +25436,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            117
+            119
         );
         assert_eq!(
             export
@@ -25016,6 +25493,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_CLOSURE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(
+            smart_home_tool_definition(SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID)
+                .is_some()
+        );
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -25469,11 +25954,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(125))
+            Some(&integer(127))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(117))
+            Some(&integer(119))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -30026,6 +30511,153 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_release_request = request(
+            "call-list-integration-activation-release",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("release_status", string("blocked")),
+                ("release_requires_attention", JsonValue::Bool(true)),
+                ("release_blocked", JsonValue::Bool(true)),
+                ("release_limit", integer(3)),
+            ]),
+            5_051,
+        );
+        let list_activation_release_trace =
+            tool_runtime.invoke_with_events(&list_activation_release_request);
+        assert!(list_activation_release_trace.result.ok);
+        assert_eq!(
+            list_activation_release_trace.summary().progress_event_count,
+            1
+        );
+        let list_activation_release_output = list_activation_release_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_release_count =
+            integer_value(field(list_activation_release_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_release_count));
+        let activation_release_summary = field(list_activation_release_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_release_summary, "total_packets"),
+            Some(&integer(activation_release_count))
+        );
+        assert_eq!(
+            field(activation_release_summary, "next_release_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_release_summary, "next_owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_release_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_release_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_release = array_item(
+            field(list_activation_release_output, "activation_release").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_release, "release_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_release, "owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_release, "release_blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_release, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_release_summary_request = request(
+            "call-integration-activation-release-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("release_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_052,
+        );
+        let activation_release_summary_trace =
+            tool_runtime.invoke_with_events(&activation_release_summary_request);
+        assert!(activation_release_summary_trace.result.ok);
+        assert_eq!(
+            activation_release_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_release_summary_output = activation_release_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_release_rollup =
+            field(activation_release_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_release_rollup, "total_packets").unwrap()).unwrap() >= 1
+        );
+        assert!(
+            integer_value(field(activation_release_rollup, "blocked_packets").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_release_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_release_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -31898,6 +32530,14 @@ mod tests {
             activation_closure_summary_request,
             activation_closure_summary_trace,
         );
+        journal.record_trace(
+            list_activation_release_request,
+            list_activation_release_trace,
+        );
+        journal.record_trace(
+            activation_release_summary_request,
+            activation_release_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -31971,9 +32611,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 125);
-        assert_eq!(journal_summary.completed_count, 125);
-        assert_eq!(journal.audit_records().len(), 125);
+        assert_eq!(journal_summary.invocation_count, 127);
+        assert_eq!(journal_summary.completed_count, 127);
+        assert_eq!(journal.audit_records().len(), 127);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -143,6 +143,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_closure` and
   `smart_home.get_integration_activation_closure_summary` tool descriptors for
   read-only activation closure gates derived from remediation status.
+- `smart_home.list_integration_activation_release` and
+  `smart_home.get_integration_activation_release_summary` tool descriptors for
+  read-only activation release packets derived from closure gates.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -121,6 +121,8 @@ Current scope:
   orders derived from activation response items
 - D18D integration activation-closure descriptors for release-gate views that
   combine remediation status, owner lanes, blockers, and verification readiness
+- D18D integration activation-release descriptors for compact go/no-go packet
+  views derived from activation closure gates
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1523,6 +1523,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationRemediationSummary,
     ListIntegrationActivationClosure,
     GetIntegrationActivationClosureSummary,
+    ListIntegrationActivationRelease,
+    GetIntegrationActivationReleaseSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1798,6 +1800,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationClosureSummary => {
                 read_tool("smart_home.get_integration_activation_closure_summary")
+            }
+            Self::ListIntegrationActivationRelease => {
+                read_tool("smart_home.list_integration_activation_release")
+            }
+            Self::GetIntegrationActivationReleaseSummary => {
+                read_tool("smart_home.get_integration_activation_release_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2504,6 +2512,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationRemediationSummary,
         SmartHomeTool::ListIntegrationActivationClosure,
         SmartHomeTool::GetIntegrationActivationClosureSummary,
+        SmartHomeTool::ListIntegrationActivationRelease,
+        SmartHomeTool::GetIntegrationActivationReleaseSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3346,7 +3356,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 125);
+        assert_eq!(catalog.len(), 127);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3853,6 +3863,14 @@ mod tests {
             == "smart_home.get_integration_activation_closure_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_release"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_release_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3860,15 +3878,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 125);
-        assert_eq!(summary.read_tools, 117);
+        assert_eq!(summary.total_tools, 127);
+        assert_eq!(summary.read_tools, 119);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 117);
+        assert_eq!(summary.read_only_tier_tools, 119);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 125);
+        assert_eq!(summary.total_required_capabilities, 127);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -114,6 +114,9 @@ All notable changes to this package will be documented in this file.
   executable owner-lane remediation queues.
 - `IntegrationActivationClosureGate` and `IntegrationActivationClosureSummary`
   for turning remediation work orders into release closure gates.
+- `IntegrationActivationReleasePacket` and
+  `IntegrationActivationReleaseSummary` for turning closure gates into compact
+  activation release go/no-go packets.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -104,6 +104,8 @@ runtime and Chief of Staff tools a typed catalog for:
   status
 - activation closure gates that turn remediation work orders into compact
   blocked, owner-action, verification-ready, ready-to-close, and tracking gates
+- activation release packets that turn closure gates into compact go/no-go
+  release views with blockers, verification requirements, and release readiness
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1563,6 +1563,47 @@ impl IntegrationActivationClosureStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationReleaseStatus {
+    Blocked,
+    OwnerActionRequired,
+    VerificationRequired,
+    ReadyForRelease,
+    Monitoring,
+}
+
+impl IntegrationActivationReleaseStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::OwnerActionRequired => "owner_action_required",
+            Self::VerificationRequired => "verification_required",
+            Self::ReadyForRelease => "ready_for_release",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_closure_gate(gate: &IntegrationActivationClosureGate) -> Self {
+        if gate.blocked() {
+            Self::Blocked
+        } else if gate.ready_to_verify()
+            || gate.closure_status == IntegrationActivationClosureStatus::ReadyForVerification
+        {
+            Self::VerificationRequired
+        } else if gate.closure_status == IntegrationActivationClosureStatus::OwnerActionRequired
+            || gate.requires_attention()
+        {
+            Self::OwnerActionRequired
+        } else if gate.closure_ready()
+            || gate.closure_status == IntegrationActivationClosureStatus::ReadyForClosure
+        {
+            Self::ReadyForRelease
+        } else {
+            Self::Monitoring
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3449,6 +3490,63 @@ pub struct IntegrationActivationClosureSummary {
     pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
     pub next_gate_sequence: Option<usize>,
     pub next_gate_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReleasePacket {
+    pub sequence: usize,
+    pub release_status: IntegrationActivationReleaseStatus,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_closure_sequence: usize,
+    pub source_closure_status: IntegrationActivationClosureStatus,
+    pub source_remediation_kind: IntegrationActivationRemediationKind,
+    pub source_remediation_status: IntegrationActivationRemediationStatus,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_required: bool,
+    pub release_blocked: bool,
+    pub requires_attention: bool,
+    pub release_ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationReleaseSummary {
+    pub total_packets: usize,
+    pub unique_integrations: usize,
+    pub packets_requiring_attention: usize,
+    pub blocked_packets: usize,
+    pub owner_action_packets: usize,
+    pub verification_required_packets: usize,
+    pub ready_for_release_packets: usize,
+    pub monitoring_packets: usize,
+    pub platform_owner_packets: usize,
+    pub integration_owner_packets: usize,
+    pub security_owner_packets: usize,
+    pub reviewer_owner_packets: usize,
+    pub verification_owner_packets: usize,
+    pub audit_owner_packets: usize,
+    pub packets_with_dependency_work: usize,
+    pub packets_with_policy_risk: usize,
+    pub packets_requiring_verification: usize,
+    pub packets_ready_for_release: usize,
+    pub packets_with_policy_surface: usize,
+    pub next_release_status: Option<IntegrationActivationReleaseStatus>,
+    pub next_closure_status: Option<IntegrationActivationClosureStatus>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_packet_sequence: Option<usize>,
+    pub next_packet_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -9607,6 +9705,240 @@ impl IntegrationActivationClosureSummary {
     }
 }
 
+impl IntegrationActivationReleasePacket {
+    fn from_closure_gate(gate: &IntegrationActivationClosureGate) -> Self {
+        let release_status = IntegrationActivationReleaseStatus::from_closure_gate(gate);
+        let verification_required =
+            release_status == IntegrationActivationReleaseStatus::VerificationRequired;
+        let release_ready = release_status == IntegrationActivationReleaseStatus::ReadyForRelease;
+        let release_blocked = matches!(
+            release_status,
+            IntegrationActivationReleaseStatus::Blocked
+                | IntegrationActivationReleaseStatus::OwnerActionRequired
+                | IntegrationActivationReleaseStatus::VerificationRequired
+        );
+
+        Self {
+            sequence: 0,
+            release_status,
+            owner_lane: gate.owner_lane,
+            source_closure_sequence: gate.sequence,
+            source_closure_status: gate.closure_status,
+            source_remediation_kind: gate.source_remediation_kind,
+            source_remediation_status: gate.source_remediation_status,
+            source_id: gate.source_id.clone(),
+            title: format!("{}: {}", release_status.as_str(), gate.title),
+            summary: gate.summary.clone(),
+            priority: gate.priority,
+            integration_ids: gate.integration_ids.clone(),
+            recommended_view: gate.recommended_view,
+            required_tier: gate.required_tier,
+            policy_surface: gate.policy_surface,
+            dependency_work: gate.has_dependency_work(),
+            policy_risk: gate.has_policy_risk(),
+            verification_required,
+            release_blocked,
+            requires_attention: gate.requires_attention() || release_status.requires_attention(),
+            release_ready,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_required
+    }
+
+    pub fn release_blocked(&self) -> bool {
+        self.release_blocked
+    }
+
+    pub fn release_ready(&self) -> bool {
+        self.release_ready
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationReleaseStatus {
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Blocked | Self::OwnerActionRequired | Self::VerificationRequired
+        )
+    }
+}
+
+impl IntegrationActivationReleaseSummary {
+    pub fn from_packets<'a>(
+        packets: impl IntoIterator<Item = &'a IntegrationActivationReleasePacket>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_packets: 0,
+            unique_integrations: 0,
+            packets_requiring_attention: 0,
+            blocked_packets: 0,
+            owner_action_packets: 0,
+            verification_required_packets: 0,
+            ready_for_release_packets: 0,
+            monitoring_packets: 0,
+            platform_owner_packets: 0,
+            integration_owner_packets: 0,
+            security_owner_packets: 0,
+            reviewer_owner_packets: 0,
+            verification_owner_packets: 0,
+            audit_owner_packets: 0,
+            packets_with_dependency_work: 0,
+            packets_with_policy_risk: 0,
+            packets_requiring_verification: 0,
+            packets_ready_for_release: 0,
+            packets_with_policy_surface: 0,
+            next_release_status: None,
+            next_closure_status: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_packet_sequence: None,
+            next_packet_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for packet in packets {
+            summary.total_packets += 1;
+            for integration_id in &packet.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_release_status.is_none()
+                && (packet.requires_attention()
+                    || packet.needs_verification()
+                    || packet.release_ready())
+            {
+                summary.next_release_status = Some(packet.release_status);
+                summary.next_closure_status = Some(packet.source_closure_status);
+                summary.next_owner_lane = Some(packet.owner_lane);
+                summary.next_recommended_view = Some(packet.recommended_view);
+                summary.next_packet_sequence = Some(packet.sequence);
+                summary.next_packet_priority = Some(packet.priority);
+            }
+
+            match packet.release_status {
+                IntegrationActivationReleaseStatus::Blocked => summary.blocked_packets += 1,
+                IntegrationActivationReleaseStatus::OwnerActionRequired => {
+                    summary.owner_action_packets += 1;
+                }
+                IntegrationActivationReleaseStatus::VerificationRequired => {
+                    summary.verification_required_packets += 1;
+                }
+                IntegrationActivationReleaseStatus::ReadyForRelease => {
+                    summary.ready_for_release_packets += 1;
+                }
+                IntegrationActivationReleaseStatus::Monitoring => summary.monitoring_packets += 1,
+            }
+
+            match packet.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_packets += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_packets += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_packets += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_packets += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_packets += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_packets += 1;
+                }
+            }
+
+            if packet.requires_attention() {
+                summary.packets_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(packet.priority));
+            }
+            if packet.has_dependency_work() {
+                summary.packets_with_dependency_work += 1;
+            }
+            if packet.has_policy_risk() {
+                summary.packets_with_policy_risk += 1;
+            }
+            if packet.needs_verification() {
+                summary.packets_requiring_verification += 1;
+            }
+            if packet.release_ready() {
+                summary.packets_ready_for_release += 1;
+            }
+            if packet.has_policy_surface() {
+                summary.packets_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(packet.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_packets > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.packets_requiring_attention > 0
+            || summary.owner_action_packets > 0
+            || summary.verification_required_packets > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_for_release_packets > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_packets == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_packets > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.owner_action_packets > 0
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_required_packets > 0 || self.packets_requiring_verification > 0
+    }
+
+    pub fn release_ready(&self) -> bool {
+        self.ready_for_release_packets > 0 || self.packets_ready_for_release > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.packets_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -14732,6 +15064,38 @@ pub fn activation_closure_gates_at_or_before_priority(
     activation_closure_gates_from_remediations(&remediations)
 }
 
+pub fn activation_release_packets_from_closure_gates(
+    gates: &[IntegrationActivationClosureGate],
+) -> Vec<IntegrationActivationReleasePacket> {
+    let mut packets: Vec<_> = gates
+        .iter()
+        .map(IntegrationActivationReleasePacket::from_closure_gate)
+        .collect();
+
+    packets.sort_by(compare_activation_release_packets);
+    for (index, packet) in packets.iter_mut().enumerate() {
+        packet.sequence = index + 1;
+    }
+    packets
+}
+
+pub fn activation_release_packets_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationReleasePacket> {
+    let gates = activation_closure_gates_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_release_packets_from_closure_gates(&gates)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -16384,6 +16748,29 @@ fn compare_activation_closure_gates(
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| right.ready_to_verify().cmp(&left.ready_to_verify()))
         .then_with(|| right.closure_ready().cmp(&left.closure_ready()))
+        .then_with(|| {
+            left.source_remediation_kind
+                .cmp(&right.source_remediation_kind)
+        })
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_release_packets(
+    left: &IntegrationActivationReleasePacket,
+    right: &IntegrationActivationReleasePacket,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.release_status.cmp(&right.release_status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.release_blocked().cmp(&left.release_blocked()))
+        .then_with(|| right.needs_verification().cmp(&left.needs_verification()))
+        .then_with(|| right.release_ready().cmp(&left.release_ready()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| left.source_closure_status.cmp(&right.source_closure_status))
         .then_with(|| {
             left.source_remediation_kind
                 .cmp(&right.source_remediation_kind)
@@ -19979,6 +20366,39 @@ mod tests {
         );
         assert_eq!(
             closure_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let release_packets = activation_release_packets_from_closure_gates(&closure_gates);
+        assert_eq!(release_packets.len(), closure_gates.len());
+        assert!(release_packets
+            .iter()
+            .any(|packet| packet.release_status == IntegrationActivationReleaseStatus::Blocked));
+        assert!(release_packets.iter().any(|packet| packet.release_status
+            == IntegrationActivationReleaseStatus::VerificationRequired));
+        assert!(release_packets
+            .iter()
+            .any(IntegrationActivationReleasePacket::requires_attention));
+        assert!(release_packets
+            .iter()
+            .any(IntegrationActivationReleasePacket::release_blocked));
+
+        let release_summary =
+            IntegrationActivationReleaseSummary::from_packets(release_packets.iter());
+        assert_eq!(release_summary.total_packets, release_packets.len());
+        assert!(release_summary.has_blockers());
+        assert!(release_summary.needs_verification());
+        assert!(release_summary.requires_attention());
+        assert_eq!(
+            release_summary.next_release_status,
+            Some(IntegrationActivationReleaseStatus::Blocked)
+        );
+        assert_eq!(
+            release_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            release_summary.overall_status,
             IntegrationActivationHealthStatus::Blocked
         );
 


### PR DESCRIPTION
## Summary
- add reusable D23A activation release packets and summaries derived from closure gates
- expose read-only D18D descriptors for smart_home.list_integration_activation_release and smart_home.get_integration_activation_release_summary
- wire Chief bridge schema, handlers, JSON output, end-to-end journal coverage, README, and changelog notes

## Validation
- cargo fmt -p smart-home-integration-catalog -p smart-home-core -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
- git diff --check

Generated code/packages/rust/Cargo.lock was removed before commit.
