### PR TITLE
feat(closurec): CLOC12.113 — close gap-110 (modifier-prefixed string method key -> computed)

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.117.0] - 2026-06-12
+
+### Fixed
+- **CLOSES gap-110** — a string method KEY preceded by a method MODIFIER
+  (`*` generator and/or `async`) is now ALSO normalised to a COMPUTED
+  key, matching upstream:
+
+      x={*"m"(){}};            ->  x={*["m"](){}};
+      class A{async"m"(){}}    ->  class A{async["m"](){}};
+      x={async*"m"(){}};       ->  x={async*["m"](){}};
+
+  This extends the gap-109 pre-pass: gap-109 only fired when the string's
+  immediate predecessor was a property boundary (`{`/`,`/`}`/`static`),
+  so a `*`/`async`-prefixed key was missed. The fix walks BACK over the
+  contiguous run of method modifiers (`*`, `async`, `static`) to the
+  ANCHOR — the token opening the member position — and requires that
+  anchor to be a property-start (`{`/`,`/`}`). This proves a leading
+  `*`/`async` is a method modifier and NOT a multiply/identifier in an
+  expression: for `a=async*b` the string guard never matches (`b` is not
+  a string), and for `a*"m"(){}` the anchor walk lands on the identifier
+  `a` (not a property-start), so the generator/multiply ambiguity is
+  correctly rejected — no spurious `[...]` wrap. The same method-body
+  guard as gap-109 applies (the `)` matching the key's `(` must be
+  followed by `{`). Seven `gap110_*` unit tests cover the generator,
+  async, async-generator, and class-member wrap cases plus the
+  `{*m(){}}`, `a=async*b`, and `a*"m"(x)` non-regressions. The three
+  `*_string_method` diff fixtures (added in CLOC14.53) are now ENFORCED.
+  Verified byte-identical to upstream Closure v20240317.
+
 ## [0.116.0] - 2026-06-12
 
 ### Fixed

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.116.0"
+version = "0.117.0"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.116.0",
+  "version": "0.117.0",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/src/whitespace_only.rs
+++ b/code/programs/rust/closurec/src/whitespace_only.rs
@@ -2184,12 +2184,46 @@ pub fn whitespace_only_minify(
                 continue;
             }
             // Property-start context.
+            //
+            // gap-110 extension: a method KEY may be preceded by method
+            // MODIFIERS — `*` (generator), `async`, and `static`:
+            //   {*"m"(){}}       -> {*["m"](){}}        (generator)
+            //   {async"m"(){}}   -> {async["m"](){}}    (async)
+            //   {async*"m"(){}}  -> {async*["m"](){}}   (async-generator)
+            // To prove a leading `*`/`async` is a method modifier and
+            // NOT a multiply/identifier in an expression (`a=async*b`,
+            // `a*"m"`), walk back over the contiguous run of modifier
+            // tokens to the ANCHOR — the token that opens the member
+            // position — and require that anchor to be a property-start
+            // (`{` / `,` / `}`). For `a*"m"(){}` the anchor walk lands on
+            // the identifier `a`, which is not a property-start, so the
+            // generator/multiply ambiguity is correctly rejected.
             let before = kept[i - 1];
+            let is_method_modifier = |t: &lexer::token::Token| {
+                is_structural_punct(t, "*")
+                    || (is_word_like(t)
+                        && (t.value == "async" || t.value == "static"))
+            };
+            // Walk back over the modifier run starting at `i - 1`.
+            let mut anchor_idx = i;
+            while anchor_idx > 0 && is_method_modifier(kept[anchor_idx - 1]) {
+                anchor_idx -= 1;
+            }
+            let had_modifier = anchor_idx < i;
+            let anchor_is_prop_start = anchor_idx > 0 && {
+                let a = kept[anchor_idx - 1];
+                is_structural_punct(a, "{")
+                    || is_structural_punct(a, ",")
+                    || is_structural_punct(a, "}")
+            };
+            // Direct (no-modifier) property-start — the gap-109 base case.
             let static_ctx = is_word_like(before) && before.value == "static";
-            let prop_start = is_structural_punct(before, "{")
+            let direct_prop_start = is_structural_punct(before, "{")
                 || is_structural_punct(before, ",")
                 || is_structural_punct(before, "}")
                 || static_ctx;
+            let prop_start =
+                direct_prop_start || (had_modifier && anchor_is_prop_start);
             // Never a member access (`.`/`?.` before the string is
             // impossible for a string but keep the guard for symmetry).
             let is_member = is_structural_punct(before, ".")
@@ -7834,6 +7868,67 @@ mod tests {
     fn gap109_string_call_untouched() {
         assert_eq!(minify("f(\"m\");"), "f(\"m\");");
         assert_eq!(minify("\"m\"(x);"), "\"m\"(x);");
+    }
+
+    /// gap-110 — GENERATOR string method: the `*` modifier precedes the
+    /// string key. `{*"m"(){}}` -> `{*["m"](){}}`.
+    #[test]
+    fn gap110_generator_string_method() {
+        assert_eq!(minify("x={*\"m\"(){}};"), "x={*[\"m\"](){}};");
+    }
+
+    /// gap-110 — ASYNC string method: the `async` modifier precedes the
+    /// string key. `class A{async"m"(){}}` -> `class A{async["m"](){}}`.
+    #[test]
+    fn gap110_async_string_method() {
+        assert_eq!(
+            minify("class A{async\"m\"(){}}"),
+            "class A{async[\"m\"](){}};"
+        );
+    }
+
+    /// gap-110 — ASYNC-GENERATOR string method: both `async` and `*`
+    /// precede the key. `{async*"m"(){}}` -> `{async*["m"](){}}`.
+    #[test]
+    fn gap110_async_generator_string_method() {
+        assert_eq!(
+            minify("x={async*\"m\"(){}};"),
+            "x={async*[\"m\"](){}};"
+        );
+    }
+
+    /// gap-110 — generator string method as a CLASS member.
+    #[test]
+    fn gap110_class_generator_string_method() {
+        assert_eq!(
+            minify("class A{*\"m\"(){}}"),
+            "class A{*[\"m\"](){}};"
+        );
+    }
+
+    /// **Non-regression**: an IDENTIFIER generator method (`{*m(){}}`)
+    /// is NOT wrapped — the key is not a string literal.
+    #[test]
+    fn gap110_identifier_generator_method_untouched() {
+        assert_eq!(minify("x={*m(){}};"), "x={*m(){}};");
+    }
+
+    /// **Non-regression**: `a=async*b` is a multiply of `async` by `b`,
+    /// NOT an async-generator method. `b` is not a string, and the
+    /// modifier-anchor walk lands on `=` (not a property-start), so the
+    /// expression is left untouched (no spurious `[...]` wrap).
+    #[test]
+    fn gap110_async_multiply_untouched() {
+        assert_eq!(minify("a=async*b;"), "a=async*b;");
+    }
+
+    /// **Non-regression**: `a*"m"(){}` — a `*` preceded by an
+    /// IDENTIFIER `a` is a multiply, not a generator modifier. The
+    /// anchor walk lands on `a` (not a property-start), so the string
+    /// is NOT wrapped even though the method-body guard would match.
+    #[test]
+    fn gap110_multiply_string_call_untouched() {
+        assert_eq!(minify("a*\"m\"(x);"), "a*\"m\"(x);");
     }
 
     /// gap-057 safety: a CALL paren must never be stripped —

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.116.0
+Version: 0.117.0
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff_minify.rs
+++ b/code/programs/rust/closurec/tests/diff_minify.rs
@@ -273,9 +273,8 @@ const IGNORE_FIXTURES: &[(&str, &str)] = &[
     // The fix extends the gap-109 property-start set to include `*` and
     // `async` (with the same method-body guard). `static"m"` already
     // works (gap-109 covered `static`).
-    ("gen_string_method",       "gap-110: generator string method key -> computed"),
-    ("async_string_method",     "gap-110: async string method key -> computed"),
-    ("async_gen_string_method", "gap-110: async-gen string method key -> computed"),
+    // gap-110 RESOLVED in CLOC12.113 — the three `*_string_method`
+    // fixtures below are now ENFORCED (un-ignored).
     // gap-111 (CLOC14.53): a reserved KEYWORD immediately before a
     // STRING LITERAL that the keyword grammatically takes needs a
     // separating SPACE that closurec omits:

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -816,9 +816,9 @@ historical context with status `RESOLVED` and a link to the fix PR.
 
 ### gap-110 — modifier-prefixed string method key not normalised to computed (WHITESPACE_ONLY)
 
-- **Status:** OPEN (discovered CLOC14.53). `minify_gen_string_method` / `minify_async_string_method` / `minify_async_gen_string_method` ignored.
+- **Status:** RESOLVED in CLOC12.113 (v0.117.0). `minify_gen_string_method` / `minify_async_string_method` / `minify_async_gen_string_method` now ENFORCED.
 - **Input:** `x={*"m"(){}};` → **Upstream:** `x={*["m"](){}};` but **closurec:** `x={*"m"(){}};`. A string method KEY preceded by a method MODIFIER (`*` generator or `async`) is normalised to a COMPUTED key just like the plain case (gap-109), but gap-109's pre-pass only fired when the string's predecessor was a property boundary (`{`/`,`/`}`/`static`), so a `*`/`async`-prefixed key was missed: `{*"m"(){}}` → `{*["m"](){}}`, `class A{async"m"(){}}` → `class A{async["m"](){}}`, `{async*"m"(){}}` → `{async*["m"](){}}`. (`static"m"` already works — gap-109 covered `static`.)
-- **What it needs:** extend gap-109's property-start before-set to include `*` and `async` (keeping the same method-body guard: the `)` matching the key's `(` must be followed by `{`). Low risk — the method-body guard already prevents matching non-method forms.
+- **Fix:** the gap-109 pre-pass now walks BACK over the contiguous run of method modifiers (`*`, `async`, `static`) from the string's predecessor to the ANCHOR — the token opening the member position — and accepts the key when that anchor is a property-start (`{`/`,`/`}`). This proves the leading `*`/`async` is a method modifier and not a multiply/identifier in an expression: `a=async*b` never matches (`b` is not a string) and `a*"m"(){}` is rejected because the anchor walk lands on the identifier `a` (not a property-start), so the generator/multiply ambiguity is resolved without a spurious `[...]` wrap. The same method-body guard as gap-109 applies (the `)` matching the key's `(` must be followed by `{`). Seven `gap110_*` unit tests cover the generator/async/async-generator/class-member wrap cases plus the `{*m(){}}`, `a=async*b`, and `a*"m"(x)` non-regressions. Verified byte-identical to upstream Closure v20240317.
 
 ### gap-111 — reserved keyword before string literal missing separating space (WHITESPACE_ONLY)
 


### PR DESCRIPTION
## Summary

Closes **gap-110**: a string method KEY preceded by a method MODIFIER (`*` generator and/or `async`) is now normalised to a COMPUTED key, matching upstream Closure v20240317.

```
x={*"m"(){}};            ->  x={*["m"](){}};
class A{async"m"(){}}    ->  class A{async["m"](){}};
x={async*"m"(){}};       ->  x={async*["m"](){}};
```

## Why it was missed

gap-109's pre-pass wraps a string method key in a synthetic `[`…`]` pair, but only fired when the string's **immediate** predecessor was a property boundary (`{`/`,`/`}`/`static`). A `*`- or `async`-prefixed key has the MODIFIER as its predecessor, so it slipped through.

## The fix

In the gap-109 pre-pass (`whitespace_only.rs`), before testing property-start context, walk **back** over the contiguous run of method modifiers (`*`, `async`, `static`) to the ANCHOR — the token opening the member position — and accept the key when that anchor is a property-start (`{`/`,`/`}`). This proves the leading `*`/`async` is a method modifier, not a multiply/identifier in an expression:

- `a=async*b` — string guard never matches (`b` is not a string);
- `a*"m"(){}` — anchor walk lands on identifier `a` (not a property-start) → rejected, no spurious wrap.

Same method-body guard as gap-109 (the `)` matching the key's `(` must be followed by `{`).

## Bookkeeping

- 7 `gap110_*` unit tests (generator / async / async-gen / class-member wraps + `{*m(){}}`, `a=async*b`, `a*"m"(x)` non-regressions)
- un-ignore the 3 `*_string_method` diff fixtures (added CLOC14.53) — now ENFORCED
- version 0.116.0 → 0.117.0 (Cargo.toml + cli.spec.json + help golden)
- CHANGELOG + CLOC12-gaps.md mark gap-110 RESOLVED

All 612 unit tests pass; diff_minify walk-test green. Verified byte-identical to upstream Closure v20240317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)