### PR TITLE
Add smart-home activation guardrail tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -44,7 +44,7 @@ use smart_home_integration_catalog::{
     activation_deployment_records_from_delivery_manifests, activation_dossiers_from_candidates,
     activation_escalation_cases_from_rollups, activation_evidence_from_candidates,
     activation_execution_packets_from_handoff_packages,
-    activation_forecasts_from_timeline_milestones,
+    activation_forecasts_from_timeline_milestones, activation_guardrail_checks_from_rollups,
     activation_handoff_packages_from_runbook_entries, activation_health_from_candidates,
     activation_incident_briefs_from_observability_probes, activation_maintenance_from_candidates,
     activation_observability_probes_from_rollups, activation_operator_tasks_from_playbook_steps,
@@ -95,7 +95,9 @@ use smart_home_integration_catalog::{
     IntegrationActivationEvidenceSummary, IntegrationActivationExecutionPacket,
     IntegrationActivationExecutionStatus, IntegrationActivationExecutionSummary,
     IntegrationActivationForecastAction, IntegrationActivationForecastItem,
-    IntegrationActivationForecastSummary, IntegrationActivationHandoffPackage,
+    IntegrationActivationForecastSummary, IntegrationActivationGuardrailCheck,
+    IntegrationActivationGuardrailKind, IntegrationActivationGuardrailSummary,
+    IntegrationActivationGuardrailVerdict, IntegrationActivationHandoffPackage,
     IntegrationActivationHandoffStatus, IntegrationActivationHandoffSummary,
     IntegrationActivationHealthStage, IntegrationActivationHealthStatus,
     IntegrationActivationHealthSummary, IntegrationActivationIncidentAction,
@@ -391,6 +393,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_INCIDENTS_TOOL_ID: &str =
     "smart_home.list_integration_activation_incidents";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_INCIDENT_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_incident_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_guardrails";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_guardrail_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -897,6 +903,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_INCIDENT_SUMMARY_TOOL_ID => {
                     let query = integration_activation_incident_query(&arguments)?;
                     Ok(get_integration_activation_incident_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID => {
+                    let query = integration_activation_guardrail_query(&arguments)?;
+                    Ok(list_integration_activation_guardrails_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_guardrail_query(&arguments)?;
+                    Ok(get_integration_activation_guardrail_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -2900,6 +2914,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation incident summary",
             "Return compact D23A activation incident counts by severity, response action, observability status, blockers, watchtower signal coverage, verification, rollback, and readiness.",
             integration_activation_incident_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID,
+            "List smart-home integration activation guardrails",
+            "List Chief-facing D23A activation guardrail checks that normalize incidents, policy risk, dependencies, and readiness gaps into pass, monitor, review, or blocked verdicts.",
+            integration_activation_guardrail_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_guardrails", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_guardrails", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation guardrail summary",
+            "Return compact D23A activation guardrail counts by verdict, guardrail kind, policy surface, blocker, and review posture.",
+            integration_activation_guardrail_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -5872,6 +5915,19 @@ struct IntegrationActivationIncidentQuery {
 }
 
 #[derive(Debug, Clone)]
+struct IntegrationActivationGuardrailQuery {
+    incident: IntegrationActivationIncidentQuery,
+    risk: IntegrationActivationRiskQuery,
+    dependency: IntegrationActivationDependencyQuery,
+    gaps: IntegrationReadinessGapQuery,
+    kind: Option<IntegrationActivationGuardrailKind>,
+    verdict: Option<IntegrationActivationGuardrailVerdict>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    guardrail_limit: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 struct IntegrationActivationRiskQuery {
     candidates: IntegrationActivationCandidateQuery,
     risk_kind: Option<IntegrationActivationRiskKind>,
@@ -6849,6 +6905,35 @@ fn integration_activation_incident_query(
     })
 }
 
+fn integration_activation_guardrail_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationGuardrailQuery, ToolCallError> {
+    let kind = optional_string(arguments, "guardrail_kind")?
+        .or(optional_string(arguments, "kind")?)
+        .map(|label| parse_activation_guardrail_kind(&label))
+        .transpose()?;
+    let verdict = optional_string(arguments, "guardrail_verdict")?
+        .or(optional_string(arguments, "verdict")?)
+        .map(|label| parse_activation_guardrail_verdict(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationGuardrailQuery {
+        incident: integration_activation_incident_query(arguments)?,
+        risk: integration_activation_risk_query(arguments)?,
+        dependency: integration_activation_dependency_query(arguments)?,
+        gaps: integration_readiness_gap_query(arguments)?,
+        kind,
+        verdict,
+        requires_attention: optional_bool(arguments, "guardrail_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "guardrail_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        guardrail_limit: optional_u64(arguments, "guardrail_limit")?
+            .or(optional_u64(arguments, "check_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
 fn integration_activation_risk_query(
     arguments: &JsonValue,
 ) -> Result<IntegrationActivationRiskQuery, ToolCallError> {
@@ -7515,7 +7600,13 @@ fn integration_activation_handoff_packages_for_query(
     let (entries, catalog_count) = integration_activation_runbook_entries_for_query(&query.runbook);
     let (risks, _) = integration_activation_risk_for_query(&query.risk);
     let (graph, _) = integration_activation_dependency_graph_for_query(&query.dependency);
-    let (gap_inventory, _) = integration_readiness_gap_inventory_for_query(&query.gaps.readiness);
+    let (mut gap_inventory, _) =
+        integration_readiness_gap_inventory_for_query(&query.gaps.readiness);
+    if let Some(limit) = query.gaps.limit_per_kind {
+        gap_inventory.primitive_gaps.truncate(limit);
+        gap_inventory.capability_gaps.truncate(limit);
+        gap_inventory.dependency_gaps.truncate(limit);
+    }
     let mut packages = activation_handoff_packages_from_runbook_entries(
         entries.iter(),
         &risks,
@@ -8274,6 +8365,36 @@ fn integration_activation_incident_briefs_for_query(
     }
 
     (briefs, catalog_count)
+}
+
+fn integration_activation_guardrail_checks_for_query(
+    query: &IntegrationActivationGuardrailQuery,
+) -> (Vec<IntegrationActivationGuardrailCheck>, usize) {
+    let (incidents, catalog_count) =
+        integration_activation_incident_briefs_for_query(&query.incident);
+    let (risks, _) = integration_activation_risk_for_query(&query.risk);
+    let (graph, _) = integration_activation_dependency_graph_for_query(&query.dependency);
+    let (gap_inventory, _) = integration_readiness_gap_inventory_for_query(&query.gaps.readiness);
+    let mut checks =
+        activation_guardrail_checks_from_rollups(&incidents, &risks, &graph, &gap_inventory);
+
+    if let Some(kind) = query.kind {
+        checks.retain(|check| check.kind == kind);
+    }
+    if let Some(verdict) = query.verdict {
+        checks.retain(|check| check.verdict == verdict);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        checks.retain(|check| check.requires_attention() == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        checks.retain(|check| check.blocks_activation() == blocked);
+    }
+    if let Some(limit) = query.guardrail_limit {
+        checks.truncate(limit);
+    }
+
+    (checks, catalog_count)
 }
 
 fn integration_activation_risk_for_query(
@@ -11658,6 +11779,71 @@ fn get_integration_activation_incident_summary_output_handler_output(
                 "briefs_incident_ready",
                 integer(summary.briefs_incident_ready as i64),
             ),
+        ]),
+    )
+}
+
+fn list_integration_activation_guardrails_output_handler_output(
+    query: IntegrationActivationGuardrailQuery,
+) -> ToolHandlerOutput {
+    let (checks, catalog_count) = integration_activation_guardrail_checks_for_query(&query);
+    let summary = IntegrationActivationGuardrailSummary::from_checks(checks.iter());
+    let count = checks.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_guardrails",
+            JsonValue::Array(checks.iter().map(activation_guardrail_check_json).collect()),
+        ),
+        (
+            "summary",
+            integration_activation_guardrail_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_guardrails"),
+            ),
+            ("checks", integer(count as i64)),
+            ("blocked_checks", integer(summary.blocked_checks as i64)),
+            (
+                "checks_requiring_attention",
+                integer(summary.checks_requiring_attention as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_guardrail_summary_output_handler_output(
+    query: IntegrationActivationGuardrailQuery,
+) -> ToolHandlerOutput {
+    let (checks, _) = integration_activation_guardrail_checks_for_query(&query);
+    let summary = IntegrationActivationGuardrailSummary::from_checks(checks.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_guardrail_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_guardrail_summary"),
+            ),
+            ("total_checks", integer(summary.total_checks as i64)),
+            ("blocked_checks", integer(summary.blocked_checks as i64)),
+            (
+                "checks_requiring_attention",
+                integer(summary.checks_requiring_attention as i64),
+            ),
+            ("overall_status", string(summary.overall_status.as_str())),
         ]),
     )
 }
@@ -23152,6 +23338,168 @@ fn integration_activation_incident_summary_json(
     ])
 }
 
+fn activation_guardrail_check_json(check: &IntegrationActivationGuardrailCheck) -> JsonValue {
+    object([
+        ("sequence", integer(check.sequence as i64)),
+        ("guardrail_id", string(&check.guardrail_id)),
+        ("kind", string(check.kind.as_str())),
+        ("verdict", string(check.verdict.as_str())),
+        ("title", string(&check.title)),
+        ("summary", string(&check.summary)),
+        ("priority", integer(check.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                check
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(check.integration_count() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(check.required_tier)),
+        ),
+        (
+            "policy_surface",
+            check
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "incident_severity",
+            check
+                .incident_severity
+                .map(|severity| string(severity.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "incident_action",
+            check
+                .incident_action
+                .map(|action| string(action.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "risk_kind",
+            check
+                .risk_kind
+                .map(|kind| string(kind.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependency_integration_id",
+            check
+                .dependency_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "dependent_integration_id",
+            check
+                .dependent_integration_id
+                .as_ref()
+                .map(|integration_id| string(integration_id.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "readiness_gap_kind",
+            check
+                .readiness_gap_kind
+                .as_deref()
+                .map(string)
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "blocks_activation",
+            JsonValue::Bool(check.blocks_activation()),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(check.requires_attention()),
+        ),
+    ])
+}
+
+fn integration_activation_guardrail_summary_json(
+    summary: &IntegrationActivationGuardrailSummary,
+) -> JsonValue {
+    object([
+        ("total_checks", integer(summary.total_checks as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "checks_requiring_attention",
+            integer(summary.checks_requiring_attention as i64),
+        ),
+        ("blocked_checks", integer(summary.blocked_checks as i64)),
+        (
+            "needs_review_checks",
+            integer(summary.needs_review_checks as i64),
+        ),
+        ("monitor_checks", integer(summary.monitor_checks as i64)),
+        ("pass_checks", integer(summary.pass_checks as i64)),
+        ("incident_checks", integer(summary.incident_checks as i64)),
+        (
+            "policy_risk_checks",
+            integer(summary.policy_risk_checks as i64),
+        ),
+        (
+            "dependency_checks",
+            integer(summary.dependency_checks as i64),
+        ),
+        (
+            "readiness_gap_checks",
+            integer(summary.readiness_gap_checks as i64),
+        ),
+        (
+            "checks_with_policy_surface",
+            integer(summary.checks_with_policy_surface as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_review_priority",
+            summary
+                .first_review_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -26376,6 +26724,38 @@ fn parse_activation_incident_action(
     }
 }
 
+fn parse_activation_guardrail_kind(
+    label: &str,
+) -> Result<IntegrationActivationGuardrailKind, ToolCallError> {
+    match label {
+        "incident" | "incidents" => Ok(IntegrationActivationGuardrailKind::Incident),
+        "policy_risk" | "risk" | "policy" => Ok(IntegrationActivationGuardrailKind::PolicyRisk),
+        "dependency" | "dependencies" => Ok(IntegrationActivationGuardrailKind::Dependency),
+        "readiness_gap" | "readiness_gaps" | "gap" | "gaps" => {
+            Ok(IntegrationActivationGuardrailKind::ReadinessGap)
+        }
+        _ => Err(validation_error(format!(
+            "unknown activation guardrail kind `{label}`"
+        ))),
+    }
+}
+
+fn parse_activation_guardrail_verdict(
+    label: &str,
+) -> Result<IntegrationActivationGuardrailVerdict, ToolCallError> {
+    match label {
+        "pass" | "passed" | "ok" => Ok(IntegrationActivationGuardrailVerdict::Pass),
+        "monitor" | "watch" | "observe" => Ok(IntegrationActivationGuardrailVerdict::Monitor),
+        "needs_review" | "review" | "attention" => {
+            Ok(IntegrationActivationGuardrailVerdict::NeedsReview)
+        }
+        "blocked" | "blocker" | "hold" => Ok(IntegrationActivationGuardrailVerdict::Blocked),
+        _ => Err(validation_error(format!(
+            "unknown activation guardrail verdict `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -28311,6 +28691,47 @@ fn integration_activation_incident_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_guardrail_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_incident_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new("guardrail_kind", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("kind", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("guardrail_verdict", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("verdict", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "guardrail_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "guardrail_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("guardrail_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("check_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("risk_kind", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("required_tier", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("policy_surface", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("blocking_only", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new("node_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("edge_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("limit_per_kind", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -28455,7 +28876,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 139);
+        assert_eq!(definitions.len(), 141);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -28844,9 +29265,15 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_INCIDENT_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            131
+            133
         );
         assert_eq!(
             export
@@ -29022,6 +29449,14 @@ mod tests {
         );
         assert!(smart_home_tool_definition(
             SMART_HOME_GET_INTEGRATION_ACTIVATION_REVIEW_SUMMARY_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID
+        )
+        .is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID
         )
         .is_some());
         assert!(
@@ -29372,11 +29807,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(139))
+            Some(&integer(141))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(131))
+            Some(&integer(133))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -35010,6 +35445,145 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_guardrails_request = request(
+            "call-list-integration-activation-guardrails",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_GUARDRAILS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("guardrail_requires_attention", JsonValue::Bool(true)),
+            ]),
+            5_065,
+        );
+        let list_activation_guardrails_trace =
+            tool_runtime.invoke_with_events(&list_activation_guardrails_request);
+        assert!(list_activation_guardrails_trace.result.ok);
+        assert_eq!(
+            list_activation_guardrails_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_guardrails_output = list_activation_guardrails_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_guardrail_count =
+            integer_value(field(list_activation_guardrails_output, "count").unwrap()).unwrap();
+        assert!(activation_guardrail_count >= 4);
+        let activation_guardrail_summary =
+            field(list_activation_guardrails_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_guardrail_summary, "total_checks"),
+            Some(&integer(activation_guardrail_count))
+        );
+        assert!(
+            integer_value(field(activation_guardrail_summary, "incident_checks").unwrap()).unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_guardrail_summary, "policy_risk_checks").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_guardrail_summary, "dependency_checks").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert!(
+            integer_value(field(activation_guardrail_summary, "readiness_gap_checks").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_guardrail_summary, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert_eq!(
+            field(activation_guardrail_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_guardrail = array_item(
+            field(list_activation_guardrails_output, "activation_guardrails").unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_guardrail, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_guardrail_summary_request = request(
+            "call-integration-activation-guardrail-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_GUARDRAIL_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("guardrail_blocked", JsonValue::Bool(true)),
+            ]),
+            5_066,
+        );
+        let activation_guardrail_summary_trace =
+            tool_runtime.invoke_with_events(&activation_guardrail_summary_request);
+        assert!(activation_guardrail_summary_trace.result.ok);
+        assert_eq!(
+            activation_guardrail_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_guardrail_summary_output = activation_guardrail_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_guardrail_rollup =
+            field(activation_guardrail_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_guardrail_rollup, "blocked_checks").unwrap()).unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_guardrail_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -36938,6 +37512,14 @@ mod tests {
             activation_incident_summary_request,
             activation_incident_summary_trace,
         );
+        journal.record_trace(
+            list_activation_guardrails_request,
+            list_activation_guardrails_trace,
+        );
+        journal.record_trace(
+            activation_guardrail_summary_request,
+            activation_guardrail_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -37011,9 +37593,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 139);
-        assert_eq!(journal_summary.completed_count, 139);
-        assert_eq!(journal.audit_records().len(), 139);
+        assert_eq!(journal_summary.invocation_count, 141);
+        assert_eq!(journal_summary.completed_count, 141);
+        assert_eq!(journal.audit_records().len(), 141);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1537,6 +1537,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationObservabilitySummary,
     ListIntegrationActivationIncidents,
     GetIntegrationActivationIncidentSummary,
+    ListIntegrationActivationGuardrails,
+    GetIntegrationActivationGuardrailSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1854,6 +1856,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationIncidentSummary => {
                 read_tool("smart_home.get_integration_activation_incident_summary")
+            }
+            Self::ListIntegrationActivationGuardrails => {
+                read_tool("smart_home.list_integration_activation_guardrails")
+            }
+            Self::GetIntegrationActivationGuardrailSummary => {
+                read_tool("smart_home.get_integration_activation_guardrail_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2574,6 +2582,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationObservabilitySummary,
         SmartHomeTool::ListIntegrationActivationIncidents,
         SmartHomeTool::GetIntegrationActivationIncidentSummary,
+        SmartHomeTool::ListIntegrationActivationGuardrails,
+        SmartHomeTool::GetIntegrationActivationGuardrailSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3416,7 +3426,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 139);
+        assert_eq!(catalog.len(), 141);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -3979,6 +3989,14 @@ mod tests {
             == "smart_home.get_integration_activation_incident_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_guardrails"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_guardrail_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -3986,15 +4004,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 139);
-        assert_eq!(summary.read_tools, 131);
+        assert_eq!(summary.total_tools, 141);
+        assert_eq!(summary.read_tools, 133);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 131);
+        assert_eq!(summary.read_only_tier_tools, 133);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 139);
+        assert_eq!(summary.total_required_capabilities, 141);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -4196,6 +4196,52 @@ impl IntegrationActivationIncidentAction {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationGuardrailKind {
+    Incident,
+    PolicyRisk,
+    Dependency,
+    ReadinessGap,
+}
+
+impl IntegrationActivationGuardrailKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Incident => "incident",
+            Self::PolicyRisk => "policy_risk",
+            Self::Dependency => "dependency",
+            Self::ReadinessGap => "readiness_gap",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntegrationActivationGuardrailVerdict {
+    Pass,
+    Monitor,
+    NeedsReview,
+    Blocked,
+}
+
+impl IntegrationActivationGuardrailVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Monitor => "monitor",
+            Self::NeedsReview => "needs_review",
+            Self::Blocked => "blocked",
+        }
+    }
+
+    pub fn blocks_activation(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
+    pub fn requires_attention(self) -> bool {
+        matches!(self, Self::NeedsReview | Self::Blocked)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntegrationActivationIncidentBrief {
     pub sequence: usize,
@@ -4261,6 +4307,49 @@ pub struct IntegrationActivationIncidentSummary {
     pub next_brief_sequence: Option<usize>,
     pub next_brief_priority: Option<u8>,
     pub first_attention_priority: Option<u8>,
+    pub highest_policy_tier: PrivilegeTier,
+    pub overall_status: IntegrationActivationHealthStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationGuardrailCheck {
+    pub sequence: usize,
+    pub guardrail_id: String,
+    pub kind: IntegrationActivationGuardrailKind,
+    pub verdict: IntegrationActivationGuardrailVerdict,
+    pub title: String,
+    pub summary: String,
+    pub priority: u8,
+    pub integration_ids: Vec<IntegrationId>,
+    pub required_tier: PrivilegeTier,
+    pub policy_surface: Option<IntegrationPolicySurface>,
+    pub incident_severity: Option<IntegrationActivationIncidentSeverity>,
+    pub incident_action: Option<IntegrationActivationIncidentAction>,
+    pub risk_kind: Option<IntegrationActivationRiskKind>,
+    pub dependency_integration_id: Option<IntegrationId>,
+    pub dependent_integration_id: Option<IntegrationId>,
+    pub readiness_gap_kind: Option<String>,
+    pub blocks_activation: bool,
+    pub requires_attention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntegrationActivationGuardrailSummary {
+    pub total_checks: usize,
+    pub unique_integrations: usize,
+    pub checks_requiring_attention: usize,
+    pub blocked_checks: usize,
+    pub needs_review_checks: usize,
+    pub monitor_checks: usize,
+    pub pass_checks: usize,
+    pub incident_checks: usize,
+    pub policy_risk_checks: usize,
+    pub dependency_checks: usize,
+    pub readiness_gap_checks: usize,
+    pub checks_with_policy_surface: usize,
+    pub first_attention_priority: Option<u8>,
+    pub first_blocked_priority: Option<u8>,
+    pub first_review_priority: Option<u8>,
     pub highest_policy_tier: PrivilegeTier,
     pub overall_status: IntegrationActivationHealthStatus,
 }
@@ -12164,6 +12253,321 @@ impl IntegrationActivationIncidentSummary {
     }
 }
 
+impl IntegrationActivationGuardrailCheck {
+    fn from_incident(brief: &IntegrationActivationIncidentBrief) -> Self {
+        let verdict = if brief.blocks_activation() {
+            IntegrationActivationGuardrailVerdict::Blocked
+        } else if brief.requires_attention() {
+            IntegrationActivationGuardrailVerdict::NeedsReview
+        } else if brief.incident_ready() {
+            IntegrationActivationGuardrailVerdict::Monitor
+        } else {
+            IntegrationActivationGuardrailVerdict::Pass
+        };
+
+        Self {
+            sequence: 0,
+            guardrail_id: format!("incident:{}", brief.source_id.as_str()),
+            kind: IntegrationActivationGuardrailKind::Incident,
+            verdict,
+            title: brief.title.clone(),
+            summary: brief.summary.clone(),
+            priority: brief.priority,
+            integration_ids: brief.integration_ids.clone(),
+            required_tier: brief.required_tier,
+            policy_surface: brief.policy_surface,
+            incident_severity: Some(brief.severity),
+            incident_action: Some(brief.action),
+            risk_kind: None,
+            dependency_integration_id: None,
+            dependent_integration_id: None,
+            readiness_gap_kind: None,
+            blocks_activation: verdict.blocks_activation() || brief.blocks_activation(),
+            requires_attention: verdict.requires_attention() || brief.requires_attention(),
+        }
+    }
+
+    fn from_risk(risk: &IntegrationActivationRiskItem) -> Self {
+        let verdict = if risk.has_blockers() {
+            IntegrationActivationGuardrailVerdict::Blocked
+        } else if risk.requires_attention()
+            || matches!(
+                risk.required_tier,
+                PrivilegeTier::HumanApproval | PrivilegeTier::HighRisk
+            )
+        {
+            IntegrationActivationGuardrailVerdict::NeedsReview
+        } else if risk.has_ready_work() {
+            IntegrationActivationGuardrailVerdict::Monitor
+        } else {
+            IntegrationActivationGuardrailVerdict::Pass
+        };
+
+        Self {
+            sequence: 0,
+            guardrail_id: format!("risk:{}", risk.risk_id.as_str()),
+            kind: IntegrationActivationGuardrailKind::PolicyRisk,
+            verdict,
+            title: format!("Policy risk: {}", risk.display_name),
+            summary: format!(
+                "{} integration(s) share this activation policy risk",
+                risk.integration_count()
+            ),
+            priority: risk.highest_priority,
+            integration_ids: risk.integration_ids.clone(),
+            required_tier: risk.required_tier,
+            policy_surface: risk.policy_surface,
+            incident_severity: None,
+            incident_action: None,
+            risk_kind: Some(risk.kind),
+            dependency_integration_id: None,
+            dependent_integration_id: None,
+            readiness_gap_kind: None,
+            blocks_activation: verdict.blocks_activation(),
+            requires_attention: verdict.requires_attention() || risk.requires_attention(),
+        }
+    }
+
+    fn from_dependency_edge(edge: &IntegrationActivationDependencyEdge) -> Self {
+        let verdict = if edge.blocks_activation {
+            IntegrationActivationGuardrailVerdict::Blocked
+        } else {
+            IntegrationActivationGuardrailVerdict::Pass
+        };
+        let dependency_name = edge
+            .dependency_display_name
+            .as_deref()
+            .unwrap_or(edge.dependency_integration_id.as_str());
+        let integration_ids = if edge.dependency_integration_id == edge.dependent_integration_id {
+            vec![edge.dependent_integration_id.clone()]
+        } else {
+            vec![
+                edge.dependency_integration_id.clone(),
+                edge.dependent_integration_id.clone(),
+            ]
+        };
+
+        Self {
+            sequence: 0,
+            guardrail_id: format!(
+                "dependency:{}->{}",
+                edge.dependency_integration_id.as_str(),
+                edge.dependent_integration_id.as_str()
+            ),
+            kind: IntegrationActivationGuardrailKind::Dependency,
+            verdict,
+            title: format!(
+                "Dependency guardrail: {} requires {}",
+                edge.dependent_display_name, dependency_name
+            ),
+            summary: if edge.satisfied {
+                "Required integration dependency is enabled".to_string()
+            } else {
+                "Required integration dependency is not enabled".to_string()
+            },
+            priority: edge.dependent_priority,
+            integration_ids,
+            required_tier: PrivilegeTier::ReadOnly,
+            policy_surface: None,
+            incident_severity: None,
+            incident_action: None,
+            risk_kind: None,
+            dependency_integration_id: Some(edge.dependency_integration_id.clone()),
+            dependent_integration_id: Some(edge.dependent_integration_id.clone()),
+            readiness_gap_kind: None,
+            blocks_activation: edge.blocks_activation,
+            requires_attention: edge.blocks_activation,
+        }
+    }
+
+    fn from_primitive_gap(gap: &IntegrationReadinessPrimitiveGap) -> Self {
+        Self {
+            sequence: 0,
+            guardrail_id: format!("readiness_gap:primitive:{}", gap.primitive.as_str()),
+            kind: IntegrationActivationGuardrailKind::ReadinessGap,
+            verdict: IntegrationActivationGuardrailVerdict::Blocked,
+            title: format!("Readiness gap: missing {}", gap.primitive.as_str()),
+            summary: format!(
+                "{} integration report(s) are blocked by this primitive gap",
+                gap.blocked_report_count
+            ),
+            priority: gap.highest_priority,
+            integration_ids: gap.integration_ids.clone(),
+            required_tier: PrivilegeTier::ReadOnly,
+            policy_surface: None,
+            incident_severity: None,
+            incident_action: None,
+            risk_kind: None,
+            dependency_integration_id: None,
+            dependent_integration_id: None,
+            readiness_gap_kind: Some("primitive".to_string()),
+            blocks_activation: true,
+            requires_attention: true,
+        }
+    }
+
+    fn from_capability_gap(gap: &IntegrationReadinessCapabilityGap) -> Self {
+        Self {
+            sequence: 0,
+            guardrail_id: format!("readiness_gap:capability:{}", gap.capability_id.as_str()),
+            kind: IntegrationActivationGuardrailKind::ReadinessGap,
+            verdict: IntegrationActivationGuardrailVerdict::Blocked,
+            title: format!("Readiness gap: missing {}", gap.capability_id.as_str()),
+            summary: format!(
+                "{} integration report(s) are blocked by this capability gap",
+                gap.blocked_report_count
+            ),
+            priority: gap.highest_priority,
+            integration_ids: gap.integration_ids.clone(),
+            required_tier: PrivilegeTier::ReadOnly,
+            policy_surface: None,
+            incident_severity: None,
+            incident_action: None,
+            risk_kind: None,
+            dependency_integration_id: None,
+            dependent_integration_id: None,
+            readiness_gap_kind: Some("capability".to_string()),
+            blocks_activation: true,
+            requires_attention: true,
+        }
+    }
+
+    fn from_dependency_gap(gap: &IntegrationReadinessDependencyGap) -> Self {
+        let mut integration_ids = gap.requested_integration_ids.clone();
+        if !integration_ids
+            .iter()
+            .any(|integration_id| integration_id == &gap.integration_id)
+        {
+            integration_ids.push(gap.integration_id.clone());
+        }
+
+        Self {
+            sequence: 0,
+            guardrail_id: format!("readiness_gap:dependency:{}", gap.integration_id.as_str()),
+            kind: IntegrationActivationGuardrailKind::ReadinessGap,
+            verdict: IntegrationActivationGuardrailVerdict::Blocked,
+            title: format!("Readiness gap: missing {}", gap.integration_id.as_str()),
+            summary: format!(
+                "{} integration report(s) are blocked by this dependency gap",
+                gap.blocked_report_count
+            ),
+            priority: gap.highest_priority,
+            integration_ids,
+            required_tier: PrivilegeTier::ReadOnly,
+            policy_surface: None,
+            incident_severity: None,
+            incident_action: None,
+            risk_kind: None,
+            dependency_integration_id: Some(gap.integration_id.clone()),
+            dependent_integration_id: None,
+            readiness_gap_kind: Some("dependency".to_string()),
+            blocks_activation: true,
+            requires_attention: true,
+        }
+    }
+
+    pub fn integration_count(&self) -> usize {
+        self.integration_ids.len()
+    }
+
+    pub fn blocks_activation(&self) -> bool {
+        self.blocks_activation || self.verdict.blocks_activation()
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.requires_attention || self.verdict.requires_attention()
+    }
+}
+
+impl IntegrationActivationGuardrailSummary {
+    pub fn from_checks<'a>(
+        checks: impl IntoIterator<Item = &'a IntegrationActivationGuardrailCheck>,
+    ) -> Self {
+        let mut integration_ids = BTreeSet::new();
+        let mut summary = Self {
+            total_checks: 0,
+            unique_integrations: 0,
+            checks_requiring_attention: 0,
+            blocked_checks: 0,
+            needs_review_checks: 0,
+            monitor_checks: 0,
+            pass_checks: 0,
+            incident_checks: 0,
+            policy_risk_checks: 0,
+            dependency_checks: 0,
+            readiness_gap_checks: 0,
+            checks_with_policy_surface: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_review_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+
+        for check in checks {
+            summary.total_checks += 1;
+            for integration_id in &check.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            match check.kind {
+                IntegrationActivationGuardrailKind::Incident => summary.incident_checks += 1,
+                IntegrationActivationGuardrailKind::PolicyRisk => summary.policy_risk_checks += 1,
+                IntegrationActivationGuardrailKind::Dependency => summary.dependency_checks += 1,
+                IntegrationActivationGuardrailKind::ReadinessGap => {
+                    summary.readiness_gap_checks += 1;
+                }
+            }
+            match check.verdict {
+                IntegrationActivationGuardrailVerdict::Pass => summary.pass_checks += 1,
+                IntegrationActivationGuardrailVerdict::Monitor => summary.monitor_checks += 1,
+                IntegrationActivationGuardrailVerdict::NeedsReview => {
+                    summary.needs_review_checks += 1;
+                    summary.first_review_priority =
+                        min_optional_priority(summary.first_review_priority, Some(check.priority));
+                }
+                IntegrationActivationGuardrailVerdict::Blocked => {
+                    summary.blocked_checks += 1;
+                    summary.first_blocked_priority =
+                        min_optional_priority(summary.first_blocked_priority, Some(check.priority));
+                }
+            }
+            if check.requires_attention() {
+                summary.checks_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, Some(check.priority));
+            }
+            if check.policy_surface.is_some() {
+                summary.checks_with_policy_surface += 1;
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(check.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.blocked_checks > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.needs_review_checks > 0 || summary.checks_requiring_attention > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else if summary.monitor_checks > 0 || summary.pass_checks > 0 {
+            IntegrationActivationHealthStatus::Ready
+        } else {
+            IntegrationActivationHealthStatus::Empty
+        };
+        summary
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_checks == 0
+    }
+
+    pub fn has_blockers(&self) -> bool {
+        self.blocked_checks > 0
+    }
+
+    pub fn requires_attention(&self) -> bool {
+        self.checks_requiring_attention > 0 || self.overall_status.requires_attention()
+    }
+}
+
 impl IntegrationActivationConstraintKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -17529,6 +17933,85 @@ pub fn activation_incident_briefs_at_or_before_priority(
     activation_incident_briefs_from_observability_probes(&probes)
 }
 
+pub fn activation_guardrail_checks_from_rollups(
+    incidents: &[IntegrationActivationIncidentBrief],
+    risks: &[IntegrationActivationRiskItem],
+    graph: &IntegrationActivationDependencyGraph,
+    gap_inventory: &IntegrationReadinessGapInventory,
+) -> Vec<IntegrationActivationGuardrailCheck> {
+    let mut checks = Vec::new();
+    checks.extend(
+        incidents
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_incident),
+    );
+    checks.extend(
+        risks
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_risk),
+    );
+    checks.extend(
+        graph
+            .edges
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_dependency_edge),
+    );
+    checks.extend(
+        gap_inventory
+            .primitive_gaps
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_primitive_gap),
+    );
+    checks.extend(
+        gap_inventory
+            .capability_gaps
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_capability_gap),
+    );
+    checks.extend(
+        gap_inventory
+            .dependency_gaps
+            .iter()
+            .map(IntegrationActivationGuardrailCheck::from_dependency_gap),
+    );
+
+    checks.sort_by(compare_activation_guardrail_checks);
+    for (index, check) in checks.iter_mut().enumerate() {
+        check.sequence = index + 1;
+    }
+    checks
+}
+
+pub fn activation_guardrail_checks_at_or_before_priority(
+    catalog: &[IntegrationCatalogEntry],
+    priority: u8,
+    available_primitives: &[PrimitiveFamily],
+    allowed_capabilities: &[CapabilityId],
+    enabled_integrations: &[IntegrationId],
+) -> Vec<IntegrationActivationGuardrailCheck> {
+    let reports = readiness_reports_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+    let candidates = activation_candidates_from_reports(reports.iter());
+    let risks = activation_risk_from_candidates(catalog, candidates.iter());
+    let graph =
+        activation_dependency_graph_from_reports(catalog, reports.iter(), enabled_integrations);
+    let gap_inventory = readiness_gap_inventory_from_reports(reports.iter());
+    let incidents = activation_incident_briefs_at_or_before_priority(
+        catalog,
+        priority,
+        available_primitives,
+        allowed_capabilities,
+        enabled_integrations,
+    );
+
+    activation_guardrail_checks_from_rollups(&incidents, &risks, &graph, &gap_inventory)
+}
+
 pub fn activation_dependency_graph_from_reports<'a>(
     catalog: &[IntegrationCatalogEntry],
     reports: impl IntoIterator<Item = &'a IntegrationReadinessReport>,
@@ -19345,6 +19828,31 @@ fn compare_activation_incident_briefs(
         .then_with(|| left.owner_lane.cmp(&right.owner_lane))
         .then_with(|| left.source_id.cmp(&right.source_id))
         .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn compare_activation_guardrail_checks(
+    left: &IntegrationActivationGuardrailCheck,
+    right: &IntegrationActivationGuardrailCheck,
+) -> Ordering {
+    left.priority
+        .cmp(&right.priority)
+        .then_with(|| right.blocks_activation().cmp(&left.blocks_activation()))
+        .then_with(|| right.requires_attention().cmp(&left.requires_attention()))
+        .then_with(|| {
+            guardrail_verdict_rank(right.verdict).cmp(&guardrail_verdict_rank(left.verdict))
+        })
+        .then_with(|| left.kind.cmp(&right.kind))
+        .then_with(|| left.guardrail_id.cmp(&right.guardrail_id))
+        .then_with(|| right.integration_count().cmp(&left.integration_count()))
+}
+
+fn guardrail_verdict_rank(verdict: IntegrationActivationGuardrailVerdict) -> u8 {
+    match verdict {
+        IntegrationActivationGuardrailVerdict::Pass => 0,
+        IntegrationActivationGuardrailVerdict::Monitor => 1,
+        IntegrationActivationGuardrailVerdict::NeedsReview => 2,
+        IntegrationActivationGuardrailVerdict::Blocked => 3,
+    }
 }
 
 fn push_activation_sentinel_alert(
@@ -23288,6 +23796,47 @@ mod tests {
         assert!(catalog_incident_briefs
             .iter()
             .any(IntegrationActivationIncidentBrief::blocks_activation));
+        let catalog_guardrail_checks = activation_guardrail_checks_at_or_before_priority(
+            &catalog,
+            2,
+            &available_primitives,
+            &allowed_capabilities,
+            &[],
+        );
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(|check| check.kind == IntegrationActivationGuardrailKind::Incident));
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(|check| check.kind == IntegrationActivationGuardrailKind::PolicyRisk));
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(|check| check.kind == IntegrationActivationGuardrailKind::Dependency));
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(|check| check.kind == IntegrationActivationGuardrailKind::ReadinessGap));
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(IntegrationActivationGuardrailCheck::requires_attention));
+        assert!(catalog_guardrail_checks
+            .iter()
+            .any(IntegrationActivationGuardrailCheck::blocks_activation));
+        let catalog_guardrail_summary =
+            IntegrationActivationGuardrailSummary::from_checks(catalog_guardrail_checks.iter());
+        assert_eq!(
+            catalog_guardrail_summary.total_checks,
+            catalog_guardrail_checks.len()
+        );
+        assert!(catalog_guardrail_summary.has_blockers());
+        assert!(catalog_guardrail_summary.requires_attention());
+        assert!(catalog_guardrail_summary.incident_checks >= 1);
+        assert!(catalog_guardrail_summary.policy_risk_checks >= 1);
+        assert!(catalog_guardrail_summary.dependency_checks >= 1);
+        assert!(catalog_guardrail_summary.readiness_gap_checks >= 1);
+        assert_eq!(
+            catalog_guardrail_summary.overall_status,
+            IntegrationActivationHealthStatus::Blocked
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable integration activation guardrail checks that normalize incidents, policy risk, dependency edges, and readiness gaps into pass/monitor/review/blocked verdicts
- expose Chief read tools for listing guardrail checks and retrieving guardrail summaries
- register the new tools in the shared smart-home core catalog and cover them in bridge/runtime tests

## Validation
- cargo test -p smart-home-integration-catalog
- cargo test -p smart-home-core
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, and chief-of-staff-smart-home-tools

Generated code/packages/rust/Cargo.lock was removed before push.