### PR TITLE
Add canvas browser-readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -890,6 +890,7 @@ pub struct BrowserDocument {
     pub template_descriptors: Vec<BrowserTemplateDescriptor>,
     pub slot_descriptors: Vec<BrowserSlotDescriptor>,
     pub custom_element_descriptors: Vec<BrowserCustomElementDescriptor>,
+    pub canvas_descriptors: Vec<BrowserCanvasDescriptor>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
     pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
     pub global_state_descriptors: Vec<BrowserGlobalStateDescriptor>,
@@ -1479,6 +1480,26 @@ pub struct BrowserCustomElementDescriptor {
     pub text: String,
     pub custom_element_blocked: bool,
     pub custom_element_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserCanvasDescriptor {
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub width: Option<String>,
+    pub height: Option<String>,
+    pub has_width: bool,
+    pub has_height: bool,
+    pub fallback_text: String,
+    pub fallback_word_count: usize,
+    pub part: Vec<String>,
+    pub data_attribute_names: Vec<String>,
+    pub event_handlers: Vec<String>,
+    pub pointer_handlers: Vec<String>,
+    pub keyboard_handlers: Vec<String>,
+    pub lifecycle_handlers: Vec<String>,
+    pub canvas_blocked: bool,
+    pub canvas_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10919,6 +10940,9 @@ fn collect_browser_facts(
         if let Some(descriptor) = browser_custom_element_descriptor(element) {
             summary.custom_element_descriptors.push(descriptor);
         }
+        if let Some(descriptor) = browser_canvas_descriptor(element) {
+            summary.canvas_descriptors.push(descriptor);
+        }
         if let Some(descriptor) = browser_data_attribute_descriptor(element) {
             summary.data_attribute_descriptors.push(descriptor);
         }
@@ -11062,6 +11086,9 @@ fn collect_head_browser_facts(nodes: &[Node], summary: &mut BrowserDocument) {
         }
         if let Some(descriptor) = browser_custom_element_descriptor(element) {
             summary.custom_element_descriptors.push(descriptor);
+        }
+        if let Some(descriptor) = browser_canvas_descriptor(element) {
+            summary.canvas_descriptors.push(descriptor);
         }
 
         match element.name.as_str() {
@@ -17770,6 +17797,67 @@ fn browser_custom_element_block_reasons(
     }
     if custom_element_name.is_some() && custom_element_is.is_some() {
         reasons.push("is-on-autonomous-custom-element".to_string());
+    }
+    reasons
+}
+
+fn browser_canvas_descriptor(element: &Element) -> Option<BrowserCanvasDescriptor> {
+    if element.name != "canvas" {
+        return None;
+    }
+
+    let fallback_text = collapse_html_whitespace(&visible_text_for_nodes(&element.children));
+    let data_attributes = browser_data_attributes(element);
+    let event_handlers = browser_event_handlers(element);
+    let canvas_block_reasons = browser_canvas_block_reasons(
+        element.attribute("width"),
+        element.attribute("height"),
+        &fallback_text,
+    );
+
+    Some(BrowserCanvasDescriptor {
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        width: element.attribute("width").map(ToOwned::to_owned),
+        height: element.attribute("height").map(ToOwned::to_owned),
+        has_width: element.attribute("width").is_some(),
+        has_height: element.attribute("height").is_some(),
+        fallback_word_count: fallback_text.split_whitespace().count(),
+        fallback_text,
+        part: browser_part_tokens(element),
+        data_attribute_names: browser_data_attribute_names(&data_attributes),
+        pointer_handlers: browser_event_handlers_by_kind(
+            &event_handlers,
+            browser_pointer_interaction_event,
+        ),
+        keyboard_handlers: browser_event_handlers_by_kind(&event_handlers, browser_keyboard_event),
+        lifecycle_handlers: browser_event_handlers_by_kind(
+            &event_handlers,
+            browser_load_lifecycle_event,
+        ),
+        event_handlers,
+        canvas_blocked: !canvas_block_reasons.is_empty(),
+        canvas_block_reasons,
+    })
+}
+
+fn browser_canvas_block_reasons(
+    width: Option<&str>,
+    height: Option<&str>,
+    fallback_text: &str,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if width.is_none() {
+        reasons.push("missing-width".to_string());
+    }
+    if height.is_none() {
+        reasons.push("missing-height".to_string());
+    }
+    if fallback_text.is_empty() {
+        reasons.push("missing-fallback-text".to_string());
     }
     reasons
 }

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -2,8 +2,8 @@ use coding_adventures_html_parser::{
     parse_browser_document, BrowserActivationDescriptor, BrowserAnchor,
     BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
     BrowserAriaDescriptionDescriptor, BrowserAriaLiveRegion, BrowserAriaNameDescriptor,
-    BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserClipboardInteractionDescriptor,
-    BrowserCommandElement, BrowserComponentHydrationTarget,
+    BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCanvasDescriptor,
+    BrowserClipboardInteractionDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
     BrowserCompositionInteractionDescriptor, BrowserContextMenuInteractionDescriptor,
     BrowserCustomElementDescriptor, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
@@ -194,6 +194,8 @@ struct ExpectedBrowserDocument {
     slot_descriptors: Option<Vec<ExpectedSlotDescriptor>>,
     #[serde(default)]
     custom_element_descriptors: Option<Vec<ExpectedCustomElementDescriptor>>,
+    #[serde(default)]
+    canvas_descriptors: Option<Vec<ExpectedCanvasDescriptor>>,
     #[serde(default)]
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
     #[serde(default)]
@@ -467,6 +469,42 @@ struct ExpectedCustomElementDescriptor {
     custom_element_blocked: bool,
     #[serde(default)]
     custom_element_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedCanvasDescriptor {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    width: Option<String>,
+    #[serde(default)]
+    height: Option<String>,
+    #[serde(default)]
+    has_width: bool,
+    #[serde(default)]
+    has_height: bool,
+    #[serde(default)]
+    fallback_text: String,
+    #[serde(default)]
+    fallback_word_count: usize,
+    #[serde(default)]
+    part: Vec<String>,
+    #[serde(default)]
+    data_attribute_names: Vec<String>,
+    #[serde(default)]
+    event_handlers: Vec<String>,
+    #[serde(default)]
+    pointer_handlers: Vec<String>,
+    #[serde(default)]
+    keyboard_handlers: Vec<String>,
+    #[serde(default)]
+    lifecycle_handlers: Vec<String>,
+    #[serde(default)]
+    canvas_blocked: bool,
+    #[serde(default)]
+    canvas_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4190,6 +4228,7 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         let tracks_template_descriptors = case.expected.template_descriptors.is_some();
         let tracks_slot_descriptors = case.expected.slot_descriptors.is_some();
         let tracks_custom_element_descriptors = case.expected.custom_element_descriptors.is_some();
+        let tracks_canvas_descriptors = case.expected.canvas_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
@@ -4205,6 +4244,9 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_custom_element_descriptors {
             expected.custom_element_descriptors = actual.custom_element_descriptors.clone();
+        }
+        if !tracks_canvas_descriptors {
+            expected.canvas_descriptors = actual.canvas_descriptors.clone();
         }
 
         assert_eq!(
@@ -6648,6 +6690,78 @@ fn browser_custom_element_descriptors_track_invalid_definition_hints() {
 }
 
 #[test]
+fn browser_canvas_descriptors_track_dimensions_fallback_and_handlers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "component-template-page")
+        .expect("component template fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("component template fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.canvas_descriptors,
+        case.expected.into_browser_document().canvas_descriptors,
+        "canvas descriptors should preserve dimensions, fallback text, part/data context, and handlers",
+    );
+}
+
+#[test]
+fn browser_canvas_descriptors_track_missing_size_and_fallback_blockers() {
+    let actual = parse_browser_document(
+        r#"<body>
+            <canvas id=paint class="surface primary" width=640 data-renderer=webgl part=viewport
+                onpointerdown=startPaint() onkeydown=hotkey() onload=ready()>Fallback drawing</canvas>
+            <canvas id=empty></canvas>
+        </body>"#,
+    )
+    .expect("canvas descriptor fixture should parse");
+
+    let paint = actual
+        .canvas_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("paint"))
+        .expect("paint canvas descriptor should be present");
+
+    assert_eq!(paint.classes, vec!["surface", "primary"]);
+    assert_eq!(paint.width.as_deref(), Some("640"));
+    assert_eq!(paint.height, None);
+    assert!(paint.has_width);
+    assert!(!paint.has_height);
+    assert_eq!(paint.fallback_text, "Fallback drawing");
+    assert_eq!(paint.fallback_word_count, 2);
+    assert_eq!(paint.part, vec!["viewport"]);
+    assert_eq!(paint.data_attribute_names, vec!["data-renderer"]);
+    assert_eq!(
+        paint.event_handlers,
+        vec!["onpointerdown", "onkeydown", "onload"]
+    );
+    assert_eq!(paint.pointer_handlers, vec!["onpointerdown"]);
+    assert_eq!(paint.keyboard_handlers, vec!["onkeydown"]);
+    assert_eq!(paint.lifecycle_handlers, vec!["onload"]);
+    assert!(paint.canvas_blocked);
+    assert_eq!(paint.canvas_block_reasons, vec!["missing-height"]);
+
+    let empty = actual
+        .canvas_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("empty"))
+        .expect("empty canvas descriptor should be present");
+
+    assert!(!empty.has_width);
+    assert!(!empty.has_height);
+    assert!(empty.fallback_text.is_empty());
+    assert!(empty.canvas_blocked);
+    assert_eq!(
+        empty.canvas_block_reasons,
+        vec!["missing-width", "missing-height", "missing-fallback-text"]
+    );
+}
+
+#[test]
 fn browser_data_attribute_descriptor_metadata_tracks_custom_and_standard_elements() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -7231,6 +7345,15 @@ impl ExpectedBrowserDocument {
                     &event_handler_descriptors,
                 )
             });
+        let canvas_descriptors = self
+            .canvas_descriptors
+            .map(|descriptors| {
+                descriptors
+                    .into_iter()
+                    .map(ExpectedCanvasDescriptor::into_browser_canvas_descriptor)
+                    .collect()
+            })
+            .unwrap_or_default();
 
         BrowserDocument {
             title: self.title,
@@ -7397,6 +7520,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedCustomElementDescriptor::into_browser_custom_element_descriptor)
                 .collect(),
+            canvas_descriptors,
             component_hydration_targets: self
                 .component_hydration_targets
                 .into_iter()
@@ -7654,6 +7778,29 @@ impl ExpectedCustomElementDescriptor {
             text: self.text,
             custom_element_blocked: self.custom_element_blocked,
             custom_element_block_reasons: self.custom_element_block_reasons,
+        }
+    }
+}
+
+impl ExpectedCanvasDescriptor {
+    fn into_browser_canvas_descriptor(self) -> BrowserCanvasDescriptor {
+        BrowserCanvasDescriptor {
+            id: self.id,
+            classes: self.classes,
+            width: self.width,
+            height: self.height,
+            has_width: self.has_width,
+            has_height: self.has_height,
+            fallback_text: self.fallback_text,
+            fallback_word_count: self.fallback_word_count,
+            part: self.part,
+            data_attribute_names: self.data_attribute_names,
+            event_handlers: self.event_handlers,
+            pointer_handlers: self.pointer_handlers,
+            keyboard_handlers: self.keyboard_handlers,
+            lifecycle_handlers: self.lifecycle_handlers,
+            canvas_blocked: self.canvas_blocked,
+            canvas_block_reasons: self.canvas_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -2359,6 +2359,9 @@
           { "element": "product-card", "id": "card", "custom_element_kind": "autonomous-custom-element", "definition_name": "product-card", "custom_element_name": "product-card", "autonomous_custom_element": true, "custom_element_name_valid": true, "part": ["host"], "exportparts": "header:title, chart", "data_attribute_names": ["data-controller", "data-state"], "text": "Widget Chart fallback Save Fallback footer" },
           { "element": "button", "custom_element_kind": "customized-built-in", "definition_name": "fancy-button", "custom_element_is": "fancy-button", "customized_builtin": true, "extends_element": "button", "custom_element_name_valid": true, "part": ["action"], "data_attribute_names": ["data-action"], "text": "Save" }
         ],
+        "canvas_descriptors": [
+          { "id": "chart", "width": "300", "height": "150", "has_width": true, "has_height": true, "fallback_text": "Chart fallback", "fallback_word_count": 2, "part": ["chart"], "data_attribute_names": ["data-renderer"] }
+        ],
         "component_hydration_targets": [
           { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "text": "Untitled Body" },
           { "element": "article", "part": ["frame"], "text": "Untitled Body" },


### PR DESCRIPTION
## Summary
- add canvas descriptors for dimensions, fallback text, part/data context, and inline handlers
- surface blocker reasons for missing canvas dimensions and fallback content
- add fixture-backed and inline tests for canvas readiness descriptors

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_canvas_descriptors
- cargo test -p coding-adventures-html-parser browser_
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser