### PR TITLE
fix(closurec): CLOC12.106 — close gap-072 (await operand paren elision + always-space)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.110.0] - 2026-06-12
+
+### Fixed
+- **CLOSES gap-072** — an `await` operator's grouping parens are now
+  elided, and the operator is always emitted with a separating space:
+
+      async function f(){await(x)}     -> async function f(){await x};
+      async function f(){await(a.b)}   -> async function f(){await a.b};
+      async function f(){a=await(b)}   -> async function f(){a=await b};
+      async function f(){await(-b)}    -> async function f(){await -b};
+      async function f(){await(a+b)}   -> async function f(){await (a+b)};
+
+  `await` binds at UNARY precedence — exactly like `typeof`/`void`/
+  `delete` — so it was added to gap-101's `is_safe_unary_kw_operand`
+  keyword block (NOT the gap-056 return/throw block, which is for the
+  looser-binding `yield`). A safe operand (identifier / literal /
+  member-chain / call / leading unary) drops its parens; a parenthesised
+  BINARY operand keeps them (`await` binds tighter than the binary op).
+  Two extra concerns are handled:
+  1. **Always-space.** Upstream emits the `await` operator with a space
+     before its operand even when the operand is non-word-like
+     (`await -b`, `await (a+b)`), to keep it distinct from `await(...)`
+     call syntax. A new `await_operator_needs_space` emit predicate
+     forces that space.
+  2. **Contextual-keyword safety.** `await` can be a function/method
+     NAME or a property. `function await(x){}` / `{await(x){}}` (the
+     matched `)` is followed by `{`) and `o.await(x)` (preceded by
+     `.`/`?.`) are guarded out of BOTH the paren-drop and the space, so
+     they are emitted unchanged. (`await` as a plain value is a parse
+     error in the upstream compiler, so it never appears in a
+     byte-identity input — only the operator form needs handling.)
+
+  Verified byte-identical against the upstream Closure JAR (v20240317)
+  across identifier / member / call / unary / binary / comma operands
+  plus the name and property guards. +3 `gap072_*` unit tests; the
+  `minify_await_paren_elide` and `minify_await_binary_kept` fixtures are
+  un-ignored and enforced. Known residual: a deeply-nested
+  `await(await(x))` keeps the inner parens (the keyword block does not
+  recurse into a dropped span — a pre-existing pattern shared with the
+  other keywords; still valid JS, just not byte-identical).
+
 ## [0.109.0] - 2026-06-12
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.109.0"
+version = "0.110.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -698,7 +698,7 @@ pub fn whitespace_only_minify(
             let is_unary_kw = is_word_like(kept[i])
                 && matches!(
                     kept[i].value.as_str(),
-                    "void" | "typeof" | "delete" | "instanceof"
+                    "void" | "typeof" | "delete" | "instanceof" | "await"
                 );
             // Property guard: skip `o.delete(`, `o?.typeof(`, …
             let is_property = i >= 1
@@ -737,15 +737,33 @@ pub fn whitespace_only_minify(
                 }
                 if let Some(close) = close {
                     let span = &kept[open + 1..close];
-                    // gap-054/070 + gap-101: the operand is "safe" if it
-                    // is a single token, a member-reference chain
-                    // (gap-054/070), a leading SYMBOL/KEYWORD unary chain,
-                    // or a call/member chain (gap-101). All bind tighter
-                    // than (or, for `instanceof`, are re-associated the
-                    // same by) the operator, so the grouping parens are
-                    // redundant. A parenthesised binary operand is still
-                    // rejected and keeps its parens.
-                    if is_safe_unary_kw_operand(span) {
+                    // gap-072 DEFINITION-NAME guard: `await` (and `yield`)
+                    // are CONTEXTUAL keywords — they can also be a
+                    // function/method NAME. `function await(x){…}` and
+                    // `{await(x){…}}` have their `)` immediately followed
+                    // by the body `{`; the operator form `await(x)` never
+                    // does (an `await` expression's `)` is followed by a
+                    // statement terminator / operator). So if the matched
+                    // `)` is directly followed by `{`, this `(` is a
+                    // parameter list, not a grouping paren — skip it.
+                    // (The other keywords `typeof`/`void`/`delete`/
+                    // `instanceof` are fully reserved and can never be a
+                    // name, so this guard is a no-op for them.)
+                    let is_definition_name = kept
+                        .get(close + 1)
+                        .map(|t| is_structural_punct(t, "{"))
+                        .unwrap_or(false);
+                    // gap-054/070 + gap-101 + gap-072: the operand is
+                    // "safe" if it is a single token, a member-reference
+                    // chain (gap-054/070), a leading SYMBOL/KEYWORD unary
+                    // chain, or a call/member chain (gap-101). All bind
+                    // tighter than (or, for `instanceof`, are
+                    // re-associated the same by) the operator, so the
+                    // grouping parens are redundant. A parenthesised
+                    // binary operand is still rejected and keeps its
+                    // parens. gap-072 adds `await`, which binds at unary
+                    // precedence like `typeof`/`void`/`delete`.
+                    if !is_definition_name && is_safe_unary_kw_operand(span) {
                         drops.push(open);
                         drops.push(close);
                         i = close + 1;
@@ -3066,6 +3084,7 @@ pub fn whitespace_only_minify(
                 || new_paren_needs_space(&kept, idx)
                 || get_set_computed_needs_space(&kept, idx)
                 || async_gen_method_needs_space(&kept, idx)
+                || await_operator_needs_space(&kept, idx)
             {
                 out.push(' ');
             }
@@ -4178,6 +4197,78 @@ fn async_gen_method_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bo
             .is_some_and(|t| is_structural_punct(t, "{")),
         None => false,
     }
+}
+
+/// gap-072: the `await` UNARY OPERATOR is always emitted with a
+/// separating space before its operand — `await x`, `await -b`,
+/// `await (a+b)` — to keep it visually distinct from the `await(...)`
+/// call syntax (upstream Closure always spaces it). The default
+/// `needs_separator` already spaces a *word-like* operand (`await x`),
+/// but NOT a non-word-like one (`await-b`, `await(a+b)`), so this
+/// predicate forces the space for the remaining cases.
+///
+/// Returns true iff the token BEFORE `idx` is the genuine `await`
+/// OPERATOR (so a space must precede `kept[idx]`, its operand). Guards
+/// keep it from spacing the contextual-keyword's NON-operator uses:
+///   - PROPERTY: `o.await(x)` — `await` preceded by `.`/`?.` is a
+///     method access, emitted without a space.
+///   - FUNCTION NAME: `function await(x){}` — preceded by `function`.
+///   - METHOD NAME: `{await(x){}}` — when `kept[idx]` is `(` whose
+///     matching `)` is immediately followed by `{`, the `(` is a
+///     parameter list, not an operand.
+/// (`await` as a plain value/identifier — `await(x)` at top level — is
+/// a PARSE ERROR in the upstream compiler, so it never appears in a
+/// byte-identity input; only the operator form needs handling.)
+fn await_operator_needs_space(kept: &[&lexer::token::Token], idx: usize) -> bool {
+    if idx == 0 {
+        return false;
+    }
+    let prev = kept[idx - 1];
+    if !is_word_like(prev) || prev.value != "await" {
+        return false;
+    }
+    // PROPERTY guard.
+    if idx >= 2
+        && (is_structural_punct(kept[idx - 2], ".")
+            || is_structural_punct(kept[idx - 2], "?."))
+    {
+        return false;
+    }
+    // FUNCTION-NAME guard.
+    if idx >= 2 && is_word_like(kept[idx - 2]) && kept[idx - 2].value == "function" {
+        return false;
+    }
+    // METHOD-NAME guard: `kept[idx]` is a `(` whose matching `)` is
+    // immediately followed by `{` (a parameter list + body).
+    if is_structural_punct(kept[idx], "(") {
+        let mut depth: i32 = 1;
+        let mut j = idx + 1;
+        while j < kept.len() {
+            let t = kept[j];
+            if is_structural_punct(t, "(")
+                || is_structural_punct(t, "[")
+                || is_structural_punct(t, "{")
+            {
+                depth += 1;
+            } else if is_structural_punct(t, ")") {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            } else if is_structural_punct(t, "]") || is_structural_punct(t, "}") {
+                depth -= 1;
+            }
+            j += 1;
+        }
+        if kept
+            .get(j + 1)
+            .map(|t| is_structural_punct(t, "{"))
+            .unwrap_or(false)
+        {
+            return false;
+        }
+    }
+    true
 }
 
 /// gap-054 + gap-070: True iff `span` (the tokens BETWEEN a unary
@@ -6433,6 +6524,70 @@ mod tests {
     fn gap102_property_yield_not_elided() {
         assert_eq!(minify("o.yield(a);"), "o.yield(a);");
         assert_eq!(minify("a=b.yield(c);"), "a=b.yield(c);");
+    }
+
+    // ---- gap-072: await operand paren elision + always-space -----
+
+    /// gap-072: an `await` operator's parenthesised SAFE operand drops
+    /// its parens (`await(x)` → `await x`), like the other unary
+    /// keywords. `await` binds at unary precedence.
+    #[test]
+    fn gap072_await_operand_elided() {
+        assert_eq!(
+            minify("async function f(){await(x)}"),
+            "async function f(){await x};"
+        );
+        assert_eq!(
+            minify("async function f(){await(a.b)}"),
+            "async function f(){await a.b};"
+        );
+        assert_eq!(
+            minify("async function f(){a=await(b)}"),
+            "async function f(){a=await b};"
+        );
+        assert_eq!(
+            minify("async function f(){await(a())}"),
+            "async function f(){await a()};"
+        );
+    }
+
+    /// gap-072: the `await` operator is ALWAYS emitted with a
+    /// separating space before its operand — even a non-word-like one —
+    /// to stay distinct from `await(...)` call syntax. A parenthesised
+    /// BINARY operand keeps its parens (await binds tighter than the
+    /// binary op) but still gains the space.
+    #[test]
+    fn gap072_await_always_spaced() {
+        assert_eq!(
+            minify("async function f(){await(-b)}"),
+            "async function f(){await -b};"
+        );
+        assert_eq!(
+            minify("async function f(){await(a+b)}"),
+            "async function f(){await (a+b)};"
+        );
+        assert_eq!(
+            minify("async function f(){await(a,b)}"),
+            "async function f(){await (a,b)};"
+        );
+        assert_eq!(
+            minify("async function f(){await-b}"),
+            "async function f(){await -b};"
+        );
+    }
+
+    /// gap-072 SAFETY: `await` is a CONTEXTUAL keyword — as a function /
+    /// method NAME or a property it must NOT be treated as the operator
+    /// (no paren-drop, no forced space).
+    #[test]
+    fn gap072_await_name_and_property_untouched() {
+        assert_eq!(
+            minify("function await(x){return x}"),
+            "function await(x){return x};"
+        );
+        assert_eq!(minify("x={await(x){}};"), "x={await(x){}};");
+        assert_eq!(minify("a.await(x);"), "a.await(x);");
+        assert_eq!(minify("o.await(a+b);"), "o.await(a+b);");
     }
 
     // ---- gap-078: binary symbol-operator right-operand elision --

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.109.0
+Version: 0.110.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -160,19 +160,17 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // a backtick-delimited string). Lexer-level gap.
     ("template_subst", "gap-044: lexer does not support `${...}`"),
     ("tagged_subst",   "gap-044: lexer does not support `${...}` (tagged variant)"),
-    // gap-072 (CLOC14.35): `await` OPERAND paren elision — strip
-    // redundant parens around a simple-reference operand
-    // (`await(x)` → `await x`). `await` binds at UNARY precedence,
-    // exactly like `typeof`/`void`/`delete` (gap-101's
-    // `is_safe_unary_kw_operand`), so it is now tractable by adding
-    // `await` to that keyword block (NOT the gap-056 return/throw
-    // block — `await` binds TIGHTER than binary operators, so a binary
-    // operand keeps its parens). CLOC14.46 detail: a kept binary
-    // operand is emitted WITH a separating space — `await(a+b)` →
-    // `await (a+b)` — so the fix must add that space, not just keep the
-    // parens. `minify_await_binary_kept` pins that case.
-    ("await_paren_elide",  "gap-072: await operand paren elision"),
-    ("await_binary_kept",  "gap-072: await binary operand keeps parens with a space"),
+    // gap-072 RESOLVED in CLOC12.106 — `await` OPERAND paren elision
+    // (`await(x)` → `await x`) plus the always-separating-space rule
+    // (`await(a+b)` → `await (a+b)`). `await` binds at UNARY precedence,
+    // so it was added to gap-101's `is_safe_unary_kw_operand` keyword
+    // block; a parenthesised binary operand keeps its parens (await
+    // binds tighter) but gains the space via `await_operator_needs_space`.
+    // Contextual-keyword guards keep `function await(x){}` /
+    // `{await(x){}}` (name) and `o.await(x)` (property) untouched. The
+    // upstream compiler rejects non-async `await` as a parse error, so
+    // identifier-`await` never appears in a byte-identity input.
+    // `minify_await_paren_elide` / `minify_await_binary_kept` enforced.
     // gap-102 RESOLVED in CLOC12.105 — a `yield` operand's grouping
     // parens (`yield(a)` → `yield a`, `yield(a+b)` → `yield a+b`,
     // `a=yield(b)` → `a=yield b`) now elide via the gap-055/056

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -557,9 +557,10 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-072 — await operand paren elision
 
-- **Status:** OPEN — discovered by CLOC14.35. `minify_await_paren_elide` ignored.
+- **Status:** RESOLVED in CLOC12.106. `minify_await_paren_elide` / `minify_await_binary_kept` enforced.
 - **Input:** `await(x)` → `await x`.
 - **What it needs:** Same simple-reference operand paren elision as gap-070/071, but for the `await` unary operator. Deferred: `await` is async-context-only, so a naive keyword-anchored elision could mis-handle a non-async `await` used as a plain identifier (`await` is only reserved inside async functions/modules). Needs an async-context guard before it can be added to the keyword set safely.
+- **CLOC12.106 resolution:** The original async-context worry dissolved once verified against the JAR: the upstream compiler **rejects** any non-async `await` as a PARSE ERROR ("await must be inside asynchronous function"), so identifier-`await` never appears in a byte-identity input — every accepted input has `await` as the operator. `await` binds at UNARY precedence (like `typeof`/`void`/`delete`), so it was added to gap-101's `is_safe_unary_kw_operand` keyword block (NOT the gap-056 `yield` block, which is for the looser-binding `yield`). A safe operand drops its parens; a parenthesised BINARY operand keeps them (`await` binds tighter than the binary op). Two extra concerns: (1) **always-space** — upstream emits the operator with a separating space before its operand even when non-word-like (`await -b`, `await (a+b)`), handled by a new `await_operator_needs_space` emit predicate; (2) **contextual-keyword guards** — `await` as a function/method NAME (`function await(x){}`, `{await(x){}}` — matched `)` followed by `{`) or a property (`o.await(x)`) is excluded from both the drop and the space. JAR-verified across all operand kinds + the name/property guards; +3 `gap072_*` unit tests. Known residual: deeply-nested `await(await(x))` keeps the inner parens (the keyword block does not recurse into a dropped span — a pre-existing pattern shared with the other keywords).
 
 ### gap-073 — `get`/`set` before a computed key needs a space
 


### PR DESCRIPTION
## CLOC12.106 — close gap-072

An `await` operator's grouping parens are now elided, and the operator is always emitted with a separating space, matching the upstream Closure JAR (v20240317, WHITESPACE_ONLY):

| input | upstream / closurec |
|---|---|
| `async function f(){await(x)}` | `async function f(){await x};` |
| `async function f(){a=await(b)}` | `async function f(){a=await b};` |
| `async function f(){await(-b)}` | `async function f(){await -b};` |
| `async function f(){await(a+b)}` | `async function f(){await (a+b)};` |

`await` binds at **unary precedence** — like `typeof`/`void`/`delete` — so it was added to gap-101's `is_safe_unary_kw_operand` keyword block (NOT the gap-056 `yield` block). A safe operand drops its parens; a parenthesised **binary** operand keeps them (await binds tighter).

### Two extra concerns
1. **Always-space.** Upstream emits the operator with a space before its operand even when non-word-like (`await -b`, `await (a+b)`), to stay distinct from `await(...)` call syntax. New `await_operator_needs_space` emit predicate.
2. **Contextual-keyword safety.** `await` as a function/method **name** (`function await(x){}`, `{await(x){}}` — matched `)` followed by `{`) or a **property** (`o.await(x)`) is guarded out of both the drop and the space.

### Why the original deferral dissolved
The async-context worry is moot: the upstream compiler **rejects** any non-async `await` as a parse error, so identifier-`await` never appears in a byte-identity input — every accepted input has `await` as the operator.

### Verification
- Byte-identical vs the JAR across identifier / member / call / unary / binary / comma operands + name/property guards.
- +3 `gap072_*` unit tests; `minify_await_paren_elide` + `minify_await_binary_kept` un-ignored and enforced. Full suite green (567).
- Spec gap-072 marked **RESOLVED**. Version `0.109.0` → `0.110.0`.

**Known residual:** deeply-nested `await(await(x))` keeps the inner parens (the keyword block doesn't recurse into a dropped span — pre-existing pattern shared with the other keywords; still valid JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)