### PR TITLE
feat(html-parser): add heading anchor readiness descriptors

### DIFF
--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -854,7 +854,9 @@ pub struct BrowserDocument {
     pub form_reset_descriptors: Vec<BrowserFormResetDescriptor>,
     pub form_validation_descriptors: Vec<BrowserFormValidationDescriptor>,
     pub anchors: Vec<BrowserAnchor>,
+    pub anchor_descriptors: Vec<BrowserAnchorDescriptor>,
     pub headings: Vec<BrowserHeading>,
+    pub heading_descriptors: Vec<BrowserHeadingDescriptor>,
     pub text_semantics: Vec<BrowserTextSemantic>,
     pub text_semantic_descriptors: Vec<BrowserTextSemanticDescriptor>,
     pub navigation_target_descriptors: Vec<BrowserNavigationTargetDescriptor>,
@@ -1426,6 +1428,19 @@ pub struct BrowserAnchor {
     pub id: Option<String>,
     pub name: Option<String>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserAnchorDescriptor {
+    pub anchor_index: usize,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub text: String,
+    pub fragment_targets: Vec<String>,
+    pub anchor_kind: String,
+    pub duplicate_target: bool,
+    pub anchor_blocked: bool,
+    pub anchor_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2291,6 +2306,18 @@ pub struct BrowserRenderNode {
 pub struct BrowserHeading {
     pub level: u8,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserHeadingDescriptor {
+    pub heading_index: usize,
+    pub level: u8,
+    pub text: String,
+    pub previous_level: Option<u8>,
+    pub outline_kind: String,
+    pub skipped_level: bool,
+    pub heading_blocked: bool,
+    pub heading_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3892,6 +3919,8 @@ impl BrowserDocument {
         summary.form_validation_descriptors = browser_form_validation_descriptors(&summary.forms);
         summary.resource_endpoint_descriptors = browser_resource_endpoint_descriptors(&summary);
         summary.link_resource_descriptors = browser_link_resource_descriptors(&summary.resources);
+        summary.anchor_descriptors = browser_anchor_descriptors(&summary.anchors);
+        summary.heading_descriptors = browser_heading_descriptors(&summary.headings);
         summary.text_semantic_descriptors =
             browser_text_semantic_descriptors(&summary.text_semantics);
         summary.navigation_group_descriptors =
@@ -13096,6 +13125,158 @@ fn browser_text_semantic_block_reasons(semantic: &BrowserTextSemantic) -> Vec<St
         reasons.push("bidi-missing-dir".to_string());
     }
     reasons
+}
+
+fn browser_anchor_descriptors(anchors: &[BrowserAnchor]) -> Vec<BrowserAnchorDescriptor> {
+    anchors
+        .iter()
+        .enumerate()
+        .map(|(index, anchor)| browser_anchor_descriptor(index + 1, anchor, anchors))
+        .collect()
+}
+
+fn browser_anchor_descriptor(
+    anchor_index: usize,
+    anchor: &BrowserAnchor,
+    anchors: &[BrowserAnchor],
+) -> BrowserAnchorDescriptor {
+    let fragment_targets = browser_anchor_fragment_targets(anchor);
+    let anchor_block_reasons = browser_anchor_block_reasons(anchor, &fragment_targets, anchors);
+    let duplicate_target = fragment_targets
+        .iter()
+        .any(|target| browser_anchor_target_count(anchors, target) > 1);
+
+    BrowserAnchorDescriptor {
+        anchor_index,
+        id: anchor.id.clone(),
+        name: anchor.name.clone(),
+        text: anchor.text.clone(),
+        fragment_targets,
+        anchor_kind: browser_anchor_kind(anchor).to_string(),
+        duplicate_target,
+        anchor_blocked: !anchor_block_reasons.is_empty(),
+        anchor_block_reasons,
+    }
+}
+
+fn browser_anchor_kind(anchor: &BrowserAnchor) -> &'static str {
+    match (&anchor.id, &anchor.name) {
+        (Some(_), Some(_)) => "id-and-name",
+        (Some(_), None) => "id",
+        (None, Some(_)) => "named-anchor",
+        (None, None) => "missing-target",
+    }
+}
+
+fn browser_anchor_fragment_targets(anchor: &BrowserAnchor) -> Vec<String> {
+    let mut targets = Vec::new();
+    if let Some(id) = &anchor.id {
+        targets.push(id.clone());
+    }
+    if let Some(name) = &anchor.name {
+        if !targets.iter().any(|target| target == name) {
+            targets.push(name.clone());
+        }
+    }
+    targets
+}
+
+fn browser_anchor_block_reasons(
+    anchor: &BrowserAnchor,
+    fragment_targets: &[String],
+    anchors: &[BrowserAnchor],
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if fragment_targets.is_empty() {
+        reasons.push("missing-fragment-target".to_string());
+    }
+    if anchor.text.trim().is_empty() {
+        reasons.push("empty-fragment-target-text".to_string());
+    }
+    if fragment_targets
+        .iter()
+        .any(|target| browser_anchor_target_count(anchors, target) > 1)
+    {
+        reasons.push("duplicate-fragment-target".to_string());
+    }
+    reasons
+}
+
+fn browser_anchor_target_count(anchors: &[BrowserAnchor], target: &str) -> usize {
+    anchors
+        .iter()
+        .filter(|anchor| {
+            browser_anchor_fragment_targets(anchor)
+                .iter()
+                .any(|value| value == target)
+        })
+        .count()
+}
+
+fn browser_heading_descriptors(headings: &[BrowserHeading]) -> Vec<BrowserHeadingDescriptor> {
+    headings
+        .iter()
+        .enumerate()
+        .map(|(index, heading)| {
+            let previous_level = index
+                .checked_sub(1)
+                .and_then(|previous_index| headings.get(previous_index))
+                .map(|previous| previous.level);
+            browser_heading_descriptor(index + 1, heading, previous_level)
+        })
+        .collect()
+}
+
+fn browser_heading_descriptor(
+    heading_index: usize,
+    heading: &BrowserHeading,
+    previous_level: Option<u8>,
+) -> BrowserHeadingDescriptor {
+    let heading_block_reasons = browser_heading_block_reasons(heading, previous_level);
+    let skipped_level = browser_heading_skipped_level(heading.level, previous_level);
+
+    BrowserHeadingDescriptor {
+        heading_index,
+        level: heading.level,
+        text: heading.text.clone(),
+        previous_level,
+        outline_kind: browser_heading_outline_kind(heading.level, previous_level).to_string(),
+        skipped_level,
+        heading_blocked: !heading_block_reasons.is_empty(),
+        heading_block_reasons,
+    }
+}
+
+fn browser_heading_outline_kind(level: u8, previous_level: Option<u8>) -> &'static str {
+    match previous_level {
+        None if level == 1 => "top-level",
+        None => "initial-skipped-level",
+        Some(previous) if level == previous => "sibling",
+        Some(previous) if level == previous + 1 => "subsection",
+        Some(previous) if level > previous + 1 => "skipped-level",
+        Some(_) => "ancestor-section",
+    }
+}
+
+fn browser_heading_block_reasons(
+    heading: &BrowserHeading,
+    previous_level: Option<u8>,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if heading.text.trim().is_empty() {
+        reasons.push("empty-heading-text".to_string());
+    }
+    if browser_heading_skipped_level(heading.level, previous_level) {
+        reasons.push("skipped-heading-level".to_string());
+    }
+    reasons
+}
+
+fn browser_heading_skipped_level(level: u8, previous_level: Option<u8>) -> bool {
+    match previous_level {
+        None => level > 1,
+        Some(previous) => level > previous + 1,
+    }
 }
 
 fn is_browser_text_semantic_element(element: &Element) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_readiness_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_readiness_test.rs
@@ -1,5 +1,5 @@
 use coding_adventures_html_parser::{
-    parse_browser_document, BrowserActivationDescriptor, BrowserAnchor,
+    parse_browser_document, BrowserActivationDescriptor, BrowserAnchor, BrowserAnchorDescriptor,
     BrowserAnimationInteractionDescriptor, BrowserAriaCollection, BrowserAriaCollectionItem,
     BrowserAriaDescriptionDescriptor, BrowserAriaLiveRegion, BrowserAriaNameDescriptor,
     BrowserAriaRange, BrowserAriaRelationDescriptor, BrowserCanvasDescriptor,
@@ -19,8 +19,8 @@ use coding_adventures_html_parser::{
     BrowserFormSelect, BrowserFormSubmissionDescriptor, BrowserFormSubmitter,
     BrowserFormSuccessfulControl, BrowserFormTextEntry, BrowserFormValidationControl,
     BrowserFormValidationDescriptor, BrowserFullscreenInteractionDescriptor,
-    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHttpEquivHint, BrowserImage,
-    BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea,
+    BrowserGlobalStateDescriptor, BrowserHeading, BrowserHeadingDescriptor, BrowserHttpEquivHint,
+    BrowserImage, BrowserImageCandidateDescriptor, BrowserImageMap, BrowserImageMapArea,
     BrowserImageMapDescriptor, BrowserImageSource, BrowserInputPlanningDescriptor,
     BrowserInteractiveElement, BrowserKeyboardInteractionDescriptor,
     BrowserLifecycleEventDescriptor, BrowserLink, BrowserLinkResourceDescriptor,
@@ -129,7 +129,11 @@ struct ExpectedBrowserDocument {
     #[serde(default)]
     form_validation_descriptors: Option<Vec<ExpectedFormValidationDescriptor>>,
     anchors: Vec<ExpectedAnchor>,
+    #[serde(default)]
+    anchor_descriptors: Option<Vec<ExpectedAnchorDescriptor>>,
     headings: Vec<ExpectedHeading>,
+    #[serde(default)]
+    heading_descriptors: Option<Vec<ExpectedHeadingDescriptor>>,
     #[serde(default)]
     text_semantics: Vec<ExpectedTextSemantic>,
     #[serde(default)]
@@ -2011,9 +2015,46 @@ struct ExpectedAnchor {
 }
 
 #[derive(Debug, Deserialize)]
+struct ExpectedAnchorDescriptor {
+    anchor_index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    fragment_targets: Vec<String>,
+    anchor_kind: String,
+    #[serde(default)]
+    duplicate_target: bool,
+    #[serde(default)]
+    anchor_blocked: bool,
+    #[serde(default)]
+    anchor_block_reasons: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ExpectedHeading {
     level: u8,
     text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedHeadingDescriptor {
+    heading_index: usize,
+    level: u8,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    previous_level: Option<u8>,
+    outline_kind: String,
+    #[serde(default)]
+    skipped_level: bool,
+    #[serde(default)]
+    heading_blocked: bool,
+    #[serde(default)]
+    heading_block_reasons: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -4534,6 +4575,8 @@ fn browser_readiness_cases_extract_browser_document_facts() {
             case.expected.table_structure_descriptors.is_some();
         let tracks_image_map_descriptors = case.expected.image_map_descriptors.is_some();
         let tracks_link_resource_descriptors = case.expected.link_resource_descriptors.is_some();
+        let tracks_anchor_descriptors = case.expected.anchor_descriptors.is_some();
+        let tracks_heading_descriptors = case.expected.heading_descriptors.is_some();
         let tracks_text_semantic_descriptors = case.expected.text_semantic_descriptors.is_some();
         let mut expected = case.expected.into_browser_document();
         if !tracks_aria_name_descriptors {
@@ -4569,6 +4612,12 @@ fn browser_readiness_cases_extract_browser_document_facts() {
         }
         if !tracks_link_resource_descriptors {
             expected.link_resource_descriptors = actual.link_resource_descriptors.clone();
+        }
+        if !tracks_anchor_descriptors {
+            expected.anchor_descriptors = actual.anchor_descriptors.clone();
+        }
+        if !tracks_heading_descriptors {
+            expected.heading_descriptors = actual.heading_descriptors.clone();
         }
         if !tracks_text_semantic_descriptors {
             expected.text_semantic_descriptors = actual.text_semantic_descriptors.clone();
@@ -5158,6 +5207,71 @@ fn browser_text_semantic_descriptors_track_missing_and_unresolved_annotations() 
     assert_eq!(
         actual.text_semantic_descriptors[4].semantic_block_reasons,
         vec!["bidi-missing-dir"],
+    );
+}
+
+#[test]
+fn browser_anchor_descriptors_track_fragment_targets_and_duplicates() {
+    let actual = parse_browser_document(
+        "<h1 id=top>Top</h1>\
+         <a name=legacy></a>\
+         <section id=dup>First</section>\
+         <p id=dup>Second</p>\
+         <a id=both name=both>Both</a>",
+    )
+    .expect("anchor descriptor fixture should parse");
+
+    assert_eq!(actual.anchor_descriptors.len(), 5);
+    assert_eq!(actual.anchor_descriptors[0].anchor_kind, "id");
+    assert_eq!(actual.anchor_descriptors[0].fragment_targets, vec!["top"]);
+    assert!(!actual.anchor_descriptors[0].anchor_blocked);
+
+    assert_eq!(actual.anchor_descriptors[1].anchor_kind, "named-anchor");
+    assert_eq!(
+        actual.anchor_descriptors[1].anchor_block_reasons,
+        vec!["empty-fragment-target-text"],
+    );
+
+    assert!(actual.anchor_descriptors[2].duplicate_target);
+    assert_eq!(
+        actual.anchor_descriptors[2].anchor_block_reasons,
+        vec!["duplicate-fragment-target"],
+    );
+    assert!(actual.anchor_descriptors[3].duplicate_target);
+
+    assert_eq!(actual.anchor_descriptors[4].anchor_kind, "id-and-name");
+    assert_eq!(actual.anchor_descriptors[4].fragment_targets, vec!["both"]);
+}
+
+#[test]
+fn browser_heading_descriptors_track_outline_levels_and_blockers() {
+    let actual = parse_browser_document("<h2>Start</h2><h4>Deep</h4><h3>Back</h3><h3></h3>")
+        .expect("heading descriptor fixture should parse");
+
+    assert_eq!(actual.heading_descriptors.len(), 4);
+    assert_eq!(
+        actual.heading_descriptors[0].outline_kind,
+        "initial-skipped-level",
+    );
+    assert_eq!(
+        actual.heading_descriptors[0].heading_block_reasons,
+        vec!["skipped-heading-level"],
+    );
+
+    assert_eq!(actual.heading_descriptors[1].previous_level, Some(2));
+    assert_eq!(actual.heading_descriptors[1].outline_kind, "skipped-level");
+    assert!(actual.heading_descriptors[1].skipped_level);
+
+    assert_eq!(
+        actual.heading_descriptors[2].outline_kind,
+        "ancestor-section",
+    );
+    assert!(!actual.heading_descriptors[2].heading_blocked);
+
+    assert_eq!(actual.heading_descriptors[3].outline_kind, "sibling");
+    assert_eq!(
+        actual.heading_descriptors[3].heading_block_reasons,
+        vec!["empty-heading-text"],
     );
 }
 
@@ -7697,6 +7811,28 @@ impl ExpectedBrowserDocument {
             .into_iter()
             .map(ExpectedResource::into_browser_resource)
             .collect();
+        let anchors: Vec<_> = self
+            .anchors
+            .into_iter()
+            .map(ExpectedAnchor::into_browser_anchor)
+            .collect();
+        let anchor_descriptors = self
+            .anchor_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedAnchorDescriptor::into_browser_anchor_descriptor)
+            .collect();
+        let headings: Vec<_> = self
+            .headings
+            .into_iter()
+            .map(ExpectedHeading::into_browser_heading)
+            .collect();
+        let heading_descriptors = self
+            .heading_descriptors
+            .unwrap_or_default()
+            .into_iter()
+            .map(ExpectedHeadingDescriptor::into_browser_heading_descriptor)
+            .collect();
         let text_semantics: Vec<_> = self
             .text_semantics
             .into_iter()
@@ -8212,16 +8348,10 @@ impl ExpectedBrowserDocument {
             form_submission_descriptors,
             form_reset_descriptors,
             form_validation_descriptors,
-            anchors: self
-                .anchors
-                .into_iter()
-                .map(ExpectedAnchor::into_browser_anchor)
-                .collect(),
-            headings: self
-                .headings
-                .into_iter()
-                .map(ExpectedHeading::into_browser_heading)
-                .collect(),
+            anchors,
+            anchor_descriptors,
+            headings,
+            heading_descriptors,
             text_semantics,
             text_semantic_descriptors,
             navigation_target_descriptors: self
@@ -14851,11 +14981,42 @@ impl ExpectedAnchor {
     }
 }
 
+impl ExpectedAnchorDescriptor {
+    fn into_browser_anchor_descriptor(self) -> BrowserAnchorDescriptor {
+        BrowserAnchorDescriptor {
+            anchor_index: self.anchor_index,
+            id: self.id,
+            name: self.name,
+            text: self.text,
+            fragment_targets: self.fragment_targets,
+            anchor_kind: self.anchor_kind,
+            duplicate_target: self.duplicate_target,
+            anchor_blocked: self.anchor_blocked,
+            anchor_block_reasons: self.anchor_block_reasons,
+        }
+    }
+}
+
 impl ExpectedHeading {
     fn into_browser_heading(self) -> BrowserHeading {
         BrowserHeading {
             level: self.level,
             text: self.text,
+        }
+    }
+}
+
+impl ExpectedHeadingDescriptor {
+    fn into_browser_heading_descriptor(self) -> BrowserHeadingDescriptor {
+        BrowserHeadingDescriptor {
+            heading_index: self.heading_index,
+            level: self.level,
+            text: self.text,
+            previous_level: self.previous_level,
+            outline_kind: self.outline_kind,
+            skipped_level: self.skipped_level,
+            heading_blocked: self.heading_blocked,
+            heading_block_reasons: self.heading_block_reasons,
         }
     }
 }

--- a/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json
@@ -29,8 +29,14 @@
         "anchors": [
           { "id": "index", "name": null, "text": "Example Directory" }
         ],
+        "anchor_descriptors": [
+          { "anchor_index": 1, "id": "index", "name": null, "text": "Example Directory", "fragment_targets": ["index"], "anchor_kind": "id" }
+        ],
         "headings": [
           { "level": 1, "text": "Example Directory" }
+        ],
+        "heading_descriptors": [
+          { "heading_index": 1, "level": 1, "text": "Example Directory", "previous_level": null, "outline_kind": "top-level" }
         ],
         "navigation_groups": [
           { "element": "ul", "role": "list", "text": "One Two", "list_kind": "unordered", "item_count": 2 }


### PR DESCRIPTION
## Summary
- add browser readiness descriptors for fragment anchors and heading outline levels
- flag duplicate/empty fragment targets and skipped/empty heading outline blockers
- wire optional fixture expectations and targeted browser readiness tests

## Validation
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- cargo test -p coding-adventures-html-parser browser_anchor_descriptors_track_fragment_targets_and_duplicates --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_heading_descriptors_track_outline_levels_and_blockers --manifest-path code/packages/rust/Cargo.toml
- cargo test -p coding-adventures-html-parser browser_ --manifest-path code/packages/rust/Cargo.toml
- cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser --manifest-path code/packages/rust/Cargo.toml
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py