### PR TITLE
feat(cas-limit-series): Taylor-series limit fallback (Track J1)

### DIFF
--- a/code/packages/python/cas-limit-series/CHANGELOG.md
+++ b/code/packages/python/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.3.0 — 2026-05-29
+
+**Track J1 — Taylor-series-expansion fallback for limit evaluation.**
+
+### Added
+
+- New module `cas_limit_series.series_limit` exporting
+  `try_series_limit(expr, var, point, *, max_order=12)`. Computes the
+  limit of an `f(x) / g(x)` quotient by Taylor-expanding numerator and
+  denominator at `point` and reading off the leading-order coefficients.
+- Supports `sin`, `cos`, `tan`, `exp`, `log(1+u)`, `Pow` (non-negative
+  and `-1` integer exponents), polynomial arithmetic. Uses exact
+  `fractions.Fraction` math throughout.
+- Internal `Series` class implements truncated-power-series arithmetic
+  (add, sub, mul, neg, reciprocal-of-nonzero-constant, integer power
+  by repeated squaring, composition with zero-constant inner series).
+- Order iteration: starts at `N = 4`, bumps by 2 up to `N = 12` if the
+  leading coefficient hasn't been resolved.
+- Wired into `limit_advanced.py`: when L'Hôpital comes back with an
+  unevaluated `Limit(...)` for a 0/0 form at a finite point, the
+  Taylor fallback is consulted before returning. Also fires for 0/0
+  forms when no `diff_fn` is supplied.
+
+### Acceptance cases (all close exactly)
+
+| Limit | Value |
+|---|---|
+| `lim_{x→0} (sin(x) − x)/x³` | `−1/6` |
+| `lim_{x→0} (1 − cos(x))/x²` | `1/2` |
+| `lim_{x→0} (exp(x) − 1 − x)/x²` | `1/2` |
+| `lim_{x→0} (tan(x) − x)/x³` | `1/3` |
+| `lim_{x→0} (log(1+x) − x)/x²` | `−1/2` |
+| `lim_{x→0} (sin(x) − x)/(exp(x²) − 1)` | `0` (p=3 > q=2) |
+
+### Changed
+
+- `test_phase20.py::test_no_diff_fn_indeterminate` now asserts that
+  `sin(x)/x` closes to `1` when `diff_fn` is absent (previously the
+  test expected an unevaluated `Limit(...)`; Taylor closes it without
+  any differentiation).
+
+### Bounds
+
+- Hard ceiling `max_order = 12` keeps polynomial multiplication
+  bounded by O(N²).
+- No recursion in the order loop — fixed number of iterations.
+- No `eval` of any user-controlled string anywhere.
+
 ## 0.2.2 - 2026-06-06
 
 ### Added

--- a/code/packages/python/cas-limit-series/pyproject.toml
+++ b/code/packages/python/cas-limit-series/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-limit-series"
-version = "0.2.2"
+version = "0.3.0"
 description = "Limit and Taylor series on symbolic IR: direct substitution, L'Hôpital, ±∞, all indeterminate forms, one-sided limits."
 requires-python = ">=3.12"
 license = "MIT"

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/__init__.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/__init__.py
@@ -30,6 +30,7 @@ Quick start::
 from cas_limit_series.heads import BIG_O, INF, LIMIT, MINF, SERIES, TAYLOR
 from cas_limit_series.limit import limit_direct
 from cas_limit_series.limit_advanced import limit_advanced
+from cas_limit_series.series_limit import try_series_limit
 from cas_limit_series.taylor import PolynomialError, taylor_polynomial
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "limit_advanced",
     "limit_direct",
     "taylor_polynomial",
+    "try_series_limit",
 ]

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/limit_advanced.py
@@ -554,9 +554,29 @@ def _handle_form(
         ):
             return IRInteger(0)
         if (is_zero_zero or is_inf_inf) and diff_fn is not None:
-            return _lhopital_step(
+            lh_result = _lhopital_step(
                 numer, denom, var, point, direction, diff_fn, eval_fn, depth
             )
+            # Track J1: if L'Hôpital came back unevaluated (recursion depth,
+            # simplifier-too-weak, etc.), try the Taylor-series fallback before
+            # giving up. Only applies to 0/0 forms at finite points.
+            if (
+                isinstance(lh_result, IRApply)
+                and lh_result.head == LIMIT
+                and is_zero_zero
+                and not (math.isinf(exact_pt) or math.isnan(exact_pt))
+            ):
+                from cas_limit_series.series_limit import try_series_limit
+                series_result = try_series_limit(expr, var, point)
+                if series_result is not None:
+                    return series_result
+            return lh_result
+        # 0/0 at a finite point but no diff_fn — try Taylor directly.
+        if is_zero_zero and not (math.isinf(exact_pt) or math.isnan(exact_pt)):
+            from cas_limit_series.series_limit import try_series_limit
+            series_result = try_series_limit(expr, var, point)
+            if series_result is not None:
+                return series_result
 
     # --- MUL(a, b): 0·∞ form ---
     if isinstance(expr, IRApply) and expr.head == MUL and len(expr.args) == 2:

--- a/code/packages/python/cas-limit-series/src/cas_limit_series/series_limit.py
+++ b/code/packages/python/cas-limit-series/src/cas_limit_series/series_limit.py
@@ -1,0 +1,675 @@
+"""``try_series_limit`` — Taylor-series-expansion fallback for limits.
+
+This module implements the **Track J1** addition to the limit dispatcher:
+a series-expansion fallback that fires AFTER direct substitution and
+L'Hôpital have already failed to close. It handles indeterminate forms
+of the shape ``f(x) / g(x)`` where both numerator and denominator
+vanish (``0/0``) or both diverge (``∞/∞``), and the leading-order
+behaviour can be read off from a Taylor expansion around the limit
+point.
+
+Why a separate fallback?
+------------------------
+L'Hôpital can fail or diverge for a few reasons:
+
+1. **Differentiation explodes the expression size**. Two passes of
+   the quotient rule on ``(sin(x)-x)/x^3`` make a big mess that the
+   stub eval_fn doesn't simplify enough to recognise as ``0/0``.
+
+2. **The recursion is bounded** (``_MAX_DEPTH = 8`` in
+   ``limit_advanced``). Deep cancellations such as
+   ``(tan(x) - x) / x^3 = 1/3`` need three L'Hôpital steps; if any
+   intermediate step doesn't simplify cleanly the recursion may bail
+   out with an unevaluated ``Limit(...)`` node.
+
+3. **Bumping the differentiation order doesn't help** if the simplifier
+   isn't strong enough — but bumping the *series* order always does,
+   because polynomial arithmetic stays small and exact.
+
+Algorithm
+---------
+For ``limit(f(x) / g(x), x, a)`` where direct sub gives ``0/0``::
+
+    1. Translate the limit point to the origin.
+        - a = 0          ⇒ u = x
+        - a finite ≠ 0   ⇒ u = x - a
+        - a = +∞ / -∞    ⇒ u = 1/x (and rebrand a as 0+ in u-space).
+          (Not implemented in this first version; falls through.)
+
+    2. Taylor-expand both numerator N(u) and denominator D(u) to
+       order N (starting N = 4) using a transcendental-aware engine.
+
+    3. Read off leading coefficients::
+
+           N(u) = c_p * u^p + O(u^(p+1))
+           D(u) = d_q * u^q + O(u^(q+1))
+
+    4. Three cases:
+          p > q   →  limit = 0
+          p < q   →  limit = sign(c_p / d_q) · ∞
+          p == q  →  limit = c_p / d_q   (exact Fraction)
+
+    5. If both leading coefficients are still zero after extraction
+       (i.e. the order-N expansion wasn't deep enough), bump N += 2
+       and retry, up to N = 12.
+
+Bounds
+------
+* ``max_order`` defaults to 12 and is hard-capped.
+* The series ring uses exact :class:`fractions.Fraction` arithmetic.
+* No recursion: the loop iterates a fixed number of times.
+* Inputs are IR nodes, not strings — no ``eval`` of user-controlled
+  data anywhere.
+
+Supported transcendentals
+-------------------------
+``sin``, ``cos``, ``tan``, ``exp``, ``log`` (where ``log(1+u)`` is
+handled by composing ``log_one_plus`` with ``arg - 1``). Pow with
+integer exponent. Polynomial expressions of any degree.
+
+Anything else raises :class:`_SeriesError` internally; ``try_series_limit``
+catches and returns ``None`` so the caller can fall through to the
+unevaluated ``Limit(...)`` node.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    NEG,
+    POW,
+    SIN,
+    SUB,
+    TAN,
+    IRApply,
+    IRFloat,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_limit_series.heads import LIMIT
+
+# ---------------------------------------------------------------------------
+# Series ring
+# ---------------------------------------------------------------------------
+#
+# A truncated power series ``a_0 + a_1·u + a_2·u² + ... + a_N·u^N`` is
+# represented as ``Series(coeffs, order)`` where ``coeffs`` is a list of
+# Fractions of length ``order + 1``. ``order`` is the maximum tracked
+# exponent; higher terms are silently discarded (this is what truncation
+# means).
+#
+# All operations preserve ``order``. They never mutate inputs.
+
+#: Hard ceiling — keeps polynomial multiplication bounded by O(N²).
+_MAX_ORDER_LIMIT = 12
+
+
+class _SeriesError(ValueError):
+    """Raised when an expression cannot be Taylor-expanded.
+
+    Internal — caught at the public boundary and converted to
+    ``None`` so the dispatcher falls through cleanly.
+    """
+
+
+class Series:
+    """A truncated power series with rational coefficients.
+
+    Attributes
+    ----------
+    coeffs:
+        ``[a_0, a_1, ..., a_N]``  — exactly ``order + 1`` entries.
+    order:
+        The truncation order ``N``. Coefficients of ``u^k`` for
+        ``k > N`` are implicitly zero.
+    """
+
+    __slots__ = ("coeffs", "order")
+
+    def __init__(self, coeffs: list[Fraction], order: int) -> None:
+        if order < 0:
+            raise _SeriesError("series order must be non-negative")
+        # Normalise length to order + 1 (pad with zeros or truncate).
+        if len(coeffs) < order + 1:
+            coeffs = coeffs + [Fraction(0)] * (order + 1 - len(coeffs))
+        elif len(coeffs) > order + 1:
+            coeffs = coeffs[: order + 1]
+        self.coeffs = coeffs
+        self.order = order
+
+    # ---- constructors -----------------------------------------------------
+
+    @classmethod
+    def constant(cls, c: Fraction, order: int) -> Series:
+        """The series ``c + 0·u + 0·u² + ...``."""
+        return cls([c], order)
+
+    @classmethod
+    def variable(cls, order: int) -> Series:
+        """The series ``u`` (i.e. ``0 + 1·u``)."""
+        if order < 1:
+            return cls([Fraction(0)], order)
+        return cls([Fraction(0), Fraction(1)], order)
+
+    # ---- arithmetic -------------------------------------------------------
+
+    def __add__(self, other: Series) -> Series:
+        n = self.order  # both have the same order in our use
+        return Series(
+            [self.coeffs[i] + other.coeffs[i] for i in range(n + 1)], n
+        )
+
+    def __sub__(self, other: Series) -> Series:
+        n = self.order
+        return Series(
+            [self.coeffs[i] - other.coeffs[i] for i in range(n + 1)], n
+        )
+
+    def __neg__(self) -> Series:
+        return Series([-c for c in self.coeffs], self.order)
+
+    def __mul__(self, other: Series) -> Series:
+        n = self.order
+        out = [Fraction(0)] * (n + 1)
+        for i in range(n + 1):
+            ai = self.coeffs[i]
+            if ai == 0:
+                continue
+            for j in range(n + 1 - i):
+                out[i + j] += ai * other.coeffs[j]
+        return Series(out, n)
+
+    def scaled(self, c: Fraction) -> Series:
+        """Return ``c · self`` — scalar multiplication."""
+        return Series([c * a for a in self.coeffs], self.order)
+
+    def leading_index(self) -> int:
+        """Smallest ``k`` such that ``coeffs[k] != 0``, or -1 if all zero.
+
+        ``-1`` means *we cannot resolve the leading term within the
+        tracked order* — the caller should bump the order and retry.
+        """
+        for k, c in enumerate(self.coeffs):
+            if c != 0:
+                return k
+        return -1
+
+    # ---- division ---------------------------------------------------------
+
+    def reciprocal(self) -> Series:
+        """Return the series of ``1 / self`` provided ``self(0) ≠ 0``.
+
+        Uses the classic Newton-style recursion::
+
+            (a_0 + a_1 u + ...)·(b_0 + b_1 u + ...) = 1
+            ⇒ b_0 = 1/a_0
+            ⇒ b_k = -1/a_0 · sum_{j=1..k} a_j · b_{k-j}
+
+        If ``a_0 == 0`` (the series vanishes at 0), we cannot directly
+        invert; the caller is expected to factor out the leading
+        ``u^p`` first.
+        """
+        a = self.coeffs
+        n = self.order
+        if a[0] == 0:
+            raise _SeriesError("reciprocal of a series with zero constant term")
+        b = [Fraction(0)] * (n + 1)
+        b[0] = Fraction(1) / a[0]
+        for k in range(1, n + 1):
+            s = Fraction(0)
+            for j in range(1, k + 1):
+                s += a[j] * b[k - j]
+            b[k] = -s / a[0]
+        return Series(b, n)
+
+    def integer_power(self, k: int) -> Series:
+        """Return ``self**k`` for non-negative integer ``k``.
+
+        Uses repeated squaring for efficiency.
+        """
+        if k < 0:
+            raise _SeriesError("series integer_power requires k >= 0")
+        if k == 0:
+            return Series.constant(Fraction(1), self.order)
+        result = Series.constant(Fraction(1), self.order)
+        base = self
+        while k > 0:
+            if k & 1:
+                result = result * base
+            k >>= 1
+            if k > 0:
+                base = base * base
+        return result
+
+    # ---- composition ------------------------------------------------------
+
+    def compose_with_zero_constant(self, inner: Series) -> Series:
+        """Return ``self(inner(u))`` provided ``inner(0) == 0``.
+
+        Composition of series only makes sense when the inner series
+        vanishes at 0 — otherwise the constant term of the inner shifts
+        the expansion point and the result is no longer truncated at
+        the same order.
+
+        Computed as ``sum_k a_k · inner^k`` (truncated at ``order``).
+        """
+        if inner.coeffs[0] != 0:
+            raise _SeriesError(
+                "compose_with_zero_constant: inner series has nonzero constant"
+            )
+        n = self.order
+        result = Series.constant(Fraction(0), n)
+        # Horner-style: result = a_n + u·(a_{n-1} + u·(...)) but with
+        # ``u`` replaced by ``inner``. Computing inner^k explicitly is
+        # simpler and stays within budget for small N.
+        inner_pow = Series.constant(Fraction(1), n)  # inner^0 = 1
+        for k in range(n + 1):
+            if self.coeffs[k] != 0:
+                result = result + inner_pow.scaled(self.coeffs[k])
+            if k < n:
+                inner_pow = inner_pow * inner
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Known transcendental Taylor series (around u = 0)
+# ---------------------------------------------------------------------------
+#
+# Each function returns the truncated Taylor series of f(u) at u = 0,
+# to the requested order.
+
+
+def _factorial(n: int) -> int:
+    out = 1
+    for k in range(2, n + 1):
+        out *= k
+    return out
+
+
+def _series_exp(order: int) -> Series:
+    """``exp(u) = sum u^k / k!``."""
+    return Series([Fraction(1, _factorial(k)) for k in range(order + 1)], order)
+
+
+def _series_sin(order: int) -> Series:
+    """``sin(u) = u - u^3/3! + u^5/5! - ...`` — odd terms only."""
+    coeffs = [Fraction(0)] * (order + 1)
+    sign = 1
+    k = 1
+    while k <= order:
+        coeffs[k] = Fraction(sign, _factorial(k))
+        sign = -sign
+        k += 2
+    return Series(coeffs, order)
+
+
+def _series_cos(order: int) -> Series:
+    """``cos(u) = 1 - u^2/2! + u^4/4! - ...`` — even terms only."""
+    coeffs = [Fraction(0)] * (order + 1)
+    sign = 1
+    k = 0
+    while k <= order:
+        coeffs[k] = Fraction(sign, _factorial(k))
+        sign = -sign
+        k += 2
+    return Series(coeffs, order)
+
+
+def _series_log_one_plus(order: int) -> Series:
+    """``log(1 + u) = u - u^2/2 + u^3/3 - ...``."""
+    coeffs = [Fraction(0)] * (order + 1)
+    sign = 1
+    for k in range(1, order + 1):
+        coeffs[k] = Fraction(sign, k)
+        sign = -sign
+    return Series(coeffs, order)
+
+
+def _series_tan(order: int) -> Series:
+    """``tan(u) = sin(u) / cos(u)``.
+
+    We expand to *at least* ``order`` and divide. Since the series
+    ring is closed under reciprocal-of-nonzero-constant (cos has
+    constant term 1), this is exact.
+    """
+    return _series_sin(order) * _series_cos(order).reciprocal()
+
+
+# ---------------------------------------------------------------------------
+# IR → Series translation
+# ---------------------------------------------------------------------------
+
+
+def _to_fraction(node: IRNode) -> Fraction:
+    """Convert a literal IR node to a Fraction. Raises on non-literals."""
+    if isinstance(node, IRInteger):
+        return Fraction(node.value)
+    if isinstance(node, IRRational):
+        return Fraction(node.numer, node.denom)
+    if isinstance(node, IRFloat):
+        # Lossy but bounded; used only as a coefficient.
+        return Fraction(node.value).limit_denominator()
+    raise _SeriesError(f"expected literal, got {node!r}")
+
+
+def _expand(expr: IRNode, var: IRSymbol, order: int) -> Series:
+    """Expand *expr* in *var* to truncated order around var = 0.
+
+    Pure recursion: each IR head dispatches to the corresponding
+    series operation. Unsupported heads raise ``_SeriesError``.
+
+    The caller MUST have already translated the limit point to the
+    origin (so ``var → 0`` is the expansion point).
+    """
+    # --- literal numbers ---
+    if isinstance(expr, (IRInteger, IRRational, IRFloat)):
+        return Series.constant(_to_fraction(expr), order)
+
+    # --- the expansion variable ---
+    if isinstance(expr, IRSymbol):
+        if expr == var:
+            return Series.variable(order)
+        # Other symbols are opaque constants. We cannot meaningfully
+        # Taylor-expand around them, so reject — the limit fallback
+        # only handles single-variable inputs.
+        raise _SeriesError(f"unsupported symbol {expr.name!r}")
+
+    if not isinstance(expr, IRApply) or not isinstance(expr.head, IRSymbol):
+        raise _SeriesError(f"unsupported expression: {expr!r}")
+
+    h = expr.head
+    args = expr.args
+
+    # --- arithmetic ---
+    if h == ADD:
+        result = Series.constant(Fraction(0), order)
+        for a in args:
+            result = result + _expand(a, var, order)
+        return result
+    if h == SUB:
+        if len(args) != 2:
+            raise _SeriesError("Sub expects 2 args")
+        return _expand(args[0], var, order) - _expand(args[1], var, order)
+    if h == NEG:
+        if len(args) != 1:
+            raise _SeriesError("Neg expects 1 arg")
+        return -_expand(args[0], var, order)
+    if h == MUL:
+        result = Series.constant(Fraction(1), order)
+        for a in args:
+            result = result * _expand(a, var, order)
+        return result
+    if h == DIV:
+        if len(args) != 2:
+            raise _SeriesError("Div expects 2 args")
+        n_ser = _expand(args[0], var, order)
+        d_ser = _expand(args[1], var, order)
+        # If denominator has nonzero constant term, direct reciprocal.
+        if d_ser.coeffs[0] != 0:
+            return n_ser * d_ser.reciprocal()
+        # Otherwise we cannot keep dividing inside the ring — the caller
+        # (``try_series_limit``) handles the top-level f/g case, and any
+        # *inner* DIV by a vanishing series would change the leading
+        # order of the surrounding expansion. Bail out.
+        raise _SeriesError(
+            "inner Div by a series vanishing at 0; cannot expand at fixed order"
+        )
+    if h == POW:
+        if len(args) != 2:
+            raise _SeriesError("Pow expects 2 args")
+        base, exp_node = args
+        # Only non-negative integer exponents are supported. Negative
+        # integers would require reciprocal (constant term must be
+        # nonzero); fractional exponents are out of scope.
+        if isinstance(exp_node, IRInteger):
+            k = exp_node.value
+            if k >= 0:
+                return _expand(base, var, order).integer_power(k)
+            # Negative integer: reciprocal-then-power.
+            base_ser = _expand(base, var, order)
+            if base_ser.coeffs[0] == 0:
+                raise _SeriesError(
+                    "Pow with negative integer exponent over vanishing base"
+                )
+            return base_ser.reciprocal().integer_power(-k)
+        raise _SeriesError("Pow exponent must be a non-negative integer literal")
+
+    # --- transcendentals ---
+    if h == EXP:
+        if len(args) != 1:
+            raise _SeriesError("Exp expects 1 arg")
+        inner = _expand(args[0], var, order)
+        # exp(a + b) = exp(a) · exp(b); split off the constant term.
+        c0 = inner.coeffs[0]
+        # If c0 != 0, the constant factor exp(c0) is opaque (no closed
+        # rational), and we cannot keep the result in the rational ring.
+        if c0 != 0:
+            raise _SeriesError("Exp with nonzero constant inner term")
+        return _series_exp(order).compose_with_zero_constant(inner)
+    if h == SIN:
+        if len(args) != 1:
+            raise _SeriesError("Sin expects 1 arg")
+        inner = _expand(args[0], var, order)
+        if inner.coeffs[0] != 0:
+            raise _SeriesError("Sin with nonzero constant inner term")
+        return _series_sin(order).compose_with_zero_constant(inner)
+    if h == COS:
+        if len(args) != 1:
+            raise _SeriesError("Cos expects 1 arg")
+        inner = _expand(args[0], var, order)
+        if inner.coeffs[0] != 0:
+            raise _SeriesError("Cos with nonzero constant inner term")
+        return _series_cos(order).compose_with_zero_constant(inner)
+    if h == TAN:
+        if len(args) != 1:
+            raise _SeriesError("Tan expects 1 arg")
+        inner = _expand(args[0], var, order)
+        if inner.coeffs[0] != 0:
+            raise _SeriesError("Tan with nonzero constant inner term")
+        return _series_tan(order).compose_with_zero_constant(inner)
+    if h == LOG:
+        if len(args) != 1:
+            raise _SeriesError("Log expects 1 arg")
+        inner = _expand(args[0], var, order)
+        # log requires inner(0) == 1: log(1 + (inner - 1)) where
+        # (inner - 1)(0) == 0.
+        c0 = inner.coeffs[0]
+        if c0 != 1:
+            raise _SeriesError(
+                f"Log with constant inner term != 1 (got {c0}); not in rational ring"
+            )
+        shifted = Series(
+            [Fraction(0)] + inner.coeffs[1:], order
+        )  # inner - 1
+        return _series_log_one_plus(order).compose_with_zero_constant(shifted)
+
+    raise _SeriesError(f"unsupported head: {h}")
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def _split_quotient(expr: IRNode) -> tuple[IRNode, IRNode] | None:
+    """Return ``(numer, denom)`` if *expr* looks like a quotient.
+
+    Recognises both ``Div(N, D)`` and ``Mul(N, Pow(D, -1))`` shapes.
+    Returns ``None`` for any other top-level shape — the Taylor
+    fallback only fires on rational structures.
+    """
+    if not isinstance(expr, IRApply):
+        return None
+    if expr.head == DIV and len(expr.args) == 2:
+        return expr.args[0], expr.args[1]
+    if expr.head == MUL and len(expr.args) == 2:
+        a, b = expr.args
+        if (
+            isinstance(b, IRApply)
+            and b.head == POW
+            and len(b.args) == 2
+            and isinstance(b.args[1], IRInteger)
+            and b.args[1].value == -1
+        ):
+            return a, b.args[0]
+        if (
+            isinstance(a, IRApply)
+            and a.head == POW
+            and len(a.args) == 2
+            and isinstance(a.args[1], IRInteger)
+            and a.args[1].value == -1
+        ):
+            return b, a.args[0]
+    return None
+
+
+def _shift_to_origin(expr: IRNode, var: IRSymbol, point: IRNode) -> IRNode:
+    """Substitute ``var := var + point`` so ``var = 0`` corresponds to
+    the original ``var = point``.
+
+    We do NOT use the package's ``cas_substitution`` here because the
+    Series expander walks the IR directly and we want the
+    substitution to be totally explicit (no reliance on a substituter
+    we don't control).
+    """
+    if isinstance(point, IRInteger) and point.value == 0:
+        return expr  # no shift needed
+
+    def _go(node: IRNode) -> IRNode:
+        if isinstance(node, IRSymbol):
+            if node == var:
+                return IRApply(ADD, (var, point))
+            return node
+        if isinstance(node, IRApply):
+            return IRApply(node.head, tuple(_go(a) for a in node.args))
+        return node
+
+    return _go(expr)
+
+
+def _coeff_to_ir(c: Fraction) -> IRNode:
+    """Convert a Fraction back to an IR literal node."""
+    if c.denominator == 1:
+        return IRInteger(c.numerator)
+    return IRRational(c.numerator, c.denominator)
+
+
+def try_series_limit(
+    expr: IRNode,
+    var: IRSymbol,
+    point: IRNode,
+    *,
+    max_order: int = _MAX_ORDER_LIMIT,
+) -> IRNode | None:
+    """Taylor-series fallback for ``limit(expr, var, point)``.
+
+    Fires when direct substitution and L'Hôpital have both failed to
+    close. Returns:
+
+    * an :class:`IRInteger` / :class:`IRRational` literal on success,
+    * ``LIMIT.INF`` / ``LIMIT.MINF`` symbol on a divergent ratio,
+    * ``None`` if the fallback cannot determine the value (caller
+      should fall through to an unevaluated ``Limit(...)``).
+
+    Parameters
+    ----------
+    expr:
+        The expression whose limit is sought. Must have a rational
+        ``f / g`` top-level structure — anything else returns ``None``.
+    var:
+        The limit variable (an ``IRSymbol``).
+    point:
+        The limit point. Must be a literal number (``IRInteger``,
+        ``IRRational``, ``IRFloat``). Limits at ±∞ are not yet
+        handled by this fallback and return ``None``.
+    max_order:
+        Hard ceiling on the Taylor-expansion order (clamped at 12 to
+        keep polynomial multiplication bounded by O(N²)).
+    """
+    # --- safety bounds ---
+    if max_order < 4:
+        max_order = 4
+    if max_order > _MAX_ORDER_LIMIT:
+        max_order = _MAX_ORDER_LIMIT
+
+    # --- top-level shape: must be a quotient ---
+    nd = _split_quotient(expr)
+    if nd is None:
+        return None
+    numer, denom = nd
+
+    # --- limit at ±∞ → not yet handled (would need u = 1/x rewrite) ---
+    if isinstance(point, IRSymbol) and point.name in ("inf", "minf"):
+        return None
+    if not isinstance(point, (IRInteger, IRRational, IRFloat)):
+        return None
+
+    # --- shift the expansion point to the origin ---
+    shifted_n = _shift_to_origin(numer, var, point)
+    shifted_d = _shift_to_origin(denom, var, point)
+
+    # --- iterate orders ---
+    order = 4
+    while order <= max_order:
+        try:
+            n_ser = _expand(shifted_n, var, order)
+            d_ser = _expand(shifted_d, var, order)
+        except _SeriesError:
+            return None
+
+        p = n_ser.leading_index()
+        q = d_ser.leading_index()
+
+        # Both fully zero → degenerate case; the limit is genuinely
+        # 0/0 with no resolvable leading term. Bump order and try again.
+        if p == -1 and q == -1:
+            order += 2
+            continue
+
+        # Numerator zero out to tracked order but denominator nonzero →
+        # the limit is 0 (numerator vanishes faster than any power we
+        # tracked, denominator does not).
+        if p == -1 and q != -1:
+            return IRInteger(0)
+
+        # Denominator zero but numerator nonzero → divergence. Sign
+        # follows the leading coefficient.
+        if q == -1 and p != -1:
+            sign = 1 if n_ser.coeffs[p] > 0 else -1
+            return IRSymbol("inf") if sign > 0 else IRSymbol("minf")
+
+        # Both leading orders found. Apply the three-way rule.
+        c_p = n_ser.coeffs[p]
+        d_q = d_ser.coeffs[q]
+        if p > q:
+            return IRInteger(0)
+        if p < q:
+            # c_p / d_q · u^(p-q) with p < q → 1/u^(q-p) · finite → ±∞
+            sign_val = c_p / d_q
+            return IRSymbol("inf") if sign_val > 0 else IRSymbol("minf")
+        # p == q
+        ratio = c_p / d_q
+        return _coeff_to_ir(ratio)
+
+    # Out of budget — caller falls through to unevaluated Limit(...).
+    return None
+
+
+__all__ = ["try_series_limit"]
+
+
+# ---------------------------------------------------------------------------
+# Re-export of LIMIT head for convenience — the dispatcher in
+# ``limit_advanced.py`` imports this symbol when wiring the fallback.
+# ---------------------------------------------------------------------------
+_LIMIT = LIMIT  # noqa: N816 — match the spec's naming

--- a/code/packages/python/cas-limit-series/tests/test_phase20.py
+++ b/code/packages/python/cas-limit-series/tests/test_phase20.py
@@ -753,11 +753,14 @@ class TestFallthrough:
     """Limits that fall through to unevaluated Limit(…)."""
 
     def test_no_diff_fn_indeterminate(self):
-        """Without diff_fn, 0/0 form cannot be resolved → unevaluated."""
+        """Without diff_fn, 0/0 form falls through to the Taylor-series
+        fallback (Track J1).  ``sin(x)/x`` at 0 closes to ``1`` via the
+        series expansion path even when L'Hôpital is unavailable."""
         x = _sym("x")
         expr = IRApply(DIV, (IRApply(SIN, (x,)), x))
         out = limit_advanced(expr, x, _i(0))  # no diff_fn
-        assert _is_unevaluated(out)
+        # Pre-J1: would return unevaluated. Post-J1: Taylor closes to 1.
+        assert isinstance(out, IRInteger) and out.value == 1
 
     def test_oscillating_sin_at_infinity(self):
         """lim_{x→∞} sin(x) is undefined (oscillates) → unevaluated."""

--- a/code/packages/python/cas-limit-series/tests/test_series_limit.py
+++ b/code/packages/python/cas-limit-series/tests/test_series_limit.py
@@ -1,0 +1,433 @@
+"""Track J1 — Taylor-series-expansion fallback for limits.
+
+Acceptance cases from ``macsyma-truly-finish-plan.md``:
+
+    limit((sin(x) - x)/x^3,        x, 0) = -1/6
+    limit((1 - cos(x))/x^2,        x, 0) =  1/2
+    limit((exp(x) - 1 - x)/x^2,    x, 0) =  1/2
+    limit((tan(x) - x)/x^3,        x, 0) =  1/3
+    limit((log(1+x) - x)/x^2,      x, 0) = -1/2
+    limit((sin(x) - x)/(exp(x^2) - 1), x, 0) = -1/6  (the (x^2 + O(x^4)) denom
+                                                       has leading u^2, and the
+                                                       numerator's leading
+                                                       coefficient is -1/6 at u^3
+                                                       — so the limit is 0)
+
+Plus regression checks that the existing direct-substitution / L'Hôpital
+paths continue to close their own cases without hitting the Taylor
+fallback.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import (
+    ADD,
+    COS,
+    DIV,
+    EXP,
+    LOG,
+    MUL,
+    POW,
+    SIN,
+    SUB,
+    TAN,
+    IRApply,
+    IRInteger,
+    IRRational,
+    IRSymbol,
+)
+
+from cas_limit_series import try_series_limit
+
+# ---------------------------------------------------------------------------
+# Tiny helpers
+# ---------------------------------------------------------------------------
+
+
+def _i(n: int) -> IRInteger:
+    return IRInteger(n)
+
+
+def _x() -> IRSymbol:
+    return IRSymbol("x")
+
+
+def _div(a, b):  # noqa: ANN001
+    return IRApply(DIV, (a, b))
+
+
+def _sub(a, b):  # noqa: ANN001
+    return IRApply(SUB, (a, b))
+
+
+def _pow(a, n):  # noqa: ANN001
+    return IRApply(POW, (a, _i(n)))
+
+
+def _mul(*args):  # noqa: ANN001
+    return IRApply(MUL, tuple(args))
+
+
+def _sin(a):  # noqa: ANN001
+    return IRApply(SIN, (a,))
+
+
+def _cos(a):  # noqa: ANN001
+    return IRApply(COS, (a,))
+
+
+def _tan(a):  # noqa: ANN001
+    return IRApply(TAN, (a,))
+
+
+def _exp(a):  # noqa: ANN001
+    return IRApply(EXP, (a,))
+
+
+def _log(a):  # noqa: ANN001
+    return IRApply(LOG, (a,))
+
+
+def _as_fraction(node):  # noqa: ANN001
+    """Convert an IR literal node back to a Fraction for asserting."""
+    if isinstance(node, IRInteger):
+        return Fraction(node.value)
+    if isinstance(node, IRRational):
+        return Fraction(node.numer, node.denom)
+    raise AssertionError(f"expected literal, got {node!r}")
+
+
+# ---------------------------------------------------------------------------
+# Acceptance cases
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptance:
+    """The six acceptance cases listed in the Track J1 spec."""
+
+    def test_sin_minus_x_over_x_cubed(self) -> None:
+        """(sin(x) − x)/x³  →  −1/6."""
+        x = _x()
+        expr = _div(_sub(_sin(x), x), _pow(x, 3))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(-1, 6)
+
+    def test_one_minus_cos_over_x_squared(self) -> None:
+        """(1 − cos(x))/x²  →  1/2."""
+        x = _x()
+        expr = _div(_sub(_i(1), _cos(x)), _pow(x, 2))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1, 2)
+
+    def test_exp_minus_1_minus_x_over_x_squared(self) -> None:
+        """(exp(x) − 1 − x)/x²  →  1/2."""
+        x = _x()
+        numer = _sub(_sub(_exp(x), _i(1)), x)
+        expr = _div(numer, _pow(x, 2))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1, 2)
+
+    def test_tan_minus_x_over_x_cubed(self) -> None:
+        """(tan(x) − x)/x³  →  1/3."""
+        x = _x()
+        expr = _div(_sub(_tan(x), x), _pow(x, 3))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1, 3)
+
+    def test_log_one_plus_x_minus_x_over_x_squared(self) -> None:
+        """(log(1+x) − x)/x²  →  −1/2."""
+        x = _x()
+        # log(1 + x)
+        one_plus_x = IRApply(ADD, (_i(1), x))
+        numer = _sub(_log(one_plus_x), x)
+        expr = _div(numer, _pow(x, 2))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(-1, 2)
+
+    def test_sin_minus_x_over_exp_x_squared_minus_one(self) -> None:
+        """(sin(x) − x) / (exp(x²) − 1).
+
+        sin(x) − x = −x³/6 + O(x⁵)          → leading u^3, c_3 = −1/6
+        exp(x²) − 1 = x² + O(x⁴)             → leading u^2, d_2 = 1
+        p = 3 > q = 2 ⇒ limit = 0.
+        """
+        x = _x()
+        numer = _sub(_sin(x), x)
+        denom = _sub(_exp(_pow(x, 2)), _i(1))
+        expr = _div(numer, denom)
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert isinstance(result, IRInteger) and result.value == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression — existing paths still close
+# ---------------------------------------------------------------------------
+
+
+class TestRegression:
+    """sin(x)/x and x^2 still close via existing paths (or via Taylor)."""
+
+    def test_sin_over_x(self) -> None:
+        """sin(x)/x  →  1.  Both Taylor and L'Hôpital should give this."""
+        x = _x()
+        expr = _div(_sin(x), x)
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)
+
+    def test_x_squared_quotient(self) -> None:
+        """x²/x → 0 by leading-order analysis."""
+        x = _x()
+        expr = _div(_pow(x, 2), x)
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert isinstance(result, IRInteger) and result.value == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — return None gracefully
+# ---------------------------------------------------------------------------
+
+
+class TestFallthrough:
+    """Inputs that the Taylor fallback cannot handle should return None."""
+
+    def test_non_quotient_returns_none(self) -> None:
+        """Bare polynomial (not a quotient) → None.
+
+        The fallback only fires on f/g shapes — anything else is the job
+        of other dispatch branches.
+        """
+        x = _x()
+        result = try_series_limit(_pow(x, 2), x, _i(0))
+        assert result is None
+
+    def test_unsupported_head_returns_none(self) -> None:
+        """A quotient containing an unsupported head (e.g. Asin) → None."""
+        x = _x()
+        # Use a synthetic head that's not in the supported transcendental
+        # list.
+        weird = IRApply(IRSymbol("Asin"), (x,))
+        expr = _div(weird, x)
+        result = try_series_limit(expr, x, _i(0))
+        assert result is None
+
+    def test_infinity_point_returns_none(self) -> None:
+        """Limits at ±∞ are not handled by this first version of the
+        fallback (they need a u = 1/x rewrite)."""
+        x = _x()
+        expr = _div(_sin(x), x)
+        result = try_series_limit(expr, x, IRSymbol("inf"))
+        assert result is None
+
+    def test_divergent_quotient(self) -> None:
+        """1/x² → ∞ (p < q, denominator vanishes faster).
+
+        The fallback should return the IRSymbol("inf") sentinel.
+        """
+        x = _x()
+        expr = _div(_i(1), _pow(x, 2))
+        result = try_series_limit(expr, x, _i(0))
+        # 1 has leading order 0, x^2 has leading order 2: p=0 < q=2
+        # ⇒ ∞ (positive, since 1/1 > 0).
+        assert result is not None
+        assert isinstance(result, IRSymbol) and result.name == "inf"
+
+    def test_negative_divergence(self) -> None:
+        """-1/x² → -∞."""
+        x = _x()
+        expr = _div(_i(-1), _pow(x, 2))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert isinstance(result, IRSymbol) and result.name == "minf"
+
+
+# ---------------------------------------------------------------------------
+# Non-origin expansion point
+# ---------------------------------------------------------------------------
+
+
+class TestShiftedPoint:
+    """Limit at a non-zero point should translate to the origin first."""
+
+    def test_polynomial_at_one(self) -> None:
+        """(x² − 1)/(x − 1) at x = 1  →  2."""
+        x = _x()
+        numer = _sub(_pow(x, 2), _i(1))
+        denom = _sub(x, _i(1))
+        expr = _div(numer, denom)
+        result = try_series_limit(expr, x, _i(1))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(2)
+
+
+# ---------------------------------------------------------------------------
+# Wiring — limit_advanced uses try_series_limit when L'Hôpital can't close
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherIntegration:
+    """The top-level ``limit_advanced`` should pick up Taylor results
+    when called without an injected diff_fn for 0/0 forms.
+    """
+
+    def test_limit_advanced_no_diff_fn_uses_taylor(self) -> None:
+        """sin(x)/x via limit_advanced without diff_fn falls through to Taylor."""
+        from cas_limit_series import limit_advanced
+
+        x = _x()
+        expr = _div(_sin(x), x)
+        # No diff_fn → L'Hôpital can't fire, but Taylor should still close.
+        result = limit_advanced(expr, x, _i(0))
+        # Result should evaluate to 1 (IRInteger(1) or a Limit fallthrough).
+        # We accept either: the contract is "Taylor closes 0/0 when L'Hôpital
+        # has no diff_fn" — for sin(x)/x specifically Taylor gives 1.
+        assert isinstance(result, IRInteger) and result.value == 1
+
+
+# ---------------------------------------------------------------------------
+# Series-ring internals — these tests exercise the low-level Series API
+# directly. They're not strictly required by the spec but they bring the
+# coverage of ``series_limit.py`` up over the 80% threshold and document
+# the boundaries of the ring.
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesRing:
+    """Direct exercises of the Series class and its arithmetic."""
+
+    def test_reciprocal_of_vanishing_series_raises(self) -> None:
+        """Reciprocal requires a nonzero constant term."""
+        from cas_limit_series.series_limit import Series, _SeriesError
+
+        s = Series([Fraction(0), Fraction(1)], 4)  # = u
+        try:
+            s.reciprocal()
+        except _SeriesError:
+            return
+        raise AssertionError("expected _SeriesError")
+
+    def test_integer_power_negative_raises(self) -> None:
+        """integer_power requires k >= 0."""
+        from cas_limit_series.series_limit import Series, _SeriesError
+
+        s = Series([Fraction(1)], 4)
+        try:
+            s.integer_power(-1)
+        except _SeriesError:
+            return
+        raise AssertionError("expected _SeriesError")
+
+    def test_integer_power_zero_is_one(self) -> None:
+        """Any series to the 0 power is the constant 1."""
+        from cas_limit_series.series_limit import Series
+
+        s = Series([Fraction(2), Fraction(3)], 4)
+        result = s.integer_power(0)
+        assert result.coeffs[0] == 1
+        assert all(c == 0 for c in result.coeffs[1:])
+
+    def test_compose_with_nonzero_constant_raises(self) -> None:
+        """Composition requires inner(0) == 0."""
+        from cas_limit_series.series_limit import Series, _SeriesError
+
+        outer = Series([Fraction(1), Fraction(1)], 4)
+        inner = Series([Fraction(1), Fraction(1)], 4)  # has nonzero constant
+        try:
+            outer.compose_with_zero_constant(inner)
+        except _SeriesError:
+            return
+        raise AssertionError("expected _SeriesError")
+
+    def test_series_padding_and_truncation(self) -> None:
+        """Series constructor pads short lists and truncates long ones."""
+        from cas_limit_series.series_limit import Series
+
+        short = Series([Fraction(1)], 3)
+        assert short.coeffs == [Fraction(1), Fraction(0), Fraction(0), Fraction(0)]
+        long = Series([Fraction(i) for i in range(10)], 3)
+        assert long.coeffs == [Fraction(0), Fraction(1), Fraction(2), Fraction(3)]
+
+    def test_negative_order_raises(self) -> None:
+        """Order must be non-negative."""
+        from cas_limit_series.series_limit import Series, _SeriesError
+
+        try:
+            Series([Fraction(1)], -1)
+        except _SeriesError:
+            return
+        raise AssertionError("expected _SeriesError")
+
+
+class TestExpanderEdges:
+    """Branches of ``_expand`` that the acceptance cases don't reach."""
+
+    def test_neg_head(self) -> None:
+        """-sin(x)/x at 0 → -1."""
+        from symbolic_ir import NEG
+
+        x = _x()
+        numer = IRApply(NEG, (_sin(x),))
+        expr = _div(numer, x)
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(-1)
+
+    def test_negative_integer_power(self) -> None:
+        """1/(1-x) / 1 at 0 → 1 via reciprocal-then-power on Pow(., -1)."""
+        # We need an actual Pow with exponent -1 sitting INSIDE a quotient
+        # so the inner ``_expand`` path takes Pow(base, IRInteger(-1)).
+        x = _x()
+        one_minus_x = _sub(_i(1), x)
+        # 1/((1-x)^-1) = (1-x); divided by 1, limit is 1.
+        inner_pow = IRApply(POW, (one_minus_x, IRInteger(-1)))
+        # Build Mul(1, Pow(1-x, -1)) / 1 — exercises Pow(., -1).
+        expr = _div(IRApply(POW, (one_minus_x, IRInteger(-1))), _i(1))
+        _ = inner_pow  # silence linter
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)
+
+    def test_mul_quotient_via_pow_neg_one(self) -> None:
+        """``Mul(N, Pow(D, -1))`` is recognised as a quotient."""
+        x = _x()
+        # sin(x) * x^(-1) — same as sin(x)/x.
+        expr = _mul(_sin(x), IRApply(POW, (x, IRInteger(-1))))
+        result = try_series_limit(expr, x, _i(0))
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)
+
+    def test_div_at_origin_with_constant_numerator(self) -> None:
+        """1/1 at 0 → 1 via the rational ring."""
+        x = _x()
+        expr = _div(_i(1), _i(1))
+        # This is not a quotient with zero-vanishing parts, but the
+        # try_series_limit fallback should still cope.
+        result = try_series_limit(expr, x, _i(0))
+        # 1/1 has p=q=0, c_p/d_q=1.
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)
+
+    def test_max_order_clamped_high(self) -> None:
+        """``max_order`` above the hard cap is clamped."""
+        x = _x()
+        expr = _div(_sin(x), x)
+        result = try_series_limit(expr, x, _i(0), max_order=999)
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)
+
+    def test_max_order_clamped_low(self) -> None:
+        """``max_order`` below 4 is bumped to 4."""
+        x = _x()
+        expr = _div(_sin(x), x)
+        result = try_series_limit(expr, x, _i(0), max_order=2)
+        assert result is not None
+        assert _as_fraction(result) == Fraction(1)


### PR DESCRIPTION
## Summary

Track J1 of `code/specs/macsyma-truly-finish-plan.md` — Taylor-series-expansion fallback for limit evaluation in `cas-limit-series`.

- New module `cas_limit_series.series_limit` with a self-contained `Series` ring (add/sub/mul/neg/reciprocal/integer-power/composition) using exact `fractions.Fraction` arithmetic. Known transcendentals: `sin`, `cos`, `tan`, `exp`, `log(1+u)`; `Pow` with integer exponents; polynomial arithmetic of any degree.
- `try_series_limit(expr, var, point, *, max_order=12)` translates the expansion point to the origin, Taylor-expands the numerator and denominator, and reads off the leading-order coefficients. Iterates orders 4 → 12 in steps of 2 (`max_order` is hard-clamped at 12 for bounded O(N²) polynomial multiplication).
- Wired into `limit_advanced`: if L'Hôpital comes back unevaluated for a 0/0 form at a finite point, the Taylor fallback is consulted before returning. Also fires for 0/0 forms when no `diff_fn` is supplied.

## Acceptance cases (all exact)

| Limit | Value |
|---|---|
| `lim_{x→0} (sin(x) − x)/x³` | `−1/6` |
| `lim_{x→0} (1 − cos(x))/x²` | `1/2` |
| `lim_{x→0} (exp(x) − 1 − x)/x²` | `1/2` |
| `lim_{x→0} (tan(x) − x)/x³` | `1/3` |
| `lim_{x→0} (log(1+x) − x)/x²` | `−1/2` |
| `lim_{x→0} (sin(x) − x)/(exp(x²) − 1)` | `0`  (p=3 > q=2) |
| `lim_{x→0} sin(x)/x` (regression) | `1` |
| `lim_{x→0} x²/x` (regression) | `0` |

Bumps `coding-adventures-cas-limit-series` to `0.3.0`.

## Test plan

- [x] `pytest tests/` — 87 passed, 7 skipped (existing VM-dependent skips); 81.96% coverage (target ≥ 80%).
- [x] `ruff check src/cas_limit_series/series_limit.py tests/test_series_limit.py` — clean.
- [x] Regression: `test_no_diff_fn_indeterminate` updated to assert the new closing behavior (Taylor now resolves `sin(x)/x` to `1` without a `diff_fn`).
- [x] Security review (inline): no `eval`/`exec`/`subprocess`/file I/O; all loops bounded; recursion is structural over IR nodes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)