### PR TITLE
Add link resource readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -846,6 +846,7 @@ pub struct BrowserDocument {
     pub loading_hint_descriptors: Vec<BrowserLoadingHintDescriptor>,
     pub fetch_policy_descriptors: Vec<BrowserFetchPolicyDescriptor>,
     pub resource_endpoint_descriptors: Vec<BrowserResourceEndpointDescriptor>,
+    pub link_resource_descriptors: Vec<BrowserLinkResourceDescriptor>,
     pub form_policy_descriptors: Vec<BrowserFormPolicyDescriptor>,
     pub form_association_descriptors: Vec<BrowserFormAssociationDescriptor>,
     pub form_autofill_descriptors: Vec<BrowserFormAutofillDescriptor>,
@@ -1022,6 +1023,30 @@ pub struct BrowserResource {
     pub default_track: bool,
     pub async_script: bool,
     pub defer_script: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserLinkResourceDescriptor {
+    pub resource_index: usize,
+    pub resource_kind: String,
+    pub url: String,
+    pub resolved_url: Option<String>,
+    pub rel_tokens: Vec<String>,
+    pub as_hint: Option<String>,
+    pub type_hint: Option<String>,
+    pub media: Option<String>,
+    pub title: Option<String>,
+    pub sizes: Option<String>,
+    pub hreflang: Option<String>,
+    pub color: Option<String>,
+    pub fetchpriority: Option<String>,
+    pub blocking_tokens: Vec<String>,
+    pub responsive_image_preload: bool,
+    pub icon_candidate: bool,
+    pub alternate_candidate: bool,
+    pub policy_hint_count: usize,
+    pub resource_blocked: bool,
+    pub resource_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3797,6 +3822,7 @@ impl BrowserDocument {
         summary.form_reset_descriptors = browser_form_reset_descriptors(&summary.forms);
         summary.form_validation_descriptors = browser_form_validation_descriptors(&summary.forms);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
+        summary.link_resource_descriptors = browser_link_resource_descriptors(&summary.resources);
         summary
     }
 }
@@ -11422,6 +11448,111 @@ fn browser_resource_endpoint_descriptors(
             .map(browser_resource_endpoint_descriptor),
     );
     descriptors
+}
+
+fn browser_link_resource_descriptors(
+    resources: &[BrowserResource],
+) -> Vec<BrowserLinkResourceDescriptor> {
+    resources
+        .iter()
+        .enumerate()
+        .filter(|(_, resource)| resource.rel.is_some())
+        .map(|(index, resource)| browser_link_resource_descriptor(index + 1, resource))
+        .collect()
+}
+
+fn browser_link_resource_descriptor(
+    resource_index: usize,
+    resource: &BrowserResource,
+) -> BrowserLinkResourceDescriptor {
+    let resource_block_reasons = browser_link_resource_block_reasons(resource);
+
+    BrowserLinkResourceDescriptor {
+        resource_index,
+        resource_kind: resource.kind.clone(),
+        url: resource.url.clone(),
+        resolved_url: resource.resolved_url.clone(),
+        rel_tokens: resource.rel_tokens.clone(),
+        as_hint: resource.as_hint.clone(),
+        type_hint: resource.type_hint.clone(),
+        media: resource.media.clone(),
+        title: resource.title.clone(),
+        sizes: resource.sizes.clone(),
+        hreflang: resource.hreflang.clone(),
+        color: resource.color.clone(),
+        fetchpriority: resource.fetchpriority.clone(),
+        blocking_tokens: resource.blocking_tokens.clone(),
+        responsive_image_preload: resource.kind == "preload"
+            && resource.as_hint.as_deref() == Some("image")
+            && (resource.imagesrcset.is_some() || resource.imagesizes.is_some()),
+        icon_candidate: resource.kind == "icon",
+        alternate_candidate: resource.kind == "alternate",
+        policy_hint_count: browser_link_resource_policy_hint_count(resource),
+        resource_blocked: !resource_block_reasons.is_empty(),
+        resource_block_reasons,
+    }
+}
+
+fn browser_link_resource_policy_hint_count(resource: &BrowserResource) -> usize {
+    [
+        resource.integrity.as_ref(),
+        resource.crossorigin.as_ref(),
+        resource.nonce.as_ref(),
+        resource.referrerpolicy.as_ref(),
+        resource.fetchpriority.as_ref(),
+        resource.blocking.as_ref(),
+    ]
+    .into_iter()
+    .filter(Option::is_some)
+    .count()
+}
+
+fn browser_link_resource_block_reasons(resource: &BrowserResource) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if resource.rel_tokens.is_empty() {
+        reasons.push("missing-rel".to_string());
+    }
+    if resource.resolved_url.is_none() {
+        reasons.push("unresolved-url".to_string());
+    }
+    if resource.kind == "preload" && resource.as_hint.is_none() {
+        reasons.push("preload-missing-as".to_string());
+    }
+    if resource.kind == "preload"
+        && resource.as_hint.as_deref() == Some("image")
+        && resource.imagesrcset.is_some()
+        && resource.imagesizes.is_none()
+    {
+        reasons.push("responsive-image-preload-missing-sizes".to_string());
+    }
+    if resource.kind == "preload"
+        && resource.as_hint.as_deref() == Some("image")
+        && resource.imagesizes.is_some()
+        && resource.imagesrcset.is_none()
+    {
+        reasons.push("responsive-image-preload-missing-srcset".to_string());
+    }
+    if resource.kind == "icon"
+        && browser_rel_tokens_contain(&resource.rel_tokens, "mask-icon")
+        && resource.color.is_none()
+    {
+        reasons.push("mask-icon-missing-color".to_string());
+    }
+    if resource.kind == "icon"
+        && !browser_rel_tokens_contain(&resource.rel_tokens, "mask-icon")
+        && resource.sizes.is_none()
+        && resource.type_hint.is_none()
+    {
+        reasons.push("icon-missing-size-or-type".to_string());
+    }
+    if resource.kind == "alternate"
+        && resource.title.is_none()
+        && resource.hreflang.is_none()
+        && resource.type_hint.is_none()
+    {
+        reasons.push("alternate-missing-descriptor".to_string());
+    }
+    reasons
 }
 
 fn browser_image_candidate_descriptors(

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -23,19 +23,19 @@ use coding_adventures_html_parser::{
     BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea,
     BrowserImageMapDescriptor, BrowserImageSource, BrowserInputPlanningDescriptor,
     BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
-    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLoadingHintDescriptor, BrowserMedia,
-    BrowserMediaPlaybackDescriptor, BrowserMediaSource, BrowserMediaTrack, BrowserMeta,
-    BrowserMetadataDirective, BrowserNavigationGroup, BrowserNavigationTargetDescriptor,
-    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
-    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
-    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
-    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
-    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSelectOption,
-    BrowserSelectionInteractionDescriptor, BrowserSlotDescriptor, BrowserStructuredDataDescriptor,
-    BrowserStructuredItem, BrowserStructuredProperty, BrowserStylesheet,
-    BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
-    BrowserTableStructureDescriptor, BrowserTemplate, BrowserTemplateDescriptor,
-    BrowserTextSemantic, BrowserThemeColor,
+    BrowserLifecycleEventDescriptor, BrowserLink, BrowserLinkResourceDescriptor,
+    BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
+    BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
+    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
+    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
+    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
+    BrowserScriptModuleGraphDescriptor, BrowserScriptStorageAccessDescriptor,
+    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
+    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
+    BrowserSlotDescriptor, BrowserStructuredDataDescriptor, BrowserStructuredItem,
+    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
+    BrowserTable, BrowserTableCell, BrowserTableStructureDescriptor, BrowserTemplate,
+    BrowserTemplateDescriptor, BrowserTextSemantic, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -113,6 +113,8 @@ struct ExpectedBrowserDocument {
     fetch_policy_descriptors: Vec<ExpectedFetchPolicyDescriptor>,
     #[serde(default)]
     resource_endpoint_descriptors: Option<Vec<ExpectedResourceEndpointDescriptor>>,
+    #[serde(default)]
+    link_resource_descriptors: Option<Vec<ExpectedLinkResourceDescriptor>>,
     #[serde(default)]
     form_policy_descriptors: Vec<ExpectedFormPolicyDescriptor>,
     #[serde(default)]
@@ -1581,6 +1583,47 @@ struct ExpectedResource {
     default_track: bool,
     async_script: bool,
     defer_script: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedLinkResourceDescriptor {
+    resource_index: usize,
+    resource_kind: String,
+    url: String,
+    #[serde(default)]
+    resolved_url: Option<String>,
+    #[serde(default)]
+    rel_tokens: Vec<String>,
+    #[serde(default)]
+    as_hint: Option<String>,
+    #[serde(default)]
+    type_hint: Option<String>,
+    #[serde(default)]
+    media: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    sizes: Option<String>,
+    #[serde(default)]
+    hreflang: Option<String>,
+    #[serde(default)]
+    color: Option<String>,
+    #[serde(default)]
+    fetchpriority: Option<String>,
+    #[serde(default)]
+    blocking_tokens: Vec<String>,
+    #[serde(default)]
+    responsive_image_preload: bool,
+    #[serde(default)]
+    icon_candidate: bool,
+    #[serde(default)]
+    alternate_candidate: bool,
+    #[serde(default)]
+    policy_hint_count: usize,
+    #[serde(default)]
+    resource_blocked: bool,
+    #[serde(default)]
+    resource_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4379,6 +4422,7 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         let tracks_table_structure_descriptors =
             case.expected.table_structure_descriptors.is_some();
         let tracks_image_map_descriptors = case.expected.image_map_descriptors.is_some();
+        let tracks_link_resource_descriptors = case.expected.link_resource_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
             expected.aria_name_descriptors = actual.aria_name_descriptors.clone();
@@ -4410,6 +4454,9 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_image_map_descriptors {
             expected.image_map_descriptors = actual.image_map_descriptors.clone();
+        }
+        if !tracks_link_resource_descriptors {
+            expected.link_resource_descriptors = actual.link_resource_descriptors.clone();
         }
 
         assert_eq!(
@@ -4698,6 +4745,60 @@ fn browser_link_descriptor_metadata_tracks_icon_and_alternate_fields() {
     assert_eq!(
         actual.resources, expected.resources,
         "link resources should preserve icon sizes, mask colors, and alternate language descriptors",
+    );
+}
+
+#[test]
+fn browser_link_resource_descriptors_track_rel_hints_policy_and_blockers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "link-resource-metadata-page")
+        .expect("link resource fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("link resource fixture should parse into browser document facts");
+
+    assert_eq!(
+        actual.link_resource_descriptors,
+        case.expected.into_browser_document().link_resource_descriptors,
+        "link resource descriptors should preserve relation kinds, scheduling hints, icon/alternate metadata, and blocker state",
+    );
+}
+
+#[test]
+fn browser_link_resource_descriptors_track_missing_and_unresolved_hints() {
+    let actual = parse_browser_document(
+        r#"<link rel=preload href=font.woff2>
+           <link rel=preload href=hero.jpg as=image imagesrcset="hero.jpg 1x">
+           <link rel=icon href=favicon.ico>
+           <link rel=mask-icon href=mask.svg>
+           <link rel=alternate href=feed.xml>"#,
+    )
+    .expect("blocked link resource descriptor fixture should parse");
+
+    assert_eq!(actual.link_resource_descriptors.len(), 5);
+    assert_eq!(
+        actual.link_resource_descriptors[0].resource_block_reasons,
+        vec!["unresolved-url", "preload-missing-as"],
+    );
+    assert_eq!(
+        actual.link_resource_descriptors[1].resource_block_reasons,
+        vec!["unresolved-url", "responsive-image-preload-missing-sizes",],
+    );
+    assert_eq!(
+        actual.link_resource_descriptors[2].resource_block_reasons,
+        vec!["unresolved-url", "icon-missing-size-or-type"],
+    );
+    assert_eq!(
+        actual.link_resource_descriptors[3].resource_block_reasons,
+        vec!["unresolved-url", "mask-icon-missing-color"],
+    );
+    assert_eq!(
+        actual.link_resource_descriptors[4].resource_block_reasons,
+        vec!["unresolved-url", "alternate-missing-descriptor"],
     );
 }
 
@@ -7414,6 +7515,12 @@ impl ExpectedBrowserDocument {
                     .collect()
             })
             .unwrap_or_else(|| expected_resource_endpoint_descriptors(&metadata, &resources));
+        let link_resource_descriptors = self
+            .link_resource_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedLinkResourceDescriptor::into_browser_link_resource_descriptor)
+            .collect();
         let media_playback_descriptors = self
             .media_playback_descriptors
             .map(|descriptors| {
@@ -7821,6 +7928,7 @@ impl ExpectedBrowserDocument {
                 .map(ExpectedFetchPolicyDescriptor::into_browser_fetch_policy_descriptor)
                 .collect(),
             resource_endpoint_descriptors,
+            link_resource_descriptors,
             form_policy_descriptors: self
                 .form_policy_descriptors
                 .into_iter()
@@ -8563,6 +8671,33 @@ impl ExpectedResource {
             default_track: self.default_track,
             async_script: self.async_script,
             defer_script: self.defer_script,
+        }
+    }
+}
+
+impl ExpectedLinkResourceDescriptor {
+    fn into_browser_link_resource_descriptor(self) -> BrowserLinkResourceDescriptor {
+        BrowserLinkResourceDescriptor {
+            resource_index: self.resource_index,
+            resource_kind: self.resource_kind,
+            url: self.url,
+            resolved_url: self.resolved_url,
+            rel_tokens: self.rel_tokens,
+            as_hint: self.as_hint,
+            type_hint: self.type_hint,
+            media: self.media,
+            title: self.title,
+            sizes: self.sizes,
+            hreflang: self.hreflang,
+            color: self.color,
+            fetchpriority: self.fetchpriority,
+            blocking_tokens: self.blocking_tokens,
+            responsive_image_preload: self.responsive_image_preload,
+            icon_candidate: self.icon_candidate,
+            alternate_candidate: self.alternate_candidate,
+            policy_hint_count: self.policy_hint_count,
+            resource_blocked: self.resource_blocked,
+            resource_block_reasons: self.resource_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -610,6 +610,18 @@
           { "kind": "icon", "url": "mask.svg", "resolved_url": "https://example.test/app/mask.svg", "rel": "mask-icon", "rel_tokens": ["mask-icon"], "color": "#0055ff", "async_script": false, "defer_script": false },
           { "kind": "alternate", "url": "feed.xml", "resolved_url": "https://example.test/app/feed.xml", "rel": "alternate", "rel_tokens": ["alternate"], "type_hint": "application/rss+xml", "title": "Feed", "hreflang": "en", "async_script": false, "defer_script": false }
         ],
+        "link_resource_descriptors": [
+          { "resource_index": 1, "resource_kind": "preconnect", "url": "https://cdn.example.test", "resolved_url": "https://cdn.example.test", "rel_tokens": ["preconnect"], "policy_hint_count": 1 },
+          { "resource_index": 2, "resource_kind": "preload", "url": "fonts/site.woff2", "resolved_url": "https://example.test/app/fonts/site.woff2", "rel_tokens": ["preload"], "as_hint": "font", "type_hint": "font/woff2", "fetchpriority": "high", "policy_hint_count": 3 },
+          { "resource_index": 3, "resource_kind": "modulepreload", "url": "scripts/app.mjs", "resolved_url": "https://example.test/app/scripts/app.mjs", "rel_tokens": ["modulepreload"], "blocking_tokens": ["render"], "policy_hint_count": 3 },
+          { "resource_index": 4, "resource_kind": "preload", "url": "hero.jpg", "resolved_url": "https://example.test/app/hero.jpg", "rel_tokens": ["preload"], "as_hint": "image", "fetchpriority": "high", "responsive_image_preload": true, "policy_hint_count": 1 },
+          { "resource_index": 5, "resource_kind": "prefetch", "url": "next.html", "resolved_url": "https://example.test/app/next.html", "rel_tokens": ["prefetch"], "as_hint": "document" },
+          { "resource_index": 6, "resource_kind": "manifest", "url": "site.webmanifest", "resolved_url": "https://example.test/app/site.webmanifest", "rel_tokens": ["manifest"], "policy_hint_count": 1 },
+          { "resource_index": 7, "resource_kind": "canonical", "url": "https://example.test/app/", "resolved_url": "https://example.test/app/", "rel_tokens": ["canonical"] },
+          { "resource_index": 8, "resource_kind": "icon", "url": "favicon.ico", "resolved_url": "https://example.test/app/favicon.ico", "rel_tokens": ["shortcut", "icon"], "type_hint": "image/x-icon", "sizes": "any", "icon_candidate": true },
+          { "resource_index": 9, "resource_kind": "icon", "url": "mask.svg", "resolved_url": "https://example.test/app/mask.svg", "rel_tokens": ["mask-icon"], "color": "#0055ff", "icon_candidate": true },
+          { "resource_index": 10, "resource_kind": "alternate", "url": "feed.xml", "resolved_url": "https://example.test/app/feed.xml", "rel_tokens": ["alternate"], "type_hint": "application/rss+xml", "title": "Feed", "hreflang": "en", "alternate_candidate": true }
+        ],
         "document_policy_descriptors": [
           {
             "canonical_url": "https://example.test/app/",


### PR DESCRIPTION
## Summary
- add BrowserLinkResourceDescriptor facts for rel/kind identity, scheduling hints, icon/alternate metadata, and policy hint counts
- flag unresolved link resources plus missing preload, responsive image preload, icon, mask-icon, and alternate descriptors
- extend browser-readiness fixture expectations and focused regression tests

## Validation
- cargo test -p coding-adventures-html-parser browser_link_resource_descriptors --manifest-path code/packages/rust/Cargo.toml
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml