### PR TITLE
[codex] Add navigation group readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -859,7 +859,9 @@ pub struct BrowserDocument {
     pub text_semantic_descriptors: Vec<BrowserTextSemanticDescriptor>,
     pub navigation_target_descriptors: Vec<BrowserNavigationTargetDescriptor>,
     pub navigation_groups: Vec<BrowserNavigationGroup>,
+    pub navigation_group_descriptors: Vec<BrowserNavigationGroupDescriptor>,
     pub section_landmarks: Vec<BrowserSectionLandmark>,
+    pub section_landmark_descriptors: Vec<BrowserSectionLandmarkDescriptor>,
     pub command_elements: Vec<BrowserCommandElement>,
     pub activation_descriptors: Vec<BrowserActivationDescriptor>,
     pub popovers: Vec<BrowserPopover>,
@@ -2382,6 +2384,27 @@ pub struct BrowserNavigationGroup {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserNavigationGroupDescriptor {
+    pub group_index: usize,
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub group_kind: String,
+    pub landmark_kind: Option<String>,
+    pub list_kind: Option<String>,
+    pub item_count: usize,
+    pub list_start: Option<String>,
+    pub list_marker_type: Option<String>,
+    pub list_reversed: bool,
+    pub navigation_blocked: bool,
+    pub navigation_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserSectionLandmark {
     pub element: String,
     pub id: Option<String>,
@@ -2395,6 +2418,26 @@ pub struct BrowserSectionLandmark {
     pub landmark_kind: Option<String>,
     pub heading_level: Option<u8>,
     pub heading_text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserSectionLandmarkDescriptor {
+    pub landmark_index: usize,
+    pub element: String,
+    pub id: Option<String>,
+    pub role: String,
+    pub authored_role: Option<String>,
+    pub text: String,
+    pub accessible_name: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby: Vec<String>,
+    pub section_kind: Option<String>,
+    pub landmark_kind: Option<String>,
+    pub heading_level: Option<u8>,
+    pub heading_text: Option<String>,
+    pub outline_kind: String,
+    pub landmark_blocked: bool,
+    pub landmark_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3851,6 +3894,10 @@ impl BrowserDocument {
         summary.link_resource_descriptors = browser_link_resource_descriptors(&summary.resources);
         summary.text_semantic_descriptors =
             browser_text_semantic_descriptors(&summary.text_semantics);
+        summary.navigation_group_descriptors =
+            browser_navigation_group_descriptors(&summary.navigation_groups);
+        summary.section_landmark_descriptors =
+            browser_section_landmark_descriptors(&summary.section_landmarks);
         summary
     }
 }
@@ -14268,6 +14315,69 @@ fn browser_navigation_group_element(
     })
 }
 
+fn browser_navigation_group_descriptors(
+    groups: &[BrowserNavigationGroup],
+) -> Vec<BrowserNavigationGroupDescriptor> {
+    groups
+        .iter()
+        .enumerate()
+        .map(|(index, group)| browser_navigation_group_descriptor(index + 1, group))
+        .collect()
+}
+
+fn browser_navigation_group_descriptor(
+    group_index: usize,
+    group: &BrowserNavigationGroup,
+) -> BrowserNavigationGroupDescriptor {
+    let navigation_block_reasons = browser_navigation_group_block_reasons(group);
+
+    BrowserNavigationGroupDescriptor {
+        group_index,
+        element: group.element.clone(),
+        id: group.id.clone(),
+        role: group.role.clone(),
+        text: group.text.clone(),
+        accessible_name: group.accessible_name.clone(),
+        aria_label: group.aria_label.clone(),
+        aria_labelledby: group.aria_labelledby.clone(),
+        group_kind: browser_navigation_group_kind(group).to_string(),
+        landmark_kind: group.landmark_kind.clone(),
+        list_kind: group.list_kind.clone(),
+        item_count: group.item_count,
+        list_start: group.list_start.clone(),
+        list_marker_type: group.list_marker_type.clone(),
+        list_reversed: group.list_reversed,
+        navigation_blocked: !navigation_block_reasons.is_empty(),
+        navigation_block_reasons,
+    }
+}
+
+fn browser_navigation_group_kind(group: &BrowserNavigationGroup) -> &'static str {
+    if group.landmark_kind.is_some() {
+        "landmark"
+    } else if group.list_kind.as_deref() == Some("menu") {
+        "menu"
+    } else if group.list_kind.is_some() {
+        "list"
+    } else {
+        "group"
+    }
+}
+
+fn browser_navigation_group_block_reasons(group: &BrowserNavigationGroup) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if group.text.is_empty() && group.item_count == 0 {
+        reasons.push("empty-navigation-group".to_string());
+    }
+    if group.landmark_kind.as_deref() == Some("navigation") && group.accessible_name.is_none() {
+        reasons.push("missing-navigation-label".to_string());
+    }
+    if group.list_kind.is_some() && group.item_count == 0 {
+        reasons.push("empty-list".to_string());
+    }
+    reasons
+}
+
 fn browser_direct_list_item_count(element: &Element) -> usize {
     element
         .children
@@ -14303,6 +14413,78 @@ fn browser_section_landmark_element(
         heading_level: heading.as_ref().map(|(level, _)| *level),
         heading_text: heading.map(|(_, text)| text),
     })
+}
+
+fn browser_section_landmark_descriptors(
+    landmarks: &[BrowserSectionLandmark],
+) -> Vec<BrowserSectionLandmarkDescriptor> {
+    landmarks
+        .iter()
+        .enumerate()
+        .map(|(index, landmark)| browser_section_landmark_descriptor(index + 1, landmark))
+        .collect()
+}
+
+fn browser_section_landmark_descriptor(
+    landmark_index: usize,
+    landmark: &BrowserSectionLandmark,
+) -> BrowserSectionLandmarkDescriptor {
+    let landmark_block_reasons = browser_section_landmark_block_reasons(landmark);
+
+    BrowserSectionLandmarkDescriptor {
+        landmark_index,
+        element: landmark.element.clone(),
+        id: landmark.id.clone(),
+        role: landmark.role.clone(),
+        authored_role: landmark.authored_role.clone(),
+        text: landmark.text.clone(),
+        accessible_name: landmark.accessible_name.clone(),
+        aria_label: landmark.aria_label.clone(),
+        aria_labelledby: landmark.aria_labelledby.clone(),
+        section_kind: landmark.section_kind.clone(),
+        landmark_kind: landmark.landmark_kind.clone(),
+        heading_level: landmark.heading_level,
+        heading_text: landmark.heading_text.clone(),
+        outline_kind: browser_section_landmark_outline_kind(landmark).to_string(),
+        landmark_blocked: !landmark_block_reasons.is_empty(),
+        landmark_block_reasons,
+    }
+}
+
+fn browser_section_landmark_outline_kind(landmark: &BrowserSectionLandmark) -> &'static str {
+    if landmark.landmark_kind.is_some() && landmark.section_kind.is_some() {
+        "landmark-section"
+    } else if landmark.landmark_kind.is_some() {
+        "landmark"
+    } else if landmark.section_kind.is_some() {
+        "section"
+    } else {
+        "generic"
+    }
+}
+
+fn browser_section_landmark_block_reasons(landmark: &BrowserSectionLandmark) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if landmark.text.is_empty() {
+        reasons.push("empty-section-landmark".to_string());
+    }
+    if landmark.element == "section" && landmark.accessible_name.is_none() {
+        reasons.push("section-missing-accessible-name".to_string());
+    }
+    if matches!(landmark.element.as_str(), "article" | "section")
+        && landmark.heading_level.is_none()
+    {
+        reasons.push("section-missing-heading".to_string());
+    }
+    if matches!(
+        landmark.landmark_kind.as_deref(),
+        Some("navigation" | "complementary")
+    ) && landmark.accessible_name.is_none()
+        && landmark.heading_text.is_none()
+    {
+        reasons.push("landmark-missing-label-or-heading".to_string());
+    }
+    reasons
 }
 
 fn browser_first_heading(element: &Element) -> Option<(u8, String)> {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -26,17 +26,17 @@ use coding_adventures_html_parser::{
     BrowserLifecycleEventDescriptor, BrowserLink, BrowserLinkResourceDescriptor,
     BrowserLoadingHintDescriptor, BrowserMedia, BrowserMediaPlaybackDescriptor, BrowserMediaSource,
     BrowserMediaTrack, BrowserMeta, BrowserMetadataDirective, BrowserNavigationGroup,
-    BrowserNavigationTargetDescriptor, BrowserPointerInteractionDescriptor, BrowserPopover,
-    BrowserPopoverInvoker, BrowserRefresh, BrowserResource, BrowserResourceEndpointDescriptor,
-    BrowserResourceHint, BrowserScript, BrowserScriptExecutionDescriptor,
-    BrowserScriptModuleGraphDescriptor, BrowserScriptStorageAccessDescriptor,
-    BrowserScriptWorkerMessagingDescriptor, BrowserScrollInteractionDescriptor,
-    BrowserSectionLandmark, BrowserSelectOption, BrowserSelectionInteractionDescriptor,
-    BrowserSlotDescriptor, BrowserStructuredDataDescriptor, BrowserStructuredItem,
-    BrowserStructuredProperty, BrowserStylesheet, BrowserStylesheetPlanningDescriptor,
-    BrowserTable, BrowserTableCell, BrowserTableStructureDescriptor, BrowserTemplate,
-    BrowserTemplateDescriptor, BrowserTextSemantic, BrowserTextSemanticDescriptor,
-    BrowserThemeColor,
+    BrowserNavigationGroupDescriptor, BrowserNavigationTargetDescriptor,
+    BrowserPointerInteractionDescriptor, BrowserPopover, BrowserPopoverInvoker, BrowserRefresh,
+    BrowserResource, BrowserResourceEndpointDescriptor, BrowserResourceHint, BrowserScript,
+    BrowserScriptExecutionDescriptor, BrowserScriptModuleGraphDescriptor,
+    BrowserScriptStorageAccessDescriptor, BrowserScriptWorkerMessagingDescriptor,
+    BrowserScrollInteractionDescriptor, BrowserSectionLandmark, BrowserSectionLandmarkDescriptor,
+    BrowserSelectOption, BrowserSelectionInteractionDescriptor, BrowserSlotDescriptor,
+    BrowserStructuredDataDescriptor, BrowserStructuredItem, BrowserStructuredProperty,
+    BrowserStylesheet, BrowserStylesheetPlanningDescriptor, BrowserTable, BrowserTableCell,
+    BrowserTableStructureDescriptor, BrowserTemplate, BrowserTemplateDescriptor,
+    BrowserTextSemantic, BrowserTextSemanticDescriptor, BrowserThemeColor,
 };
 use serde::Deserialize;
 
@@ -139,7 +139,11 @@ struct ExpectedBrowserDocument {
     #[serde(default)]
     navigation_groups: Vec<ExpectedNavigationGroup>,
     #[serde(default)]
+    navigation_group_descriptors: Option<Vec<ExpectedNavigationGroupDescriptor>>,
+    #[serde(default)]
     section_landmarks: Vec<ExpectedSectionLandmark>,
+    #[serde(default)]
+    section_landmark_descriptors: Option<Vec<ExpectedSectionLandmarkDescriptor>>,
     #[serde(default)]
     command_elements: Vec<ExpectedCommandElement>,
     #[serde(default)]
@@ -2115,6 +2119,38 @@ struct ExpectedNavigationGroup {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExpectedNavigationGroupDescriptor {
+    group_index: usize,
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    group_kind: String,
+    #[serde(default)]
+    landmark_kind: Option<String>,
+    #[serde(default)]
+    list_kind: Option<String>,
+    item_count: usize,
+    #[serde(default)]
+    list_start: Option<String>,
+    #[serde(default)]
+    list_marker_type: Option<String>,
+    #[serde(default)]
+    list_reversed: bool,
+    #[serde(default)]
+    navigation_blocked: bool,
+    #[serde(default)]
+    navigation_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ExpectedSectionLandmark {
     element: String,
     #[serde(default)]
@@ -2137,6 +2173,37 @@ struct ExpectedSectionLandmark {
     heading_level: Option<u8>,
     #[serde(default)]
     heading_text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedSectionLandmarkDescriptor {
+    landmark_index: usize,
+    element: String,
+    #[serde(default)]
+    id: Option<String>,
+    role: String,
+    #[serde(default)]
+    authored_role: Option<String>,
+    text: String,
+    #[serde(default)]
+    accessible_name: Option<String>,
+    #[serde(default)]
+    aria_label: Option<String>,
+    #[serde(default)]
+    aria_labelledby: Vec<String>,
+    #[serde(default)]
+    section_kind: Option<String>,
+    #[serde(default)]
+    landmark_kind: Option<String>,
+    #[serde(default)]
+    heading_level: Option<u8>,
+    #[serde(default)]
+    heading_text: Option<String>,
+    outline_kind: String,
+    #[serde(default)]
+    landmark_blocked: bool,
+    #[serde(default)]
+    landmark_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5115,6 +5182,58 @@ fn browser_navigation_group_descriptor_metadata_tracks_lists_and_landmarks() {
 }
 
 #[test]
+fn browser_navigation_group_descriptors_track_kinds_counts_and_labels() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "navigation-menu-descriptor-page")
+        .expect("navigation menu fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("navigation menu fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.navigation_group_descriptors, expected.navigation_group_descriptors,
+        "navigation group descriptors should classify landmarks, lists, menus, and readiness state",
+    );
+    assert_eq!(
+        actual.navigation_group_descriptors[0].navigation_block_reasons,
+        Vec::<String>::new(),
+    );
+    assert_eq!(
+        actual.navigation_group_descriptors[3].group_kind, "list",
+        "ordered lists should remain list descriptors with marker metadata",
+    );
+}
+
+#[test]
+fn browser_navigation_group_descriptors_track_missing_landmark_labels() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "document-outline-landmark-page")
+        .expect("document outline fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("document outline fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.navigation_group_descriptors, expected.navigation_group_descriptors,
+        "navigation group descriptors should report unlabeled navigation landmarks as blocked",
+    );
+    assert_eq!(
+        actual.navigation_group_descriptors[0].navigation_block_reasons,
+        vec!["missing-navigation-label"],
+    );
+}
+
+#[test]
 fn browser_section_landmark_descriptor_metadata_tracks_outline_roles_and_names() {
     let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
         .expect("browser readiness fixture should parse");
@@ -5131,6 +5250,35 @@ fn browser_section_landmark_descriptor_metadata_tracks_outline_roles_and_names()
     assert_eq!(
         actual.section_landmarks, expected.section_landmarks,
         "section landmarks should preserve roles, accessible names, landmark kinds, and first headings",
+    );
+}
+
+#[test]
+fn browser_section_landmark_descriptors_track_outline_kinds_and_blockers() {
+    let suite: BrowserReadinessSuite = serde_json::from_str(BROWSER_READINESS_FIXTURE)
+        .expect("browser readiness fixture should parse");
+    let case = suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == "document-outline-landmark-page")
+        .expect("document outline fixture case should exist");
+
+    let actual = parse_browser_document(&case.input)
+        .expect("document outline fixture should parse into browser document facts");
+    let expected = case.expected.into_browser_document();
+
+    assert_eq!(
+        actual.section_landmark_descriptors, expected.section_landmark_descriptors,
+        "section landmark descriptors should classify outline/landmark kinds and readiness blockers",
+    );
+    assert_eq!(
+        actual.section_landmark_descriptors[1].outline_kind, "landmark-section",
+        "navigation landmarks should remain visible as sectioning landmarks",
+    );
+    assert_eq!(
+        actual.section_landmark_descriptors[3].landmark_block_reasons,
+        Vec::<String>::new(),
+        "headed articles should not be blocked",
     );
 }
 
@@ -7560,6 +7708,18 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedTextSemanticDescriptor::into_browser_text_semantic_descriptor)
             .collect();
+        let navigation_group_descriptors = self
+            .navigation_group_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedNavigationGroupDescriptor::into_browser_navigation_group_descriptor)
+            .collect();
+        let section_landmark_descriptors = self
+            .section_landmark_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedSectionLandmarkDescriptor::into_browser_section_landmark_descriptor)
+            .collect();
         let scripts: Vec<_> = self
             .scripts
             .into_iter()
@@ -8074,11 +8234,13 @@ impl ExpectedBrowserDocument {
                 .into_iter()
                 .map(ExpectedNavigationGroup::into_browser_navigation_group)
                 .collect(),
+            navigation_group_descriptors,
             section_landmarks: self
                 .section_landmarks
                 .into_iter()
                 .map(ExpectedSectionLandmark::into_browser_section_landmark)
                 .collect(),
+            section_landmark_descriptors,
             command_elements,
             activation_descriptors,
             popovers,
@@ -14770,6 +14932,30 @@ impl ExpectedNavigationGroup {
     }
 }
 
+impl ExpectedNavigationGroupDescriptor {
+    fn into_browser_navigation_group_descriptor(self) -> BrowserNavigationGroupDescriptor {
+        BrowserNavigationGroupDescriptor {
+            group_index: self.group_index,
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            group_kind: self.group_kind,
+            landmark_kind: self.landmark_kind,
+            list_kind: self.list_kind,
+            item_count: self.item_count,
+            list_start: self.list_start,
+            list_marker_type: self.list_marker_type,
+            list_reversed: self.list_reversed,
+            navigation_blocked: self.navigation_blocked,
+            navigation_block_reasons: self.navigation_block_reasons,
+        }
+    }
+}
+
 impl ExpectedSectionLandmark {
     fn into_browser_section_landmark(self) -> BrowserSectionLandmark {
         BrowserSectionLandmark {
@@ -14785,6 +14971,29 @@ impl ExpectedSectionLandmark {
             landmark_kind: self.landmark_kind,
             heading_level: self.heading_level,
             heading_text: self.heading_text,
+        }
+    }
+}
+
+impl ExpectedSectionLandmarkDescriptor {
+    fn into_browser_section_landmark_descriptor(self) -> BrowserSectionLandmarkDescriptor {
+        BrowserSectionLandmarkDescriptor {
+            landmark_index: self.landmark_index,
+            element: self.element,
+            id: self.id,
+            role: self.role,
+            authored_role: self.authored_role,
+            text: self.text,
+            accessible_name: self.accessible_name,
+            aria_label: self.aria_label,
+            aria_labelledby: self.aria_labelledby,
+            section_kind: self.section_kind,
+            landmark_kind: self.landmark_kind,
+            heading_level: self.heading_level,
+            heading_text: self.heading_text,
+            outline_kind: self.outline_kind,
+            landmark_blocked: self.landmark_blocked,
+            landmark_block_reasons: self.landmark_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -35,6 +35,9 @@
         "navigation_groups": [
           { "element": "ul", "role": "list", "text": "One Two", "list_kind": "unordered", "item_count": 2 }
         ],
+        "navigation_group_descriptors": [
+          { "group_index": 1, "element": "ul", "role": "list", "text": "One Two", "group_kind": "list", "list_kind": "unordered", "item_count": 2 }
+        ],
         "fetch_policy_descriptors": [
           { "element": "a", "url": "intro.html", "resolved_url": "https://example.test/docs/intro.html", "referrerpolicy": "no-referrer" }
         ],
@@ -1316,8 +1319,17 @@
           { "element": "menu", "id": "actions", "role": "list", "text": "Open Save", "accessible_name": "Actions", "aria_label": "Actions", "list_kind": "menu", "item_count": 2 },
           { "element": "ol", "id": "steps", "role": "list", "text": "Review Ship", "list_kind": "ordered", "item_count": 2, "list_start": "2", "list_marker_type": "A", "list_reversed": true }
         ],
+        "navigation_group_descriptors": [
+          { "group_index": 1, "element": "nav", "id": "site-nav", "role": "navigation", "text": "Home Docs API", "accessible_name": "Site", "aria_labelledby": ["nav-title"], "group_kind": "landmark", "landmark_kind": "navigation", "item_count": 0 },
+          { "group_index": 2, "element": "ul", "id": "primary", "role": "list", "text": "Docs API", "group_kind": "list", "list_kind": "unordered", "item_count": 2 },
+          { "group_index": 3, "element": "menu", "id": "actions", "role": "list", "text": "Open Save", "accessible_name": "Actions", "aria_label": "Actions", "group_kind": "menu", "list_kind": "menu", "item_count": 2 },
+          { "group_index": 4, "element": "ol", "id": "steps", "role": "list", "text": "Review Ship", "group_kind": "list", "list_kind": "ordered", "item_count": 2, "list_start": "2", "list_marker_type": "A", "list_reversed": true }
+        ],
         "section_landmarks": [
           { "element": "nav", "id": "site-nav", "role": "navigation", "text": "Home Docs API", "accessible_name": "Site", "aria_labelledby": ["nav-title"], "section_kind": "navigation", "landmark_kind": "navigation" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "nav", "id": "site-nav", "role": "navigation", "text": "Home Docs API", "accessible_name": "Site", "aria_labelledby": ["nav-title"], "section_kind": "navigation", "landmark_kind": "navigation", "outline_kind": "landmark-section" }
         ],
         "links": [
           { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
@@ -1351,6 +1363,9 @@
         "navigation_groups": [
           { "element": "nav", "role": "navigation", "text": "Nav Home", "landmark_kind": "navigation", "item_count": 0 }
         ],
+        "navigation_group_descriptors": [
+          { "group_index": 1, "element": "nav", "role": "navigation", "text": "Nav Home", "group_kind": "landmark", "landmark_kind": "navigation", "item_count": 0, "navigation_blocked": true, "navigation_block_reasons": ["missing-navigation-label"] }
+        ],
         "section_landmarks": [
           { "element": "header", "role": "header", "text": "Site", "section_kind": "header", "landmark_kind": "header", "heading_level": 1, "heading_text": "Site" },
           { "element": "nav", "role": "navigation", "text": "Nav Home", "section_kind": "navigation", "landmark_kind": "navigation", "heading_level": 2, "heading_text": "Nav" },
@@ -1359,6 +1374,15 @@
           { "element": "section", "role": "section", "text": "Chapter", "accessible_name": "Chapter", "aria_label": "Chapter", "section_kind": "section", "heading_level": 3, "heading_text": "Chapter" },
           { "element": "aside", "role": "aside", "text": "Related", "section_kind": "aside", "landmark_kind": "complementary", "heading_level": 2, "heading_text": "Related" },
           { "element": "footer", "role": "footer", "text": "Fine print", "section_kind": "footer", "landmark_kind": "footer" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "header", "role": "header", "text": "Site", "section_kind": "header", "landmark_kind": "header", "heading_level": 1, "heading_text": "Site", "outline_kind": "landmark-section" },
+          { "landmark_index": 2, "element": "nav", "role": "navigation", "text": "Nav Home", "section_kind": "navigation", "landmark_kind": "navigation", "heading_level": 2, "heading_text": "Nav", "outline_kind": "landmark-section" },
+          { "landmark_index": 3, "element": "main", "role": "main", "text": "Post Chapter Related", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Post", "outline_kind": "landmark-section" },
+          { "landmark_index": 4, "element": "article", "id": "post", "role": "article", "text": "Post Chapter", "section_kind": "article", "heading_level": 2, "heading_text": "Post", "outline_kind": "section" },
+          { "landmark_index": 5, "element": "section", "role": "section", "text": "Chapter", "accessible_name": "Chapter", "aria_label": "Chapter", "section_kind": "section", "heading_level": 3, "heading_text": "Chapter", "outline_kind": "section" },
+          { "landmark_index": 6, "element": "aside", "role": "aside", "text": "Related", "section_kind": "aside", "landmark_kind": "complementary", "heading_level": 2, "heading_text": "Related", "outline_kind": "landmark-section" },
+          { "landmark_index": 7, "element": "footer", "role": "footer", "text": "Fine print", "section_kind": "footer", "landmark_kind": "footer", "outline_kind": "landmark-section" }
         ],
         "links": [
           { "href": "/home", "resolved_href": null, "name": null, "target": null, "rel": null, "title": null, "text": "Home" }
@@ -1394,6 +1418,9 @@
         ],
         "section_landmarks": [
           { "element": "article", "id": "product", "role": "article", "text": "Widget Pro Product page Widget SKU today 19.99", "section_kind": "article", "heading_level": 2, "heading_text": "Widget Pro" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "article", "id": "product", "role": "article", "text": "Widget Pro Product page Widget SKU today 19.99", "section_kind": "article", "heading_level": 2, "heading_text": "Widget Pro", "outline_kind": "section" }
         ],
         "links": [
           { "href": "../products/widget", "resolved_href": "https://example.test/products/widget", "name": null, "target": null, "rel": null, "title": null, "text": "Product page" }
@@ -1459,6 +1486,9 @@
         ],
         "navigation_groups": [
           { "element": "ol", "role": "list", "text": "Seven Eight", "list_kind": "ordered", "item_count": 2, "list_start": "3", "list_marker_type": "A", "list_reversed": true }
+        ],
+        "navigation_group_descriptors": [
+          { "group_index": 1, "element": "ol", "role": "list", "text": "Seven Eight", "group_kind": "list", "list_kind": "ordered", "item_count": 2, "list_start": "3", "list_marker_type": "A", "list_reversed": true }
         ],
         "links": [],
         "images": [],
@@ -1586,6 +1616,9 @@
         "section_landmarks": [
           { "element": "main", "id": "app", "role": "main", "text": "Save", "section_kind": "main", "landmark_kind": "main" }
         ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "main", "id": "app", "role": "main", "text": "Save", "section_kind": "main", "landmark_kind": "main", "outline_kind": "landmark-section" }
+        ],
         "links": [],
         "images": [
           { "src": "hero.jpg", "resolved_src": null, "alt": "Hero" }
@@ -1642,6 +1675,10 @@
         "section_landmarks": [
           { "element": "main", "id": "app", "role": "main", "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative", "accessible_name": "App shell", "aria_label": "App shell", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Settings" },
           { "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "aria_labelledby": ["panel-title"], "section_kind": "section", "heading_level": 2, "heading_text": "Settings" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "main", "id": "app", "role": "main", "text": "Menu Settings Choose options Inline action Editable copy Dialog copy More Extra Hidden copy Decorative", "accessible_name": "App shell", "aria_label": "App shell", "section_kind": "main", "landmark_kind": "main", "heading_level": 2, "heading_text": "Settings", "outline_kind": "landmark-section" },
+          { "landmark_index": 2, "element": "section", "id": "panel", "role": "section", "authored_role": "region", "text": "Settings Choose options Inline action Editable copy", "accessible_name": "Settings", "aria_labelledby": ["panel-title"], "section_kind": "section", "heading_level": 2, "heading_text": "Settings", "outline_kind": "section" }
         ],
         "command_elements": [
           { "element": "button", "id": "menu", "role": "control", "command_kind": "command", "text": "Menu", "accessible_name": "Menu", "control_type": "submit", "command": "show-modal", "command_for": "dialog", "popover_target": "panel-pop", "popover_target_action": "toggle", "aria_controls": ["panel"], "aria_expanded": "false", "aria_haspopup": "menu", "aria_disabled": "false", "tabindex": "0", "accesskey": ["m", "/"], "event_handlers": ["onclick"], "focusable": true },
@@ -1749,6 +1786,9 @@
         "headings": [],
         "section_landmarks": [
           { "element": "main", "role": "main", "text": "Ready", "section_kind": "main", "landmark_kind": "main" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "main", "role": "main", "text": "Ready", "section_kind": "main", "landmark_kind": "main", "outline_kind": "landmark-section" }
         ],
         "links": [],
         "images": [],
@@ -2372,6 +2412,9 @@
         "headings": [],
         "section_landmarks": [
           { "element": "article", "role": "article", "text": "Untitled Body", "section_kind": "article" }
+        ],
+        "section_landmark_descriptors": [
+          { "landmark_index": 1, "element": "article", "role": "article", "text": "Untitled Body", "section_kind": "article", "outline_kind": "section", "landmark_blocked": true, "landmark_block_reasons": ["section-missing-heading"] }
         ],
         "links": [],
         "images": [],


### PR DESCRIPTION
## Summary
- add navigation group descriptors for landmark/list/menu inventories and readiness blockers
- add section landmark descriptors for outline kind, heading/name state, and blockers
- update browser-readiness fixtures and focused descriptor tests

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- cargo test -p coding-adventures-html-parser browser_navigation_group_descriptors --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_section_landmark_descriptors --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml