### PR TITLE
feat(semantic-ir-to-typescript): native emit for SIR16 expression features

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.1.4 — SIR16 expression features (native)
+
+Accepts and emits the SIR16 expression features as **native** TypeScript (per
+`code/specs/sir-runtime.md`):
+
+- `Feature::Floats` → number literal; `Feature::Sequences` → array literal /
+  `((s) as __Sir.Val[])[i]` / `.length`; `Feature::Maps` → `new Map<…>([[k,v]…])`
+  / `.get(k) ?? null`.
+- `Feature::ShortCircuit` (`LogicalAnd`/`LogicalOr`, from case/in pattern
+  desugaring) → a **truthy-guarded arrow** `((__l: __Sir.Val) => __Sir.truthy(__l)
+  ? (rhs) : __l)(lhs)`: rhs stays lazy AND the test uses SIR truthiness (only
+  `false`/`nil` falsy), never a bare `&&`/`||`.
+- `Feature::StringInterpolation` (`StrConcat`) → parts joined through
+  `__Sir.toDisplay`.
+
+Requires `@coding-adventures/sir-runtime-core` ≥ 0.1.1 (its `Val` union now
+includes `Val[]` / `Map<Val,Val>` so emitted native arrays/maps typecheck).
+New Ruby→TS E2E tests for array literal, hash literal, pattern short-circuit,
+and interpolation.
+
 ## 0.1.3 — import runtime from `@coding-adventures/sir-runtime-core`
 
 The TypeScript runtime is no longer inlined into every artifact.  Emitted modules

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -9,3 +9,4 @@ semantic-ir = { path = "../semantic-ir" }
 
 [dev-dependencies]
 twig-to-semantic-ir = { path = "../twig-to-semantic-ir" }
+ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -250,17 +250,84 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 name, span
             );
         }
-        // SIR16 expression kinds — TS backend hasn't been extended yet.
-        Expr::FloatLit { span, .. }
-        | Expr::SeqLit { span, .. }
-        | Expr::SeqIndex { span, .. }
-        | Expr::SeqLen { span, .. }
-        | Expr::MapLit { span, .. }
-        | Expr::MapGet { span, .. }
-        | Expr::LogicalAnd { span, .. }
-        | Expr::LogicalOr { span, .. }
-        | Expr::StrConcat { span, .. } => {
-            panic!("ts backend reached SIR16+ expression at {} — capability check should have rejected it", span);
+        // ── SIR16 expression kinds — native TypeScript ─────────────
+        Expr::FloatLit { value, .. } => {
+            let _ = write!(out, "{:?}", value);
+        }
+        Expr::SeqLit { items, .. } => {
+            out.push('[');
+            emit_args(out, items, indent);
+            out.push(']');
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            // `Val` is a union; cast to an array/number for the native
+            // index.
+            out.push_str("((");
+            emit_expr(out, seq, indent);
+            out.push_str(") as __Sir.Val[])[(");
+            emit_expr(out, index, indent);
+            out.push_str(") as number]");
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push_str("((");
+            emit_expr(out, seq, indent);
+            out.push_str(") as __Sir.Val[]).length");
+        }
+        Expr::MapLit { entries, .. } => {
+            out.push_str("new Map<__Sir.Val, __Sir.Val>([");
+            for (i, entry) in entries.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push('[');
+                emit_expr(out, &entry.key, indent);
+                out.push_str(", ");
+                emit_expr(out, &entry.value, indent);
+                out.push(']');
+            }
+            out.push_str("])");
+        }
+        Expr::MapGet { map, key, .. } => {
+            out.push_str("(((");
+            emit_expr(out, map, indent);
+            out.push_str(") as Map<__Sir.Val, __Sir.Val>).get(");
+            emit_expr(out, key, indent);
+            out.push_str(") ?? null)");
+        }
+        // Short-circuit: an arrow closure keeps the rhs unevaluated until
+        // the lhs decides, routing the test through SIR truthiness (only
+        // `false`/`nil` are falsy — not `0`/`""`).  The param `__l` gives
+        // each occurrence its own scope, so nested `&&`/`||` never collide.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            out.push_str("((__l: __Sir.Val) => __Sir.truthy(__l) ? (");
+            emit_expr(out, rhs, indent);
+            out.push_str(") : __l)(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            out.push_str("((__l: __Sir.Val) => __Sir.truthy(__l) ? __l : (");
+            emit_expr(out, rhs, indent);
+            out.push_str("))(");
+            emit_expr(out, lhs, indent);
+            out.push(')');
+        }
+        // String interpolation: each part rendered through the SIR display
+        // helper (a string part renders to itself) and joined.
+        Expr::StrConcat { parts, .. } => {
+            out.push('(');
+            if parts.is_empty() {
+                out.push_str("\"\"");
+            }
+            for (i, p) in parts.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(" + ");
+                }
+                out.push_str("__Sir.toDisplay(");
+                emit_expr(out, p, indent);
+                out.push(')');
+            }
+            out.push(')');
         }
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -78,6 +78,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // SIR16 expression features — emitted natively (sequences → Array,
+    // maps → Map, short-circuit → truthy-guarded arrow, interpolation →
+    // display-joined), per code/specs/sir-runtime.md.
+    Feature::Floats,
+    Feature::Sequences,
+    Feature::Maps,
+    Feature::ShortCircuit,
+    Feature::StringInterpolation,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -292,5 +300,56 @@ mod tests {
         m.name = "compiler/lexer".into();
         let a = compile(&m).expect("compile");
         assert_eq!(a.filename, "compiler_lexer.ts");
+    }
+
+    // ── SIR16 expression features: Ruby → native TypeScript ─────────
+
+    #[test]
+    fn end_to_end_ruby_array_literal_ts() {
+        let module =
+            ruby_to_semantic_ir::compile_source("x = [10, 20, 30]\nputs(x)\n", "demo")
+                .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(a.source.contains("[10, 20, 30]"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn end_to_end_ruby_hash_literal_ts() {
+        let module =
+            ruby_to_semantic_ir::compile_source("puts({a: 1})\n", "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains("new Map<__Sir.Val, __Sir.Val>("),
+            "expected a native Map; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_short_circuit_ts() {
+        // case/in array pattern desugars to LogicalAnd → truthy-guarded arrow.
+        let module = ruby_to_semantic_ir::compile_source(
+            "x = [7, 8]\ncase x\nin [7, b]\n  puts(b)\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains("__Sir.truthy(__l)") && a.source.contains("(__l: __Sir.Val) =>"),
+            "expected truthy-guarded arrow for &&; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_interpolation_ts() {
+        let module = ruby_to_semantic_ir::compile_source("x = 5\nputs(\"v=#{x}\")\n", "demo")
+            .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains("__Sir.toDisplay("),
+            "expected interpolation via __Sir.toDisplay; got:\n{}",
+            a.source
+        );
     }
 }

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.1] - 2026-06-13
+
+### Changed
+
+- Widened the `Val` union to include the SIR16 collection types — `Val[]`
+  (sequences) and `Map<Val, Val>` (maps) — so emitted native arrays/maps type as
+  `Val`. Additive; existing values are unaffected. Both are truthy under SIR
+  truthiness and display via `String(v)` in `toDisplay`.
+
 ## [0.1.0] - 2026-06-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/values.ts
+++ b/code/packages/typescript/sir-runtime-core/src/values.ts
@@ -20,8 +20,22 @@ export interface ClosureLike {
   readonly __sirClosure: true;
 }
 
-/** A SIR value in the v0 surface. */
-export type Val = number | boolean | null | string | Sym | Pair | ClosureLike;
+/**
+ * A SIR value.  Includes the SIR16 collection types — sequences
+ * (`Val[]`) and maps (`Map<Val, Val>`) — so backends can emit native
+ * arrays/maps that still type as `Val`.  Both are truthy under SIR
+ * truthiness and display via `String(v)` in {@link toDisplay}.
+ */
+export type Val =
+  | number
+  | boolean
+  | null
+  | string
+  | Sym
+  | Pair
+  | ClosureLike
+  | Val[]
+  | Map<Val, Val>;
 
 /** SIR truthiness: everything is true except `false` and `nil`. */
 export function truthy(v: Val): boolean {


### PR DESCRIPTION
## What

The TypeScript counterpart to #5588 (Python). `semantic-ir-to-typescript` now
**accepts and natively emits** the SIR16 expression features (per
[`code/specs/sir-runtime.md`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/sir-runtime.md)):

| SIR node | Native TS |
|---|---|
| `FloatLit` | number literal |
| `SeqLit` / `SeqIndex` / `SeqLen` | `[...]` / `((s) as __Sir.Val[])[i]` / `.length` |
| `MapLit` / `MapGet` | `new Map<__Sir.Val,__Sir.Val>([[k,v]…])` / `.get(k) ?? null` |
| `LogicalAnd` / `LogicalOr` | **truthy-guarded arrow** (lazy + SIR truthiness) |
| `StrConcat` | parts joined via `__Sir.toDisplay` |

`ACCEPTED_FEATURES += Floats, Sequences, Maps, ShortCircuit, StringInterpolation`.

Also widens the first-party `@coding-adventures/sir-runtime-core` `Val` union to
include `Val[] | Map<Val,Val>` (**0.1.0 → 0.1.1**, additive) so emitted native
arrays/maps typecheck under TS strict mode.

## Verification

- `cargo test -p semantic-ir-to-typescript`: 37 tests pass, incl. new Ruby→TS E2E
  (array, hash, pattern short-circuit asserting the truthy-guarded arrow,
  interpolation).
- `tsc --noEmit` + 18 vitest tests green in the core package with the widened `Val`.
- Security review: passed (leaves route through `quote_ts_string`; `Map`/array
  emit has no prototype-pollution or code-exec sink; `as` casts are compile-time).

Python (#5588) and TS are now at parity for SIR16 expression features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
