### PR TITLE
feat(spice): route parsed save/probe output

### DIFF
--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `resolve_deck_outputs`, `select_deck_output_probes`, and
+  `format_deck_*_table` helpers so parsed `.save` and `.probe` deck cards can
+  drive stable operating-point, DC sweep, AC sweep, and transient table output
+  in the live Rust package.
 - Add `resolve_deck_measurements`, `measure_transient_cards`, and
   `measure_transient_deck` for parsed transient `.measure` / `.meas` card
   routing into stable scalar measurement rows, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -157,3 +157,10 @@ signatures, arguments, or empty expressions.
 before `.end`, keeps non-measure active lines, evaluates optional `FROM=` /
 `TO=` scalar time windows, and reports stable diagnostics for unsupported
 analyses, modes, options, expressions, and invalid windows.
+`resolve_deck_outputs` extracts `.save` and scoped or global `.probe` cards
+before `.end`, keeps non-output active lines, and reports stable diagnostics for
+malformed output probes. `select_deck_output_probes` deduplicates the selected
+probes for a requested analysis, while `format_deck_op_table`,
+`format_deck_dc_sweep_table`, `format_deck_ac_table`, and
+`format_deck_transient_table` feed those deck-card selections into the stable
+text table formatters.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3288,6 +3288,33 @@ pub struct DeckMeasurementSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckOutputSelection {
+    pub directive: String,
+    pub analysis: Option<String>,
+    pub probes: Vec<String>,
+    pub line_number: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckOutputDiagnostic {
+    pub code: String,
+    pub directive: String,
+    pub line_number: usize,
+    pub message: String,
+    pub severity: String,
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeckOutputSummary {
+    pub active_lines: Vec<String>,
+    pub terminated: bool,
+    pub end_line_number: Option<usize>,
+    pub selections: Vec<DeckOutputSelection>,
+    pub diagnostics: Vec<DeckOutputDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseReadinessIssue {
     pub deck_id: String,
     pub field: String,
@@ -3627,6 +3654,69 @@ pub fn resolve_deck_measurements(netlist: &str) -> DeckMeasurementSummary {
     }
 }
 
+pub fn resolve_deck_outputs(netlist: &str) -> DeckOutputSummary {
+    let mut state = DeckOutputState::new();
+    let mut active_lines = Vec::new();
+    let mut end_line_number = None;
+
+    for (index, raw_line) in netlist.lines().enumerate() {
+        let line_number = index + 1;
+        let stripped = raw_line.trim();
+        if stripped.is_empty() || stripped.starts_with('*') || stripped.starts_with(';') {
+            continue;
+        }
+        let directive = deck_directive(stripped);
+        if directive.as_deref() == Some(".end") {
+            end_line_number = Some(line_number);
+            break;
+        }
+        if matches!(directive.as_deref(), Some(".save" | ".probe")) {
+            resolve_output_line(
+                stripped,
+                line_number,
+                directive.as_deref().unwrap(),
+                &mut state,
+            );
+            continue;
+        }
+        active_lines.push(stripped.to_string());
+    }
+
+    DeckOutputSummary {
+        active_lines,
+        terminated: end_line_number.is_some(),
+        end_line_number,
+        selections: state.selections,
+        diagnostics: state.diagnostics,
+    }
+}
+
+pub fn select_deck_output_probes(netlist: &str, analysis: &str) -> Result<Vec<String>, SpiceError> {
+    let summary = resolve_deck_outputs(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_output_probes",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for selection in summary.selections {
+        if !selection.analysis.as_deref().map_or(true, |requested| {
+            deck_output_analysis_matches(requested, analysis)
+        }) {
+            continue;
+        }
+        for probe in selection.probes {
+            let key = deck_output_probe_key(&probe);
+            if seen.insert(key) {
+                selected.push(probe);
+            }
+        }
+    }
+    Ok(selected)
+}
+
 pub fn release_readiness_gates(corpus: &[CompatibilityDeck]) -> ReleaseReadinessReport {
     let mut issues = Vec::new();
     let mut seen_ids = HashSet::new();
@@ -3953,6 +4043,20 @@ impl DeckMeasurementState {
         Self {
             diagnostics: Vec::new(),
             measurements: Vec::new(),
+        }
+    }
+}
+
+struct DeckOutputState {
+    diagnostics: Vec<DeckOutputDiagnostic>,
+    selections: Vec<DeckOutputSelection>,
+}
+
+impl DeckOutputState {
+    fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            selections: Vec::new(),
         }
     }
 }
@@ -4566,6 +4670,76 @@ fn resolve_measurement_line(
     });
 }
 
+fn resolve_output_line(
+    line: &str,
+    line_number: usize,
+    directive: &str,
+    state: &mut DeckOutputState,
+) {
+    let tokens = directive_tokens(line);
+    if tokens.len() < 2 {
+        add_output_diagnostic(
+            state,
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            directive,
+            line_number,
+            &format!("{directive} requires at least one probe token"),
+            None,
+        );
+        return;
+    }
+
+    let (analysis, probe_tokens) = if directive == ".probe"
+        && tokens
+            .get(1)
+            .and_then(|token| normalize_deck_output_analysis(token))
+            .is_some()
+    {
+        (
+            normalize_deck_output_analysis(tokens[1]).map(str::to_string),
+            &tokens[2..],
+        )
+    } else {
+        (None, &tokens[1..])
+    };
+    if probe_tokens.is_empty() {
+        add_output_diagnostic(
+            state,
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            directive,
+            line_number,
+            &format!("{directive} requires at least one probe token"),
+            None,
+        );
+        return;
+    }
+
+    let mut probes = Vec::new();
+    for token in probe_tokens {
+        let token = unquote_token(token);
+        match normalize_deck_output_probe(&token) {
+            Some(probe) => probes.push(probe),
+            None => add_output_diagnostic(
+                state,
+                "SPICE_DECK_OUTPUT_PROBE",
+                directive,
+                line_number,
+                &format!("{directive} probe must be V(node) or I(source), got {token:?}"),
+                Some(token),
+            ),
+        }
+    }
+    if probes.is_empty() {
+        return;
+    }
+    state.selections.push(DeckOutputSelection {
+        directive: directive.to_string(),
+        analysis,
+        probes,
+        line_number,
+    });
+}
+
 fn resolve_param_line(line: &str, line_number: usize, state: &mut DeckParameterState) {
     let tokens = directive_tokens(line);
     if tokens.len() == 1 {
@@ -5097,6 +5271,24 @@ fn add_measurement_diagnostic(
     });
 }
 
+fn add_output_diagnostic(
+    state: &mut DeckOutputState,
+    code: &str,
+    directive: &str,
+    line_number: usize,
+    message: &str,
+    token: Option<String>,
+) {
+    state.diagnostics.push(DeckOutputDiagnostic {
+        code: code.to_string(),
+        directive: directive.to_string(),
+        line_number,
+        message: message.to_string(),
+        severity: "error".to_string(),
+        token,
+    });
+}
+
 fn parse_node_condition_target(target: &str) -> Option<String> {
     if target.len() < 4 || !target.to_ascii_lowercase().starts_with("v(") || !target.ends_with(')')
     {
@@ -5154,6 +5346,49 @@ fn normalize_measurement_mode_token(mode: &str) -> Option<&'static str> {
         "last" | "final" => Some("last"),
         _ => None,
     }
+}
+
+fn normalize_deck_output_analysis(analysis: &str) -> Option<&'static str> {
+    match analysis.trim().to_ascii_lowercase().as_str() {
+        "op" | "dcop" => Some("op"),
+        "dc" => Some("dc"),
+        "ac" => Some("ac"),
+        "tran" | "transient" => Some("tran"),
+        _ => None,
+    }
+}
+
+fn deck_output_analysis_matches(requested: &str, analysis: &str) -> bool {
+    normalize_deck_output_analysis(requested) == normalize_deck_output_analysis(analysis)
+}
+
+fn normalize_deck_output_probe(token: &str) -> Option<String> {
+    let text = token.trim();
+    if !text.ends_with(')') {
+        return None;
+    }
+    let lower = text.to_ascii_lowercase();
+    let prefix = if lower.starts_with("v(") {
+        "V"
+    } else if lower.starts_with("i(") {
+        "I"
+    } else {
+        return None;
+    };
+    let target = text[2..text.len() - 1].trim();
+    if target.is_empty()
+        || target.contains('(')
+        || target.contains(')')
+        || target.contains(',')
+        || target.chars().any(char::is_whitespace)
+    {
+        return None;
+    }
+    Some(format!("{prefix}({target})"))
+}
+
+fn deck_output_probe_key(probe: &str) -> String {
+    probe.to_ascii_lowercase()
 }
 
 fn strip_expression_delimiters(expression: &str) -> String {
@@ -7824,6 +8059,37 @@ pub fn format_ac_table(points: &[AcPoint], probes: &[&str]) -> Result<String, Sp
     }
     rows.push(String::new());
     Ok(rows.join("\n"))
+}
+
+pub fn format_deck_op_table(result: &DcResult, netlist: &str) -> Result<String, SpiceError> {
+    let probes = select_deck_output_probes(netlist, "op")?;
+    let probe_refs = probes.iter().map(String::as_str).collect::<Vec<_>>();
+    format_dc_table(result, &probe_refs)
+}
+
+pub fn format_deck_dc_sweep_table(
+    source_name: &str,
+    points: &[DcSweepPoint],
+    netlist: &str,
+) -> Result<String, SpiceError> {
+    let probes = select_deck_output_probes(netlist, "dc")?;
+    let probe_refs = probes.iter().map(String::as_str).collect::<Vec<_>>();
+    format_dc_sweep_table(source_name, points, &probe_refs)
+}
+
+pub fn format_deck_ac_table(points: &[AcPoint], netlist: &str) -> Result<String, SpiceError> {
+    let probes = select_deck_output_probes(netlist, "ac")?;
+    let probe_refs = probes.iter().map(String::as_str).collect::<Vec<_>>();
+    format_ac_table(points, &probe_refs)
+}
+
+pub fn format_deck_transient_table(
+    points: &[TransientPoint],
+    netlist: &str,
+) -> Result<String, SpiceError> {
+    let probes = select_deck_output_probes(netlist, "tran")?;
+    let probe_refs = probes.iter().map(String::as_str).collect::<Vec<_>>();
+    format_transient_table(points, &probe_refs)
 }
 
 pub fn format_corner_ac_table(

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use spice_engine::{
     analyze_deck_controls, compatibility_corpus, format_compatibility_corpus_table,
     format_release_readiness_report, release_readiness_gates, resolve_deck_functions,
-    resolve_deck_initial_conditions, resolve_deck_measurements, resolve_deck_parameters,
-    resolve_deck_sources, CompatibilityDeck, CompatibilityGoldenValue, CompatibilityOracle,
+    resolve_deck_initial_conditions, resolve_deck_measurements, resolve_deck_outputs,
+    resolve_deck_parameters, resolve_deck_sources, select_deck_output_probes, CompatibilityDeck,
+    CompatibilityGoldenValue, CompatibilityOracle,
 };
 
 #[test]
@@ -659,4 +660,87 @@ fn resolve_deck_measurements_reports_unsupported_subset() {
             "SPICE_DECK_MEASURE_WINDOW",
         ]
     );
+}
+
+#[test]
+fn resolve_deck_outputs_extracts_save_and_probe_cards() {
+    let summary = resolve_deck_outputs(
+        "
+V1 in 0 DC 1
+.save V(out) i(V1)
+.probe tran V(clk)
+.probe AC V(out)
+.end
+.save V(ignored)
+",
+    );
+
+    assert_eq!(summary.active_lines, vec!["V1 in 0 DC 1"]);
+    assert!(summary.terminated);
+    assert_eq!(summary.end_line_number, Some(6));
+    assert!(summary.diagnostics.is_empty());
+    assert_eq!(
+        summary
+            .selections
+            .iter()
+            .map(|selection| (
+                selection.directive.as_str(),
+                selection.analysis.as_deref(),
+                selection.probes.as_slice()
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                ".save",
+                None,
+                &["V(out)".to_string(), "I(V1)".to_string()][..]
+            ),
+            (".probe", Some("tran"), &["V(clk)".to_string()][..]),
+            (".probe", Some("ac"), &["V(out)".to_string()][..]),
+        ]
+    );
+
+    assert_eq!(
+        select_deck_output_probes(
+            "
+.save V(out) I(V1)
+.probe tran V(out) V(clk)
+.probe ac V(freq)
+.end
+",
+            "transient",
+        )
+        .unwrap(),
+        vec!["V(out)", "I(V1)", "V(clk)"]
+    );
+}
+
+#[test]
+fn resolve_deck_outputs_reports_invalid_cards() {
+    let summary = resolve_deck_outputs(
+        "
+.save
+.probe tran
+.save P(out)
+.probe dc V(out) bad-token
+.end
+",
+    );
+
+    let mut codes = summary
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        vec![
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_ARGUMENT",
+            "SPICE_DECK_OUTPUT_PROBE",
+            "SPICE_DECK_OUTPUT_PROBE",
+        ]
+    );
+    assert_eq!(summary.selections[0].probes, vec!["V(out)".to_string()]);
 }

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -7,12 +7,13 @@ use spice_engine::{
     format_corner_adaptive_digital_event_stream_table, format_corner_adaptive_transient_table,
     format_corner_digital_event_stream_table, format_corner_distortion_table,
     format_corner_fourier_table, format_corner_pole_zero_table, format_corner_pss_table,
-    format_corner_transient_table, format_dc_table, format_digital_bridge_schedule_table,
-    format_digital_event_stream_table, format_digital_event_table, format_distortion_table,
-    format_fourier_table, format_measurement_table, format_pole_zero_table, format_pss_table,
-    format_transient_table, fourier, fourier_corners, measure_transient_deck,
-    measure_transient_probe, pole_zero_rc_highpass, pole_zero_rc_lowpass, pole_zero_rlc_bandpass,
-    pole_zero_rlc_highpass, pole_zero_rlc_lowpass, pole_zero_rlc_notch, pss_corners_with_tolerance,
+    format_corner_transient_table, format_dc_table, format_deck_transient_table,
+    format_digital_bridge_schedule_table, format_digital_event_stream_table,
+    format_digital_event_table, format_distortion_table, format_fourier_table,
+    format_measurement_table, format_pole_zero_table, format_pss_table, format_transient_table,
+    fourier, fourier_corners, measure_transient_deck, measure_transient_probe,
+    pole_zero_rc_highpass, pole_zero_rc_lowpass, pole_zero_rlc_bandpass, pole_zero_rlc_highpass,
+    pole_zero_rlc_lowpass, pole_zero_rlc_notch, pss_corners_with_tolerance,
     pss_newton_candidate_with_tolerance, pss_newton_iteration_with_tolerance,
     pss_newton_solve_with_tolerance, pss_newton_update, pss_newton_update_with_tolerance,
     pss_residual, pss_residual_jacobian_with_tolerance, pss_residual_with_tolerance,
@@ -1706,6 +1707,46 @@ V1 in 0 DC 1
     assert_eq!(
         format_measurement_table(&measurements),
         "Name\tAnalysis\tProbe\tMode\tFrom\tTo\tValue\nswing\ttran\tV(out)\tpp\t1.000000e-03\t3.000000e-03\t1.500000e+00\nsettled\ttran\tV(out)\tlast\t\t\t7.500000e-01\n"
+    );
+}
+
+#[test]
+fn transient_deck_output_cards_select_table_probes() {
+    let points = vec![
+        TransientPoint {
+            time: 0.0,
+            node_voltages: BTreeMap::from([
+                ("out".to_string(), 0.0),
+                ("clk".to_string(), 0.0),
+                ("ignored".to_string(), 1.0),
+            ]),
+            branch_currents: BTreeMap::from([("I(V1)".to_string(), -1.0e-3)]),
+        },
+        TransientPoint {
+            time: 1.0e-3,
+            node_voltages: BTreeMap::from([
+                ("out".to_string(), 1.0),
+                ("clk".to_string(), 5.0),
+                ("ignored".to_string(), 2.0),
+            ]),
+            branch_currents: BTreeMap::from([("I(V1)".to_string(), -2.0e-3)]),
+        },
+    ];
+
+    let table = format_deck_transient_table(
+        &points,
+        "
+.save V(out) I(V1)
+.probe tran V(clk) V(out)
+.probe ac V(ignored)
+.end
+",
+    )
+    .unwrap();
+
+    assert_eq!(
+        table,
+        "Index\tTime\tV(out)\tI(V1)\tV(clk)\n0\t0.000000e+00\t0.000000e+00\t-1.000000e-03\t0.000000e+00\n1\t1.000000e-03\t1.000000e+00\t-2.000000e-03\t5.000000e+00\n"
     );
 }
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -28,9 +28,11 @@ downstream tools to compare.
      diagnostic and solver footholds; transient scalar `.measure`-style output
      helpers now cover shared peak-to-peak and final-value measurement output,
      and parsed transient `.measure` / `.meas` cards can now feed those
-     measurement helpers from deck text.
-   - Expand `.save` and `.probe` execution plus richer `.measure` modes toward
-     full SPICE compatibility while keeping unsupported control-flow
+     measurement helpers from deck text; parsed `.save` and `.probe` cards now
+     drive stable Rust table output for operating-point, DC sweep, AC sweep, and
+     transient results.
+   - Expand richer `.measure` modes and non-transient measurement analyses
+     toward full SPICE compatibility while keeping unsupported control-flow
      diagnostics explicit.
 
 ## Completed Slices
@@ -254,13 +256,24 @@ downstream tools to compare.
       measurement rows, while diagnostics keep unsupported analyses, modes,
       options, expressions, and invalid windows explicit.
 
+23. Parsed save/probe output execution routing.
+    - Status: completed in this parsed save/probe execution slice.
+    - The live Rust package now exposes `resolve_deck_outputs`,
+      `select_deck_output_probes`, and deck-aware table formatters that extract
+      `.save` plus scoped or global `.probe` cards before `.end`.
+    - Selected probes are normalized, deduplicated in deck order, scoped by
+      analysis for `.probe`, and routed into stable operating-point, DC sweep,
+      AC sweep, and transient text tables.
+    - Stable diagnostics cover missing probe lists and malformed output probes;
+      richer `.measure` modes and non-transient measurement analyses remain in
+      the deck execution backlog.
+
 ## Backlog
 
 1. Deck execution layer.
    - Convert parsed netlists into runnable analysis plans.
-   - Expand parsed `.save` and `.probe` deck-card execution plus richer
-     `.measure` modes and non-transient measurement analyses toward full SPICE
-     compatibility.
+   - Expand richer `.measure` modes and non-transient measurement analyses
+     toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature
      diagnostics are now present for the current non-executed state.
 


### PR DESCRIPTION
## Summary

- Add Rust SPICE deck-output routing helpers for parsed `.save` and `.probe` cards.
- Route selected deck probes through stable OP, DC sweep, AC, and transient table formatters while preserving default output when no cards select probes.
- Add diagnostics, tests, README notes, changelog entry, and update the SPICE implementation plan with the completed slice.

## Notes

Latest `origin/main` currently contains the Rust SPICE package surfaces for this slice; Python and TypeScript SPICE package paths were absent in the fresh worktree, so verification focused on the touched Rust package.

## Verification

- `cargo fmt --check --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`