### PR TITLE
feat(sir-runtime-core): importable core runtime packages for SIR-emitted Python & TS

### DIFF
--- a/code/packages/python/sir-runtime-core/BUILD
+++ b/code/packages/python/sir-runtime-core/BUILD
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-core/BUILD_windows
+++ b/code/packages/python/sir-runtime-core/BUILD_windows
@@ -1,0 +1,5 @@
+uv venv --quiet --clear
+uv pip install -e .[dev] --quiet
+.venv\Scripts\python.exe -m ruff check src tests
+.venv\Scripts\python.exe -m mypy
+.venv\Scripts\python.exe -m pytest tests/ -v

--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to `coding-adventures-sir-runtime-core` are documented here.
+
+## [0.1.0] - 2026-06-11
+
+### Added
+
+Initial release — the core runtime imported by Semantic-IR-emitted Python.
+Provides the SIR semantics that have no faithful native Python equivalent:
+
+- **SIR truthiness** (`truthy`) — only `False` and `nil` are falsy (`0`, `""`,
+  `[]`, `{}` are truthy), the Lisp/Ruby convention.
+- **Symbols** (`Symbol`, `intern`) — interned identity objects.
+- **Pairs** (`Pair`, `cons`, `car`, `cdr`, `is_pair`) — cons cells with Lisp
+  list display.
+- **Equality / predicates** (`eq`, `is_null`, `is_number`, `is_symbol`) and
+  **display** (`to_display`, `print`).
+- **Arithmetic** (`add`, `sub`, `mul`, variadic; `div` truncating-integer;
+  `lt`, `gt`).
+- **Closures** (`Closure`, `apply`, `make_closure`), an in-memory **global
+  store** (`global_set`, `global_get`, `global_get_static`), and **builtin
+  dispatch** (`call_builtin`, `builtin_closure`).
+
+Migrated verbatim (behaviour-preserving) from the inline `_sir_*` prelude that
+`semantic-ir-to-python` used to paste into every artifact. See
+`code/specs/sir-runtime.md`.

--- a/code/packages/python/sir-runtime-core/README.md
+++ b/code/packages/python/sir-runtime-core/README.md
@@ -1,0 +1,53 @@
+# coding-adventures-sir-runtime-core
+
+Core runtime imported by **Semantic-IR-emitted Python**.
+
+## What it is
+
+Semantic-IR (SIR) backends translate most constructs to **native** Python — a
+sequence is a `list`, a map is a `dict`, a loop is a `for`, a class is a `class`.
+A handful of SIR semantics have **no faithful native equivalent**, and those live
+here so the emitted code can `import` and call them instead of inlining a runtime
+prelude into every file:
+
+| Provided | Why it's not native |
+|---|---|
+| `truthy(v)` | SIR truthiness is **false/nil-only** — `0`, `""`, `[]`, `{}` are *truthy*, unlike Python's `bool()`. |
+| `Symbol` / `intern` | Interned identity objects; Python has no symbol type. |
+| `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
+| `eq`, `to_display`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
+| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. |
+| `Closure`/`apply`/`make_closure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
+
+It implements **SIR** semantics, not any one source language's — so a Ruby
+frontend today and a JavaScript or Python frontend tomorrow all reuse it.
+
+## How emitted code uses it
+
+```python
+import coding_adventures_sir_runtime_core as _sir
+
+def add(a, b):
+    return a + b
+
+xs = [1, 2, 3]
+i = 0
+while _sir.truthy(i < len(xs)):
+    _sir.print(xs[i])
+    i = i + 1
+```
+
+## Where it fits
+
+Frontend (Ruby / JS / Python …) → `semantic-ir` → `semantic-ir-to-python` →
+emitted `.py` that imports this package. See
+[`code/specs/sir-runtime.md`](../../../specs/sir-runtime.md).
+
+## Development
+
+```sh
+uv venv && uv pip install -e .[dev]
+.venv/bin/python -m ruff check src tests
+.venv/bin/python -m mypy
+.venv/bin/python -m pytest
+```

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-sir-runtime-core"
+version = "0.1.0"
+description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
+requires-python = ">=3.12"
+dependencies = []
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["sir", "semantic-ir", "runtime", "compiler", "cross-language", "education"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Education",
+    "Topic :: Education",
+    "Topic :: Software Development :: Compilers",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+Documentation = "https://github.com/adhithyan15/coding-adventures/tree/main/code/specs/sir-runtime.md"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coding_adventures_sir_runtime_core"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]
+
+[tool.mypy]
+strict = true
+python_version = "3.12"
+files = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=coding_adventures_sir_runtime_core --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/coding_adventures_sir_runtime_core"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true

--- a/code/packages/python/sir-runtime-core/required_capabilities.json
+++ b/code/packages/python/sir-runtime-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "python/sir-runtime-core",
+  "capabilities": [],
+  "justification": "Pure in-process runtime helpers (truthiness, symbols, pairs, arithmetic, closures, an in-memory global store, and stdout printing). No filesystem, network, process, or environment access."
+}

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
@@ -1,0 +1,76 @@
+"""coding-adventures-sir-runtime-core — core runtime for SIR-emitted Python.
+
+Semantic-IR backends translate most constructs to **native** Python (a
+sequence is a ``list``, a loop is a ``for``, a class is a ``class``).  The
+handful of SIR semantics with **no faithful native equivalent** live here
+and are imported by the emitted module:
+
+    import coding_adventures_sir_runtime_core as _sir
+    _sir.truthy(x)        # SIR truthiness: only False / nil are falsy
+    _sir.cons(a, b)       # cons pairs
+    _sir.print(v)         # SIR display + newline
+
+This library implements **SIR** semantics (not any one source language's),
+so a Ruby frontend today and a JavaScript or Python frontend tomorrow all
+reuse it.  See ``code/specs/sir-runtime.md``.
+"""
+
+from __future__ import annotations
+
+from .arithmetic import add, div, gt, lt, mul, sub
+from .pairs import Pair, car, cdr, cons, is_pair
+from .runtime import (
+    Closure,
+    apply,
+    builtin_closure,
+    call_builtin,
+    global_get,
+    global_get_static,
+    global_set,
+    make_closure,
+    sir_print,
+)
+from .symbols import Symbol, intern
+from .values import eq, is_null, is_number, is_symbol, to_display, truthy
+
+# ``print`` is exposed as an attribute alias so emitted code can call
+# ``_sir.print(v)`` (mirroring the old ``_sir_print`` name) without
+# shadowing the builtin inside this package.
+print = sir_print
+
+__all__ = [
+    # values
+    "truthy",
+    "eq",
+    "to_display",
+    "is_null",
+    "is_number",
+    "is_symbol",
+    # symbols
+    "Symbol",
+    "intern",
+    # pairs
+    "Pair",
+    "cons",
+    "car",
+    "cdr",
+    "is_pair",
+    # arithmetic
+    "add",
+    "sub",
+    "mul",
+    "div",
+    "lt",
+    "gt",
+    # closures / globals / dispatch
+    "Closure",
+    "apply",
+    "make_closure",
+    "global_set",
+    "global_get",
+    "global_get_static",
+    "sir_print",
+    "print",
+    "call_builtin",
+    "builtin_closure",
+]

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/arithmetic.py
@@ -1,0 +1,68 @@
+"""SIR arithmetic and comparison.
+
+These differ from Python's native operators in two ways that justify a
+runtime helper rather than a bare ``a + b``:
+
+1. **Variadic** — ``add`` / ``sub`` / ``mul`` fold over any number of
+   arguments (``add()`` is ``0``, ``mul()`` is ``1``), matching the SIR
+   builtin contract shared with the Lisp/Twig frontends.
+2. **Truncating integer division** — ``div`` truncates toward zero
+   (``div(7, 2) == 3``, ``div(-7, 2) == -3``) to match SIR semantics,
+   where Python's ``/`` would yield a float.
+
+Comparisons (``lt`` / ``gt``) are thin wrappers kept here so the dispatch
+table can expose them by SIR name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def add(*args: Any) -> Any:
+    """Variadic sum; ``add()`` is ``0``."""
+    total: Any = 0
+    for a in args:
+        total += a
+    return total
+
+
+def sub(*args: Any) -> Any:
+    """Variadic difference; ``sub(x)`` negates, ``sub()`` is ``0``."""
+    if not args:
+        return 0
+    if len(args) == 1:
+        return -args[0]
+    acc = args[0]
+    for a in args[1:]:
+        acc -= a
+    return acc
+
+
+def mul(*args: Any) -> Any:
+    """Variadic product; ``mul()`` is ``1``."""
+    acc: Any = 1
+    for a in args:
+        acc *= a
+    return acc
+
+
+def div(*args: Any) -> Any:
+    """Variadic quotient with **truncating integer** division (toward
+    zero), matching SIR semantics rather than Python's float ``/``."""
+    if not args:
+        return 0
+    acc = args[0]
+    for a in args[1:]:
+        acc = int(acc / a)
+    return acc
+
+
+def lt(a: Any, b: Any) -> bool:
+    """Less-than."""
+    return bool(a < b)
+
+
+def gt(a: Any, b: Any) -> bool:
+    """Greater-than."""
+    return bool(a > b)

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/pairs.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/pairs.py
@@ -1,0 +1,73 @@
+"""Cons pairs — the SIR ``Pair`` value type (``cons`` / ``car`` / ``cdr``).
+
+A *pair* is the Lisp cons cell: an immutable two-field record holding a
+``car`` (first) and ``cdr`` (rest).  Linked pairs build lists.  Python has
+no native cons cell — a ``tuple`` is close but is variadic and has no list
+*display* — so pairs are an SIR quirk that lives here.
+
+A proper list ``(1 2 3)`` is ``cons(1, cons(2, cons(3, nil)))`` where
+``nil`` is ``None``.  The display follows Lisp convention: space-separated
+inside parens, with a dotted tail when the final ``cdr`` is not ``nil``:
+
+    cons(1, cons(2, None))   ->  "(1 2)"
+    cons(1, 2)               ->  "(1 . 2)"     (improper / dotted pair)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type-checkers
+    pass
+
+
+class Pair:
+    """An immutable cons cell with ``car`` and ``cdr`` fields."""
+
+    __slots__ = ("car", "cdr")
+
+    def __init__(self, car: Any, cdr: Any) -> None:
+        self.car = car
+        self.cdr = cdr
+
+    def __repr__(self) -> str:
+        # Lisp list display.  Deferred import of ``to_display`` avoids a
+        # module-load cycle (values -> pairs -> values).
+        from .values import to_display
+
+        parts = ["(", to_display(self.car)]
+        rest: Any = self.cdr
+        while isinstance(rest, Pair):
+            parts.append(" ")
+            parts.append(to_display(rest.car))
+            rest = rest.cdr
+        if rest is not None:
+            parts.append(" . ")
+            parts.append(to_display(rest))
+        parts.append(")")
+        return "".join(parts)
+
+
+def cons(a: Any, b: Any) -> Pair:
+    """Construct a pair ``(a . b)``."""
+    return Pair(a, b)
+
+
+def car(p: Any) -> Any:
+    """First field of a pair.  Errors on a non-pair (SIR has no silent nil
+    coercion here)."""
+    if not isinstance(p, Pair):
+        raise TypeError("car on non-pair")
+    return p.car
+
+
+def cdr(p: Any) -> Any:
+    """Rest field of a pair.  Errors on a non-pair."""
+    if not isinstance(p, Pair):
+        raise TypeError("cdr on non-pair")
+    return p.cdr
+
+
+def is_pair(v: Any) -> bool:
+    """True iff ``v`` is a pair."""
+    return isinstance(v, Pair)

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/runtime.py
@@ -1,0 +1,118 @@
+"""Closures, the global store, printing, and the builtin dispatch table.
+
+These tie the value-level helpers together into the small runtime surface
+that SIR-emitted Python calls into.
+
+- **Closures** — SIR closures carry their captured values explicitly (the
+  frontend computed them).  ``make_closure`` binds the captures ahead of
+  the call-time arguments; ``apply`` invokes a closure handle.  A uniform
+  ``Closure`` object lets an ``IndirectCall`` invoke *any* callable target
+  the same way.
+- **Globals** — a process-global name→value store backing SIR ``Globals``.
+- **Dispatch** — when a builtin is used as a *first-class value* (passed
+  around, not called directly), ``builtin_closure`` wraps it; ``call_builtin``
+  looks it up by SIR name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from . import arithmetic, pairs, values
+from .symbols import Symbol
+
+# --- Closures --------------------------------------------------------------
+
+
+class Closure:
+    """A callable handle wrapping a Python function."""
+
+    __slots__ = ("fn",)
+
+    def __init__(self, fn: Callable[..., Any]) -> None:
+        self.fn = fn
+
+
+def apply(c: Any, args: list[Any]) -> Any:
+    """Invoke a closure handle with ``args``.  Errors on a non-closure."""
+    if not isinstance(c, Closure):
+        raise TypeError("apply on non-closure")
+    return c.fn(*args)
+
+
+def make_closure(fn: Callable[..., Any], captures: list[Any]) -> Closure:
+    """Build a closure that prepends the captured values to each call's
+    arguments."""
+    return Closure(lambda *args: fn(*captures, *args))
+
+
+# --- Global store ----------------------------------------------------------
+
+_globals: dict[str, Any] = {}
+
+
+def global_set(name: Any, value: Any) -> Any:
+    """Store ``value`` under ``name`` (a string or :class:`Symbol`)."""
+    key = name.name if isinstance(name, Symbol) else str(name)
+    _globals[key] = value
+    return value
+
+
+def global_get(name: Any) -> Any:
+    """Fetch a global by ``name`` (string or :class:`Symbol`).  Errors if
+    undefined."""
+    key = name.name if isinstance(name, Symbol) else str(name)
+    if key not in _globals:
+        raise NameError(f"undefined global: {key}")
+    return _globals[key]
+
+
+def global_get_static(name: str) -> Any:
+    """Fetch a global by a statically-known string name."""
+    if name not in _globals:
+        raise NameError(f"undefined global: {name}")
+    return _globals[name]
+
+
+# --- Printing --------------------------------------------------------------
+
+
+def sir_print(v: Any) -> None:
+    """Print the SIR display form of ``v`` followed by a newline."""
+    print(values.to_display(v))
+    return None
+
+
+# --- Builtin dispatch ------------------------------------------------------
+
+_builtins: dict[str, Callable[..., Any]] = {
+    "+": arithmetic.add,
+    "-": arithmetic.sub,
+    "*": arithmetic.mul,
+    "/": arithmetic.div,
+    "=": values.eq,
+    "<": arithmetic.lt,
+    ">": arithmetic.gt,
+    "cons": pairs.cons,
+    "car": pairs.car,
+    "cdr": pairs.cdr,
+    "null?": values.is_null,
+    "pair?": pairs.is_pair,
+    "number?": values.is_number,
+    "symbol?": values.is_symbol,
+    "print": sir_print,
+}
+
+
+def call_builtin(name: str, args: list[Any]) -> Any:
+    """Invoke a builtin by SIR name with a list of arguments."""
+    fn = _builtins.get(name)
+    if fn is None:
+        raise NameError(f"unknown builtin: {name}")
+    return fn(*args)
+
+
+def builtin_closure(name: str) -> Closure:
+    """Wrap a builtin as a first-class :class:`Closure`."""
+    return Closure(lambda *args: call_builtin(name, list(args)))

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/symbols.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/symbols.py
@@ -1,0 +1,56 @@
+"""Interned symbols — the SIR ``Symbol`` value type.
+
+A Lisp/Ruby *symbol* (``:foo``) is an interned, immutable name with
+**identity** semantics: two symbols with the same text are the *same*
+object, so equality is a pointer compare.  Python has no native symbol
+type — the closest native thing, a ``str``, has *value* semantics and no
+distinct identity — so symbols are a genuine SIR quirk that lives here in
+the runtime library rather than being faked inline in emitted code.
+
+Interning is process-global and single-threaded (CPython's GIL makes the
+table safe in-process), mirroring how the original inlined runtime worked.
+
+Truth table — what counts as "the same symbol":
+
+    intern("a") is intern("a")   -> True   (same text -> same object)
+    intern("a") is intern("b")   -> False  (different text)
+    intern("a") == intern("a")   -> True
+    Symbol("a") == Symbol("a")   -> True   (value equality still holds)
+"""
+
+from __future__ import annotations
+
+
+class Symbol:
+    """An interned symbol.  Construct via :func:`intern`, not directly,
+    so identity (``is``) comparisons hold across the program."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Symbol) and self.name == other.name
+
+    def __hash__(self) -> int:
+        # Namespaced so a Symbol never collides with the bare string in a
+        # dict that mixes the two.
+        return hash(("__SIR_SYM__", self.name))
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+_symbol_table: dict[str, Symbol] = {}
+
+
+def intern(name: str) -> Symbol:
+    """Return the canonical :class:`Symbol` for ``name``, creating it on
+    first sight.  Repeated calls with the same text return the *same*
+    object."""
+    existing = _symbol_table.get(name)
+    if existing is None:
+        existing = Symbol(name)
+        _symbol_table[name] = existing
+    return existing

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/values.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/values.py
@@ -1,0 +1,70 @@
+"""Value-level SIR semantics: truthiness, equality, display, predicates.
+
+These are the behaviours that differ from Python's native ones and so
+cannot be emitted as bare native code.
+
+**SIR truthiness is false/nil-only.**  Only ``False`` and ``nil`` (``None``)
+are falsy.  Everything else — including ``0``, ``0.0``, ``""``, ``[]``,
+``{}``, a symbol, a pair — is **truthy**.  This is the Lisp/Ruby
+convention and is the single most important reason this library exists:
+Python's native ``bool()`` would (wrongly, for SIR) call ``0``/``""``/``[]``
+falsy.
+
+    truthy(False) -> False     truthy(None) -> False
+    truthy(0)     -> True       truthy("")   -> True
+    truthy([])    -> True       truthy(0.0)  -> True
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .pairs import Pair
+from .symbols import Symbol
+
+
+def truthy(v: Any) -> bool:
+    """SIR truthiness: everything is true except ``False`` and ``nil``."""
+    return v is not False and v is not None
+
+
+def is_null(v: Any) -> bool:
+    """True iff ``v`` is ``nil`` (``None``)."""
+    return v is None
+
+
+def is_number(v: Any) -> bool:
+    """True iff ``v`` is an integer (``bool`` is excluded — in Python
+    ``bool`` is an ``int`` subclass, but SIR keeps them distinct)."""
+    return isinstance(v, int) and not isinstance(v, bool)
+
+
+def is_symbol(v: Any) -> bool:
+    """True iff ``v`` is a :class:`Symbol`."""
+    return isinstance(v, Symbol)
+
+
+def eq(a: Any, b: Any) -> bool:
+    """SIR equality.  Symbol-aware (two symbols are equal iff their names
+    match); otherwise native ``==``."""
+    if isinstance(a, Symbol) and isinstance(b, Symbol):
+        return a.name == b.name
+    return bool(a == b)
+
+
+def to_display(v: Any) -> str:
+    """SIR display form of a value.
+
+    Distinct from ``repr``: ``nil`` prints as ``nil``, booleans as
+    ``#t`` / ``#f``, a symbol as its bare name, a pair as a Lisp list.
+    Everything else falls back to ``str`` (which renders ints/floats/
+    sequences/maps natively, and pairs via :meth:`Pair.__repr__`)."""
+    if v is None:
+        return "nil"
+    if isinstance(v, bool):
+        return "#t" if v else "#f"
+    if isinstance(v, Symbol):
+        return v.name
+    if isinstance(v, Pair):
+        return repr(v)
+    return str(v)

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -1,0 +1,178 @@
+"""Tests for coding-adventures-sir-runtime-core."""
+
+from __future__ import annotations
+
+import pytest
+
+import coding_adventures_sir_runtime_core as sir
+
+# --- truthiness (false/nil-only) -------------------------------------------
+
+
+def test_only_false_and_nil_are_falsy() -> None:
+    assert sir.truthy(False) is False
+    assert sir.truthy(None) is False
+
+
+@pytest.mark.parametrize("v", [0, 0.0, "", [], {}, 1, "x", [1], sir.intern("s")])
+def test_everything_else_is_truthy(v: object) -> None:
+    # The whole point of the library: 0/""/[]/{} are TRUE under SIR.
+    assert sir.truthy(v) is True
+
+
+# --- symbols (interned identity) -------------------------------------------
+
+
+def test_interned_symbols_share_identity() -> None:
+    assert sir.intern("a") is sir.intern("a")
+    assert sir.intern("a") is not sir.intern("b")
+
+
+def test_symbol_equality_and_repr() -> None:
+    assert sir.intern("a") == sir.Symbol("a")
+    assert repr(sir.intern("foo")) == "foo"
+    assert hash(sir.intern("a")) == hash(sir.Symbol("a"))
+
+
+def test_symbol_not_equal_to_string() -> None:
+    assert sir.intern("a") != "a"
+
+
+# --- pairs -----------------------------------------------------------------
+
+
+def test_cons_car_cdr() -> None:
+    p = sir.cons(1, 2)
+    assert sir.car(p) == 1
+    assert sir.cdr(p) == 2
+    assert sir.is_pair(p) is True
+    assert sir.is_pair(1) is False
+
+
+def test_car_cdr_reject_non_pair() -> None:
+    with pytest.raises(TypeError):
+        sir.car(1)
+    with pytest.raises(TypeError):
+        sir.cdr(1)
+
+
+def test_pair_list_display() -> None:
+    proper = sir.cons(1, sir.cons(2, sir.cons(3, None)))
+    assert sir.to_display(proper) == "(1 2 3)"
+    dotted = sir.cons(1, 2)
+    assert sir.to_display(dotted) == "(1 . 2)"
+
+
+# --- equality + predicates -------------------------------------------------
+
+
+def test_eq_symbol_aware() -> None:
+    assert sir.eq(sir.intern("a"), sir.intern("a")) is True
+    assert sir.eq(sir.intern("a"), sir.intern("b")) is False
+    assert sir.eq(1, 1) is True
+    assert sir.eq(1, 2) is False
+
+
+def test_predicates() -> None:
+    assert sir.is_null(None) is True
+    assert sir.is_null(0) is False
+    assert sir.is_number(3) is True
+    assert sir.is_number(True) is False  # bool is not a SIR number
+    assert sir.is_symbol(sir.intern("x")) is True
+    assert sir.is_symbol("x") is False
+
+
+# --- display ---------------------------------------------------------------
+
+
+def test_to_display_forms() -> None:
+    assert sir.to_display(None) == "nil"
+    assert sir.to_display(True) == "#t"
+    assert sir.to_display(False) == "#f"
+    assert sir.to_display(sir.intern("sym")) == "sym"
+    assert sir.to_display(42) == "42"
+    assert sir.to_display("hi") == "hi"
+
+
+def test_print_uses_display(capsys: pytest.CaptureFixture[str]) -> None:
+    assert sir.print(None) is None
+    out = capsys.readouterr().out
+    assert out == "nil\n"
+
+
+# --- arithmetic ------------------------------------------------------------
+
+
+def test_variadic_arithmetic() -> None:
+    assert sir.add(1, 2, 3) == 6
+    assert sir.add() == 0
+    assert sir.sub(10, 3, 2) == 5
+    assert sir.sub(5) == -5
+    assert sir.sub() == 0
+    assert sir.mul(2, 3, 4) == 24
+    assert sir.mul() == 1
+
+
+def test_truncating_division() -> None:
+    assert sir.div(7, 2) == 3
+    assert sir.div(-7, 2) == -3  # truncates toward zero, not floor
+    assert sir.div() == 0
+    assert sir.div(9, 3, 1) == 3
+
+
+def test_comparisons() -> None:
+    assert sir.lt(1, 2) is True
+    assert sir.gt(2, 1) is True
+    assert sir.lt(2, 1) is False
+
+
+# --- closures --------------------------------------------------------------
+
+
+def test_make_closure_prepends_captures() -> None:
+    def f(a: int, b: int, c: int) -> int:
+        return a + b + c
+
+    c = sir.make_closure(f, [10, 20])
+    assert sir.apply(c, [5]) == 35
+
+
+def test_apply_rejects_non_closure() -> None:
+    with pytest.raises(TypeError):
+        sir.apply(42, [])
+
+
+# --- globals ---------------------------------------------------------------
+
+
+def test_global_store_roundtrip() -> None:
+    sir.global_set("g1", 99)
+    assert sir.global_get("g1") == 99
+    assert sir.global_get_static("g1") == 99
+    sir.global_set(sir.intern("g2"), 7)
+    assert sir.global_get(sir.intern("g2")) == 7
+
+
+def test_global_get_undefined_errors() -> None:
+    with pytest.raises(NameError):
+        sir.global_get("never_defined")
+    with pytest.raises(NameError):
+        sir.global_get_static("also_never")
+
+
+# --- builtin dispatch ------------------------------------------------------
+
+
+def test_call_builtin() -> None:
+    assert sir.call_builtin("+", [1, 2, 3]) == 6
+    assert sir.call_builtin("print", [None]) is None
+
+
+def test_call_unknown_builtin_errors() -> None:
+    with pytest.raises(NameError):
+        sir.call_builtin("nope", [])
+
+
+def test_builtin_closure_is_callable_handle() -> None:
+    plus = sir.builtin_closure("+")
+    assert sir.apply(plus, [4, 5]) == 9

--- a/code/packages/typescript/sir-runtime-core/BUILD
+++ b/code/packages/typescript/sir-runtime-core/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-core",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-core/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-core/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
+
+## [0.1.0] - 2026-06-11
+
+### Added
+
+Initial release — the core runtime imported by Semantic-IR-emitted
+TypeScript/JavaScript. Provides the SIR semantics that have no faithful native
+equivalent:
+
+- **SIR truthiness** (`truthy`) — only `false` and `nil` are falsy (`0`, `""`,
+  `[]`, `{}` are truthy), the Lisp/Ruby convention.
+- **Symbols** (`Sym`, `intern`) — interned identity objects.
+- **Pairs** (`Pair`, `cons`, `car`, `cdr`, `isPair`) — cons cells with Lisp list
+  display.
+- **Equality / predicates** (`eq`, `isNull`, `isNumber`, `isSymbol`) and
+  **display** (`toDisplay`, `print`).
+- **Arithmetic** (`add`, `sub`, `mul`, variadic; `div` truncating-integer;
+  `lt`, `gt`).
+- **Closures** (`Closure`, `apply`, `makeClosure`), an in-memory **global store**
+  (`globalSet`, `globalGet`, `globalGetStatic`), and **builtin dispatch**
+  (`callBuiltin`, `builtinClosure`).
+
+Migrated (behaviour-preserving) from the inline `__Sir` namespace that
+`semantic-ir-to-typescript` used to paste into every artifact. See
+`code/specs/sir-runtime.md`.

--- a/code/packages/typescript/sir-runtime-core/README.md
+++ b/code/packages/typescript/sir-runtime-core/README.md
@@ -1,0 +1,54 @@
+# @coding-adventures/sir-runtime-core
+
+Core runtime imported by **Semantic-IR-emitted TypeScript / JavaScript**.
+
+## What it is
+
+Semantic-IR (SIR) backends translate most constructs to **native** code — a
+sequence is an `Array`, a map is a `Map`, a loop is a `for`, a class is a `class`.
+A handful of SIR semantics have **no faithful native equivalent**, and those live
+here so emitted code can `import` and call them instead of inlining a runtime
+namespace into every file:
+
+| Provided | Why it's not native |
+|---|---|
+| `truthy(v)` | SIR truthiness is **false/nil-only** — `0`, `""`, `[]`, `{}` are *truthy*, unlike JS coercion. |
+| `Sym` / `intern` | Interned identity objects; JS has no symbol *value* type with names. |
+| `Pair` / `cons` / `car` / `cdr` | Lisp cons cells; no native type. |
+| `eq`, `toDisplay`, `print` | Symbol-aware equality and Lisp/Ruby display (`nil`, `#t`/`#f`). |
+| `add`/`sub`/`mul`/`div`, `lt`/`gt` | Variadic folds + truncating-integer `/`. |
+| `Closure`/`apply`/`makeClosure`, global store, builtin dispatch | Uniform closure handles + SIR `Globals`. |
+
+It implements **SIR** semantics, not any one source language's — so a Ruby
+frontend today and a JavaScript or Python frontend tomorrow all reuse it.
+
+## How emitted code uses it
+
+```ts
+import * as _sir from "@coding-adventures/sir-runtime-core";
+
+function add(a, b) {
+  return a + b;
+}
+
+const xs = [1, 2, 3];
+let i = 0;
+while (_sir.truthy(i < xs.length)) {
+  _sir.print(xs[i]);
+  i = i + 1;
+}
+```
+
+## Where it fits
+
+Frontend (Ruby / JS / Python …) → `semantic-ir` → `semantic-ir-to-typescript` →
+emitted `.ts` that imports this package. See
+[`code/specs/sir-runtime.md`](../../../specs/sir-runtime.md).
+
+## Development
+
+```sh
+npm install
+npx tsc --noEmit
+npx vitest run
+```

--- a/code/packages/typescript/sir-runtime-core/package-lock.json
+++ b/code/packages/typescript/sir-runtime-core/package-lock.json
@@ -1,0 +1,1552 @@
+{
+  "name": "@coding-adventures/sir-runtime-core",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@coding-adventures/sir-runtime-core",
+  "version": "0.1.0",
+  "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "compiler",
+    "cross-language",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-core/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-core",
+  "capabilities": [],
+  "justification": "Pure in-process runtime helpers (truthiness, symbols, pairs, arithmetic, closures, an in-memory global store, and stdout printing). No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
+++ b/code/packages/typescript/sir-runtime-core/src/arithmetic.ts
@@ -1,0 +1,70 @@
+/**
+ * SIR arithmetic and comparison.
+ *
+ * These differ from JavaScript's native operators in two ways that justify
+ * a runtime helper rather than a bare `a + b`:
+ *
+ * 1. **Variadic** — `add`/`sub`/`mul` fold over any number of arguments
+ *    (`add()` is `0`, `mul()` is `1`), matching the SIR builtin contract.
+ * 2. **Truncating integer division** — `div` truncates toward zero
+ *    (`div(7, 2) === 3`, `div(-7, 2) === -3`), where JS `/` yields a float.
+ */
+
+import type { Val } from "./values.js";
+
+const num = (v: Val): number => v as number;
+
+/** Variadic sum; `add()` is `0`. */
+export function add(...args: Val[]): Val {
+  let total = 0;
+  for (const a of args) {
+    total += num(a);
+  }
+  return total;
+}
+
+/** Variadic difference; `sub(x)` negates, `sub()` is `0`. */
+export function sub(...args: Val[]): Val {
+  if (args.length === 0) {
+    return 0;
+  }
+  if (args.length === 1) {
+    return -num(args[0]!);
+  }
+  let acc = num(args[0]!);
+  for (let i = 1; i < args.length; i++) {
+    acc -= num(args[i]!);
+  }
+  return acc;
+}
+
+/** Variadic product; `mul()` is `1`. */
+export function mul(...args: Val[]): Val {
+  let acc = 1;
+  for (const a of args) {
+    acc *= num(a);
+  }
+  return acc;
+}
+
+/** Variadic quotient with truncating-integer division (toward zero). */
+export function div(...args: Val[]): Val {
+  if (args.length === 0) {
+    return 0;
+  }
+  let acc = num(args[0]!);
+  for (let i = 1; i < args.length; i++) {
+    acc = Math.trunc(acc / num(args[i]!));
+  }
+  return acc;
+}
+
+/** Less-than. */
+export function lt(a: Val, b: Val): boolean {
+  return num(a) < num(b);
+}
+
+/** Greater-than. */
+export function gt(a: Val, b: Val): boolean {
+  return num(a) > num(b);
+}

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @coding-adventures/sir-runtime-core — core runtime for SIR-emitted
+ * TypeScript / JavaScript.
+ *
+ * Semantic-IR backends translate most constructs to **native** code (a
+ * sequence is an `Array`, a loop is a `for`, a class is a `class`). The
+ * handful of SIR semantics with **no faithful native equivalent** live
+ * here and are imported by the emitted module:
+ *
+ *     import * as _sir from "@coding-adventures/sir-runtime-core";
+ *     _sir.truthy(x);     // SIR truthiness: only false / nil are falsy
+ *     _sir.cons(a, b);    // cons pairs
+ *     _sir.print(v);      // SIR display + newline
+ *
+ * It implements **SIR** semantics (not any one source language's), so a
+ * Ruby frontend today and a JavaScript or Python frontend tomorrow all
+ * reuse it. See `code/specs/sir-runtime.md`.
+ */
+
+export { Sym, intern } from "./symbols.js";
+export { Pair, cons, car, cdr, isPair } from "./pairs.js";
+export { truthy, isNull, isNumber, isSymbol, eq, toDisplay } from "./values.js";
+export type { Val, ClosureLike } from "./values.js";
+export { add, sub, mul, div, lt, gt } from "./arithmetic.js";
+export {
+  Closure,
+  apply,
+  makeClosure,
+  globalSet,
+  globalGet,
+  globalGetStatic,
+  print,
+  callBuiltin,
+  builtinClosure,
+} from "./runtime.js";

--- a/code/packages/typescript/sir-runtime-core/src/pairs.ts
+++ b/code/packages/typescript/sir-runtime-core/src/pairs.ts
@@ -1,0 +1,65 @@
+/**
+ * Cons pairs — the SIR `Pair` value type (`cons` / `car` / `cdr`).
+ *
+ * A *pair* is the Lisp cons cell: an immutable two-field record holding a
+ * `car` (first) and `cdr` (rest). Linked pairs build lists. JavaScript has
+ * no native cons cell, so pairs are an SIR quirk that lives here.
+ *
+ * A proper list `(1 2 3)` is `cons(1, cons(2, cons(3, null)))`. Display
+ * follows Lisp convention, with a dotted tail when the final `cdr` is not
+ * `null`:
+ *
+ *     cons(1, cons(2, null))  ->  "(1 2)"
+ *     cons(1, 2)              ->  "(1 . 2)"   (improper / dotted pair)
+ */
+
+import { toDisplay } from "./values.js";
+import type { Val } from "./values.js";
+
+/** An immutable cons cell. */
+export class Pair {
+  constructor(
+    public readonly car: Val,
+    public readonly cdr: Val,
+  ) {}
+
+  toString(): string {
+    const parts: string[] = ["(", toDisplay(this.car)];
+    let rest: Val = this.cdr;
+    while (rest instanceof Pair) {
+      parts.push(" ", toDisplay(rest.car));
+      rest = rest.cdr;
+    }
+    if (rest !== null) {
+      parts.push(" . ", toDisplay(rest));
+    }
+    parts.push(")");
+    return parts.join("");
+  }
+}
+
+/** Construct a pair `(a . b)`. */
+export function cons(a: Val, b: Val): Pair {
+  return new Pair(a, b);
+}
+
+/** First field of a pair. Throws on a non-pair. */
+export function car(p: Val): Val {
+  if (!(p instanceof Pair)) {
+    throw new TypeError("car on non-pair");
+  }
+  return p.car;
+}
+
+/** Rest field of a pair. Throws on a non-pair. */
+export function cdr(p: Val): Val {
+  if (!(p instanceof Pair)) {
+    throw new TypeError("cdr on non-pair");
+  }
+  return p.cdr;
+}
+
+/** True iff `v` is a pair. */
+export function isPair(v: Val): boolean {
+  return v instanceof Pair;
+}

--- a/code/packages/typescript/sir-runtime-core/src/runtime.ts
+++ b/code/packages/typescript/sir-runtime-core/src/runtime.ts
@@ -1,0 +1,112 @@
+/**
+ * Closures, the global store, printing, and the builtin dispatch table.
+ *
+ * - **Closures** carry their captured values explicitly (the frontend
+ *   computed them). `makeClosure` binds captures ahead of the call-time
+ *   arguments; `apply` invokes a handle. A uniform `Closure` lets an
+ *   `IndirectCall` invoke any target the same way.
+ * - **Globals** — a process-global name→value store backing SIR `Globals`.
+ * - **Dispatch** — `builtinClosure` wraps a builtin used as a first-class
+ *   value; `callBuiltin` looks one up by SIR name.
+ */
+
+import { add, div, gt, lt, mul, sub } from "./arithmetic.js";
+import { car, cdr, cons, isPair } from "./pairs.js";
+import { Sym } from "./symbols.js";
+import { eq, isNull, isNumber, isSymbol, toDisplay } from "./values.js";
+import type { ClosureLike, Val } from "./values.js";
+
+// --- Closures --------------------------------------------------------------
+
+/** A callable handle wrapping a function. */
+export class Closure implements ClosureLike {
+  readonly __sirClosure = true as const;
+  constructor(public readonly fn: (...args: Val[]) => Val) {}
+}
+
+/** Invoke a closure handle with `args`. Throws on a non-closure. */
+export function apply(c: Val, args: Val[]): Val {
+  if (!(c instanceof Closure)) {
+    throw new TypeError("apply on non-closure");
+  }
+  return c.fn(...args);
+}
+
+/** Build a closure that prepends captured values to each call's arguments. */
+export function makeClosure(fn: (...args: Val[]) => Val, captures: Val[]): Closure {
+  return new Closure((...args: Val[]) => fn(...captures, ...args));
+}
+
+// --- Global store ----------------------------------------------------------
+
+const globals = new Map<string, Val>();
+
+function keyOf(name: Val): string {
+  return name instanceof Sym ? name.name : String(name);
+}
+
+/** Store `value` under `name` (a string or symbol). */
+export function globalSet(name: Val, value: Val): Val {
+  globals.set(keyOf(name), value);
+  return value;
+}
+
+/** Fetch a global by `name` (string or symbol). Throws if undefined. */
+export function globalGet(name: Val): Val {
+  const key = keyOf(name);
+  if (!globals.has(key)) {
+    throw new Error(`undefined global: ${key}`);
+  }
+  return globals.get(key)!;
+}
+
+/** Fetch a global by a statically-known string name. */
+export function globalGetStatic(name: string): Val {
+  if (!globals.has(name)) {
+    throw new Error(`undefined global: ${name}`);
+  }
+  return globals.get(name)!;
+}
+
+// --- Printing --------------------------------------------------------------
+
+/** Print the SIR display form of `v` followed by a newline. */
+export function print(v: Val): null {
+  // eslint-disable-next-line no-console
+  console.log(toDisplay(v));
+  return null;
+}
+
+// --- Builtin dispatch ------------------------------------------------------
+
+const builtins: Record<string, (...args: Val[]) => Val> = {
+  "+": add,
+  "-": sub,
+  "*": mul,
+  "/": div,
+  "=": (a, b) => eq(a!, b!),
+  "<": (a, b) => lt(a!, b!),
+  ">": (a, b) => gt(a!, b!),
+  cons: (a, b) => cons(a!, b!),
+  car: (p) => car(p!),
+  cdr: (p) => cdr(p!),
+  "null?": (v) => isNull(v!),
+  "pair?": (v) => isPair(v!),
+  "number?": (v) => isNumber(v!),
+  "symbol?": (v) => isSymbol(v!),
+  print: (v) => print(v!),
+};
+
+/** Invoke a builtin by SIR name with a list of arguments. */
+export function callBuiltin(name: string, args: Val[]): Val {
+  const fn = builtins[name];
+  if (fn === undefined) {
+    throw new Error(`unknown builtin: ${name}`);
+  }
+  return fn(...args);
+}
+
+/** Wrap a builtin as a first-class {@link Closure}. */
+export function builtinClosure(name: string): Closure {
+  return new Closure((...args: Val[]) => callBuiltin(name, args));
+}

--- a/code/packages/typescript/sir-runtime-core/src/symbols.ts
+++ b/code/packages/typescript/sir-runtime-core/src/symbols.ts
@@ -1,0 +1,33 @@
+/**
+ * Interned symbols — the SIR `Sym` value type.
+ *
+ * A Lisp/Ruby *symbol* (`:foo`) is an interned, immutable name with
+ * **identity** semantics: two symbols with the same text are the *same*
+ * object. JavaScript's nearest native thing, a string, has value
+ * semantics and no distinct identity, so symbols are a genuine SIR quirk
+ * that lives here in the runtime library rather than being faked inline.
+ *
+ *     intern("a") === intern("a")   // true  (same text -> same object)
+ *     intern("a") === intern("b")   // false
+ */
+
+/** An interned symbol. Construct via {@link intern}, not `new Sym`. */
+export class Sym {
+  constructor(public readonly name: string) {}
+
+  toString(): string {
+    return this.name;
+  }
+}
+
+const table = new Map<string, Sym>();
+
+/** Return the canonical {@link Sym} for `name`, creating it on first sight. */
+export function intern(name: string): Sym {
+  let existing = table.get(name);
+  if (existing === undefined) {
+    existing = new Sym(name);
+    table.set(name, existing);
+  }
+  return existing;
+}

--- a/code/packages/typescript/sir-runtime-core/src/values.ts
+++ b/code/packages/typescript/sir-runtime-core/src/values.ts
@@ -1,0 +1,77 @@
+/**
+ * Value-level SIR semantics: the `Val` type, truthiness, equality,
+ * display, and predicates.
+ *
+ * **SIR truthiness is false/nil-only.** Only `false` and `nil` (`null`)
+ * are falsy. Everything else — including `0`, `""`, `[]`, `{}`, a symbol,
+ * a pair — is **truthy**. This is the Lisp/Ruby convention and the single
+ * most important reason this library exists: JavaScript's native coercion
+ * would (wrongly, for SIR) call `0`/`""`/`NaN` falsy.
+ *
+ *     truthy(false) -> false    truthy(null) -> false
+ *     truthy(0)     -> true      truthy("")   -> true
+ */
+
+import { Pair } from "./pairs.js";
+import { Sym } from "./symbols.js";
+
+/** Forward declaration of the closure handle (defined in runtime.ts). */
+export interface ClosureLike {
+  readonly __sirClosure: true;
+}
+
+/** A SIR value in the v0 surface. */
+export type Val = number | boolean | null | string | Sym | Pair | ClosureLike;
+
+/** SIR truthiness: everything is true except `false` and `nil`. */
+export function truthy(v: Val): boolean {
+  return v !== false && v !== null;
+}
+
+/** True iff `v` is `nil` (`null`). */
+export function isNull(v: Val): boolean {
+  return v === null;
+}
+
+/** True iff `v` is a number. */
+export function isNumber(v: Val): boolean {
+  return typeof v === "number";
+}
+
+/** True iff `v` is a {@link Sym}. */
+export function isSymbol(v: Val): boolean {
+  return v instanceof Sym;
+}
+
+/** SIR equality. Symbol-aware (two symbols are equal iff their names
+ * match); otherwise native `===`. */
+export function eq(a: Val, b: Val): boolean {
+  if (a instanceof Sym && b instanceof Sym) {
+    return a.name === b.name;
+  }
+  return a === b;
+}
+
+/**
+ * SIR display form. Distinct from JSON: `nil` prints as `nil`, booleans
+ * as `#t`/`#f`, a symbol as its bare name, a pair as a Lisp list.
+ * Everything else falls back to `String(v)`.
+ */
+export function toDisplay(v: Val): string {
+  if (v === null) {
+    return "nil";
+  }
+  if (v === true) {
+    return "#t";
+  }
+  if (v === false) {
+    return "#f";
+  }
+  if (v instanceof Sym) {
+    return v.name;
+  }
+  if (v instanceof Pair) {
+    return v.toString();
+  }
+  return String(v);
+}

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -1,0 +1,137 @@
+/** Tests for @coding-adventures/sir-runtime-core. */
+
+import { describe, it, expect, vi } from "vitest";
+import * as sir from "../src/index.js";
+
+describe("truthiness (false/nil-only)", () => {
+  it("only false and nil are falsy", () => {
+    expect(sir.truthy(false)).toBe(false);
+    expect(sir.truthy(null)).toBe(false);
+  });
+
+  it("everything else is truthy", () => {
+    for (const v of [0, "", 1, "x", sir.intern("s")] as sir.Val[]) {
+      expect(sir.truthy(v)).toBe(true);
+    }
+  });
+});
+
+describe("symbols", () => {
+  it("interned symbols share identity", () => {
+    expect(sir.intern("a")).toBe(sir.intern("a"));
+    expect(sir.intern("a")).not.toBe(sir.intern("b"));
+  });
+
+  it("eq is symbol-aware", () => {
+    expect(sir.eq(sir.intern("a"), sir.intern("a"))).toBe(true);
+    expect(sir.eq(sir.intern("a"), sir.intern("b"))).toBe(false);
+    expect(sir.eq(1, 1)).toBe(true);
+  });
+});
+
+describe("pairs", () => {
+  it("cons/car/cdr", () => {
+    const p = sir.cons(1, 2);
+    expect(sir.car(p)).toBe(1);
+    expect(sir.cdr(p)).toBe(2);
+    expect(sir.isPair(p)).toBe(true);
+    expect(sir.isPair(1)).toBe(false);
+  });
+
+  it("car/cdr reject non-pairs", () => {
+    expect(() => sir.car(1)).toThrow(TypeError);
+    expect(() => sir.cdr(1)).toThrow(TypeError);
+  });
+
+  it("list display", () => {
+    const proper = sir.cons(1, sir.cons(2, sir.cons(3, null)));
+    expect(sir.toDisplay(proper)).toBe("(1 2 3)");
+    expect(sir.toDisplay(sir.cons(1, 2))).toBe("(1 . 2)");
+  });
+});
+
+describe("predicates and display", () => {
+  it("predicates", () => {
+    expect(sir.isNull(null)).toBe(true);
+    expect(sir.isNull(0)).toBe(false);
+    expect(sir.isNumber(3)).toBe(true);
+    expect(sir.isSymbol(sir.intern("x"))).toBe(true);
+    expect(sir.isSymbol("x")).toBe(false);
+  });
+
+  it("display forms", () => {
+    expect(sir.toDisplay(null)).toBe("nil");
+    expect(sir.toDisplay(true)).toBe("#t");
+    expect(sir.toDisplay(false)).toBe("#f");
+    expect(sir.toDisplay(sir.intern("sym"))).toBe("sym");
+    expect(sir.toDisplay(42)).toBe("42");
+    expect(sir.toDisplay("hi")).toBe("hi");
+  });
+
+  it("print returns null and writes display form", () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((s: string) => {
+      lines.push(s);
+    });
+    expect(sir.print(null)).toBe(null);
+    spy.mockRestore();
+    expect(lines).toEqual(["nil"]);
+  });
+});
+
+describe("arithmetic", () => {
+  it("variadic", () => {
+    expect(sir.add(1, 2, 3)).toBe(6);
+    expect(sir.add()).toBe(0);
+    expect(sir.sub(10, 3, 2)).toBe(5);
+    expect(sir.sub(5)).toBe(-5);
+    expect(sir.sub()).toBe(0);
+    expect(sir.mul(2, 3, 4)).toBe(24);
+    expect(sir.mul()).toBe(1);
+  });
+
+  it("truncating division", () => {
+    expect(sir.div(7, 2)).toBe(3);
+    expect(sir.div(-7, 2)).toBe(-3);
+    expect(sir.div()).toBe(0);
+    expect(sir.div(9, 3, 1)).toBe(3);
+  });
+
+  it("comparisons", () => {
+    expect(sir.lt(1, 2)).toBe(true);
+    expect(sir.gt(2, 1)).toBe(true);
+  });
+});
+
+describe("closures, globals, dispatch", () => {
+  it("makeClosure prepends captures", () => {
+    const f = (a: sir.Val, b: sir.Val, c: sir.Val): sir.Val =>
+      (a as number) + (b as number) + (c as number);
+    const c = sir.makeClosure(f, [10, 20]);
+    expect(sir.apply(c, [5])).toBe(35);
+  });
+
+  it("apply rejects non-closures", () => {
+    expect(() => sir.apply(42, [])).toThrow(TypeError);
+  });
+
+  it("global store roundtrip", () => {
+    sir.globalSet("g1", 99);
+    expect(sir.globalGet("g1")).toBe(99);
+    expect(sir.globalGetStatic("g1")).toBe(99);
+    sir.globalSet(sir.intern("g2"), 7);
+    expect(sir.globalGet(sir.intern("g2"))).toBe(7);
+  });
+
+  it("undefined globals throw", () => {
+    expect(() => sir.globalGet("nope")).toThrow();
+    expect(() => sir.globalGetStatic("nope2")).toThrow();
+  });
+
+  it("callBuiltin and builtinClosure", () => {
+    expect(sir.callBuiltin("+", [1, 2, 3])).toBe(6);
+    expect(() => sir.callBuiltin("nope", [])).toThrow();
+    const plus = sir.builtinClosure("+");
+    expect(sir.apply(plus, [4, 5])).toBe(9);
+  });
+});

--- a/code/packages/typescript/sir-runtime-core/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-core/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-core/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What

Two new publishable runtime packages that hold the SIR semantics with **no
faithful native equivalent**, so SIR backends can `import` and call them instead
of inlining a runtime prelude into every emitted file:

- `packages/python/sir-runtime-core` → `import coding_adventures_sir_runtime_core as _sir`
- `packages/typescript/sir-runtime-core` → `import * as _sir from "@coding-adventures/sir-runtime-core"`

Both expose the same **SIR-keyed** surface (not Ruby-specific — a JS/Python
frontend reuses it):

- **SIR truthiness** (`truthy`): only `false`/`nil` are falsy (`0`/`""`/`[]`/`{}`
  are truthy).
- **Symbols** (`intern` + `Symbol`/`Sym`): interned identity objects.
- **Pairs** (`cons`/`car`/`cdr`/`is_pair`) with Lisp list display.
- **Equality** (`eq`, symbol-aware), **display** (`to_display`), `print`.
- **Arithmetic**: variadic `add`/`sub`/`mul`, truncating-integer `div`, `lt`/`gt`.
- **Closures** (`apply`/`make_closure`), in-memory **global store**, **builtin
  dispatch** (`call_builtin`/`builtin_closure`).

## Why

Per [`code/specs/sir-runtime.md`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/sir-runtime.md):
the Python/TS backends will translate most SIR to native code and import these
packages only for the quirks. This is the behaviour-preserving extraction of the
inline `_sir_*` / `__Sir` preludes. **Backend wiring to import these packages
follows in the next PR.**

## Verification

- Python: `mypy --strict` + `ruff` clean, 30 tests, **100% coverage**.
- TypeScript: `tsc` clean, **18 vitest tests** pass.
- Security review: passed (no filesystem/network/subprocess; closed-allow-list
  dispatch; `Map`-backed global store — no prototype pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
