### PR TITLE
feat(sir-ts): SIR17 OOP & scopes — native emit + sir-runtime-oop (Q6a)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.1.6 — SIR17 OOP & scopes (native + sir-runtime-oop)
+
+Accepts and emits the SIR17 object-orientation statements and scopes, per
+`code/specs/sir-runtime.md`. Because the Ruby→SIR frontend **hoists methods to
+detached, receiver-less top-level functions**, there is no native `this`/`self`
+to hang members on; the object model is supplied by the new
+`@coding-adventures/sir-runtime-oop` package, imported (as `__SirOop`) **only**
+when a module uses an OOP feature.
+
+- `Stmt::ClassDef{name, superclass, body}` → `__SirOop.defineClass(name, super)`
+  (registers ancestry) followed by the body statements (constant / class-var
+  assigns) in source order. `Stmt::ModuleDef` → `defineClass(name, null)`.
+  `Stmt::SingletonClassDef` → its (non-`def`) body statements.
+- `Scope::Instance` (`@x`) → `__SirOop.ivarGet/ivarSet` against the current-self
+  stack; `Scope::ClassVar` (`@@x`) → `__SirOop.cvarGet/cvarSet`; `Scope::Const`
+  → an ordinary module-level `const NAME` (reads emit the bare identifier).
+- `BuiltinCall("__method__", [recv, "meth", args…])` (reflective dispatch, e.g.
+  `is_a?`) → `__SirOop.callMethod(recv, "meth", …)`; for the class predicates
+  (`is_a?`/`kind_of?`/`instance_of?`) a `Const`-scoped class operand is passed
+  as its **name string** so the predicate works without a binding for the
+  built-in class name.
+- `ACCEPTED_FEATURES += Classes, Modules, InstanceVars, ClassVars, Constants`.
+
+**v0 limitation (documented):** since the frontend does not thread receivers,
+the current-self is a process-global stack and class variables share one
+namespace — single-instance / single-class programs are faithful and never
+crash; full multi-object semantics await frontend receiver threading. New
+Ruby→TS and direct-SIR tests; a non-OOP module is asserted to omit the OOP
+import; emitted output verified to compile under `tsc --strict` and to execute
+on Node against the real `@coding-adventures/sir-runtime-oop`
+(`is_a?` ancestry/exact/primitive, ivar round-trip, cvar, `class`).
+
 ## 0.1.5 — SIR16 mutation & loops (native)
 
 Accepts and emits the SIR16 mutation and loop statements as **native**

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -21,10 +21,24 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Function, Global, Module, Scope, Stmt,
+    Block, Expr, Feature, Function, Global, Module, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
+
+/// True if the module uses any object-orientation feature, in which
+/// case the emitted artifact imports `@coding-adventures/sir-runtime-oop`.
+fn uses_oop(m: &Module) -> bool {
+    [
+        Feature::Classes,
+        Feature::Modules,
+        Feature::InstanceVars,
+        Feature::ClassVars,
+        Feature::Constants,
+    ]
+    .iter()
+    .any(|f| m.manifest.contains(*f))
+}
 
 thread_local! {
     /// Monotonic counter for synthesised loop temporaries (the
@@ -54,6 +68,11 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     out.push_str(RUNTIME);
+    // Only OOP-using modules import the OOP runtime, so a pure
+    // arithmetic module gains no dependency on it.
+    if uses_oop(m) {
+        out.push_str(crate::runtime::RUNTIME_OOP);
+    }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');
@@ -404,27 +423,66 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_block_as_stmts(out, body, indent + 2);
             let _ = write!(out, "{}}}\n", pad);
         }
-        // `Assign` to an instance var / class var / constant — those
-        // scopes belong to `Feature::InstanceVars`/`ClassVars`/
-        // `Constants`, none of which this backend accepts yet, so the
-        // capability check rejects such modules before emit.
-        Stmt::Assign { scope, span, .. } => {
-            panic!(
-                "ts backend reached SIR17 assign to {:?}-scoped var at {} — capability check should have rejected it",
-                scope, span
-            );
+        // ── SIR17 scopes (assignment) ───────────────────────────────
+        // `@x = v` → current-self instance-variable write via the OOP
+        // runtime (no native `this` — methods are receiver-less).
+        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+            let _ = write!(out, "{}__SirOop.ivarSet({}, ", pad, quote_ts_string(name));
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
-        // SIR17 (classes) — `Feature::Classes` is not accepted by
-        // this backend, so a class-using module is rejected by the
-        // capability check before emit.  Reaching this arm is a bug.
-        Stmt::ClassDef { span, .. } => {
-            panic!("ts backend reached SIR17 class-def statement at {} — capability check should have rejected it", span);
+        // `@@x = v` → class-variable store write.
+        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+            let _ = write!(out, "{}__SirOop.cvarSet({}, ", pad, quote_ts_string(name));
+            emit_expr(out, value, indent);
+            out.push_str(");\n");
         }
-        Stmt::ModuleDef { span, .. } => {
-            panic!("ts backend reached SIR17 module-def statement at {} — capability check should have rejected it", span);
+        // `CONST = v` → an ordinary module-level binding.  Constants are
+        // assign-once in Ruby, so `const` is faithful; reads elsewhere
+        // emit the bare identifier (see `emit_var_ref`).
+        Stmt::Assign { name, scope: Scope::Const, value, .. } => {
+            let _ = write!(out, "{}const {}: __Sir.Val = ", pad, sanitize_ident(name));
+            emit_expr(out, value, indent);
+            out.push_str(";\n");
         }
-        Stmt::SingletonClassDef { span, .. } => {
-            panic!("ts backend reached SIR17 singleton-class-def statement at {} — capability check should have rejected it", span);
+        // `Assign` to a builtin is never produced by any frontend (you
+        // cannot rebind `+`); a validated module never reaches here.
+        Stmt::Assign { scope: Scope::Builtin, span, .. } => {
+            panic!("ts backend reached an assign to a Builtin-scoped name at {} — invalid SIR", span);
+        }
+        // ── SIR17 class / module / singleton declarations ───────────
+        // The Ruby→SIR frontend hoists method `def`s to top-level
+        // functions, so a `ClassDef` body carries only its non-`def`
+        // statements (constant / class-variable assigns).  We register
+        // the class in the OOP runtime (for ancestry-aware `is_a?`) and
+        // emit the body statements in source order.
+        Stmt::ClassDef { name, superclass, body, .. } => {
+            let _ = write!(out, "{}__SirOop.defineClass({}, ", pad, quote_ts_string(name));
+            match superclass {
+                Some(sup) => {
+                    let _ = write!(out, "{}", quote_ts_string(sup));
+                }
+                None => out.push_str("null"),
+            }
+            out.push_str(");\n");
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
+        }
+        // A module is a namespace with no superclass; register it so it
+        // can participate in `is_a?`/ancestry, then emit its body.
+        Stmt::ModuleDef { name, body, .. } => {
+            let _ = write!(out, "{}__SirOop.defineClass({}, null);\n", pad, quote_ts_string(name));
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
+        }
+        // `class << receiver; …; end` — method `def`s are hoisted out by
+        // the frontend, so only the body's non-`def` statements remain.
+        Stmt::SingletonClassDef { body, .. } => {
+            for st in body {
+                emit_stmt(out, st, indent);
+            }
         }
         Stmt::TryCatch { span, .. } => {
             panic!("ts backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
@@ -597,21 +655,21 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "__Sir.builtinClosure({})", quote_ts_string(name));
         }
+        // SIR17 scopes — emitted via the OOP runtime, since the
+        // Ruby→SIR frontend hoists methods to receiver-less top-level
+        // functions (no native `this` to read members from).
         Scope::Instance => {
-            // SIR17 Phase 15a — `Feature::InstanceVars` is not accepted
-            // by this backend; instance-var-using modules are rejected
-            // at the capability check before emit.  Unreachable.
-            panic!("ts backend reached SIR17 instance-var ref `{}` — capability check should have rejected it", name);
+            // `@x` → current-self instance-variable read.
+            let _ = write!(out, "__SirOop.ivarGet({})", quote_ts_string(name));
         }
         Scope::ClassVar => {
-            // SIR17 Phase 15b — `Feature::ClassVars` likewise unaccepted;
-            // class-var modules are rejected before emit.  Unreachable.
-            panic!("ts backend reached SIR17 class-var ref `{}` — capability check should have rejected it", name);
+            // `@@x` → class-variable store read.
+            let _ = write!(out, "__SirOop.cvarGet({})", quote_ts_string(name));
         }
         Scope::Const => {
-            // SIR17 Phase 15c — `Feature::Constants` likewise unaccepted;
-            // constant-using modules are rejected before emit.  Unreachable.
-            panic!("ts backend reached SIR17 const ref `{}` — capability check should have rejected it", name);
+            // Constants are ordinary module-level bindings — a bare,
+            // sanitised identifier (e.g. `LEGS`).
+            out.push_str(&sanitize_ident(name));
         }
     }
 }
@@ -626,6 +684,34 @@ fn emit_args(out: &mut String, args: &[Expr], indent: usize) {
 }
 
 fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize) {
+    // Reflective method dispatch: the Ruby→SIR frontend lowers
+    // `recv.meth(args…)` to `BuiltinCall("__method__", [recv, "meth",
+    // args…])`.  Route it through the OOP runtime's `callMethod`.  For
+    // the class-predicate methods, a `Const`-scoped class operand (e.g.
+    // `Integer`) is passed as its *name string* so the predicate works
+    // without a binding for the built-in class name.
+    if name == "__method__" && args.len() >= 2 {
+        if let Expr::StrLit { value: meth, .. } = &args[1] {
+            out.push_str("__SirOop.callMethod(");
+            emit_expr(out, &args[0], indent);
+            let _ = write!(out, ", {}", quote_ts_string(meth));
+            let is_class_pred =
+                matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
+            for (i, a) in args[2..].iter().enumerate() {
+                out.push_str(", ");
+                match a {
+                    // First operand of a class predicate, given as a
+                    // constant class name → emit the name as a string.
+                    Expr::VarRef { name: cn, scope: Scope::Const, .. } if is_class_pred && i == 0 => {
+                        out.push_str(&quote_ts_string(cn));
+                    }
+                    _ => emit_expr(out, a, indent),
+                }
+            }
+            out.push(')');
+            return;
+        }
+    }
     let helper = match name {
         "+" => "__Sir.add",
         "-" => "__Sir.sub",

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -92,6 +92,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `for`-each → `for…of`), per code/specs/sir-runtime.md.
     Feature::MutableBindings,
     Feature::Loops,
+    // SIR17 OOP & scopes — class/module declarations register in the
+    // OOP runtime; instance/class vars route through its stores; consts
+    // are module-level bindings; `is_a?`-style dispatch goes through
+    // `__SirOop.callMethod`.  Per code/specs/sir-runtime.md, with the
+    // documented v0 limit (frontend hoists methods without receivers).
+    Feature::Classes,
+    Feature::Modules,
+    Feature::InstanceVars,
+    Feature::ClassVars,
+    Feature::Constants,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -531,6 +541,127 @@ mod tests {
             "got:\n{}",
             a.source
         );
+    }
+
+    // ── SIR17 OOP & scopes: Ruby → native TS + sir-runtime-oop ──────
+
+    #[test]
+    fn end_to_end_ruby_class_inheritance_and_is_a_ts() {
+        // `class Dog < Animal` registers ancestry; `is_a?(Integer)`
+        // dispatches through the OOP runtime with the class operand
+        // passed as a name string.
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Dog < Animal\n  def speak\n    42\n  end\nend\nd = 5\nputs(d.is_a?(Integer))\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains(r#"import * as __SirOop from "@coding-adventures/sir-runtime-oop";"#),
+            "expected the OOP import; got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__SirOop.defineClass("Dog", "Animal");"#),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__SirOop.callMethod(d, "is_a?", "Integer")"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_const_in_class_body_ts() {
+        let module =
+            ruby_to_semantic_ir::compile_source("class Foo\n  LEGS = 4\nend\n", "demo")
+                .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(a.source.contains(r#"__SirOop.defineClass("Foo", null);"#), "got:\n{}", a.source);
+        assert!(a.source.contains("const LEGS: __Sir.Val = 4;"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn end_to_end_ruby_class_var_ts() {
+        // `@@count` reads/writes route through the class-variable store
+        // (no class context survives method hoisting).
+        let module = ruby_to_semantic_ir::compile_source(
+            "class Foo\n  @@count = 0\n  def inc\n    @@count = @@count + 1\n  end\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(a.source.contains(r#"__SirOop.cvarSet("@@count", 0);"#), "got:\n{}", a.source);
+        assert!(
+            a.source.contains(r#"__SirOop.cvarSet("@@count", __Sir.add(__SirOop.cvarGet("@@count"), 1));"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_ruby_instance_var_ts() {
+        use semantic_ir::{Scope, Stmt};
+        // The frontend mis-parses multi-statement method bodies, so
+        // exercise the Instance scope directly: a method that writes and
+        // reads `@x` → ivarSet/ivarGet against the current self.
+        let body = Block {
+            stmts: vec![Stmt::Assign {
+                name: "@x".into(),
+                scope: Scope::Instance,
+                value: Expr::IntLit { value: 1, span: s() },
+                span: s(),
+            }],
+            value: Expr::VarRef { name: "@x".into(), scope: Scope::Instance, span: s() },
+            span: s(),
+        };
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::from_features(&[
+                Feature::InstanceVars,
+                Feature::MutableBindings,
+            ]),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "bar".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body,
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("test")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(a.source.contains(r#"__SirOop.ivarSet("@x", 1);"#), "got:\n{}", a.source);
+        assert!(a.source.contains(r#"__SirOop.ivarGet("@x")"#), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn end_to_end_ruby_module_ts() {
+        let module =
+            ruby_to_semantic_ir::compile_source("module Greet\n  def hi\n    1\n  end\nend\n", "demo")
+                .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(a.source.contains(r#"__SirOop.defineClass("Greet", null);"#), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn non_oop_module_omits_oop_import() {
+        // A pure arithmetic module must not gain a dependency on the OOP
+        // runtime package.
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir-runtime-oop"), "got:\n{}", a.source);
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -15,6 +15,15 @@
 pub const RUNTIME: &str = r##"import * as __Sir from "@coding-adventures/sir-runtime-core";
 "##;
 
+/// The OOP-runtime import, emitted **only** when a module uses an
+/// object-orientation feature (classes/modules/instance vars/class
+/// vars/constants or reflective `is_a?`-style dispatch).  Pure
+/// non-OOP modules never gain a dependency on this package.  Bound as
+/// `__SirOop` so the emitter's `__SirOop.*` call sites resolve; see
+/// `code/specs/sir-runtime.md`.
+pub const RUNTIME_OOP: &str = r##"import * as __SirOop from "@coding-adventures/sir-runtime-oop";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/code/packages/typescript/sir-runtime-oop/BUILD
+++ b/code/packages/typescript/sir-runtime-oop/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-oop",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-oop/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-oop/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
+
+## [0.1.0] - 2026-06-13
+
+### Added
+
+Initial release — the OOP runtime imported by Semantic-IR-emitted
+TypeScript/JavaScript. Provides the object-model semantics that have no faithful
+native equivalent once the Ruby→SIR frontend has hoisted methods to detached,
+receiver-less top-level functions:
+
+- **Class registry** — `defineClass(name, superName?)`, `superclassOf(name)`.
+- **Class identity / ancestry** — `classOf(value)` (maps JS values to Ruby class
+  names, including `Integer`/`Float`/`String`/`Array`/`Hash`/`NilClass`/
+  `TrueClass`/`FalseClass`), and `isA(value, className)` with ancestry-chain
+  walking, the `Numeric` umbrella, and `Object`/`BasicObject` universal roots
+  (cycle-safe).
+- **Instances** — `SirInstance` (class tag + instance-variable bag),
+  `newInstance(className)`.
+- **Instance-variable store** — `pushSelf`/`popSelf` (a current-self stack) +
+  `ivarGet`/`ivarSet`; unset reads yield `null` (nil).
+- **Class-variable store** — `cvarGet`/`cvarSet`.
+- **Method dispatch** — `callMethod(recv, name, ...args)` handling the reflective
+  built-ins the frontend emits as `__method__` calls (`is_a?`, `kind_of?`,
+  `instance_of?`, `class`) plus a `defineMethod` fallback table; unknown methods
+  return `null` rather than throwing.
+- `resetOop()` for test isolation.
+
+**v0 limitation (documented):** the frontend does not thread receivers into
+method bodies, so the current-self is a process-global stack and class variables
+share one namespace keyed by bare name. This models single-instance /
+single-class programs faithfully without crashing; full multi-object semantics
+await frontend receiver threading. See `code/specs/sir-runtime.md`.

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -1,0 +1,57 @@
+# @coding-adventures/sir-runtime-oop
+
+OOP runtime imported by **Semantic-IR-emitted TypeScript / JavaScript**.
+
+## What it is
+
+SIR backends translate most constructs to **native** code. Ruby-style object
+orientation is the exception, for one structural reason: the Ruby→SIR frontend
+**hoists every method to a detached top-level function with no receiver
+(`self`)**. Inside an emitted method there is therefore no `this`/`self` to hang
+an instance variable on, and a class-variable write carries no enclosing-class
+context — so native member access (`this.x`) is impossible. This package
+supplies the missing object model as an explicit, in-process runtime that
+emitted code imports and calls.
+
+| Provided | Why it's not native |
+|---|---|
+| `defineClass` / `superclassOf` | A class registry so `is_a?` can walk ancestry; SIR `ClassDef` carries only a name + optional superclass. |
+| `isA` / `classOf` | Ruby class identity (incl. `Integer`/`Float`/`String`/`Array`/`Hash`/`NilClass`/… and the `Numeric`/`Object` umbrellas). |
+| `newInstance` / `SirInstance` | Tagged objects with an instance-variable bag. |
+| `pushSelf` / `popSelf` / `ivarGet` / `ivarSet` | Instance variables addressed through a *current-self* stack, since methods have no receiver. |
+| `cvarGet` / `cvarSet` | Class-variable store. |
+| `callMethod` / `defineMethod` | Reflective dispatch for `is_a?`/`kind_of?`/`instance_of?`/`class` (emitted as SIR `__method__` calls) + a singleton-method table. |
+
+## Usage
+
+```ts
+import * as __SirOop from "@coding-adventures/sir-runtime-oop";
+
+__SirOop.defineClass("Dog", "Animal");        // class Dog < Animal
+const d = __SirOop.newInstance("Dog");
+__SirOop.pushSelf(d);
+__SirOop.ivarSet("@name", "Rex");             // @name = "Rex"
+__SirOop.ivarGet("@name");                     // "Rex"
+__SirOop.popSelf();
+__SirOop.callMethod(d, "is_a?", "Animal");     // true
+__SirOop.cvarSet("@@count", 0);                // @@count = 0
+```
+
+## Honest v0 limitation
+
+Because the frontend does not thread receivers into method bodies, the *current
+self* is a process-global stack (not a true per-call binding) and class
+variables share a single namespace keyed by bare name. This faithfully models
+single-instance / single-class programs and never crashes on the OO surface, but
+full multi-object Ruby semantics await a frontend that carries receivers into
+methods (out of scope for the backend). See `code/specs/sir-runtime.md`.
+
+## Where it fits
+
+```
+Ruby → semantic-ir → semantic-ir-to-typescript → emitted .ts
+                                                    └─ import * as __SirOop from "@coding-adventures/sir-runtime-oop"
+```
+
+The package implements **SIR** semantics, not Ruby's, so a future
+JavaScript → SIR → TypeScript path reuses it unchanged.

--- a/code/packages/typescript/sir-runtime-oop/package-lock.json
+++ b/code/packages/typescript/sir-runtime-oop/package-lock.json
@@ -1,0 +1,1552 @@
+{
+  "name": "@coding-adventures/sir-runtime-oop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-oop",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@coding-adventures/sir-runtime-oop",
+  "version": "0.1.0",
+  "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "oop",
+    "compiler",
+    "cross-language",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-oop/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-oop/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-oop",
+  "capabilities": [],
+  "justification": "Pure in-process OOP runtime helpers (class registry, ancestry-aware is_a?, instance- and class-variable stores, reflective method dispatch). No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -1,0 +1,243 @@
+// @coding-adventures/sir-runtime-oop
+//
+// OOP runtime primitives for Semantic-IR-emitted TypeScript / JavaScript.
+//
+// ## Why this package exists
+//
+// Most SIR constructs translate to *native* TypeScript (a sequence is an
+// `Array`, a loop is a `for`).  Ruby-style object orientation does not survive
+// that translation cleanly, for one structural reason:
+//
+//   **The Ruby→SIR frontend HOISTS every method to a detached top-level
+//   function with no receiver (no `self`).**
+//
+// So inside an emitted method there is no `this`/`self` to hang an instance
+// variable on, and a class-variable assignment carries no enclosing-class
+// context.  Native member access (`this.x`) is therefore impossible.  This
+// package supplies the missing object model as an explicit, in-process runtime:
+//
+//   - a **class registry** (`defineClass`) + ancestry-aware `isA`,
+//   - an **instance-variable store** addressed through a *current-self* stack
+//     (`pushSelf` / `popSelf` / `ivarGet` / `ivarSet`),
+//   - a **class-variable store** (`cvarGet` / `cvarSet`),
+//   - **method dispatch** (`callMethod`) covering the reflective built-ins the
+//     frontend emits (`is_a?`, `kind_of?`, `instance_of?`, `class`) plus a
+//     `defineMethod` table for singleton-method attachment.
+//
+// ## Honest v0 limitation
+//
+// Because the frontend does not thread receivers, the *current self* is a
+// process-global stack rather than a true per-call binding, and class variables
+// share a single namespace keyed by bare name.  This faithfully models
+// single-instance / single-class programs and never crashes on the OO surface,
+// but full multi-object Ruby semantics await a frontend that carries receivers
+// into method bodies (out of scope for the backend).  See
+// `code/specs/sir-runtime.md`.
+
+/**
+ * The SIR universal value type at this package's boundary.  Kept as `unknown`'s
+ * permissive sibling so emitted code can pass `@coding-adventures/sir-runtime-core`
+ * `Val`s in and assign results back without casts.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Val = any;
+
+// ── Class registry ──────────────────────────────────────────────────────────
+
+interface ClassInfo {
+  readonly name: string;
+  readonly superName: string | null;
+}
+
+const classes = new Map<string, ClassInfo>();
+
+/**
+ * Register a class and (optionally) its superclass.  Emitted from a SIR
+ * `ClassDef` so later `isA` queries can walk the ancestry chain.  Re-defining a
+ * class replaces its prior registration (matching Ruby's open classes).
+ */
+export function defineClass(name: string, superName: string | null = null): void {
+  classes.set(name, { name, superName });
+}
+
+/** The registered superclass name of `name`, or `null` if none/unknown. */
+export function superclassOf(name: string): string | null {
+  return classes.get(name)?.superName ?? null;
+}
+
+// ── Instances ────────────────────────────────────────────────────────────────
+
+/**
+ * A SIR object instance: a class tag plus a bag of instance variables.  Created
+ * by `newInstance`; instance variables are read/written through the current-self
+ * stack rather than direct field access (see module docs).
+ */
+export class SirInstance {
+  readonly sirClass: string;
+  readonly ivars: Map<string, Val> = new Map<string, Val>();
+  constructor(sirClass: string) {
+    this.sirClass = sirClass;
+  }
+}
+
+/** Allocate a fresh instance tagged with `className`. */
+export function newInstance(className: string): SirInstance {
+  return new SirInstance(className);
+}
+
+// ── Current-self stack + instance-variable store ─────────────────────────────
+
+const selfStack: SirInstance[] = [];
+
+// A program that never pushes a self (the common detached-method case) still
+// needs a place to put instance variables; this default object provides it so
+// `@x` reads/writes never throw.
+const defaultSelf = new SirInstance("Object");
+
+function currentSelf(): SirInstance {
+  return selfStack.length > 0 ? selfStack[selfStack.length - 1]! : defaultSelf;
+}
+
+/** Make `obj` the receiver for subsequent `ivarGet`/`ivarSet` calls. */
+export function pushSelf(obj: SirInstance): void {
+  selfStack.push(obj);
+}
+
+/** Pop the most recently pushed receiver. */
+export function popSelf(): void {
+  selfStack.pop();
+}
+
+/**
+ * Read instance variable `name` (including the leading `@`) on the current self.
+ * Unset instance variables read as `null` (Ruby's `nil`), never throw.
+ */
+export function ivarGet(name: string): Val {
+  const v = currentSelf().ivars.get(name);
+  return v === undefined ? null : v;
+}
+
+/** Set instance variable `name` on the current self; returns the value. */
+export function ivarSet(name: string, value: Val): Val {
+  currentSelf().ivars.set(name, value);
+  return value;
+}
+
+// ── Class-variable store ─────────────────────────────────────────────────────
+
+const cvars = new Map<string, Val>();
+
+/** Read class variable `name` (including `@@`); unset reads as `null`. */
+export function cvarGet(name: string): Val {
+  const v = cvars.get(name);
+  return v === undefined ? null : v;
+}
+
+/** Set class variable `name`; returns the value. */
+export function cvarSet(name: string, value: Val): Val {
+  cvars.set(name, value);
+  return value;
+}
+
+// ── Class identity / ancestry ────────────────────────────────────────────────
+
+/**
+ * The Ruby class name of a value: registered `SirInstance` tag for objects, or
+ * the conventional built-in name for primitives (`Integer`, `Float`, `String`,
+ * `Array`, `Hash`, `NilClass`, `TrueClass`, `FalseClass`, else `Object`).
+ */
+export function classOf(value: Val): string {
+  if (value instanceof SirInstance) return value.sirClass;
+  if (value === null || value === undefined) return "NilClass";
+  switch (typeof value) {
+    case "boolean":
+      return value ? "TrueClass" : "FalseClass";
+    case "number":
+      return Number.isInteger(value) ? "Integer" : "Float";
+    case "string":
+      return "String";
+    default:
+      if (Array.isArray(value)) return "Array";
+      if (value instanceof Map) return "Hash";
+      return "Object";
+  }
+}
+
+/**
+ * `true` if `value` is an instance of class `className` or any of its
+ * registered ancestors.  Primitive built-in names are matched structurally;
+ * `Numeric` matches both `Integer` and `Float`; `Object`/`BasicObject` match
+ * everything (the universal Ruby roots).
+ */
+export function isA(value: Val, className: string): boolean {
+  if (className === "Object" || className === "BasicObject") return true;
+  const actual = classOf(value);
+  if (className === "Numeric") return actual === "Integer" || actual === "Float";
+  // Walk the registered ancestry chain (guards against cycles).
+  let cur: string | null = actual;
+  const seen = new Set<string>();
+  while (cur !== null && !seen.has(cur)) {
+    if (cur === className) return true;
+    seen.add(cur);
+    cur = superclassOf(cur);
+  }
+  return false;
+}
+
+// ── Method dispatch ──────────────────────────────────────────────────────────
+
+const methods = new Map<string, (recv: Val, args: Val[]) => Val>();
+
+/**
+ * Attach a (singleton/instance) method implementation under `name`.  Used to
+ * model `def obj.m` / `class << self` once a frontend supplies bodies; today it
+ * backs the `callMethod` fallback.
+ */
+export function defineMethod(name: string, fn: (recv: Val, args: Val[]) => Val): void {
+  methods.set(name, fn);
+}
+
+/**
+ * Dispatch reflective method `name` on `recv`.  Handles the built-ins the SIR
+ * frontend emits as `__method__` calls — `is_a?`/`kind_of?`/`instance_of?`
+ * (predicate against a class) and `class` (the class name) — then falls back to
+ * a `defineMethod` table, returning `null` (nil) for an unknown method rather
+ * than throwing.
+ *
+ * The class argument to a predicate may arrive as a class-name **string** or as
+ * a value whose class is taken; `instance_of?` additionally requires an exact
+ * (non-ancestor) match.
+ */
+export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
+  switch (name) {
+    case "is_a?":
+    case "kind_of?": {
+      return isA(recv, classNameArg(args[0]));
+    }
+    case "instance_of?": {
+      return classOf(recv) === classNameArg(args[0]);
+    }
+    case "class":
+      return classOf(recv);
+    default: {
+      const m = methods.get(name);
+      return m ? m(recv, args) : null;
+    }
+  }
+}
+
+function classNameArg(arg: Val): string {
+  return typeof arg === "string" ? arg : classOf(arg);
+}
+
+/**
+ * Reset all OOP runtime state — class registry, self stack, instance/class
+ * variable stores, and the method table.  Primarily for test isolation.
+ */
+export function resetOop(): void {
+  classes.clear();
+  selfStack.length = 0;
+  defaultSelf.ivars.clear();
+  cvars.clear();
+  methods.clear();
+}

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  callMethod,
+  classOf,
+  cvarGet,
+  cvarSet,
+  defineClass,
+  defineMethod,
+  isA,
+  ivarGet,
+  ivarSet,
+  newInstance,
+  popSelf,
+  pushSelf,
+  resetOop,
+  SirInstance,
+  superclassOf,
+} from "../src/index.js";
+
+beforeEach(() => {
+  resetOop();
+});
+
+describe("class registry + ancestry", () => {
+  it("records superclass and resolves direct is_a?", () => {
+    defineClass("Animal", null);
+    defineClass("Dog", "Animal");
+    expect(superclassOf("Dog")).toBe("Animal");
+    expect(superclassOf("Animal")).toBeNull();
+    const d = newInstance("Dog");
+    expect(isA(d, "Dog")).toBe(true);
+    expect(isA(d, "Animal")).toBe(true);
+    expect(isA(d, "Cat")).toBe(false);
+  });
+
+  it("Object/BasicObject match everything; cycles terminate", () => {
+    defineClass("A", "B");
+    defineClass("B", "A"); // pathological cycle
+    const a = newInstance("A");
+    expect(isA(a, "Object")).toBe(true);
+    expect(isA(a, "BasicObject")).toBe(true);
+    expect(isA(a, "A")).toBe(true);
+    expect(isA(a, "B")).toBe(true);
+    expect(isA(a, "Z")).toBe(false);
+  });
+
+  it("re-defining a class replaces its registration", () => {
+    defineClass("C", "X");
+    defineClass("C", "Y");
+    expect(superclassOf("C")).toBe("Y");
+  });
+});
+
+describe("classOf primitive mapping", () => {
+  it("maps JS values to Ruby class names", () => {
+    expect(classOf(null)).toBe("NilClass");
+    expect(classOf(undefined)).toBe("NilClass");
+    expect(classOf(true)).toBe("TrueClass");
+    expect(classOf(false)).toBe("FalseClass");
+    expect(classOf(3)).toBe("Integer");
+    expect(classOf(3.5)).toBe("Float");
+    expect(classOf("hi")).toBe("String");
+    expect(classOf([1, 2])).toBe("Array");
+    expect(classOf(new Map())).toBe("Hash");
+    expect(classOf(newInstance("Foo"))).toBe("Foo");
+  });
+
+  it("isA handles primitives and the Numeric umbrella", () => {
+    expect(isA(3, "Integer")).toBe(true);
+    expect(isA(3, "Numeric")).toBe(true);
+    expect(isA(3.5, "Numeric")).toBe(true);
+    expect(isA("x", "Numeric")).toBe(false);
+    expect(isA("x", "String")).toBe(true);
+  });
+});
+
+describe("instance-variable store via current-self stack", () => {
+  it("reads nil before set; round-trips after set on the default self", () => {
+    expect(ivarGet("@x")).toBeNull();
+    expect(ivarSet("@x", 7)).toBe(7);
+    expect(ivarGet("@x")).toBe(7);
+  });
+
+  it("push/pop self isolates instance variables per object", () => {
+    const a = newInstance("Foo");
+    const b = newInstance("Foo");
+    pushSelf(a);
+    ivarSet("@v", "a");
+    popSelf();
+    pushSelf(b);
+    ivarSet("@v", "b");
+    expect(ivarGet("@v")).toBe("b");
+    popSelf();
+    pushSelf(a);
+    expect(ivarGet("@v")).toBe("a");
+    popSelf();
+  });
+});
+
+describe("class-variable store", () => {
+  it("reads nil before set; round-trips after set", () => {
+    expect(cvarGet("@@count")).toBeNull();
+    expect(cvarSet("@@count", 0)).toBe(0);
+    expect(cvarSet("@@count", 1)).toBe(1);
+    expect(cvarGet("@@count")).toBe(1);
+  });
+});
+
+describe("method dispatch", () => {
+  it("is_a?/kind_of? accept a class-name string or a value", () => {
+    defineClass("Animal", null);
+    defineClass("Dog", "Animal");
+    const d = newInstance("Dog");
+    expect(callMethod(d, "is_a?", "Animal")).toBe(true);
+    expect(callMethod(d, "kind_of?", "Dog")).toBe(true);
+    expect(callMethod(3, "is_a?", "Integer")).toBe(true);
+    // Class given as a value whose class is taken.
+    expect(callMethod(3, "is_a?", 99)).toBe(true);
+  });
+
+  it("instance_of? requires an exact (non-ancestor) match", () => {
+    defineClass("Animal", null);
+    defineClass("Dog", "Animal");
+    const d = newInstance("Dog");
+    expect(callMethod(d, "instance_of?", "Dog")).toBe(true);
+    expect(callMethod(d, "instance_of?", "Animal")).toBe(false);
+  });
+
+  it("class returns the class name; unknown methods return nil", () => {
+    expect(callMethod(newInstance("Foo"), "class")).toBe("Foo");
+    expect(callMethod(3, "class")).toBe("Integer");
+    expect(callMethod(3, "no_such_method")).toBeNull();
+  });
+
+  it("defineMethod backs the dispatch fallback", () => {
+    defineMethod("double", (recv) => (recv as number) * 2);
+    expect(callMethod(21, "double")).toBe(42);
+  });
+});
+
+describe("SirInstance", () => {
+  it("carries its class tag and an empty ivar bag", () => {
+    const i = new SirInstance("Widget");
+    expect(i.sirClass).toBe("Widget");
+    expect(i.ivars.size).toBe(0);
+  });
+});

--- a/code/packages/typescript/sir-runtime-oop/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-oop/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-oop/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-oop/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Q6a — SIR17 OOP & scopes: native TypeScript emit + `sir-runtime-oop`

The TypeScript SIR backend now accepts and emits the SIR17 object-orientation statements and scopes. This is the **TypeScript half** of the OOP work (Python half follows as Q6b).

### The structural constraint

The Ruby→SIR frontend **hoists every method to a detached, receiver-less top-level function** — inside an emitted method there is no native `this`/`self` to hang an instance variable on, and a class-variable write carries no enclosing-class context. Native member access is therefore impossible, so the object model is supplied by a new runtime package, imported (as `__SirOop`) **only when a module uses an OOP feature**.

### New package: `@coding-adventures/sir-runtime-oop`

Full standard scaffolding (package.json, src layout, tests, BUILD, BUILD_windows, README, CHANGELOG, required_capabilities.json, tsconfig, vitest.config). `tsc --strict` clean; **13 vitest tests at 98% line / 98% branch coverage**. Provides: class registry (`defineClass`/`superclassOf`), `classOf`/`isA` (ancestry walk + `Numeric`/`Object` umbrellas, cycle-safe, primitive class names), `SirInstance`/`newInstance`, a current-self stack (`pushSelf`/`popSelf`) + `ivarGet`/`ivarSet`, `cvarGet`/`cvarSet`, and `callMethod`/`defineMethod` reflective dispatch.

### Backend emission

| SIR | Emitted |
|---|---|
| `ClassDef{name,super,body}` | `__SirOop.defineClass(name, super\|null);` + body stmts |
| `ModuleDef` | `__SirOop.defineClass(name, null);` + body |
| `SingletonClassDef` | its non-`def` body stmts |
| `Scope::Instance` (`@x`) | `__SirOop.ivarGet/ivarSet` |
| `Scope::ClassVar` (`@@x`) | `__SirOop.cvarGet/cvarSet` |
| `Scope::Const` | module-level `const NAME` (reads → bare identifier) |
| `BuiltinCall("__method__", …)` | `__SirOop.callMethod(recv, "meth", …)` — class predicates pass a `Const` class operand as its **name string** |

`ACCEPTED_FEATURES += Classes, Modules, InstanceVars, ClassVars, Constants`.

### v0 limitation (documented)

Because the frontend does not thread receivers, the current-self is a process-global stack and class variables share one namespace — single-instance / single-class programs are faithful and never crash; full multi-object semantics await frontend receiver threading (out of scope for the backend). See `code/specs/sir-runtime.md`.

### Verification

- Ruby→TS E2E (inheritance + `is_a?`, const-in-class, classvar, module) + a direct-SIR instance-var test + a non-OOP module asserted to **omit** the OOP import. **All 49 backend tests pass**; full `semantic-ir-to-{typescript,python}` + `ruby-to-semantic-ir` suites green (346 + 33 + 49).
- Emitted output verified to compile under **`tsc --strict`** and **execute on Node** against the real `@coding-adventures/sir-runtime-oop`: `is_a?` ancestry → `true`, `instance_of?` exact → `false`, primitive `is_a?(Integer)` → `true`, ivar round-trip → `7`, cvar set → `0`, `class` → `Dog`.
- `/security-review` passed (no findings — every name routes through `sanitize_ident`/`quote_ts_string`; stores use `Map` so no prototype pollution; ancestry walk is cycle-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
