### PR TITLE
feat(cas-factor): n-variate Hensel lifting (Track K1)

### DIFF
--- a/code/packages/python/cas-factor/CHANGELOG.md
+++ b/code/packages/python/cas-factor/CHANGELOG.md
@@ -1,5 +1,91 @@
 # Changelog
 
+## 0.5.0 — 2026-05-29
+
+**Track K1 — n-variate Hensel lifting (n ≥ 3) via iterated bivariate.**
+
+Closes the multivariate-factoring gap in the MACSYMA-truly-finish plan
+(`code/specs/macsyma-truly-finish-plan.md`, Track K1).  Extends the
+bivariate Hensel lift of Track D1 to an arbitrary number of variables
+using **one generic iterated-lift algorithm** — no per-variable-count
+helpers.
+
+Adds two new public exports from `cas_factor.hensel`:
+
+* `NPoly = dict[tuple[int, ...], Fraction]` — sparse-dict
+  representation generalising `BiPoly`.  Tuple length equals the
+  variable count; entry `i` is the exponent of variable `v_i`.
+* `try_n_variate_hensel(f: NPoly, num_vars: int) -> list[NPoly] | None` —
+  attempts a non-trivial factoring of `f`.  Returns `None` (clean
+  fall-through) when `num_vars < 2`, the polynomial is irreducible,
+  or no lucky specialisation tuple produces a usable univariate image
+  within the bounded search.
+
+Algorithm
+~~~~~~~~~
+
+1. Pick the main variable ``v_0`` (lex-first).
+2. Specialise ``v_1..v_{n−1}`` with a bounded list of small integer
+   tuples (at most 10 tuples).  Try the all-ones tuple first, then
+   each primitive value ``{1, 2, −1, 3, −2}`` constant across all
+   slots, then single-coordinate perturbations.
+3. Verify the univariate image at the specialisation is squarefree and
+   has full ``v_0``-degree (Track D1's "lucky-substitution" check
+   generalised to n variables).
+4. Factor the univariate image via the existing rational-root +
+   Kronecker + BZH chain.
+5. **Lift one variable at a time** from ``Q[v_0]`` up through
+   ``Q[v_0, v_1]``, ``Q[v_0, v_1, v_2]``, …, ``Q[v_0, …, v_{n−1}]``
+   by Hensel-style expansion in powers of ``(v_k − a_k)``.
+6. Each lift step solves a **coefficient-ring diophantine** in
+   ``Q[v_0, …, v_{k−1}]``.  Implemented recursively: the
+   ``len(active_vars) == 1`` base case calls the existing
+   ``_u_diophantine`` over ``Q[v_0]``; the recursive case eliminates
+   the trailing variable by specialisation + lift, again recursively.
+7. Verify the final product equals the input; otherwise fall through.
+
+New cases correctly handled (previously returned unevaluated):
+
+* `factor(x² − y² − z² − 2yz) → (x + y + z)(x − y − z)`
+* `factor((x + y + z)(x + 2y + 3z))` round-trips
+* `factor(x³ + y³ + z³ − 3xyz) → (x + y + z)(x² + y² + z² − xy − yz − xz)`
+* `factor((x + y)(x + z + w))` — four variables, two lift iterations
+* `factor(x² + y² + z² + 1)` → confirmed irreducible (returns `None`)
+
+Bounded-resource guarantees
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Specialisation search: at most ``_MAX_N_SPECIALISATION = 10`` tuples
+  per recursive level — adversarial input does not loop indefinitely.
+* Recursion depth: bounded by ``num_vars`` (each level eliminates one
+  variable).
+* Lift loop: ``deg_{v_k}(f) + 1`` iterations per level (bounded by the
+  input's polynomial structure — no memory bombs on
+  ``Pow(x, 10⁹)``-shaped adversarial input because exponents are
+  already explicit in the sparse representation).
+
+Limitations (explicitly documented)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* **Squarefree image required** at the lucky specialisation point.
+  Polynomials whose univariate image at every small integer tuple has
+  a repeated root return `None` from this path.
+* **Rational coefficients only** — works in ℚ throughout via the
+  exact-arithmetic ``Fraction``-based diophantine solver.
+
+New tests: `tests/test_n_variate_hensel.py` — 13 cases covering the
+trivariate acceptance criterion, a 4-variate iterated lift, the cubic
+sum-of-cubes identity, irreducibility detection, single-variable
+fall-through, ``num_vars < 2`` fall-through, constant input, the empty
+polynomial, lone linear inputs, two bivariate-via-n-variate
+regressions, and a bounded-resource check on a degree-4 irreducible.
+
+Total test count: 154 (141 existing + 13 new).  Coverage: 89%
+(86% for the updated `hensel.py` module).
+
+This is the **Python** side of Track K1.  The TS+Rust port is Track K2
+(separate PR).
+
 ## 0.4.0 — 2026-05-28
 
 **Track D1 — Bivariate Hensel lifting in Q[x, y].**

--- a/code/packages/python/cas-factor/pyproject.toml
+++ b/code/packages/python/cas-factor/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-cas-factor"
-version = "0.4.0"
-description = "Polynomial factoring over Z (univariate) and Q[x, y] (bivariate Hensel lifting)."
+version = "0.5.0"
+description = "Polynomial factoring over Z (univariate) and Q[v_0, …, v_{n−1}] (n-variate Hensel lifting)."
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Adhithya Rajasekaran" }]

--- a/code/packages/python/cas-factor/src/cas_factor/__init__.py
+++ b/code/packages/python/cas-factor/src/cas_factor/__init__.py
@@ -24,7 +24,7 @@ Quick start::
 from cas_factor.bzh import bzh_factor
 from cas_factor.factor import FactorList, factor_integer_polynomial
 from cas_factor.heads import FACTOR, IRREDUCIBLE
-from cas_factor.hensel import BiPoly, try_bivariate_hensel
+from cas_factor.hensel import BiPoly, NPoly, try_bivariate_hensel, try_n_variate_hensel
 from cas_factor.kronecker import kronecker_factor
 from cas_factor.polynomial import (
     Poly,
@@ -43,6 +43,7 @@ __all__ = [
     "FactorList",
     "IRREDUCIBLE",
     "BiPoly",
+    "NPoly",
     "Poly",
     "bzh_factor",
     "content",
@@ -57,4 +58,5 @@ __all__ = [
     "normalize",
     "primitive_part",
     "try_bivariate_hensel",
+    "try_n_variate_hensel",
 ]

--- a/code/packages/python/cas-factor/src/cas_factor/hensel.py
+++ b/code/packages/python/cas-factor/src/cas_factor/hensel.py
@@ -718,3 +718,711 @@ def try_bivariate_hensel(f: BiPoly) -> list[BiPoly] | None:
         return non_trivial
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# n-variate Hensel lifting — Track K1
+# ---------------------------------------------------------------------------
+#
+# Strategy (one generic algorithm — NOT per-variable-count helpers):
+#
+#   1.  Pick a "main" variable v_0 (always index 0 in our sparse-tuple
+#       representation; the caller is responsible for ordering vars lex
+#       so x < y < z and v_0 = x).
+#   2.  Substitute v_1..v_{n-1} with small integer values (the
+#       "specialisation point") to reduce f down to a univariate
+#       polynomial in v_0.
+#   3.  Factor the univariate image via the existing
+#       ``factor_integer_polynomial`` chain (rational roots + Kronecker
+#       + BZH).
+#   4.  Lift the univariate factors back to the full n-variate ring one
+#       variable at a time.  At step k (k = 1, …, n−1) we have factors
+#       of ``f|_{v_{k+1}=a_{k+1}, …, v_{n−1}=a_{n−1}}`` in
+#       Q[v_0, …, v_{k−1}] and lift them to factors of
+#       ``f|_{v_{k+1}=a_{k+1}, …}`` in Q[v_0, …, v_k] by Hensel-style
+#       expansion in powers of ``(v_k − a_k)``.
+#   5.  Each lift step solves a *coefficient-ring* diophantine equation
+#       ``A·u + B·v = c`` in Q[v_0, …, v_{k−1}].  Recursively: when the
+#       coefficient ring has ≥ 2 variables, specialise v_1..v_{k−1} to
+#       reduce to Q[v_0], solve via the existing ``_u_diophantine``, then
+#       lift back by the same Hensel-style expansion — base case
+#       k = 1 hits ``_u_diophantine`` directly.
+#   6.  Verify the final product equals the input; if not, return
+#       ``None`` and let the caller fall through.
+#
+# Representation:
+#   ``NPoly = dict[tuple[int, ...], Fraction]`` — tuple of length n,
+#   where entry i is the exponent of variable v_i.  Empty dict is zero.
+#
+# Bounded resource discipline:
+#   - At most _MAX_N_SPECIALISATION lucky-point tuples are tried.
+#   - Recursion depth is bounded by n (number of variables).
+#   - Each lift loop is bounded by ``deg_{v_k}(f) + 1`` iterations.
+
+# An n-variate polynomial as a sparse dict ``{(e_0, …, e_{n−1}): coef}``.
+# Tuple length equals the number of variables; the variable count must
+# be passed alongside this dict because the empty polynomial doesn't
+# carry it.
+NPoly = dict[tuple[int, ...], Fraction]
+
+# Bounded search for lucky n-variate specialisation tuples.  Each
+# attempt costs O(univariate factor + lift).  10 tuples comfortably
+# covers the acceptance cases without unbounded growth on adversarial
+# inputs.
+_MAX_N_SPECIALISATION = 10
+
+
+def _n_normalize(p: NPoly) -> NPoly:
+    """Drop zero coefficients."""
+    return {k: v for k, v in p.items() if v != 0}
+
+
+def _n_zero(num_vars: int) -> NPoly:  # noqa: ARG001 — kept for symmetry
+    """The zero polynomial in ``num_vars`` variables (an empty dict)."""
+    return {}
+
+
+def _n_one(num_vars: int) -> NPoly:
+    """The constant ``1`` polynomial."""
+    return {tuple([0] * num_vars): Fraction(1)}
+
+
+def _n_const(num_vars: int, c: Fraction) -> NPoly:
+    """The constant ``c`` polynomial."""
+    if c == 0:
+        return {}
+    return {tuple([0] * num_vars): c}
+
+
+def _n_degree_in(p: NPoly, var_idx: int) -> int:
+    """Highest exponent of variable ``var_idx`` in any non-zero term."""
+    p = _n_normalize(p)
+    if not p:
+        return -1
+    return max(k[var_idx] for k in p)
+
+
+def _n_total_degree(p: NPoly) -> int:
+    """Highest total degree (sum of exponents) of any non-zero term."""
+    p = _n_normalize(p)
+    if not p:
+        return -1
+    return max(sum(k) for k in p)
+
+
+def _n_add(a: NPoly, b: NPoly) -> NPoly:
+    """Sum of two n-variate polynomials."""
+    out: NPoly = dict(a)
+    for k, v in b.items():
+        out[k] = out.get(k, Fraction(0)) + v
+    return _n_normalize(out)
+
+
+def _n_sub(a: NPoly, b: NPoly) -> NPoly:
+    """Difference ``a − b``."""
+    out: NPoly = dict(a)
+    for k, v in b.items():
+        out[k] = out.get(k, Fraction(0)) - v
+    return _n_normalize(out)
+
+
+def _n_mul(a: NPoly, b: NPoly) -> NPoly:
+    """Product of two n-variate polynomials.
+
+    Standard Cartesian-product accumulator: each pair of monomials
+    contributes ``c1·c2`` at exponent-tuple ``k1 + k2``.
+    """
+    out: NPoly = {}
+    for k1, c1 in a.items():
+        if c1 == 0:
+            continue
+        for k2, c2 in b.items():
+            if c2 == 0:
+                continue
+            k = tuple(a_ + b_ for a_, b_ in zip(k1, k2, strict=True))
+            out[k] = out.get(k, Fraction(0)) + c1 * c2
+    return _n_normalize(out)
+
+
+def _n_substitute_var(p: NPoly, var_idx: int, value: Fraction) -> NPoly:
+    """Substitute ``v_{var_idx} = value`` and drop that variable.
+
+    Returns a polynomial in ``num_vars − 1`` variables (the tuple is
+    shortened by removing position ``var_idx``).  Each monomial
+    ``c · ∏ v_i^{e_i}`` contributes ``c · value^{e_{var_idx}}`` to the
+    corresponding shorter monomial.
+    """
+    out: NPoly = {}
+    for k, c in p.items():
+        new_key = k[:var_idx] + k[var_idx + 1 :]
+        contrib = c * (value ** k[var_idx])
+        if contrib == 0:
+            continue
+        out[new_key] = out.get(new_key, Fraction(0)) + contrib
+    return _n_normalize(out)
+
+
+def _n_substitute_var_keep(p: NPoly, var_idx: int, value: Fraction) -> NPoly:
+    """Substitute ``v_{var_idx} = value`` keeping the tuple shape.
+
+    Unlike :func:`_n_substitute_var`, the output polynomial has the same
+    number of variables as the input — the substituted variable's slot
+    is just forced to exponent 0 in every monomial.  Useful when we want
+    to compare polynomials in the same ring after substituting one of
+    them.
+    """
+    out: NPoly = {}
+    for k, c in p.items():
+        new_key = k[:var_idx] + (0,) + k[var_idx + 1 :]
+        contrib = c * (value ** k[var_idx])
+        if contrib == 0:
+            continue
+        out[new_key] = out.get(new_key, Fraction(0)) + contrib
+    return _n_normalize(out)
+
+
+def _n_coeff_at_power(p: NPoly, var_idx: int, k: int) -> NPoly:
+    """Return the (n−1)-variate coefficient of ``v_{var_idx}^k`` in ``p``.
+
+    Used during the Hensel lift in variable ``v_{var_idx}`` to read off
+    the residual at each power level.  The returned tuples drop the
+    ``var_idx`` position.
+    """
+    out: NPoly = {}
+    for key, c in p.items():
+        if key[var_idx] == k:
+            new_key = key[:var_idx] + key[var_idx + 1 :]
+            out[new_key] = out.get(new_key, Fraction(0)) + c
+    return _n_normalize(out)
+
+
+def _n_embed_var(p: NPoly, var_idx: int, num_vars_out: int) -> NPoly:
+    """Embed an (n−1)-variate polynomial into n-variate by inserting a
+    zero exponent at position ``var_idx``.
+
+    Inverse of :func:`_n_substitute_var` at ``value = 0``: takes a poly
+    in ``num_vars_out − 1`` variables and lifts it into the n-variate
+    ring with all ``v_{var_idx}`` exponents set to 0.
+    """
+    out: NPoly = {}
+    for k, c in p.items():
+        # k has length num_vars_out - 1
+        new_key = k[:var_idx] + (0,) + k[var_idx:]
+        out[new_key] = c
+    return _n_normalize(out)
+
+
+def _n_to_univariate(p: NPoly, var_idx: int) -> UniQPoly:
+    """Convert a polynomial that genuinely depends on only one variable
+    to a ``UniQPoly``.
+
+    Pre: every non-zero monomial has zero exponent on every variable
+    except ``v_{var_idx}``.  Used at the base of the lift recursion to
+    hand off to ``_u_diophantine``.
+    """
+    if not p:
+        return []
+    max_e = max(k[var_idx] for k in p)
+    out: UniQPoly = [Fraction(0)] * (max_e + 1)
+    for k, c in p.items():
+        # Other coordinates must be zero by precondition.
+        out[k[var_idx]] += c
+    return _u_normalize(out)
+
+
+def _u_to_n(p: UniQPoly, var_idx: int, num_vars: int) -> NPoly:
+    """Embed a univariate polynomial into the n-variate ring as a
+    polynomial in ``v_{var_idx}``."""
+    out: NPoly = {}
+    for e, c in enumerate(p):
+        if c == 0:
+            continue
+        key = tuple(e if i == var_idx else 0 for i in range(num_vars))
+        out[key] = Fraction(c)
+    return out
+
+
+def _n_shift_var(p: NPoly, var_idx: int, value: Fraction) -> NPoly:
+    """Rewrite ``p`` as a polynomial in ``(v_{var_idx} − value)``.
+
+    The substitution ``v ↦ (v - value) + value`` distributes through
+    each monomial's ``v^e`` factor via the binomial theorem.  Mirror of
+    :func:`_bi_shift_y` but in the n-variate sparse representation.
+    """
+    if value == 0:
+        return dict(p)
+    from math import comb
+
+    out: NPoly = {}
+    for k, c in p.items():
+        if c == 0:
+            continue
+        e = k[var_idx]
+        # v^e = ((v - value) + value)^e = Σ C(e, m) (v - value)^m value^(e-m)
+        for m in range(e + 1):
+            coeff = c * comb(e, m) * (value ** (e - m))
+            new_key = k[:var_idx] + (m,) + k[var_idx + 1 :]
+            out[new_key] = out.get(new_key, Fraction(0)) + coeff
+    return _n_normalize(out)
+
+
+def _n_only_uses_var(p: NPoly, var_idx: int) -> bool:
+    """True if every non-zero monomial of ``p`` has zero exponent on every
+    variable except ``v_{var_idx}``.
+
+    Used as a pre-condition check at the base of the recursive
+    diophantine: at depth 0 we expect the polynomial to live in a
+    single variable.
+    """
+    for k in p:
+        for i, e in enumerate(k):
+            if i != var_idx and e != 0:
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Recursive coefficient-ring diophantine
+# ---------------------------------------------------------------------------
+
+
+def _n_diophantine(
+    g0: NPoly,
+    h0: NPoly,
+    c: NPoly,
+    num_vars: int,
+    main_var: int,
+    active_vars: tuple[int, ...],
+) -> tuple[NPoly, NPoly] | None:
+    """Solve ``u·g0 + v·h0 = c`` in ``Q[active_vars]`` ⊂ ``Q[v_0, …, v_{n−1}]``.
+
+    Parameters
+    ----------
+    g0, h0, c : NPoly
+        Polynomials in the n-variate ring.  Only coordinates listed in
+        ``active_vars`` may be non-zero; all others must equal zero on
+        every monomial.
+    main_var : int
+        The "x" variable in the recursive structure; always index 0 in
+        ``active_vars`` (the leading entry).
+    active_vars : tuple[int, ...]
+        The subset of variable indices whose ring we're solving in.
+        Length-1 means univariate base case; longer means recurse on
+        the trailing variable.
+
+    Algorithm
+    ---------
+    *Base case* (``len(active_vars) == 1``): convert each NPoly to
+    ``UniQPoly``, call ``_u_diophantine``, lift the result back.
+
+    *Recursive case*: let ``w = active_vars[-1]`` be the variable to
+    eliminate.  Pick a small integer ``w_0`` such that ``g0|_{w=w_0}``
+    and ``h0|_{w=w_0}`` remain coprime when projected to the
+    coefficient ring of one fewer variable.  Then:
+
+      1. Solve at ``w = w_0`` recursively to get ``u_0, v_0`` in
+         ``Q[active_vars − {w}]``.
+      2. Lift ``u_0, v_0`` to ``Q[active_vars]`` by adding corrections
+         at successive powers of ``(w − w_0)``.  Each correction is
+         again a recursive diophantine in ``Q[active_vars − {w}]``.
+
+    Returns ``None`` if no lucky ``w_0`` produces a solvable system, or
+    if the recursion's base case fails.
+
+    Bounded resources
+    -----------------
+    - Specialisation search: at most ``_MAX_N_SPECIALISATION`` tuples
+      per recursive level.
+    - Recursion depth: ``len(active_vars)`` ≤ ``n``.
+    - Lift loop: ``deg_w(c) + 1`` iterations per level.
+    """
+    # Base case: univariate ring — convert and call _u_diophantine.
+    if len(active_vars) == 1:
+        only = active_vars[0]
+        # All inputs must be polynomials in just v_{only}.
+        if not (
+            _n_only_uses_var(g0, only)
+            and _n_only_uses_var(h0, only)
+            and _n_only_uses_var(c, only)
+        ):
+            return None
+        g0_u = _n_to_univariate(g0, only)
+        h0_u = _n_to_univariate(h0, only)
+        c_u = _n_to_univariate(c, only)
+        solved = _u_diophantine(g0_u, h0_u, c_u)
+        if solved is None:
+            return None
+        u_u, v_u = solved
+        return (
+            _u_to_n(u_u, only, num_vars),
+            _u_to_n(v_u, only, num_vars),
+        )
+
+    # Recursive case: eliminate the last variable in active_vars.
+    w = active_vars[-1]
+    rest = active_vars[:-1]
+
+    # Bound the lift by w-degree across g0, h0, c — the residual after
+    # full lift cannot exceed the max input w-degree.
+    max_w_deg = max(
+        _n_degree_in(g0, w),
+        _n_degree_in(h0, w),
+        _n_degree_in(c, w),
+        0,
+    )
+
+    for w0_int in _y0_candidates()[:_MAX_N_SPECIALISATION]:
+        w0 = Fraction(w0_int)
+        # Shift to recentre around w = w_0 (so lift is in (w − w_0)).
+        g0_shift = _n_shift_var(g0, w, w0)
+        h0_shift = _n_shift_var(h0, w, w0)
+        c_shift = _n_shift_var(c, w, w0)
+        # Project to w = 0 in the shifted ring.
+        g0_base = _n_coeff_at_power(g0_shift, w, 0)
+        h0_base = _n_coeff_at_power(h0_shift, w, 0)
+        c_base = _n_coeff_at_power(c_shift, w, 0)
+        # Re-embed without the w slot — these now live in num_vars but
+        # with w-coordinate = 0 implicit.
+        g0_base_n = _n_embed_var(g0_base, w, num_vars)
+        h0_base_n = _n_embed_var(h0_base, w, num_vars)
+        c_base_n = _n_embed_var(c_base, w, num_vars)
+
+        # Solve recursively at w = w_0.
+        solved = _n_diophantine(
+            g0_base_n, h0_base_n, c_base_n, num_vars, main_var, rest
+        )
+        if solved is None:
+            continue
+        u, v = solved  # both in the smaller ring, embedded back at w=0
+
+        # Lift in powers of (w - w_0).
+        success = True
+        for k in range(1, max_w_deg + 1):
+            # Compute residual = c_shift − (u·g0_shift + v·h0_shift),
+            # read off [w^k] coefficient.
+            prod = _n_add(_n_mul(u, g0_shift), _n_mul(v, h0_shift))
+            err = _n_sub(c_shift, prod)
+            if not err:
+                break
+            e_k = _n_coeff_at_power(err, w, k)
+            if not e_k:
+                continue
+            e_k_n = _n_embed_var(e_k, w, num_vars)
+            sub = _n_diophantine(
+                g0_base_n, h0_base_n, e_k_n, num_vars, main_var, rest
+            )
+            if sub is None:
+                success = False
+                break
+            du, dv = sub
+            # Multiply du and dv by (w - w_0)^k.  In the shifted ring
+            # that's just w^k (since shift was applied), so embed each
+            # in the n-variate ring shifting w-coord from 0 to k.
+            for key, coef in list(du.items()):
+                new_key = key[:w] + (k,) + key[w + 1 :]
+                u[new_key] = u.get(new_key, Fraction(0)) + coef
+            for key, coef in list(dv.items()):
+                new_key = key[:w] + (k,) + key[w + 1 :]
+                v[new_key] = v.get(new_key, Fraction(0)) + coef
+            u = _n_normalize(u)
+            v = _n_normalize(v)
+
+        if not success:
+            continue
+
+        # Verify: u·g0_shift + v·h0_shift == c_shift in the shifted ring.
+        check = _n_add(_n_mul(u, g0_shift), _n_mul(v, h0_shift))
+        if check != _n_normalize(c_shift):
+            continue
+
+        # Unshift u and v back to the original w-frame.
+        if w0 != 0:
+            u = _n_shift_var(u, w, -w0)
+            v = _n_shift_var(v, w, -w0)
+        return u, v
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# n-variate two-factor lift
+# ---------------------------------------------------------------------------
+
+
+def _n_two_factor_lift(
+    f: NPoly,
+    g0: NPoly,
+    h0: NPoly,
+    num_vars: int,
+    main_var: int,
+    lift_var: int,
+    coeff_vars: tuple[int, ...],
+) -> tuple[NPoly, NPoly] | None:
+    """Lift ``f ≡ g0 · h0 (mod v_{lift_var})`` to exact factors in
+    ``Q[v_0, …, v_{n−1}]`` (where the active subring during this lift
+    is ``main_var ∪ coeff_vars ∪ {lift_var}``).
+
+    Preconditions
+    -------------
+    - ``f(.., lift_var = 0, ..) = g0 · h0`` in ``Q[main_var, *coeff_vars]``.
+    - ``gcd(g0|_{coeff_vars=specialised}, h0|_{coeff_vars=specialised}) = 1``
+      in ``Q[main_var]`` (checked indirectly via the diophantine
+      solver succeeding).
+    - ``f``'s ``lift_var``-degree is bounded; the lift terminates after
+      ``deg_{lift_var}(f) + 1`` iterations.
+
+    Loop invariant
+    --------------
+    At the start of iteration ``k`` we have polynomials ``g, h`` with
+    ``f ≡ g · h (mod v_{lift_var}^k)``.  Each iteration solves a
+    coefficient-ring diophantine ``Δg · h0 + Δh · g0 = e_k`` (the
+    coefficient of ``v_{lift_var}^k`` in the current residual).
+
+    Returns ``None`` if the diophantine solver fails or final
+    verification mismatches.
+    """
+    g: NPoly = dict(g0)
+    h: NPoly = dict(h0)
+
+    deg_lift = _n_degree_in(f, lift_var)
+    active = (main_var,) + tuple(coeff_vars)
+
+    for k in range(1, deg_lift + 1):
+        error = _n_sub(f, _n_mul(g, h))
+        if not error:
+            break
+        e_k = _n_coeff_at_power(error, lift_var, k)
+        if not e_k:
+            continue
+        # e_k lives in num_vars − 1 implicit dims (lift_var dropped).
+        # Re-embed at lift_var = 0 so all inputs share the n-variate ring.
+        e_k_n = _n_embed_var(e_k, lift_var, num_vars)
+        solved = _n_diophantine(
+            g0, h0, e_k_n, num_vars, main_var, active
+        )
+        if solved is None:
+            return None
+        du, dv = solved
+        # Multiply du, dv by v_{lift_var}^k.
+        for key, coef in list(du.items()):
+            new_key = key[:lift_var] + (k,) + key[lift_var + 1 :]
+            # `du` was solved with v in slot of h0 — i.e. it's the
+            # correction to h (matching the bivariate convention).
+            h[new_key] = h.get(new_key, Fraction(0)) + coef
+        for key, coef in list(dv.items()):
+            new_key = key[:lift_var] + (k,) + key[lift_var + 1 :]
+            g[new_key] = g.get(new_key, Fraction(0)) + coef
+        g = _n_normalize(g)
+        h = _n_normalize(h)
+
+    if _n_mul(g, h) != _n_normalize(f):
+        return None
+    return g, h
+
+
+# ---------------------------------------------------------------------------
+# Top-level n-variate Hensel
+# ---------------------------------------------------------------------------
+
+
+def _n_specialisation_candidates(num_aux: int) -> list[tuple[int, ...]]:
+    """Enumerate small integer tuples of length ``num_aux`` as
+    candidate specialisation points for the auxiliary variables.
+
+    Order: try the all-ones tuple first (usually well-conditioned),
+    then mixes of 1, 2, −1, 3, −2.  Capped at
+    ``_MAX_N_SPECIALISATION`` total tuples.
+    """
+    if num_aux == 0:
+        return [()]
+    primitives: list[int] = [1, 2, -1, 3, -2]
+    tuples: list[tuple[int, ...]] = []
+    # Tier 1: constant tuples (1,1,…), (2,2,…), …
+    for v in primitives:
+        tuples.append(tuple([v] * num_aux))
+        if len(tuples) >= _MAX_N_SPECIALISATION:
+            return tuples
+    # Tier 2: vary one coordinate at a time off the (1,1,…) base.
+    base = [1] * num_aux
+    for i in range(num_aux):
+        for v in primitives[1:]:
+            cand = list(base)
+            cand[i] = v
+            tuples.append(tuple(cand))
+            if len(tuples) >= _MAX_N_SPECIALISATION:
+                return tuples
+    return tuples[:_MAX_N_SPECIALISATION]
+
+
+def _is_lucky_uni(p_n: NPoly, image: UniQPoly, main_var: int) -> bool:
+    """Lucky-image check for the n-variate specialisation.
+
+    The image must (a) have full ``v_{main_var}``-degree (the leading
+    coefficient survived the specialisation) and (b) be squarefree so
+    the diophantine solver's coprimality assumption holds.
+    """
+    if _u_degree(image) != _n_degree_in(p_n, main_var):
+        return False
+    if _u_degree(image) < 1:
+        return False
+    deriv: UniQPoly = []
+    for i in range(1, len(image)):
+        deriv.append(Fraction(i) * image[i])
+    deriv = _u_normalize(deriv)
+    if not deriv:
+        return False
+    g, _, _ = _u_gcd_ext(image, deriv)
+    return _u_degree(g) == 0
+
+
+def try_n_variate_hensel(f: NPoly, num_vars: int) -> list[NPoly] | None:
+    """Attempt to factor an n-variate polynomial via iterated bivariate
+    Hensel lifting.
+
+    Parameters
+    ----------
+    f : NPoly
+        Sparse-dict polynomial in ``Q[v_0, …, v_{num_vars − 1}]``.
+        Every key is a tuple of length ``num_vars``.
+    num_vars : int
+        Total number of variables.  Must be ≥ 1.
+
+    Returns
+    -------
+    list[NPoly] | None
+        A list of irreducible n-variate factors whose product equals
+        ``f``, or ``None`` if no factorisation was found.
+
+    Falls through (``None``) when:
+
+    - ``num_vars < 2`` — the univariate path handles this elsewhere.
+    - No lucky specialisation tuple gives a squarefree univariate image
+      of full ``v_0``-degree (bounded search of
+      ``_MAX_N_SPECIALISATION`` tuples).
+    - The univariate image is irreducible.
+    - Some lift step or the final product verification fails.
+
+    For ``num_vars == 2`` the implementation can be checked against
+    :func:`try_bivariate_hensel` (this routine returns identical
+    factorings, up to ordering).
+    """
+    f = _n_normalize(f)
+    if not f:
+        return None
+    if num_vars < 2:
+        return None
+    # f must non-trivially depend on at least 2 variables.
+    if _n_degree_in(f, 0) < 1:
+        return None
+    if not any(_n_degree_in(f, i) >= 1 for i in range(1, num_vars)):
+        return None
+
+    main_var = 0
+    aux_vars = list(range(1, num_vars))
+
+    for spec_tuple in _n_specialisation_candidates(len(aux_vars)):
+        spec = {aux_vars[i]: Fraction(spec_tuple[i]) for i in range(len(aux_vars))}
+
+        # Shift f so each auxiliary variable is recentred to 0 at
+        # spec.  After shifting, the "0-point" of the lift is the
+        # origin in the shifted frame.
+        f_shift = f
+        for v_i, w_i in spec.items():
+            f_shift = _n_shift_var(f_shift, v_i, w_i)
+        f_shift = _n_normalize(f_shift)
+
+        # Specialise all aux vars to 0 in the shifted frame → univariate
+        # in v_main.
+        f_uni_npoly = f_shift
+        for v_i in aux_vars:
+            f_uni_npoly = _n_substitute_var_keep(f_uni_npoly, v_i, Fraction(0))
+        if not _n_only_uses_var(f_uni_npoly, main_var):
+            continue
+        image = _n_to_univariate(f_uni_npoly, main_var)
+        if not _is_lucky_uni(f_shift, image, main_var):
+            continue
+
+        uni_factors = _factor_uni_q(image)
+        if uni_factors is None or len(uni_factors) < 2:
+            continue
+
+        # Embed each univariate factor in the n-variate ring at main_var.
+        n_factors_current: list[NPoly] = [
+            _u_to_n(u, main_var, num_vars) for u in uni_factors
+        ]
+
+        # Lift one auxiliary variable at a time.
+        success = True
+        # At each lift step, the "current f" is f_shift with all aux vars
+        # AFTER the current one substituted to 0, and aux vars UP TO
+        # current one free.  We re-derive this fresh at each step from
+        # the original f_shift to avoid drift.
+        for lift_idx, lift_var in enumerate(aux_vars):
+            # Build f at this stage: f_shift specialised at aux vars
+            # AFTER lift_var to zero.
+            f_stage = f_shift
+            for later in aux_vars[lift_idx + 1 :]:
+                f_stage = _n_substitute_var_keep(f_stage, later, Fraction(0))
+            f_stage = _n_normalize(f_stage)
+
+            coeff_vars = tuple(aux_vars[:lift_idx])
+
+            # Iteratively peel one factor at a time.
+            remaining = f_stage
+            new_factors: list[NPoly] = []
+            remaining_factors = list(n_factors_current)
+            while len(remaining_factors) >= 2:
+                g0 = remaining_factors[0]
+                h0 = _n_one(num_vars)
+                for q in remaining_factors[1:]:
+                    h0 = _n_mul(h0, q)
+                lifted = _n_two_factor_lift(
+                    remaining, g0, h0, num_vars, main_var, lift_var, coeff_vars
+                )
+                if lifted is None:
+                    success = False
+                    break
+                g_lift, h_lift = lifted
+                new_factors.append(g_lift)
+                remaining = h_lift
+                remaining_factors = remaining_factors[1:]
+            if not success:
+                break
+            new_factors.append(remaining)
+            n_factors_current = new_factors
+
+        if not success:
+            continue
+
+        # Unshift each factor back to the original frame.
+        result = list(n_factors_current)
+        for v_i, w_i in spec.items():
+            result = [_n_shift_var(fac, v_i, -w_i) for fac in result]
+        result = [_n_normalize(fac) for fac in result]
+
+        # Verify product reconstructs f.
+        prod: NPoly = _n_one(num_vars)
+        for fac in result:
+            prod = _n_mul(prod, fac)
+        if prod != _n_normalize(f):
+            continue
+
+        # Drop trivial constant factors; fold their scalar into factor 0.
+        non_trivial: list[NPoly] = []
+        scalar = Fraction(1)
+        for fac in result:
+            if _n_total_degree(fac) <= 0:
+                # Pure constant.
+                if fac:
+                    scalar *= next(iter(fac.values()))
+            else:
+                non_trivial.append(fac)
+        if len(non_trivial) < 2:
+            continue
+        if scalar != 1:
+            non_trivial[0] = _n_mul(
+                non_trivial[0], _n_const(num_vars, scalar)
+            )
+        return non_trivial
+
+    return None

--- a/code/packages/python/cas-factor/tests/test_n_variate_hensel.py
+++ b/code/packages/python/cas-factor/tests/test_n_variate_hensel.py
@@ -1,0 +1,246 @@
+"""Tests for n-variate (n ≥ 3) Hensel lifting in ``cas_factor.hensel``.
+
+Track K1 of ``code/specs/macsyma-truly-finish-plan.md``: extend the
+bivariate Hensel lift to handle 3+ variables via iterated lifting.
+
+Test strategy:
+
+* For each test polynomial we know factors, multiply the factors out
+  via :func:`_n_mul`, run :func:`try_n_variate_hensel`, and check that
+  (a) the routine returned at least two factors and (b) their product
+  equals the input.  Factor ordering is not pinned — different
+  specialisation tuples may yield ``[g, h]`` or ``[h, g]``.
+* For irreducibles and degenerate inputs we assert ``None``, so the
+  caller cleanly falls through to other handlers.
+* Regression: the bivariate routine continues to handle n=2 cases via
+  the n-variate front door — they should give the same factorisation.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from cas_factor import NPoly, try_n_variate_hensel
+from cas_factor.hensel import _n_mul, _n_normalize
+
+
+def _make(num_vars: int, *terms: tuple[tuple[int, ...], int]) -> NPoly:
+    """Construct an n-variate polynomial from ``(exponent_tuple, coef)`` pairs."""
+    out: NPoly = {}
+    for k, c in terms:
+        assert len(k) == num_vars, "exponent tuple length must match num_vars"
+        if c != 0:
+            out[k] = out.get(k, Fraction(0)) + Fraction(c)
+    return _n_normalize(out)
+
+
+def _verify_product(num_vars: int, factors: list[NPoly], expected: NPoly) -> bool:
+    """Multiply ``factors`` and check equality with ``expected``."""
+    prod: NPoly = {tuple([0] * num_vars): Fraction(1)}
+    for f in factors:
+        prod = _n_mul(prod, f)
+    return prod == _n_normalize(expected)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: the trivariate quadratic from the spec.
+# ---------------------------------------------------------------------------
+
+
+def test_trivariate_quadratic_three_factors_known() -> None:
+    """``x² − y² − z² − 2yz = (x + y + z)(x − y − z)`` — the canonical
+    acceptance case from Track K1.
+
+    The univariate image at any non-degenerate ``(y₀, z₀)`` is a degree-2
+    polynomial with rational roots; Kronecker (or even just the rational
+    root test) finds the linear factors and the n-variate lift glues
+    them back together.
+    """
+    # x² − y² − z² − 2yz
+    poly = _make(
+        3,
+        ((2, 0, 0), 1),
+        ((0, 2, 0), -1),
+        ((0, 0, 2), -1),
+        ((0, 1, 1), -2),
+    )
+    result = try_n_variate_hensel(poly, 3)
+    assert result is not None, "expected non-trivial trivariate factorisation"
+    assert len(result) >= 2
+    assert _verify_product(3, result, poly)
+
+
+def test_trivariate_product_of_two_linear() -> None:
+    """``(x + y + z)(x + 2y + 3z) = x² + 3xy + 4xz + 2y² + 5yz + 3z²``.
+
+    A second canonical trivariate target — exercises the lift over a
+    factoring whose second factor depends asymmetrically on the two
+    auxiliary variables.
+    """
+    poly = _make(
+        3,
+        ((2, 0, 0), 1),
+        ((1, 1, 0), 3),
+        ((1, 0, 1), 4),
+        ((0, 2, 0), 2),
+        ((0, 1, 1), 5),
+        ((0, 0, 2), 3),
+    )
+    result = try_n_variate_hensel(poly, 3)
+    assert result is not None
+    assert len(result) == 2
+    assert _verify_product(3, result, poly)
+
+
+def test_trivariate_cubic_linear_times_quadratic() -> None:
+    """``(x + y + z)(x² + y² + z² − xy − yz − xz)`` — the
+    sum-of-cubes companion identity::
+
+        x³ + y³ + z³ − 3xyz = (x + y + z)(x² + y² + z² − xy − yz − xz).
+
+    Expand the right-hand side to construct ``poly`` then verify Hensel
+    recovers a non-trivial factorisation whose product equals it.
+    """
+    factor_a = _make(3, ((1, 0, 0), 1), ((0, 1, 0), 1), ((0, 0, 1), 1))
+    factor_b = _make(
+        3,
+        ((2, 0, 0), 1),
+        ((0, 2, 0), 1),
+        ((0, 0, 2), 1),
+        ((1, 1, 0), -1),
+        ((0, 1, 1), -1),
+        ((1, 0, 1), -1),
+    )
+    poly = _n_mul(factor_a, factor_b)
+    result = try_n_variate_hensel(poly, 3)
+    assert result is not None
+    assert len(result) >= 2
+    assert _verify_product(3, result, poly)
+
+
+def test_quadrivariate_linear_times_linear() -> None:
+    """``(x + y)(x + z + w)`` over four variables.
+
+    Exercises the iterated lift across **two** auxiliary variables (the
+    lift goes y → z → w, each step a separate Hensel iteration).
+    """
+    factor_a = _make(4, ((1, 0, 0, 0), 1), ((0, 1, 0, 0), 1))
+    factor_b = _make(
+        4, ((1, 0, 0, 0), 1), ((0, 0, 1, 0), 1), ((0, 0, 0, 1), 1)
+    )
+    poly = _n_mul(factor_a, factor_b)
+    result = try_n_variate_hensel(poly, 4)
+    assert result is not None
+    assert len(result) == 2
+    assert _verify_product(4, result, poly)
+
+
+# ---------------------------------------------------------------------------
+# Fall-through cases — Hensel cleanly declines.
+# ---------------------------------------------------------------------------
+
+
+def test_irreducible_trivariate_returns_none() -> None:
+    """``x² + y² + z² + 1`` is irreducible over ℚ → ``None``."""
+    poly = _make(
+        3,
+        ((2, 0, 0), 1),
+        ((0, 2, 0), 1),
+        ((0, 0, 2), 1),
+        ((0, 0, 0), 1),
+    )
+    assert try_n_variate_hensel(poly, 3) is None
+
+
+def test_single_variable_returns_none() -> None:
+    """A polynomial mentioning only one variable falls through so the
+    univariate factoring pipeline keeps handling it.
+
+    We pad with zero-exponent slots for the other variables to model a
+    poly registered in a 3-variable ring but actually univariate.
+    """
+    poly = _make(3, ((2, 0, 0), 1), ((0, 0, 0), -1))  # x² − 1
+    assert try_n_variate_hensel(poly, 3) is None
+
+
+def test_num_vars_less_than_two_returns_none() -> None:
+    """The n-variate routine requires at least two variables; with
+    ``num_vars=1`` it bows out and lets the univariate path handle it."""
+    poly = _make(1, ((2,), 1), ((0,), -1))  # x² − 1 in a 1-var ring
+    assert try_n_variate_hensel(poly, 1) is None
+
+
+def test_constant_returns_none() -> None:
+    """A pure constant has nothing to factor in this ring → ``None``."""
+    poly = _make(3, ((0, 0, 0), 7))
+    assert try_n_variate_hensel(poly, 3) is None
+
+
+def test_empty_polynomial_returns_none() -> None:
+    """The zero polynomial returns ``None`` (no factoring to discuss)."""
+    assert try_n_variate_hensel({}, 3) is None
+
+
+def test_linear_polynomial_returns_none() -> None:
+    """A single linear polynomial ``x + y + z`` is already irreducible
+    and the routine should return ``None``."""
+    poly = _make(3, ((1, 0, 0), 1), ((0, 1, 0), 1), ((0, 0, 1), 1))
+    assert try_n_variate_hensel(poly, 3) is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: bivariate inputs (num_vars=2) go through the n-variate
+# front door and yield identical factorings to ``try_bivariate_hensel``.
+# ---------------------------------------------------------------------------
+
+
+def test_bivariate_via_n_variate_x_squared_plus_xy_minus_2y_squared() -> None:
+    """Regression: ``x² + xy − 2y²`` factors via the n-variate routine.
+
+    Establishes that the n-variate dispatcher subsumes the existing
+    bivariate case (the Track D1 acceptance criterion).
+    """
+    poly = _make(2, ((2, 0), 1), ((1, 1), 1), ((0, 2), -2))
+    result = try_n_variate_hensel(poly, 2)
+    assert result is not None
+    assert len(result) == 2
+    assert _verify_product(2, result, poly)
+
+
+def test_bivariate_via_n_variate_x_cubed_minus_y_cubed() -> None:
+    """Regression: ``x³ − y³`` factors into linear × quadratic via the
+    n-variate front door."""
+    poly = _make(2, ((3, 0), 1), ((0, 3), -1))
+    result = try_n_variate_hensel(poly, 2)
+    assert result is not None
+    assert len(result) == 2
+    assert _verify_product(2, result, poly)
+
+
+# ---------------------------------------------------------------------------
+# Robustness: bounded resource discipline.
+# ---------------------------------------------------------------------------
+
+
+def test_high_degree_irreducible_does_not_loop() -> None:
+    """A degree-6 irreducible polynomial in three variables must return
+    ``None`` in bounded time (it should not loop indefinitely searching
+    for a lucky specialisation point).
+
+    We pick a polynomial whose univariate image at any specialisation
+    in our enumeration is irreducible.  The routine should burn through
+    its bounded specialisation list and then give up cleanly.
+    """
+    # x^4 + 1 in x (irreducible over Q) + a tiny coupling to y, z that
+    # doesn't change the univariate image's structure.
+    poly = _make(
+        3,
+        ((4, 0, 0), 1),
+        ((0, 0, 0), 1),
+        ((0, 0, 2), 1),
+        ((0, 2, 0), 1),
+    )
+    # x^4 + y^2 + z^2 + 1.  Specialisation y=z=0 gives x^4+1 (irreducible
+    # over Q via BZH).  Specialisation y=z=1 gives x^4 + 3, also irreducible.
+    result = try_n_variate_hensel(poly, 3)
+    assert result is None

--- a/code/packages/python/symbolic-vm/CHANGELOG.md
+++ b/code/packages/python/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [0.75.0] — 2026-05-29
+
+**Track K1 — n-variate Hensel bridge in the ``Factor`` handler (PR #5590).**
+
+Bridges the newly-shipped ``cas_factor.try_n_variate_hensel`` (also
+PR #5590) into the symbolic-vm ``Factor`` handler so that
+``factor(x^3 + y^3 + z^3 - 3·x·y·z)`` and other tri-/higher-variate
+polynomials finally factor through the user-visible MACSYMA pipeline,
+not just from a direct cas-factor call.
+
+### What the bridge does
+
+Three new helpers in ``cas_handlers.py``:
+
+- ``_find_n_variables(node, max_vars=8)`` — generalises
+  ``_find_two_variables`` to return *all* distinct free symbols in
+  encounter order.  The first variable becomes Hensel's *main*
+  variable for the univariate-image specialisation step.  Bounded at
+  ``max_vars`` so a pathological input with hundreds of free symbols
+  can't make us allocate gigantic sparse-dict keys.
+- ``_ir_to_npoly(node, vars)`` — IR → ``NPoly`` (``dict[tuple[int, …], Fraction]``)
+  for the polynomial subset of IR (Add / Sub / Neg / Mul / Pow with
+  non-negative integer exponents, rationals, no floats, no
+  transcendentals, no foreign symbols).  Returns ``None`` on anything
+  outside ℚ[v_0, …, v_{n-1}].
+- ``_npoly_to_ir(p, vars)`` — round-trip back to IR with a stable
+  canonical monomial order (descending total degree, then lex on the
+  exponent tuple).
+
+These compose in ``_try_n_variate_hensel_ir(inner)``, which is hooked
+into ``factor_handler`` immediately after the existing bivariate path:
+
+```text
+factor(expr)
+├─ univariate over Z → rational-root + Kronecker
+├─ pattern handlers (perfect cube, cubic identity, …)
+├─ bivariate Hensel (Track D1)
+└─ NEW: n-variate Hensel (Track K1)   ← three or more free symbols
+```
+
+The bridge is ONE generic helper that serves ``n = 3, 4, 5, …`` — no
+per-arity copies.
+
+### Tests
+
+New file ``tests/test_n_variate_factor.py`` with end-to-end Factor
+pipeline tests:
+
+- ``x^3 + y^3 + z^3 - 3·x·y·z`` factors successfully; round-trip
+  verifies algebraic equality (the expanded result equals the input).
+- ``(x+y+z)·(x+2·y+3·z)`` — accepts either a successful factoring or
+  unevaluated fall-through, but if a factoring is returned it must
+  round-trip.
+- ``x^2 + y^2 + z^2 + 1`` (irreducible over Q) — must fall through
+  cleanly without producing a wrong factoring.
+- ``sin(x) + y + z`` (transcendental) — must not crash.
+
+### What this unblocks
+
+Track K2 (TS + Rust port) — the Python bridge defines the canonical
+shape the port will follow.  Track N (final spec closure) can mark
+n-variate factoring done across the matrix.
+
 ## [0.74.0] — 2026-05-29
 
 **Track G1 — symbolic-coefficient Weierzstrass lift.**

--- a/code/packages/python/symbolic-vm/pyproject.toml
+++ b/code/packages/python/symbolic-vm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-symbolic-vm"
-version = "0.74.0"
+version = "0.75.0"
 description = "Pluggable symbolic VM — evaluates symbolic-ir trees through swappable backends (strict numeric vs. Mathematica-style symbolic rewriting)."
 requires-python = ">=3.12"
 license = "MIT"
@@ -19,7 +19,7 @@ dependencies = [
     "coding-adventures-cas-pattern-matching>=0.2.0",
     "coding-adventures-cas-substitution",
     "coding-adventures-cas-simplify>=0.4.0",
-    "coding-adventures-cas-factor>=0.3.0",
+    "coding-adventures-cas-factor>=0.5.0",
     "coding-adventures-cas-solve>=0.8.0",
     "coding-adventures-cas-list-operations",
     "coding-adventures-cas-matrix>=0.3.0",

--- a/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
+++ b/code/packages/python/symbolic-vm/src/symbolic_vm/cas_handlers.py
@@ -53,7 +53,12 @@ from cas_complex.handlers import (
 )
 from cas_complex.normalize import contains_imaginary as _contains_imaginary
 from cas_factor import BiPoly as _BiPoly
-from cas_factor import factor_integer_polynomial, try_bivariate_hensel
+from cas_factor import NPoly as _NPoly
+from cas_factor import (
+    factor_integer_polynomial,
+    try_bivariate_hensel,
+    try_n_variate_hensel,
+)
 from cas_fourier import build_fourier_handler_table as _build_fourier
 from cas_laplace import build_laplace_handler_table as _build_laplace
 from cas_limit_series import (
@@ -2044,6 +2049,250 @@ def _bipoly_to_ir(p: _BiPoly, x: IRSymbol, y: IRSymbol) -> IRNode:
     return IRApply(ADD, tuple(terms))
 
 
+def _find_n_variables(node: IRNode, max_vars: int = 8) -> list[IRSymbol] | None:
+    """Return all distinct free variables found in ``node``, in encounter order.
+
+    This is the n-variate generalisation of :func:`_find_two_variables`.
+    The encounter order matters: the first variable becomes the *main*
+    variable for Hensel's univariate image step.  We bound the search at
+    ``max_vars`` distinct symbols so a pathological input with hundreds
+    of free symbols can't make us allocate gigantic sparse-dict keys.
+
+    Returns ``None`` when zero variables appear (constant — caller already
+    handles that) or when ``max_vars`` is exceeded.
+    """
+    seen: list[IRSymbol] = []
+
+    def walk(n: IRNode) -> bool:
+        if isinstance(n, IRSymbol):
+            if n.name in _CONSTANT_NAMES:
+                return True
+            if n not in seen:
+                seen.append(n)
+                if len(seen) > max_vars:
+                    return False
+            return True
+        if isinstance(n, IRApply):
+            for arg in n.args:
+                if not walk(arg):
+                    return False
+        return True
+
+    if not walk(node):
+        return None
+    if not seen:
+        return None
+    return seen
+
+
+def _ir_to_npoly(node: IRNode, vars: list[IRSymbol]) -> _NPoly | None:
+    """Convert an IR expression to an n-variate polynomial in ``vars``.
+
+    Structurally identical to :func:`_ir_to_bipoly` but with an ``n``-length
+    exponent tuple instead of ``(i, j)``.  Returns ``None`` for anything
+    outside ℚ[v_0, …, v_{n-1}]:
+
+    - Floats (would destroy exact arithmetic).
+    - A free symbol not in ``vars``.
+    - Transcendental functions (Sin, Log, Exp, Sqrt, …).
+    - Non-integer or non-constant exponents, negative exponents.
+    """
+    n_vars = len(vars)
+    var_index = {v: i for i, v in enumerate(vars)}
+    zero_key = (0,) * n_vars
+
+    def unit_for(v: IRSymbol) -> tuple[int, ...]:
+        i = var_index[v]
+        key = [0] * n_vars
+        key[i] = 1
+        return tuple(key)
+
+    def add_key(a: tuple[int, ...], b: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(a[i] + b[i] for i in range(n_vars))
+
+    def walk(n: IRNode) -> _NPoly | None:
+        # Numeric literals → constant monomial.
+        if isinstance(n, IRInteger):
+            return {zero_key: Fraction(n.value)} if n.value != 0 else {}
+        if isinstance(n, IRRational):
+            return {zero_key: Fraction(n.numer, n.denom)}
+        if isinstance(n, IRFloat):
+            return None  # floats are out — Q-only
+
+        # Variables.
+        if isinstance(n, IRSymbol):
+            if n.name in _CONSTANT_NAMES:
+                return None
+            if n in var_index:
+                return {unit_for(n): Fraction(1)}
+            return None  # foreign symbol
+
+        if not isinstance(n, IRApply):
+            return None
+        head = n.head
+
+        if head == ADD:
+            acc: _NPoly = {}
+            for arg in n.args:
+                sub = walk(arg)
+                if sub is None:
+                    return None
+                for k, v in sub.items():
+                    acc[k] = acc.get(k, Fraction(0)) + v
+            return {k: v for k, v in acc.items() if v != 0}
+
+        if head == SUB:
+            if len(n.args) != 2:
+                return None
+            a = walk(n.args[0])
+            b = walk(n.args[1])
+            if a is None or b is None:
+                return None
+            acc = dict(a)
+            for k, v in b.items():
+                acc[k] = acc.get(k, Fraction(0)) - v
+            return {k: v for k, v in acc.items() if v != 0}
+
+        if head == NEG:
+            if len(n.args) != 1:
+                return None
+            a = walk(n.args[0])
+            if a is None:
+                return None
+            return {k: -v for k, v in a.items() if v != 0}
+
+        if head == MUL:
+            acc = {zero_key: Fraction(1)}
+            for arg in n.args:
+                sub = walk(arg)
+                if sub is None:
+                    return None
+                new_acc: _NPoly = {}
+                for k1, c1 in acc.items():
+                    for k2, c2 in sub.items():
+                        k = add_key(k1, k2)
+                        new_acc[k] = new_acc.get(k, Fraction(0)) + c1 * c2
+                acc = {k: v for k, v in new_acc.items() if v != 0}
+            return acc
+
+        if head == POW:
+            if len(n.args) != 2:
+                return None
+            base = walk(n.args[0])
+            if base is None:
+                return None
+            exp_node = n.args[1]
+            if not isinstance(exp_node, IRInteger):
+                return None
+            e = exp_node.value
+            if e < 0:
+                return None
+            if e == 0:
+                return {zero_key: Fraction(1)}
+            result = base
+            for _ in range(e - 1):
+                new_acc: _NPoly = {}
+                for k1, c1 in result.items():
+                    for k2, c2 in base.items():
+                        k = add_key(k1, k2)
+                        new_acc[k] = new_acc.get(k, Fraction(0)) + c1 * c2
+                result = {k: v for k, v in new_acc.items() if v != 0}
+            return result
+
+        # Any other head (Sin, Log, …) is not a polynomial term.
+        return None
+
+    return walk(node)
+
+
+def _npoly_to_ir(p: _NPoly, vars: list[IRSymbol]) -> IRNode:
+    """Convert an n-variate ℚ-polynomial back to an IR expression.
+
+    Each monomial ``c · v_0^{e_0} · … · v_{n-1}^{e_{n-1}}`` becomes a
+    left-nested binary Mul node (singleton factors elided).  The
+    polynomial is a left-nested binary Add of monomial nodes, sorted
+    by descending total degree then lex on the exponent tuple for
+    deterministic canonical form.
+
+    Binary nesting matters: the symbolic-vm primitive Add / Mul
+    handlers are strictly binary (see ``handlers.py::_binary_args``),
+    so an ``IRApply(ADD, (a, b, c))`` with three or more children
+    would crash when re-evaluated.  We mirror the cubic-identity
+    handler's nesting convention: ``Add(Add(a, b), c)`` for three
+    terms, ``Add(Add(Add(a, b), c), d)`` for four, etc.
+
+    Empty dict → ``IRInteger(0)``.  Single all-zero key → the constant.
+    """
+    if not p:
+        return IRInteger(0)
+    n_vars = len(vars)
+
+    def fold_binary(head: IRSymbol, parts: list[IRNode]) -> IRNode:
+        """Left-fold a list of children into nested binary IRApply nodes."""
+        assert parts, "fold_binary requires at least one node"
+        result = parts[0]
+        for nxt in parts[1:]:
+            result = IRApply(head, (result, nxt))
+        return result
+
+    def monomial_node(key: tuple[int, ...], c: Fraction) -> IRNode:
+        parts: list[IRNode] = []
+        all_zero = all(e == 0 for e in key)
+        if c != 1 or all_zero:
+            if c.denominator == 1:
+                parts.append(IRInteger(c.numerator))
+            else:
+                parts.append(IRRational(c.numerator, c.denominator))
+        for i in range(n_vars):
+            e = key[i]
+            if e <= 0:
+                continue
+            v = vars[i]
+            parts.append(v if e == 1 else IRApply(POW, (v, IRInteger(e))))
+        if not parts:
+            # c == 1 and all exponents zero — should be caught above,
+            # but if we somehow have a unit monomial with no factors,
+            # the value is just 1.
+            return IRInteger(1)
+        return fold_binary(MUL, parts)
+
+    keys = sorted(
+        p.keys(),
+        key=lambda k: (-sum(k), tuple(-e for e in k)),
+    )
+    terms = [monomial_node(k, p[k]) for k in keys]
+    return fold_binary(ADD, terms)
+
+
+def _try_n_variate_hensel_ir(inner: IRNode) -> IRNode | None:
+    """Top-level glue for n-variate (n ≥ 3) Hensel lifting.
+
+    Identifies all free variables, converts to an NPoly, calls
+    :func:`try_n_variate_hensel`, and converts the factor list back to
+    a ``Mul(...)`` IR node.  Returns ``None`` on any failure (foreign
+    variable, transcendental, Hensel falls through, …) so the caller
+    continues with the next fallback path.
+
+    Note: this routine is generic in ``n`` — the same code path serves
+    ``n = 3, 4, 5, …``.  The caller restricts dispatch to ``n ≥ 3``
+    only because the bivariate (``n == 2``) path is handled by the
+    dedicated bivariate bridge which has been battle-tested longer.
+    """
+    vars = _find_n_variables(inner)
+    if vars is None or len(vars) < 2:
+        return None
+    npoly = _ir_to_npoly(inner, vars)
+    if npoly is None:
+        return None
+    factors = try_n_variate_hensel(npoly, len(vars))
+    if factors is None or len(factors) < 2:
+        return None
+    factor_nodes = [_npoly_to_ir(f, vars) for f in factors]
+    if len(factor_nodes) == 1:
+        return factor_nodes[0]
+    return IRApply(MUL, tuple(factor_nodes))
+
+
 def _try_bivariate_hensel_ir(inner: IRNode) -> IRNode | None:
     """Top-level glue: identify two variables, convert to BiPoly, Hensel,
     convert factors back, return a ``Mul(...)`` IR node.
@@ -2122,6 +2371,14 @@ def factor_handler(_vm: VM, expr: IRApply) -> IRNode:
         hensel = _try_bivariate_hensel_ir(inner)
         if hensel is not None:
             return _vm.eval(hensel)
+        # n-variate (n ≥ 3) Hensel — the generalised algorithmic
+        # fallback for tri- and higher-variate polynomials.  Examples
+        # this catches: x^3 + y^3 + z^3 − 3·x·y·z = (x+y+z)·(…).
+        # Returns None for transcendentals, foreign symbols, or when
+        # the iterated lift can't pin down a factorisation.
+        n_hensel = _try_n_variate_hensel_ir(inner)
+        if n_hensel is not None:
+            return _vm.eval(n_hensel)
         return expr  # transcendental or unsupported multi-variable
     num_frac, den_frac = rational
 

--- a/code/packages/python/symbolic-vm/tests/test_n_variate_factor.py
+++ b/code/packages/python/symbolic-vm/tests/test_n_variate_factor.py
@@ -1,0 +1,316 @@
+"""Pipeline tests for n-variate Hensel-lift factorisation (Track K1).
+
+These tests exercise the end-to-end ``Factor(expr)`` path through the
+VM: they construct ``Factor(...)`` IR directly, evaluate it on a
+:class:`SymbolicBackend`, and verify the result by expanding the
+returned product back to a sparse-dict polynomial and comparing
+against the sparse-dict expansion of the input.
+
+Verifying *shape* (e.g. asserting "the result is Mul(x+y+z, ...)") is
+brittle — Hensel may emit factors in a different deterministic order
+than the human-recognisable canonical order, and integer-content can
+get pulled out separately.  Instead we verify the *algebraic* property
+that the returned product equals the input as polynomials.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from symbolic_ir import (
+    ADD,
+    MUL,
+    NEG,
+    POW,
+    SUB,
+    IRApply,
+    IRInteger,
+    IRNode,
+    IRRational,
+    IRSymbol,
+)
+
+from symbolic_vm import VM, SymbolicBackend
+
+_FACTOR = IRSymbol("Factor")
+
+x = IRSymbol("x")
+y = IRSymbol("y")
+z = IRSymbol("z")
+w = IRSymbol("w")
+
+
+def make_vm() -> VM:
+    return VM(SymbolicBackend())
+
+
+# ---------------------------------------------------------------------------
+# Local IR → sparse-dict polynomial expander.
+#
+# We deliberately do NOT reuse the production ``_ir_to_npoly`` from
+# ``cas_handlers`` here — tests should round-trip through their own
+# independent expander so a bug in production code can't masquerade as
+# a bug-compatible test result.  The grammar is identical: literals,
+# variables in ``vars``, Add/Sub/Neg/Mul/Pow over those.
+# ---------------------------------------------------------------------------
+
+PolyDict = dict[tuple[int, ...], Fraction]
+
+
+def expand_to_dict(node: IRNode, vars: list[IRSymbol]) -> PolyDict:
+    """Recursive structural expander for the polynomial subset of IR."""
+    n = len(vars)
+    zero = (0,) * n
+    var_idx = {v: i for i, v in enumerate(vars)}
+
+    def unit(v: IRSymbol) -> tuple[int, ...]:
+        i = var_idx[v]
+        k = [0] * n
+        k[i] = 1
+        return tuple(k)
+
+    def add_keys(a: tuple[int, ...], b: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(a[i] + b[i] for i in range(n))
+
+    def normalize(d: PolyDict) -> PolyDict:
+        return {k: v for k, v in d.items() if v != 0}
+
+    def add(a: PolyDict, b: PolyDict) -> PolyDict:
+        out: PolyDict = dict(a)
+        for k, v in b.items():
+            out[k] = out.get(k, Fraction(0)) + v
+        return normalize(out)
+
+    def neg(a: PolyDict) -> PolyDict:
+        return {k: -v for k, v in a.items()}
+
+    def mul(a: PolyDict, b: PolyDict) -> PolyDict:
+        out: PolyDict = {}
+        for ka, va in a.items():
+            for kb, vb in b.items():
+                k = add_keys(ka, kb)
+                out[k] = out.get(k, Fraction(0)) + va * vb
+        return normalize(out)
+
+    def walk(node: IRNode) -> PolyDict:
+        if isinstance(node, IRInteger):
+            return {zero: Fraction(node.value)} if node.value != 0 else {}
+        if isinstance(node, IRRational):
+            return {zero: Fraction(node.numer, node.denom)}
+        if isinstance(node, IRSymbol):
+            if node in var_idx:
+                return {unit(node): Fraction(1)}
+            raise ValueError(f"unexpected symbol in test expander: {node!r}")
+        assert isinstance(node, IRApply)
+        head = node.head
+        if head == ADD:
+            acc: PolyDict = {}
+            for a in node.args:
+                acc = add(acc, walk(a))
+            return acc
+        if head == SUB:
+            a, b = walk(node.args[0]), walk(node.args[1])
+            return add(a, neg(b))
+        if head == NEG:
+            return neg(walk(node.args[0]))
+        if head == MUL:
+            acc = {zero: Fraction(1)}
+            for a in node.args:
+                acc = mul(acc, walk(a))
+            return acc
+        if head == POW:
+            base = walk(node.args[0])
+            exp = node.args[1]
+            assert isinstance(exp, IRInteger)
+            e = exp.value
+            assert e >= 0
+            if e == 0:
+                return {zero: Fraction(1)}
+            out = base
+            for _ in range(e - 1):
+                out = mul(out, base)
+            return out
+        raise ValueError(f"unexpected IR head in test expander: {head!r}")
+
+    return walk(node)
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+def test_n_variate_factor_pipeline_x3_y3_z3_minus_3xyz() -> None:
+    """factor(x^3 + y^3 + z^3 - 3*x*y*z).
+
+    The classical identity:
+
+        x^3 + y^3 + z^3 - 3·x·y·z = (x + y + z) · (x^2 + y^2 + z^2 - x·y - y·z - z·x)
+
+    We verify via algebraic equality (expand the result, compare
+    sparse-dict polynomials) rather than by shape — that lets the
+    Hensel lift emit factors in any order it likes.
+    """
+    vm = make_vm()
+    # x^3 + y^3 + z^3 - 3*x*y*z, built left-to-right.
+    target = IRApply(
+        SUB,
+        (
+            IRApply(
+                ADD,
+                (
+                    IRApply(
+                        ADD,
+                        (
+                            IRApply(POW, (x, IRInteger(3))),
+                            IRApply(POW, (y, IRInteger(3))),
+                        ),
+                    ),
+                    IRApply(POW, (z, IRInteger(3))),
+                ),
+            ),
+            IRApply(MUL, (IRInteger(3), IRApply(MUL, (IRApply(MUL, (x, y)), z)))),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+
+    # The handler must produce something other than the unevaluated
+    # Factor(...) shell — otherwise no factorisation was found.
+    assert not (isinstance(result, IRApply) and result.head == _FACTOR), (
+        f"Expected a successful factorisation, got unevaluated wrapper: {result!r}"
+    )
+
+    # Round-trip: expand result and compare to the input polynomial.
+    vars = [x, y, z]
+    result_dict = expand_to_dict(result, vars)
+    target_dict = expand_to_dict(target, vars)
+    assert result_dict == target_dict
+
+
+def test_n_variate_factor_pipeline_linear_product() -> None:
+    """factor((x + y + z)·(x + 2·y + 3·z)) round-trips.
+
+    Expanded input:
+        x^2 + 3·x·y + 4·x·z + 2·y^2 + 5·y·z + 3·z^2
+    """
+    vm = make_vm()
+    # Build the *expanded* input — Factor sees only the unfactored sum.
+    # x^2 + 3xy + 4xz + 2y^2 + 5yz + 3z^2
+    expanded = IRApply(
+        ADD,
+        (
+            IRApply(POW, (x, IRInteger(2))),
+            IRApply(
+                ADD,
+                (
+                    IRApply(MUL, (IRInteger(3), IRApply(MUL, (x, y)))),
+                    IRApply(
+                        ADD,
+                        (
+                            IRApply(MUL, (IRInteger(4), IRApply(MUL, (x, z)))),
+                            IRApply(
+                                ADD,
+                                (
+                                    IRApply(
+                                        MUL,
+                                        (IRInteger(2), IRApply(POW, (y, IRInteger(2)))),
+                                    ),
+                                    IRApply(
+                                        ADD,
+                                        (
+                                            IRApply(
+                                                MUL,
+                                                (IRInteger(5), IRApply(MUL, (y, z))),
+                                            ),
+                                            IRApply(
+                                                MUL,
+                                                (
+                                                    IRInteger(3),
+                                                    IRApply(POW, (z, IRInteger(2))),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    expr = IRApply(_FACTOR, (expanded,))
+    result = vm.eval(expr)
+    vars = [x, y, z]
+    # If Hensel found a factorisation, the expanded result equals the
+    # input.  If not, the wrapper survives unevaluated.  Either way,
+    # the algebraic identity must hold: result-product == input.
+    if isinstance(result, IRApply) and result.head == _FACTOR:
+        return  # unevaluated — nothing to round-trip
+    result_dict = expand_to_dict(result, vars)
+    expanded_dict = expand_to_dict(expanded, vars)
+    assert result_dict == expanded_dict
+
+
+def test_n_variate_factor_pipeline_fall_through_irreducible() -> None:
+    """factor(x^2 + y^2 + z^2 + 1) — irreducible over Q, falls through.
+
+    No pattern handler recognises this, Hensel can't find a factor (it
+    is irreducible over Q in three variables — a sum of three squares
+    plus a positive constant has no rational zero), and the result
+    must be the unevaluated ``Factor(...)`` IR or the input itself.
+    The contract is: do not crash, do not produce a wrong factoring.
+    """
+    vm = make_vm()
+    target = IRApply(
+        ADD,
+        (
+            IRApply(POW, (x, IRInteger(2))),
+            IRApply(
+                ADD,
+                (
+                    IRApply(POW, (y, IRInteger(2))),
+                    IRApply(
+                        ADD,
+                        (IRApply(POW, (z, IRInteger(2))), IRInteger(1)),
+                    ),
+                ),
+            ),
+        ),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    # Either the Factor(...) wrapper stays (no factorisation found) or
+    # — should the lift ever produce something — the round-trip must
+    # still equal the input polynomial.  Both outcomes are correct.
+    # Detect "unevaluated" by head, not by raw structural equality:
+    # the VM canonicalises nested Add into a left-associative chain,
+    # so ``result == expr`` can be ``False`` even when the wrapper
+    # was preserved.
+    if isinstance(result, IRApply) and result.head == _FACTOR:
+        return  # unevaluated wrapper — accepted
+    vars = [x, y, z]
+    target_dict = expand_to_dict(target, vars)
+    result_dict = expand_to_dict(result, vars)
+    assert result_dict == target_dict
+
+
+def test_n_variate_factor_pipeline_does_not_crash_on_transcendental() -> None:
+    """factor(sin(x) + y + z) — transcendental, must fall through cleanly.
+
+    Regression guard: the n-variate bridge must return None when the
+    input has a non-polynomial head, not raise or produce nonsense.
+    """
+    vm = make_vm()
+    sin = IRSymbol("Sin")
+    target = IRApply(
+        ADD,
+        (IRApply(sin, (x,)), IRApply(ADD, (y, z))),
+    )
+    expr = IRApply(_FACTOR, (target,))
+    result = vm.eval(expr)
+    # The expected outcome is "unchanged" — Factor doesn't know what
+    # to do with a transcendental, so it leaves the call wrapper in
+    # place.  We just require it not to crash.
+    assert isinstance(result, IRNode)


### PR DESCRIPTION
## Summary

Closes Track K1 of `code/specs/macsyma-truly-finish-plan.md` — extends
the bivariate Hensel lift (Track D1) to handle n ≥ 3 variables via one
generic iterated-bivariate algorithm.  No per-variable-count helpers;
the number of lift iterations is determined at runtime from the input
polynomial's variable count.

## Algorithm

1.  Specialise `v_1..v_{n−1}` with a bounded list of small integer
    tuples (≤ 10 candidates).
2.  Verify the univariate image is squarefree and full-`v_0`-degree.
3.  Factor the univariate image via the existing rational-roots +
    Kronecker + BZH chain.
4.  Lift one auxiliary variable at a time from `Q[v_0]` up through
    `Q[v_0, ..., v_{n−1}]` by Hensel-style expansion in powers of
    `(v_k − a_k)`.
5.  Each lift step solves a coefficient-ring diophantine
    `A·u + B·v = c` in `Q[v_0, …, v_{k−1}]`.  Implemented recursively:
    base case calls the existing `_u_diophantine` over `Q[v_0]`; the
    recursive case eliminates the trailing variable by specialisation
    + lift, again recursively.
6.  Verify the final product equals the input; otherwise fall through
    to the existing handler chain.

## Acceptance cases

| Polynomial | Result |
|---|---|
| `x² − y² − z² − 2yz` | `(x + y + z)(x − y − z)` |
| `(x + y + z)(x + 2y + 3z)` | round-trips (degree-2, trivariate) |
| `x³ + y³ + z³ − 3xyz` | `(x+y+z)(x²+y²+z²−xy−yz−xz)` |
| `(x + y)(x + z + w)` | round-trips (4 variables, 2 lifts) |
| `x² + y² + z² + 1` | irreducible → `None` (clean fall-through) |
| univariate `x² − 1` in n-var ring | `None` (univariate path keeps it) |
| `num_vars = 1` | `None` (delegates to existing univariate) |

Note: the spec also listed `x² + xy + xz − 2y² − 3yz − z²` as a case
expected to factor — that polynomial is actually irreducible over
ℚ[x, y, z] (discriminant in x is `9y² + 14yz + 5z²`, which is *not* a
square of a polynomial; the factored form claimed in the spec
mis-expands).  The implementation correctly returns `None` for it; we
covered the case structurally with the third polynomial above instead.

## Bounded-resource guarantees

* `_MAX_N_SPECIALISATION = 10` tuples per recursive level.
* Recursion depth bounded by `num_vars`.
* Lift loop bounded by `deg_{v_k}(f) + 1` per level.
* Sparse-dict representation: `Pow(x, 10⁹)`-shaped adversarial input
  stays a single dict entry; the early variable-presence check makes
  such input fall through immediately without expansion.

## Test plan

- [x] 13 new tests in `tests/test_n_variate_hensel.py` — trivariate
  acceptance, 4-variate iterated lift, sum-of-cubes identity,
  irreducible-trivariate fall-through, `num_vars < 2` fall-through,
  empty/constant/linear inputs, two bivariate-via-n-variate regressions,
  bounded-resource check on a degree-4 irreducible.
- [x] All 141 existing tests still pass (regressions: bivariate Track
  D1 acceptance unchanged).
- [x] BUILD passes locally on Windows (`bash ./BUILD` → 154 / 154,
  coverage 89%).
- [x] `ruff check src/ tests/` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)