### PR TITLE
Add smart-home activation delivery tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -112,6 +112,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation release packets:
   `smart_home.list_integration_activation_release` and
   `smart_home.get_integration_activation_release_summary`.
+- Added D18D handlers for D23A activation delivery manifests:
+  `smart_home.list_integration_activation_delivery` and
+  `smart_home.get_integration_activation_delivery_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -72,6 +72,7 @@ Chief of Staff job/session/agent
   -> activation-remediation list and summary reads for owner-lane work orders
   -> activation-closure list and summary reads for verification/close gates
   -> activation-release list and summary reads for go/no-go release packets
+  -> activation-delivery list and summary reads for delivery-channel manifests
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -167,6 +168,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_closure_summary`
 - `smart_home.list_integration_activation_release`
 - `smart_home.get_integration_activation_release_summary`
+- `smart_home.list_integration_activation_delivery`
+- `smart_home.get_integration_activation_delivery_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -40,9 +40,9 @@ use smart_home_integration_catalog::{
     activation_command_center_sections_from_control_room_panels,
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
-    activation_dependency_graph_from_reports, activation_dossiers_from_candidates,
-    activation_escalation_cases_from_rollups, activation_evidence_from_candidates,
-    activation_execution_packets_from_handoff_packages,
+    activation_delivery_manifests_from_release_packets, activation_dependency_graph_from_reports,
+    activation_dossiers_from_candidates, activation_escalation_cases_from_rollups,
+    activation_evidence_from_candidates, activation_execution_packets_from_handoff_packages,
     activation_forecasts_from_timeline_milestones,
     activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
@@ -79,6 +79,8 @@ use smart_home_integration_catalog::{
     IntegrationActivationControlRoomSummary, IntegrationActivationDashboardCard,
     IntegrationActivationDashboardSummary, IntegrationActivationDecisionItem,
     IntegrationActivationDecisionStatus, IntegrationActivationDecisionSummary,
+    IntegrationActivationDeliveryChannel, IntegrationActivationDeliveryManifest,
+    IntegrationActivationDeliveryStatus, IntegrationActivationDeliverySummary,
     IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
     IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
     IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
@@ -353,6 +355,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RELEASE_TOOL_ID: &str =
     "smart_home.list_integration_activation_release";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_release_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID: &str =
+    "smart_home.list_integration_activation_delivery";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_delivery_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -801,6 +807,16 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_release_query(&arguments)?;
                     Ok(get_integration_activation_release_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID => {
+                    let query = integration_activation_delivery_query(&arguments)?;
+                    Ok(list_integration_activation_delivery_output_handler_output(
+                        query,
+                    ))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_delivery_query(&arguments)?;
+                    Ok(get_integration_activation_delivery_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2605,6 +2621,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation release summary",
             "Return compact D23A activation release-packet counts by release status, owner lane, blockers, verification requirements, release readiness, policy, and dependency work.",
             integration_activation_release_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID,
+            "List smart-home integration activation delivery",
+            "List Chief-facing D23A activation delivery manifests derived from release packets with delivery status, delivery channel, owner lanes, blockers, verification requirements, and delivery readiness.",
+            integration_activation_delivery_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_delivery", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_delivery",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation delivery summary",
+            "Return compact D23A activation delivery-manifest counts by delivery status, delivery channel, owner lane, blockers, verification requirements, delivery readiness, policy, and dependency work.",
+            integration_activation_delivery_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5482,6 +5532,19 @@ struct IntegrationActivationReleaseQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationDeliveryQuery {
+    release: IntegrationActivationReleaseQuery,
+    delivery_status: Option<IntegrationActivationDeliveryStatus>,
+    delivery_channel: Option<IntegrationActivationDeliveryChannel>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    needs_verification: Option<bool>,
+    delivery_ready: Option<bool>,
+    delivery_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6210,6 +6273,36 @@ fn integration_activation_release_query(
             .or(optional_bool(arguments, "release_needs_verification")?),
         release_ready: optional_bool(arguments, "release_ready")?,
         release_limit: optional_u64(arguments, "release_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_delivery_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationDeliveryQuery, ToolCallError> {
+    let delivery_status = optional_string(arguments, "delivery_status")?
+        .or(optional_string(arguments, "delivery_state")?)
+        .map(|label| parse_activation_delivery_status(&label))
+        .transpose()?;
+    let delivery_channel = optional_string(arguments, "delivery_channel")?
+        .or(optional_string(arguments, "delivery_lane")?)
+        .map(|label| parse_activation_delivery_channel(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "delivery_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationDeliveryQuery {
+        release: integration_activation_release_query(arguments)?,
+        delivery_status,
+        delivery_channel,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "delivery_requires_attention")?,
+        blocked: optional_bool(arguments, "delivery_blocked")?,
+        needs_verification: optional_bool(arguments, "delivery_needs_verification")?
+            .or(optional_bool(arguments, "needs_verification")?),
+        delivery_ready: optional_bool(arguments, "delivery_ready")?,
+        delivery_limit: optional_u64(arguments, "delivery_limit")?.map(|value| value as usize),
     })
 }
 
@@ -7381,6 +7474,40 @@ fn integration_activation_release_packets_for_query(
     }
 
     (packets, catalog_count)
+}
+
+fn integration_activation_delivery_manifests_for_query(
+    query: &IntegrationActivationDeliveryQuery,
+) -> (Vec<IntegrationActivationDeliveryManifest>, usize) {
+    let (packets, catalog_count) = integration_activation_release_packets_for_query(&query.release);
+    let mut manifests = activation_delivery_manifests_from_release_packets(&packets);
+
+    if let Some(delivery_status) = query.delivery_status {
+        manifests.retain(|manifest| manifest.delivery_status == delivery_status);
+    }
+    if let Some(delivery_channel) = query.delivery_channel {
+        manifests.retain(|manifest| manifest.delivery_channel == delivery_channel);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        manifests.retain(|manifest| manifest.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        manifests.retain(|manifest| manifest.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        manifests.retain(|manifest| manifest.delivery_blocked() == blocked);
+    }
+    if let Some(needs_verification) = query.needs_verification {
+        manifests.retain(|manifest| manifest.needs_verification() == needs_verification);
+    }
+    if let Some(delivery_ready) = query.delivery_ready {
+        manifests.retain(|manifest| manifest.delivery_ready() == delivery_ready);
+    }
+    if let Some(limit) = query.delivery_limit {
+        manifests.truncate(limit);
+    }
+
+    (manifests, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -10250,6 +10377,100 @@ fn get_integration_activation_release_summary_output_handler_output(
             (
                 "ready_for_release_packets",
                 integer(summary.ready_for_release_packets as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_delivery_output_handler_output(
+    query: IntegrationActivationDeliveryQuery,
+) -> ToolHandlerOutput {
+    let (manifests, catalog_count) = integration_activation_delivery_manifests_for_query(&query);
+    let summary = IntegrationActivationDeliverySummary::from_manifests(manifests.iter());
+    let count = manifests.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_delivery",
+            JsonValue::Array(
+                manifests
+                    .iter()
+                    .map(activation_delivery_manifest_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_delivery_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            ("operation", string("list_integration_activation_delivery")),
+            ("manifests", integer(count as i64)),
+            (
+                "manifests_requiring_attention",
+                integer(summary.manifests_requiring_attention as i64),
+            ),
+            (
+                "blocked_manifests",
+                integer(summary.blocked_manifests as i64),
+            ),
+            (
+                "awaiting_verification_manifests",
+                integer(summary.awaiting_verification_manifests as i64),
+            ),
+            (
+                "ready_to_deliver_manifests",
+                integer(summary.ready_to_deliver_manifests as i64),
+            ),
+            (
+                "next_delivery_status",
+                summary
+                    .next_delivery_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_delivery_summary_output_handler_output(
+    query: IntegrationActivationDeliveryQuery,
+) -> ToolHandlerOutput {
+    let (manifests, _) = integration_activation_delivery_manifests_for_query(&query);
+    let summary = IntegrationActivationDeliverySummary::from_manifests(manifests.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_delivery_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_delivery_summary"),
+            ),
+            ("total_manifests", integer(summary.total_manifests as i64)),
+            (
+                "manifests_requiring_attention",
+                integer(summary.manifests_requiring_attention as i64),
+            ),
+            (
+                "blocked_manifests",
+                integer(summary.blocked_manifests as i64),
+            ),
+            (
+                "awaiting_verification_manifests",
+                integer(summary.awaiting_verification_manifests as i64),
+            ),
+            (
+                "ready_to_deliver_manifests",
+                integer(summary.ready_to_deliver_manifests as i64),
             ),
         ]),
     )
@@ -20269,6 +20490,275 @@ fn integration_activation_release_summary_json(
     ])
 }
 
+fn activation_delivery_manifest_json(
+    manifest: &IntegrationActivationDeliveryManifest,
+) -> JsonValue {
+    object([
+        ("sequence", integer(manifest.sequence as i64)),
+        ("delivery_status", string(manifest.delivery_status.as_str())),
+        (
+            "delivery_channel",
+            string(manifest.delivery_channel.as_str()),
+        ),
+        ("owner_lane", string(manifest.owner_lane.as_str())),
+        (
+            "source_release_sequence",
+            integer(manifest.source_release_sequence as i64),
+        ),
+        (
+            "source_release_status",
+            string(manifest.source_release_status.as_str()),
+        ),
+        (
+            "source_closure_status",
+            string(manifest.source_closure_status.as_str()),
+        ),
+        (
+            "source_remediation_kind",
+            string(manifest.source_remediation_kind.as_str()),
+        ),
+        (
+            "source_remediation_status",
+            string(manifest.source_remediation_status.as_str()),
+        ),
+        ("source_id", string(&manifest.source_id)),
+        ("title", string(&manifest.title)),
+        ("summary", string(&manifest.summary)),
+        ("priority", integer(manifest.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                manifest
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(manifest.integration_count() as i64),
+        ),
+        (
+            "recommended_view",
+            string(manifest.recommended_view.as_str()),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(manifest.required_tier)),
+        ),
+        (
+            "policy_surface",
+            manifest
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(manifest.has_dependency_work()),
+        ),
+        (
+            "has_policy_risk",
+            JsonValue::Bool(manifest.has_policy_risk()),
+        ),
+        (
+            "needs_verification",
+            JsonValue::Bool(manifest.needs_verification()),
+        ),
+        ("release_ready", JsonValue::Bool(manifest.release_ready())),
+        (
+            "delivery_blocked",
+            JsonValue::Bool(manifest.delivery_blocked()),
+        ),
+        ("delivery_ready", JsonValue::Bool(manifest.delivery_ready())),
+        (
+            "requires_attention",
+            JsonValue::Bool(manifest.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_delivery_summary_json(
+    summary: &IntegrationActivationDeliverySummary,
+) -> JsonValue {
+    object([
+        ("total_manifests", integer(summary.total_manifests as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "manifests_requiring_attention",
+            integer(summary.manifests_requiring_attention as i64),
+        ),
+        (
+            "blocked_manifests",
+            integer(summary.blocked_manifests as i64),
+        ),
+        (
+            "awaiting_verification_manifests",
+            integer(summary.awaiting_verification_manifests as i64),
+        ),
+        (
+            "awaiting_owner_manifests",
+            integer(summary.awaiting_owner_manifests as i64),
+        ),
+        (
+            "ready_to_deliver_manifests",
+            integer(summary.ready_to_deliver_manifests as i64),
+        ),
+        (
+            "monitoring_manifests",
+            integer(summary.monitoring_manifests as i64),
+        ),
+        (
+            "platform_channel_manifests",
+            integer(summary.platform_channel_manifests as i64),
+        ),
+        (
+            "integration_channel_manifests",
+            integer(summary.integration_channel_manifests as i64),
+        ),
+        (
+            "security_channel_manifests",
+            integer(summary.security_channel_manifests as i64),
+        ),
+        (
+            "verification_channel_manifests",
+            integer(summary.verification_channel_manifests as i64),
+        ),
+        (
+            "audit_channel_manifests",
+            integer(summary.audit_channel_manifests as i64),
+        ),
+        (
+            "monitoring_channel_manifests",
+            integer(summary.monitoring_channel_manifests as i64),
+        ),
+        (
+            "platform_owner_manifests",
+            integer(summary.platform_owner_manifests as i64),
+        ),
+        (
+            "integration_owner_manifests",
+            integer(summary.integration_owner_manifests as i64),
+        ),
+        (
+            "security_owner_manifests",
+            integer(summary.security_owner_manifests as i64),
+        ),
+        (
+            "reviewer_owner_manifests",
+            integer(summary.reviewer_owner_manifests as i64),
+        ),
+        (
+            "verification_owner_manifests",
+            integer(summary.verification_owner_manifests as i64),
+        ),
+        (
+            "audit_owner_manifests",
+            integer(summary.audit_owner_manifests as i64),
+        ),
+        (
+            "manifests_with_dependency_work",
+            integer(summary.manifests_with_dependency_work as i64),
+        ),
+        (
+            "manifests_with_policy_risk",
+            integer(summary.manifests_with_policy_risk as i64),
+        ),
+        (
+            "manifests_requiring_verification",
+            integer(summary.manifests_requiring_verification as i64),
+        ),
+        (
+            "manifests_ready_to_deliver",
+            integer(summary.manifests_ready_to_deliver as i64),
+        ),
+        (
+            "manifests_with_policy_surface",
+            integer(summary.manifests_with_policy_surface as i64),
+        ),
+        (
+            "next_delivery_status",
+            summary
+                .next_delivery_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_delivery_channel",
+            summary
+                .next_delivery_channel
+                .map(|channel| string(channel.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_release_status",
+            summary
+                .next_release_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_manifest_sequence",
+            summary
+                .next_manifest_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_manifest_priority",
+            summary
+                .next_manifest_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "needs_verification",
+            JsonValue::Bool(summary.needs_verification()),
+        ),
+        ("delivery_ready", JsonValue::Bool(summary.delivery_ready())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -23287,6 +23777,51 @@ fn parse_activation_release_status(
     }
 }
 
+fn parse_activation_delivery_status(
+    label: &str,
+) -> Result<IntegrationActivationDeliveryStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" => Ok(IntegrationActivationDeliveryStatus::Blocked),
+        "awaiting_verification" | "needs_verification" | "verify" | "verification" => {
+            Ok(IntegrationActivationDeliveryStatus::AwaitingVerification)
+        }
+        "awaiting_owner" | "owner_action" | "needs_owner_action" | "action_required" => {
+            Ok(IntegrationActivationDeliveryStatus::AwaitingOwner)
+        }
+        "ready_to_deliver" | "delivery_ready" | "ready_for_delivery" | "deliver" => {
+            Ok(IntegrationActivationDeliveryStatus::ReadyToDeliver)
+        }
+        "monitoring" | "monitor" | "tracking" => {
+            Ok(IntegrationActivationDeliveryStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation delivery status `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_delivery_channel(
+    label: &str,
+) -> Result<IntegrationActivationDeliveryChannel, ToolCallError> {
+    match label {
+        "platform" | "platform_release" => Ok(IntegrationActivationDeliveryChannel::Platform),
+        "integration" | "integration_owner" => {
+            Ok(IntegrationActivationDeliveryChannel::Integration)
+        }
+        "security" | "security_review" => Ok(IntegrationActivationDeliveryChannel::Security),
+        "verification" | "review" | "reviewer" => {
+            Ok(IntegrationActivationDeliveryChannel::Verification)
+        }
+        "audit" | "audit_trail" => Ok(IntegrationActivationDeliveryChannel::Audit),
+        "monitoring" | "monitor" | "tracking" => {
+            Ok(IntegrationActivationDeliveryChannel::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation delivery channel `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -24945,6 +25480,37 @@ fn integration_activation_release_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_delivery_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_release_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("delivery_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("delivery_state", JsonSchema::String));
+        properties.push(SchemaProperty::new("delivery_channel", JsonSchema::String));
+        properties.push(SchemaProperty::new("delivery_lane", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "delivery_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "delivery_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("delivery_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "delivery_needs_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("delivery_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("delivery_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -25089,7 +25655,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 127);
+        assert_eq!(definitions.len(), 129);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -25442,9 +26008,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            119
+            121
         );
         assert_eq!(
             export
@@ -25501,6 +26073,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_RELEASE_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -25954,11 +26534,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(127))
+            Some(&integer(129))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(119))
+            Some(&integer(121))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -30658,6 +31238,161 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_delivery_request = request(
+            "call-list-integration-activation-delivery",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("delivery_status", string("blocked")),
+                ("delivery_requires_attention", JsonValue::Bool(true)),
+                ("delivery_blocked", JsonValue::Bool(true)),
+                ("delivery_limit", integer(3)),
+            ]),
+            5_053,
+        );
+        let list_activation_delivery_trace =
+            tool_runtime.invoke_with_events(&list_activation_delivery_request);
+        assert!(list_activation_delivery_trace.result.ok);
+        assert_eq!(
+            list_activation_delivery_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_delivery_output = list_activation_delivery_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_delivery_count =
+            integer_value(field(list_activation_delivery_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_delivery_count));
+        let activation_delivery_summary =
+            field(list_activation_delivery_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_delivery_summary, "total_manifests"),
+            Some(&integer(activation_delivery_count))
+        );
+        assert_eq!(
+            field(activation_delivery_summary, "next_delivery_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_delivery_summary, "next_delivery_channel"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_delivery_summary, "next_owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_delivery_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_delivery_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_delivery = array_item(
+            field(list_activation_delivery_output, "activation_delivery").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_delivery, "delivery_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_delivery, "delivery_channel"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_delivery, "delivery_blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_delivery, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_delivery_summary_request = request(
+            "call-integration-activation-delivery-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("delivery_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_054,
+        );
+        let activation_delivery_summary_trace =
+            tool_runtime.invoke_with_events(&activation_delivery_summary_request);
+        assert!(activation_delivery_summary_trace.result.ok);
+        assert_eq!(
+            activation_delivery_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_delivery_summary_output = activation_delivery_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_delivery_rollup =
+            field(activation_delivery_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_delivery_rollup, "total_manifests").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_delivery_rollup, "blocked_manifests").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_delivery_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_delivery_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -32538,6 +33273,14 @@ mod tests {
             activation_release_summary_request,
             activation_release_summary_trace,
         );
+        journal.record_trace(
+            list_activation_delivery_request,
+            list_activation_delivery_trace,
+        );
+        journal.record_trace(
+            activation_delivery_summary_request,
+            activation_delivery_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -32611,9 +33354,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 127);
-        assert_eq!(journal_summary.completed_count, 127);
-        assert_eq!(journal.audit_records().len(), 127);
+        assert_eq!(journal_summary.invocation_count, 129);
+        assert_eq!(journal_summary.completed_count, 129);
+        assert_eq!(journal.audit_records().len(), 129);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -146,6 +146,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_release` and
   `smart_home.get_integration_activation_release_summary` tool descriptors for
   read-only activation release packets derived from closure gates.
+- `smart_home.list_integration_activation_delivery` and
+  `smart_home.get_integration_activation_delivery_summary` tool descriptors for
+  read-only activation delivery manifests derived from release packets.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -123,6 +123,8 @@ Current scope:
   combine remediation status, owner lanes, blockers, and verification readiness
 - D18D integration activation-release descriptors for compact go/no-go packet
   views derived from activation closure gates
+- D18D integration activation-delivery descriptors for delivery-channel
+  manifests derived from activation release packets
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1525,6 +1525,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationClosureSummary,
     ListIntegrationActivationRelease,
     GetIntegrationActivationReleaseSummary,
+    ListIntegrationActivationDelivery,
+    GetIntegrationActivationDeliverySummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1806,6 +1808,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationReleaseSummary => {
                 read_tool("smart_home.get_integration_activation_release_summary")
+            }
+            Self::ListIntegrationActivationDelivery => {
+                read_tool("smart_home.list_integration_activation_delivery")
+            }
+            Self::GetIntegrationActivationDeliverySummary => {
+                read_tool("smart_home.get_integration_activation_delivery_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2514,6 +2522,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationClosureSummary,
         SmartHomeTool::ListIntegrationActivationRelease,
         SmartHomeTool::GetIntegrationActivationReleaseSummary,
+        SmartHomeTool::ListIntegrationActivationDelivery,
+        SmartHomeTool::GetIntegrationActivationDeliverySummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3356,7 +3366,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 127);
+        assert_eq!(catalog.len(), 129);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3871,6 +3881,14 @@ mod tests {
             == "smart_home.get_integration_activation_release_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_delivery"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_delivery_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3878,15 +3896,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 127);
-        assert_eq!(summary.read_tools, 119);
+        assert_eq!(summary.total_tools, 129);
+        assert_eq!(summary.read_tools, 121);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 119);
+        assert_eq!(summary.read_only_tier_tools, 121);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 127);
+        assert_eq!(summary.total_required_capabilities, 129);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -117,6 +117,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationReleasePacket` and
   `IntegrationActivationReleaseSummary` for turning closure gates into compact
   activation release go/no-go packets.
+- `IntegrationActivationDeliveryManifest` and
+  `IntegrationActivationDeliverySummary` for turning release packets into
+  delivery-channel manifests and readiness rollups.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -106,6 +106,8 @@ runtime and Chief of Staff tools a typed catalog for:
   blocked, owner-action, verification-ready, ready-to-close, and tracking gates
 - activation release packets that turn closure gates into compact go/no-go
   release views with blockers, verification requirements, and release readiness
+- activation delivery manifests that turn release packets into compact delivery
+  views with channel, blocker, verification, and delivery-readiness rollups
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1604,6 +1604,82 @@ impl IntegrationActivationReleaseStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationDeliveryStatus {
+    Blocked,
+    AwaitingVerification,
+    AwaitingOwner,
+    ReadyToDeliver,
+    Monitoring,
+}
+
+impl IntegrationActivationDeliveryStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::AwaitingVerification => "awaiting_verification",
+            Self::AwaitingOwner => "awaiting_owner",
+            Self::ReadyToDeliver => "ready_to_deliver",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_release_packet(packet: &IntegrationActivationReleasePacket) -> Self {
+        if packet.release_blocked() {
+            if packet.needs_verification() {
+                Self::AwaitingVerification
+            } else if packet.release_status
+                == IntegrationActivationReleaseStatus::OwnerActionRequired
+            {
+                Self::AwaitingOwner
+            } else {
+                Self::Blocked
+            }
+        } else if packet.release_ready() {
+            Self::ReadyToDeliver
+        } else {
+            Self::Monitoring
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationDeliveryChannel {
+    Platform,
+    Integration,
+    Security,
+    Verification,
+    Audit,
+    Monitoring,
+}
+
+impl IntegrationActivationDeliveryChannel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::Integration => "integration",
+            Self::Security => "security",
+            Self::Verification => "verification",
+            Self::Audit => "audit",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_release_packet(packet: &IntegrationActivationReleasePacket) -> Self {
+        if packet.release_status == IntegrationActivationReleaseStatus::Monitoring {
+            return Self::Monitoring;
+        }
+        match packet.owner_lane {
+            IntegrationActivationResponseOwnerLane::Platform => Self::Platform,
+            IntegrationActivationResponseOwnerLane::Integration => Self::Integration,
+            IntegrationActivationResponseOwnerLane::Security => Self::Security,
+            IntegrationActivationResponseOwnerLane::Reviewer
+            | IntegrationActivationResponseOwnerLane::Verification => Self::Verification,
+            IntegrationActivationResponseOwnerLane::Audit => Self::Audit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3547,6 +3623,73 @@ pub struct IntegrationActivationReleaseSummary {
     pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
     pub next_packet_sequence: Option<usize>,
     pub next_packet_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDeliveryManifest {
+    pub sequence: usize,
+    pub delivery_status: IntegrationActivationDeliveryStatus,
+    pub delivery_channel: IntegrationActivationDeliveryChannel,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_release_sequence: usize,
+    pub source_release_status: IntegrationActivationReleaseStatus,
+    pub source_closure_status: IntegrationActivationClosureStatus,
+    pub source_remediation_kind: IntegrationActivationRemediationKind,
+    pub source_remediation_status: IntegrationActivationRemediationStatus,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_required: bool,
+    pub release_ready: bool,
+    pub delivery_blocked: bool,
+    pub delivery_ready: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDeliverySummary {
+    pub total_manifests: usize,
+    pub unique_integrations: usize,
+    pub manifests_requiring_attention: usize,
+    pub blocked_manifests: usize,
+    pub awaiting_verification_manifests: usize,
+    pub awaiting_owner_manifests: usize,
+    pub ready_to_deliver_manifests: usize,
+    pub monitoring_manifests: usize,
+    pub platform_channel_manifests: usize,
+    pub integration_channel_manifests: usize,
+    pub security_channel_manifests: usize,
+    pub verification_channel_manifests: usize,
+    pub audit_channel_manifests: usize,
+    pub monitoring_channel_manifests: usize,
+    pub platform_owner_manifests: usize,
+    pub integration_owner_manifests: usize,
+    pub security_owner_manifests: usize,
+    pub reviewer_owner_manifests: usize,
+    pub verification_owner_manifests: usize,
+    pub audit_owner_manifests: usize,
+    pub manifests_with_dependency_work: usize,
+    pub manifests_with_policy_risk: usize,
+    pub manifests_requiring_verification: usize,
+    pub manifests_ready_to_deliver: usize,
+    pub manifests_with_policy_surface: usize,
+    pub next_delivery_status: Option<IntegrationActivationDeliveryStatus>,
+    pub next_delivery_channel: Option<IntegrationActivationDeliveryChannel>,
+    pub next_release_status: Option<IntegrationActivationReleaseStatus>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_manifest_sequence: Option<usize>,
+    pub next_manifest_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -9939,6 +10082,279 @@ impl IntegrationActivationReleaseSummary {
     }
 }
 
+impl IntegrationActivationDeliveryManifest {
+    fn from_release_packet(packet: &IntegrationActivationReleasePacket) -> Self {
+        let delivery_status = IntegrationActivationDeliveryStatus::from_release_packet(packet);
+        let delivery_channel = IntegrationActivationDeliveryChannel::from_release_packet(packet);
+        let delivery_ready = delivery_status == IntegrationActivationDeliveryStatus::ReadyToDeliver;
+        let delivery_blocked = matches!(
+            delivery_status,
+            IntegrationActivationDeliveryStatus::Blocked
+                | IntegrationActivationDeliveryStatus::AwaitingVerification
+                | IntegrationActivationDeliveryStatus::AwaitingOwner
+        );
+
+        Self {
+            sequence: 0,
+            delivery_status,
+            delivery_channel,
+            owner_lane: packet.owner_lane,
+            source_release_sequence: packet.sequence,
+            source_release_status: packet.release_status,
+            source_closure_status: packet.source_closure_status,
+            source_remediation_kind: packet.source_remediation_kind,
+            source_remediation_status: packet.source_remediation_status,
+            source_id: packet.source_id.clone(),
+            title: format!("{}: {}", delivery_status.as_str(), packet.title),
+            summary: packet.summary.clone(),
+            priority: packet.priority,
+            integration_ids: packet.integration_ids.clone(),
+            recommended_view: packet.recommended_view,
+            required_tier: packet.required_tier,
+            policy_surface: packet.policy_surface,
+            dependency_work: packet.has_dependency_work(),
+            policy_risk: packet.has_policy_risk(),
+            verification_required: packet.needs_verification(),
+            release_ready: packet.release_ready(),
+            delivery_blocked,
+            delivery_ready,
+            requires_attention: packet.requires_attention() || delivery_status.requires_attention(),
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_required
+    }
+
+    pub fn delivery_blocked(&self) -> bool {
+        self.delivery_blocked
+    }
+
+    pub fn delivery_ready(&self) -> bool {
+        self.delivery_ready
+    }
+
+    pub fn release_ready(&self) -> bool {
+        self.release_ready
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationDeliveryStatus {
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Blocked | Self::AwaitingVerification | Self::AwaitingOwner
+        )
+    }
+}
+
+impl IntegrationActivationDeliverySummary {
+    pub fn from_manifests<'a>(
+        manifests: impl IntoIterator<Item = &'a IntegrationActivationDeliveryManifest>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_manifests: 0,
+            unique_integrations: 0,
+            manifests_requiring_attention: 0,
+            blocked_manifests: 0,
+            awaiting_verification_manifests: 0,
+            awaiting_owner_manifests: 0,
+            ready_to_deliver_manifests: 0,
+            monitoring_manifests: 0,
+            platform_channel_manifests: 0,
+            integration_channel_manifests: 0,
+            security_channel_manifests: 0,
+            verification_channel_manifests: 0,
+            audit_channel_manifests: 0,
+            monitoring_channel_manifests: 0,
+            platform_owner_manifests: 0,
+            integration_owner_manifests: 0,
+            security_owner_manifests: 0,
+            reviewer_owner_manifests: 0,
+            verification_owner_manifests: 0,
+            audit_owner_manifests: 0,
+            manifests_with_dependency_work: 0,
+            manifests_with_policy_risk: 0,
+            manifests_requiring_verification: 0,
+            manifests_ready_to_deliver: 0,
+            manifests_with_policy_surface: 0,
+            next_delivery_status: None,
+            next_delivery_channel: None,
+            next_release_status: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_manifest_sequence: None,
+            next_manifest_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for manifest in manifests {
+            summary.total_manifests += 1;
+            for integration_id in &manifest.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_delivery_status.is_none()
+                && (manifest.requires_attention()
+                    || manifest.needs_verification()
+                    || manifest.delivery_ready())
+            {
+                summary.next_delivery_status = Some(manifest.delivery_status);
+                summary.next_delivery_channel = Some(manifest.delivery_channel);
+                summary.next_release_status = Some(manifest.source_release_status);
+                summary.next_owner_lane = Some(manifest.owner_lane);
+                summary.next_recommended_view = Some(manifest.recommended_view);
+                summary.next_manifest_sequence = Some(manifest.sequence);
+                summary.next_manifest_priority = Some(manifest.priority);
+            }
+
+            match manifest.delivery_status {
+                IntegrationActivationDeliveryStatus::Blocked => summary.blocked_manifests += 1,
+                IntegrationActivationDeliveryStatus::AwaitingVerification => {
+                    summary.awaiting_verification_manifests += 1;
+                }
+                IntegrationActivationDeliveryStatus::AwaitingOwner => {
+                    summary.awaiting_owner_manifests += 1;
+                }
+                IntegrationActivationDeliveryStatus::ReadyToDeliver => {
+                    summary.ready_to_deliver_manifests += 1;
+                }
+                IntegrationActivationDeliveryStatus::Monitoring => {
+                    summary.monitoring_manifests += 1;
+                }
+            }
+
+            match manifest.delivery_channel {
+                IntegrationActivationDeliveryChannel::Platform => {
+                    summary.platform_channel_manifests += 1;
+                }
+                IntegrationActivationDeliveryChannel::Integration => {
+                    summary.integration_channel_manifests += 1;
+                }
+                IntegrationActivationDeliveryChannel::Security => {
+                    summary.security_channel_manifests += 1;
+                }
+                IntegrationActivationDeliveryChannel::Verification => {
+                    summary.verification_channel_manifests += 1;
+                }
+                IntegrationActivationDeliveryChannel::Audit => {
+                    summary.audit_channel_manifests += 1;
+                }
+                IntegrationActivationDeliveryChannel::Monitoring => {
+                    summary.monitoring_channel_manifests += 1;
+                }
+            }
+
+            match manifest.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_manifests += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_manifests += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_manifests += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_manifests += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_manifests += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_manifests += 1;
+                }
+            }
+
+            if manifest.requires_attention() {
+                summary.manifests_requiring_attention += 1;
+                summary.first_attention_priority = min_optional_priority(
+                    summary.first_attention_priority,
+                    Some(manifest.priority),
+                );
+            }
+            if manifest.has_dependency_work() {
+                summary.manifests_with_dependency_work += 1;
+            }
+            if manifest.has_policy_risk() {
+                summary.manifests_with_policy_risk += 1;
+            }
+            if manifest.needs_verification() {
+                summary.manifests_requiring_verification += 1;
+            }
+            if manifest.delivery_ready() {
+                summary.manifests_ready_to_deliver += 1;
+            }
+            if manifest.has_policy_surface() {
+                summary.manifests_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(manifest.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_manifests > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.manifests_requiring_attention > 0
+            || summary.awaiting_verification_manifests > 0
+            || summary.awaiting_owner_manifests > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_to_deliver_manifests > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_manifests == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_manifests > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.awaiting_owner_manifests > 0
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.awaiting_verification_manifests > 0 || self.manifests_requiring_verification > 0
+    }
+
+    pub fn delivery_ready(&self) -> bool {
+        self.ready_to_deliver_manifests > 0 || self.manifests_ready_to_deliver > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.manifests_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -15096,6 +15512,38 @@ pub fn activation_release_packets_at_or_before_priority(
     activation_release_packets_from_closure_gates(&gates)
 }
 
+pub fn activation_delivery_manifests_from_release_packets(
+    packets: &[IntegrationActivationReleasePacket],
+) -> Vec<IntegrationActivationDeliveryManifest> {
+    let mut manifests: Vec<_> = packets
+        .iter()
+        .map(IntegrationActivationDeliveryManifest::from_release_packet)
+        .collect();
+
+    manifests.sort_by(compare_activation_delivery_manifests);
+    for (index, manifest) in manifests.iter_mut().enumerate() {
+        manifest.sequence = index + 1;
+    }
+    manifests
+}
+
+pub fn activation_delivery_manifests_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDeliveryManifest> {
+    let packets = activation_release_packets_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_delivery_manifests_from_release_packets(&packets)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -16771,6 +17219,30 @@ fn compare_activation_release_packets(
         .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| left.source_closure_status.cmp(&right.source_closure_status))
+        .then_with(|| {
+            left.source_remediation_kind
+                .cmp(&right.source_remediation_kind)
+        })
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_delivery_manifests(
+    left: &IntegrationActivationDeliveryManifest,
+    right: &IntegrationActivationDeliveryManifest,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.delivery_status.cmp(&right.delivery_status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.delivery_blocked().cmp(&left.delivery_blocked()))
+        .then_with(|| right.needs_verification().cmp(&left.needs_verification()))
+        .then_with(|| right.delivery_ready().cmp(&left.delivery_ready()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| left.delivery_channel.cmp(&right.delivery_channel))
+        .then_with(|| left.source_release_status.cmp(&right.source_release_status))
         .then_with(|| {
             left.source_remediation_kind
                 .cmp(&right.source_remediation_kind)
@@ -20399,6 +20871,42 @@ mod tests {
         );
         assert_eq!(
             release_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let delivery_manifests =
+            activation_delivery_manifests_from_release_packets(&release_packets);
+        assert_eq!(delivery_manifests.len(), release_packets.len());
+        assert!(delivery_manifests.iter().any(
+            |manifest| manifest.delivery_status == IntegrationActivationDeliveryStatus::Blocked
+        ));
+        assert!(delivery_manifests
+            .iter()
+            .any(|manifest| manifest.delivery_status
+                == IntegrationActivationDeliveryStatus::AwaitingVerification));
+        assert!(delivery_manifests
+            .iter()
+            .any(IntegrationActivationDeliveryManifest::requires_attention));
+        assert!(delivery_manifests
+            .iter()
+            .any(IntegrationActivationDeliveryManifest::delivery_blocked));
+
+        let delivery_summary =
+            IntegrationActivationDeliverySummary::from_manifests(delivery_manifests.iter());
+        assert_eq!(delivery_summary.total_manifests, delivery_manifests.len());
+        assert!(delivery_summary.has_blockers());
+        assert!(delivery_summary.needs_verification());
+        assert!(delivery_summary.requires_attention());
+        assert_eq!(
+            delivery_summary.next_delivery_status,
+            Some(IntegrationActivationDeliveryStatus::Blocked)
+        );
+        assert_eq!(
+            delivery_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            delivery_summary.overall_status,
             IntegrationActivationHealthStatus::Blocked
         );
 


### PR DESCRIPTION
## Summary
- add reusable D23A activation delivery manifests and summaries derived from activation release packets
- expose read-only D18D descriptors for smart_home.list_integration_activation_delivery and smart_home.get_integration_activation_delivery_summary
- wire Chief bridge schema, filters, handlers, JSON output, end-to-end journal coverage, README, and changelog notes

## Validation
- cargo fmt -p smart-home-integration-catalog -p smart-home-core -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
- git diff --check HEAD

Branch was rebased onto latest origin/main after #5529 landed. Generated code/packages/rust/Cargo.lock was removed before push.
