### PR TITLE
feat(semantic-ir-to-python): native emit for SIR16 expression features

### DIFF
--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.5 — SIR16 expression features (native)
+
+Accepts and emits the SIR16 expression features, all translated to **native**
+Python (per `code/specs/sir-runtime.md`):
+
+- `Feature::Floats` → float literal; `Feature::Sequences` → list literal /
+  `s[i]` / `len(s)`; `Feature::Maps` → dict literal / `m[k]`.
+- `Feature::ShortCircuit` (`LogicalAnd`/`LogicalOr`, emitted by case/in pattern
+  desugaring) → a **truthy-guarded lambda** `(lambda __l: (rhs) if
+  _sir_truthy(__l) else __l)(lhs)`: keeps the rhs lazy AND uses SIR truthiness
+  (only `False`/`nil` falsy), never a bare Python `and`/`or`.
+- `Feature::StringInterpolation` (`StrConcat`) → parts joined through
+  `_sir_to_display` (a string part renders to itself).
+
+`to_display` added to the runtime import header as `_sir_to_display`.
+New Ruby→Python E2E tests for array literal, hash literal, pattern short-circuit,
+and interpolation. (TS counterpart lands separately.)
+
 ## 0.1.4 — import runtime from `coding-adventures-sir-runtime-core`
 
 The Python runtime is no longer inlined into every artifact.  Emitted modules

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -262,18 +262,81 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 name, span
             );
         }
-        // SIR16 expression kinds — Python backend's SIR-v1 extension
-        // (per SIR20) lands separately.
-        Expr::FloatLit { span, .. }
-        | Expr::SeqLit { span, .. }
-        | Expr::SeqIndex { span, .. }
-        | Expr::SeqLen { span, .. }
-        | Expr::MapLit { span, .. }
-        | Expr::MapGet { span, .. }
-        | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. }
-        | Expr::StrConcat { span, .. } => {
-            panic!("python backend reached SIR16+ expression at {} — capability check should have rejected it", span);
+        // ── SIR16 expression kinds — native Python ──────────────────
+        Expr::FloatLit { value, .. } => {
+            // `{:?}` keeps a decimal point (e.g. `3.0`, `3.14`) so the
+            // literal stays a float, not an int.
+            let _ = write!(out, "{:?}", value);
+        }
+        Expr::SeqLit { items, .. } => {
+            out.push('[');
+            emit_args(out, items, indent);
+            out.push(']');
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            emit_expr(out, seq, indent);
+            out.push('[');
+            emit_expr(out, index, indent);
+            out.push(']');
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push_str("len(");
+            emit_expr(out, seq, indent);
+            out.push(')');
+        }
+        Expr::MapLit { entries, .. } => {
+            out.push('{');
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_expr(out, &entry.key, indent);
+                out.push_str(": ");
+                emit_expr(out, &entry.value, indent);
+            }
+            out.push('}');
+        }
+        Expr::MapGet { map, key, .. } => {
+            emit_expr(out, map, indent);
+            out.push('[');
+            emit_expr(out, key, indent);
+            out.push(']');
+        }
+        // Short-circuit: a lambda keeps the rhs unevaluated until the
+        // lhs decides, and routes the test through SIR truthiness (only
+        // `False`/`nil` are falsy — not `0`/`""`/`[]`).  The lambda
+        // param `__l` gives each occurrence its own scope, so nested
+        // `&&`/`||` never collide.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            out.push_str("(lambda __l: (");
+            emit_expr(out, rhs, indent);
+            out.push_str(") if _sir_truthy(__l) else __l)(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            out.push_str("(lambda __l: __l if _sir_truthy(__l) else (");
+            emit_expr(out, rhs, indent);
+            out.push_str("))(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
+        // String interpolation: every part rendered through the SIR
+        // display helper (a string part renders to itself) and joined.
+        Expr::StrConcat { parts, .. } => {
+            out.push('(');
+            if parts.is_empty() {
+                out.push_str("\"\"");
+            }
+            for (i, p) in parts.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(" + ");
+                }
+                out.push_str("_sir_to_display(");
+                emit_expr(out, p, indent);
+                out.push(')');
+            }
+            out.push(')');
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/lib.rs
@@ -49,6 +49,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // SIR16 expression features — emitted natively (sequences → list,
+    // maps → dict, short-circuit → truthy-guarded lambda, interpolation →
+    // display-joined), per code/specs/sir-runtime.md.
+    Feature::Floats,
+    Feature::Sequences,
+    Feature::Maps,
+    Feature::ShortCircuit,
+    Feature::StringInterpolation,
 ];
 
 impl Backend for PythonBackend {
@@ -314,5 +322,63 @@ mod tests {
         let a = compile(&module).expect("compile");
         let b = compile(&module).expect("compile again");
         assert_eq!(a.source, b.source);
+    }
+
+    // ── SIR16 expression features: Ruby → native Python ─────────────
+
+    #[test]
+    fn end_to_end_ruby_array_literal() {
+        // `[10, 20, 30]` → native Python list literal.  (Native `SeqIndex`
+        // emission `x[i]` is exercised by the case/in pattern test below.)
+        let module =
+            ruby_to_semantic_ir::compile_source("x = [10, 20, 30]\nputs(x)\n", "demo")
+                .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(a.source.contains("[10, 20, 30]"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn end_to_end_ruby_hash_literal() {
+        // `{a: 1}` → native dict keyed by an interned symbol.
+        let module =
+            ruby_to_semantic_ir::compile_source("puts({a: 1})\n", "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("{_sir_intern(\"a\"): 1}"),
+            "expected a dict keyed by an interned symbol; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_short_circuit_is_lazy_and_truthy() {
+        // A `case/in` array pattern desugars to `LogicalAnd`-chained
+        // checks (`len(x) == 2 && x[0] == 7`), which emit as a
+        // truthy-guarded lambda (lazy rhs, SIR truthiness) — never a
+        // bare Python `and`.
+        let module = ruby_to_semantic_ir::compile_source(
+            "x = [7, 8]\ncase x\nin [7, b]\n  puts(b)\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("lambda __l:") && a.source.contains("_sir_truthy(__l)"),
+            "expected truthy-guarded lambda for &&; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_string_interpolation() {
+        // `"v=#{x}"` → display-joined parts.
+        let module = ruby_to_semantic_ir::compile_source("x = 5\nputs(\"v=#{x}\")\n", "demo")
+            .expect("lower ruby");
+        let a = compile(&module).expect("compile to python");
+        assert!(
+            a.source.contains("_sir_to_display("),
+            "expected interpolation via _sir_to_display; got:\n{}",
+            a.source
+        );
     }
 }

--- a/code/packages/rust/semantic-ir-to-python/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/runtime.rs
@@ -36,6 +36,7 @@ from coding_adventures_sir_runtime_core import (
     is_number as _sir_is_number,
     is_symbol as _sir_is_symbol,
     sir_print as _sir_print,
+    to_display as _sir_to_display,
 )
 "##;
 
@@ -84,6 +85,7 @@ mod tests {
             "is_number as _sir_is_number",
             "is_symbol as _sir_is_symbol",
             "sir_print as _sir_print",
+            "to_display as _sir_to_display",
         ] {
             assert!(RUNTIME.contains(alias), "runtime missing alias `{}`", alias);
         }


### PR DESCRIPTION
## What

The `semantic-ir-to-python` backend now **accepts and natively emits** the SIR16
expression features the Ruby frontend produces (per
[`code/specs/sir-runtime.md`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/sir-runtime.md)):

| SIR node | Native Python |
|---|---|
| `FloatLit` | float literal (`3.14`) |
| `SeqLit` / `SeqIndex` / `SeqLen` | `[...]` / `s[i]` / `len(s)` |
| `MapLit` / `MapGet` | `{...}` / `m[k]` |
| `LogicalAnd` / `LogicalOr` | **truthy-guarded lambda** (see below) |
| `StrConcat` | parts joined via `_sir_to_display` |

`ACCEPTED_FEATURES += Floats, Sequences, Maps, ShortCircuit, StringInterpolation`.

### The short-circuit detail

`LogicalAnd`/`LogicalOr` (emitted by `case/in` pattern desugaring) become
`(lambda __l: (rhs) if _sir_truthy(__l) else __l)(lhs)` — the rhs stays **lazy**
*and* the test uses **SIR truthiness** (only `False`/`nil` are falsy, unlike
Python's native `bool()`), so we never emit a bare `and`/`or`.

## Verification

- `cargo test -p semantic-ir-to-python`: 27 tests pass, incl. new Ruby→Python E2E
  tests for array literal, hash literal, pattern short-circuit (asserts the lazy
  truthy lambda), and interpolation.
- Security review: passed (all leaves route through the existing escaped emitters;
  no raw user-data interpolation).

The TypeScript counterpart lands as a follow-up (it needs widening the TS core
`Val` union to include sequences/maps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
