### PR TITLE
Add table structure readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -901,6 +901,7 @@ pub struct BrowserDocument {
     pub forms: Vec<BrowserForm>,
     pub tables: Vec<BrowserTable>,
     pub table_cells: Vec<BrowserTableCell>,
+    pub table_structure_descriptors: Vec<BrowserTableStructureDescriptor>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -3631,6 +3632,25 @@ pub struct BrowserTableCell {
     pub abbr: Option<String>,
     pub rowspan: Option<String>,
     pub colspan: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserTableStructureDescriptor {
+    pub table_index: usize,
+    pub table_id: Option<String>,
+    pub caption: Option<String>,
+    pub row_count: usize,
+    pub column_count: usize,
+    pub column_hint_count: usize,
+    pub cell_count: usize,
+    pub header_cell_count: usize,
+    pub section_kinds: Vec<String>,
+    pub header_scopes: Vec<String>,
+    pub header_ids: Vec<String>,
+    pub cells_with_headers_count: usize,
+    pub spanning_cell_count: usize,
+    pub table_blocked: bool,
+    pub table_block_reasons: Vec<String>,
 }
 
 impl BrowserDocument {
@@ -11079,7 +11099,7 @@ fn collect_browser_facts(
             }
             "table" => {
                 let table_index = summary.tables.len() + 1;
-                summary.tables.push(BrowserTable {
+                let table = BrowserTable {
                     caption: find_first_element_in_nodes(&element.children, "caption")
                         .map(element_text),
                     row_count: browser_table_rows(element).len(),
@@ -11087,10 +11107,25 @@ fn collect_browser_facts(
                     column_hint_count: browser_table_column_hint_count(element),
                     cell_count: browser_table_cell_count(element),
                     header_cell_count: browser_table_header_cell_count(element),
-                });
+                };
+                let table_cells = browser_table_cells(element, table_index, id_texts);
                 summary
-                    .table_cells
-                    .extend(browser_table_cells(element, table_index, id_texts));
+                    .table_structure_descriptors
+                    .push(browser_table_structure_descriptor(
+                        element,
+                        table_index,
+                        &table,
+                        &table_cells,
+                    ));
+                summary.table_cells.extend(table_cells);
+                summary.tables.push(BrowserTable {
+                    caption: table.caption,
+                    row_count: table.row_count,
+                    column_count: table.column_count,
+                    column_hint_count: table.column_hint_count,
+                    cell_count: table.cell_count,
+                    header_cell_count: table.header_cell_count,
+                });
             }
             name if heading_level(name).is_some() => summary.headings.push(BrowserHeading {
                 level: heading_level(name).expect("heading level was checked above"),
@@ -23736,6 +23771,94 @@ fn browser_table_cells(
     }
 
     cells
+}
+
+fn browser_table_structure_descriptor(
+    table_element: &Element,
+    table_index: usize,
+    table: &BrowserTable,
+    cells: &[BrowserTableCell],
+) -> BrowserTableStructureDescriptor {
+    let table_block_reasons = browser_table_block_reasons(table, cells);
+
+    BrowserTableStructureDescriptor {
+        table_index,
+        table_id: table_element.attribute("id").map(ToOwned::to_owned),
+        caption: table.caption.clone(),
+        row_count: table.row_count,
+        column_count: table.column_count,
+        column_hint_count: table.column_hint_count,
+        cell_count: table.cell_count,
+        header_cell_count: table.header_cell_count,
+        section_kinds: browser_table_section_kinds(cells),
+        header_scopes: browser_table_header_scopes(cells),
+        header_ids: browser_table_header_ids(cells),
+        cells_with_headers_count: cells.iter().filter(|cell| !cell.headers.is_empty()).count(),
+        spanning_cell_count: cells
+            .iter()
+            .filter(|cell| cell.rowspan.is_some() || cell.colspan.is_some())
+            .count(),
+        table_blocked: !table_block_reasons.is_empty(),
+        table_block_reasons,
+    }
+}
+
+fn browser_table_section_kinds(cells: &[BrowserTableCell]) -> Vec<String> {
+    let mut section_kinds = Vec::new();
+    for cell in cells {
+        let Some(section_kind) = &cell.section_kind else {
+            continue;
+        };
+        if !section_kinds.contains(section_kind) {
+            section_kinds.push(section_kind.clone());
+        }
+    }
+    section_kinds
+}
+
+fn browser_table_header_scopes(cells: &[BrowserTableCell]) -> Vec<String> {
+    let mut scopes = Vec::new();
+    for cell in cells.iter().filter(|cell| cell.header) {
+        let Some(scope) = &cell.scope else {
+            continue;
+        };
+        if !scopes.contains(scope) {
+            scopes.push(scope.clone());
+        }
+    }
+    scopes
+}
+
+fn browser_table_header_ids(cells: &[BrowserTableCell]) -> Vec<String> {
+    cells
+        .iter()
+        .filter(|cell| cell.header)
+        .filter_map(|cell| cell.id.clone())
+        .collect()
+}
+
+fn browser_table_block_reasons(table: &BrowserTable, cells: &[BrowserTableCell]) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if table.row_count == 0 {
+        reasons.push("missing-rows".to_string());
+    }
+    if table.caption.as_deref().map_or(true, str::is_empty) {
+        reasons.push("missing-caption".to_string());
+    }
+    if table.header_cell_count == 0 {
+        reasons.push("missing-header-cells".to_string());
+    }
+    if table.column_hint_count > 0 && table.column_hint_count != table.column_count {
+        reasons.push("column-hint-count-mismatch".to_string());
+    }
+    if table.header_cell_count > 0
+        && cells
+            .iter()
+            .any(|cell| !cell.header && cell.headers.is_empty())
+    {
+        reasons.push("data-cells-without-header-references".to_string());
+    }
+    reasons
 }
 
 fn collect_browser_table_rows<'a>(nodes: &'a [Node], rows: &mut Vec<&'a Element>) {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -33,8 +33,8 @@ use coding_adventures_html_parser::{
     BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
     BrowserSlotDescriptor, BrowserStructuredDataDescriptor, BrowserStructuredItem,
     BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
-    BrowserTable, BrowserTableCell, BrowserTemplate, BrowserTemplateDescriptor,
-    BrowserTextSemantic, BrowserThemeColor,
+    BrowserTable, BrowserTableCell, BrowserTableStructureDescriptor, BrowserTemplate,
+    BrowserTemplateDescriptor, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -216,6 +216,8 @@ struct ExpectedBrowserDocument {
     tables: Vec<ExpectedTable>,
     #[serde(default)]
     table_cells: Vec<ExpectedTableCell>,
+    #[serde(default)]
+    table_structure_descriptors: Option<Vec<ExpectedTableStructureDescriptor>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -4285,6 +4287,36 @@ struct ExpectedTableCell {
     colspan: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct ExpectedTableStructureDescriptor {
+    table_index: usize,
+    #[serde(default)]
+    table_id: Option<String>,
+    #[serde(default)]
+    caption: Option<String>,
+    row_count: usize,
+    #[serde(default)]
+    column_count: usize,
+    #[serde(default)]
+    column_hint_count: usize,
+    cell_count: usize,
+    header_cell_count: usize,
+    #[serde(default)]
+    section_kinds: Vec<String>,
+    #[serde(default)]
+    header_scopes: Vec<String>,
+    #[serde(default)]
+    header_ids: Vec<String>,
+    #[serde(default)]
+    cells_with_headers_count: usize,
+    #[serde(default)]
+    spanning_cell_count: usize,
+    #[serde(default)]
+    table_blocked: bool,
+    #[serde(default)]
+    table_block_reasons: Vec<String>,
+}
+
 #[test]
 fn browser_readiness_cases_extract_browser_document_facts() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
@@ -4308,6 +4340,8 @@ fn browser_readiness_cases_extract_browser_document_facts() {
             case.expected.component_hydration_descriptors.is_some();
         let tracks_structured_data_descriptors =
             case.expected.structured_data_descriptors.is_some();
+        let tracks_table_structure_descriptors =
+            case.expected.table_structure_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
@@ -4333,6 +4367,9 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_structured_data_descriptors {
             expected.structured_data_descriptors = actual.structured_data_descriptors.clone();
+        }
+        if !tracks_table_structure_descriptors {
+            expected.table_structure_descriptors = actual.table_structure_descriptors.clone();
         }
 
         assert_eq!(
@@ -4360,6 +4397,48 @@ fn browser_table_cell_descriptor_metadata_tracks_headers_spans_and_sections() {
     assert_eq!(
         actual.table_cells, expected.table_cells,
         "table cell descriptors should preserve table context, sections, spans, headers, and grid positions",
+    );
+}
+
+#[test]
+fn browser_table_structure_descriptors_track_sections_headers_spans_and_blockers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "table-cell-descriptor-page")
+        .expect("table cell descriptor fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("table structure descriptor fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.table_structure_descriptors,
+        case.expected
+            .into_browser_document()
+            .table_structure_descriptors,
+        "table structure descriptors should preserve sections, header scopes, ids, spans, header references, and blocker metadata",
+    );
+}
+
+#[test]
+fn browser_table_structure_descriptors_track_layout_blockers() {
+    let actual =
+        parse_browser_document("<body><table><colgroup><col span=3><tr><td>Loose<td>Cells</table>")
+            .expect("blocked table fixture should parse into browser document facts");
+
+    assert_eq!(actual.table_structure_descriptors.len(), 1);
+    let descriptor = &actual.table_structure_descriptors[0];
+
+    assert!(descriptor.table_blocked);
+    assert_eq!(
+        descriptor.table_block_reasons,
+        vec![
+            "missing-caption",
+            "missing-header-cells",
+            "column-hint-count-mismatch"
+        ],
     );
 }
 
@@ -7781,6 +7860,12 @@ impl ExpectedBrowserDocument {
                 .table_cells
                 .into_iter()
                 .map(ExpectedTableCell::into_browser_table_cell)
+                .collect(),
+            table_structure_descriptors: self
+                .table_structure_descriptors
+                .unwrap_or_default()
+                .into_iter()
+                .map(ExpectedTableStructureDescriptor::into_browser_table_structure_descriptor)
                 .collect(),
         }
     }
@@ -15963,6 +16048,28 @@ impl ExpectedTableCell {
             abbr: self.abbr,
             rowspan: self.rowspan,
             colspan: self.colspan,
+        }
+    }
+}
+
+impl ExpectedTableStructureDescriptor {
+    fn into_browser_table_structure_descriptor(self) -> BrowserTableStructureDescriptor {
+        BrowserTableStructureDescriptor {
+            table_index: self.table_index,
+            table_id: self.table_id,
+            caption: self.caption,
+            row_count: self.row_count,
+            column_count: self.column_count,
+            column_hint_count: self.column_hint_count,
+            cell_count: self.cell_count,
+            header_cell_count: self.header_cell_count,
+            section_kinds: self.section_kinds,
+            header_scopes: self.header_scopes,
+            header_ids: self.header_ids,
+            cells_with_headers_count: self.cells_with_headers_count,
+            spanning_cell_count: self.spanning_cell_count,
+            table_blocked: self.table_blocked,
+            table_block_reasons: self.table_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -1268,6 +1268,9 @@
           { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 1, "element": "th", "text": "Totals", "header": true, "scope": "row" },
           { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 2, "element": "td", "text": "3", "headers": ["morning"] },
           { "table_index": 1, "table_id": "matrix", "table_caption": "Schedule", "section_kind": "tfoot", "row_index": 4, "column_index": 3, "element": "td", "text": "2", "headers": ["evening"] }
+        ],
+        "table_structure_descriptors": [
+          { "table_index": 1, "table_id": "matrix", "caption": "Schedule", "row_count": 4, "column_count": 4, "column_hint_count": 0, "cell_count": 11, "header_cell_count": 5, "section_kinds": ["thead", "tbody", "tfoot"], "header_scopes": ["col", "row"], "header_ids": ["day", "morning", "evening", "mon"], "cells_with_headers_count": 7, "spanning_cell_count": 2 }
         ]
       }
     },


### PR DESCRIPTION
## Summary
- add BrowserTableStructureDescriptor facts for table ids, captions, section coverage, header scopes/ids, spans, and header reference coverage
- surface table readiness blockers for missing captions, missing headers, column hint mismatches, and unreferenced data cells
- extend browser-readiness fixture governance and focused tests for complete and blocked table structures

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_table_structure_descriptors --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml