### PR TITLE
feat(cas-limit-series): Taylor-series limit fallback port (Track J2)

### DIFF
--- a/code/packages/rust/cas-limit-series/CHANGELOG.md
+++ b/code/packages/rust/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — cas-limit-series (Rust)
 
+## [0.3.0] - 2026-05-29
+
+### Added
+
+- Track J2: `series_limit` module porting Python Track J1 (PR #5574). New
+  `try_series_limit` / `try_series_limit_default` resolve transcendental
+  `0/0` limits via a self-contained rational-coefficient series ring
+  with bounded order (4 → 6 → 8 → 10 → 12). Wired into `limit_advanced`
+  after the L'Hopital path and before the unevaluated `Limit(...)`
+  fallthrough. Closes the canonical acceptance set:
+  `limit((sin(x) - x)/x^3, x, 0) = -1/6`,
+  `limit((1 - cos(x))/x^2, x, 0) = 1/2`,
+  `limit((exp(x) - 1 - x)/x^2, x, 0) = 1/2`,
+  `limit((tan(x) - x)/x^3, x, 0) = 1/3`,
+  `limit((log(1 + x) - x)/x^2, x, 0) = -1/2`.
+- `limit_advanced(sin(x)/x, x, 0)` without a `diff_fn` now closes to `1`.
+
 ## [0.2.2] - 2026-06-06
 
 ### Added

--- a/code/packages/rust/cas-limit-series/Cargo.toml
+++ b/code/packages/rust/cas-limit-series/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-limit-series"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Limit (direct substitution) and polynomial Taylor series for symbolic IR"
 license = "MIT"

--- a/code/packages/rust/cas-limit-series/src/lib.rs
+++ b/code/packages/rust/cas-limit-series/src/lib.rs
@@ -56,10 +56,12 @@
 
 pub mod limit;
 pub mod limit_advanced;
+pub mod series_limit;
 pub mod taylor;
 
 pub use limit::limit_direct;
 pub use limit_advanced::{limit_advanced, LimitAdvancedOptions, LimitDirection};
+pub use series_limit::{try_series_limit, try_series_limit_default, MAX_ORDER_LIMIT};
 pub use taylor::{taylor_polynomial, PolynomialError};
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/cas-limit-series/src/limit_advanced.rs
+++ b/code/packages/rust/cas-limit-series/src/limit_advanced.rs
@@ -11,6 +11,7 @@ use symbolic_ir::{
     SQRT, SUB, TAN, TANH,
 };
 
+use crate::series_limit::try_series_limit_default;
 use crate::LIMIT;
 
 const EPS: f64 = 1e-300;
@@ -156,6 +157,13 @@ fn handle_form(
                 return result;
             }
         }
+    }
+
+    // Track J2: Taylor-series fallback. Fires after L'Hopital (or instead
+    // of it if no diff_fn was supplied) and the product/power rewrites.
+    // Handles transcendental 0/0 via bounded local series expansion.
+    if let Some(result) = try_series_limit_default(&expr, var, &point) {
+        return result;
     }
 
     build_unevaluated(expr, var, point, options.direction)

--- a/code/packages/rust/cas-limit-series/src/series_limit.rs
+++ b/code/packages/rust/cas-limit-series/src/series_limit.rs
@@ -1,0 +1,690 @@
+//! `try_series_limit` — Taylor-series-expansion fallback for limits.
+//!
+//! Track J2 Rust port of the Python Track J1 implementation
+//! (`code/packages/python/cas-limit-series/src/cas_limit_series/series_limit.py`).
+//!
+//! Fires inside [`crate::limit_advanced`] after L'Hopital (or instead
+//! of it if no `diff_fn` was supplied) and before the unevaluated
+//! `Limit(...)` fallthrough. Resolves transcendental `0/0` limits via
+//! a self-contained rational-coefficient series ring.
+//!
+//! ## Algorithm
+//!
+//! For `limit(f(var) / g(var), var, a)` where direct substitution
+//! gives `0/0`:
+//!
+//! 1. Translate the limit point to the origin:
+//!    - `a = 0`        → `u = var`
+//!    - finite `a ≠ 0` → `u = var − a`
+//!    - `a = ±∞`        → not implemented; returns `None`.
+//! 2. Taylor-expand both numerator and denominator to bounded order
+//!    `N` starting at `N = 4` using a transcendental-aware series
+//!    ring (`Add`, `Sub`, `Neg`, `Mul`, `Div` of non-vanishing
+//!    denominators, integer `Pow`, `Sin`, `Cos`, `Tan`, `Exp`, `Log`).
+//! 3. Read off leading coefficients and dispatch on `p` vs `q`.
+//! 4. Bump `N` by 2 and retry, up to `N = 12`.
+//!
+//! ## Bounds
+//!
+//! * `MAX_ORDER_LIMIT = 12` — keeps polynomial multiplication bounded
+//!   by O(N²) within a fixed, small constant.
+//! * The series ring uses exact `Frac { numer: i128, denom: i128 }`
+//!   rationals.
+//! * No recursion: a fixed loop runs at most five iterations.
+//! * Inputs are `IRNode` trees, not strings — no `eval` of user data.
+
+use symbolic_ir::{
+    apply, int, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, NEG, POW, SIN, SUB, TAN,
+};
+
+/// Hard ceiling on the Taylor-expansion order.
+pub const MAX_ORDER_LIMIT: usize = 12;
+
+// ---------------------------------------------------------------------------
+// Exact rational over i128
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Frac {
+    numer: i128,
+    denom: i128,
+}
+
+fn igcd(a: u128, b: u128) -> u128 {
+    let (mut a, mut b) = (a, b);
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    if a == 0 {
+        1
+    } else {
+        a
+    }
+}
+
+impl Frac {
+    fn new(n: i128, d: i128) -> Self {
+        assert!(d != 0, "Frac: denominator zero");
+        if n == 0 {
+            return Self { numer: 0, denom: 1 };
+        }
+        let (n, d) = if d < 0 { (-n, -d) } else { (n, d) };
+        let g = igcd(n.unsigned_abs(), d.unsigned_abs()) as i128;
+        Self {
+            numer: n / g,
+            denom: d / g,
+        }
+    }
+
+    fn zero() -> Self {
+        Self { numer: 0, denom: 1 }
+    }
+
+    fn one() -> Self {
+        Self { numer: 1, denom: 1 }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.numer == 0
+    }
+
+    fn is_positive(&self) -> bool {
+        self.numer > 0
+    }
+
+    fn neg(self) -> Self {
+        Self {
+            numer: -self.numer,
+            denom: self.denom,
+        }
+    }
+
+    fn add(self, rhs: Self) -> Self {
+        Self::new(
+            self.numer * rhs.denom + rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+    }
+
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(
+            self.numer * rhs.denom - rhs.numer * self.denom,
+            self.denom * rhs.denom,
+        )
+    }
+
+    fn mul(self, rhs: Self) -> Self {
+        Self::new(self.numer * rhs.numer, self.denom * rhs.denom)
+    }
+
+    fn div(self, rhs: Self) -> Self {
+        assert!(rhs.numer != 0, "Frac: division by zero");
+        Self::new(self.numer * rhs.denom, self.denom * rhs.numer)
+    }
+
+    fn to_ir(self) -> IRNode {
+        if self.denom == 1 {
+            // Saturating cast — coefficients within bounded order are tiny.
+            int(self.numer as i64)
+        } else {
+            IRNode::rational(self.numer as i64, self.denom as i64)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Series — truncated power series a_0 + a_1·u + ... + a_N·u^N
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Series {
+    coeffs: Vec<Frac>,
+    order: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SeriesError(#[allow(dead_code)] String);
+
+impl Series {
+    fn new(mut coeffs: Vec<Frac>, order: usize) -> Self {
+        // Normalise length to order + 1.
+        if coeffs.len() < order + 1 {
+            coeffs.resize(order + 1, Frac::zero());
+        } else if coeffs.len() > order + 1 {
+            coeffs.truncate(order + 1);
+        }
+        Self { coeffs, order }
+    }
+
+    fn constant(c: Frac, order: usize) -> Self {
+        Self::new(vec![c], order)
+    }
+
+    fn variable(order: usize) -> Self {
+        if order < 1 {
+            return Self::new(vec![Frac::zero()], order);
+        }
+        Self::new(vec![Frac::zero(), Frac::one()], order)
+    }
+
+    fn add(&self, other: &Self) -> Self {
+        let n = self.order;
+        let mut out = Vec::with_capacity(n + 1);
+        for i in 0..=n {
+            out.push(self.coeffs[i].add(other.coeffs[i]));
+        }
+        Self::new(out, n)
+    }
+
+    fn sub(&self, other: &Self) -> Self {
+        let n = self.order;
+        let mut out = Vec::with_capacity(n + 1);
+        for i in 0..=n {
+            out.push(self.coeffs[i].sub(other.coeffs[i]));
+        }
+        Self::new(out, n)
+    }
+
+    fn neg(&self) -> Self {
+        Self::new(self.coeffs.iter().map(|c| c.neg()).collect(), self.order)
+    }
+
+    fn mul(&self, other: &Self) -> Self {
+        let n = self.order;
+        let mut out = vec![Frac::zero(); n + 1];
+        for i in 0..=n {
+            let ai = self.coeffs[i];
+            if ai.is_zero() {
+                continue;
+            }
+            for j in 0..=(n - i) {
+                out[i + j] = out[i + j].add(ai.mul(other.coeffs[j]));
+            }
+        }
+        Self::new(out, n)
+    }
+
+    fn scaled(&self, c: Frac) -> Self {
+        Self::new(self.coeffs.iter().map(|a| c.mul(*a)).collect(), self.order)
+    }
+
+    fn leading_index(&self) -> Option<usize> {
+        self.coeffs.iter().position(|c| !c.is_zero())
+    }
+
+    /// `1 / self` provided `self(0) ≠ 0`. Newton-style recursion.
+    fn reciprocal(&self) -> Result<Self, SeriesError> {
+        let a = &self.coeffs;
+        let n = self.order;
+        if a[0].is_zero() {
+            return Err(SeriesError("reciprocal of series with zero constant".into()));
+        }
+        let mut b = vec![Frac::zero(); n + 1];
+        b[0] = Frac::one().div(a[0]);
+        for k in 1..=n {
+            let mut s = Frac::zero();
+            for j in 1..=k {
+                s = s.add(a[j].mul(b[k - j]));
+            }
+            b[k] = s.neg().div(a[0]);
+        }
+        Ok(Self::new(b, n))
+    }
+
+    /// `self ** k`, non-negative integer k, via repeated squaring.
+    fn integer_power(&self, mut k: u32) -> Self {
+        if k == 0 {
+            return Self::constant(Frac::one(), self.order);
+        }
+        let mut result = Self::constant(Frac::one(), self.order);
+        let mut base = self.clone();
+        while k > 0 {
+            if k & 1 == 1 {
+                result = result.mul(&base);
+            }
+            k >>= 1;
+            if k > 0 {
+                base = base.mul(&base);
+            }
+        }
+        result
+    }
+
+    /// `self(inner(u))` provided `inner(0) == 0`.
+    fn compose_with_zero_constant(&self, inner: &Self) -> Result<Self, SeriesError> {
+        if !inner.coeffs[0].is_zero() {
+            return Err(SeriesError(
+                "compose_with_zero_constant: inner has nonzero constant".into(),
+            ));
+        }
+        let n = self.order;
+        let mut result = Self::constant(Frac::zero(), n);
+        let mut inner_pow = Self::constant(Frac::one(), n);
+        for k in 0..=n {
+            if !self.coeffs[k].is_zero() {
+                result = result.add(&inner_pow.scaled(self.coeffs[k]));
+            }
+            if k < n {
+                inner_pow = inner_pow.mul(inner);
+            }
+        }
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Known transcendental Taylor series (around u = 0)
+// ---------------------------------------------------------------------------
+
+fn factorial(n: usize) -> i128 {
+    let mut out: i128 = 1;
+    for k in 2..=n {
+        out *= k as i128;
+    }
+    out
+}
+
+fn series_exp(order: usize) -> Series {
+    let coeffs: Vec<Frac> = (0..=order).map(|k| Frac::new(1, factorial(k))).collect();
+    Series::new(coeffs, order)
+}
+
+fn series_sin(order: usize) -> Series {
+    let mut coeffs = vec![Frac::zero(); order + 1];
+    let mut sign: i128 = 1;
+    let mut k = 1;
+    while k <= order {
+        coeffs[k] = Frac::new(sign, factorial(k));
+        sign = -sign;
+        k += 2;
+    }
+    Series::new(coeffs, order)
+}
+
+fn series_cos(order: usize) -> Series {
+    let mut coeffs = vec![Frac::zero(); order + 1];
+    let mut sign: i128 = 1;
+    let mut k = 0;
+    while k <= order {
+        coeffs[k] = Frac::new(sign, factorial(k));
+        sign = -sign;
+        k += 2;
+    }
+    Series::new(coeffs, order)
+}
+
+fn series_log_one_plus(order: usize) -> Series {
+    let mut coeffs = vec![Frac::zero(); order + 1];
+    let mut sign: i128 = 1;
+    for k in 1..=order {
+        coeffs[k] = Frac::new(sign, k as i128);
+        sign = -sign;
+    }
+    Series::new(coeffs, order)
+}
+
+fn series_tan(order: usize) -> Result<Series, SeriesError> {
+    // tan = sin / cos. cos has nonzero constant term, direct reciprocal.
+    Ok(series_sin(order).mul(&series_cos(order).reciprocal()?))
+}
+
+// ---------------------------------------------------------------------------
+// IR → Series translation
+// ---------------------------------------------------------------------------
+
+fn to_frac(node: &IRNode) -> Result<Frac, SeriesError> {
+    match node {
+        IRNode::Integer(v) => Ok(Frac::new(*v as i128, 1)),
+        IRNode::Rational(n, d) => Ok(Frac::new(*n as i128, *d as i128)),
+        IRNode::Float(v) => Ok(float_to_frac(*v)),
+        _ => Err(SeriesError(format!("expected literal, got {node:?}"))),
+    }
+}
+
+fn float_to_frac(value: f64) -> Frac {
+    if !value.is_finite() {
+        // Caller is responsible for guarding against non-finite floats.
+        return Frac::zero();
+    }
+    if value == 0.0 {
+        return Frac::zero();
+    }
+    let sign: i128 = if value < 0.0 { -1 } else { 1 };
+    let av = value.abs();
+    let mut best_n = av.round() as i128;
+    let mut best_d: i128 = 1;
+    let mut best_err = (av - best_n as f64).abs();
+    let max_d: i128 = 1_000_000;
+    let mut d: i128 = 1;
+    while d <= max_d {
+        let n = (av * d as f64).round() as i128;
+        let err = (av - (n as f64) / (d as f64)).abs();
+        if err < best_err {
+            best_err = err;
+            best_n = n;
+            best_d = d;
+        }
+        if best_err == 0.0 {
+            break;
+        }
+        d += 1;
+    }
+    Frac::new(sign * best_n, best_d)
+}
+
+fn head_name(node: &IRNode) -> Option<&str> {
+    if let IRNode::Symbol(name) = node {
+        Some(name.as_str())
+    } else {
+        None
+    }
+}
+
+fn expand(expr: &IRNode, variable: &IRNode, order: usize) -> Result<Series, SeriesError> {
+    // --- literal numbers ---
+    if matches!(expr, IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_)) {
+        return Ok(Series::constant(to_frac(expr)?, order));
+    }
+
+    // --- the expansion variable ---
+    if let IRNode::Symbol(name) = expr {
+        if expr == variable {
+            return Ok(Series::variable(order));
+        }
+        return Err(SeriesError(format!("unsupported symbol {name:?}")));
+    }
+
+    let IRNode::Apply(ap) = expr else {
+        return Err(SeriesError(format!("unsupported expression: {expr:?}")));
+    };
+    let Some(h) = head_name(&ap.head) else {
+        return Err(SeriesError(format!("non-symbol head: {:?}", ap.head)));
+    };
+    let args = &ap.args;
+
+    // --- arithmetic ---
+    if h == ADD {
+        let mut result = Series::constant(Frac::zero(), order);
+        for a in args {
+            result = result.add(&expand(a, variable, order)?);
+        }
+        return Ok(result);
+    }
+    if h == SUB {
+        if args.len() != 2 {
+            return Err(SeriesError("Sub expects 2 args".into()));
+        }
+        return Ok(expand(&args[0], variable, order)?.sub(&expand(&args[1], variable, order)?));
+    }
+    if h == NEG {
+        if args.len() != 1 {
+            return Err(SeriesError("Neg expects 1 arg".into()));
+        }
+        return Ok(expand(&args[0], variable, order)?.neg());
+    }
+    if h == MUL {
+        let mut result = Series::constant(Frac::one(), order);
+        for a in args {
+            result = result.mul(&expand(a, variable, order)?);
+        }
+        return Ok(result);
+    }
+    if h == DIV {
+        if args.len() != 2 {
+            return Err(SeriesError("Div expects 2 args".into()));
+        }
+        let ns = expand(&args[0], variable, order)?;
+        let ds = expand(&args[1], variable, order)?;
+        if !ds.coeffs[0].is_zero() {
+            return Ok(ns.mul(&ds.reciprocal()?));
+        }
+        return Err(SeriesError("inner Div by series vanishing at 0".into()));
+    }
+    if h == POW {
+        if args.len() != 2 {
+            return Err(SeriesError("Pow expects 2 args".into()));
+        }
+        let base = &args[0];
+        let exp_node = &args[1];
+        if let IRNode::Integer(k) = exp_node {
+            let k = *k;
+            if k >= 0 {
+                let k_u: u32 = k
+                    .try_into()
+                    .map_err(|_| SeriesError("Pow exponent too large".into()))?;
+                return Ok(expand(base, variable, order)?.integer_power(k_u));
+            }
+            let base_ser = expand(base, variable, order)?;
+            if base_ser.coeffs[0].is_zero() {
+                return Err(SeriesError("Pow neg-int over vanishing base".into()));
+            }
+            let k_u: u32 = (-k)
+                .try_into()
+                .map_err(|_| SeriesError("Pow exponent too large".into()))?;
+            return Ok(base_ser.reciprocal()?.integer_power(k_u));
+        }
+        return Err(SeriesError(
+            "Pow exponent must be a non-negative integer literal".into(),
+        ));
+    }
+
+    // --- transcendentals ---
+    if h == EXP {
+        if args.len() != 1 {
+            return Err(SeriesError("Exp expects 1 arg".into()));
+        }
+        let inner = expand(&args[0], variable, order)?;
+        if !inner.coeffs[0].is_zero() {
+            return Err(SeriesError("Exp with nonzero constant inner term".into()));
+        }
+        return series_exp(order).compose_with_zero_constant(&inner);
+    }
+    if h == SIN {
+        if args.len() != 1 {
+            return Err(SeriesError("Sin expects 1 arg".into()));
+        }
+        let inner = expand(&args[0], variable, order)?;
+        if !inner.coeffs[0].is_zero() {
+            return Err(SeriesError("Sin with nonzero constant inner term".into()));
+        }
+        return series_sin(order).compose_with_zero_constant(&inner);
+    }
+    if h == COS {
+        if args.len() != 1 {
+            return Err(SeriesError("Cos expects 1 arg".into()));
+        }
+        let inner = expand(&args[0], variable, order)?;
+        if !inner.coeffs[0].is_zero() {
+            return Err(SeriesError("Cos with nonzero constant inner term".into()));
+        }
+        return series_cos(order).compose_with_zero_constant(&inner);
+    }
+    if h == TAN {
+        if args.len() != 1 {
+            return Err(SeriesError("Tan expects 1 arg".into()));
+        }
+        let inner = expand(&args[0], variable, order)?;
+        if !inner.coeffs[0].is_zero() {
+            return Err(SeriesError("Tan with nonzero constant inner term".into()));
+        }
+        return series_tan(order)?.compose_with_zero_constant(&inner);
+    }
+    if h == LOG {
+        if args.len() != 1 {
+            return Err(SeriesError("Log expects 1 arg".into()));
+        }
+        let inner = expand(&args[0], variable, order)?;
+        let c0 = inner.coeffs[0];
+        if c0 != Frac::one() {
+            return Err(SeriesError(format!(
+                "Log with constant inner term != 1 (got {c0:?})"
+            )));
+        }
+        // log(1 + (inner - 1)) where (inner - 1)(0) = 0.
+        let mut shifted_coeffs = inner.coeffs.clone();
+        shifted_coeffs[0] = Frac::zero();
+        let shifted = Series::new(shifted_coeffs, order);
+        return series_log_one_plus(order).compose_with_zero_constant(&shifted);
+    }
+
+    Err(SeriesError(format!("unsupported head: {h}")))
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point
+// ---------------------------------------------------------------------------
+
+/// Recognise `Div(N, D)` and `Mul(N, Pow(D, -1))` as quotients.
+fn split_quotient(expr: &IRNode) -> Option<(IRNode, IRNode)> {
+    let IRNode::Apply(ap) = expr else {
+        return None;
+    };
+    if head_name(&ap.head) == Some(DIV) && ap.args.len() == 2 {
+        return Some((ap.args[0].clone(), ap.args[1].clone()));
+    }
+    if head_name(&ap.head) == Some(MUL) && ap.args.len() == 2 {
+        let a = &ap.args[0];
+        let b = &ap.args[1];
+        if let Some(base) = pow_neg_one_base(b) {
+            return Some((a.clone(), base));
+        }
+        if let Some(base) = pow_neg_one_base(a) {
+            return Some((b.clone(), base));
+        }
+    }
+    None
+}
+
+fn pow_neg_one_base(node: &IRNode) -> Option<IRNode> {
+    let IRNode::Apply(ap) = node else { return None };
+    if head_name(&ap.head) != Some(POW) || ap.args.len() != 2 {
+        return None;
+    }
+    if let IRNode::Integer(-1) = ap.args[1] {
+        return Some(ap.args[0].clone());
+    }
+    None
+}
+
+/// Substitute `variable := variable + point` so the original
+/// `variable = point` corresponds to `variable = 0` after the shift.
+fn shift_to_origin(expr: &IRNode, variable: &IRNode, point: &IRNode) -> IRNode {
+    if let IRNode::Integer(0) = point {
+        return expr.clone();
+    }
+    fn go(node: &IRNode, variable: &IRNode, point: &IRNode) -> IRNode {
+        if let IRNode::Symbol(_) = node {
+            if node == variable {
+                return apply(sym(ADD), vec![variable.clone(), point.clone()]);
+            }
+            return node.clone();
+        }
+        if let IRNode::Apply(ap) = node {
+            return apply(
+                ap.head.clone(),
+                ap.args.iter().map(|a| go(a, variable, point)).collect(),
+            );
+        }
+        node.clone()
+    }
+    go(expr, variable, point)
+}
+
+/// Taylor-series fallback for `limit(expr, variable, point)`.
+///
+/// Returns:
+///   - an integer or rational literal on success,
+///   - `Symbol("inf")` / `Symbol("minf")` on a divergent ratio,
+///   - `None` if the fallback cannot determine the value (caller
+///     should fall through to an unevaluated `Limit(...)`).
+///
+/// `point` must be a literal number. Limits at `±∞` are not yet
+/// handled (they would need a `u = 1/x` rewrite) and return `None`.
+///
+/// `max_order` is clamped to `[4, 12]`.
+pub fn try_series_limit(
+    expr: &IRNode,
+    variable: &IRNode,
+    point: &IRNode,
+    max_order: usize,
+) -> Option<IRNode> {
+    let cap = max_order.clamp(4, MAX_ORDER_LIMIT);
+
+    let (numer, denom) = split_quotient(expr)?;
+
+    // Limit at ±∞ is not yet implemented in this fallback.
+    if let IRNode::Symbol(name) = point {
+        if name == "inf" || name == "minf" {
+            return None;
+        }
+    }
+    if !matches!(
+        point,
+        IRNode::Integer(_) | IRNode::Rational(_, _) | IRNode::Float(_)
+    ) {
+        return None;
+    }
+
+    let shifted_n = shift_to_origin(&numer, variable, point);
+    let shifted_d = shift_to_origin(&denom, variable, point);
+
+    let mut order = 4;
+    while order <= cap {
+        let n_ser = match expand(&shifted_n, variable, order) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+        let d_ser = match expand(&shifted_d, variable, order) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+
+        let p = n_ser.leading_index();
+        let q = d_ser.leading_index();
+
+        match (p, q) {
+            (None, None) => {
+                order += 2;
+                continue;
+            }
+            (None, Some(_)) => return Some(int(0)),
+            (Some(p), None) => {
+                let cp = n_ser.coeffs[p];
+                return Some(if cp.is_positive() {
+                    sym("inf")
+                } else {
+                    sym("minf")
+                });
+            }
+            (Some(p), Some(q)) => {
+                let cp = n_ser.coeffs[p];
+                let dq = d_ser.coeffs[q];
+                if p > q {
+                    return Some(int(0));
+                }
+                if p < q {
+                    let signv = cp.div(dq);
+                    return Some(if signv.is_positive() {
+                        sym("inf")
+                    } else {
+                        sym("minf")
+                    });
+                }
+                return Some(cp.div(dq).to_ir());
+            }
+        }
+    }
+
+    None
+}
+
+/// Convenience entry point using the default `MAX_ORDER_LIMIT`.
+pub fn try_series_limit_default(
+    expr: &IRNode,
+    variable: &IRNode,
+    point: &IRNode,
+) -> Option<IRNode> {
+    try_series_limit(expr, variable, point, MAX_ORDER_LIMIT)
+}

--- a/code/packages/rust/cas-limit-series/tests/tests.rs
+++ b/code/packages/rust/cas-limit-series/tests/tests.rs
@@ -4,10 +4,10 @@
 // code/packages/python/cas-limit-series/tests/.
 
 use cas_limit_series::{
-    limit_advanced, limit_direct, taylor_polynomial, LimitAdvancedOptions, LimitDirection,
-    PolynomialError, LIMIT,
+    limit_advanced, limit_direct, taylor_polynomial, try_series_limit_default,
+    LimitAdvancedOptions, LimitDirection, PolynomialError, LIMIT,
 };
-use symbolic_ir::{apply, int, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, POW, SIN, SUB};
+use symbolic_ir::{apply, int, sym, IRNode, ADD, COS, DIV, EXP, LOG, MUL, NEG, POW, SIN, SUB, TAN};
 
 // ---------------------------------------------------------------------------
 // limit_direct
@@ -218,11 +218,14 @@ fn limit_advanced_direct_finite_result() {
 }
 
 #[test]
-fn limit_advanced_indeterminate_without_callbacks_is_unevaluated() {
+fn limit_advanced_indeterminate_without_callbacks_closes_via_taylor() {
+    // Track J2: the Taylor-series fallback now closes simple 0/0 forms
+    // without an injected `diff_fn`. `x/x` at x = 0 expands to leading
+    // u^1 / u^1 with ratio 1/1 = 1.
     let x = sym("x");
     let expr = apply(sym(DIV), vec![x.clone(), x.clone()]);
     let out = limit_advanced(expr.clone(), &x, int(0), LimitAdvancedOptions::default());
-    assert_eq!(out, apply(sym(LIMIT), vec![expr, x, int(0)]));
+    assert_eq!(out, int(1));
 }
 
 #[test]
@@ -495,4 +498,211 @@ fn taylor_order_zero_gives_constant_term() {
     );
     let out = taylor_polynomial(&expr, &x, &int(0), 0).unwrap();
     assert_eq!(out, int(1));
+}
+
+// ---------------------------------------------------------------------------
+// Track J2: Taylor-series limit fallback (`try_series_limit`)
+// ---------------------------------------------------------------------------
+
+fn xs() -> IRNode {
+    sym("x")
+}
+
+#[test]
+fn series_limit_sin_minus_x_over_x_cubed() {
+    // (sin(x) - x)/x^3 → -1/6
+    let x = xs();
+    let numer = apply(sym(SUB), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(3)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(IRNode::rational(-1, 6)));
+}
+
+#[test]
+fn series_limit_one_minus_cos_over_x_squared() {
+    let x = xs();
+    let numer = apply(sym(SUB), vec![int(1), apply(sym(COS), vec![x.clone()])]);
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(2)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(IRNode::rational(1, 2)));
+}
+
+#[test]
+fn series_limit_exp_minus_1_minus_x_over_x_squared() {
+    let x = xs();
+    let numer = apply(
+        sym(SUB),
+        vec![
+            apply(sym(SUB), vec![apply(sym(EXP), vec![x.clone()]), int(1)]),
+            x.clone(),
+        ],
+    );
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(2)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(IRNode::rational(1, 2)));
+}
+
+#[test]
+fn series_limit_tan_minus_x_over_x_cubed() {
+    let x = xs();
+    let numer = apply(sym(SUB), vec![apply(sym(TAN), vec![x.clone()]), x.clone()]);
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(3)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(IRNode::rational(1, 3)));
+}
+
+#[test]
+fn series_limit_log_one_plus_x_minus_x_over_x_squared() {
+    let x = xs();
+    let one_plus_x = apply(sym(ADD), vec![int(1), x.clone()]);
+    let numer = apply(sym(SUB), vec![apply(sym(LOG), vec![one_plus_x]), x.clone()]);
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(2)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(IRNode::rational(-1, 2)));
+}
+
+#[test]
+fn series_limit_sin_minus_x_over_exp_x_squared_minus_one() {
+    // (sin(x) - x) / (exp(x^2) - 1) → 0  (leading u^3 / u^2, p > q ⇒ 0)
+    let x = xs();
+    let numer = apply(sym(SUB), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    let denom = apply(
+        sym(SUB),
+        vec![
+            apply(sym(EXP), vec![apply(sym(POW), vec![x.clone(), int(2)])]),
+            int(1),
+        ],
+    );
+    let expr = apply(sym(DIV), vec![numer, denom]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(int(0)));
+}
+
+#[test]
+fn series_limit_sin_over_x_regression() {
+    let x = xs();
+    let expr = apply(sym(DIV), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(int(1)));
+}
+
+#[test]
+fn series_limit_x_squared_over_x_regression() {
+    let x = xs();
+    let expr = apply(
+        sym(DIV),
+        vec![apply(sym(POW), vec![x.clone(), int(2)]), x.clone()],
+    );
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(int(0)));
+}
+
+#[test]
+fn series_limit_bare_polynomial_returns_none() {
+    let x = xs();
+    let result = try_series_limit_default(&apply(sym(POW), vec![x.clone(), int(2)]), &x, &int(0));
+    assert!(result.is_none());
+}
+
+#[test]
+fn series_limit_unsupported_head_returns_none() {
+    let x = xs();
+    let weird = apply(sym("Asin"), vec![x.clone()]);
+    let expr = apply(sym(DIV), vec![weird, x.clone()]);
+    assert!(try_series_limit_default(&expr, &x, &int(0)).is_none());
+}
+
+#[test]
+fn series_limit_infinity_point_returns_none() {
+    let x = xs();
+    let expr = apply(sym(DIV), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    assert!(try_series_limit_default(&expr, &x, &sym("inf")).is_none());
+    assert!(try_series_limit_default(&expr, &x, &sym("minf")).is_none());
+}
+
+#[test]
+fn series_limit_limit_advanced_sin_x_unevaluated_at_infinity() {
+    // limit(sin(x), x, inf) — not a quotient that Taylor can handle.
+    // limitAdvanced still falls through to an unevaluated Limit(...).
+    let x = xs();
+    let expr = apply(sym(SIN), vec![x.clone()]);
+    let out = limit_advanced(expr.clone(), &x, sym("inf"), LimitAdvancedOptions::default());
+    // Either it returns an unevaluated Limit or some sentinel; the
+    // critical property is that the dispatcher does not crash and the
+    // Taylor fallback gracefully returns None for non-quotients.
+    if let IRNode::Apply(a) = &out {
+        assert_eq!(a.head, sym(LIMIT));
+    } else {
+        panic!("expected unevaluated Limit, got {out:?}");
+    }
+}
+
+#[test]
+fn series_limit_divergent_one_over_x_squared() {
+    let x = xs();
+    let expr = apply(sym(DIV), vec![int(1), apply(sym(POW), vec![x.clone(), int(2)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(sym("inf")));
+}
+
+#[test]
+fn series_limit_divergent_neg_one_over_x_squared() {
+    let x = xs();
+    let expr = apply(sym(DIV), vec![int(-1), apply(sym(POW), vec![x.clone(), int(2)])]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(sym("minf")));
+}
+
+#[test]
+fn series_limit_polynomial_at_one() {
+    // (x^2 - 1)/(x - 1) at x = 1 → 2.
+    let x = xs();
+    let numer = apply(sym(SUB), vec![apply(sym(POW), vec![x.clone(), int(2)]), int(1)]);
+    let denom = apply(sym(SUB), vec![x.clone(), int(1)]);
+    let expr = apply(sym(DIV), vec![numer, denom]);
+    let result = try_series_limit_default(&expr, &x, &int(1));
+    assert_eq!(result, Some(int(2)));
+}
+
+#[test]
+fn series_limit_neg_head_expansion() {
+    // -sin(x)/x → -1
+    let x = xs();
+    let numer = apply(sym(NEG), vec![apply(sym(SIN), vec![x.clone()])]);
+    let expr = apply(sym(DIV), vec![numer, x.clone()]);
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(int(-1)));
+}
+
+#[test]
+fn series_limit_mul_pow_neg_one_recognised_as_quotient() {
+    // sin(x) * x^(-1) → 1
+    let x = xs();
+    let expr = apply(
+        sym(MUL),
+        vec![
+            apply(sym(SIN), vec![x.clone()]),
+            apply(sym(POW), vec![x.clone(), int(-1)]),
+        ],
+    );
+    let result = try_series_limit_default(&expr, &x, &int(0));
+    assert_eq!(result, Some(int(1)));
+}
+
+#[test]
+fn series_limit_dispatcher_no_diff_fn_closes_sin_over_x() {
+    // limit_advanced(sin(x)/x, x, 0) without diff_fn now closes via Taylor.
+    let x = xs();
+    let expr = apply(sym(DIV), vec![apply(sym(SIN), vec![x.clone()]), x.clone()]);
+    let out = limit_advanced(expr, &x, int(0), LimitAdvancedOptions::default());
+    assert_eq!(out, int(1));
+}
+
+#[test]
+fn series_limit_dispatcher_no_diff_fn_closes_one_minus_cos_over_x_sq() {
+    let x = xs();
+    let numer = apply(sym(SUB), vec![int(1), apply(sym(COS), vec![x.clone()])]);
+    let expr = apply(sym(DIV), vec![numer, apply(sym(POW), vec![x.clone(), int(2)])]);
+    let out = limit_advanced(expr, &x, int(0), LimitAdvancedOptions::default());
+    assert_eq!(out, IRNode::rational(1, 2));
 }

--- a/code/packages/typescript/cas-limit-series/CHANGELOG.md
+++ b/code/packages/typescript/cas-limit-series/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.3.0 - 2026-05-29
+
+### Added
+
+- Track J2: Taylor-series-expansion limit fallback (`trySeriesLimit`)
+  porting Python Track J1 (PR #5574). Fires inside `limitAdvanced` after
+  L'Hopital (or instead of it if no `differentiate` callback is supplied)
+  and resolves transcendental `0/0` limits via a self-contained
+  rational-coefficient series ring with bounded order (4 → 6 → 8 → 10 →
+  12). Closes the canonical acceptance set:
+  `limit((sin(x) - x)/x^3, x, 0) = -1/6`,
+  `limit((1 - cos(x))/x^2, x, 0) = 1/2`,
+  `limit((exp(x) - 1 - x)/x^2, x, 0) = 1/2`,
+  `limit((tan(x) - x)/x^3, x, 0) = 1/3`,
+  `limit((log(1 + x) - x)/x^2, x, 0) = -1/2`.
+- `limitAdvanced(sin(x)/x, x, 0)` now closes to `1` without an injected
+  `differentiate` callback (was previously an unevaluated `Limit(...)`).
+
 ## 0.2.2 - 2026-06-06
 
 - Add bounded-over-diverging limit recognition at infinity, closing

--- a/code/packages/typescript/cas-limit-series/package.json
+++ b/code/packages/typescript/cas-limit-series/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-limit-series",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Pure TypeScript direct limits and polynomial Taylor expansion over symbolic IR",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-limit-series/src/index.ts
+++ b/code/packages/typescript/cas-limit-series/src/index.ts
@@ -25,6 +25,9 @@ import {
   sym,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
+import { trySeriesLimit } from "./seriesLimit";
+
+export { trySeriesLimit } from "./seriesLimit";
 
 export const LIMIT = "Limit";
 export const TAYLOR = "Taylor";
@@ -242,6 +245,14 @@ function handleIndeterminateForm(
     const rewritten = rewriteIndeterminatePower(expr.args[0], expr.args[1], variable, point, exactPoint, options, depth);
     if (rewritten !== null) return rewritten;
   }
+
+  // Track J2: Taylor-series fallback. Fires after L'Hopital (or instead
+  // of it if no diff_fn was supplied) and after the product/power
+  // rewrites. Handles transcendental 0/0 forms via local series
+  // expansion. Returns null on anything outside its rational-ring
+  // domain; we then fall through to the unevaluated `Limit(...)` node.
+  const series = trySeriesLimit(expr, variable, point);
+  if (series !== null) return series;
 
   return buildUnevaluatedLimit(expr, variable, point, options.direction);
 }

--- a/code/packages/typescript/cas-limit-series/src/seriesLimit.ts
+++ b/code/packages/typescript/cas-limit-series/src/seriesLimit.ts
@@ -1,0 +1,629 @@
+/**
+ * `trySeriesLimit` — Taylor-series-expansion fallback for limits.
+ *
+ * This module is the **Track J2** TypeScript port of the Python Track J1
+ * fallback (`series_limit.py`). It mirrors that file 1:1 so the two
+ * implementations stay in lockstep.
+ *
+ * Why a separate fallback?
+ * ------------------------
+ * L'Hopital can fail for several reasons: differentiation blows up the
+ * expression size, the recursion is bounded, and the simplifier may
+ * not collapse intermediate forms back to a recognisable `0/0`.
+ * A series expansion sidesteps all of that — polynomial arithmetic
+ * stays small and exact, and reading the leading order is a constant-
+ * time table lookup once the expansion exists.
+ *
+ * Algorithm
+ * ---------
+ * For `limit(f(x) / g(x), x, a)` where direct sub gives `0/0`:
+ *
+ *   1. Translate the limit point to the origin.
+ *        a = 0          ⇒ u = x
+ *        a finite ≠ 0   ⇒ u = x − a
+ *        a = ±∞         ⇒ u = 1/x (not implemented here — falls through)
+ *   2. Taylor-expand both numerator and denominator to bounded order N,
+ *      starting at N = 4, using a transcendental-aware series ring.
+ *   3. Read off leading coefficients
+ *        N(u) = c_p · u^p + O(u^{p+1})
+ *        D(u) = d_q · u^q + O(u^{q+1})
+ *      and dispatch on p vs q.
+ *   4. If both leading orders are still zero, bump N += 2 (max 12) and
+ *      retry.
+ *
+ * Bounds
+ * ------
+ *   - `maxOrder` defaults to 12 and is hard-capped at 12.
+ *   - The series ring uses exact `bigint` rationals.
+ *   - No recursion: a fixed loop runs at most five iterations
+ *     (orders 4, 6, 8, 10, 12).
+ *   - Inputs are IRNode trees, never strings — no `eval` of user data.
+ */
+
+import {
+  ADD,
+  COS,
+  DIV,
+  EXP,
+  LOG,
+  MUL,
+  NEG,
+  POW,
+  SIN,
+  SUB,
+  TAN,
+  app,
+  equals,
+  headName,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+
+// ---------------------------------------------------------------------------
+// Hard cap and error type
+// ---------------------------------------------------------------------------
+
+const MAX_ORDER_LIMIT = 12;
+
+class SeriesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SeriesError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RatQ — exact rational over BigInt
+// ---------------------------------------------------------------------------
+//
+// A self-contained `Fraction`-like type matching Python's
+// `fractions.Fraction`. Keeps every coefficient exact; no float drift.
+
+function bgcd(a: bigint, b: bigint): bigint {
+  if (a < 0n) a = -a;
+  if (b < 0n) b = -b;
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a === 0n ? 1n : a;
+}
+
+class RatQ {
+  readonly n: bigint;
+  readonly d: bigint;
+
+  constructor(n: bigint, d: bigint = 1n) {
+    if (d === 0n) throw new RangeError("RatQ denominator is zero");
+    if (d < 0n) {
+      n = -n;
+      d = -d;
+    }
+    if (n === 0n) {
+      this.n = 0n;
+      this.d = 1n;
+      return;
+    }
+    const g = bgcd(n < 0n ? -n : n, d);
+    this.n = n / g;
+    this.d = d / g;
+  }
+
+  static zero(): RatQ {
+    return new RatQ(0n, 1n);
+  }
+
+  static one(): RatQ {
+    return new RatQ(1n, 1n);
+  }
+
+  isZero(): boolean {
+    return this.n === 0n;
+  }
+
+  isPositive(): boolean {
+    return this.n > 0n;
+  }
+
+  eq(rhs: RatQ): boolean {
+    return this.n === rhs.n && this.d === rhs.d;
+  }
+
+  neg(): RatQ {
+    return new RatQ(-this.n, this.d);
+  }
+
+  add(rhs: RatQ): RatQ {
+    return new RatQ(this.n * rhs.d + rhs.n * this.d, this.d * rhs.d);
+  }
+
+  sub(rhs: RatQ): RatQ {
+    return new RatQ(this.n * rhs.d - rhs.n * this.d, this.d * rhs.d);
+  }
+
+  mul(rhs: RatQ): RatQ {
+    return new RatQ(this.n * rhs.n, this.d * rhs.d);
+  }
+
+  div(rhs: RatQ): RatQ {
+    if (rhs.n === 0n) throw new RangeError("RatQ: division by zero");
+    return new RatQ(this.n * rhs.d, this.d * rhs.n);
+  }
+
+  toIrNode(): IRNode {
+    return this.d === 1n ? int(this.n) : rational(this.n, this.d);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Series — truncated power series a_0 + a_1·u + ... + a_N·u^N
+// ---------------------------------------------------------------------------
+//
+// `coeffs` is always exactly `order + 1` long. Higher-order terms are
+// silently dropped — that is what truncation means.
+
+class Series {
+  readonly coeffs: RatQ[];
+  readonly order: number;
+
+  constructor(coeffs: RatQ[], order: number) {
+    if (order < 0) throw new SeriesError("series order must be non-negative");
+    let c = coeffs;
+    if (c.length < order + 1) {
+      c = c.slice();
+      while (c.length < order + 1) c.push(RatQ.zero());
+    } else if (c.length > order + 1) {
+      c = c.slice(0, order + 1);
+    }
+    this.coeffs = c;
+    this.order = order;
+  }
+
+  static constant(c: RatQ, order: number): Series {
+    return new Series([c], order);
+  }
+
+  static variable(order: number): Series {
+    if (order < 1) return new Series([RatQ.zero()], order);
+    return new Series([RatQ.zero(), RatQ.one()], order);
+  }
+
+  add(other: Series): Series {
+    const n = this.order;
+    const out: RatQ[] = [];
+    for (let i = 0; i <= n; i += 1) out.push(this.coeffs[i].add(other.coeffs[i]));
+    return new Series(out, n);
+  }
+
+  sub(other: Series): Series {
+    const n = this.order;
+    const out: RatQ[] = [];
+    for (let i = 0; i <= n; i += 1) out.push(this.coeffs[i].sub(other.coeffs[i]));
+    return new Series(out, n);
+  }
+
+  neg(): Series {
+    return new Series(this.coeffs.map((c) => c.neg()), this.order);
+  }
+
+  mul(other: Series): Series {
+    const n = this.order;
+    const out: RatQ[] = Array.from({ length: n + 1 }, () => RatQ.zero());
+    for (let i = 0; i <= n; i += 1) {
+      const ai = this.coeffs[i];
+      if (ai.isZero()) continue;
+      for (let j = 0; j <= n - i; j += 1) {
+        out[i + j] = out[i + j].add(ai.mul(other.coeffs[j]));
+      }
+    }
+    return new Series(out, n);
+  }
+
+  scaled(c: RatQ): Series {
+    return new Series(this.coeffs.map((a) => c.mul(a)), this.order);
+  }
+
+  leadingIndex(): number {
+    for (let k = 0; k < this.coeffs.length; k += 1) {
+      if (!this.coeffs[k].isZero()) return k;
+    }
+    return -1;
+  }
+
+  /**
+   * `1 / self` provided `self(0) ≠ 0`. Newton-style recursion:
+   *   b_0 = 1/a_0
+   *   b_k = -1/a_0 · sum_{j=1..k} a_j · b_{k-j}
+   */
+  reciprocal(): Series {
+    const a = this.coeffs;
+    const n = this.order;
+    if (a[0].isZero()) throw new SeriesError("reciprocal of series with zero constant term");
+    const b: RatQ[] = Array.from({ length: n + 1 }, () => RatQ.zero());
+    b[0] = RatQ.one().div(a[0]);
+    for (let k = 1; k <= n; k += 1) {
+      let s = RatQ.zero();
+      for (let j = 1; j <= k; j += 1) s = s.add(a[j].mul(b[k - j]));
+      b[k] = s.neg().div(a[0]);
+    }
+    return new Series(b, n);
+  }
+
+  /** `self ** k`, non-negative integer k, via repeated squaring. */
+  integerPower(k: number): Series {
+    if (k < 0) throw new SeriesError("series integerPower requires k >= 0");
+    if (k === 0) return Series.constant(RatQ.one(), this.order);
+    let result = Series.constant(RatQ.one(), this.order);
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let base: Series = this;
+    let e = k;
+    while (e > 0) {
+      if ((e & 1) === 1) result = result.mul(base);
+      e >>= 1;
+      if (e > 0) base = base.mul(base);
+    }
+    return result;
+  }
+
+  /**
+   * `self(inner(u))` provided `inner(0) == 0`. Sum of `a_k · inner^k`
+   * truncated at `order`.
+   */
+  composeWithZeroConstant(inner: Series): Series {
+    if (!inner.coeffs[0].isZero()) {
+      throw new SeriesError("composeWithZeroConstant: inner series has nonzero constant");
+    }
+    const n = this.order;
+    let result = Series.constant(RatQ.zero(), n);
+    let innerPow = Series.constant(RatQ.one(), n);  // inner^0 = 1
+    for (let k = 0; k <= n; k += 1) {
+      if (!this.coeffs[k].isZero()) {
+        result = result.add(innerPow.scaled(this.coeffs[k]));
+      }
+      if (k < n) innerPow = innerPow.mul(inner);
+    }
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Known transcendental Taylor series (around u = 0)
+// ---------------------------------------------------------------------------
+
+function factorial(n: number): bigint {
+  let out = 1n;
+  for (let k = 2; k <= n; k += 1) out *= BigInt(k);
+  return out;
+}
+
+function seriesExp(order: number): Series {
+  const coeffs: RatQ[] = [];
+  for (let k = 0; k <= order; k += 1) coeffs.push(new RatQ(1n, factorial(k)));
+  return new Series(coeffs, order);
+}
+
+function seriesSin(order: number): Series {
+  const coeffs: RatQ[] = Array.from({ length: order + 1 }, () => RatQ.zero());
+  let sign = 1n;
+  for (let k = 1; k <= order; k += 2) {
+    coeffs[k] = new RatQ(sign, factorial(k));
+    sign = -sign;
+  }
+  return new Series(coeffs, order);
+}
+
+function seriesCos(order: number): Series {
+  const coeffs: RatQ[] = Array.from({ length: order + 1 }, () => RatQ.zero());
+  let sign = 1n;
+  for (let k = 0; k <= order; k += 2) {
+    coeffs[k] = new RatQ(sign, factorial(k));
+    sign = -sign;
+  }
+  return new Series(coeffs, order);
+}
+
+function seriesLogOnePlus(order: number): Series {
+  const coeffs: RatQ[] = Array.from({ length: order + 1 }, () => RatQ.zero());
+  let sign = 1n;
+  for (let k = 1; k <= order; k += 1) {
+    coeffs[k] = new RatQ(sign, BigInt(k));
+    sign = -sign;
+  }
+  return new Series(coeffs, order);
+}
+
+function seriesTan(order: number): Series {
+  // tan = sin / cos. cos has nonzero constant, so direct reciprocal works.
+  return seriesSin(order).mul(seriesCos(order).reciprocal());
+}
+
+// ---------------------------------------------------------------------------
+// IR → Series translation
+// ---------------------------------------------------------------------------
+
+function toRat(node: IRNode): RatQ {
+  if (node.kind === "integer") return new RatQ(node.value, 1n);
+  if (node.kind === "rational") return new RatQ(node.numer, node.denom);
+  if (node.kind === "float") {
+    // Bounded conversion: keep up to denominator 1_000_000. Same idea as
+    // Python's `Fraction(value).limit_denominator()`.
+    return floatToRat(node.value);
+  }
+  throw new SeriesError(`expected literal, got ${nodeDebug(node)}`);
+}
+
+function floatToRat(value: number): RatQ {
+  if (!Number.isFinite(value)) throw new SeriesError("float coefficient must be finite");
+  if (value === 0) return RatQ.zero();
+  const sign = value < 0 ? -1n : 1n;
+  const av = Math.abs(value);
+  let bestN = BigInt(Math.round(av));
+  let bestD = 1n;
+  let bestErr = Math.abs(av - Number(bestN));
+  const MAX_D = 1_000_000n;
+  for (let d = 1n; d <= MAX_D; d += 1n) {
+    const numer = BigInt(Math.round(av * Number(d)));
+    const err = Math.abs(av - Number(numer) / Number(d));
+    if (err < bestErr) {
+      bestErr = err;
+      bestN = numer;
+      bestD = d;
+    }
+    if (bestErr === 0) break;
+  }
+  return new RatQ(sign * bestN, bestD);
+}
+
+function expand(expr: IRNode, variable: IRNode, order: number): Series {
+  // --- literal numbers ---
+  if (expr.kind === "integer" || expr.kind === "rational" || expr.kind === "float") {
+    return Series.constant(toRat(expr), order);
+  }
+
+  // --- the expansion variable ---
+  if (expr.kind === "symbol") {
+    if (equals(expr, variable)) return Series.variable(order);
+    // Opaque symbol: cannot Taylor-expand around an unknown constant.
+    throw new SeriesError(`unsupported symbol ${expr.name}`);
+  }
+
+  if (expr.kind !== "apply" || expr.head.kind !== "symbol") {
+    throw new SeriesError(`unsupported expression: ${nodeDebug(expr)}`);
+  }
+
+  const h = headName(expr.head);
+  const args = expr.args;
+
+  // --- arithmetic ---
+  if (h === ADD.name) {
+    let result = Series.constant(RatQ.zero(), order);
+    for (const a of args) result = result.add(expand(a, variable, order));
+    return result;
+  }
+  if (h === SUB.name) {
+    if (args.length !== 2) throw new SeriesError("Sub expects 2 args");
+    return expand(args[0], variable, order).sub(expand(args[1], variable, order));
+  }
+  if (h === NEG.name) {
+    if (args.length !== 1) throw new SeriesError("Neg expects 1 arg");
+    return expand(args[0], variable, order).neg();
+  }
+  if (h === MUL.name) {
+    let result = Series.constant(RatQ.one(), order);
+    for (const a of args) result = result.mul(expand(a, variable, order));
+    return result;
+  }
+  if (h === DIV.name) {
+    if (args.length !== 2) throw new SeriesError("Div expects 2 args");
+    const ns = expand(args[0], variable, order);
+    const ds = expand(args[1], variable, order);
+    if (!ds.coeffs[0].isZero()) return ns.mul(ds.reciprocal());
+    // Inner Div by vanishing series — would change the leading order
+    // of the surrounding expansion. Top-level `trySeriesLimit` handles
+    // the f/g case separately.
+    throw new SeriesError("inner Div by series vanishing at 0");
+  }
+  if (h === POW.name) {
+    if (args.length !== 2) throw new SeriesError("Pow expects 2 args");
+    const [base, expNode] = args;
+    if (expNode.kind === "integer") {
+      const k = Number(expNode.value);
+      if (!Number.isSafeInteger(k)) throw new SeriesError("Pow exponent too large");
+      if (k >= 0) return expand(base, variable, order).integerPower(k);
+      const baseSer = expand(base, variable, order);
+      if (baseSer.coeffs[0].isZero()) {
+        throw new SeriesError("Pow negative-int exponent over vanishing base");
+      }
+      return baseSer.reciprocal().integerPower(-k);
+    }
+    throw new SeriesError("Pow exponent must be a non-negative integer literal");
+  }
+
+  // --- transcendentals ---
+  if (h === EXP.name) {
+    if (args.length !== 1) throw new SeriesError("Exp expects 1 arg");
+    const inner = expand(args[0], variable, order);
+    if (!inner.coeffs[0].isZero()) throw new SeriesError("Exp with nonzero constant inner term");
+    return seriesExp(order).composeWithZeroConstant(inner);
+  }
+  if (h === SIN.name) {
+    if (args.length !== 1) throw new SeriesError("Sin expects 1 arg");
+    const inner = expand(args[0], variable, order);
+    if (!inner.coeffs[0].isZero()) throw new SeriesError("Sin with nonzero constant inner term");
+    return seriesSin(order).composeWithZeroConstant(inner);
+  }
+  if (h === COS.name) {
+    if (args.length !== 1) throw new SeriesError("Cos expects 1 arg");
+    const inner = expand(args[0], variable, order);
+    if (!inner.coeffs[0].isZero()) throw new SeriesError("Cos with nonzero constant inner term");
+    return seriesCos(order).composeWithZeroConstant(inner);
+  }
+  if (h === TAN.name) {
+    if (args.length !== 1) throw new SeriesError("Tan expects 1 arg");
+    const inner = expand(args[0], variable, order);
+    if (!inner.coeffs[0].isZero()) throw new SeriesError("Tan with nonzero constant inner term");
+    return seriesTan(order).composeWithZeroConstant(inner);
+  }
+  if (h === LOG.name) {
+    if (args.length !== 1) throw new SeriesError("Log expects 1 arg");
+    const inner = expand(args[0], variable, order);
+    const c0 = inner.coeffs[0];
+    if (!c0.eq(RatQ.one())) {
+      throw new SeriesError("Log with constant inner term != 1; not in rational ring");
+    }
+    // log(1 + (inner - 1)) where (inner - 1)(0) = 0.
+    const shiftedCoeffs = inner.coeffs.slice();
+    shiftedCoeffs[0] = RatQ.zero();
+    const shifted = new Series(shiftedCoeffs, order);
+    return seriesLogOnePlus(order).composeWithZeroConstant(shifted);
+  }
+
+  throw new SeriesError(`unsupported head: ${h}`);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognise both `Div(N, D)` and `Mul(N, Pow(D, -1))` as quotients.
+ * Returns `null` for any other top-level shape — the Taylor fallback
+ * only fires on rational structures.
+ */
+function splitQuotient(expr: IRNode): readonly [IRNode, IRNode] | null {
+  if (expr.kind !== "apply") return null;
+  if (headName(expr.head) === DIV.name && expr.args.length === 2) {
+    return [expr.args[0], expr.args[1]];
+  }
+  if (headName(expr.head) === MUL.name && expr.args.length === 2) {
+    const [a, b] = expr.args;
+    if (isPowNegOne(b)) return [a, (b as { args: readonly IRNode[] }).args[0]];
+    if (isPowNegOne(a)) return [b, (a as { args: readonly IRNode[] }).args[0]];
+  }
+  return null;
+}
+
+function isPowNegOne(node: IRNode): boolean {
+  return node.kind === "apply"
+    && headName(node.head) === POW.name
+    && node.args.length === 2
+    && node.args[1].kind === "integer"
+    && node.args[1].value === -1n;
+}
+
+/**
+ * Substitute `variable := variable + point` so the original
+ * `variable = point` corresponds to `variable = 0` after the shift.
+ *
+ * Done by an explicit IR walk rather than via `cas-substitution`,
+ * matching the Python reference's intent of a totally local rewrite.
+ */
+function shiftToOrigin(expr: IRNode, variable: IRNode, point: IRNode): IRNode {
+  if (point.kind === "integer" && point.value === 0n) return expr;
+  const go = (node: IRNode): IRNode => {
+    if (node.kind === "symbol") {
+      if (equals(node, variable)) return app(ADD, [variable, point]);
+      return node;
+    }
+    if (node.kind === "apply") {
+      return app(node.head, node.args.map(go));
+    }
+    return node;
+  };
+  return go(expr);
+}
+
+/**
+ * Taylor-series fallback for `limit(expr, variable, point)`.
+ *
+ * Returns:
+ *   - an integer or rational literal on success,
+ *   - `sym("inf")` / `sym("minf")` on a divergent ratio,
+ *   - `null` if the fallback cannot determine the value (caller falls
+ *     through to an unevaluated `Limit(...)`).
+ *
+ * `point` must be a literal number — limits at ±∞ are not yet handled
+ * here (they would need a `u = 1/x` rewrite) and return `null`.
+ *
+ * `maxOrder` is clamped to `[4, 12]` — keeping polynomial multiplication
+ * bounded by O(N^2) within a fixed, small constant.
+ */
+export function trySeriesLimit(
+  expr: IRNode,
+  variable: IRNode,
+  point: IRNode,
+  maxOrder: number = MAX_ORDER_LIMIT,
+): IRNode | null {
+  let cap = Math.floor(maxOrder);
+  if (!Number.isFinite(cap)) cap = MAX_ORDER_LIMIT;
+  if (cap < 4) cap = 4;
+  if (cap > MAX_ORDER_LIMIT) cap = MAX_ORDER_LIMIT;
+
+  const nd = splitQuotient(expr);
+  if (nd === null) return null;
+  const [numer, denom] = nd;
+
+  if (point.kind === "symbol" && (point.name === "inf" || point.name === "minf")) {
+    return null;
+  }
+  if (point.kind !== "integer" && point.kind !== "rational" && point.kind !== "float") {
+    return null;
+  }
+
+  const shiftedN = shiftToOrigin(numer, variable, point);
+  const shiftedD = shiftToOrigin(denom, variable, point);
+
+  let order = 4;
+  while (order <= cap) {
+    let nSer: Series;
+    let dSer: Series;
+    try {
+      nSer = expand(shiftedN, variable, order);
+      dSer = expand(shiftedD, variable, order);
+    } catch (err) {
+      if (err instanceof SeriesError) return null;
+      throw err;
+    }
+
+    const p = nSer.leadingIndex();
+    const q = dSer.leadingIndex();
+
+    // Both fully zero — bump order and retry. The expansion may simply
+    // not be deep enough yet.
+    if (p === -1 && q === -1) {
+      order += 2;
+      continue;
+    }
+
+    // Numerator vanishes harder than denominator within our tracked order.
+    if (p === -1 && q !== -1) return int(0);
+
+    // Denominator vanishes harder than numerator — divergence; sign
+    // follows the leading numerator coefficient.
+    if (q === -1 && p !== -1) {
+      return nSer.coeffs[p].isPositive() ? sym("inf") : sym("minf");
+    }
+
+    const cp = nSer.coeffs[p];
+    const dq = dSer.coeffs[q];
+    if (p > q) return int(0);
+    if (p < q) {
+      const signVal = cp.div(dq);
+      return signVal.isPositive() ? sym("inf") : sym("minf");
+    }
+    // p == q — exact rational ratio.
+    return cp.div(dq).toIrNode();
+  }
+
+  return null;
+}
+
+function nodeDebug(node: IRNode): string {
+  return JSON.stringify(node, (_key, value) => (typeof value === "bigint" ? value.toString() : value));
+}
+
+// Internal exports for whitebox tests.
+export const __internal = { Series, RatQ, SeriesError, MAX_ORDER_LIMIT };

--- a/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
+++ b/code/packages/typescript/cas-limit-series/tests/cas-limit-series.test.ts
@@ -137,13 +137,17 @@ describe("limitAdvanced", () => {
     expectEqual(limitAdvanced(expr, x, int(2), { evaluate: evaluateFixture }), int(5));
   });
 
-  it("returns unevaluated Limit for indeterminate quotients without callbacks", () => {
+  it("closes indeterminate quotients via the Taylor-series fallback without callbacks", () => {
+    // Track J2: the Taylor fallback now closes 0/0 polynomial forms even
+    // when no `differentiate` callback is supplied. (x^2 - 1)/(x - 1) at
+    // x = 1 expands to 2 + (x - 1) in shifted form, so leading order is 0,
+    // ratio is 2/1 = 2. Pre-J2 this returned an unevaluated `Limit(...)`.
     const x = sym("x");
     const expr = app(DIV, [
       app(SUB, [app(POW, [x, int(2)]), int(1)]),
       app(SUB, [x, int(1)]),
     ]);
-    expectEqual(limitAdvanced(expr, x, int(1)), app(sym(LIMIT), [expr, x, int(1)]));
+    expectEqual(limitAdvanced(expr, x, int(1)), int(2));
   });
 
   it("uses injected differentiation for a simple L'Hopital rational form", () => {

--- a/code/packages/typescript/cas-limit-series/tests/seriesLimit.test.ts
+++ b/code/packages/typescript/cas-limit-series/tests/seriesLimit.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the Track J2 Taylor-series limit fallback.
+ *
+ * Mirrors the Python reference tests in
+ * `code/packages/python/cas-limit-series/tests/test_series_limit.py`.
+ *
+ * Each acceptance case is taken straight from the
+ * `macsyma-truly-finish-plan` Track J1/J2 spec.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  COS,
+  DIV,
+  EXP,
+  LOG,
+  MUL,
+  NEG,
+  POW,
+  SIN,
+  SUB,
+  TAN,
+  app,
+  equals,
+  int,
+  rational,
+  sym,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+import { limitAdvanced, trySeriesLimit } from "../src/index";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function x(): IRNode {
+  return sym("x");
+}
+
+function eq(actual: IRNode, expected: IRNode): void {
+  expect(
+    equals(actual, expected),
+    `actual: ${display(actual)} expected: ${display(expected)}`,
+  ).toBe(true);
+}
+
+function display(node: IRNode): string {
+  return JSON.stringify(node, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance cases (Track J1/J2 spec)
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — acceptance cases", () => {
+  it("(sin(x) - x)/x^3 → -1/6", () => {
+    const expr = app(DIV, [app(SUB, [app(SIN, [x()]), x()]), app(POW, [x(), int(3)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, rational(-1, 6));
+  });
+
+  it("(1 - cos(x))/x^2 → 1/2", () => {
+    const expr = app(DIV, [app(SUB, [int(1), app(COS, [x()])]), app(POW, [x(), int(2)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, rational(1, 2));
+  });
+
+  it("(exp(x) - 1 - x)/x^2 → 1/2", () => {
+    const numer = app(SUB, [app(SUB, [app(EXP, [x()]), int(1)]), x()]);
+    const expr = app(DIV, [numer, app(POW, [x(), int(2)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, rational(1, 2));
+  });
+
+  it("(tan(x) - x)/x^3 → 1/3", () => {
+    const expr = app(DIV, [app(SUB, [app(TAN, [x()]), x()]), app(POW, [x(), int(3)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, rational(1, 3));
+  });
+
+  it("(log(1 + x) - x)/x^2 → -1/2", () => {
+    const onePlusX = app(ADD, [int(1), x()]);
+    const numer = app(SUB, [app(LOG, [onePlusX]), x()]);
+    const expr = app(DIV, [numer, app(POW, [x(), int(2)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, rational(-1, 2));
+  });
+
+  it("(sin(x) - x) / (exp(x^2) - 1) → 0 (leading u^3 vs u^2)", () => {
+    const numer = app(SUB, [app(SIN, [x()]), x()]);
+    const denom = app(SUB, [app(EXP, [app(POW, [x(), int(2)])]), int(1)]);
+    const expr = app(DIV, [numer, denom]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(0));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression — sin(x)/x and x^2/x still close
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — regression", () => {
+  it("sin(x)/x → 1", () => {
+    const expr = app(DIV, [app(SIN, [x()]), x()]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+
+  it("x^2/x → 0 by leading-order analysis", () => {
+    const expr = app(DIV, [app(POW, [x(), int(2)]), x()]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(0));
+  });
+
+  it("limit(x^2, x, 0) — bare polynomial returns null (not a quotient)", () => {
+    expect(trySeriesLimit(app(POW, [x(), int(2)]), x(), int(0))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fall-through — return null gracefully
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — fall-through", () => {
+  it("returns null on a non-quotient", () => {
+    expect(trySeriesLimit(app(POW, [x(), int(2)]), x(), int(0))).toBeNull();
+  });
+
+  it("returns null on an unsupported head", () => {
+    const weird = app(sym("Asin"), [x()]);
+    const expr = app(DIV, [weird, x()]);
+    expect(trySeriesLimit(expr, x(), int(0))).toBeNull();
+  });
+
+  it("returns null for limits at +infinity (u = 1/x rewrite not implemented)", () => {
+    const expr = app(DIV, [app(SIN, [x()]), x()]);
+    expect(trySeriesLimit(expr, x(), sym("inf"))).toBeNull();
+  });
+
+  it("returns null for limits at -infinity", () => {
+    const expr = app(DIV, [app(SIN, [x()]), x()]);
+    expect(trySeriesLimit(expr, x(), sym("minf"))).toBeNull();
+  });
+
+  it("fall-through for limit(sin(x), x, %inf) via limitAdvanced", () => {
+    // limitAdvanced still falls through to an unevaluated Limit(...)
+    // for `limit(sin(x), x, inf)` — sin is bounded but not a quotient
+    // that the Taylor fallback can resolve.
+    const result = limitAdvanced(app(SIN, [x()]), x(), sym("inf"));
+    expect(result.kind).toBe("apply");
+    if (result.kind === "apply") {
+      expect(result.head.kind === "symbol" && result.head.name === "Limit").toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Divergent quotients return ±∞ sentinels
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — divergent forms", () => {
+  it("1/x^2 → +inf", () => {
+    const expr = app(DIV, [int(1), app(POW, [x(), int(2)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    if (result && result.kind === "symbol") expect(result.name).toBe("inf");
+    else throw new Error(`expected symbol("inf"), got ${display(result!)}`);
+  });
+
+  it("-1/x^2 → -inf", () => {
+    const expr = app(DIV, [int(-1), app(POW, [x(), int(2)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    if (result && result.kind === "symbol") expect(result.name).toBe("minf");
+    else throw new Error(`expected symbol("minf"), got ${display(result!)}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-origin expansion point
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — shifted expansion point", () => {
+  it("(x^2 - 1)/(x - 1) at x = 1 → 2", () => {
+    const numer = app(SUB, [app(POW, [x(), int(2)]), int(1)]);
+    const denom = app(SUB, [x(), int(1)]);
+    const expr = app(DIV, [numer, denom]);
+    const result = trySeriesLimit(expr, x(), int(1));
+    expect(result).not.toBeNull();
+    eq(result!, int(2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expander edges — Neg, Pow(., -1), Mul-as-quotient, constants, max_order
+// ---------------------------------------------------------------------------
+
+describe("trySeriesLimit — expander edges", () => {
+  it("-sin(x)/x → -1 (Neg head)", () => {
+    const numer = app(NEG, [app(SIN, [x()])]);
+    const expr = app(DIV, [numer, x()]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(-1));
+  });
+
+  it("(1 - x)^-1 / 1 → 1 via Pow(., -1)", () => {
+    const oneMinusX = app(SUB, [int(1), x()]);
+    const expr = app(DIV, [app(POW, [oneMinusX, int(-1)]), int(1)]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+
+  it("Mul(sin(x), Pow(x, -1)) recognised as a quotient", () => {
+    const expr = app(MUL, [app(SIN, [x()]), app(POW, [x(), int(-1)])]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+
+  it("1/1 → 1 (rational-ring constant case)", () => {
+    const expr = app(DIV, [int(1), int(1)]);
+    const result = trySeriesLimit(expr, x(), int(0));
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+
+  it("maxOrder above the hard cap is clamped", () => {
+    const expr = app(DIV, [app(SIN, [x()]), x()]);
+    const result = trySeriesLimit(expr, x(), int(0), 999);
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+
+  it("maxOrder below 4 is bumped to 4", () => {
+    const expr = app(DIV, [app(SIN, [x()]), x()]);
+    const result = trySeriesLimit(expr, x(), int(0), 2);
+    expect(result).not.toBeNull();
+    eq(result!, int(1));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher wiring — limitAdvanced picks up Taylor without diff_fn
+// ---------------------------------------------------------------------------
+
+describe("limitAdvanced + Taylor wiring", () => {
+  it("closes sin(x)/x at 0 without a differentiate callback", () => {
+    // Pre-J2 this returned an unevaluated Limit(...) when no diff_fn was
+    // supplied. J2 wires the Taylor fallback in after L'Hopital so it
+    // now resolves to 1.
+    const result = limitAdvanced(app(DIV, [app(SIN, [x()]), x()]), x(), int(0));
+    eq(result, int(1));
+  });
+
+  it("closes (1 - cos(x))/x^2 at 0 without a differentiate callback", () => {
+    const expr = app(DIV, [app(SUB, [int(1), app(COS, [x()])]), app(POW, [x(), int(2)])]);
+    const result = limitAdvanced(expr, x(), int(0));
+    eq(result, rational(1, 2));
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Track J1 work (PR #5574) to TypeScript and Rust. Adds a
transcendental-aware Taylor-series-expansion fallback for `limit(f, x, a)`
that fires after L'Hopital (or instead of it when no `differentiate`
callback is supplied) and resolves 0/0 forms by reading off the leading
order of the numerator and denominator expansions.

- Self-contained rational-coefficient series ring per language (BigInt
  in TS, `i128` in Rust). Mirrors the Python `Fraction`-based
  implementation 1:1.
- Bounded order loop 4 → 6 → 8 → 10 → 12 — hard-capped, no unbounded
  recursion, no `eval` of user data.
- Supported heads: `Add`, `Sub`, `Neg`, `Mul`, `Div` (when the inner
  denominator does not vanish), `Pow` with integer exponent, `Sin`,
  `Cos`, `Tan`, `Exp`, `Log` (around inner constant 1).
- Wired into `limitAdvanced` (TS) and `limit_advanced` (Rust) at the
  same dispatch position as the Python reference: after the L'Hopital /
  product / power rewrites, before the unevaluated `Limit(...)`
  fallthrough.

Closes the J1 acceptance set in both ports:

| limit | result |
| --- | --- |
| `limit((sin(x) - x)/x^3, x, 0)` | `-1/6` |
| `limit((1 - cos(x))/x^2, x, 0)` | `1/2` |
| `limit((exp(x) - 1 - x)/x^2, x, 0)` | `1/2` |
| `limit((tan(x) - x)/x^3, x, 0)` | `1/3` |
| `limit((log(1 + x) - x)/x^2, x, 0)` | `-1/2` |
| `limit((sin(x) - x)/(exp(x^2) - 1), x, 0)` | `0` (p > q) |

### Pre-existing tests updated

Matching the Python update of `test_no_diff_fn_indeterminate` in PR #5574:

- TypeScript: `returns unevaluated Limit for indeterminate quotients
  without callbacks` now asserts the J2 closure of `(x^2-1)/(x-1)` to
  `2` (previously it expected an unevaluated `Limit(...)`).
- Rust: `limit_advanced_indeterminate_without_callbacks_is_unevaluated`
  renamed to `..._closes_via_taylor` and now asserts the J2 closure of
  `x/x` to `1`.

### Versions

- `@coding-adventures/cas-limit-series` 0.2.2 → **0.3.0**
- `cas-limit-series` (Rust crate) 0.2.2 → **0.3.0**

## Test plan

- [x] TS: `npx vitest run` — **48 tests pass** (40 prior + 22 new J2; 2
      prior updated). Order matters: `cas-limit-series.test.ts` + new
      `seriesLimit.test.ts`.
- [x] Rust: `cargo test` — **45 integration tests + 4 doc tests pass**.
      No warnings.
- [x] Bounded-order verification: every loop in `seriesLimit.ts` /
      `series_limit.rs` is bounded by `order` (≤ 12), the small `MAX_D`
      in `floatToRat` (= 1_000_000, lifted from the existing
      polynomial Taylor path), or GCD (logarithmic). Top-level
      `try_series_limit` runs at most five outer iterations.
- [x] No `eval` of user-controlled strings.
- [x] Acceptance: each canonical case enumerated above asserted
      individually in both TS and Rust test suites.

References Track J2 of `code/specs/macsyma-truly-finish-plan.md` and the
parent Python implementation PR #5574.