### PR TITLE
Add component hydration readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -892,6 +892,7 @@ pub struct BrowserDocument {
     pub custom_element_descriptors: Vec<BrowserCustomElementDescriptor>,
     pub canvas_descriptors: Vec<BrowserCanvasDescriptor>,
     pub component_hydration_targets: Vec<BrowserComponentHydrationTarget>,
+    pub component_hydration_descriptors: Vec<BrowserComponentHydrationDescriptor>,
     pub data_attribute_descriptors: Vec<BrowserDataAttributeDescriptor>,
     pub global_state_descriptors: Vec<BrowserGlobalStateDescriptor>,
     pub structured_data_descriptors: Vec<BrowserStructuredDataDescriptor>,
@@ -1535,6 +1536,28 @@ pub struct BrowserComponentHydrationTarget {
     pub data_attributes: Vec<BrowserDataAttribute>,
     pub canvas_fallback_text: Option<String>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserComponentHydrationDescriptor {
+    pub element: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub hydration_kind: String,
+    pub custom_element: bool,
+    pub custom_element_name: Option<String>,
+    pub custom_element_is: Option<String>,
+    pub shadowrootmode: Option<String>,
+    pub slot: Option<String>,
+    pub slot_name: Option<String>,
+    pub part: Vec<String>,
+    pub exportparts: Option<String>,
+    pub data_attribute_names: Vec<String>,
+    pub data_attribute_count: usize,
+    pub canvas_fallback_text: Option<String>,
+    pub text: String,
+    pub hydration_blocked: bool,
+    pub hydration_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10952,6 +10975,9 @@ fn collect_browser_facts(
         if let Some(target) = browser_component_hydration_target(element) {
             summary.component_hydration_targets.push(target);
         }
+        if let Some(descriptor) = browser_component_hydration_descriptor(element) {
+            summary.component_hydration_descriptors.push(descriptor);
+        }
         if let Some(descriptor) = browser_slot_descriptor(element) {
             summary.slot_descriptors.push(descriptor);
         }
@@ -17931,6 +17957,134 @@ fn browser_component_hydration_target(
         canvas_fallback_text: is_canvas.then(|| visible_text_for_nodes(&element.children)),
         text: visible_text_for_nodes(&element.children),
     })
+}
+
+fn browser_component_hydration_descriptor(
+    element: &Element,
+) -> Option<BrowserComponentHydrationDescriptor> {
+    let custom_element_name = browser_custom_element_name(element);
+    let custom_element_is = browser_custom_element_is(element);
+    let custom_element = custom_element_name.is_some() || custom_element_is.is_some();
+    let shadowrootmode = (element.name == "template")
+        .then(|| element.attribute("shadowrootmode").map(ToOwned::to_owned))
+        .flatten();
+    let slot = browser_slot_assignment(element);
+    let slot_name = browser_slot_name(element);
+    let part = browser_part_tokens(element);
+    let exportparts = browser_exportparts(element);
+    let data_attributes = browser_data_attributes(element);
+    let canvas_fallback_text = (element.name == "canvas")
+        .then(|| collapse_html_whitespace(&visible_text_for_nodes(&element.children)));
+    let hydration_kind = browser_component_hydration_kind(
+        element,
+        custom_element_name.as_deref(),
+        custom_element_is.as_deref(),
+        shadowrootmode.as_deref(),
+        slot.as_deref(),
+        slot_name.as_deref(),
+        &part,
+        exportparts.as_deref(),
+        &data_attributes,
+    )?;
+    let hydration_block_reasons = browser_component_hydration_block_reasons(
+        element,
+        custom_element_name.as_deref(),
+        custom_element_is.as_deref(),
+        shadowrootmode.as_deref(),
+        slot.as_deref(),
+        slot_name.as_deref(),
+        canvas_fallback_text.as_deref(),
+    );
+
+    Some(BrowserComponentHydrationDescriptor {
+        element: element.name.clone(),
+        id: element.attribute("id").map(ToOwned::to_owned),
+        classes: element
+            .attribute("class")
+            .map(split_html_classes)
+            .unwrap_or_default(),
+        hydration_kind,
+        custom_element,
+        custom_element_name,
+        custom_element_is,
+        shadowrootmode,
+        slot,
+        slot_name,
+        part,
+        exportparts,
+        data_attribute_names: browser_data_attribute_names(&data_attributes),
+        data_attribute_count: data_attributes.len(),
+        canvas_fallback_text,
+        text: collapse_html_whitespace(&visible_text_for_nodes(&element.children)),
+        hydration_blocked: !hydration_block_reasons.is_empty(),
+        hydration_block_reasons,
+    })
+}
+
+fn browser_component_hydration_kind(
+    element: &Element,
+    custom_element_name: Option<&str>,
+    custom_element_is: Option<&str>,
+    shadowrootmode: Option<&str>,
+    slot: Option<&str>,
+    slot_name: Option<&str>,
+    part: &[String],
+    exportparts: Option<&str>,
+    data_attributes: &[BrowserDataAttribute],
+) -> Option<String> {
+    if custom_element_name.is_some() {
+        Some("autonomous-custom-element".to_string())
+    } else if custom_element_is.is_some() {
+        Some("customized-built-in".to_string())
+    } else if shadowrootmode.is_some() {
+        Some("declarative-shadow-template".to_string())
+    } else if element.name == "slot" || slot_name.is_some() {
+        Some("slot-outlet".to_string())
+    } else if slot.is_some() {
+        Some("slotted-element".to_string())
+    } else if element.name == "canvas" {
+        Some("canvas-fallback".to_string())
+    } else if exportparts.is_some() {
+        Some("exported-parts".to_string())
+    } else if !part.is_empty() {
+        Some("part-target".to_string())
+    } else if !data_attributes.is_empty() {
+        Some("data-hydration-marker".to_string())
+    } else {
+        None
+    }
+}
+
+fn browser_component_hydration_block_reasons(
+    element: &Element,
+    custom_element_name: Option<&str>,
+    custom_element_is: Option<&str>,
+    shadowrootmode: Option<&str>,
+    slot: Option<&str>,
+    slot_name: Option<&str>,
+    canvas_fallback_text: Option<&str>,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    let definition_name = custom_element_is.or(custom_element_name);
+    if definition_name.is_some_and(|name| !is_browser_custom_element_name(name)) {
+        reasons.push("invalid-custom-element-name".to_string());
+    }
+    if custom_element_name.is_some() && custom_element_is.is_some() {
+        reasons.push("is-on-autonomous-custom-element".to_string());
+    }
+    if shadowrootmode.is_some_and(|mode| !matches!(mode, "open" | "closed")) {
+        reasons.push("invalid-shadowrootmode".to_string());
+    }
+    if slot.is_some_and(|slot| !slot.is_empty() && slot.trim().is_empty()) {
+        reasons.push("blank-slot-assignment".to_string());
+    }
+    if slot_name.is_some_and(|slot_name| !slot_name.is_empty() && slot_name.trim().is_empty()) {
+        reasons.push("blank-slot-name".to_string());
+    }
+    if element.name == "canvas" && canvas_fallback_text.is_some_and(str::is_empty) {
+        reasons.push("missing-canvas-fallback-text".to_string());
+    }
+    reasons
 }
 
 fn browser_data_attribute_descriptor(element: &Element) -> Option<BrowserDataAttributeDescriptor> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -3,7 +3,8 @@ use coding_adventures_html_parser::{
     BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
     BrowserAriaDescriptionDescriptor, BrowserAriaLiveRegion, BrowserAriaNameDescriptor,
     BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCanvasDescriptor,
-    BrowserClipboardInteractionDescriptor, BrowserCommandElement, BrowserComponentHydrationTarget,
+    BrowserClipboardInteractionDescriptor, BrowserCommandElement,
+    BrowserComponentHydrationDescriptor, BrowserComponentHydrationTarget,
     BrowserCompositionInteractionDescriptor, BrowserContextMenuInteractionDescriptor,
     BrowserCustomElementDescriptor, BrowserDataAttribute, BrowserDataAttributeDescriptor,
     BrowserDatalistOption, BrowserDisclosure, BrowserDisclosureStateDescriptor, BrowserDocument,
@@ -199,6 +200,8 @@ struct ExpectedBrowserDocument {
     canvas_descriptors: Option<Vec<ExpectedCanvasDescriptor>>,
     #[serde(default)]
     component_hydration_targets: Vec<ExpectedComponentHydrationTarget>,
+    #[serde(default)]
+    component_hydration_descriptors: Option<Vec<ExpectedComponentHydrationDescriptor>>,
     #[serde(default)]
     data_attribute_descriptors: Vec<ExpectedDataAttributeDescriptor>,
     #[serde(default)]
@@ -567,6 +570,45 @@ struct ExpectedComponentHydrationTarget {
     canvas_fallback_text: Option<String>,
     #[serde(default)]
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedComponentHydrationDescriptor {
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+    #[serde(default)]
+    hydration_kind: String,
+    #[serde(default)]
+    custom_element: bool,
+    #[serde(default)]
+    custom_element_name: Option<String>,
+    #[serde(default)]
+    custom_element_is: Option<String>,
+    #[serde(default)]
+    shadowrootmode: Option<String>,
+    #[serde(default)]
+    slot: Option<String>,
+    #[serde(default)]
+    slot_name: Option<String>,
+    #[serde(default)]
+    part: Vec<String>,
+    #[serde(default)]
+    exportparts: Option<String>,
+    #[serde(default)]
+    data_attribute_names: Vec<String>,
+    #[serde(default)]
+    data_attribute_count: usize,
+    #[serde(default)]
+    canvas_fallback_text: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    hydration_blocked: bool,
+    #[serde(default)]
+    hydration_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4262,6 +4304,8 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         let tracks_slot_descriptors = case.expected.slot_descriptors.is_some();
         let tracks_custom_element_descriptors = case.expected.custom_element_descriptors.is_some();
         let tracks_canvas_descriptors = case.expected.canvas_descriptors.is_some();
+        let tracks_component_hydration_descriptors =
+            case.expected.component_hydration_descriptors.is_some();
         let tracks_structured_data_descriptors =
             case.expected.structured_data_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
@@ -4282,6 +4326,10 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_canvas_descriptors {
             expected.canvas_descriptors = actual.canvas_descriptors.clone();
+        }
+        if !tracks_component_hydration_descriptors {
+            expected.component_hydration_descriptors =
+                actual.component_hydration_descriptors.clone();
         }
         if !tracks_structured_data_descriptors {
             expected.structured_data_descriptors = actual.structured_data_descriptors.clone();
@@ -6571,6 +6619,63 @@ fn browser_component_hydration_metadata_tracks_custom_elements_slots_parts_and_d
 }
 
 #[test]
+fn browser_component_hydration_descriptors_track_kinds_signals_and_blockers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "component-template-page")
+        .expect("component template fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("component template fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.component_hydration_descriptors,
+        case.expected
+            .into_browser_document()
+            .component_hydration_descriptors,
+        "component hydration descriptors should preserve target kind, component, slot, part, data, canvas, and blocker metadata",
+    );
+}
+
+#[test]
+fn browser_component_hydration_descriptors_track_invalid_targets() {
+    let actual = parse_browser_document(
+        "<body><template shadowrootmode=light><span>Bad mode</span></template>\
+         <slot name=\"   \">Fallback</slot><span slot=\"   \">Item</span>\
+         <canvas id=empty></canvas><button is=bad>Bad</button>",
+    )
+    .expect("invalid component hydration fixture should parse into browser document facts");
+
+    let blocked: Vec<_> = actual
+        .component_hydration_descriptors
+        .iter()
+        .filter(|descriptor| descriptor.hydration_blocked)
+        .collect();
+
+    assert_eq!(blocked.len(), 5);
+    assert_eq!(
+        blocked[0].hydration_block_reasons,
+        vec!["invalid-shadowrootmode"]
+    );
+    assert_eq!(blocked[1].hydration_block_reasons, vec!["blank-slot-name"]);
+    assert_eq!(
+        blocked[2].hydration_block_reasons,
+        vec!["blank-slot-assignment"]
+    );
+    assert_eq!(
+        blocked[3].hydration_block_reasons,
+        vec!["missing-canvas-fallback-text"]
+    );
+    assert_eq!(
+        blocked[4].hydration_block_reasons,
+        vec!["invalid-custom-element-name"]
+    );
+}
+
+#[test]
 fn browser_template_descriptors_track_shadowroot_mode_and_flags() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -7465,6 +7570,12 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_default();
+        let component_hydration_descriptors = self
+            .component_hydration_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedComponentHydrationDescriptor::into_browser_component_hydration_descriptor)
+            .collect();
 
         BrowserDocument {
             title: self.title,
@@ -7637,6 +7748,7 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedComponentHydrationTarget::into_browser_component_hydration_target)
                 .collect(),
+            component_hydration_descriptors,
             data_attribute_descriptors: self
                 .data_attribute_descriptors
                 .into_iter()
@@ -7962,6 +8074,31 @@ impl ExpectedComponentHydrationTarget {
                 .collect(),
             canvas_fallback_text: self.canvas_fallback_text,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedComponentHydrationDescriptor {
+    fn into_browser_component_hydration_descriptor(self) -> BrowserComponentHydrationDescriptor {
+        BrowserComponentHydrationDescriptor {
+            element: self.element,
+            id: self.id,
+            classes: self.classes,
+            hydration_kind: self.hydration_kind,
+            custom_element: self.custom_element,
+            custom_element_name: self.custom_element_name,
+            custom_element_is: self.custom_element_is,
+            shadowrootmode: self.shadowrootmode,
+            slot: self.slot,
+            slot_name: self.slot_name,
+            part: self.part,
+            exportparts: self.exportparts,
+            data_attribute_names: self.data_attribute_names,
+            data_attribute_count: self.data_attribute_count,
+            canvas_fallback_text: self.canvas_fallback_text,
+            text: self.text,
+            hydration_blocked: self.hydration_blocked,
+            hydration_block_reasons: self.hydration_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -2377,6 +2377,17 @@
           { "element": "button", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attributes": [{ "name": "data-action", "value": "save" }], "text": "Save" },
           { "element": "slot", "slot_name": "footer", "part": ["footer"], "text": "Fallback footer" }
         ],
+        "component_hydration_descriptors": [
+          { "element": "template", "id": "card-template", "hydration_kind": "declarative-shadow-template", "shadowrootmode": "open", "data_attribute_names": ["data-template"], "data_attribute_count": 1, "text": "Untitled Body" },
+          { "element": "article", "hydration_kind": "part-target", "part": ["frame"], "text": "Untitled Body" },
+          { "element": "slot", "hydration_kind": "slot-outlet", "slot_name": "title", "text": "Untitled" },
+          { "element": "slot", "hydration_kind": "slot-outlet", "text": "Body" },
+          { "element": "product-card", "id": "card", "hydration_kind": "autonomous-custom-element", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "exportparts": "header:title, chart", "data_attribute_names": ["data-controller", "data-state"], "data_attribute_count": 2, "text": "Widget Chart fallback Save Fallback footer" },
+          { "element": "span", "hydration_kind": "slotted-element", "slot": "title", "part": ["title"], "data_attribute_names": ["data-field"], "data_attribute_count": 1, "text": "Widget" },
+          { "element": "canvas", "id": "chart", "hydration_kind": "canvas-fallback", "part": ["chart"], "data_attribute_names": ["data-renderer"], "data_attribute_count": 1, "canvas_fallback_text": "Chart fallback", "text": "Chart fallback" },
+          { "element": "button", "hydration_kind": "customized-built-in", "custom_element": true, "custom_element_is": "fancy-button", "part": ["action"], "data_attribute_names": ["data-action"], "data_attribute_count": 1, "text": "Save" },
+          { "element": "slot", "hydration_kind": "slot-outlet", "slot_name": "footer", "part": ["footer"], "text": "Fallback footer" }
+        ],
         "data_attribute_descriptors": [
           { "element": "template", "id": "card-template", "data_attributes": [{ "name": "data-template", "value": "card" }], "data_attribute_names": ["data-template"], "data_attribute_count": 1, "text": "Untitled Body" },
           { "element": "product-card", "id": "card", "custom_element": true, "custom_element_name": "product-card", "part": ["host"], "data_attributes": [{ "name": "data-controller", "value": "product" }, { "name": "data-state", "value": "ready" }], "data_attribute_names": ["data-controller", "data-state"], "data_attribute_count": 2, "text": "Widget Chart fallback Save Fallback footer" },


### PR DESCRIPTION
## Summary
- add component_hydration_descriptors to BrowserDocument with kind classification and blocker reasons
- preserve hydration signals for custom elements, declarative shadow templates, slots, parts, data attributes, and canvas fallback content
- extend the browser-readiness fixture harness and component template fixture expectations

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_component_hydration_descriptors --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml