### PR TITLE
Add image map readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -871,6 +871,7 @@ pub struct BrowserDocument {
     pub images: Vec<BrowserImage>,
     pub image_candidate_descriptors: Vec<BrowserImageCandidateDescriptor>,
     pub image_maps: Vec<BrowserImageMap>,
+    pub image_map_descriptors: Vec<BrowserImageMapDescriptor>,
     pub media: Vec<BrowserMedia>,
     pub media_playback_descriptors: Vec<BrowserMediaPlaybackDescriptor>,
     pub embedded_contexts: Vec<BrowserEmbeddedContext>,
@@ -2613,6 +2614,25 @@ pub struct BrowserImageMap {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserImageMapDescriptor {
+    pub map_index: usize,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub referenced_image_sources: Vec<String>,
+    pub area_count: usize,
+    pub navigable_area_count: usize,
+    pub area_shapes: Vec<String>,
+    pub missing_alt_area_count: usize,
+    pub missing_href_area_count: usize,
+    pub missing_coords_area_count: usize,
+    pub default_shape_area_count: usize,
+    pub ping_area_count: usize,
+    pub attribution_area_count: usize,
+    pub map_blocked: bool,
+    pub map_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserImageMapArea {
     pub id: Option<String>,
     pub shape: String,
@@ -3737,6 +3757,8 @@ impl BrowserDocument {
         summary.stylesheet_planning_descriptors =
             browser_stylesheet_planning_descriptors(&summary.stylesheets);
         summary.image_candidate_descriptors = browser_image_candidate_descriptors(&summary.images);
+        summary.image_map_descriptors =
+            browser_image_map_descriptors(&summary.image_maps, &summary.images);
         summary.media_playback_descriptors = browser_media_playback_descriptors(&summary.media);
         summary.embedded_policy_descriptors =
             browser_embedded_policy_descriptors(&summary.embedded_contexts);
@@ -11461,6 +11483,168 @@ fn browser_image_candidate_descriptor(image: &BrowserImage) -> BrowserImageCandi
             .collect(),
         sources: image.sources.clone(),
     }
+}
+
+fn browser_image_map_descriptors(
+    maps: &[BrowserImageMap],
+    images: &[BrowserImage],
+) -> Vec<BrowserImageMapDescriptor> {
+    let mut descriptors = maps
+        .iter()
+        .enumerate()
+        .map(|(index, map)| browser_image_map_descriptor(index + 1, map, images))
+        .collect::<Vec<_>>();
+
+    for image in images {
+        let Some(map_name) = image.usemap.as_deref().and_then(browser_image_usemap_name) else {
+            continue;
+        };
+        if maps
+            .iter()
+            .any(|map| map.name.as_deref() == Some(map_name.as_str()))
+        {
+            continue;
+        }
+        let referenced_image_sources = vec![browser_image_reference_source(image)];
+        descriptors.push(BrowserImageMapDescriptor {
+            map_index: descriptors.len() + 1,
+            id: None,
+            name: Some(map_name),
+            referenced_image_sources,
+            area_count: 0,
+            navigable_area_count: 0,
+            area_shapes: Vec::new(),
+            missing_alt_area_count: 0,
+            missing_href_area_count: 0,
+            missing_coords_area_count: 0,
+            default_shape_area_count: 0,
+            ping_area_count: 0,
+            attribution_area_count: 0,
+            map_blocked: true,
+            map_block_reasons: vec!["missing-map".to_string()],
+        });
+    }
+
+    descriptors
+}
+
+fn browser_image_map_descriptor(
+    map_index: usize,
+    map: &BrowserImageMap,
+    images: &[BrowserImage],
+) -> BrowserImageMapDescriptor {
+    let referenced_image_sources = map
+        .name
+        .as_deref()
+        .map(|name| browser_image_map_referenced_image_sources(name, images))
+        .unwrap_or_default();
+    let map_block_reasons =
+        browser_image_map_block_reasons(map, referenced_image_sources.is_empty());
+
+    BrowserImageMapDescriptor {
+        map_index,
+        id: map.id.clone(),
+        name: map.name.clone(),
+        referenced_image_sources,
+        area_count: map.areas.len(),
+        navigable_area_count: map.areas.iter().filter(|area| area.href.is_some()).count(),
+        area_shapes: browser_image_map_area_shapes(&map.areas),
+        missing_alt_area_count: map
+            .areas
+            .iter()
+            .filter(|area| area.alt.as_deref().map_or(true, str::is_empty))
+            .count(),
+        missing_href_area_count: map.areas.iter().filter(|area| area.href.is_none()).count(),
+        missing_coords_area_count: map
+            .areas
+            .iter()
+            .filter(|area| area.coords.is_none())
+            .count(),
+        default_shape_area_count: map.areas.iter().filter(|area| area.shape == "rect").count(),
+        ping_area_count: map
+            .areas
+            .iter()
+            .filter(|area| !area.ping.is_empty())
+            .count(),
+        attribution_area_count: map
+            .areas
+            .iter()
+            .filter(|area| !area.attributionsrc.is_empty())
+            .count(),
+        map_blocked: !map_block_reasons.is_empty(),
+        map_block_reasons,
+    }
+}
+
+fn browser_image_map_referenced_image_sources(name: &str, images: &[BrowserImage]) -> Vec<String> {
+    images
+        .iter()
+        .filter(|image| {
+            image
+                .usemap
+                .as_deref()
+                .and_then(browser_image_usemap_name)
+                .as_deref()
+                == Some(name)
+        })
+        .map(browser_image_reference_source)
+        .collect()
+}
+
+fn browser_image_reference_source(image: &BrowserImage) -> String {
+    image
+        .src
+        .clone()
+        .or_else(|| image.srcset.clone())
+        .unwrap_or_else(|| "<inline-image>".to_string())
+}
+
+fn browser_image_usemap_name(usemap: &str) -> Option<String> {
+    usemap
+        .strip_prefix('#')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn browser_image_map_area_shapes(areas: &[BrowserImageMapArea]) -> Vec<String> {
+    let mut shapes = Vec::new();
+    for area in areas {
+        if !shapes.contains(&area.shape) {
+            shapes.push(area.shape.clone());
+        }
+    }
+    shapes
+}
+
+fn browser_image_map_block_reasons(
+    map: &BrowserImageMap,
+    missing_image_reference: bool,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if map.name.as_deref().map_or(true, str::is_empty) {
+        reasons.push("missing-name".to_string());
+    }
+    if map.areas.is_empty() {
+        reasons.push("missing-areas".to_string());
+    }
+    if missing_image_reference {
+        reasons.push("unreferenced-map".to_string());
+    }
+    if map.areas.iter().any(|area| area.href.is_none()) {
+        reasons.push("areas-without-href".to_string());
+    }
+    if map
+        .areas
+        .iter()
+        .any(|area| area.alt.as_deref().map_or(true, str::is_empty))
+    {
+        reasons.push("areas-without-alt".to_string());
+    }
+    if map.areas.iter().any(|area| area.coords.is_none()) {
+        reasons.push("areas-without-coords".to_string());
+    }
+    reasons
 }
 
 fn browser_srcset_candidate_count(srcset: &str) -> usize {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -20,21 +20,22 @@ use coding_adventures_html_parser::{
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserFormValidationDescriptor, BrowserFullscreenInteractionDescriptor,
     BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea, BrowserImageSource,
-    BrowserInputPlanningDescriptor, BrowserInteractiveElement,
-    BrowserKeyboardInteractionDescriptor, BrowserLifecycleEventDescriptor, BrowserLink,
-    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
-    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
-    BrowserScriptModuleGraphDescriptor, BrowserScriptStorageAccessDescriptor,
-    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
-    BrowserSlotDescriptor, BrowserStructuredDataDescriptor, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
-    BrowserTable, BrowserTableCell, BrowserTableStructureDescriptor, BrowserTemplate,
-    BrowserTemplateDescriptor, BrowserTextSemantic, BrowserThemeColor,
+    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea,
+    BrowserImageMapDescriptor, BrowserImageSource, BrowserInputPlanningDescriptor,
+    BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
+    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
+    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
+    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
+    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
+    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
+    BrowserSelectionInteractionDescriptor, BrowserSlotDescriptor, BrowserStructuredDataDescriptor,
+    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
+    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTableStructureDescriptor, BrowserTemplate, BrowserTemplateDescriptor,
+    BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -158,6 +159,8 @@ struct ExpectedBrowserDocument {
     image_candidate_descriptors: Option<Vec<ExpectedImageCandidateDescriptor>>,
     #[serde(default)]
     image_maps: Vec<ExpectedImageMap>,
+    #[serde(default)]
+    image_map_descriptors: Option<Vec<ExpectedImageMapDescriptor>>,
     #[serde(default)]
     media: Vec<ExpectedMedia>,
     #[serde(default)]
@@ -2599,6 +2602,39 @@ struct ExpectedImageMapArea {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExpectedImageMapDescriptor {
+    map_index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    referenced_image_sources: Vec<String>,
+    #[serde(default)]
+    area_count: usize,
+    #[serde(default)]
+    navigable_area_count: usize,
+    #[serde(default)]
+    area_shapes: Vec<String>,
+    #[serde(default)]
+    missing_alt_area_count: usize,
+    #[serde(default)]
+    missing_href_area_count: usize,
+    #[serde(default)]
+    missing_coords_area_count: usize,
+    #[serde(default)]
+    default_shape_area_count: usize,
+    #[serde(default)]
+    ping_area_count: usize,
+    #[serde(default)]
+    attribution_area_count: usize,
+    #[serde(default)]
+    map_blocked: bool,
+    #[serde(default)]
+    map_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ExpectedMedia {
     kind: String,
     src: Option<String>,
@@ -4342,6 +4378,7 @@ fn browser_readiness_cases_extract_browser_document_facts() {
             case.expected.structured_data_descriptors.is_some();
         let tracks_table_structure_descriptors =
             case.expected.table_structure_descriptors.is_some();
+        let tracks_image_map_descriptors = case.expected.image_map_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
@@ -4370,6 +4407,9 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_table_structure_descriptors {
             expected.table_structure_descriptors = actual.table_structure_descriptors.clone();
+        }
+        if !tracks_image_map_descriptors {
+            expected.image_map_descriptors = actual.image_map_descriptors.clone();
         }
 
         assert_eq!(
@@ -4678,6 +4718,83 @@ fn browser_image_map_descriptor_metadata_tracks_area_navigation() {
     assert_eq!(
         actual.image_maps, expected.image_maps,
         "image maps should preserve area geometry, link policy, and resolved navigation metadata",
+    );
+}
+
+#[test]
+fn browser_image_map_descriptors_track_map_links_area_coverage_and_navigation() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "responsive-image-metadata-page")
+        .expect("responsive image fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("responsive image fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.image_map_descriptors,
+        case.expected.into_browser_document().image_map_descriptors,
+        "image map descriptors should preserve image usemap links, area geometry coverage, navigation counts, and blocker state",
+    );
+}
+
+#[test]
+fn browser_image_map_descriptors_track_unresolved_and_blocked_maps() {
+    let actual = parse_browser_document(
+        r##"<body>
+            <img src="hero.png" usemap="#missing" alt="Hero">
+            <map id="empty"></map>
+            <map name="empty-shapes">
+              <area alt="No href">
+              <area href="details.html" coords="0,0,20,20">
+            </map>
+        </body>"##,
+    )
+    .expect("blocked image map descriptor fixture should parse");
+
+    assert_eq!(actual.image_map_descriptors.len(), 3);
+
+    let missing = actual
+        .image_map_descriptors
+        .iter()
+        .find(|descriptor| descriptor.name.as_deref() == Some("missing"))
+        .expect("missing usemap descriptor should be present");
+    assert!(missing.map_blocked);
+    assert_eq!(missing.referenced_image_sources, vec!["hero.png"]);
+    assert_eq!(missing.map_block_reasons, vec!["missing-map"]);
+
+    let unnamed = actual
+        .image_map_descriptors
+        .iter()
+        .find(|descriptor| descriptor.id.as_deref() == Some("empty"))
+        .expect("empty map descriptor should be present");
+    assert!(unnamed.map_blocked);
+    assert_eq!(
+        unnamed.map_block_reasons,
+        vec!["missing-name", "missing-areas", "unreferenced-map"],
+    );
+
+    let blocked = actual
+        .image_map_descriptors
+        .iter()
+        .find(|descriptor| descriptor.name.as_deref() == Some("empty-shapes"))
+        .expect("blocked area map descriptor should be present");
+    assert_eq!(blocked.area_count, 2);
+    assert_eq!(blocked.navigable_area_count, 1);
+    assert_eq!(blocked.missing_alt_area_count, 1);
+    assert_eq!(blocked.missing_href_area_count, 1);
+    assert_eq!(blocked.missing_coords_area_count, 1);
+    assert_eq!(
+        blocked.map_block_reasons,
+        vec![
+            "unreferenced-map",
+            "areas-without-href",
+            "areas-without-alt",
+            "areas-without-coords",
+        ],
     );
 }
 
@@ -7786,6 +7903,12 @@ impl ExpectedBrowserDocument {
                 .image_maps
                 .into_iter()
                 .map(ExpectedImageMap::into_browser_image_map)
+                .collect(),
+            image_map_descriptors: self
+                .image_map_descriptors
+                .unwrap_or_default()
+                .into_iter()
+                .map(ExpectedImageMapDescriptor::into_browser_image_map_descriptor)
                 .collect(),
             media,
             media_playback_descriptors,
@@ -14853,6 +14976,28 @@ impl ExpectedImageMapArea {
             download: self.download,
             hreflang: self.hreflang,
             referrerpolicy: self.referrerpolicy,
+        }
+    }
+}
+
+impl ExpectedImageMapDescriptor {
+    fn into_browser_image_map_descriptor(self) -> BrowserImageMapDescriptor {
+        BrowserImageMapDescriptor {
+            map_index: self.map_index,
+            id: self.id,
+            name: self.name,
+            referenced_image_sources: self.referenced_image_sources,
+            area_count: self.area_count,
+            navigable_area_count: self.navigable_area_count,
+            area_shapes: self.area_shapes,
+            missing_alt_area_count: self.missing_alt_area_count,
+            missing_href_area_count: self.missing_href_area_count,
+            missing_coords_area_count: self.missing_coords_area_count,
+            default_shape_area_count: self.default_shape_area_count,
+            ping_area_count: self.ping_area_count,
+            attribution_area_count: self.attribution_area_count,
+            map_blocked: self.map_blocked,
+            map_block_reasons: self.map_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -300,6 +300,9 @@
             ]
           }
         ],
+        "image_map_descriptors": [
+          { "map_index": 1, "name": "hero-map", "referenced_image_sources": ["hero.jpg"], "area_count": 1, "navigable_area_count": 1, "area_shapes": ["rect"], "default_shape_area_count": 1, "ping_area_count": 1, "attribution_area_count": 1 }
+        ],
         "forms": [],
         "tables": []
       }


### PR DESCRIPTION
## Summary
- add BrowserImageMapDescriptor facts for map linkage, area geometry coverage, navigation counts, and link policy hints
- detect unresolved image usemap references and blocked maps with missing names, areas, hrefs, alt text, or coords
- extend browser-readiness fixture expectations and focused image-map descriptor tests

## Validation
- cargo test -p coding-adventures-html-parser browser_image_map_descriptors --manifest-path code/packages/rust/Cargo.toml
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml