### PR TITLE
Add smart-home activation deployment tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -115,6 +115,9 @@ All notable changes to this package will be documented in this file.
 - Added D18D handlers for D23A activation delivery manifests:
   `smart_home.list_integration_activation_delivery` and
   `smart_home.get_integration_activation_delivery_summary`.
+- Added D18D handlers for D23A activation deployment records:
+  `smart_home.list_integration_activation_deployment` and
+  `smart_home.get_integration_activation_deployment_summary`.
 - Added D18D handlers for D23A activation risk planning:
   `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary`.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -73,6 +73,7 @@ Chief of Staff job/session/agent
   -> activation-closure list and summary reads for verification/close gates
   -> activation-release list and summary reads for go/no-go release packets
   -> activation-delivery list and summary reads for delivery-channel manifests
+  -> activation-deployment list and summary reads for deployment-ring records
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, desired-state, and pairing-session inventory reads
@@ -170,6 +171,8 @@ Chief of Staff job/session/agent
 - `smart_home.get_integration_activation_release_summary`
 - `smart_home.list_integration_activation_delivery`
 - `smart_home.get_integration_activation_delivery_summary`
+- `smart_home.list_integration_activation_deployment`
+- `smart_home.get_integration_activation_deployment_summary`
 - `smart_home.list_integration_activation_risk`
 - `smart_home.get_integration_activation_risk_summary`
 - `smart_home.list_integration_activation_dependencies`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -41,8 +41,9 @@ use smart_home_integration_catalog::{
     activation_constraints_from_candidates, activation_control_room_panels_from_operator_tasks,
     activation_dashboard_cards_from_readouts, activation_decisions_from_candidates,
     activation_delivery_manifests_from_release_packets, activation_dependency_graph_from_reports,
-    activation_dossiers_from_candidates, activation_escalation_cases_from_rollups,
-    activation_evidence_from_candidates, activation_execution_packets_from_handoff_packages,
+    activation_deployment_records_from_delivery_manifests, activation_dossiers_from_candidates,
+    activation_escalation_cases_from_rollups, activation_evidence_from_candidates,
+    activation_execution_packets_from_handoff_packages,
     activation_forecasts_from_timeline_milestones,
     activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
     activation_maintenance_from_candidates, activation_operator_tasks_from_playbook_steps,
@@ -83,6 +84,8 @@ use smart_home_integration_catalog::{
     IntegrationActivationDeliveryStatus, IntegrationActivationDeliverySummary,
     IntegrationActivationDependencyEdge, IntegrationActivationDependencyGraph,
     IntegrationActivationDependencyNode, IntegrationActivationDependencySummary,
+    IntegrationActivationDeploymentRecord, IntegrationActivationDeploymentRing,
+    IntegrationActivationDeploymentStatus, IntegrationActivationDeploymentSummary,
     IntegrationActivationDossierItem, IntegrationActivationDossierSummary,
     IntegrationActivationEscalationCase, IntegrationActivationEscalationCaseKind,
     IntegrationActivationEscalationSummary, IntegrationActivationEvidenceItem,
@@ -359,6 +362,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DELIVERY_TOOL_ID: &str =
     "smart_home.list_integration_activation_delivery";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_delivery_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID: &str =
+    "smart_home.list_integration_activation_deployment";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_deployment_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -817,6 +824,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID => {
                     let query = integration_activation_delivery_query(&arguments)?;
                     Ok(get_integration_activation_delivery_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID => {
+                    let query = integration_activation_deployment_query(&arguments)?;
+                    Ok(list_integration_activation_deployment_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_deployment_query(&arguments)?;
+                    Ok(get_integration_activation_deployment_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2655,6 +2670,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation delivery summary",
             "Return compact D23A activation delivery-manifest counts by delivery status, delivery channel, owner lane, blockers, verification requirements, delivery readiness, policy, and dependency work.",
             integration_activation_delivery_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID,
+            "List smart-home integration activation deployment",
+            "List Chief-facing D23A activation deployment records derived from delivery manifests with deployment status, deployment ring, owner lanes, blockers, verification requirements, and deployment readiness.",
+            integration_activation_deployment_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_deployment", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_deployment",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation deployment summary",
+            "Return compact D23A activation deployment-record counts by deployment status, deployment ring, owner lane, blockers, verification requirements, deployment readiness, policy, and dependency work.",
+            integration_activation_deployment_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5545,6 +5594,19 @@ struct IntegrationActivationDeliveryQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationDeploymentQuery {
+    delivery: IntegrationActivationDeliveryQuery,
+    deployment_status: Option<IntegrationActivationDeploymentStatus>,
+    deployment_ring: Option<IntegrationActivationDeploymentRing>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    needs_verification: Option<bool>,
+    deployment_ready: Option<bool>,
+    deployment_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6303,6 +6365,36 @@ fn integration_activation_delivery_query(
             .or(optional_bool(arguments, "needs_verification")?),
         delivery_ready: optional_bool(arguments, "delivery_ready")?,
         delivery_limit: optional_u64(arguments, "delivery_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_deployment_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationDeploymentQuery, ToolCallError> {
+    let deployment_status = optional_string(arguments, "deployment_status")?
+        .or(optional_string(arguments, "deployment_state")?)
+        .map(|label| parse_activation_deployment_status(&label))
+        .transpose()?;
+    let deployment_ring = optional_string(arguments, "deployment_ring")?
+        .or(optional_string(arguments, "deployment_lane")?)
+        .map(|label| parse_activation_deployment_ring(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "deployment_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationDeploymentQuery {
+        delivery: integration_activation_delivery_query(arguments)?,
+        deployment_status,
+        deployment_ring,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "deployment_requires_attention")?,
+        blocked: optional_bool(arguments, "deployment_blocked")?,
+        needs_verification: optional_bool(arguments, "deployment_needs_verification")?
+            .or(optional_bool(arguments, "needs_verification")?),
+        deployment_ready: optional_bool(arguments, "deployment_ready")?,
+        deployment_limit: optional_u64(arguments, "deployment_limit")?.map(|value| value as usize),
     })
 }
 
@@ -7508,6 +7600,41 @@ fn integration_activation_delivery_manifests_for_query(
     }
 
     (manifests, catalog_count)
+}
+
+fn integration_activation_deployment_records_for_query(
+    query: &IntegrationActivationDeploymentQuery,
+) -> (Vec<IntegrationActivationDeploymentRecord>, usize) {
+    let (manifests, catalog_count) =
+        integration_activation_delivery_manifests_for_query(&query.delivery);
+    let mut records = activation_deployment_records_from_delivery_manifests(&manifests);
+
+    if let Some(deployment_status) = query.deployment_status {
+        records.retain(|record| record.deployment_status == deployment_status);
+    }
+    if let Some(deployment_ring) = query.deployment_ring {
+        records.retain(|record| record.deployment_ring == deployment_ring);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        records.retain(|record| record.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.deployment_blocked() == blocked);
+    }
+    if let Some(needs_verification) = query.needs_verification {
+        records.retain(|record| record.needs_verification() == needs_verification);
+    }
+    if let Some(deployment_ready) = query.deployment_ready {
+        records.retain(|record| record.deployment_ready() == deployment_ready);
+    }
+    if let Some(limit) = query.deployment_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -10471,6 +10598,97 @@ fn get_integration_activation_delivery_summary_output_handler_output(
             (
                 "ready_to_deliver_manifests",
                 integer(summary.ready_to_deliver_manifests as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_deployment_output_handler_output(
+    query: IntegrationActivationDeploymentQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_deployment_records_for_query(&query);
+    let summary = IntegrationActivationDeploymentSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_deployment",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_deployment_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_deployment_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_deployment"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "awaiting_verification_records",
+                integer(summary.awaiting_verification_records as i64),
+            ),
+            (
+                "ready_to_deploy_records",
+                integer(summary.ready_to_deploy_records as i64),
+            ),
+            (
+                "next_deployment_status",
+                summary
+                    .next_deployment_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_deployment_summary_output_handler_output(
+    query: IntegrationActivationDeploymentQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_deployment_records_for_query(&query);
+    let summary = IntegrationActivationDeploymentSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_deployment_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_deployment_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "records_requiring_attention",
+                integer(summary.records_requiring_attention as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            (
+                "awaiting_verification_records",
+                integer(summary.awaiting_verification_records as i64),
+            ),
+            (
+                "ready_to_deploy_records",
+                integer(summary.ready_to_deploy_records as i64),
             ),
         ]),
     )
@@ -20759,6 +20977,275 @@ fn integration_activation_delivery_summary_json(
     ])
 }
 
+fn activation_deployment_record_json(record: &IntegrationActivationDeploymentRecord) -> JsonValue {
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        (
+            "deployment_status",
+            string(record.deployment_status.as_str()),
+        ),
+        ("deployment_ring", string(record.deployment_ring.as_str())),
+        ("delivery_channel", string(record.delivery_channel.as_str())),
+        ("owner_lane", string(record.owner_lane.as_str())),
+        (
+            "source_delivery_sequence",
+            integer(record.source_delivery_sequence as i64),
+        ),
+        (
+            "source_delivery_status",
+            string(record.source_delivery_status.as_str()),
+        ),
+        (
+            "source_release_status",
+            string(record.source_release_status.as_str()),
+        ),
+        (
+            "source_closure_status",
+            string(record.source_closure_status.as_str()),
+        ),
+        (
+            "source_remediation_kind",
+            string(record.source_remediation_kind.as_str()),
+        ),
+        (
+            "source_remediation_status",
+            string(record.source_remediation_status.as_str()),
+        ),
+        ("source_id", string(&record.source_id)),
+        ("title", string(&record.title)),
+        ("summary", string(&record.summary)),
+        ("priority", integer(record.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                record
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(record.integration_count() as i64),
+        ),
+        ("recommended_view", string(record.recommended_view.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(record.required_tier)),
+        ),
+        (
+            "policy_surface",
+            record
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(record.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(record.has_policy_risk())),
+        (
+            "needs_verification",
+            JsonValue::Bool(record.needs_verification()),
+        ),
+        ("delivery_ready", JsonValue::Bool(record.delivery_ready())),
+        (
+            "deployment_blocked",
+            JsonValue::Bool(record.deployment_blocked()),
+        ),
+        (
+            "deployment_ready",
+            JsonValue::Bool(record.deployment_ready()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_deployment_summary_json(
+    summary: &IntegrationActivationDeploymentSummary,
+) -> JsonValue {
+    object([
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        (
+            "awaiting_verification_records",
+            integer(summary.awaiting_verification_records as i64),
+        ),
+        (
+            "awaiting_owner_records",
+            integer(summary.awaiting_owner_records as i64),
+        ),
+        (
+            "ready_to_deploy_records",
+            integer(summary.ready_to_deploy_records as i64),
+        ),
+        (
+            "monitoring_records",
+            integer(summary.monitoring_records as i64),
+        ),
+        (
+            "platform_ring_records",
+            integer(summary.platform_ring_records as i64),
+        ),
+        (
+            "integration_ring_records",
+            integer(summary.integration_ring_records as i64),
+        ),
+        (
+            "security_ring_records",
+            integer(summary.security_ring_records as i64),
+        ),
+        (
+            "verification_ring_records",
+            integer(summary.verification_ring_records as i64),
+        ),
+        (
+            "audit_ring_records",
+            integer(summary.audit_ring_records as i64),
+        ),
+        (
+            "monitoring_ring_records",
+            integer(summary.monitoring_ring_records as i64),
+        ),
+        (
+            "platform_owner_records",
+            integer(summary.platform_owner_records as i64),
+        ),
+        (
+            "integration_owner_records",
+            integer(summary.integration_owner_records as i64),
+        ),
+        (
+            "security_owner_records",
+            integer(summary.security_owner_records as i64),
+        ),
+        (
+            "reviewer_owner_records",
+            integer(summary.reviewer_owner_records as i64),
+        ),
+        (
+            "verification_owner_records",
+            integer(summary.verification_owner_records as i64),
+        ),
+        (
+            "audit_owner_records",
+            integer(summary.audit_owner_records as i64),
+        ),
+        (
+            "records_with_dependency_work",
+            integer(summary.records_with_dependency_work as i64),
+        ),
+        (
+            "records_with_policy_risk",
+            integer(summary.records_with_policy_risk as i64),
+        ),
+        (
+            "records_requiring_verification",
+            integer(summary.records_requiring_verification as i64),
+        ),
+        (
+            "records_ready_to_deploy",
+            integer(summary.records_ready_to_deploy as i64),
+        ),
+        (
+            "records_with_policy_surface",
+            integer(summary.records_with_policy_surface as i64),
+        ),
+        (
+            "next_deployment_status",
+            summary
+                .next_deployment_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_deployment_ring",
+            summary
+                .next_deployment_ring
+                .map(|ring| string(ring.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_delivery_status",
+            summary
+                .next_delivery_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_record_sequence",
+            summary
+                .next_record_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_record_priority",
+            summary
+                .next_record_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "needs_verification",
+            JsonValue::Bool(summary.needs_verification()),
+        ),
+        (
+            "deployment_ready",
+            JsonValue::Bool(summary.deployment_ready()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -23822,6 +24309,49 @@ fn parse_activation_delivery_channel(
     }
 }
 
+fn parse_activation_deployment_status(
+    label: &str,
+) -> Result<IntegrationActivationDeploymentStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" => Ok(IntegrationActivationDeploymentStatus::Blocked),
+        "awaiting_verification" | "needs_verification" | "verify" | "verification" => {
+            Ok(IntegrationActivationDeploymentStatus::AwaitingVerification)
+        }
+        "awaiting_owner" | "owner_action" | "needs_owner_action" | "action_required" => {
+            Ok(IntegrationActivationDeploymentStatus::AwaitingOwner)
+        }
+        "ready_to_deploy" | "deployment_ready" | "ready_for_deployment" | "deploy" => {
+            Ok(IntegrationActivationDeploymentStatus::ReadyToDeploy)
+        }
+        "monitoring" | "monitor" | "tracking" => {
+            Ok(IntegrationActivationDeploymentStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation deployment status `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_deployment_ring(
+    label: &str,
+) -> Result<IntegrationActivationDeploymentRing, ToolCallError> {
+    match label {
+        "platform" | "platform_release" => Ok(IntegrationActivationDeploymentRing::Platform),
+        "integration" | "integration_owner" => Ok(IntegrationActivationDeploymentRing::Integration),
+        "security" | "security_review" => Ok(IntegrationActivationDeploymentRing::Security),
+        "verification" | "review" | "reviewer" => {
+            Ok(IntegrationActivationDeploymentRing::Verification)
+        }
+        "audit" | "audit_trail" => Ok(IntegrationActivationDeploymentRing::Audit),
+        "monitoring" | "monitor" | "tracking" => {
+            Ok(IntegrationActivationDeploymentRing::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation deployment ring `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -25511,6 +26041,40 @@ fn integration_activation_delivery_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_deployment_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_delivery_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("deployment_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("deployment_state", JsonSchema::String));
+        properties.push(SchemaProperty::new("deployment_ring", JsonSchema::String));
+        properties.push(SchemaProperty::new("deployment_lane", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "deployment_owner_lane",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new(
+            "deployment_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "deployment_blocked",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "deployment_needs_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("deployment_ready", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("deployment_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -25655,7 +26219,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 129);
+        assert_eq!(definitions.len(), 131);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -26014,9 +26578,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            121
+            123
         );
         assert_eq!(
             export
@@ -26081,6 +26651,14 @@ mod tests {
         .is_some());
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_DELIVERY_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_LIST_DISCOVERY_WORKERS_TOOL_ID).is_some());
@@ -26534,11 +27112,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(129))
+            Some(&integer(131))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(121))
+            Some(&integer(123))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -31393,6 +31971,161 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_deployment_request = request(
+            "call-list-integration-activation-deployment",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("deployment_status", string("blocked")),
+                ("deployment_requires_attention", JsonValue::Bool(true)),
+                ("deployment_blocked", JsonValue::Bool(true)),
+                ("deployment_limit", integer(3)),
+            ]),
+            5_055,
+        );
+        let list_activation_deployment_trace =
+            tool_runtime.invoke_with_events(&list_activation_deployment_request);
+        assert!(list_activation_deployment_trace.result.ok);
+        assert_eq!(
+            list_activation_deployment_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_deployment_output = list_activation_deployment_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_deployment_count =
+            integer_value(field(list_activation_deployment_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_deployment_count));
+        let activation_deployment_summary =
+            field(list_activation_deployment_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_deployment_summary, "total_records"),
+            Some(&integer(activation_deployment_count))
+        );
+        assert_eq!(
+            field(activation_deployment_summary, "next_deployment_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_deployment_summary, "next_deployment_ring"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_deployment_summary, "next_owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_deployment_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_deployment_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_deployment = array_item(
+            field(list_activation_deployment_output, "activation_deployment").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_deployment, "deployment_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_deployment, "deployment_ring"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_deployment, "deployment_blocked"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_deployment, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_deployment_summary_request = request(
+            "call-integration-activation-deployment-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("deployment_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_056,
+        );
+        let activation_deployment_summary_trace =
+            tool_runtime.invoke_with_events(&activation_deployment_summary_request);
+        assert!(activation_deployment_summary_trace.result.ok);
+        assert_eq!(
+            activation_deployment_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_deployment_summary_output = activation_deployment_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_deployment_rollup =
+            field(activation_deployment_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_deployment_rollup, "total_records").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_deployment_rollup, "blocked_records").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_deployment_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_deployment_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -33281,6 +34014,14 @@ mod tests {
             activation_delivery_summary_request,
             activation_delivery_summary_trace,
         );
+        journal.record_trace(
+            list_activation_deployment_request,
+            list_activation_deployment_trace,
+        );
+        journal.record_trace(
+            activation_deployment_summary_request,
+            activation_deployment_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -33354,9 +34095,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 129);
-        assert_eq!(journal_summary.completed_count, 129);
-        assert_eq!(journal.audit_records().len(), 129);
+        assert_eq!(journal_summary.invocation_count, 131);
+        assert_eq!(journal_summary.completed_count, 131);
+        assert_eq!(journal.audit_records().len(), 131);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -149,6 +149,9 @@ All notable changes to this package will be documented in this file.
 - `smart_home.list_integration_activation_delivery` and
   `smart_home.get_integration_activation_delivery_summary` tool descriptors for
   read-only activation delivery manifests derived from release packets.
+- `smart_home.list_integration_activation_deployment` and
+  `smart_home.get_integration_activation_deployment_summary` tool descriptors
+  for read-only activation deployment records derived from delivery manifests.
 - `smart_home.list_integration_activation_risk` and
   `smart_home.get_integration_activation_risk_summary` tool descriptors for
   read-only policy-tier and policy-surface activation risk planning.

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -125,6 +125,8 @@ Current scope:
   views derived from activation closure gates
 - D18D integration activation-delivery descriptors for delivery-channel
   manifests derived from activation release packets
+- D18D integration activation-deployment descriptors for deployment-ring
+  records derived from activation delivery manifests
 - D18D integration activation-risk descriptors for policy-tier and
   policy-surface rollout risk summaries
 - D18D integration activation-dependency descriptors for prerequisite node and

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1527,6 +1527,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationReleaseSummary,
     ListIntegrationActivationDelivery,
     GetIntegrationActivationDeliverySummary,
+    ListIntegrationActivationDeployment,
+    GetIntegrationActivationDeploymentSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1814,6 +1816,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationDeliverySummary => {
                 read_tool("smart_home.get_integration_activation_delivery_summary")
+            }
+            Self::ListIntegrationActivationDeployment => {
+                read_tool("smart_home.list_integration_activation_deployment")
+            }
+            Self::GetIntegrationActivationDeploymentSummary => {
+                read_tool("smart_home.get_integration_activation_deployment_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2524,6 +2532,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationReleaseSummary,
         SmartHomeTool::ListIntegrationActivationDelivery,
         SmartHomeTool::GetIntegrationActivationDeliverySummary,
+        SmartHomeTool::ListIntegrationActivationDeployment,
+        SmartHomeTool::GetIntegrationActivationDeploymentSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3366,7 +3376,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 129);
+        assert_eq!(catalog.len(), 131);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3889,6 +3899,14 @@ mod tests {
             == "smart_home.get_integration_activation_delivery_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_deployment"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_deployment_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3896,15 +3914,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 129);
-        assert_eq!(summary.read_tools, 121);
+        assert_eq!(summary.total_tools, 131);
+        assert_eq!(summary.read_tools, 123);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 121);
+        assert_eq!(summary.read_only_tier_tools, 123);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 129);
+        assert_eq!(summary.total_required_capabilities, 131);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -120,6 +120,9 @@ All notable changes to this package will be documented in this file.
 - `IntegrationActivationDeliveryManifest` and
   `IntegrationActivationDeliverySummary` for turning release packets into
   delivery-channel manifests and readiness rollups.
+- `IntegrationActivationDeploymentRecord` and
+  `IntegrationActivationDeploymentSummary` for turning delivery manifests into
+  deployment-ring records and deploy-readiness rollups.
 - `IntegrationActivationRiskItem` and `IntegrationActivationRiskSummary` for
   grouping rollout candidates by policy tier and policy surface after applying
   host-specific readiness context.

--- a/code/packages/rust/smart-home-integration-catalog/README.md
+++ b/code/packages/rust/smart-home-integration-catalog/README.md
@@ -108,6 +108,9 @@ runtime and Chief of Staff tools a typed catalog for:
   release views with blockers, verification requirements, and release readiness
 - activation delivery manifests that turn release packets into compact delivery
   views with channel, blocker, verification, and delivery-readiness rollups
+- activation deployment records that turn delivery manifests into compact
+  deployment views with ring, blocker, verification, and deploy-readiness
+  rollups
 - activation risk rows that group rollout candidates by policy tier and policy
   surface after applying host-specific readiness context
 - activation dependency graphs that expose prerequisite nodes, satisfied edges,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -1680,6 +1680,81 @@ impl IntegrationActivationDeliveryChannel {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationDeploymentStatus {
+    Blocked,
+    AwaitingVerification,
+    AwaitingOwner,
+    ReadyToDeploy,
+    Monitoring,
+}
+
+impl IntegrationActivationDeploymentStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::AwaitingVerification => "awaiting_verification",
+            Self::AwaitingOwner => "awaiting_owner",
+            Self::ReadyToDeploy => "ready_to_deploy",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_delivery_manifest(manifest: &IntegrationActivationDeliveryManifest) -> Self {
+        if manifest.delivery_blocked() {
+            if manifest.needs_verification() {
+                Self::AwaitingVerification
+            } else if manifest.delivery_status == IntegrationActivationDeliveryStatus::AwaitingOwner
+            {
+                Self::AwaitingOwner
+            } else {
+                Self::Blocked
+            }
+        } else if manifest.delivery_ready() {
+            Self::ReadyToDeploy
+        } else {
+            Self::Monitoring
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationDeploymentRing {
+    Platform,
+    Integration,
+    Security,
+    Verification,
+    Audit,
+    Monitoring,
+}
+
+impl IntegrationActivationDeploymentRing {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::Integration => "integration",
+            Self::Security => "security",
+            Self::Verification => "verification",
+            Self::Audit => "audit",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_delivery_manifest(manifest: &IntegrationActivationDeliveryManifest) -> Self {
+        if manifest.delivery_status == IntegrationActivationDeliveryStatus::Monitoring {
+            return Self::Monitoring;
+        }
+        match manifest.delivery_channel {
+            IntegrationActivationDeliveryChannel::Platform => Self::Platform,
+            IntegrationActivationDeliveryChannel::Integration => Self::Integration,
+            IntegrationActivationDeliveryChannel::Security => Self::Security,
+            IntegrationActivationDeliveryChannel::Verification => Self::Verification,
+            IntegrationActivationDeliveryChannel::Audit => Self::Audit,
+            IntegrationActivationDeliveryChannel::Monitoring => Self::Monitoring,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrationActivationAuditRecordKind {
     Sentinel,
     Watchtower,
@@ -3690,6 +3765,75 @@ pub struct IntegrationActivationDeliverySummary {
     pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
     pub next_manifest_sequence: Option<usize>,
     pub next_manifest_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDeploymentRecord {
+    pub sequence: usize,
+    pub deployment_status: IntegrationActivationDeploymentStatus,
+    pub deployment_ring: IntegrationActivationDeploymentRing,
+    pub delivery_channel: IntegrationActivationDeliveryChannel,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_delivery_sequence: usize,
+    pub source_delivery_status: IntegrationActivationDeliveryStatus,
+    pub source_release_status: IntegrationActivationReleaseStatus,
+    pub source_closure_status: IntegrationActivationClosureStatus,
+    pub source_remediation_kind: IntegrationActivationRemediationKind,
+    pub source_remediation_status: IntegrationActivationRemediationStatus,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_required: bool,
+    pub delivery_ready: bool,
+    pub deployment_blocked: bool,
+    pub deployment_ready: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationDeploymentSummary {
+    pub total_records: usize,
+    pub unique_integrations: usize,
+    pub records_requiring_attention: usize,
+    pub blocked_records: usize,
+    pub awaiting_verification_records: usize,
+    pub awaiting_owner_records: usize,
+    pub ready_to_deploy_records: usize,
+    pub monitoring_records: usize,
+    pub platform_ring_records: usize,
+    pub integration_ring_records: usize,
+    pub security_ring_records: usize,
+    pub verification_ring_records: usize,
+    pub audit_ring_records: usize,
+    pub monitoring_ring_records: usize,
+    pub platform_owner_records: usize,
+    pub integration_owner_records: usize,
+    pub security_owner_records: usize,
+    pub reviewer_owner_records: usize,
+    pub verification_owner_records: usize,
+    pub audit_owner_records: usize,
+    pub records_with_dependency_work: usize,
+    pub records_with_policy_risk: usize,
+    pub records_requiring_verification: usize,
+    pub records_ready_to_deploy: usize,
+    pub records_with_policy_surface: usize,
+    pub next_deployment_status: Option<IntegrationActivationDeploymentStatus>,
+    pub next_deployment_ring: Option<IntegrationActivationDeploymentRing>,
+    pub next_delivery_status: Option<IntegrationActivationDeliveryStatus>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_record_sequence: Option<usize>,
+    pub next_record_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
@@ -10355,6 +10499,282 @@ impl IntegrationActivationDeliverySummary {
     }
 }
 
+impl IntegrationActivationDeploymentRecord {
+    fn from_delivery_manifest(manifest: &IntegrationActivationDeliveryManifest) -> Self {
+        let deployment_status =
+            IntegrationActivationDeploymentStatus::from_delivery_manifest(manifest);
+        let deployment_ring = IntegrationActivationDeploymentRing::from_delivery_manifest(manifest);
+        let deployment_ready =
+            deployment_status == IntegrationActivationDeploymentStatus::ReadyToDeploy;
+        let deployment_blocked = matches!(
+            deployment_status,
+            IntegrationActivationDeploymentStatus::Blocked
+                | IntegrationActivationDeploymentStatus::AwaitingVerification
+                | IntegrationActivationDeploymentStatus::AwaitingOwner
+        );
+
+        Self {
+            sequence: 0,
+            deployment_status,
+            deployment_ring,
+            delivery_channel: manifest.delivery_channel,
+            owner_lane: manifest.owner_lane,
+            source_delivery_sequence: manifest.sequence,
+            source_delivery_status: manifest.delivery_status,
+            source_release_status: manifest.source_release_status,
+            source_closure_status: manifest.source_closure_status,
+            source_remediation_kind: manifest.source_remediation_kind,
+            source_remediation_status: manifest.source_remediation_status,
+            source_id: manifest.source_id.clone(),
+            title: format!("{}: {}", deployment_status.as_str(), manifest.title),
+            summary: manifest.summary.clone(),
+            priority: manifest.priority,
+            integration_ids: manifest.integration_ids.clone(),
+            recommended_view: manifest.recommended_view,
+            required_tier: manifest.required_tier,
+            policy_surface: manifest.policy_surface,
+            dependency_work: manifest.has_dependency_work(),
+            policy_risk: manifest.has_policy_risk(),
+            verification_required: manifest.needs_verification(),
+            delivery_ready: manifest.delivery_ready(),
+            deployment_blocked,
+            deployment_ready,
+            requires_attention: manifest.requires_attention()
+                || deployment_status.requires_attention(),
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_required
+    }
+
+    pub fn deployment_blocked(&self) -> bool {
+        self.deployment_blocked
+    }
+
+    pub fn deployment_ready(&self) -> bool {
+        self.deployment_ready
+    }
+
+    pub fn delivery_ready(&self) -> bool {
+        self.delivery_ready
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+}
+
+impl IntegrationActivationDeploymentStatus {
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Blocked | Self::AwaitingVerification | Self::AwaitingOwner
+        )
+    }
+}
+
+impl IntegrationActivationDeploymentSummary {
+    pub fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationDeploymentRecord>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            awaiting_verification_records: 0,
+            awaiting_owner_records: 0,
+            ready_to_deploy_records: 0,
+            monitoring_records: 0,
+            platform_ring_records: 0,
+            integration_ring_records: 0,
+            security_ring_records: 0,
+            verification_ring_records: 0,
+            audit_ring_records: 0,
+            monitoring_ring_records: 0,
+            platform_owner_records: 0,
+            integration_owner_records: 0,
+            security_owner_records: 0,
+            reviewer_owner_records: 0,
+            verification_owner_records: 0,
+            audit_owner_records: 0,
+            records_with_dependency_work: 0,
+            records_with_policy_risk: 0,
+            records_requiring_verification: 0,
+            records_ready_to_deploy: 0,
+            records_with_policy_surface: 0,
+            next_deployment_status: None,
+            next_deployment_ring: None,
+            next_delivery_status: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_record_sequence: None,
+            next_record_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for record in records {
+            summary.total_records += 1;
+            for integration_id in &record.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_deployment_status.is_none()
+                && (record.requires_attention()
+                    || record.needs_verification()
+                    || record.deployment_ready())
+            {
+                summary.next_deployment_status = Some(record.deployment_status);
+                summary.next_deployment_ring = Some(record.deployment_ring);
+                summary.next_delivery_status = Some(record.source_delivery_status);
+                summary.next_owner_lane = Some(record.owner_lane);
+                summary.next_recommended_view = Some(record.recommended_view);
+                summary.next_record_sequence = Some(record.sequence);
+                summary.next_record_priority = Some(record.priority);
+            }
+
+            match record.deployment_status {
+                IntegrationActivationDeploymentStatus::Blocked => summary.blocked_records += 1,
+                IntegrationActivationDeploymentStatus::AwaitingVerification => {
+                    summary.awaiting_verification_records += 1;
+                }
+                IntegrationActivationDeploymentStatus::AwaitingOwner => {
+                    summary.awaiting_owner_records += 1;
+                }
+                IntegrationActivationDeploymentStatus::ReadyToDeploy => {
+                    summary.ready_to_deploy_records += 1;
+                }
+                IntegrationActivationDeploymentStatus::Monitoring => {
+                    summary.monitoring_records += 1;
+                }
+            }
+
+            match record.deployment_ring {
+                IntegrationActivationDeploymentRing::Platform => {
+                    summary.platform_ring_records += 1;
+                }
+                IntegrationActivationDeploymentRing::Integration => {
+                    summary.integration_ring_records += 1;
+                }
+                IntegrationActivationDeploymentRing::Security => {
+                    summary.security_ring_records += 1;
+                }
+                IntegrationActivationDeploymentRing::Verification => {
+                    summary.verification_ring_records += 1;
+                }
+                IntegrationActivationDeploymentRing::Audit => {
+                    summary.audit_ring_records += 1;
+                }
+                IntegrationActivationDeploymentRing::Monitoring => {
+                    summary.monitoring_ring_records += 1;
+                }
+            }
+
+            match record.owner_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_owner_records += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_owner_records += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_owner_records += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_owner_records += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_owner_records += 1;
+                }
+                IntegrationActivationResponseOwnerLane::Audit => {
+                    summary.audit_owner_records += 1;
+                }
+            }
+
+            if record.requires_attention() {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(record.priority));
+            }
+            if record.has_dependency_work() {
+                summary.records_with_dependency_work += 1;
+            }
+            if record.has_policy_risk() {
+                summary.records_with_policy_risk += 1;
+            }
+            if record.needs_verification() {
+                summary.records_requiring_verification += 1;
+            }
+            if record.deployment_ready() {
+                summary.records_ready_to_deploy += 1;
+            }
+            if record.has_policy_surface() {
+                summary.records_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(record.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.records_requiring_attention > 0
+            || summary.awaiting_verification_records > 0
+            || summary.awaiting_owner_records > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_to_deploy_records > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_records == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.awaiting_owner_records > 0
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.awaiting_verification_records > 0 || self.records_requiring_verification > 0
+    }
+
+    pub fn deployment_ready(&self) -> bool {
+        self.ready_to_deploy_records > 0 || self.records_ready_to_deploy > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -15544,6 +15964,38 @@ pub fn activation_delivery_manifests_at_or_before_priority(
     activation_delivery_manifests_from_release_packets(&packets)
 }
 
+pub fn activation_deployment_records_from_delivery_manifests(
+    manifests: &[IntegrationActivationDeliveryManifest],
+) -> Vec<IntegrationActivationDeploymentRecord> {
+    let mut records: Vec<_> = manifests
+        .iter()
+        .map(IntegrationActivationDeploymentRecord::from_delivery_manifest)
+        .collect();
+
+    records.sort_by(compare_activation_deployment_records);
+    for (index, record) in records.iter_mut().enumerate() {
+        record.sequence = index + 1;
+    }
+    records
+}
+
+pub fn activation_deployment_records_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationDeploymentRecord> {
+    let manifests = activation_delivery_manifests_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_deployment_records_from_delivery_manifests(&manifests)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -17242,6 +17694,34 @@ fn compare_activation_delivery_manifests(
         .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
         .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
         .then_with(|| left.delivery_channel.cmp(&right.delivery_channel))
+        .then_with(|| left.source_release_status.cmp(&right.source_release_status))
+        .then_with(|| {
+            left.source_remediation_kind
+                .cmp(&right.source_remediation_kind)
+        })
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_deployment_records(
+    left: &IntegrationActivationDeploymentRecord,
+    right: &IntegrationActivationDeploymentRecord,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.deployment_status.cmp(&right.deployment_status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.deployment_blocked().cmp(&left.deployment_blocked()))
+        .then_with(|| right.needs_verification().cmp(&left.needs_verification()))
+        .then_with(|| right.deployment_ready().cmp(&left.deployment_ready()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| left.deployment_ring.cmp(&right.deployment_ring))
+        .then_with(|| {
+            left.source_delivery_status
+                .cmp(&right.source_delivery_status)
+        })
         .then_with(|| left.source_release_status.cmp(&right.source_release_status))
         .then_with(|| {
             left.source_remediation_kind
@@ -20907,6 +21387,42 @@ mod tests {
         );
         assert_eq!(
             delivery_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let deployment_records =
+            activation_deployment_records_from_delivery_manifests(&delivery_manifests);
+        assert_eq!(deployment_records.len(), delivery_manifests.len());
+        assert!(deployment_records.iter().any(
+            |record| record.deployment_status == IntegrationActivationDeploymentStatus::Blocked
+        ));
+        assert!(deployment_records
+            .iter()
+            .any(|record| record.deployment_status
+                == IntegrationActivationDeploymentStatus::AwaitingVerification));
+        assert!(deployment_records
+            .iter()
+            .any(IntegrationActivationDeploymentRecord::requires_attention));
+        assert!(deployment_records
+            .iter()
+            .any(IntegrationActivationDeploymentRecord::deployment_blocked));
+
+        let deployment_summary =
+            IntegrationActivationDeploymentSummary::from_records(deployment_records.iter());
+        assert_eq!(deployment_summary.total_records, deployment_records.len());
+        assert!(deployment_summary.has_blockers());
+        assert!(deployment_summary.needs_verification());
+        assert!(deployment_summary.requires_attention());
+        assert_eq!(
+            deployment_summary.next_deployment_status,
+            Some(IntegrationActivationDeploymentStatus::Blocked)
+        );
+        assert_eq!(
+            deployment_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            deployment_summary.overall_status,
             IntegrationActivationHealthStatus::Blocked
         );
 


### PR DESCRIPTION
## Summary
- add reusable D23A activation deployment records and summaries derived from activation delivery manifests
- expose read-only D18D descriptors for smart_home.list_integration_activation_deployment and smart_home.get_integration_activation_deployment_summary
- wire Chief bridge schema, filters, handlers, JSON output, end-to-end journal coverage, README, and changelog notes

## Validation
- cargo fmt -p smart-home-integration-catalog -p smart-home-core -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools
- git diff --check HEAD

Generated code/packages/rust/Cargo.lock was removed before push.