### PR TITLE
Add smart-home activation safety gates

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -52,8 +52,8 @@ use smart_home_integration_catalog::{
     activation_release_packets_from_closure_gates, activation_remediation_items_from_responses,
     activation_response_items_from_escalation_cases, activation_reviews_from_candidates,
     activation_risk_from_candidates, activation_runbook_entries_from_playbook_steps,
-    activation_runway_from_candidates, activation_sentinel_alerts_from_rollups,
-    activation_timeline_milestones_from_dashboard_cards,
+    activation_runway_from_candidates, activation_safety_gates_from_deployment_records,
+    activation_sentinel_alerts_from_rollups, activation_timeline_milestones_from_dashboard_cards,
     activation_verification_checkpoints_from_execution_packets,
     activation_watchtower_signals_from_command_center_sections, describe_primitive_family,
     ecosystem_platform_coverage, ecosystem_platforms_requiring_primitive, ecosystem_survey_sources,
@@ -112,19 +112,21 @@ use smart_home_integration_catalog::{
     IntegrationActivationRiskKind, IntegrationActivationRiskSummary,
     IntegrationActivationRunbookEntry, IntegrationActivationRunbookPhase,
     IntegrationActivationRunbookSummary, IntegrationActivationRunwayStage,
-    IntegrationActivationRunwaySummary, IntegrationActivationSentinelAlert,
-    IntegrationActivationSentinelAlertKind, IntegrationActivationSentinelSummary,
-    IntegrationActivationTarget, IntegrationActivationTimelineMilestone,
-    IntegrationActivationTimelineSummary, IntegrationActivationVerificationCheckpoint,
-    IntegrationActivationVerificationStatus, IntegrationActivationVerificationSummary,
-    IntegrationActivationWatchtowerSignal, IntegrationActivationWatchtowerSignalKind,
-    IntegrationActivationWatchtowerSummary, IntegrationCatalogEntry, IntegrationCatalogQuery,
-    IntegrationCatalogSort, IntegrationCategory, IntegrationPolicySurface,
-    IntegrationPolicySurfaceInventoryItem, IntegrationPolicySurfaceSummary,
-    IntegrationReadinessCapabilityGap, IntegrationReadinessDependencyGap,
-    IntegrationReadinessGapInventory, IntegrationReadinessPrimitiveGap, IntegrationReadinessReport,
-    IntegrationReadinessSummary, PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary,
-    PrimitiveBacklogItem, PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
+    IntegrationActivationRunwaySummary, IntegrationActivationSafetyGate,
+    IntegrationActivationSafetyGateStatus, IntegrationActivationSafetySummary,
+    IntegrationActivationSentinelAlert, IntegrationActivationSentinelAlertKind,
+    IntegrationActivationSentinelSummary, IntegrationActivationTarget,
+    IntegrationActivationTimelineMilestone, IntegrationActivationTimelineSummary,
+    IntegrationActivationVerificationCheckpoint, IntegrationActivationVerificationStatus,
+    IntegrationActivationVerificationSummary, IntegrationActivationWatchtowerSignal,
+    IntegrationActivationWatchtowerSignalKind, IntegrationActivationWatchtowerSummary,
+    IntegrationCatalogEntry, IntegrationCatalogQuery, IntegrationCatalogSort, IntegrationCategory,
+    IntegrationPolicySurface, IntegrationPolicySurfaceInventoryItem,
+    IntegrationPolicySurfaceSummary, IntegrationReadinessCapabilityGap,
+    IntegrationReadinessDependencyGap, IntegrationReadinessGapInventory,
+    IntegrationReadinessPrimitiveGap, IntegrationReadinessReport, IntegrationReadinessSummary,
+    PrimitiveBacklogCoverageItem, PrimitiveBacklogCoverageSummary, PrimitiveBacklogItem,
+    PrimitiveFamily, PrimitiveFamilyDescriptor, SourceReference,
 };
 use smart_home_registry::RegistryTopologySummary;
 use smart_home_registry::StateRefreshReason;
@@ -366,6 +368,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_DEPLOYMENT_TOOL_ID: &str =
     "smart_home.list_integration_activation_deployment";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_deployment_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_SAFETY_GATES_TOOL_ID: &str =
+    "smart_home.list_integration_activation_safety_gates";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_SAFETY_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_safety_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -832,6 +838,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID => {
                     let query = integration_activation_deployment_query(&arguments)?;
                     Ok(get_integration_activation_deployment_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_SAFETY_GATES_TOOL_ID => {
+                    let query = integration_activation_safety_query(&arguments)?;
+                    Ok(list_integration_activation_safety_gates_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_SAFETY_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_safety_query(&arguments)?;
+                    Ok(get_integration_activation_safety_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2704,6 +2718,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation deployment summary",
             "Return compact D23A activation deployment-record counts by deployment status, deployment ring, owner lane, blockers, verification requirements, deployment readiness, policy, and dependency work.",
             integration_activation_deployment_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_SAFETY_GATES_TOOL_ID,
+            "List smart-home integration activation safety gates",
+            "List Chief-facing D23A activation safety gates derived from deployment records with blocker, verification, owner approval, readiness, policy-risk, and dependency-work signals.",
+            integration_activation_safety_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_safety_gates", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_safety_gates",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_SAFETY_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation safety summary",
+            "Return compact D23A activation safety-gate counts by gate status, deployment ring, owner lane, blockers, verification requirements, deployment readiness, policy, and dependency work.",
+            integration_activation_safety_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5607,6 +5655,19 @@ struct IntegrationActivationDeploymentQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationSafetyQuery {
+    deployment: IntegrationActivationDeploymentQuery,
+    gate_status: Option<IntegrationActivationSafetyGateStatus>,
+    deployment_ring: Option<IntegrationActivationDeploymentRing>,
+    owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    needs_verification: Option<bool>,
+    deployment_ready: Option<bool>,
+    safety_gate_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6395,6 +6456,43 @@ fn integration_activation_deployment_query(
             .or(optional_bool(arguments, "needs_verification")?),
         deployment_ready: optional_bool(arguments, "deployment_ready")?,
         deployment_limit: optional_u64(arguments, "deployment_limit")?.map(|value| value as usize),
+    })
+}
+
+fn integration_activation_safety_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationSafetyQuery, ToolCallError> {
+    let gate_status = optional_string(arguments, "gate_status")?
+        .or(optional_string(arguments, "safety_status")?)
+        .or(optional_string(arguments, "safety_state")?)
+        .map(|label| parse_activation_safety_gate_status(&label))
+        .transpose()?;
+    let deployment_ring = optional_string(arguments, "safety_deployment_ring")?
+        .or(optional_string(arguments, "deployment_ring")?)
+        .or(optional_string(arguments, "safety_ring")?)
+        .map(|label| parse_activation_deployment_ring(&label))
+        .transpose()?;
+    let owner_lane = optional_string(arguments, "safety_owner_lane")?
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationSafetyQuery {
+        deployment: integration_activation_deployment_query(arguments)?,
+        gate_status,
+        deployment_ring,
+        owner_lane,
+        requires_attention: optional_bool(arguments, "safety_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "safety_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        needs_verification: optional_bool(arguments, "safety_needs_verification")?
+            .or(optional_bool(arguments, "needs_verification")?),
+        deployment_ready: optional_bool(arguments, "safety_deployment_ready")?
+            .or(optional_bool(arguments, "deployment_ready")?),
+        safety_gate_limit: optional_u64(arguments, "safety_gate_limit")?
+            .or(optional_u64(arguments, "gate_limit")?)
+            .map(|value| value as usize),
     })
 }
 
@@ -7635,6 +7733,41 @@ fn integration_activation_deployment_records_for_query(
     }
 
     (records, catalog_count)
+}
+
+fn integration_activation_safety_gates_for_query(
+    query: &IntegrationActivationSafetyQuery,
+) -> (Vec<IntegrationActivationSafetyGate>, usize) {
+    let (records, catalog_count) =
+        integration_activation_deployment_records_for_query(&query.deployment);
+    let mut gates = activation_safety_gates_from_deployment_records(&records);
+
+    if let Some(gate_status) = query.gate_status {
+        gates.retain(|gate| gate.gate_status == gate_status);
+    }
+    if let Some(deployment_ring) = query.deployment_ring {
+        gates.retain(|gate| gate.deployment_ring == deployment_ring);
+    }
+    if let Some(owner_lane) = query.owner_lane {
+        gates.retain(|gate| gate.owner_lane == owner_lane);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        gates.retain(|gate| gate.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        gates.retain(|gate| gate.blocks_activation() == blocked);
+    }
+    if let Some(needs_verification) = query.needs_verification {
+        gates.retain(|gate| gate.needs_verification() == needs_verification);
+    }
+    if let Some(deployment_ready) = query.deployment_ready {
+        gates.retain(|gate| gate.deployment_ready() == deployment_ready);
+    }
+    if let Some(limit) = query.safety_gate_limit {
+        gates.truncate(limit);
+    }
+
+    (gates, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -10689,6 +10822,92 @@ fn get_integration_activation_deployment_summary_output_handler_output(
             (
                 "ready_to_deploy_records",
                 integer(summary.ready_to_deploy_records as i64),
+            ),
+        ]),
+    )
+}
+
+fn list_integration_activation_safety_gates_output_handler_output(
+    query: IntegrationActivationSafetyQuery,
+) -> ToolHandlerOutput {
+    let (gates, catalog_count) = integration_activation_safety_gates_for_query(&query);
+    let summary = IntegrationActivationSafetySummary::from_gates(gates.iter());
+    let count = gates.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_safety_gates",
+            JsonValue::Array(gates.iter().map(activation_safety_gate_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_safety_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_safety_gates"),
+            ),
+            ("gates", integer(count as i64)),
+            (
+                "gates_requiring_attention",
+                integer(summary.gates_requiring_attention as i64),
+            ),
+            ("blocked_gates", integer(summary.blocked_gates as i64)),
+            (
+                "verification_gates",
+                integer(summary.verification_gates as i64),
+            ),
+            (
+                "ready_to_deploy_gates",
+                integer(summary.ready_to_deploy_gates as i64),
+            ),
+            (
+                "next_gate_status",
+                summary
+                    .next_gate_status
+                    .map(|status| string(status.as_str()))
+                    .unwrap_or(JsonValue::Null),
+            ),
+        ]),
+    )
+}
+
+fn get_integration_activation_safety_summary_output_handler_output(
+    query: IntegrationActivationSafetyQuery,
+) -> ToolHandlerOutput {
+    let (gates, _) = integration_activation_safety_gates_for_query(&query);
+    let summary = IntegrationActivationSafetySummary::from_gates(gates.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_safety_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_safety_summary"),
+            ),
+            ("total_gates", integer(summary.total_gates as i64)),
+            (
+                "gates_requiring_attention",
+                integer(summary.gates_requiring_attention as i64),
+            ),
+            ("blocked_gates", integer(summary.blocked_gates as i64)),
+            (
+                "verification_gates",
+                integer(summary.verification_gates as i64),
+            ),
+            (
+                "ready_to_deploy_gates",
+                integer(summary.ready_to_deploy_gates as i64),
             ),
         ]),
     )
@@ -21246,6 +21465,214 @@ fn integration_activation_deployment_summary_json(
     ])
 }
 
+fn activation_safety_gate_json(gate: &IntegrationActivationSafetyGate) -> JsonValue {
+    object([
+        ("sequence", integer(gate.sequence as i64)),
+        ("gate_status", string(gate.gate_status.as_str())),
+        ("deployment_status", string(gate.deployment_status.as_str())),
+        ("deployment_ring", string(gate.deployment_ring.as_str())),
+        ("delivery_channel", string(gate.delivery_channel.as_str())),
+        ("owner_lane", string(gate.owner_lane.as_str())),
+        (
+            "source_deployment_sequence",
+            integer(gate.source_deployment_sequence as i64),
+        ),
+        (
+            "source_delivery_sequence",
+            integer(gate.source_delivery_sequence as i64),
+        ),
+        ("source_id", string(&gate.source_id)),
+        ("title", string(&gate.title)),
+        ("summary", string(&gate.summary)),
+        ("priority", integer(gate.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                gate.integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(gate.integration_count() as i64),
+        ),
+        ("recommended_view", string(gate.recommended_view.as_str())),
+        (
+            "required_tier",
+            string(privilege_tier_label(gate.required_tier)),
+        ),
+        (
+            "policy_surface",
+            gate.policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "has_dependency_work",
+            JsonValue::Bool(gate.has_dependency_work()),
+        ),
+        ("has_policy_risk", JsonValue::Bool(gate.has_policy_risk())),
+        (
+            "needs_verification",
+            JsonValue::Bool(gate.needs_verification()),
+        ),
+        ("deployment_ready", JsonValue::Bool(gate.deployment_ready())),
+        (
+            "blocks_activation",
+            JsonValue::Bool(gate.blocks_activation()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(gate.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_safety_summary_json(
+    summary: &IntegrationActivationSafetySummary,
+) -> JsonValue {
+    object([
+        ("total_gates", integer(summary.total_gates as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "gates_requiring_attention",
+            integer(summary.gates_requiring_attention as i64),
+        ),
+        ("blocked_gates", integer(summary.blocked_gates as i64)),
+        (
+            "verification_gates",
+            integer(summary.verification_gates as i64),
+        ),
+        (
+            "owner_approval_gates",
+            integer(summary.owner_approval_gates as i64),
+        ),
+        (
+            "ready_to_deploy_gates",
+            integer(summary.ready_to_deploy_gates as i64),
+        ),
+        ("monitoring_gates", integer(summary.monitoring_gates as i64)),
+        (
+            "platform_ring_gates",
+            integer(summary.platform_ring_gates as i64),
+        ),
+        (
+            "integration_ring_gates",
+            integer(summary.integration_ring_gates as i64),
+        ),
+        (
+            "security_ring_gates",
+            integer(summary.security_ring_gates as i64),
+        ),
+        (
+            "verification_ring_gates",
+            integer(summary.verification_ring_gates as i64),
+        ),
+        ("audit_ring_gates", integer(summary.audit_ring_gates as i64)),
+        (
+            "monitoring_ring_gates",
+            integer(summary.monitoring_ring_gates as i64),
+        ),
+        (
+            "gates_with_dependency_work",
+            integer(summary.gates_with_dependency_work as i64),
+        ),
+        (
+            "gates_with_policy_risk",
+            integer(summary.gates_with_policy_risk as i64),
+        ),
+        (
+            "gates_requiring_verification",
+            integer(summary.gates_requiring_verification as i64),
+        ),
+        (
+            "gates_ready_to_deploy",
+            integer(summary.gates_ready_to_deploy as i64),
+        ),
+        (
+            "gates_with_policy_surface",
+            integer(summary.gates_with_policy_surface as i64),
+        ),
+        (
+            "next_gate_status",
+            summary
+                .next_gate_status
+                .map(|status| string(status.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_deployment_ring",
+            summary
+                .next_deployment_ring
+                .map(|ring| string(ring.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_owner_lane",
+            summary
+                .next_owner_lane
+                .map(|lane| string(lane.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_recommended_view",
+            summary
+                .next_recommended_view
+                .map(|view| string(view.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_gate_sequence",
+            summary
+                .next_gate_sequence
+                .map(|sequence| integer(sequence as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "next_gate_priority",
+            summary
+                .next_gate_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "has_owner_action",
+            JsonValue::Bool(summary.has_owner_action()),
+        ),
+        (
+            "needs_verification",
+            JsonValue::Bool(summary.needs_verification()),
+        ),
+        (
+            "deployment_ready",
+            JsonValue::Bool(summary.deployment_ready()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -24352,6 +24779,34 @@ fn parse_activation_deployment_ring(
     }
 }
 
+fn parse_activation_safety_gate_status(
+    label: &str,
+) -> Result<IntegrationActivationSafetyGateStatus, ToolCallError> {
+    match label {
+        "blocked" | "blocker" | "blocks_activation" => {
+            Ok(IntegrationActivationSafetyGateStatus::Blocked)
+        }
+        "needs_verification" | "awaiting_verification" | "verify" | "verification" => {
+            Ok(IntegrationActivationSafetyGateStatus::NeedsVerification)
+        }
+        "needs_owner_approval"
+        | "owner_approval"
+        | "awaiting_owner"
+        | "owner_action"
+        | "needs_owner_action"
+        | "action_required" => Ok(IntegrationActivationSafetyGateStatus::NeedsOwnerApproval),
+        "ready_to_deploy" | "deployment_ready" | "ready_for_deployment" | "deploy" => {
+            Ok(IntegrationActivationSafetyGateStatus::ReadyToDeploy)
+        }
+        "monitoring" | "monitor" | "tracking" => {
+            Ok(IntegrationActivationSafetyGateStatus::Monitoring)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation safety gate status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -26075,6 +26530,46 @@ fn integration_activation_deployment_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_safety_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_deployment_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        properties.push(SchemaProperty::new("gate_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("safety_status", JsonSchema::String));
+        properties.push(SchemaProperty::new("safety_state", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "safety_deployment_ring",
+            JsonSchema::String,
+        ));
+        properties.push(SchemaProperty::new("safety_ring", JsonSchema::String));
+        properties.push(SchemaProperty::new("safety_owner_lane", JsonSchema::String));
+        properties.push(SchemaProperty::new(
+            "safety_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new("safety_blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new("blocked", JsonSchema::Boolean));
+        properties.push(SchemaProperty::new(
+            "safety_needs_verification",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "safety_deployment_ready",
+            JsonSchema::Boolean,
+        ));
+        properties.push(SchemaProperty::new(
+            "safety_gate_limit",
+            JsonSchema::Integer,
+        ));
+        properties.push(SchemaProperty::new("gate_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -26219,7 +26714,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 131);
+        assert_eq!(definitions.len(), 133);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -26321,6 +26816,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_APPROVAL_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_SAFETY_GATES_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_SAFETY_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID));
@@ -26586,7 +27087,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_DEPLOYMENT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            123
+            125
         );
         assert_eq!(
             export
@@ -27112,11 +27613,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(131))
+            Some(&integer(133))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(123))
+            Some(&integer(125))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -32126,6 +32627,162 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_safety_gates_request = request(
+            "call-list-integration-activation-safety-gates",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_SAFETY_GATES_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("gate_status", string("blocked")),
+                ("safety_requires_attention", JsonValue::Bool(true)),
+                ("safety_blocked", JsonValue::Bool(true)),
+                ("safety_gate_limit", integer(3)),
+            ]),
+            5_057,
+        );
+        let list_activation_safety_gates_trace =
+            tool_runtime.invoke_with_events(&list_activation_safety_gates_request);
+        assert!(list_activation_safety_gates_trace.result.ok);
+        assert_eq!(
+            list_activation_safety_gates_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_safety_gates_output = list_activation_safety_gates_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_safety_gate_count =
+            integer_value(field(list_activation_safety_gates_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_safety_gate_count));
+        let activation_safety_summary =
+            field(list_activation_safety_gates_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_safety_summary, "total_gates"),
+            Some(&integer(activation_safety_gate_count))
+        );
+        assert_eq!(
+            field(activation_safety_summary, "next_gate_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_safety_summary, "next_deployment_ring"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_safety_summary, "next_owner_lane"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_safety_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_safety_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_safety_gate = array_item(
+            field(
+                list_activation_safety_gates_output,
+                "activation_safety_gates",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_safety_gate, "gate_status"),
+            Some(&string("blocked"))
+        );
+        assert_eq!(
+            field(activation_safety_gate, "deployment_ring"),
+            Some(&string("verification"))
+        );
+        assert_eq!(
+            field(activation_safety_gate, "blocks_activation"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_safety_gate, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_safety_summary_request = request(
+            "call-integration-activation-safety-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_SAFETY_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("safety_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_058,
+        );
+        let activation_safety_summary_trace =
+            tool_runtime.invoke_with_events(&activation_safety_summary_request);
+        assert!(activation_safety_summary_trace.result.ok);
+        assert_eq!(
+            activation_safety_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_safety_summary_output = activation_safety_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_safety_rollup = field(activation_safety_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_safety_rollup, "total_gates").unwrap()).unwrap() >= 1
+        );
+        assert!(
+            integer_value(field(activation_safety_rollup, "blocked_gates").unwrap()).unwrap() >= 1
+        );
+        assert_eq!(
+            field(activation_safety_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_safety_rollup, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -34022,6 +34679,14 @@ mod tests {
             activation_deployment_summary_request,
             activation_deployment_summary_trace,
         );
+        journal.record_trace(
+            list_activation_safety_gates_request,
+            list_activation_safety_gates_trace,
+        );
+        journal.record_trace(
+            activation_safety_summary_request,
+            activation_safety_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -34095,9 +34760,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 131);
-        assert_eq!(journal_summary.completed_count, 131);
-        assert_eq!(journal.audit_records().len(), 131);
+        assert_eq!(journal_summary.invocation_count, 133);
+        assert_eq!(journal_summary.completed_count, 133);
+        assert_eq!(journal.audit_records().len(), 133);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1529,6 +1529,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationDeliverySummary,
     ListIntegrationActivationDeployment,
     GetIntegrationActivationDeploymentSummary,
+    ListIntegrationActivationSafetyGates,
+    GetIntegrationActivationSafetySummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1822,6 +1824,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationDeploymentSummary => {
                 read_tool("smart_home.get_integration_activation_deployment_summary")
+            }
+            Self::ListIntegrationActivationSafetyGates => {
+                read_tool("smart_home.list_integration_activation_safety_gates")
+            }
+            Self::GetIntegrationActivationSafetySummary => {
+                read_tool("smart_home.get_integration_activation_safety_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2534,6 +2542,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationDeliverySummary,
         SmartHomeTool::ListIntegrationActivationDeployment,
         SmartHomeTool::GetIntegrationActivationDeploymentSummary,
+        SmartHomeTool::ListIntegrationActivationSafetyGates,
+        SmartHomeTool::GetIntegrationActivationSafetySummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3376,7 +3386,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 131);
+        assert_eq!(catalog.len(), 133);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3907,6 +3917,14 @@ mod tests {
             == "smart_home.get_integration_activation_deployment_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_safety_gates"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_safety_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3914,15 +3932,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 131);
-        assert_eq!(summary.read_tools, 123);
+        assert_eq!(summary.total_tools, 133);
+        assert_eq!(summary.read_tools, 125);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 123);
+        assert_eq!(summary.read_only_tier_tools, 125);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 131);
+        assert_eq!(summary.total_required_capabilities, 133);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -3839,6 +3839,106 @@ pub struct IntegrationActivationDeploymentSummary {
     pub overall_status: IntegrationActivationHealthStatus,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationSafetyGateStatus {
+    Blocked,
+    NeedsVerification,
+    NeedsOwnerApproval,
+    ReadyToDeploy,
+    Monitoring,
+}
+
+impl IntegrationActivationSafetyGateStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blocked => "blocked",
+            Self::NeedsVerification => "needs_verification",
+            Self::NeedsOwnerApproval => "needs_owner_approval",
+            Self::ReadyToDeploy => "ready_to_deploy",
+            Self::Monitoring => "monitoring",
+        }
+    }
+
+    pub fn from_deployment_status(status: IntegrationActivationDeploymentStatus) -> Self {
+        match status {
+            IntegrationActivationDeploymentStatus::Blocked => Self::Blocked,
+            IntegrationActivationDeploymentStatus::AwaitingVerification => Self::NeedsVerification,
+            IntegrationActivationDeploymentStatus::AwaitingOwner => Self::NeedsOwnerApproval,
+            IntegrationActivationDeploymentStatus::ReadyToDeploy => Self::ReadyToDeploy,
+            IntegrationActivationDeploymentStatus::Monitoring => Self::Monitoring,
+        }
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Blocked | Self::NeedsVerification | Self::NeedsOwnerApproval
+        )
+    }
+
+    pub fn blocks_activation(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationSafetyGate {
+    pub sequence: usize,
+    pub gate_status: IntegrationActivationSafetyGateStatus,
+    pub deployment_status: IntegrationActivationDeploymentStatus,
+    pub deployment_ring: IntegrationActivationDeploymentRing,
+    pub delivery_channel: IntegrationActivationDeliveryChannel,
+    pub owner_lane: IntegrationActivationResponseOwnerLane,
+    pub source_deployment_sequence: usize,
+    pub source_delivery_sequence: usize,
+    pub source_id: String,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub recommended_view: IntegrationActivationPlaybookView,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub dependency_work: bool,
+    pub policy_risk: bool,
+    pub verification_required: bool,
+    pub deployment_ready: bool,
+    pub blocks_activation: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationSafetySummary {
+    pub total_gates: usize,
+    pub unique_integrations: usize,
+    pub gates_requiring_attention: usize,
+    pub blocked_gates: usize,
+    pub verification_gates: usize,
+    pub owner_approval_gates: usize,
+    pub ready_to_deploy_gates: usize,
+    pub monitoring_gates: usize,
+    pub platform_ring_gates: usize,
+    pub integration_ring_gates: usize,
+    pub security_ring_gates: usize,
+    pub verification_ring_gates: usize,
+    pub audit_ring_gates: usize,
+    pub monitoring_ring_gates: usize,
+    pub gates_with_dependency_work: usize,
+    pub gates_with_policy_risk: usize,
+    pub gates_requiring_verification: usize,
+    pub gates_ready_to_deploy: usize,
+    pub gates_with_policy_surface: usize,
+    pub next_gate_status: Option<IntegrationActivationSafetyGateStatus>,
+    pub next_deployment_ring: Option<IntegrationActivationDeploymentRing>,
+    pub next_owner_lane: Option<IntegrationActivationResponseOwnerLane>,
+    pub next_recommended_view: Option<IntegrationActivationPlaybookView>,
+    pub next_gate_sequence: Option<usize>,
+    pub next_gate_priority: Option<u8>,
+    pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
 impl IntegrationActivationPlanSummary {
     pub fn from_plans<'a>(plans: impl IntoIterator<Item = &'a IntegrationActivationPlan>) -> Self {
         let mut summary = Self {
@@ -10775,6 +10875,220 @@ impl IntegrationActivationDeploymentSummary {
     }
 }
 
+impl IntegrationActivationSafetyGate {
+    fn from_deployment_record(record: &IntegrationActivationDeploymentRecord) -> Self {
+        let gate_status =
+            IntegrationActivationSafetyGateStatus::from_deployment_status(record.deployment_status);
+        let blocks_activation = gate_status.blocks_activation() || record.deployment_blocked();
+        let requires_attention =
+            gate_status.requires_attention() || record.requires_attention() || blocks_activation;
+
+        Self {
+            sequence: 0,
+            gate_status,
+            deployment_status: record.deployment_status,
+            deployment_ring: record.deployment_ring,
+            delivery_channel: record.delivery_channel,
+            owner_lane: record.owner_lane,
+            source_deployment_sequence: record.sequence,
+            source_delivery_sequence: record.source_delivery_sequence,
+            source_id: record.source_id.clone(),
+            title: format!("{} safety gate: {}", gate_status.as_str(), record.title),
+            summary: record.summary.clone(),
+            priority: record.priority,
+            integration_ids: record.integration_ids.clone(),
+            recommended_view: record.recommended_view,
+            required_tier: record.required_tier,
+            policy_surface: record.policy_surface,
+            dependency_work: record.dependency_work,
+            policy_risk: record.policy_risk,
+            verification_required: record.verification_required
+                || gate_status == IntegrationActivationSafetyGateStatus::NeedsVerification,
+            deployment_ready: record.deployment_ready(),
+            blocks_activation,
+            requires_attention,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn has_dependency_work(&self) -> bool {
+        self.dependency_work
+    }
+
+    pub fn has_policy_risk(&self) -> bool {
+        self.policy_risk
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_required
+    }
+
+    pub fn deployment_ready(&self) -> bool {
+        self.deployment_ready
+    }
+
+    pub fn blocks_activation(&self) -> bool {
+        self.blocks_activation
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention
+    }
+
+    pub fn has_policy_surface(&self) -> bool {
+        self.policy_surface.is_some()
+    }
+}
+
+impl IntegrationActivationSafetySummary {
+    pub fn from_gates<'a>(
+        gates: impl IntoIterator<Item = &'a IntegrationActivationSafetyGate>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_gates: 0,
+            unique_integrations: 0,
+            gates_requiring_attention: 0,
+            blocked_gates: 0,
+            verification_gates: 0,
+            owner_approval_gates: 0,
+            ready_to_deploy_gates: 0,
+            monitoring_gates: 0,
+            platform_ring_gates: 0,
+            integration_ring_gates: 0,
+            security_ring_gates: 0,
+            verification_ring_gates: 0,
+            audit_ring_gates: 0,
+            monitoring_ring_gates: 0,
+            gates_with_dependency_work: 0,
+            gates_with_policy_risk: 0,
+            gates_requiring_verification: 0,
+            gates_ready_to_deploy: 0,
+            gates_with_policy_surface: 0,
+            next_gate_status: None,
+            next_deployment_ring: None,
+            next_owner_lane: None,
+            next_recommended_view: None,
+            next_gate_sequence: None,
+            next_gate_priority: None,
+            first_attention_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for gate in gates {
+            summary.total_gates += 1;
+            for integration_id in &gate.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+
+            if summary.next_gate_status.is_none()
+                && (gate.requires_attention() || gate.deployment_ready())
+            {
+                summary.next_gate_status = Some(gate.gate_status);
+                summary.next_deployment_ring = Some(gate.deployment_ring);
+                summary.next_owner_lane = Some(gate.owner_lane);
+                summary.next_recommended_view = Some(gate.recommended_view);
+                summary.next_gate_sequence = Some(gate.sequence);
+                summary.next_gate_priority = Some(gate.priority);
+            }
+
+            match gate.gate_status {
+                IntegrationActivationSafetyGateStatus::Blocked => summary.blocked_gates += 1,
+                IntegrationActivationSafetyGateStatus::NeedsVerification => {
+                    summary.verification_gates += 1;
+                }
+                IntegrationActivationSafetyGateStatus::NeedsOwnerApproval => {
+                    summary.owner_approval_gates += 1;
+                }
+                IntegrationActivationSafetyGateStatus::ReadyToDeploy => {
+                    summary.ready_to_deploy_gates += 1;
+                }
+                IntegrationActivationSafetyGateStatus::Monitoring => summary.monitoring_gates += 1,
+            }
+
+            match gate.deployment_ring {
+                IntegrationActivationDeploymentRing::Platform => summary.platform_ring_gates += 1,
+                IntegrationActivationDeploymentRing::Integration => {
+                    summary.integration_ring_gates += 1;
+                }
+                IntegrationActivationDeploymentRing::Security => summary.security_ring_gates += 1,
+                IntegrationActivationDeploymentRing::Verification => {
+                    summary.verification_ring_gates += 1;
+                }
+                IntegrationActivationDeploymentRing::Audit => summary.audit_ring_gates += 1,
+                IntegrationActivationDeploymentRing::Monitoring => {
+                    summary.monitoring_ring_gates += 1;
+                }
+            }
+
+            if gate.requires_attention() {
+                summary.gates_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(gate.priority));
+            }
+            if gate.has_dependency_work() {
+                summary.gates_with_dependency_work += 1;
+            }
+            if gate.has_policy_risk() {
+                summary.gates_with_policy_risk += 1;
+            }
+            if gate.needs_verification() {
+                summary.gates_requiring_verification += 1;
+            }
+            if gate.deployment_ready() {
+                summary.gates_ready_to_deploy += 1;
+            }
+            if gate.has_policy_surface() {
+                summary.gates_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(gate.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_gates > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.gates_requiring_attention > 0
+            || summary.verification_gates > 0
+            || summary.owner_approval_gates > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.ready_to_deploy_gates > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_gates == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_gates > 0
+    }
+
+    pub fn has_owner_action(&self) -> bool {
+        self.owner_approval_gates > 0
+    }
+
+    pub fn needs_verification(&self) -> bool {
+        self.verification_gates > 0 || self.gates_requiring_verification > 0
+    }
+
+    pub fn deployment_ready(&self) -> bool {
+        self.ready_to_deploy_gates > 0 || self.gates_ready_to_deploy > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.gates_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -15996,6 +16310,38 @@ pub fn activation_deployment_records_at_or_before_priority(
     activation_deployment_records_from_delivery_manifests(&manifests)
 }
 
+pub fn activation_safety_gates_from_deployment_records(
+    records: &[IntegrationActivationDeploymentRecord],
+) -> Vec<IntegrationActivationSafetyGate> {
+    let mut gates: Vec<_> = records
+        .iter()
+        .map(IntegrationActivationSafetyGate::from_deployment_record)
+        .collect();
+
+    gates.sort_by(compare_activation_safety_gates);
+    for (index, gate) in gates.iter_mut().enumerate() {
+        gate.sequence = index + 1;
+    }
+    gates
+}
+
+pub fn activation_safety_gates_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationSafetyGate> {
+    let records = activation_deployment_records_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    activation_safety_gates_from_deployment_records(&records)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -17727,6 +18073,25 @@ fn compare_activation_deployment_records(
             left.source_remediation_kind
                 .cmp(&right.source_remediation_kind)
         })
+        .then_with(|| left.owner_lane.cmp(&right.owner_lane))
+        .then_with(|| left.source_id.cmp(&right.source_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_safety_gates(
+    left: &IntegrationActivationSafetyGate,
+    right: &IntegrationActivationSafetyGate,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| left.gate_status.cmp(&right.gate_status))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| right.blocks_activation().cmp(&left.blocks_activation()))
+        .then_with(|| right.needs_verification().cmp(&left.needs_verification()))
+        .then_with(|| right.deployment_ready().cmp(&left.deployment_ready()))
+        .then_with(|| right.has_dependency_work().cmp(&left.has_dependency_work()))
+        .then_with(|| right.has_policy_risk().cmp(&left.has_policy_risk()))
+        .then_with(|| left.deployment_ring.cmp(&right.deployment_ring))
         .then_with(|| left.owner_lane.cmp(&right.owner_lane))
         .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
@@ -21423,6 +21788,39 @@ mod tests {
         );
         assert_eq!(
             deployment_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
+
+        let safety_gates = activation_safety_gates_from_deployment_records(&deployment_records);
+        assert_eq!(safety_gates.len(), deployment_records.len());
+        assert!(safety_gates
+            .iter()
+            .any(|gate| gate.gate_status == IntegrationActivationSafetyGateStatus::Blocked));
+        assert!(safety_gates.iter().any(
+            |gate| gate.gate_status == IntegrationActivationSafetyGateStatus::NeedsVerification
+        ));
+        assert!(safety_gates
+            .iter()
+            .any(IntegrationActivationSafetyGate::requires_attention));
+        assert!(safety_gates
+            .iter()
+            .any(IntegrationActivationSafetyGate::blocks_activation));
+
+        let safety_summary = IntegrationActivationSafetySummary::from_gates(safety_gates.iter());
+        assert_eq!(safety_summary.total_gates, safety_gates.len());
+        assert!(safety_summary.has_blockers());
+        assert!(safety_summary.needs_verification());
+        assert!(safety_summary.requires_attention());
+        assert_eq!(
+            safety_summary.next_gate_status,
+            Some(IntegrationActivationSafetyGateStatus::Blocked)
+        );
+        assert_eq!(
+            safety_summary.next_owner_lane,
+            Some(IntegrationActivationResponseOwnerLane::Platform)
+        );
+        assert_eq!(
+            safety_summary.overall_status,
             IntegrationActivationHealthStatus::Blocked
         );
 


### PR DESCRIPTION
## Summary
- add activation safety gate/status/summary derivation from integration deployment records
- expose Chief read tools for listing activation safety gates and summarizing safety blockers
- register the new read-only tool descriptors in the shared smart-home core catalog and bridge e2e coverage

## Validation
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core
- sh BUILD in smart-home-integration-catalog
- sh BUILD in hue-core
- sh BUILD in smart-home-runtime
- sh BUILD in smart-home-testkit
- sh BUILD in smart-home-local-http
- sh BUILD in smart-home-discovery
- sh BUILD in chief-of-staff-smart-home-tools
