### PR TITLE
Add Z-Wave serial frame summary helpers

### DIFF
--- a/code/packages/rust/zwave-core/CHANGELOG.md
+++ b/code/packages/rust/zwave-core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Serial API per-frame summaries for request/response, function id, and payload
+  shape diagnostics.
 - Command-class and Serial API frame batch summaries for supervisor coverage
   views.
 

--- a/code/packages/rust/zwave-core/README.md
+++ b/code/packages/rust/zwave-core/README.md
@@ -10,7 +10,8 @@ Current scope:
 - network summary counts for classic/Long Range nodes and command-class coverage
 - common command-class ids
 - command-class payload frame parse/encode for short and extended class ids
-- command-class and Serial API frame batch summaries for supervisor views
+- command-class frame summaries plus Serial API per-frame and batch summaries
+  for supervisor views
 - Serial API SOF/ACK/NAK/CAN constants
 - Serial API request/response frame parse and encode
 - checksum validation

--- a/code/packages/rust/zwave-core/src/lib.rs
+++ b/code/packages/rust/zwave-core/src/lib.rs
@@ -407,6 +407,47 @@ impl SerialFrame {
         out.push(checksum);
         Ok(out)
     }
+
+    pub fn summary(&self) -> SerialFrameSummary {
+        SerialFrameSummary::from_frame(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SerialFrameSummary {
+    pub frame_type: SerialFrameType,
+    pub function_id: u8,
+    pub payload_len: usize,
+}
+
+impl SerialFrameSummary {
+    pub fn from_frame(frame: &SerialFrame) -> Self {
+        Self {
+            frame_type: frame.frame_type,
+            function_id: frame.function_id,
+            payload_len: frame.payload.len(),
+        }
+    }
+
+    pub fn is_request(&self) -> bool {
+        self.frame_type == SerialFrameType::Request
+    }
+
+    pub fn is_response(&self) -> bool {
+        self.frame_type == SerialFrameType::Response
+    }
+
+    pub fn has_payload(&self) -> bool {
+        self.payload_len > 0
+    }
+
+    pub fn is_function(&self, function_id: u8) -> bool {
+        self.function_id == function_id
+    }
+
+    pub fn is_empty_payload(&self) -> bool {
+        self.payload_len == 0
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -541,6 +582,21 @@ mod tests {
 
         assert_eq!(encoded[0], SOF);
         assert_eq!(SerialFrame::parse(&encoded).unwrap(), frame);
+        let summary = frame.summary();
+        assert_eq!(
+            summary,
+            SerialFrameSummary {
+                frame_type: SerialFrameType::Request,
+                function_id: 0x13,
+                payload_len: 3,
+            }
+        );
+        assert!(summary.is_request());
+        assert!(!summary.is_response());
+        assert!(summary.has_payload());
+        assert!(!summary.is_empty_payload());
+        assert!(summary.is_function(0x13));
+        assert!(!summary.is_function(0x02));
     }
 
     #[test]
@@ -563,6 +619,16 @@ mod tests {
         assert!(summary.has_requests());
         assert!(summary.has_responses());
         assert!(!summary.is_empty());
+
+        let response_summary = response.summary();
+        assert_eq!(response_summary.payload_len, 1);
+        assert!(!response_summary.is_request());
+        assert!(response_summary.is_response());
+        assert!(response_summary.is_function(0x02));
+
+        let empty_response = SerialFrame::new(SerialFrameType::Response, 0x15, Vec::new());
+        assert!(empty_response.summary().is_empty_payload());
+        assert!(!empty_response.summary().has_payload());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add SerialFrameSummary for per-frame Z-Wave Serial API request/response, function id, and payload shape diagnostics
- expose SerialFrame::summary() and small predicate helpers for supervisor views
- document the per-frame summary surface

## Tests
- cargo test --manifest-path code\\packages\\rust\\zwave-core\\Cargo.toml -- --nocapture