### PR TITLE
feat(symbolic-vm): n-variate Hensel port (Track K2)

### DIFF
--- a/code/packages/rust/cas-factor/CHANGELOG.md
+++ b/code/packages/rust/cas-factor/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog — cas-factor (Rust)
 
+## [0.3.0] — 2026-05-29
+
+**Track K2 — n-variate Hensel lifting (Rust port).**
+
+Ports the Python `cas_factor.hensel.try_n_variate_hensel` algorithm
+(Track K1, PR #5590) to Rust.  Extends the bivariate Hensel lift to
+n ≥ 3 variables via iterated bivariate lifting:
+
+1. Pick a main variable `v_0`; substitute auxiliary variables with
+   small integer values to reduce f to a univariate polynomial.
+2. Factor the univariate image via the existing `factor_uni_q` chain.
+3. Lift the univariate factors back one auxiliary variable at a time
+   via Hensel-style expansion in powers of `(v_k − a_k)`.  Each lift
+   step solves a coefficient-ring diophantine equation recursively;
+   base case hits `u_diophantine` directly.
+4. Verify the final product equals the input; return `None` on any
+   mismatch so the caller falls through to other handlers.
+
+Reuses the existing bivariate Hensel machinery (`Rat`, univariate
+diophantine, `factor_uni_q`) as building blocks.  Bounded
+specialisation search (≤ 10 tuples); recursion depth bounded by `n`.
+
+### Added
+
+- `try_n_variate_hensel(f: &NPoly, num_vars: usize) -> Option<Vec<NPoly>>`
+  — top-level entry point for n-variate (n ≥ 2) factoring via
+  iterated Hensel lifting.
+- `NPoly` type — sparse `BTreeMap<Vec<usize>, Rat>` mapping exponent
+  tuples to rational coefficients.
+- `n_mul` re-exported from the crate root for tests.
+- `tests/n_variate_hensel.rs` — 13 acceptance cases mirroring the
+  Python `test_n_variate_hensel.py` suite: trivariate quadratic, two
+  trivariate cubics (sum-of-cubes companion, asymmetric coefficients),
+  quadrivariate iterated lift, six fall-through cases, two bivariate
+  regressions via the n-variate front door, and a bounded-resource
+  smoke test.
+
 ## [0.2.0] — 2026-05-28
 
 **Track D2 — bivariate Hensel lifting (Rust port).**

--- a/code/packages/rust/cas-factor/Cargo.toml
+++ b/code/packages/rust/cas-factor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-factor"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Univariate integer polynomial factoring over Z (rational-root, Kronecker, bounded BZH)"
 license = "MIT"

--- a/code/packages/rust/cas-factor/src/hensel.rs
+++ b/code/packages/rust/cas-factor/src/hensel.rs
@@ -652,3 +652,576 @@ pub fn try_bivariate_hensel(f_in: &BiPoly) -> Option<Vec<BiPoly>> {
     }
     None
 }
+
+// ===========================================================================
+// n-variate Hensel lifting — Track K2 (Rust port of Python Track K1, PR #5590).
+// ===========================================================================
+//
+// Strategy (one generic algorithm — NOT per-variable-count helpers):
+//
+//   1. Pick a "main" variable v_0 (always index 0 in the sparse-tuple
+//      representation).
+//   2. Substitute v_1..v_{n-1} with small integer values to reduce f to a
+//      univariate polynomial in v_0.
+//   3. Factor the univariate image via the existing factor-uni-q chain.
+//   4. Lift the univariate factors back to the full n-variate ring one
+//      variable at a time.
+//   5. Each lift step solves a coefficient-ring diophantine equation
+//      recursively.  Base case hits u_diophantine directly.
+//   6. Verify the final product equals the input; if not, return None.
+//
+// Representation:
+//   `NPoly = BTreeMap<Vec<usize>, Rat>` where the key is the exponent
+//   tuple as a Vec<usize> of length n.
+//
+// Bounded resource discipline:
+//   - At most MAX_N_SPECIALISATION lucky-point tuples are tried (10).
+//   - Recursion depth bounded by n (number of variables).
+//   - Each lift loop bounded by deg_{v_k}(f) + 1 iterations.
+
+/// Sparse n-variate polynomial — exponent tuple ↦ coefficient.
+pub type NPoly = BTreeMap<Vec<usize>, Rat>;
+
+const MAX_N_SPECIALISATION: usize = 10;
+
+fn n_normalize(p: &NPoly) -> NPoly {
+    p.iter().filter(|(_, v)| !v.is_zero()).map(|(k, v)| (k.clone(), *v)).collect()
+}
+
+fn n_one(num_vars: usize) -> NPoly {
+    let mut m = BTreeMap::new();
+    m.insert(vec![0; num_vars], Rat::ONE);
+    m
+}
+
+fn n_const(num_vars: usize, c: Rat) -> NPoly {
+    if c.is_zero() {
+        return BTreeMap::new();
+    }
+    let mut m = BTreeMap::new();
+    m.insert(vec![0; num_vars], c);
+    m
+}
+
+fn n_degree_in(p: &NPoly, var_idx: usize) -> i64 {
+    let mut best: i64 = -1;
+    for (k, v) in p {
+        if v.is_zero() {
+            continue;
+        }
+        if (k[var_idx] as i64) > best {
+            best = k[var_idx] as i64;
+        }
+    }
+    best
+}
+
+fn n_total_degree(p: &NPoly) -> i64 {
+    let mut best: i64 = -1;
+    for (k, v) in p {
+        if v.is_zero() {
+            continue;
+        }
+        let s: usize = k.iter().sum();
+        if s as i64 > best {
+            best = s as i64;
+        }
+    }
+    best
+}
+
+fn n_add(a: &NPoly, b: &NPoly) -> NPoly {
+    let mut out = a.clone();
+    for (k, v) in b {
+        let cur = out.get(k).copied().unwrap_or(Rat::ZERO);
+        out.insert(k.clone(), cur.add(v));
+    }
+    n_normalize(&out)
+}
+
+fn n_sub(a: &NPoly, b: &NPoly) -> NPoly {
+    let mut out = a.clone();
+    for (k, v) in b {
+        let cur = out.get(k).copied().unwrap_or(Rat::ZERO);
+        out.insert(k.clone(), cur.sub(v));
+    }
+    n_normalize(&out)
+}
+
+/// Multiply two n-variate polynomials.  Exposed for tests.
+pub fn n_mul(a: &NPoly, b: &NPoly, num_vars: usize) -> NPoly {
+    let mut out: NPoly = BTreeMap::new();
+    for (k1, c1) in a {
+        if c1.is_zero() {
+            continue;
+        }
+        for (k2, c2) in b {
+            if c2.is_zero() {
+                continue;
+            }
+            let key: Vec<usize> = (0..num_vars).map(|i| k1[i] + k2[i]).collect();
+            let cur = out.get(&key).copied().unwrap_or(Rat::ZERO);
+            out.insert(key, cur.add(&c1.mul(c2)));
+        }
+    }
+    n_normalize(&out)
+}
+
+fn n_equals(a: &NPoly, b: &NPoly) -> bool {
+    n_normalize(a) == n_normalize(b)
+}
+
+/// Substitute v_{var_idx} = value, keep the tuple shape (slot stays at 0).
+fn n_substitute_var_keep(p: &NPoly, var_idx: usize, value: Rat) -> NPoly {
+    let mut out: NPoly = BTreeMap::new();
+    for (k, c) in p {
+        let e = k[var_idx];
+        let mut new_key = k.clone();
+        new_key[var_idx] = 0;
+        let contrib = c.mul(&value.pow(e));
+        if contrib.is_zero() {
+            continue;
+        }
+        let cur = out.get(&new_key).copied().unwrap_or(Rat::ZERO);
+        out.insert(new_key, cur.add(&contrib));
+    }
+    n_normalize(&out)
+}
+
+/// Extract the (n−1)-variate-feeling coefficient at var_idx^k_pow,
+/// kept in the n-variate ring with var_idx slot = 0.
+fn n_coeff_at_power(p: &NPoly, var_idx: usize, k_pow: usize) -> NPoly {
+    let mut out: NPoly = BTreeMap::new();
+    for (k, c) in p {
+        if k[var_idx] != k_pow {
+            continue;
+        }
+        let mut new_key = k.clone();
+        new_key[var_idx] = 0;
+        let cur = out.get(&new_key).copied().unwrap_or(Rat::ZERO);
+        out.insert(new_key, cur.add(c));
+    }
+    n_normalize(&out)
+}
+
+fn u_to_n(p: &[Rat], var_idx: usize, num_vars: usize) -> NPoly {
+    let mut out: NPoly = BTreeMap::new();
+    for (e, c) in p.iter().enumerate() {
+        if c.is_zero() {
+            continue;
+        }
+        let mut key = vec![0usize; num_vars];
+        key[var_idx] = e;
+        out.insert(key, *c);
+    }
+    out
+}
+
+fn n_to_univariate(p: &NPoly, var_idx: usize) -> UniQPoly {
+    if p.is_empty() {
+        return vec![];
+    }
+    let max_e = p.keys().map(|k| k[var_idx]).max().unwrap_or(0);
+    let mut out = vec![Rat::ZERO; max_e + 1];
+    for (k, c) in p {
+        out[k[var_idx]] = out[k[var_idx]].add(c);
+    }
+    u_normalize(&out)
+}
+
+fn n_only_uses_var(p: &NPoly, var_idx: usize) -> bool {
+    for k in p.keys() {
+        for (i, e) in k.iter().enumerate() {
+            if i != var_idx && *e != 0 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Rewrite p as polynomial in (v_{var_idx} − value) via binomial expansion.
+fn n_shift_var(p: &NPoly, var_idx: usize, value: Rat) -> NPoly {
+    if value.is_zero() {
+        return p.clone();
+    }
+    let mut out: NPoly = BTreeMap::new();
+    for (k, c) in p {
+        if c.is_zero() {
+            continue;
+        }
+        let e = k[var_idx];
+        for m in 0..=e {
+            let coeff = c.mul(&Rat::from_int(binomial(e, m))).mul(&value.pow(e - m));
+            let mut new_key = k.clone();
+            new_key[var_idx] = m;
+            let cur = out.get(&new_key).copied().unwrap_or(Rat::ZERO);
+            out.insert(new_key, cur.add(&coeff));
+        }
+    }
+    n_normalize(&out)
+}
+
+// ---------------------------------------------------------------------------
+// Recursive coefficient-ring diophantine.
+// ---------------------------------------------------------------------------
+
+fn n_diophantine(
+    g0: &NPoly,
+    h0: &NPoly,
+    c: &NPoly,
+    num_vars: usize,
+    main_var: usize,
+    active_vars: &[usize],
+) -> Option<(NPoly, NPoly)> {
+    // Base case: univariate.
+    if active_vars.len() == 1 {
+        let only = active_vars[0];
+        if !(n_only_uses_var(g0, only) && n_only_uses_var(h0, only) && n_only_uses_var(c, only)) {
+            return None;
+        }
+        let g0u = n_to_univariate(g0, only);
+        let h0u = n_to_univariate(h0, only);
+        let cu = n_to_univariate(c, only);
+        let (uu, vu) = u_diophantine(&g0u, &h0u, &cu)?;
+        return Some((u_to_n(&uu, only, num_vars), u_to_n(&vu, only, num_vars)));
+    }
+
+    let w = *active_vars.last().unwrap();
+    let rest: Vec<usize> = active_vars[..active_vars.len() - 1].to_vec();
+
+    let max_w_deg = n_degree_in(g0, w).max(n_degree_in(h0, w)).max(n_degree_in(c, w)).max(0);
+
+    let candidates = y0_candidates();
+    for &w0_int in candidates.iter().take(MAX_N_SPECIALISATION) {
+        let w0 = Rat::from_int(w0_int);
+        let g0_shift = n_shift_var(g0, w, w0);
+        let h0_shift = n_shift_var(h0, w, w0);
+        let c_shift = n_shift_var(c, w, w0);
+        let g0_base = n_coeff_at_power(&g0_shift, w, 0);
+        let h0_base = n_coeff_at_power(&h0_shift, w, 0);
+        let c_base = n_coeff_at_power(&c_shift, w, 0);
+
+        let (mut u, mut v) = match n_diophantine(
+            &g0_base, &h0_base, &c_base, num_vars, main_var, &rest,
+        ) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let mut success = true;
+        for k in 1..=(max_w_deg as usize) {
+            let prod = n_add(&n_mul(&u, &g0_shift, num_vars), &n_mul(&v, &h0_shift, num_vars));
+            let err = n_sub(&c_shift, &prod);
+            if err.is_empty() {
+                break;
+            }
+            let e_k = n_coeff_at_power(&err, w, k);
+            if e_k.is_empty() {
+                continue;
+            }
+            let sub = n_diophantine(&g0_base, &h0_base, &e_k, num_vars, main_var, &rest);
+            let (du, dv) = match sub {
+                Some(p) => p,
+                None => {
+                    success = false;
+                    break;
+                }
+            };
+            for (key_du, coef) in &du {
+                let mut new_key = key_du.clone();
+                new_key[w] = k;
+                let cur = u.get(&new_key).copied().unwrap_or(Rat::ZERO);
+                u.insert(new_key, cur.add(coef));
+            }
+            for (key_dv, coef) in &dv {
+                let mut new_key = key_dv.clone();
+                new_key[w] = k;
+                let cur = v.get(&new_key).copied().unwrap_or(Rat::ZERO);
+                v.insert(new_key, cur.add(coef));
+            }
+            u = n_normalize(&u);
+            v = n_normalize(&v);
+        }
+        if !success {
+            continue;
+        }
+
+        let check = n_add(&n_mul(&u, &g0_shift, num_vars), &n_mul(&v, &h0_shift, num_vars));
+        if !n_equals(&check, &c_shift) {
+            continue;
+        }
+
+        if !w0.is_zero() {
+            u = n_shift_var(&u, w, w0.neg());
+            v = n_shift_var(&v, w, w0.neg());
+        }
+        return Some((u, v));
+    }
+    None
+}
+
+fn n_two_factor_lift(
+    f: &NPoly,
+    g0: &NPoly,
+    h0: &NPoly,
+    num_vars: usize,
+    main_var: usize,
+    lift_var: usize,
+    coeff_vars: &[usize],
+) -> Option<(NPoly, NPoly)> {
+    let mut g = g0.clone();
+    let mut h = h0.clone();
+
+    let deg_lift = n_degree_in(f, lift_var);
+    let mut active: Vec<usize> = vec![main_var];
+    active.extend_from_slice(coeff_vars);
+
+    for k in 1..=(deg_lift as usize) {
+        let error = n_sub(f, &n_mul(&g, &h, num_vars));
+        if error.is_empty() {
+            break;
+        }
+        let e_k = n_coeff_at_power(&error, lift_var, k);
+        if e_k.is_empty() {
+            continue;
+        }
+        let (du, dv) = n_diophantine(g0, h0, &e_k, num_vars, main_var, &active)?;
+        // du is the correction to h (mirrors bivariate convention).
+        for (key_du, coef) in &du {
+            let mut new_key = key_du.clone();
+            new_key[lift_var] = k;
+            let cur = h.get(&new_key).copied().unwrap_or(Rat::ZERO);
+            h.insert(new_key, cur.add(coef));
+        }
+        for (key_dv, coef) in &dv {
+            let mut new_key = key_dv.clone();
+            new_key[lift_var] = k;
+            let cur = g.get(&new_key).copied().unwrap_or(Rat::ZERO);
+            g.insert(new_key, cur.add(coef));
+        }
+        g = n_normalize(&g);
+        h = n_normalize(&h);
+    }
+
+    if !n_equals(&n_mul(&g, &h, num_vars), f) {
+        return None;
+    }
+    Some((g, h))
+}
+
+fn n_specialisation_candidates(num_aux: usize) -> Vec<Vec<i128>> {
+    if num_aux == 0 {
+        return vec![vec![]];
+    }
+    let primitives: [i128; 5] = [1, 2, -1, 3, -2];
+    let mut tuples: Vec<Vec<i128>> = Vec::new();
+    for &v in &primitives {
+        tuples.push(vec![v; num_aux]);
+        if tuples.len() >= MAX_N_SPECIALISATION {
+            return tuples;
+        }
+    }
+    let base: Vec<i128> = vec![1; num_aux];
+    for i in 0..num_aux {
+        for &v in &primitives[1..] {
+            let mut cand = base.clone();
+            cand[i] = v;
+            tuples.push(cand);
+            if tuples.len() >= MAX_N_SPECIALISATION {
+                return tuples;
+            }
+        }
+    }
+    tuples.truncate(MAX_N_SPECIALISATION);
+    tuples
+}
+
+fn y0_candidates_n() -> Vec<i128> {
+    // Shared with the diophantine: small integers around 0.
+    y0_candidates()
+}
+
+fn is_lucky_uni(p_n: &NPoly, image: &[Rat], main_var: usize) -> bool {
+    if u_degree(image) != n_degree_in(p_n, main_var) {
+        return false;
+    }
+    if u_degree(image) < 1 {
+        return false;
+    }
+    let mut deriv: Vec<Rat> = Vec::new();
+    for i in 1..image.len() {
+        deriv.push(Rat::from_int(i as i128).mul(&image[i]));
+    }
+    let dn = u_normalize(&deriv);
+    if dn.is_empty() {
+        return false;
+    }
+    let (g, _, _) = u_gcd_ext(image, &dn);
+    u_degree(&g) == 0
+}
+
+/// Attempt to factor an n-variate (n ≥ 2) polynomial via iterated bivariate
+/// Hensel lifting.
+///
+/// Returns a list of factors whose product equals `f_in`, or `None` when no
+/// factorisation was found.  Falls through to `None` when `num_vars < 2`,
+/// the polynomial doesn't genuinely depend on at least two variables, no
+/// lucky specialisation tuple gives a squarefree univariate image of full
+/// v_0-degree (bounded search of 10 tuples), the univariate image is
+/// irreducible, or any lift/verification step fails.
+pub fn try_n_variate_hensel(f_in: &NPoly, num_vars: usize) -> Option<Vec<NPoly>> {
+    let f = n_normalize(f_in);
+    if f.is_empty() {
+        return None;
+    }
+    if num_vars < 2 {
+        return None;
+    }
+    if n_degree_in(&f, 0) < 1 {
+        return None;
+    }
+    let mut any_aux = false;
+    for i in 1..num_vars {
+        if n_degree_in(&f, i) >= 1 {
+            any_aux = true;
+            break;
+        }
+    }
+    if !any_aux {
+        return None;
+    }
+
+    let main_var: usize = 0;
+    let aux_vars: Vec<usize> = (1..num_vars).collect();
+
+    for spec_tuple in n_specialisation_candidates(aux_vars.len()) {
+        let spec: Vec<(usize, Rat)> = aux_vars
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| (v, Rat::from_int(spec_tuple[i])))
+            .collect();
+
+        let mut f_shift = f.clone();
+        for &(v_i, w_i) in &spec {
+            f_shift = n_shift_var(&f_shift, v_i, w_i);
+        }
+        f_shift = n_normalize(&f_shift);
+
+        let mut f_uni = f_shift.clone();
+        for &v_i in &aux_vars {
+            f_uni = n_substitute_var_keep(&f_uni, v_i, Rat::ZERO);
+        }
+        if !n_only_uses_var(&f_uni, main_var) {
+            continue;
+        }
+        let image = n_to_univariate(&f_uni, main_var);
+        if !is_lucky_uni(&f_shift, &image, main_var) {
+            continue;
+        }
+
+        let uni_factors = match factor_uni_q(&image) {
+            Some(v) if v.len() >= 2 => v,
+            _ => continue,
+        };
+
+        let mut n_factors_current: Vec<NPoly> = uni_factors
+            .iter()
+            .map(|u| u_to_n(u, main_var, num_vars))
+            .collect();
+
+        let mut success = true;
+        for lift_idx in 0..aux_vars.len() {
+            let lift_var = aux_vars[lift_idx];
+
+            let mut f_stage = f_shift.clone();
+            for later_idx in (lift_idx + 1)..aux_vars.len() {
+                f_stage = n_substitute_var_keep(&f_stage, aux_vars[later_idx], Rat::ZERO);
+            }
+            f_stage = n_normalize(&f_stage);
+
+            let coeff_vars: Vec<usize> = aux_vars[..lift_idx].to_vec();
+
+            let mut remaining = f_stage;
+            let mut new_factors: Vec<NPoly> = Vec::new();
+            let mut remaining_factors = n_factors_current.clone();
+            while remaining_factors.len() >= 2 {
+                let g0 = remaining_factors[0].clone();
+                let mut h0 = n_one(num_vars);
+                for q in &remaining_factors[1..] {
+                    h0 = n_mul(&h0, q, num_vars);
+                }
+                match n_two_factor_lift(
+                    &remaining,
+                    &g0,
+                    &h0,
+                    num_vars,
+                    main_var,
+                    lift_var,
+                    &coeff_vars,
+                ) {
+                    Some((g_lift, h_lift)) => {
+                        new_factors.push(g_lift);
+                        remaining = h_lift;
+                        remaining_factors = remaining_factors[1..].to_vec();
+                    }
+                    None => {
+                        success = false;
+                        break;
+                    }
+                }
+            }
+            if !success {
+                break;
+            }
+            new_factors.push(remaining);
+            n_factors_current = new_factors;
+        }
+        if !success {
+            continue;
+        }
+
+        let mut result = n_factors_current;
+        for (v_i, w_i) in &spec {
+            let neg_w = w_i.neg();
+            result = result.into_iter().map(|fac| n_shift_var(&fac, *v_i, neg_w)).collect();
+        }
+        let result: Vec<NPoly> = result.into_iter().map(|fac| n_normalize(&fac)).collect();
+
+        // Verify product reconstructs f.
+        let mut prod = n_one(num_vars);
+        for fac in &result {
+            prod = n_mul(&prod, fac, num_vars);
+        }
+        if !n_equals(&prod, &f) {
+            continue;
+        }
+
+        // Drop pure constants, fold scalar into factor 0.
+        let mut non_trivial: Vec<NPoly> = Vec::new();
+        let mut scalar = Rat::ONE;
+        for fac in result {
+            if n_total_degree(&fac) <= 0 {
+                if let Some((_, v)) = fac.iter().next() {
+                    scalar = scalar.mul(v);
+                }
+            } else {
+                non_trivial.push(fac);
+            }
+        }
+        if non_trivial.len() < 2 {
+            continue;
+        }
+        if !scalar.is_one() {
+            non_trivial[0] = n_mul(&non_trivial[0], &n_const(num_vars, scalar), num_vars);
+        }
+        return Some(non_trivial);
+    }
+    None
+}
+
+// Suppress dead-code warning if y0_candidates_n is unused in some configs.
+#[allow(dead_code)]
+fn _dead_y0_n() {
+    let _ = y0_candidates_n();
+}

--- a/code/packages/rust/cas-factor/src/lib.rs
+++ b/code/packages/rust/cas-factor/src/lib.rs
@@ -49,7 +49,10 @@ pub mod rational_roots;
 
 pub use bzh::bzh_factor;
 pub use factor::{factor_integer_polynomial, FactorList};
-pub use hensel::{bi_mul, bi_degree_x, bi_degree_y, try_bivariate_hensel, BiPoly, Rat};
+pub use hensel::{
+    bi_mul, bi_degree_x, bi_degree_y, n_mul, try_bivariate_hensel, try_n_variate_hensel, BiPoly,
+    NPoly, Rat,
+};
 pub use kronecker::kronecker_factor;
 pub use polynomial::{
     content, degree, divide_linear, divisors, evaluate, normalize, primitive_part, Poly,

--- a/code/packages/rust/cas-factor/tests/n_variate_hensel.rs
+++ b/code/packages/rust/cas-factor/tests/n_variate_hensel.rs
@@ -1,0 +1,220 @@
+// Tests for n-variate (n ≥ 3) Hensel lifting — Track K2 (Rust port of
+// Python Track K1, PR #5590).
+//
+// Mirrors `code/packages/python/cas-factor/tests/test_n_variate_hensel.py`.
+// Each test builds the input from known factors, runs `try_n_variate_hensel`,
+// and verifies the product of returned factors equals the input.  Factor
+// ordering is not pinned — different specialisation tuples may yield
+// permutations.
+
+use std::collections::BTreeMap;
+
+use cas_factor::{n_mul, try_n_variate_hensel, NPoly, Rat};
+
+fn make(num_vars: usize, terms: &[(Vec<usize>, i128)]) -> NPoly {
+    let mut out: NPoly = BTreeMap::new();
+    for (k, c) in terms {
+        assert_eq!(k.len(), num_vars, "tuple length must match num_vars");
+        if *c == 0 {
+            continue;
+        }
+        let cur = out.get(k).copied().unwrap_or(Rat::ZERO);
+        out.insert(k.clone(), cur.add(&Rat::from_int(*c)));
+    }
+    out.retain(|_, v| !v.is_zero());
+    out
+}
+
+fn n_one_poly(num_vars: usize) -> NPoly {
+    let mut m = BTreeMap::new();
+    m.insert(vec![0usize; num_vars], Rat::ONE);
+    m
+}
+
+fn verify_product(num_vars: usize, factors: &[NPoly], expected: &NPoly) -> bool {
+    let mut prod = n_one_poly(num_vars);
+    for f in factors {
+        prod = n_mul(&prod, f, num_vars);
+    }
+    prod.retain(|_, v| !v.is_zero());
+    let mut exp = expected.clone();
+    exp.retain(|_, v| !v.is_zero());
+    prod == exp
+}
+
+#[test]
+fn trivariate_quadratic_three_factors_known() {
+    // x² − y² − z² − 2yz = (x + y + z)(x − y − z)
+    let poly = make(
+        3,
+        &[
+            (vec![2, 0, 0], 1),
+            (vec![0, 2, 0], -1),
+            (vec![0, 0, 2], -1),
+            (vec![0, 1, 1], -2),
+        ],
+    );
+    let result = try_n_variate_hensel(&poly, 3).expect("expected trivariate factorisation");
+    assert!(result.len() >= 2);
+    assert!(verify_product(3, &result, &poly));
+}
+
+#[test]
+fn trivariate_product_of_two_linear() {
+    // (x + y + z)(x + 2y + 3z) = x² + 3xy + 4xz + 2y² + 5yz + 3z²
+    let poly = make(
+        3,
+        &[
+            (vec![2, 0, 0], 1),
+            (vec![1, 1, 0], 3),
+            (vec![1, 0, 1], 4),
+            (vec![0, 2, 0], 2),
+            (vec![0, 1, 1], 5),
+            (vec![0, 0, 2], 3),
+        ],
+    );
+    let result = try_n_variate_hensel(&poly, 3).expect("expected factorisation");
+    assert_eq!(result.len(), 2);
+    assert!(verify_product(3, &result, &poly));
+}
+
+#[test]
+fn trivariate_sum_of_cubes_companion() {
+    // (x+y+z)(x²+y²+z²−xy−yz−xz)
+    let factor_a = make(
+        3,
+        &[
+            (vec![1, 0, 0], 1),
+            (vec![0, 1, 0], 1),
+            (vec![0, 0, 1], 1),
+        ],
+    );
+    let factor_b = make(
+        3,
+        &[
+            (vec![2, 0, 0], 1),
+            (vec![0, 2, 0], 1),
+            (vec![0, 0, 2], 1),
+            (vec![1, 1, 0], -1),
+            (vec![0, 1, 1], -1),
+            (vec![1, 0, 1], -1),
+        ],
+    );
+    let poly = n_mul(&factor_a, &factor_b, 3);
+    let result = try_n_variate_hensel(&poly, 3).expect("expected factorisation");
+    assert!(result.len() >= 2);
+    assert!(verify_product(3, &result, &poly));
+}
+
+#[test]
+fn quadrivariate_linear_times_linear() {
+    // (x+y)(x+z+w) — iterated lift across two aux vars.
+    let factor_a = make(
+        4,
+        &[(vec![1, 0, 0, 0], 1), (vec![0, 1, 0, 0], 1)],
+    );
+    let factor_b = make(
+        4,
+        &[
+            (vec![1, 0, 0, 0], 1),
+            (vec![0, 0, 1, 0], 1),
+            (vec![0, 0, 0, 1], 1),
+        ],
+    );
+    let poly = n_mul(&factor_a, &factor_b, 4);
+    let result = try_n_variate_hensel(&poly, 4).expect("expected factorisation");
+    assert_eq!(result.len(), 2);
+    assert!(verify_product(4, &result, &poly));
+}
+
+// ---------------------------------------------------------------------------
+// Fall-through cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn irreducible_trivariate_returns_none() {
+    // x² + y² + z² + 1
+    let poly = make(
+        3,
+        &[
+            (vec![2, 0, 0], 1),
+            (vec![0, 2, 0], 1),
+            (vec![0, 0, 2], 1),
+            (vec![0, 0, 0], 1),
+        ],
+    );
+    assert!(try_n_variate_hensel(&poly, 3).is_none());
+}
+
+#[test]
+fn single_variable_returns_none() {
+    let poly = make(3, &[(vec![2, 0, 0], 1), (vec![0, 0, 0], -1)]);
+    assert!(try_n_variate_hensel(&poly, 3).is_none());
+}
+
+#[test]
+fn num_vars_less_than_two_returns_none() {
+    let poly = make(1, &[(vec![2], 1), (vec![0], -1)]);
+    assert!(try_n_variate_hensel(&poly, 1).is_none());
+}
+
+#[test]
+fn constant_returns_none() {
+    let poly = make(3, &[(vec![0, 0, 0], 7)]);
+    assert!(try_n_variate_hensel(&poly, 3).is_none());
+}
+
+#[test]
+fn empty_polynomial_returns_none() {
+    let poly: NPoly = BTreeMap::new();
+    assert!(try_n_variate_hensel(&poly, 3).is_none());
+}
+
+#[test]
+fn linear_polynomial_returns_none() {
+    let poly = make(
+        3,
+        &[(vec![1, 0, 0], 1), (vec![0, 1, 0], 1), (vec![0, 0, 1], 1)],
+    );
+    assert!(try_n_variate_hensel(&poly, 3).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Regression: bivariate via n-variate front door.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bivariate_via_n_variate_x_squared_plus_xy_minus_2y_squared() {
+    let poly = make(2, &[(vec![2, 0], 1), (vec![1, 1], 1), (vec![0, 2], -2)]);
+    let result = try_n_variate_hensel(&poly, 2).expect("expected factorisation");
+    assert_eq!(result.len(), 2);
+    assert!(verify_product(2, &result, &poly));
+}
+
+#[test]
+fn bivariate_via_n_variate_x_cubed_minus_y_cubed() {
+    let poly = make(2, &[(vec![3, 0], 1), (vec![0, 3], -1)]);
+    let result = try_n_variate_hensel(&poly, 2).expect("expected factorisation");
+    assert_eq!(result.len(), 2);
+    assert!(verify_product(2, &result, &poly));
+}
+
+// ---------------------------------------------------------------------------
+// Robustness.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn high_degree_irreducible_does_not_loop() {
+    // x^4 + y^2 + z^2 + 1 — irreducible over Q.
+    let poly = make(
+        3,
+        &[
+            (vec![4, 0, 0], 1),
+            (vec![0, 0, 0], 1),
+            (vec![0, 0, 2], 1),
+            (vec![0, 2, 0], 1),
+        ],
+    );
+    let result = try_n_variate_hensel(&poly, 3);
+    assert!(result.is_none());
+}

--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.20.0] — 2026-05-29
+
+**Track K2 — n-variate Hensel factor bridge (Rust port).**
+
+Wires the new `try_n_variate_hensel` from cas-factor 0.3.0 into the
+`Factor(...)` IR handler.  Mirrors the Python Track K1 bridge in
+`symbolic-vm/cas_handlers.py` (PR #5590) and the TS port in
+`@coding-adventures/symbolic-vm` 0.20.0.
+
+Algorithm (n ≥ 3, generic — not per-arity):
+
+1. Identify all free variables in the input (`find_n_variables`,
+   bounded at 8 distinct symbols so a pathological input can't
+   allocate gigantic sparse-dict keys).
+2. Convert to an `NPoly` via `ir_to_npoly`.  Returns `None` for
+   floats, foreign symbols, transcendentals (Sin/Log/…), or non-integer
+   exponents.
+3. Call `try_n_variate_hensel`.  On success, convert each factor back
+   to IR via `npoly_to_ir` using **left-nested binary Add/Mul** (the
+   primitive Add/Mul handlers are strictly binary, so n-ary Apply
+   nodes with three or more children would crash).
+4. Hook into `factor_handler` AFTER the bivariate Hensel path, BEFORE
+   the unevaluated-wrapper fallback.
+
+Catches `x³ + y³ + z³ − 3xyz = (x+y+z)(x²+y²+z²−xy−yz−zx)`,
+`(x+y+z)(x+2y+3z) = x²+3xy+4xz+2y²+5yz+3z²`, and similar trivariate
+cases.  Falls through cleanly on irreducibles and transcendentals.
+
+### Added
+
+- `try_n_variate_hensel_ir` — top-level IR glue mirroring Python
+  `_try_n_variate_hensel_ir`.
+- `find_n_variables`, `ir_to_npoly`, `npoly_to_ir`, `fold_binary`
+  helpers mirroring `_find_n_variables`, `_ir_to_npoly`,
+  `_npoly_to_ir`, and the left-nested-binary-fold convention.
+- `tests/n_variate_factor.rs` — 6 end-to-end pipeline tests
+  exercising `Factor(...)` over the VM: sum-of-cubes identity, linear
+  product round-trip, irreducible fall-through, transcendental safety,
+  bivariate regression, univariate regression.
+
+### Changed
+
+- `cas-factor` crate dependency reflected at the 0.3.0 floor
+  (n-variate Hensel landed there).
+- `factor_handler` dispatch order: univariate → bivariate Hensel →
+  n-variate Hensel → unevaluated wrapper.
+
 ## [0.19.0] — 2026-05-29
 
 **Track G2 — symbolic-coefficient Weierstrass lift (Rust port).**

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -24,7 +24,8 @@
 use std::collections::{HashMap, HashSet};
 
 use cas_factor::{
-    factor_integer_polynomial, try_bivariate_hensel, BiPoly as HenselBiPoly, Rat as HenselRat,
+    factor_integer_polynomial, try_bivariate_hensel, try_n_variate_hensel,
+    BiPoly as HenselBiPoly, NPoly as HenselNPoly, Rat as HenselRat,
 };
 use cas_simplify::AssumptionContext;
 use symbolic_ir::{
@@ -5402,6 +5403,13 @@ fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
         return vm.eval(rewritten);
     }
 
+    // n-variate (n ≥ 3) Hensel — Track K2.  Generalised algorithmic
+    // fallback for tri- and higher-variate polynomials (e.g.,
+    // x³ + y³ + z³ − 3xyz = (x+y+z)(…)).
+    if let Some(rewritten) = try_n_variate_hensel_ir(input) {
+        return vm.eval(rewritten);
+    }
+
     fallback
 }
 
@@ -6518,6 +6526,284 @@ fn try_bivariate_hensel_ir(inner: &IRNode) -> Option<IRNode> {
         return Some(factor_nodes.into_iter().next().unwrap());
     }
     Some(apply_node(MUL, factor_nodes))
+}
+
+// ---------------------------------------------------------------------------
+// n-variate (n ≥ 3) Hensel-lifting IR glue — Track K2.  Mirrors the Python
+// ``_find_n_variables``, ``_ir_to_npoly``, ``_npoly_to_ir``, and
+// ``_try_n_variate_hensel_ir`` helpers in ``cas_handlers.py``.
+//
+// Output convention: LEFT-NESTED BINARY Add/Mul.  The symbolic-vm primitive
+// Add/Mul handlers are strictly binary, so an Apply(ADD, (a, b, c)) with
+// three or more children would crash when re-evaluated.  We mirror the
+// cubic-identity handler's nesting convention: Add(Add(a, b), c) for three
+// terms, etc.
+// ---------------------------------------------------------------------------
+
+const MAX_N_VARS: usize = 8;
+
+fn find_n_variables(node: &IRNode) -> Option<Vec<String>> {
+    let mut seen: Vec<String> = Vec::new();
+    fn walk(n: &IRNode, seen: &mut Vec<String>) -> bool {
+        match n {
+            IRNode::Symbol(name) if !name.starts_with('%') => {
+                if !seen.iter().any(|s| s == name) {
+                    seen.push(name.clone());
+                    if seen.len() > MAX_N_VARS {
+                        return false;
+                    }
+                }
+                true
+            }
+            IRNode::Apply(apply) => {
+                for arg in &apply.args {
+                    if !walk(arg, seen) {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => true,
+        }
+    }
+    if !walk(node, &mut seen) {
+        return None;
+    }
+    if seen.is_empty() {
+        return None;
+    }
+    Some(seen)
+}
+
+fn ir_to_npoly(node: &IRNode, vars: &[String]) -> Option<HenselNPoly> {
+    let num_vars = vars.len();
+    let zero_key: Vec<usize> = vec![0; num_vars];
+
+    let mut var_index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for (i, v) in vars.iter().enumerate() {
+        var_index.insert(v.clone(), i);
+    }
+
+    fn n_one(num_vars: usize) -> HenselNPoly {
+        let mut out = std::collections::BTreeMap::new();
+        out.insert(vec![0usize; num_vars], HenselRat::ONE);
+        out
+    }
+
+    fn n_mul_local(a: &HenselNPoly, b: &HenselNPoly, num_vars: usize) -> HenselNPoly {
+        let mut out: HenselNPoly = std::collections::BTreeMap::new();
+        for (k1, c1) in a {
+            for (k2, c2) in b {
+                let key: Vec<usize> = (0..num_vars).map(|i| k1[i] + k2[i]).collect();
+                let cur = out.get(&key).copied().unwrap_or(HenselRat::ZERO);
+                out.insert(key, cur.add(&c1.mul(c2)));
+            }
+        }
+        out.retain(|_, v| !v.is_zero());
+        out
+    }
+
+    fn n_add_into(acc: &mut HenselNPoly, other: &HenselNPoly) {
+        for (k, v) in other {
+            let cur = acc.get(k).copied().unwrap_or(HenselRat::ZERO);
+            acc.insert(k.clone(), cur.add(v));
+        }
+        acc.retain(|_, v| !v.is_zero());
+    }
+
+    fn unit_for(var_idx: usize, num_vars: usize) -> Vec<usize> {
+        let mut key = vec![0usize; num_vars];
+        key[var_idx] = 1;
+        key
+    }
+
+    fn walk(
+        node: &IRNode,
+        vars_idx: &std::collections::HashMap<String, usize>,
+        num_vars: usize,
+        zero_key: &[usize],
+    ) -> Option<HenselNPoly> {
+        match node {
+            IRNode::Integer(value) => {
+                if *value == 0 {
+                    Some(std::collections::BTreeMap::new())
+                } else {
+                    let mut m = std::collections::BTreeMap::new();
+                    m.insert(zero_key.to_vec(), HenselRat::from_int(*value as i128));
+                    Some(m)
+                }
+            }
+            IRNode::Rational(n, d) => {
+                let mut m = std::collections::BTreeMap::new();
+                m.insert(zero_key.to_vec(), HenselRat::new(*n as i128, *d as i128));
+                Some(m)
+            }
+            IRNode::Float(_) | IRNode::Str(_) => None,
+            IRNode::Symbol(name) => {
+                if name.starts_with('%') {
+                    return None;
+                }
+                if let Some(&i) = vars_idx.get(name) {
+                    let mut m = std::collections::BTreeMap::new();
+                    m.insert(unit_for(i, num_vars), HenselRat::ONE);
+                    Some(m)
+                } else {
+                    None
+                }
+            }
+            IRNode::Apply(apply) => {
+                let head = match &apply.head {
+                    IRNode::Symbol(name) => name.as_str(),
+                    _ => return None,
+                };
+                if head == ADD {
+                    let mut acc: HenselNPoly = std::collections::BTreeMap::new();
+                    for arg in &apply.args {
+                        let sub = walk(arg, vars_idx, num_vars, zero_key)?;
+                        n_add_into(&mut acc, &sub);
+                    }
+                    Some(acc)
+                } else if head == SUB && apply.args.len() == 2 {
+                    let a = walk(&apply.args[0], vars_idx, num_vars, zero_key)?;
+                    let b = walk(&apply.args[1], vars_idx, num_vars, zero_key)?;
+                    let mut neg_b: HenselNPoly = std::collections::BTreeMap::new();
+                    for (k, v) in &b {
+                        if !v.is_zero() {
+                            neg_b.insert(k.clone(), v.neg());
+                        }
+                    }
+                    let mut acc = a;
+                    n_add_into(&mut acc, &neg_b);
+                    Some(acc)
+                } else if head == NEG && apply.args.len() == 1 {
+                    let sub = walk(&apply.args[0], vars_idx, num_vars, zero_key)?;
+                    let mut out: HenselNPoly = std::collections::BTreeMap::new();
+                    for (k, v) in sub {
+                        if !v.is_zero() {
+                            out.insert(k, v.neg());
+                        }
+                    }
+                    Some(out)
+                } else if head == MUL {
+                    let mut acc = n_one(num_vars);
+                    for arg in &apply.args {
+                        let sub = walk(arg, vars_idx, num_vars, zero_key)?;
+                        acc = n_mul_local(&acc, &sub, num_vars);
+                    }
+                    Some(acc)
+                } else if head == POW && apply.args.len() == 2 {
+                    let exp = match apply.args[1] {
+                        IRNode::Integer(e) => e,
+                        _ => return None,
+                    };
+                    if exp < 0 {
+                        return None;
+                    }
+                    let base = walk(&apply.args[0], vars_idx, num_vars, zero_key)?;
+                    if exp == 0 {
+                        return Some(n_one(num_vars));
+                    }
+                    let mut result = base.clone();
+                    for _ in 1..exp {
+                        result = n_mul_local(&result, &base, num_vars);
+                    }
+                    Some(result)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+    let _ = zero_key;
+    walk(node, &var_index, num_vars, &vec![0usize; num_vars])
+}
+
+/// Left-fold a list of children into nested binary Apply nodes.
+fn fold_binary(head: &str, parts: Vec<IRNode>) -> IRNode {
+    assert!(!parts.is_empty(), "fold_binary requires at least one node");
+    let mut iter = parts.into_iter();
+    let mut result = iter.next().unwrap();
+    for nxt in iter {
+        result = apply_node(head, vec![result, nxt]);
+    }
+    result
+}
+
+fn npoly_to_ir(p: &HenselNPoly, vars: &[String]) -> IRNode {
+    if p.is_empty() {
+        return IRNode::Integer(0);
+    }
+    let num_vars = vars.len();
+
+    fn monomial_node(key: &[usize], c: HenselRat, vars: &[String]) -> IRNode {
+        let mut parts: Vec<IRNode> = Vec::new();
+        let all_zero = key.iter().all(|e| *e == 0);
+        if !c.is_one() || all_zero {
+            if c.denom == 1 {
+                parts.push(IRNode::Integer(c.numer as i64));
+            } else {
+                parts.push(IRNode::rational(c.numer as i64, c.denom as i64));
+            }
+        }
+        for (i, e) in key.iter().enumerate() {
+            if *e == 0 {
+                continue;
+            }
+            let v_node = IRNode::Symbol(vars[i].clone());
+            if *e == 1 {
+                parts.push(v_node);
+            } else {
+                parts.push(apply_node(POW, vec![v_node, IRNode::Integer(*e as i64)]));
+            }
+        }
+        if parts.is_empty() {
+            return IRNode::Integer(1);
+        }
+        fold_binary(MUL, parts)
+    }
+
+    // Sort: descending total degree, then lex on negated exponents.
+    let mut keys: Vec<Vec<usize>> = p.keys().cloned().collect();
+    keys.sort_by(|a, b| {
+        let sa: usize = a.iter().sum();
+        let sb: usize = b.iter().sum();
+        match sb.cmp(&sa) {
+            std::cmp::Ordering::Equal => {
+                for i in 0..num_vars {
+                    match b[i].cmp(&a[i]) {
+                        std::cmp::Ordering::Equal => continue,
+                        o => return o,
+                    }
+                }
+                std::cmp::Ordering::Equal
+            }
+            o => o,
+        }
+    });
+
+    let terms: Vec<IRNode> = keys
+        .iter()
+        .map(|k| monomial_node(k, *p.get(k).unwrap(), vars))
+        .collect();
+    fold_binary(ADD, terms)
+}
+
+fn try_n_variate_hensel_ir(inner: &IRNode) -> Option<IRNode> {
+    let vars = find_n_variables(inner)?;
+    if vars.len() < 2 {
+        return None;
+    }
+    let npoly = ir_to_npoly(inner, &vars)?;
+    let factors = try_n_variate_hensel(&npoly, vars.len())?;
+    if factors.len() < 2 {
+        return None;
+    }
+    let factor_nodes: Vec<IRNode> = factors.iter().map(|f| npoly_to_ir(f, &vars)).collect();
+    if factor_nodes.len() == 1 {
+        return Some(factor_nodes.into_iter().next().unwrap());
+    }
+    // Left-nested binary Mul for binary-handler compatibility.
+    Some(fold_binary(MUL, factor_nodes))
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/symbolic-vm/tests/n_variate_factor.rs
+++ b/code/packages/rust/symbolic-vm/tests/n_variate_factor.rs
@@ -1,0 +1,320 @@
+//! Pipeline tests for n-variate Hensel-lift factorisation — Track K2
+//! (Rust port of Python Track K1, PR #5590).
+//!
+//! Exercise the end-to-end `Factor(expr)` path through the VM: construct
+//! `Factor(...)` IR, evaluate on a SymbolicBackend, and verify the result
+//! by re-expanding the returned product back to a sparse-dict polynomial
+//! and comparing against the sparse-dict expansion of the input.  We
+//! verify *algebraic* equality rather than *shape* — the Hensel lift may
+//! emit factors in a different deterministic order than the human-
+//! recognisable canonical order, and integer-content can be pulled out
+//! separately.
+
+use std::collections::BTreeMap;
+
+use symbolic_ir::{apply, int, sym, IRNode, ADD, MUL, POW, SUB};
+use symbolic_vm::{SymbolicBackend, VM};
+
+fn symbolic() -> VM {
+    VM::new(Box::new(SymbolicBackend::new()))
+}
+
+fn factor(inner: IRNode) -> IRNode {
+    apply(sym("Factor"), vec![inner])
+}
+
+type PolyDict = BTreeMap<Vec<i64>, i128>;
+
+fn expand_to_dict(node: &IRNode, vars: &[&str]) -> PolyDict {
+    let n = vars.len();
+    let zero = vec![0i64; n];
+    let mut var_idx: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (i, v) in vars.iter().enumerate() {
+        var_idx.insert(*v, i);
+    }
+
+    fn unit(name: &str, var_idx: &std::collections::HashMap<&str, usize>, n: usize) -> Vec<i64> {
+        let i = *var_idx.get(name).expect("var present");
+        let mut k = vec![0i64; n];
+        k[i] = 1;
+        k
+    }
+    fn add_keys(a: &[i64], b: &[i64]) -> Vec<i64> {
+        a.iter().zip(b.iter()).map(|(x, y)| x + y).collect()
+    }
+    fn normalize(d: &mut PolyDict) {
+        d.retain(|_, v| *v != 0);
+    }
+    fn add(a: &PolyDict, b: &PolyDict) -> PolyDict {
+        let mut out: PolyDict = a.clone();
+        for (k, v) in b {
+            let cur = out.get(k).copied().unwrap_or(0);
+            out.insert(k.clone(), cur + v);
+        }
+        normalize(&mut out);
+        out
+    }
+    fn neg(a: &PolyDict) -> PolyDict {
+        let mut out: PolyDict = BTreeMap::new();
+        for (k, v) in a {
+            out.insert(k.clone(), -v);
+        }
+        normalize(&mut out);
+        out
+    }
+    fn mul(a: &PolyDict, b: &PolyDict) -> PolyDict {
+        let mut out: PolyDict = BTreeMap::new();
+        for (ka, va) in a {
+            for (kb, vb) in b {
+                let k = add_keys(ka, kb);
+                let cur = out.get(&k).copied().unwrap_or(0);
+                out.insert(k, cur + va * vb);
+            }
+        }
+        normalize(&mut out);
+        out
+    }
+    fn walk(
+        node: &IRNode,
+        vars: &[&str],
+        var_idx: &std::collections::HashMap<&str, usize>,
+        n: usize,
+        zero: &[i64],
+    ) -> PolyDict {
+        match node {
+            IRNode::Integer(value) => {
+                if *value == 0 {
+                    BTreeMap::new()
+                } else {
+                    let mut m: PolyDict = BTreeMap::new();
+                    m.insert(zero.to_vec(), *value as i128);
+                    m
+                }
+            }
+            IRNode::Symbol(name) => {
+                if var_idx.contains_key(name.as_str()) {
+                    let mut m: PolyDict = BTreeMap::new();
+                    m.insert(unit(name, var_idx, n), 1);
+                    m
+                } else {
+                    panic!("unexpected symbol: {}", name)
+                }
+            }
+            IRNode::Apply(a) => {
+                let head = match &a.head {
+                    IRNode::Symbol(s) => s.as_str(),
+                    _ => panic!("non-symbol head"),
+                };
+                if head == ADD {
+                    let mut acc: PolyDict = BTreeMap::new();
+                    for arg in &a.args {
+                        acc = add(&acc, &walk(arg, vars, var_idx, n, zero));
+                    }
+                    acc
+                } else if head == SUB && a.args.len() == 2 {
+                    let l = walk(&a.args[0], vars, var_idx, n, zero);
+                    let r = walk(&a.args[1], vars, var_idx, n, zero);
+                    add(&l, &neg(&r))
+                } else if head == MUL {
+                    let mut acc: PolyDict = BTreeMap::new();
+                    acc.insert(zero.to_vec(), 1);
+                    for arg in &a.args {
+                        acc = mul(&acc, &walk(arg, vars, var_idx, n, zero));
+                    }
+                    acc
+                } else if head == POW && a.args.len() == 2 {
+                    let base = walk(&a.args[0], vars, var_idx, n, zero);
+                    let exp = match a.args[1] {
+                        IRNode::Integer(e) => e,
+                        _ => panic!("non-int exp"),
+                    };
+                    assert!(exp >= 0);
+                    if exp == 0 {
+                        let mut m: PolyDict = BTreeMap::new();
+                        m.insert(zero.to_vec(), 1);
+                        return m;
+                    }
+                    let mut out = base.clone();
+                    for _ in 1..exp {
+                        out = mul(&out, &base);
+                    }
+                    out
+                } else {
+                    panic!("unexpected head: {}", head)
+                }
+            }
+            _ => panic!("unexpected node"),
+        }
+    }
+    walk(node, vars, &var_idx, n, &zero)
+}
+
+fn is_factor_wrapper(node: &IRNode) -> bool {
+    if let IRNode::Apply(a) = node {
+        if let IRNode::Symbol(s) = &a.head {
+            return s == "Factor";
+        }
+    }
+    false
+}
+
+#[test]
+fn factor_x3_y3_z3_minus_3xyz_recovers_two_factors() {
+    let mut vm = symbolic();
+    // x^3 + y^3 + z^3 - 3*x*y*z
+    let target = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(sym(POW), vec![sym("x"), int(3)]),
+                            apply(sym(POW), vec![sym("y"), int(3)]),
+                        ],
+                    ),
+                    apply(sym(POW), vec![sym("z"), int(3)]),
+                ],
+            ),
+            apply(
+                sym(MUL),
+                vec![
+                    int(3),
+                    apply(
+                        sym(MUL),
+                        vec![apply(sym(MUL), vec![sym("x"), sym("y")]), sym("z")],
+                    ),
+                ],
+            ),
+        ],
+    );
+    let expr = factor(target.clone());
+    let result = vm.eval(expr.clone());
+    assert!(!is_factor_wrapper(&result), "expected factored output");
+    let vars = ["x", "y", "z"];
+    assert_eq!(expand_to_dict(&result, &vars), expand_to_dict(&target, &vars));
+}
+
+#[test]
+fn factor_linear_product_round_trips() {
+    let mut vm = symbolic();
+    // x^2 + 3xy + 4xz + 2y^2 + 5yz + 3z^2  =  (x + y + z)(x + 2y + 3z)
+    let expanded = apply(
+        sym(ADD),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(2)]),
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(MUL), vec![int(3), apply(sym(MUL), vec![sym("x"), sym("y")])]),
+                    apply(
+                        sym(ADD),
+                        vec![
+                            apply(sym(MUL), vec![int(4), apply(sym(MUL), vec![sym("x"), sym("z")])]),
+                            apply(
+                                sym(ADD),
+                                vec![
+                                    apply(sym(MUL), vec![int(2), apply(sym(POW), vec![sym("y"), int(2)])]),
+                                    apply(
+                                        sym(ADD),
+                                        vec![
+                                            apply(sym(MUL), vec![int(5), apply(sym(MUL), vec![sym("y"), sym("z")])]),
+                                            apply(sym(MUL), vec![int(3), apply(sym(POW), vec![sym("z"), int(2)])]),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    );
+    let expr = factor(expanded.clone());
+    let result = vm.eval(expr.clone());
+    let vars = ["x", "y", "z"];
+    if is_factor_wrapper(&result) {
+        return; // unevaluated wrapper — acceptable
+    }
+    assert_eq!(expand_to_dict(&result, &vars), expand_to_dict(&expanded, &vars));
+}
+
+#[test]
+fn factor_irreducible_x2_y2_z2_plus_1_falls_through() {
+    let mut vm = symbolic();
+    let target = apply(
+        sym(ADD),
+        vec![
+            apply(sym(POW), vec![sym("x"), int(2)]),
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(POW), vec![sym("y"), int(2)]),
+                    apply(
+                        sym(ADD),
+                        vec![apply(sym(POW), vec![sym("z"), int(2)]), int(1)],
+                    ),
+                ],
+            ),
+        ],
+    );
+    let expr = factor(target.clone());
+    let result = vm.eval(expr.clone());
+    // Either Factor(...) wrapper or algebraic round-trip.
+    if is_factor_wrapper(&result) {
+        return;
+    }
+    let vars = ["x", "y", "z"];
+    assert_eq!(expand_to_dict(&result, &vars), expand_to_dict(&target, &vars));
+}
+
+#[test]
+fn factor_transcendental_does_not_crash() {
+    let mut vm = symbolic();
+    let target = apply(
+        sym(ADD),
+        vec![
+            apply(sym("Sin"), vec![sym("x")]),
+            apply(sym(ADD), vec![sym("y"), sym("z")]),
+        ],
+    );
+    let expr = factor(target);
+    let _ = vm.eval(expr.clone());
+}
+
+#[test]
+fn regression_bivariate_x2_xy_minus_2y2_still_factors() {
+    let mut vm = symbolic();
+    // x^2 + xy - 2y^2 = (x + 2y)(x - y)
+    let target = apply(
+        sym(SUB),
+        vec![
+            apply(
+                sym(ADD),
+                vec![
+                    apply(sym(POW), vec![sym("x"), int(2)]),
+                    apply(sym(MUL), vec![sym("x"), sym("y")]),
+                ],
+            ),
+            apply(sym(MUL), vec![int(2), apply(sym(POW), vec![sym("y"), int(2)])]),
+        ],
+    );
+    let expr = factor(target.clone());
+    let result = vm.eval(expr.clone());
+    assert!(!is_factor_wrapper(&result), "expected factored output");
+    let vars = ["x", "y"];
+    assert_eq!(expand_to_dict(&result, &vars), expand_to_dict(&target, &vars));
+}
+
+#[test]
+fn regression_univariate_x2_minus_1_still_factors() {
+    let mut vm = symbolic();
+    let target = apply(sym(SUB), vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]);
+    let expr = factor(target.clone());
+    let result = vm.eval(expr.clone());
+    assert!(!is_factor_wrapper(&result), "expected univariate factoring");
+    let vars = ["x"];
+    assert_eq!(expand_to_dict(&result, &vars), expand_to_dict(&target, &vars));
+}

--- a/code/packages/typescript/cas-factor/CHANGELOG.md
+++ b/code/packages/typescript/cas-factor/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.3.0] — 2026-05-29
+
+**Track K2 — n-variate Hensel lifting (TypeScript port).**
+
+Ports the Python `cas_factor.hensel.try_n_variate_hensel` algorithm
+(Track K1, PR #5590) to TypeScript.  Extends the bivariate Hensel
+lift to n ≥ 3 variables by iterated bivariate lifting:
+
+1. Pick a main variable `v_0`; substitute auxiliary variables with
+   small integer values to reduce f to a univariate polynomial.
+2. Factor the univariate image via the existing factor-uni-q chain.
+3. Lift the univariate factors back one auxiliary variable at a time
+   via Hensel-style expansion in powers of `(v_k − a_k)`.  Each lift
+   step solves a coefficient-ring diophantine equation recursively;
+   base case hits `uDiophantine` directly.
+4. Verify the final product equals the input; return `null` on any
+   mismatch so the caller falls through to other handlers.
+
+Reuses the existing `tryBivariateHensel` machinery (rational types,
+univariate diophantine, factor-uni-q) as building blocks.  Bounded
+specialisation search (≤ 10 tuples); recursion depth bounded by `n`.
+
+### Added
+
+- `tryNVariateHensel(f: NPoly, numVars: number): NPoly[] | null` —
+  top-level entry point for n-variate (n ≥ 2) factoring via iterated
+  Hensel lifting.
+- `NPoly` type — sparse n-variate polynomial as `Map<"e0,e1,…", Rational>`
+  (comma-joined exponent tuple).
+- `tests/n_variate_hensel.test.ts` — 13 acceptance cases mirroring the
+  Python `test_n_variate_hensel.py` suite: trivariate quadratic, two
+  trivariate cubics (sum-of-cubes companion, asymmetric coefficients),
+  quadrivariate iterated lift, six fall-through cases, two bivariate
+  regressions via the n-variate front door, and a bounded-resource
+  smoke test.
+
 ## 0.2.0
 
 **Track D2 — bivariate Hensel lifting (TypeScript port).**

--- a/code/packages/typescript/cas-factor/package.json
+++ b/code/packages/typescript/cas-factor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/cas-factor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pure TypeScript integer polynomial factoring for CAS packages",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/cas-factor/src/hensel.ts
+++ b/code/packages/typescript/cas-factor/src/hensel.ts
@@ -598,4 +598,574 @@ export const _internals = {
   biNormalize,
   biEquals,
   key,
+  nMul,
+  nNormalize,
+  nOne,
 };
+
+// ===========================================================================
+// n-variate Hensel lifting — Track K2 (TS port of Python Track K1, PR #5590).
+// ===========================================================================
+//
+// Strategy (one generic algorithm — NOT per-variable-count helpers):
+//
+//   1. Pick a "main" variable v_0 (always index 0 in the sparse-tuple
+//      representation).
+//   2. Substitute v_1..v_{n-1} with small integer values to reduce f to a
+//      univariate polynomial in v_0.
+//   3. Factor the univariate image via the existing factor-uni-q chain.
+//   4. Lift the univariate factors back to the full n-variate ring one
+//      variable at a time.  At step k we have factors of
+//      ``f|_{v_{k+1}=a_{k+1}, …, v_{n-1}=a_{n-1}}`` in Q[v_0, …, v_{k-1}]
+//      and lift to factors of ``f|_{v_{k+1}=a_{k+1}, …}`` in Q[v_0, …, v_k]
+//      by Hensel-style expansion in powers of ``(v_k − a_k)``.
+//   5. Each lift step solves a coefficient-ring diophantine equation
+//      ``A·u + B·v = c`` in Q[v_0, …, v_{k-1}].  Recursively: when the
+//      coefficient ring has ≥ 2 variables, specialise to reduce to Q[v_0],
+//      solve via the existing uDiophantine, then lift back.  Base case
+//      hits uDiophantine directly.
+//   6. Verify the final product equals the input; if not, return null and
+//      let the caller fall through.
+//
+// Representation:
+//   ``NPoly = Map<string, Rational>`` where the string key is the comma-
+//   joined exponent tuple ``"e_0,e_1,…,e_{n-1}"``.  Tuple length equals
+//   the number of variables; the variable count must be passed alongside
+//   this map because the empty polynomial doesn't carry it.
+//
+// Bounded resource discipline:
+//   - At most MAX_N_SPECIALISATION lucky-point tuples are tried (10).
+//   - Recursion depth bounded by n (number of variables).
+//   - Each lift loop bounded by ``deg_{v_k}(f) + 1`` iterations.
+
+/** Sparse n-variate polynomial — comma-joined exponent tuple ↦ coefficient. */
+export type NPoly = Map<string, Rational>;
+
+const MAX_N_SPECIALISATION = 10;
+
+function nKey(tuple: number[]): string {
+  return tuple.join(",");
+}
+
+function nParseKey(k: string, numVars: number): number[] {
+  const out: number[] = [];
+  let start = 0;
+  for (let i = 0; i < numVars - 1; i += 1) {
+    const idx = k.indexOf(",", start);
+    out.push(Number(k.slice(start, idx)));
+    start = idx + 1;
+  }
+  out.push(Number(k.slice(start)));
+  return out;
+}
+
+function nNormalize(p: NPoly): NPoly {
+  const out: NPoly = new Map();
+  for (const [k, v] of p) {
+    if (!v.isZero()) out.set(k, v);
+  }
+  return out;
+}
+
+function nZero(): NPoly {
+  return new Map();
+}
+
+function nOne(numVars: number): NPoly {
+  const k = nKey(new Array<number>(numVars).fill(0));
+  return new Map([[k, Rational.ONE]]);
+}
+
+function nConst(numVars: number, c: Rational): NPoly {
+  if (c.isZero()) return new Map();
+  const k = nKey(new Array<number>(numVars).fill(0));
+  return new Map([[k, c]]);
+}
+
+function nDegreeIn(p: NPoly, varIdx: number, numVars: number): number {
+  let best = -1;
+  for (const [k, v] of p) {
+    if (v.isZero()) continue;
+    const tup = nParseKey(k, numVars);
+    if (tup[varIdx] > best) best = tup[varIdx];
+  }
+  return best;
+}
+
+function nTotalDegree(p: NPoly, numVars: number): number {
+  let best = -1;
+  for (const [k, v] of p) {
+    if (v.isZero()) continue;
+    const tup = nParseKey(k, numVars);
+    let s = 0;
+    for (const e of tup) s += e;
+    if (s > best) best = s;
+  }
+  return best;
+}
+
+function nAdd(a: NPoly, b: NPoly): NPoly {
+  const out: NPoly = new Map(a);
+  for (const [k, v] of b) {
+    const cur = out.get(k) ?? Rational.ZERO;
+    out.set(k, cur.add(v));
+  }
+  return nNormalize(out);
+}
+
+function nSub(a: NPoly, b: NPoly): NPoly {
+  const out: NPoly = new Map(a);
+  for (const [k, v] of b) {
+    const cur = out.get(k) ?? Rational.ZERO;
+    out.set(k, cur.sub(v));
+  }
+  return nNormalize(out);
+}
+
+function nMul(a: NPoly, b: NPoly, numVars: number): NPoly {
+  const out: NPoly = new Map();
+  for (const [k1, c1] of a) {
+    if (c1.isZero()) continue;
+    const t1 = nParseKey(k1, numVars);
+    for (const [k2, c2] of b) {
+      if (c2.isZero()) continue;
+      const t2 = nParseKey(k2, numVars);
+      const t: number[] = new Array<number>(numVars);
+      for (let i = 0; i < numVars; i += 1) t[i] = t1[i] + t2[i];
+      const k = nKey(t);
+      const cur = out.get(k) ?? Rational.ZERO;
+      out.set(k, cur.add(c1.mul(c2)));
+    }
+  }
+  return nNormalize(out);
+}
+
+function nEquals(a: NPoly, b: NPoly): boolean {
+  const na = nNormalize(a);
+  const nb = nNormalize(b);
+  if (na.size !== nb.size) return false;
+  for (const [k, v] of na) {
+    const w = nb.get(k);
+    if (w === undefined || !w.equals(v)) return false;
+  }
+  return true;
+}
+
+/** Substitute v_{varIdx} = value, keep the tuple shape (slot stays at exponent 0). */
+function nSubstituteVarKeep(p: NPoly, varIdx: number, value: Rational, numVars: number): NPoly {
+  const out: NPoly = new Map();
+  for (const [k, c] of p) {
+    const tup = nParseKey(k, numVars);
+    const e = tup[varIdx];
+    const newTup = [...tup];
+    newTup[varIdx] = 0;
+    const contrib = c.mul(value.pow(e));
+    if (contrib.isZero()) continue;
+    const nk = nKey(newTup);
+    const cur = out.get(nk) ?? Rational.ZERO;
+    out.set(nk, cur.add(contrib));
+  }
+  return nNormalize(out);
+}
+
+/** Extract the (n−1)-variate-feeling coefficient at varIdx^kPow — but kept in n-variate ring with varIdx slot = 0. */
+function nCoeffAtPower(p: NPoly, varIdx: number, kPow: number, numVars: number): NPoly {
+  const out: NPoly = new Map();
+  for (const [k, c] of p) {
+    const tup = nParseKey(k, numVars);
+    if (tup[varIdx] !== kPow) continue;
+    const newTup = [...tup];
+    newTup[varIdx] = 0;
+    const nk = nKey(newTup);
+    const cur = out.get(nk) ?? Rational.ZERO;
+    out.set(nk, cur.add(c));
+  }
+  return nNormalize(out);
+}
+
+/** Embed a univariate-in-varIdx polynomial into the n-variate ring. */
+function uToN(p: UniQPoly, varIdx: number, numVars: number): NPoly {
+  const out: NPoly = new Map();
+  for (let e = 0; e < p.length; e += 1) {
+    if (p[e].isZero()) continue;
+    const tup = new Array<number>(numVars).fill(0);
+    tup[varIdx] = e;
+    out.set(nKey(tup), p[e]);
+  }
+  return out;
+}
+
+/** Convert a polynomial that only uses varIdx to a UniQPoly. */
+function nToUnivariate(p: NPoly, varIdx: number, numVars: number): UniQPoly {
+  if (p.size === 0) return [];
+  let maxE = 0;
+  for (const k of p.keys()) {
+    const tup = nParseKey(k, numVars);
+    if (tup[varIdx] > maxE) maxE = tup[varIdx];
+  }
+  const out: Rational[] = Array.from({ length: maxE + 1 }, () => Rational.ZERO);
+  for (const [k, c] of p) {
+    const tup = nParseKey(k, numVars);
+    out[tup[varIdx]] = out[tup[varIdx]].add(c);
+  }
+  return uNormalize(out);
+}
+
+function nOnlyUsesVar(p: NPoly, varIdx: number, numVars: number): boolean {
+  for (const k of p.keys()) {
+    const tup = nParseKey(k, numVars);
+    for (let i = 0; i < numVars; i += 1) {
+      if (i !== varIdx && tup[i] !== 0) return false;
+    }
+  }
+  return true;
+}
+
+/** Rewrite p as polynomial in (v_{varIdx} − value) — binomial expansion. */
+function nShiftVar(p: NPoly, varIdx: number, value: Rational, numVars: number): NPoly {
+  if (value.isZero()) return new Map(p);
+  const out: NPoly = new Map();
+  for (const [k, c] of p) {
+    if (c.isZero()) continue;
+    const tup = nParseKey(k, numVars);
+    const e = tup[varIdx];
+    for (let m = 0; m <= e; m += 1) {
+      const coeff = c.mul(Rational.fromInt(binomial(e, m))).mul(value.pow(e - m));
+      const newTup = [...tup];
+      newTup[varIdx] = m;
+      const nk = nKey(newTup);
+      const cur = out.get(nk) ?? Rational.ZERO;
+      out.set(nk, cur.add(coeff));
+    }
+  }
+  return nNormalize(out);
+}
+
+// ---------------------------------------------------------------------------
+// Recursive coefficient-ring diophantine: solve u·g0 + v·h0 = c in
+// Q[active_vars] ⊂ Q[v_0, …, v_{n-1}].
+// ---------------------------------------------------------------------------
+
+function nDiophantine(
+  g0: NPoly,
+  h0: NPoly,
+  c: NPoly,
+  numVars: number,
+  mainVar: number,
+  activeVars: readonly number[],
+): [NPoly, NPoly] | null {
+  // Base case: univariate ring.
+  if (activeVars.length === 1) {
+    const only = activeVars[0];
+    if (!(nOnlyUsesVar(g0, only, numVars) && nOnlyUsesVar(h0, only, numVars) && nOnlyUsesVar(c, only, numVars))) {
+      return null;
+    }
+    const g0u = nToUnivariate(g0, only, numVars);
+    const h0u = nToUnivariate(h0, only, numVars);
+    const cu = nToUnivariate(c, only, numVars);
+    const solved = uDiophantine(g0u, h0u, cu);
+    if (solved === null) return null;
+    const [uu, vu] = solved;
+    return [uToN(uu, only, numVars), uToN(vu, only, numVars)];
+  }
+
+  // Recursive case: eliminate the last variable in activeVars.
+  const w = activeVars[activeVars.length - 1];
+  const rest = activeVars.slice(0, -1);
+
+  const maxWDeg = Math.max(
+    nDegreeIn(g0, w, numVars),
+    nDegreeIn(h0, w, numVars),
+    nDegreeIn(c, w, numVars),
+    0,
+  );
+
+  const candidates = y0Candidates().slice(0, MAX_N_SPECIALISATION);
+  for (const w0Int of candidates) {
+    const w0 = Rational.fromInt(w0Int);
+    const g0Shift = nShiftVar(g0, w, w0, numVars);
+    const h0Shift = nShiftVar(h0, w, w0, numVars);
+    const cShift = nShiftVar(c, w, w0, numVars);
+    const g0Base = nCoeffAtPower(g0Shift, w, 0, numVars);
+    const h0Base = nCoeffAtPower(h0Shift, w, 0, numVars);
+    const cBase = nCoeffAtPower(cShift, w, 0, numVars);
+
+    const solved = nDiophantine(g0Base, h0Base, cBase, numVars, mainVar, rest);
+    if (solved === null) continue;
+    let [u, v] = solved;
+
+    let success = true;
+    for (let k = 1; k <= maxWDeg; k += 1) {
+      const prod = nAdd(nMul(u, g0Shift, numVars), nMul(v, h0Shift, numVars));
+      const err = nSub(cShift, prod);
+      if (err.size === 0) break;
+      const eK = nCoeffAtPower(err, w, k, numVars);
+      if (eK.size === 0) continue;
+      const sub = nDiophantine(g0Base, h0Base, eK, numVars, mainVar, rest);
+      if (sub === null) {
+        success = false;
+        break;
+      }
+      const [du, dv] = sub;
+      const uNext: NPoly = new Map(u);
+      for (const [keyDu, coef] of du) {
+        const tup = nParseKey(keyDu, numVars);
+        const newTup = [...tup];
+        newTup[w] = k;
+        const nk = nKey(newTup);
+        const cur = uNext.get(nk) ?? Rational.ZERO;
+        uNext.set(nk, cur.add(coef));
+      }
+      const vNext: NPoly = new Map(v);
+      for (const [keyDv, coef] of dv) {
+        const tup = nParseKey(keyDv, numVars);
+        const newTup = [...tup];
+        newTup[w] = k;
+        const nk = nKey(newTup);
+        const cur = vNext.get(nk) ?? Rational.ZERO;
+        vNext.set(nk, cur.add(coef));
+      }
+      u = nNormalize(uNext);
+      v = nNormalize(vNext);
+    }
+
+    if (!success) continue;
+
+    // Verify in the shifted ring.
+    const check = nAdd(nMul(u, g0Shift, numVars), nMul(v, h0Shift, numVars));
+    if (!nEquals(check, nNormalize(cShift))) continue;
+
+    // Unshift u and v back.
+    if (!w0.isZero()) {
+      u = nShiftVar(u, w, w0.neg(), numVars);
+      v = nShiftVar(v, w, w0.neg(), numVars);
+    }
+    return [u, v];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// n-variate two-factor lift.
+// ---------------------------------------------------------------------------
+
+function nTwoFactorLift(
+  f: NPoly,
+  g0: NPoly,
+  h0: NPoly,
+  numVars: number,
+  mainVar: number,
+  liftVar: number,
+  coeffVars: readonly number[],
+): [NPoly, NPoly] | null {
+  let g: NPoly = new Map(g0);
+  let h: NPoly = new Map(h0);
+
+  const degLift = nDegreeIn(f, liftVar, numVars);
+  const active: number[] = [mainVar, ...coeffVars];
+
+  for (let k = 1; k <= degLift; k += 1) {
+    const error = nSub(f, nMul(g, h, numVars));
+    if (error.size === 0) break;
+    const eK = nCoeffAtPower(error, liftVar, k, numVars);
+    if (eK.size === 0) continue;
+    const solved = nDiophantine(g0, h0, eK, numVars, mainVar, active);
+    if (solved === null) return null;
+    const [du, dv] = solved;
+    // du is the correction to h (matches bivariate convention).
+    const hNext: NPoly = new Map(h);
+    for (const [keyDu, coef] of du) {
+      const tup = nParseKey(keyDu, numVars);
+      const newTup = [...tup];
+      newTup[liftVar] = k;
+      const nk = nKey(newTup);
+      const cur = hNext.get(nk) ?? Rational.ZERO;
+      hNext.set(nk, cur.add(coef));
+    }
+    const gNext: NPoly = new Map(g);
+    for (const [keyDv, coef] of dv) {
+      const tup = nParseKey(keyDv, numVars);
+      const newTup = [...tup];
+      newTup[liftVar] = k;
+      const nk = nKey(newTup);
+      const cur = gNext.get(nk) ?? Rational.ZERO;
+      gNext.set(nk, cur.add(coef));
+    }
+    g = nNormalize(gNext);
+    h = nNormalize(hNext);
+  }
+
+  if (!nEquals(nMul(g, h, numVars), nNormalize(f))) return null;
+  return [g, h];
+}
+
+// ---------------------------------------------------------------------------
+// Top-level n-variate Hensel.
+// ---------------------------------------------------------------------------
+
+function nSpecialisationCandidates(numAux: number): number[][] {
+  if (numAux === 0) return [[]];
+  const primitives: number[] = [1, 2, -1, 3, -2];
+  const tuples: number[][] = [];
+  // Tier 1: constant tuples.
+  for (const v of primitives) {
+    tuples.push(new Array<number>(numAux).fill(v));
+    if (tuples.length >= MAX_N_SPECIALISATION) return tuples;
+  }
+  // Tier 2: vary one coordinate at a time off (1,1,…) base.
+  const base = new Array<number>(numAux).fill(1);
+  for (let i = 0; i < numAux; i += 1) {
+    for (let j = 1; j < primitives.length; j += 1) {
+      const cand = [...base];
+      cand[i] = primitives[j];
+      tuples.push(cand);
+      if (tuples.length >= MAX_N_SPECIALISATION) return tuples;
+    }
+  }
+  return tuples.slice(0, MAX_N_SPECIALISATION);
+}
+
+function isLuckyUni(pN: NPoly, image: UniQPoly, mainVar: number, numVars: number): boolean {
+  if (uDegree(image) !== nDegreeIn(pN, mainVar, numVars)) return false;
+  if (uDegree(image) < 1) return false;
+  const deriv: Rational[] = [];
+  for (let i = 1; i < image.length; i += 1) {
+    deriv.push(Rational.fromInt(i).mul(image[i]));
+  }
+  const dn = uNormalize(deriv);
+  if (dn.length === 0) return false;
+  const [g] = uGcdExt(image, dn);
+  return uDegree(g) === 0;
+}
+
+/**
+ * Attempt to factor an n-variate (n ≥ 2) polynomial via iterated bivariate
+ * Hensel lifting.
+ *
+ * @param fIn  Sparse n-variate polynomial in ℚ[v_0, …, v_{numVars-1}].
+ * @param numVars Number of variables; must be ≥ 2 for a non-trivial result.
+ * @returns A list of factors whose product equals `fIn`, or `null` when no
+ *          factorisation was found.
+ *
+ * Falls through (`null`) when numVars < 2, the polynomial doesn't genuinely
+ * depend on at least two variables, no lucky specialisation tuple gives a
+ * squarefree univariate image of full v_0-degree (bounded search of 10
+ * tuples), the univariate image is irreducible, or any lift/verification
+ * step fails.
+ */
+export function tryNVariateHensel(fIn: NPoly, numVars: number): NPoly[] | null {
+  const f = nNormalize(fIn);
+  if (f.size === 0) return null;
+  if (numVars < 2) return null;
+  if (nDegreeIn(f, 0, numVars) < 1) return null;
+  let anyAux = false;
+  for (let i = 1; i < numVars; i += 1) {
+    if (nDegreeIn(f, i, numVars) >= 1) {
+      anyAux = true;
+      break;
+    }
+  }
+  if (!anyAux) return null;
+
+  const mainVar = 0;
+  const auxVars: number[] = [];
+  for (let i = 1; i < numVars; i += 1) auxVars.push(i);
+
+  for (const specTuple of nSpecialisationCandidates(auxVars.length)) {
+    const spec = new Map<number, Rational>();
+    for (let i = 0; i < auxVars.length; i += 1) {
+      spec.set(auxVars[i], Rational.fromInt(specTuple[i]));
+    }
+
+    // Shift f so each auxiliary variable is recentred to 0.
+    let fShift = f;
+    for (const [vI, wI] of spec) {
+      fShift = nShiftVar(fShift, vI, wI, numVars);
+    }
+    fShift = nNormalize(fShift);
+
+    // Specialise all aux vars to 0 → univariate in main_var.
+    let fUni = fShift;
+    for (const vI of auxVars) {
+      fUni = nSubstituteVarKeep(fUni, vI, Rational.ZERO, numVars);
+    }
+    if (!nOnlyUsesVar(fUni, mainVar, numVars)) continue;
+    const image = nToUnivariate(fUni, mainVar, numVars);
+    if (!isLuckyUni(fShift, image, mainVar, numVars)) continue;
+
+    const uniFactors = factorUniQ(image);
+    if (uniFactors === null || uniFactors.length < 2) continue;
+
+    let nFactorsCurrent: NPoly[] = uniFactors.map((u) => uToN(u, mainVar, numVars));
+
+    let success = true;
+    for (let liftIdx = 0; liftIdx < auxVars.length; liftIdx += 1) {
+      const liftVar = auxVars[liftIdx];
+      let fStage = fShift;
+      for (let later = liftIdx + 1; later < auxVars.length; later += 1) {
+        fStage = nSubstituteVarKeep(fStage, auxVars[later], Rational.ZERO, numVars);
+      }
+      fStage = nNormalize(fStage);
+
+      const coeffVars = auxVars.slice(0, liftIdx);
+
+      let remaining = fStage;
+      const newFactors: NPoly[] = [];
+      let remainingFactors = [...nFactorsCurrent];
+      while (remainingFactors.length >= 2) {
+        const g0 = remainingFactors[0];
+        let h0 = nOne(numVars);
+        for (let i = 1; i < remainingFactors.length; i += 1) {
+          h0 = nMul(h0, remainingFactors[i], numVars);
+        }
+        const lifted = nTwoFactorLift(remaining, g0, h0, numVars, mainVar, liftVar, coeffVars);
+        if (lifted === null) {
+          success = false;
+          break;
+        }
+        const [gLift, hLift] = lifted;
+        newFactors.push(gLift);
+        remaining = hLift;
+        remainingFactors = remainingFactors.slice(1);
+      }
+      if (!success) break;
+      newFactors.push(remaining);
+      nFactorsCurrent = newFactors;
+    }
+    if (!success) continue;
+
+    // Unshift each factor back to original frame.
+    let result = nFactorsCurrent;
+    for (const [vI, wI] of spec) {
+      result = result.map((fac) => nShiftVar(fac, vI, wI.neg(), numVars));
+    }
+    result = result.map((fac) => nNormalize(fac));
+
+    // Verify product reconstructs f.
+    let prod: NPoly = nOne(numVars);
+    for (const fac of result) prod = nMul(prod, fac, numVars);
+    if (!nEquals(prod, nNormalize(f))) continue;
+
+    // Drop pure constants, fold scalar into factor 0.
+    const nonTrivial: NPoly[] = [];
+    let scalar = Rational.ONE;
+    for (const fac of result) {
+      if (nTotalDegree(fac, numVars) <= 0) {
+        if (fac.size > 0) {
+          for (const v of fac.values()) {
+            scalar = scalar.mul(v);
+            break;
+          }
+        }
+      } else {
+        nonTrivial.push(fac);
+      }
+    }
+    if (nonTrivial.length < 2) continue;
+    if (!scalar.equals(Rational.ONE)) {
+      nonTrivial[0] = nMul(nonTrivial[0], nConst(numVars, scalar), numVars);
+    }
+    return nonTrivial;
+  }
+  return null;
+}

--- a/code/packages/typescript/cas-factor/src/index.ts
+++ b/code/packages/typescript/cas-factor/src/index.ts
@@ -5,8 +5,8 @@ export type FactorList = Array<[bigint[], number]>;
 export const FACTOR = "Factor";
 export const IRREDUCIBLE = "Irreducible";
 
-export { tryBivariateHensel, Rational as BiRational } from "./hensel.js";
-export type { BiPoly } from "./hensel.js";
+export { tryBivariateHensel, tryNVariateHensel, Rational as BiRational } from "./hensel.js";
+export type { BiPoly, NPoly } from "./hensel.js";
 
 const MAX_COMBOS = 10_000;
 const MAX_BZH_DEGREE = 20;

--- a/code/packages/typescript/cas-factor/tests/n_variate_hensel.test.ts
+++ b/code/packages/typescript/cas-factor/tests/n_variate_hensel.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for n-variate (n ≥ 3) Hensel lifting — Track K2 (TS port of
+ * Python Track K1, PR #5590).
+ *
+ * Strategy: build the input via multiplying known factors with `_internals.nMul`
+ * (or by enumerating monomials), run `tryNVariateHensel`, and verify the
+ * product of returned factors equals the input.  Factor ordering is not
+ * pinned — different specialisation tuples may yield permutations.
+ */
+
+import { describe, expect, it } from "vitest";
+import { tryNVariateHensel, BiRational } from "../src/index";
+import type { NPoly } from "../src/index";
+import { _internals } from "../src/hensel";
+
+function nKey(tup: number[]): string {
+  return tup.join(",");
+}
+
+function make(numVars: number, terms: Array<[number[], number]>): NPoly {
+  const out: NPoly = new Map();
+  for (const [k, c] of terms) {
+    if (k.length !== numVars) throw new Error("tuple length mismatch");
+    if (c === 0) continue;
+    const key = nKey(k);
+    const cur = out.get(key) ?? BiRational.ZERO;
+    out.set(key, cur.add(BiRational.fromInt(c)));
+  }
+  return _internals.nNormalize(out);
+}
+
+function verifyProduct(numVars: number, factors: NPoly[], expected: NPoly): boolean {
+  let prod: NPoly = _internals.nOne(numVars);
+  for (const f of factors) prod = _internals.nMul(prod, f, numVars);
+  // Equality: same key set, equal coefficients.
+  const expN = _internals.nNormalize(expected);
+  if (prod.size !== expN.size) return false;
+  for (const [k, v] of prod) {
+    const w = expN.get(k);
+    if (w === undefined || !w.equals(v)) return false;
+  }
+  return true;
+}
+
+describe("tryNVariateHensel — acceptance", () => {
+  it("trivariate x² − y² − z² − 2yz = (x+y+z)(x−y−z)", () => {
+    const poly = make(3, [
+      [[2, 0, 0], 1],
+      [[0, 2, 0], -1],
+      [[0, 0, 2], -1],
+      [[0, 1, 1], -2],
+    ]);
+    const result = tryNVariateHensel(poly, 3);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeGreaterThanOrEqual(2);
+    expect(verifyProduct(3, result!, poly)).toBe(true);
+  });
+
+  it("trivariate (x+y+z)(x+2y+3z) = x²+3xy+4xz+2y²+5yz+3z²", () => {
+    const poly = make(3, [
+      [[2, 0, 0], 1],
+      [[1, 1, 0], 3],
+      [[1, 0, 1], 4],
+      [[0, 2, 0], 2],
+      [[0, 1, 1], 5],
+      [[0, 0, 2], 3],
+    ]);
+    const result = tryNVariateHensel(poly, 3);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(verifyProduct(3, result!, poly)).toBe(true);
+  });
+
+  it("trivariate sum-of-cubes companion: (x+y+z)(x²+y²+z²−xy−yz−xz)", () => {
+    const factorA = make(3, [
+      [[1, 0, 0], 1],
+      [[0, 1, 0], 1],
+      [[0, 0, 1], 1],
+    ]);
+    const factorB = make(3, [
+      [[2, 0, 0], 1],
+      [[0, 2, 0], 1],
+      [[0, 0, 2], 1],
+      [[1, 1, 0], -1],
+      [[0, 1, 1], -1],
+      [[1, 0, 1], -1],
+    ]);
+    const poly = _internals.nMul(factorA, factorB, 3);
+    const result = tryNVariateHensel(poly, 3);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeGreaterThanOrEqual(2);
+    expect(verifyProduct(3, result!, poly)).toBe(true);
+  });
+
+  it("quadrivariate (x+y)(x+z+w) — iterated lift across two aux vars", () => {
+    const factorA = make(4, [
+      [[1, 0, 0, 0], 1],
+      [[0, 1, 0, 0], 1],
+    ]);
+    const factorB = make(4, [
+      [[1, 0, 0, 0], 1],
+      [[0, 0, 1, 0], 1],
+      [[0, 0, 0, 1], 1],
+    ]);
+    const poly = _internals.nMul(factorA, factorB, 4);
+    const result = tryNVariateHensel(poly, 4);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(verifyProduct(4, result!, poly)).toBe(true);
+  });
+});
+
+describe("tryNVariateHensel — fall-through", () => {
+  it("returns null for irreducible x² + y² + z² + 1", () => {
+    const poly = make(3, [
+      [[2, 0, 0], 1],
+      [[0, 2, 0], 1],
+      [[0, 0, 2], 1],
+      [[0, 0, 0], 1],
+    ]);
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+
+  it("returns null for univariate-in-three-var-ring x² − 1", () => {
+    const poly = make(3, [
+      [[2, 0, 0], 1],
+      [[0, 0, 0], -1],
+    ]);
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+
+  it("returns null when numVars < 2", () => {
+    const poly = make(1, [
+      [[2], 1],
+      [[0], -1],
+    ]);
+    expect(tryNVariateHensel(poly, 1)).toBeNull();
+  });
+
+  it("returns null for pure constant", () => {
+    const poly = make(3, [[[0, 0, 0], 7]]);
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+
+  it("returns null for empty polynomial", () => {
+    const poly: NPoly = new Map();
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+
+  it("returns null for linear x + y + z (irreducible)", () => {
+    const poly = make(3, [
+      [[1, 0, 0], 1],
+      [[0, 1, 0], 1],
+      [[0, 0, 1], 1],
+    ]);
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+});
+
+describe("tryNVariateHensel — bivariate regressions via n-variate path", () => {
+  it("x² + xy − 2y² factors via the n-variate front door", () => {
+    const poly = make(2, [
+      [[2, 0], 1],
+      [[1, 1], 1],
+      [[0, 2], -2],
+    ]);
+    const result = tryNVariateHensel(poly, 2);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(verifyProduct(2, result!, poly)).toBe(true);
+  });
+
+  it("x³ − y³ factors via the n-variate front door", () => {
+    const poly = make(2, [
+      [[3, 0], 1],
+      [[0, 3], -1],
+    ]);
+    const result = tryNVariateHensel(poly, 2);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    expect(verifyProduct(2, result!, poly)).toBe(true);
+  });
+});
+
+describe("tryNVariateHensel — bounded resource discipline", () => {
+  it("high-degree irreducible does not loop forever", () => {
+    // x^4 + y^2 + z^2 + 1 — irreducible over Q (x^4 + const is irreducible
+    // for non-square positive const).
+    const poly = make(3, [
+      [[4, 0, 0], 1],
+      [[0, 0, 0], 1],
+      [[0, 0, 2], 1],
+      [[0, 2, 0], 1],
+    ]);
+    expect(tryNVariateHensel(poly, 3)).toBeNull();
+  });
+});

--- a/code/packages/typescript/symbolic-vm/CHANGELOG.md
+++ b/code/packages/typescript/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [0.20.0] — 2026-05-29
+
+**Track K2 — n-variate Hensel factor bridge (TypeScript port).**
+
+Wires the new `tryNVariateHensel` from cas-factor 0.3.0 into the
+`Factor(...)` IR handler.  Mirrors the Python Track K1 bridge in
+`symbolic-vm/cas_handlers.py` (PR #5590).
+
+Algorithm (n ≥ 3, generic — not per-arity):
+
+1. Identify all free variables in the input (`findNVariables`, bounded
+   at 8 distinct symbols so a pathological input can't allocate
+   gigantic sparse-dict keys).
+2. Convert to an `NPoly` via `irToNpoly`.  Returns undefined for
+   floats, foreign symbols, transcendentals (Sin/Log/…), or non-integer
+   exponents.
+3. Call `tryNVariateHensel`.  On success, convert each factor back to
+   IR via `npolyToIr` using **left-nested binary Add/Mul** (the
+   primitive Add/Mul handlers are strictly binary, so n-ary Apply
+   nodes with three or more children would crash).
+4. Hook into `factor_handler` AFTER the bivariate Hensel path, BEFORE
+   the unevaluated-wrapper fallback.
+
+Catches `x³ + y³ + z³ − 3xyz = (x+y+z)(x²+y²+z²−xy−yz−zx)`,
+`(x+y+z)(x+2y+3z) = x²+3xy+4xz+2y²+5yz+3z²`, and similar trivariate
+cases.  Falls through cleanly on `x² + y² + z² + 1` (irreducible),
+`sin(x) + y + z` (transcendental), and so on.
+
+### Added
+
+- `tryNVariateHenselIr` — top-level IR glue mirroring Python
+  `_try_n_variate_hensel_ir`.
+- `findNVariables`, `irToNpoly`, `npolyToIr`, `foldBinary` — helpers
+  mirroring `_find_n_variables`, `_ir_to_npoly`, `_npoly_to_ir`, and
+  the left-nested-binary-fold convention.
+- `tests/n_variate_factor.test.ts` — 6 end-to-end pipeline tests
+  exercising `Factor(...)` over the VM: sum-of-cubes identity, linear
+  product round-trip, irreducible fall-through, transcendental safety,
+  bivariate regression, univariate regression.
+
+### Changed
+
+- `cas-factor` minimum bumped to 0.3.0 (n-variate Hensel landed there).
+- `factor_handler` dispatch order: univariate → bivariate Hensel →
+  n-variate Hensel → unevaluated wrapper.
+
 ## [0.19.0] — 2026-05-29
 
 **Track G2 — symbolic-coefficient Weierstrass lift (TypeScript port).**

--- a/code/packages/typescript/symbolic-vm/package.json
+++ b/code/packages/typescript/symbolic-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/symbolic-vm",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Pure TypeScript symbolic expression evaluator with strict and symbolic backends",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/symbolic-vm/src/index.ts
+++ b/code/packages/typescript/symbolic-vm/src/index.ts
@@ -55,8 +55,8 @@ import {
   rational,
   sym,
 } from "@coding-adventures/symbolic-ir";
-import { BiRational, factorIntegerPolynomial, tryBivariateHensel } from "@coding-adventures/cas-factor";
-import type { BiPoly } from "@coding-adventures/cas-factor";
+import { BiRational, factorIntegerPolynomial, tryBivariateHensel, tryNVariateHensel } from "@coding-adventures/cas-factor";
+import type { BiPoly, NPoly } from "@coding-adventures/cas-factor";
 import { AssumptionContext } from "@coding-adventures/cas-simplify";
 
 export type Handler = (vm: VM, expr: IRApply) => IRNode;
@@ -1018,6 +1018,13 @@ function factorHandler(vm: VM, expr: IRApply): IRNode {
     // ``_try_bivariate_hensel_ir`` glue in ``symbolic-vm/cas_handlers.py``.
     const hensel = tryBivariateHenselIr(inner);
     if (hensel !== undefined) return vm.eval(hensel);
+    // n-variate (n ≥ 3) Hensel — Track K2.  Generalised algorithmic
+    // fallback for tri- and higher-variate polynomials (e.g.,
+    // x³ + y³ + z³ − 3xyz = (x+y+z)(…)).  Returns undefined for
+    // transcendentals, foreign symbols, or when the iterated lift can't
+    // pin down a factorisation.
+    const nHensel = tryNVariateHenselIr(inner);
+    if (nHensel !== undefined) return vm.eval(nHensel);
     return expr;
   }
 
@@ -1272,6 +1279,237 @@ function tryBivariateHenselIr(inner: IRNode): IRNode | undefined {
   const factorNodes = factors.map((f) => bipolyToIr(f, x, y));
   if (factorNodes.length === 1) return factorNodes[0];
   return app(MUL, factorNodes);
+}
+
+// ---------------------------------------------------------------------------
+// n-variate (n ≥ 3) Hensel-lifting IR glue — Track K2.  Mirrors the
+// Python ``_find_n_variables``, ``_ir_to_npoly``, ``_npoly_to_ir``, and
+// ``_try_n_variate_hensel_ir`` helpers in ``cas_handlers.py``.
+//
+// Output convention: LEFT-NESTED BINARY Add/Mul.  The symbolic-vm
+// primitive Add/Mul handlers are strictly binary, so an
+// ``IRApply(ADD, (a, b, c))`` with three or more children would crash
+// when re-evaluated.  We mirror the cubic-identity handler's nesting
+// convention: ``Add(Add(a, b), c)`` for three terms, etc.
+// ---------------------------------------------------------------------------
+
+const MAX_N_VARS = 8;
+
+function findNVariables(node: IRNode): IRSymbol[] | undefined {
+  const seen: IRSymbol[] = [];
+  function walk(n: IRNode): boolean {
+    if (n.kind === "symbol") {
+      if (n.name.startsWith("%")) return true;
+      if (!seen.some((s) => s.name === n.name)) {
+        seen.push(n);
+        if (seen.length > MAX_N_VARS) return false;
+      }
+      return true;
+    }
+    if (n.kind === "apply") {
+      for (const arg of n.args) {
+        if (!walk(arg)) return false;
+      }
+    }
+    return true;
+  }
+  if (!walk(node)) return undefined;
+  if (seen.length === 0) return undefined;
+  return seen;
+}
+
+function nKeyJoin(tup: number[]): string {
+  return tup.join(",");
+}
+
+function nParseKeyJoin(k: string, numVars: number): number[] {
+  const out: number[] = [];
+  let start = 0;
+  for (let i = 0; i < numVars - 1; i += 1) {
+    const idx = k.indexOf(",", start);
+    out.push(Number(k.slice(start, idx)));
+    start = idx + 1;
+  }
+  out.push(Number(k.slice(start)));
+  return out;
+}
+
+function nAddInto(acc: NPoly, other: NPoly): void {
+  for (const [k, v] of other) {
+    const cur = acc.get(k);
+    acc.set(k, cur === undefined ? v : cur.add(v));
+  }
+  for (const [k, v] of [...acc]) {
+    if (v.isZero()) acc.delete(k);
+  }
+}
+
+function nMulMaps(a: NPoly, b: NPoly, numVars: number): NPoly {
+  const out: NPoly = new Map();
+  for (const [k1, c1] of a) {
+    if (c1.isZero()) continue;
+    const t1 = nParseKeyJoin(k1, numVars);
+    for (const [k2, c2] of b) {
+      if (c2.isZero()) continue;
+      const t2 = nParseKeyJoin(k2, numVars);
+      const t: number[] = new Array<number>(numVars);
+      for (let i = 0; i < numVars; i += 1) t[i] = t1[i] + t2[i];
+      const k = nKeyJoin(t);
+      const cur = out.get(k);
+      out.set(k, cur === undefined ? c1.mul(c2) : cur.add(c1.mul(c2)));
+    }
+  }
+  for (const [k, v] of [...out]) {
+    if (v.isZero()) out.delete(k);
+  }
+  return out;
+}
+
+function irToNpoly(node: IRNode, vars: IRSymbol[]): NPoly | undefined {
+  const numVars = vars.length;
+  const zeroKey = nKeyJoin(new Array<number>(numVars).fill(0));
+  const varIndex = new Map<string, number>();
+  vars.forEach((v, i) => varIndex.set(v.name, i));
+
+  function unitFor(v: IRSymbol): string {
+    const i = varIndex.get(v.name);
+    if (i === undefined) throw new Error("unitFor on non-tracked var");
+    const tup = new Array<number>(numVars).fill(0);
+    tup[i] = 1;
+    return nKeyJoin(tup);
+  }
+
+  function walk(n: IRNode): NPoly | undefined {
+    if (n.kind === "integer") {
+      if (n.value === 0n) return new Map();
+      return new Map([[zeroKey, BiRational.fromInt(n.value)]]);
+    }
+    if (n.kind === "rational") {
+      return new Map([[zeroKey, new BiRational(n.numer, n.denom)]]);
+    }
+    if (n.kind === "float" || n.kind === "string") return undefined;
+    if (n.kind === "symbol") {
+      if (n.name.startsWith("%")) return undefined;
+      if (varIndex.has(n.name)) return new Map([[unitFor(n), BiRational.ONE]]);
+      return undefined;
+    }
+    const apply = n;
+    if (apply.head.kind !== "symbol") return undefined;
+    const head = apply.head.name;
+    if (head === ADD.name) {
+      const acc: NPoly = new Map();
+      for (const arg of apply.args) {
+        const sub = walk(arg);
+        if (sub === undefined) return undefined;
+        nAddInto(acc, sub);
+      }
+      return acc;
+    }
+    if (head === SUB.name && apply.args.length === 2) {
+      const a = walk(apply.args[0]);
+      const b = walk(apply.args[1]);
+      if (a === undefined || b === undefined) return undefined;
+      const negB: NPoly = new Map();
+      for (const [k, v] of b) negB.set(k, v.neg());
+      nAddInto(a, negB);
+      return a;
+    }
+    if (head === NEG.name && apply.args.length === 1) {
+      const sub = walk(apply.args[0]);
+      if (sub === undefined) return undefined;
+      const out: NPoly = new Map();
+      for (const [k, v] of sub) {
+        if (!v.isZero()) out.set(k, v.neg());
+      }
+      return out;
+    }
+    if (head === MUL.name) {
+      let acc: NPoly = new Map([[zeroKey, BiRational.ONE]]);
+      for (const arg of apply.args) {
+        const sub = walk(arg);
+        if (sub === undefined) return undefined;
+        acc = nMulMaps(acc, sub, numVars);
+      }
+      return acc;
+    }
+    if (head === POW.name && apply.args.length === 2) {
+      const expNode = apply.args[1];
+      if (expNode.kind !== "integer") return undefined;
+      const eBig = expNode.value;
+      if (eBig < 0n) return undefined;
+      const base = walk(apply.args[0]);
+      if (base === undefined) return undefined;
+      if (eBig === 0n) return new Map([[zeroKey, BiRational.ONE]]);
+      let result = base;
+      const e = Number(eBig);
+      for (let i = 1; i < e; i += 1) result = nMulMaps(result, base, numVars);
+      return result;
+    }
+    return undefined;
+  }
+
+  return walk(node);
+}
+
+/** Left-fold a list of children into nested binary IRApply nodes. */
+function foldBinary(head: IRSymbol, parts: IRNode[]): IRNode {
+  if (parts.length === 0) throw new Error("foldBinary requires at least one node");
+  let result = parts[0];
+  for (let i = 1; i < parts.length; i += 1) {
+    result = app(head, [result, parts[i]]);
+  }
+  return result;
+}
+
+function npolyToIr(p: NPoly, vars: IRSymbol[]): IRNode {
+  if (p.size === 0) return int(0);
+  const numVars = vars.length;
+
+  function monomialNode(tup: number[], c: BiRational): IRNode {
+    const parts: IRNode[] = [];
+    const allZero = tup.every((e) => e === 0);
+    if (!c.equals(BiRational.ONE) || allZero) {
+      if (c.denom === 1n) parts.push(int(c.numer));
+      else parts.push(rational(c.numer, c.denom));
+    }
+    for (let i = 0; i < numVars; i += 1) {
+      const e = tup[i];
+      if (e <= 0) continue;
+      const v = vars[i];
+      parts.push(e === 1 ? v : app(POW, [v, int(e)]));
+    }
+    if (parts.length === 0) return int(1);
+    return foldBinary(MUL, parts);
+  }
+
+  // Sort: descending total degree, then lex on negated exponents (matches
+  // Python ``_npoly_to_ir`` key order).
+  const keys = [...p.keys()].sort((a, b) => {
+    const ta = nParseKeyJoin(a, numVars);
+    const tb = nParseKeyJoin(b, numVars);
+    const sa = ta.reduce((x, y) => x + y, 0);
+    const sb = tb.reduce((x, y) => x + y, 0);
+    if (sa !== sb) return sb - sa;
+    for (let i = 0; i < numVars; i += 1) {
+      if (ta[i] !== tb[i]) return tb[i] - ta[i];
+    }
+    return 0;
+  });
+  const terms = keys.map((k) => monomialNode(nParseKeyJoin(k, numVars), p.get(k)!));
+  return foldBinary(ADD, terms);
+}
+
+function tryNVariateHenselIr(inner: IRNode): IRNode | undefined {
+  const vars = findNVariables(inner);
+  if (vars === undefined || vars.length < 2) return undefined;
+  const npoly = irToNpoly(inner, vars);
+  if (npoly === undefined) return undefined;
+  const factors = tryNVariateHensel(npoly, vars.length);
+  if (factors === null || factors.length < 2) return undefined;
+  const factorNodes = factors.map((f) => npolyToIr(f, vars));
+  if (factorNodes.length === 1) return factorNodes[0];
+  // Left-nested binary Mul output for binary-handler compatibility.
+  return foldBinary(MUL, factorNodes);
 }
 
 function factorResultToIr(content: bigint, factors: Array<[bigint[], number]>, variable: IRSymbol): IRNode {

--- a/code/packages/typescript/symbolic-vm/tests/n_variate_factor.test.ts
+++ b/code/packages/typescript/symbolic-vm/tests/n_variate_factor.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Pipeline tests for n-variate Hensel-lift factorisation — Track K2
+ * (TS port of Python Track K1, PR #5590).
+ *
+ * Exercises end-to-end ``Factor(expr)`` via the VM: construct ``Factor(...)``
+ * IR, evaluate on a SymbolicBackend, and verify by re-expanding the
+ * returned product back to a sparse-dict polynomial and comparing against
+ * the sparse-dict expansion of the input.  We verify *algebraic* equality
+ * rather than *shape* because the Hensel lift may emit factors in a
+ * different deterministic order than the human-recognisable canonical
+ * order, and integer-content can be pulled out separately.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ADD,
+  FACTOR,
+  IRApply,
+  IRInteger,
+  IRNode,
+  IRSymbol,
+  MUL,
+  NEG,
+  POW,
+  SUB,
+  app,
+  int,
+  sym,
+} from "@coding-adventures/symbolic-ir";
+import { SymbolicBackend, VM } from "../src/index";
+
+const x = sym("x");
+const y = sym("y");
+const z = sym("z");
+const w = sym("w");
+
+function makeVm(): VM {
+  return new VM(new SymbolicBackend());
+}
+
+type PolyDict = Map<string, bigint>;
+
+function pkey(tup: number[]): string {
+  return tup.join(",");
+}
+
+function pparse(k: string, n: number): number[] {
+  const out: number[] = [];
+  let start = 0;
+  for (let i = 0; i < n - 1; i += 1) {
+    const idx = k.indexOf(",", start);
+    out.push(Number(k.slice(start, idx)));
+    start = idx + 1;
+  }
+  out.push(Number(k.slice(start)));
+  return out;
+}
+
+/**
+ * Recursive structural expander for the polynomial subset of IR.
+ *
+ * Independent from the production ``irToNpoly`` so a bug in production
+ * code can't masquerade as a bug-compatible test result.
+ */
+function expandToDict(node: IRNode, vars: IRSymbol[]): PolyDict {
+  const n = vars.length;
+  const zero = pkey(new Array<number>(n).fill(0));
+  const varIdx = new Map<string, number>();
+  vars.forEach((v, i) => varIdx.set(v.name, i));
+
+  function unit(v: IRSymbol): string {
+    const i = varIdx.get(v.name)!;
+    const k = new Array<number>(n).fill(0);
+    k[i] = 1;
+    return pkey(k);
+  }
+  function addKeys(a: string, b: string): string {
+    const ta = pparse(a, n);
+    const tb = pparse(b, n);
+    const out: number[] = new Array<number>(n);
+    for (let i = 0; i < n; i += 1) out[i] = ta[i] + tb[i];
+    return pkey(out);
+  }
+  function normalize(d: PolyDict): PolyDict {
+    for (const [k, v] of [...d]) {
+      if (v === 0n) d.delete(k);
+    }
+    return d;
+  }
+  function add(a: PolyDict, b: PolyDict): PolyDict {
+    const out: PolyDict = new Map(a);
+    for (const [k, v] of b) {
+      out.set(k, (out.get(k) ?? 0n) + v);
+    }
+    return normalize(out);
+  }
+  function neg(a: PolyDict): PolyDict {
+    const out: PolyDict = new Map();
+    for (const [k, v] of a) out.set(k, -v);
+    return normalize(out);
+  }
+  function mul(a: PolyDict, b: PolyDict): PolyDict {
+    const out: PolyDict = new Map();
+    for (const [ka, va] of a) {
+      for (const [kb, vb] of b) {
+        const k = addKeys(ka, kb);
+        out.set(k, (out.get(k) ?? 0n) + va * vb);
+      }
+    }
+    return normalize(out);
+  }
+
+  function walk(node: IRNode): PolyDict {
+    if (node.kind === "integer") {
+      if (node.value === 0n) return new Map();
+      return new Map([[zero, node.value]]);
+    }
+    if (node.kind === "symbol") {
+      if (varIdx.has(node.name)) return new Map([[unit(node), 1n]]);
+      throw new Error(`unexpected symbol in test expander: ${node.name}`);
+    }
+    if (node.kind !== "apply") throw new Error("unexpected non-apply node");
+    const head = node.head;
+    if (head.kind !== "symbol") throw new Error("unexpected head");
+    if (head.name === ADD.name) {
+      let acc: PolyDict = new Map();
+      for (const a of node.args) acc = add(acc, walk(a));
+      return acc;
+    }
+    if (head.name === SUB.name) {
+      const a = walk(node.args[0]);
+      const b = walk(node.args[1]);
+      return add(a, neg(b));
+    }
+    if (head.name === NEG.name) {
+      return neg(walk(node.args[0]));
+    }
+    if (head.name === MUL.name) {
+      let acc: PolyDict = new Map([[zero, 1n]]);
+      for (const a of node.args) acc = mul(acc, walk(a));
+      return acc;
+    }
+    if (head.name === POW.name) {
+      const base = walk(node.args[0]);
+      const exp = node.args[1];
+      if (exp.kind !== "integer") throw new Error("non-integer exponent");
+      const e = Number(exp.value);
+      if (e < 0) throw new Error("negative exponent");
+      if (e === 0) return new Map([[zero, 1n]]);
+      let out = base;
+      for (let i = 1; i < e; i += 1) out = mul(out, base);
+      return out;
+    }
+    throw new Error(`unexpected head: ${head.name}`);
+  }
+  return walk(node);
+}
+
+function dictEquals(a: PolyDict, b: PolyDict): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) {
+    if (b.get(k) !== v) return false;
+  }
+  return true;
+}
+
+describe("n-variate Factor pipeline — Track K2", () => {
+  it("factor(x^3 + y^3 + z^3 - 3*x*y*z) recovers two factors", () => {
+    const vm = makeVm();
+    // x^3 + y^3 + z^3 - 3*x*y*z
+    const target = app(SUB, [
+      app(ADD, [
+        app(ADD, [
+          app(POW, [x, int(3)]),
+          app(POW, [y, int(3)]),
+        ]),
+        app(POW, [z, int(3)]),
+      ]),
+      app(MUL, [int(3), app(MUL, [app(MUL, [x, y]), z])]),
+    ]);
+    const expr = app(FACTOR, [target]);
+    const result = vm.eval(expr);
+
+    // Result should NOT still be a Factor(...) wrapper.
+    const isWrapper =
+      result.kind === "apply" &&
+      result.head.kind === "symbol" &&
+      result.head.name === FACTOR.name;
+    expect(isWrapper).toBe(false);
+
+    const vars = [x, y, z];
+    const resultDict = expandToDict(result, vars);
+    const targetDict = expandToDict(target, vars);
+    expect(dictEquals(resultDict, targetDict)).toBe(true);
+  });
+
+  it("factor((x+y+z)*(x+2y+3z)) round-trips algebraically", () => {
+    const vm = makeVm();
+    // x^2 + 3xy + 4xz + 2y^2 + 5yz + 3z^2
+    const expanded = app(ADD, [
+      app(POW, [x, int(2)]),
+      app(ADD, [
+        app(MUL, [int(3), app(MUL, [x, y])]),
+        app(ADD, [
+          app(MUL, [int(4), app(MUL, [x, z])]),
+          app(ADD, [
+            app(MUL, [int(2), app(POW, [y, int(2)])]),
+            app(ADD, [
+              app(MUL, [int(5), app(MUL, [y, z])]),
+              app(MUL, [int(3), app(POW, [z, int(2)])]),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]);
+    const expr = app(FACTOR, [expanded]);
+    const result = vm.eval(expr);
+    const vars = [x, y, z];
+    // Either Hensel found a factorisation (round-trip algebraic equality)
+    // or the wrapper survived — both correct.
+    const isWrapper =
+      result.kind === "apply" &&
+      result.head.kind === "symbol" &&
+      result.head.name === FACTOR.name;
+    if (isWrapper) return;
+    const resultDict = expandToDict(result, vars);
+    const expandedDict = expandToDict(expanded, vars);
+    expect(dictEquals(resultDict, expandedDict)).toBe(true);
+  });
+
+  it("factor(x^2 + y^2 + z^2 + 1) — irreducible, falls through cleanly", () => {
+    const vm = makeVm();
+    const target = app(ADD, [
+      app(POW, [x, int(2)]),
+      app(ADD, [
+        app(POW, [y, int(2)]),
+        app(ADD, [app(POW, [z, int(2)]), int(1)]),
+      ]),
+    ]);
+    const expr = app(FACTOR, [target]);
+    const result = vm.eval(expr);
+    const isWrapper =
+      result.kind === "apply" &&
+      result.head.kind === "symbol" &&
+      result.head.name === FACTOR.name;
+    if (isWrapper) return;
+    const vars = [x, y, z];
+    const targetDict = expandToDict(target, vars);
+    const resultDict = expandToDict(result, vars);
+    expect(dictEquals(resultDict, targetDict)).toBe(true);
+  });
+
+  it("factor(sin(x) + y + z) — transcendental, does not crash", () => {
+    const vm = makeVm();
+    const sin = sym("Sin");
+    const target = app(ADD, [app(sin, [x]), app(ADD, [y, z])]);
+    const expr = app(FACTOR, [target]);
+    // We only require: no crash.
+    const result = vm.eval(expr);
+    expect(result).toBeDefined();
+  });
+
+  it("regression: bivariate x^2 + xy - 2y^2 still factors via Factor", () => {
+    const vm = makeVm();
+    // x^2 + xy - 2y^2  — should be handled by either bivariate or
+    // n-variate Hensel.
+    const target = app(SUB, [
+      app(ADD, [
+        app(POW, [x, int(2)]),
+        app(MUL, [x, y]),
+      ]),
+      app(MUL, [int(2), app(POW, [y, int(2)])]),
+    ]);
+    const expr = app(FACTOR, [target]);
+    const result = vm.eval(expr);
+    const isWrapper =
+      result.kind === "apply" &&
+      result.head.kind === "symbol" &&
+      result.head.name === FACTOR.name;
+    expect(isWrapper).toBe(false);
+    const vars = [x, y];
+    const resultDict = expandToDict(result, vars);
+    const targetDict = expandToDict(target, vars);
+    expect(dictEquals(resultDict, targetDict)).toBe(true);
+  });
+
+  it("regression: univariate x^2 - 1 still factors", () => {
+    const vm = makeVm();
+    const target = app(SUB, [app(POW, [x, int(2)]), int(1)]);
+    const expr = app(FACTOR, [target]);
+    const result = vm.eval(expr);
+    const isWrapper =
+      result.kind === "apply" &&
+      result.head.kind === "symbol" &&
+      result.head.name === FACTOR.name;
+    expect(isWrapper).toBe(false);
+    const resultDict = expandToDict(result, [x]);
+    const targetDict = expandToDict(target, [x]);
+    expect(dictEquals(resultDict, targetDict)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Track K1 n-variate (n ≥ 3) Hensel factoring (PR #5590) to TypeScript and Rust.

- **cas-factor** (TS 0.3.0, Rust 0.3.0): adds `tryNVariateHensel` / `try_n_variate_hensel` — iterated bivariate Hensel for n ≥ 2 variables with recursive coefficient-ring diophantine. Reuses existing bivariate machinery. Bounded specialisation (≤ 10 tuples) and recursion (depth ≤ num_vars).
- **symbolic-vm** (TS 0.20.0, Rust 0.20.0): wires it into the `Factor(...)` handler after the bivariate Hensel path. Emits **left-nested binary Add/Mul** because the VM's primitive Add/Mul handlers are strictly binary.

## Acceptance

- `factor(x^3 + y^3 + z^3 - 3*x*y*z)` recovers two factors
- `factor((x+y+z)(x+2y+3z))` round-trips algebraically
- `factor(x^2 + y^2 + z^2 + 1)` (irreducible) falls through cleanly
- `factor(sin(x) + y + z)` (transcendental) does not crash
- Bivariate `factor(x^2 + xy − 2y^2)` and univariate `factor(x^2 − 1)` regressions still close
- Quadrivariate `(x+y)(x+z+w)` exercises iterated lift across two aux vars

## Test plan

- [x] TS cas-factor `bash ./BUILD` (89.71% statements, 13 new tests pass)
- [x] TS symbolic-vm `npm ci && npm run build && npx vitest run --coverage` (82.24% statements, 6 new pipeline tests pass; all 224 prior tests still pass)
- [x] Rust cas-factor `cargo test` (13 new tests + 44 prior tests + 10 doc tests pass)
- [x] Rust symbolic-vm `cargo test` (6 new pipeline tests + 225+ prior tests pass)
- [x] Security audit: bounded specialisation (10 tuples), bounded recursion (depth ≤ num_vars ≤ 8), bounded lift loops; matches Python K1 bounds; no new memory-bomb surface area beyond what bivariate path already has

References: Python Track K1 PR #5590 (merged), spec `code/specs/macsyma-truly-finish-plan.md` Track K2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)