### PR TITLE
feat(sir-ts): SIR17 exceptions — native try/catch + sir-runtime-exceptions

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.1.7 — SIR17 exceptions (native try/catch + sir-runtime-exceptions)
+
+Accepts and emits the SIR17 `Exceptions` feature, per
+`code/specs/sir-runtime.md`. `begin/rescue/ensure` translates to a **native**
+`try { … } catch (__exc) { … } finally { … }`; the two pieces with no faithful
+native equivalent come from the new `@coding-adventures/sir-runtime-exceptions`
+package, imported (as `__SirExc`) **only** when a module throws or rescues.
+
+- `Stmt::TryCatch{body, rescues, ensure_body}` → `try { body }`. Because a
+  native `catch` binds one variable and catches everything while Ruby has an
+  ordered list of typed `rescue` clauses, the `catch (__exc)` body is an
+  if/else-if chain calling `__SirExc.rescueMatches(__exc, [class names])` per
+  clause in source order; a `rescue Foo => e` binds `const e = __exc`; if no
+  clause matches the original exception is re-`throw`n (Ruby's "propagate when
+  unrescued"). `ensure_body` → a `finally` block (omitted when absent).
+- `BuiltinCall("raise", …)` → `__SirExc.raiseError(…)`: a `Const` class operand
+  (`raise Foo` / `raise Foo, "m"`) is passed as its *name string* with the
+  optional message; a non-`Const` first arg (`raise "m"`) becomes an implicit
+  `RuntimeError` carrying that message; bare `raise` → a generic re-raise.
+- `collect_assigned_locals` now descends into try/rescue/ensure bodies so an
+  outer local reassigned inside a `begin` still emits `let`.
+- `ACCEPTED_FEATURES += Exceptions`.
+
+New Ruby→TS and direct-SIR tests (begin/rescue/ensure shape, message-only
+`raise`, bare-rescue catch-all + rethrow, non-throwing module omits the import).
+Emitted output verified to execute on Node against the real
+`@coding-adventures/sir-runtime-exceptions` (ancestor-matched rescue with bound
+message, `ensure` runs, unmatched exception propagates). Mirrors the Python
+backend's Q7b.
+
 ## 0.1.6 — SIR17 OOP & scopes (native + sir-runtime-oop)
 
 Accepts and emits the SIR17 object-orientation statements and scopes, per

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -40,6 +40,12 @@ fn uses_oop(m: &Module) -> bool {
     .any(|f| m.manifest.contains(*f))
 }
 
+/// True if the module uses exception handling, in which case the emitted
+/// artifact imports `@coding-adventures/sir-runtime-exceptions`.
+fn uses_exceptions(m: &Module) -> bool {
+    m.manifest.contains(Feature::Exceptions)
+}
+
 thread_local! {
     /// Monotonic counter for synthesised loop temporaries (the
     /// once-evaluated `__stop`/`__step` bounds of a `ForRange`).  Reset
@@ -72,6 +78,10 @@ pub fn emit_module(m: &Module) -> String {
     // arithmetic module gains no dependency on it.
     if uses_oop(m) {
         out.push_str(crate::runtime::RUNTIME_OOP);
+    }
+    // Only throwing/rescuing modules import the exception runtime.
+    if uses_exceptions(m) {
+        out.push_str(crate::runtime::RUNTIME_EXC);
     }
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -202,12 +212,26 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
             collect_expr_assigned(key, out);
             collect_expr_assigned(value, out);
         }
-        // Class/module/try bodies are rejected at the capability check
-        // for this backend; nothing to collect.
-        Stmt::ClassDef { .. }
-        | Stmt::ModuleDef { .. }
-        | Stmt::SingletonClassDef { .. }
-        | Stmt::TryCatch { .. } => {}
+        // A try/rescue/ensure carries bare statement lists that may reassign
+        // an outer local, so descend into every one.
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            for st in body {
+                collect_stmt_assigned(st, out);
+            }
+            for r in rescues {
+                for st in &r.body {
+                    collect_stmt_assigned(st, out);
+                }
+            }
+            if let Some(ens) = ensure_body {
+                for st in ens {
+                    collect_stmt_assigned(st, out);
+                }
+            }
+        }
+        // Class/module bodies are rejected at the capability check for this
+        // backend; nothing to collect.
+        Stmt::ClassDef { .. } | Stmt::ModuleDef { .. } | Stmt::SingletonClassDef { .. } => {}
     }
 }
 
@@ -484,8 +508,60 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 emit_stmt(out, st, indent);
             }
         }
-        Stmt::TryCatch { span, .. } => {
-            panic!("ts backend reached SIR17 try-catch statement at {} — capability check should have rejected it", span);
+        // `begin … rescue … ensure … end` → native `try { … } catch (e) {
+        // … } finally { … }`.  A native `catch` binds *one* variable and
+        // catches *everything*, while Ruby has an ordered list of typed
+        // `rescue` clauses, so the catch body is an if/else-if chain that asks
+        // the exception runtime `rescueMatches(exc, [class names])` for each
+        // clause in source order and re-`throw`s if none match (matching
+        // Ruby's "propagate when unrescued").
+        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            let pad = " ".repeat(indent);
+            let _ = write!(out, "{}try {{\n", pad);
+            emit_stmt_block(out, body, indent + 2);
+            let _ = write!(out, "{}}}", pad);
+            if !rescues.is_empty() {
+                out.push_str(" catch (__exc) {\n");
+                let inner = indent + 2;
+                let ipad = " ".repeat(inner);
+                for (i, r) in rescues.iter().enumerate() {
+                    let mut types = String::from("[");
+                    for (j, t) in r.exception_types.iter().enumerate() {
+                        if j > 0 {
+                            types.push_str(", ");
+                        }
+                        types.push_str(&quote_ts_string(t));
+                    }
+                    types.push(']');
+                    let kw = if i == 0 { "if" } else { "} else if" };
+                    let _ = write!(
+                        out,
+                        "{}{} (__SirExc.rescueMatches(__exc, {})) {{\n",
+                        ipad, kw, types
+                    );
+                    // `rescue Foo => e` binds the caught value as a local.
+                    if let Some(bind) = &r.binding {
+                        let _ = write!(
+                            out,
+                            "{}  const {}: __Sir.Val = __exc;\n",
+                            ipad,
+                            sanitize_ident(bind)
+                        );
+                    }
+                    emit_stmt_block(out, &r.body, inner + 2);
+                }
+                // No clause matched → propagate the original exception.
+                let _ = write!(out, "{}}} else {{\n", ipad);
+                let _ = write!(out, "{}  throw __exc;\n", ipad);
+                let _ = write!(out, "{}}}\n", ipad);
+                let _ = write!(out, "{}}}", pad);
+            }
+            if let Some(ens) = ensure_body {
+                out.push_str(" finally {\n");
+                emit_stmt_block(out, ens, indent + 2);
+                let _ = write!(out, "{}}}", pad);
+            }
+            out.push('\n');
         }
     }
 }
@@ -712,6 +788,33 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             return;
         }
     }
+    // `raise` → throw a SIR exception via the exception runtime.  The first
+    // argument decides the shape:
+    //   • a `Const` class name (`raise Foo` / `raise Foo, "msg"`) → the class
+    //     name is passed as a *string* (no binding needed for a built-in
+    //     class), with the optional message second;
+    //   • any other first arg (`raise "msg"`) → an implicit `RuntimeError`
+    //     carrying that value as the message (matching Ruby);
+    //   • no args (bare `raise`) → a generic re-raise (`RuntimeError`).
+    if name == "raise" {
+        out.push_str("__SirExc.raiseError(");
+        match args.first() {
+            None => {}
+            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+                out.push_str(&quote_ts_string(cn));
+                if let Some(msg) = args.get(1) {
+                    out.push_str(", ");
+                    emit_expr(out, msg, indent);
+                }
+            }
+            Some(other) => {
+                out.push_str("\"RuntimeError\", ");
+                emit_expr(out, other, indent);
+            }
+        }
+        out.push(')');
+        return;
+    }
     let helper = match name {
         "+" => "__Sir.add",
         "-" => "__Sir.sub",
@@ -742,6 +845,14 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
     let _ = write!(out, "{}(", helper);
     emit_args(out, args, indent);
     out.push(')');
+}
+
+/// Emit a bare statement list (a `Vec<Stmt>`, as carried by `TryCatch`
+/// bodies / rescue clauses / `ensure`) at the given indent.
+fn emit_stmt_block(out: &mut String, stmts: &[Stmt], indent: usize) {
+    for s in stmts {
+        emit_stmt(out, s, indent);
+    }
 }
 
 fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -102,6 +102,10 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::InstanceVars,
     Feature::ClassVars,
     Feature::Constants,
+    // SIR17 exceptions — `try/catch/finally` is native; the SIR exception
+    // object, `raise`, and ordered rescue-clause class matching come from
+    // `@coding-adventures/sir-runtime-exceptions`.  Per code/specs/sir-runtime.md.
+    Feature::Exceptions,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -696,5 +700,107 @@ mod tests {
         let a = compile(&m).expect("compile");
         assert!(a.source.contains("(() => {"), "expected IIFE; got:\n{}", a.source);
         assert!(a.source.contains("while (__Sir.truthy(false))"), "got:\n{}", a.source);
+    }
+
+    // ─── SIR17 exceptions (Q7) ──────────────────────────────────────────────
+
+    #[test]
+    fn end_to_end_ruby_begin_rescue_ensure_ts() {
+        // begin … raise … rescue Type => e … ensure … end → native
+        // try/catch/finally, dispatching on the rescue class through the
+        // exception runtime and binding the caught value.
+        let module = ruby_to_semantic_ir::compile_source(
+            "begin\n  raise ArgumentError, \"bad\"\nrescue ArgumentError => e\n  puts(e)\nensure\n  puts(1)\nend\n",
+            "demo",
+        )
+        .expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        let src = &a.source;
+        assert!(src.contains("import * as __SirExc"), "got:\n{}", src);
+        assert!(src.contains("try {"), "got:\n{}", src);
+        assert!(
+            src.contains(r#"__SirExc.raiseError("ArgumentError", "bad")"#),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains("catch (__exc) {"), "got:\n{}", src);
+        assert!(
+            src.contains(r#"if (__SirExc.rescueMatches(__exc, ["ArgumentError"]))"#),
+            "got:\n{}",
+            src
+        );
+        assert!(src.contains("const e: __Sir.Val = __exc;"), "got:\n{}", src);
+        assert!(src.contains("throw __exc;"), "got:\n{}", src);
+        assert!(src.contains("finally {"), "got:\n{}", src);
+    }
+
+    #[test]
+    fn end_to_end_ruby_raise_message_only_ts() {
+        // `raise "boom"` (no class) → implicit RuntimeError carrying the
+        // message, matching Ruby.
+        let module =
+            ruby_to_semantic_ir::compile_source("raise \"boom\"\n", "demo").expect("lower ruby");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains(r#"__SirExc.raiseError("RuntimeError", "boom")"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn non_throwing_module_omits_exc_import() {
+        // A pure arithmetic module must not depend on the exception runtime.
+        let module = twig_to_semantic_ir::compile_source("(print (+ 1 2))", "demo").expect("lower");
+        let a = compile(&module).expect("compile");
+        assert!(!a.source.contains("sir-runtime-exceptions"), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn try_catch_bare_rescue_and_rethrow_ts() {
+        use semantic_ir::{RescueClause, Scope, Stmt};
+        // A bare `rescue` (no exception types, no binding) is a catch-all:
+        // `rescueMatches(__exc, [])` is always true.  No `ensure` → no
+        // `finally`.  Built directly because the frontend mis-parses some
+        // bare-rescue surface forms.
+        let try_stmt = Stmt::TryCatch {
+            body: vec![Stmt::ExprStmt {
+                expr: Expr::BuiltinCall {
+                    name: "raise".into(),
+                    args: vec![Expr::VarRef {
+                        name: "RuntimeError".into(),
+                        scope: Scope::Const,
+                        span: s(),
+                    }],
+                    effects: EffectSet::PURE,
+                    span: s(),
+                },
+                span: s(),
+            }],
+            rescues: vec![RescueClause {
+                exception_types: vec![],
+                binding: None,
+                body: vec![Stmt::ExprStmt {
+                    expr: Expr::IntLit { value: 7, span: s() },
+                    span: s(),
+                }],
+                span: s(),
+            }],
+            ensure_body: None,
+            span: s(),
+        };
+        let m = module_with_main_body(
+            vec![try_stmt],
+            Expr::NilLit { span: s() },
+            &[Feature::Exceptions, Feature::Constants],
+        );
+        let a = compile(&m).expect("compile");
+        let src = &a.source;
+        assert!(src.contains(r#"__SirExc.raiseError("RuntimeError")"#), "got:\n{}", src);
+        assert!(src.contains("__SirExc.rescueMatches(__exc, [])"), "got:\n{}", src);
+        assert!(src.contains("} else {"), "got:\n{}", src);
+        assert!(src.contains("throw __exc;"), "got:\n{}", src);
+        // No ensure → no finally clause.
+        assert!(!src.contains("finally {"), "got:\n{}", src);
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -24,6 +24,14 @@ pub const RUNTIME: &str = r##"import * as __Sir from "@coding-adventures/sir-run
 pub const RUNTIME_OOP: &str = r##"import * as __SirOop from "@coding-adventures/sir-runtime-oop";
 "##;
 
+/// The exception-runtime import, emitted **only** when a module uses the
+/// `Exceptions` feature (a `try/catch` or a `raise`).  Pure non-throwing
+/// modules never gain a dependency on this package.  Bound as `__SirExc`
+/// so the emitter's `__SirExc.*` call sites resolve; see
+/// `code/specs/sir-runtime.md`.
+pub const RUNTIME_EXC: &str = r##"import * as __SirExc from "@coding-adventures/sir-runtime-exceptions";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,5 +50,17 @@ mod tests {
         // No inline runtime any more.
         assert!(!RUNTIME.contains("namespace __Sir"));
         assert!(!RUNTIME.contains("export function truthy"));
+    }
+
+    #[test]
+    fn oop_and_exc_imports_bind_their_namespaces() {
+        assert!(RUNTIME_OOP.contains(
+            r#"import * as __SirOop from "@coding-adventures/sir-runtime-oop";"#
+        ));
+        assert!(RUNTIME_EXC.contains(
+            r#"import * as __SirExc from "@coding-adventures/sir-runtime-exceptions";"#
+        ));
+        assert!(RUNTIME_OOP.ends_with('\n'));
+        assert!(RUNTIME_EXC.ends_with('\n'));
     }
 }

--- a/code/packages/typescript/sir-runtime-exceptions/BUILD
+++ b/code/packages/typescript/sir-runtime-exceptions/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-exceptions",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-exceptions/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-exceptions/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-exceptions/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-exceptions/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 0.1.0 — initial release
+
+First release of the SIR exception runtime for TypeScript/JavaScript, per
+`code/specs/sir-runtime.md`. Supplies the two pieces of Ruby-surface exception
+handling that have no faithful native equivalent, so the rest can translate to
+a native `try/catch/finally`.
+
+### Added
+
+- `class SirError extends Error` — the thrown object, a real `Error` carrying
+  the Ruby/SIR class name in `sirClass`; `message` defaults to the class name
+  and a prototype fix-up keeps `instanceof` working under down-level targets.
+- `raiseError(className?, message?): never` — throws a `SirError`; bare
+  `raiseError()` re-raises as a generic `RuntimeError`.
+- `classOfThrown(err)` — the SIR class name of a caught value (native errors and
+  thrown non-errors bucket as `StandardError`).
+- `rescueMatches(err, classNames)` — rescue-clause class matching against a
+  curated built-in Ruby ancestry table; empty list = bare `rescue` (catch-all),
+  `Exception` = universal root, user classes match by exact name.
+- Full standard layout: `package.json`, `tsconfig.json`, `vitest.config.ts`,
+  `BUILD`, `BUILD_windows`, `required_capabilities.json` (no capabilities),
+  README. 13 vitest cases; `tsc --strict` clean.
+
+### v0 limitation (documented)
+
+User-defined exception-class ancestry is unknown (no SIR exception-class symbol
+table), so `rescue StandardError` matches only the built-in subclasses, and user
+classes match by exact name. A bare re-raise becomes a generic `RuntimeError`.
+Both await a frontend that threads the exception model into SIR.

--- a/code/packages/typescript/sir-runtime-exceptions/README.md
+++ b/code/packages/typescript/sir-runtime-exceptions/README.md
@@ -1,0 +1,115 @@
+# @coding-adventures/sir-runtime-exceptions
+
+Exception runtime for **Semantic-IR-emitted TypeScript/JavaScript**.
+
+The SIR (Semantic IR) backends translate most Ruby-surface constructs to
+*native* TypeScript: a sequence becomes an `Array`, a loop becomes a `for`,
+a `begin/rescue/ensure` becomes a native `try { … } catch (e) { … } finally
+{ … }`. Two pieces of exception handling have **no faithful native
+equivalent**, and this package supplies them:
+
+1. **A SIR exception object** — `SirError`, a real `Error` (so stack traces
+   work) tagged with the Ruby/SIR class name in `sirClass`. JavaScript's
+   `throw`/`Error` carries no class tag of its own.
+2. **Rescue-clause type matching** — a native `catch` binds one variable and
+   catches *everything*. Ruby's `rescue TypeError, ArgumentError => e` matches a
+   *set* of classes (and their subclasses) and falls through otherwise.
+   `rescueMatches` answers "does this caught value match this clause?" so the
+   emitted `catch` body can dispatch to the right clause or re-`throw`.
+
+It is **keyed to SIR, not Ruby**: a future JavaScript→SIR→TypeScript path reuses
+it unchanged. See [`code/specs/sir-runtime.md`](../../../specs/sir-runtime.md).
+
+## Where it fits in the stack
+
+```
+Ruby source ─▶ ruby-to-semantic-ir ─▶ Semantic IR ─▶ semantic-ir-to-typescript ─▶ .ts
+                                                                                  │ imports
+                                                                                  ▼
+                                                              @coding-adventures/sir-runtime-exceptions
+```
+
+The TypeScript backend emits an `import * as __SirExc from
+"@coding-adventures/sir-runtime-exceptions"` **only** when a module uses the
+`Exceptions` feature (a `try/catch` or a `raise`); pure modules never gain the
+dependency.
+
+## API
+
+| Export | Purpose |
+|---|---|
+| `class SirError extends Error` | The thrown object; `sirClass` holds the Ruby class name, `message` the raise message (defaults to the class name). |
+| `raiseError(className?, message?): never` | Throw a `SirError`. Bare `raiseError()` re-raises as a generic `RuntimeError`. |
+| `classOfThrown(err): string` | The SIR class name of a caught value (native errors and non-errors → `StandardError`). |
+| `rescueMatches(err, classNames): boolean` | Does a caught value match a `rescue` clause naming `classNames`? Empty list = bare `rescue` (catch-all). |
+
+### Emitted shape
+
+```ts
+import * as __SirExc from "@coding-adventures/sir-runtime-exceptions";
+
+try {
+  __SirExc.raiseError("ArgumentError", "bad");
+} catch (__exc) {
+  if (__SirExc.rescueMatches(__exc, ["StandardError"])) {
+    const e = __exc;
+    // … rescue StandardError => e body …
+  } else {
+    throw __exc; // no clause matched → propagate
+  }
+} finally {
+  // … ensure body …
+}
+```
+
+## Usage
+
+```ts
+import { SirError, raiseError, rescueMatches } from "@coding-adventures/sir-runtime-exceptions";
+
+try {
+  raiseError("KeyError", "missing");
+} catch (e) {
+  rescueMatches(e, ["IndexError"]); // true — KeyError < IndexError
+  (e as SirError).sirClass;         // "KeyError"
+}
+```
+
+## Built-in exception hierarchy
+
+SIR has no exception-class symbol table, so this package bakes in a curated
+slice of Ruby's built-in tree so `rescue StandardError` catches the everyday
+subclasses:
+
+```
+Exception
+└─ StandardError
+   ├─ RuntimeError  ├─ ArgumentError      ├─ TypeError
+   ├─ NameError ─ NoMethodError           ├─ RangeError
+   ├─ IndexError ─ KeyError               ├─ ZeroDivisionError
+   ├─ IOError     ├─ StopIteration        └─ NotImplementedError
+```
+
+`Exception` (and a bare `rescue`) matches anything; **user-defined** exception
+classes match by exact name only.
+
+## v0 limitation (honest)
+
+Because SIR threads no exception-class definitions, the ancestry of
+*user-defined* classes is unknown here — `rescue StandardError` will **not**
+catch a user `class MyError < StandardError` (it matches `MyError` by exact
+name only). A bare `raise` with no in-flight exception re-raises as a generic
+`RuntimeError` rather than the original. Both await a frontend that threads the
+exception class model and in-flight exception into SIR.
+
+## Development
+
+```bash
+npm ci
+npx tsc --noEmit      # strict typecheck
+npx vitest run --coverage
+```
+
+## License
+
+MIT

--- a/code/packages/typescript/sir-runtime-exceptions/package-lock.json
+++ b/code/packages/typescript/sir-runtime-exceptions/package-lock.json
@@ -1,0 +1,1552 @@
+{
+  "name": "@coding-adventures/sir-runtime-exceptions",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-exceptions",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-exceptions/package.json
+++ b/code/packages/typescript/sir-runtime-exceptions/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@coding-adventures/sir-runtime-exceptions",
+  "version": "0.1.0",
+  "description": "Exception runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR exception base class, raise helper, and rescue-clause class matching",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "exceptions",
+    "compiler",
+    "cross-language",
+    "education"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-exceptions/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-exceptions/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-exceptions",
+  "capabilities": [],
+  "justification": "Pure in-process exception runtime helpers (SIR exception base class, raise helper, rescue-clause class matching against a built-in ancestry table). No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-exceptions/src/index.ts
+++ b/code/packages/typescript/sir-runtime-exceptions/src/index.ts
@@ -1,0 +1,158 @@
+/**
+ * Exception runtime primitives for Semantic-IR-emitted TypeScript/JavaScript.
+ *
+ * Most SIR constructs translate to *native* TypeScript (a sequence is an
+ * `Array`, a loop is a `for`).  Exception handling translates *mostly*
+ * natively — `Stmt::TryCatch` becomes a native `try { … } catch (e) { … }
+ * finally { … }` — but two pieces have no faithful native equivalent and live
+ * here:
+ *
+ *   1. **A SIR exception object.**  Ruby's `raise StandardError, "boom"` names a
+ *      *class* and carries a message.  JavaScript's `throw` takes any value and
+ *      its `Error` carries no Ruby class tag.  {@link SirError} is the base
+ *      thrown object: a real `Error` (so stack traces work) that also records
+ *      the SIR class name in `sirClass`.
+ *
+ *   2. **Rescue-clause type matching.**  A native `catch` binds *one* variable
+ *      and catches *everything*; Ruby's `rescue TypeError, ArgumentError => e`
+ *      matches a *set* of classes (and their subclasses) and falls through to
+ *      the next clause otherwise.  {@link rescueMatches} answers "does this
+ *      caught value match this clause's class list?" so the emitted `catch`
+ *      body can dispatch to the right clause (or re-`throw` if none match).
+ *
+ * **Keyed to SIR, not Ruby.**  These helpers implement the SIR exception model,
+ * so a future JavaScript→SIR→TS path reuses them unchanged.  See
+ * `code/specs/sir-runtime.md`.
+ *
+ * **Honest v0 limitation.**  SIR has no exception-class symbol table, so the
+ * ancestry of *user-defined* exception classes is unknown here.  We bake in the
+ * common built-in Ruby hierarchy (so `rescue StandardError` catches a
+ * `RuntimeError`/`ArgumentError`/…), match user classes by exact name, and let
+ * the universal root `Exception` (and a bare `rescue`) catch anything.  Full
+ * user-class ancestry awaits a frontend that threads class definitions into the
+ * exception model.
+ */
+
+/** The SIR universal value type at this package's boundary. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Val = any;
+
+/**
+ * Built-in Ruby exception ancestry: subclass name → immediate superclass name.
+ *
+ * Walked by {@link isAncestorOrSelf} so a `rescue StandardError` also catches
+ * the everyday subclasses a program raises.  This is intentionally a small,
+ * curated slice of Ruby's tree (the classes the frontend is likely to name),
+ * not the whole standard library.  Every entry ultimately chains up to
+ * `StandardError → Exception`.
+ *
+ * ```text
+ * Exception
+ * └─ StandardError
+ *    ├─ RuntimeError ├─ ArgumentError ├─ TypeError
+ *    ├─ NameError ─ NoMethodError      ├─ RangeError
+ *    ├─ IndexError ─ KeyError          ├─ ZeroDivisionError
+ *    ├─ IOError    ├─ StopIteration    └─ NotImplementedError
+ * ```
+ */
+const ANCESTRY: Readonly<Record<string, string>> = {
+  RuntimeError: "StandardError",
+  ArgumentError: "StandardError",
+  TypeError: "StandardError",
+  NameError: "StandardError",
+  NoMethodError: "NameError",
+  IndexError: "StandardError",
+  KeyError: "IndexError",
+  RangeError: "StandardError",
+  ZeroDivisionError: "StandardError",
+  IOError: "StandardError",
+  StopIteration: "StandardError",
+  NotImplementedError: "StandardError",
+  StandardError: "Exception",
+};
+
+/**
+ * A SIR exception: a native `Error` tagged with its Ruby class name.
+ *
+ * `sirClass` is what {@link rescueMatches} dispatches on; `message` is the
+ * human string Ruby's `raise Klass, "msg"` carries.  When no message is given
+ * the class name itself is used (matching Ruby's default `exception.message`).
+ */
+export class SirError extends Error {
+  /** The Ruby/SIR class name this exception was raised as. */
+  readonly sirClass: string;
+
+  constructor(sirClass: string, message?: Val) {
+    const text =
+      message === undefined || message === null ? sirClass : String(message);
+    super(text);
+    this.sirClass = sirClass;
+    // `name` shows up in stack traces / `String(err)`; make it the Ruby class.
+    this.name = sirClass;
+    // Restore the prototype chain (TS-down-to-ES5 `extends Error` caveat) so
+    // `err instanceof SirError` holds even under older targets.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Raise a SIR exception of class `className` with an optional `message`.
+ *
+ * Emitted for SIR `BuiltinCall("raise", …)`:
+ *   - `raise Foo, "msg"` → `raiseError("Foo", "msg")`
+ *   - `raise Foo`        → `raiseError("Foo")`
+ *   - bare `raise`       → `raiseError()` → re-raises as a generic
+ *     `RuntimeError` (SIR v0 does not thread the in-flight exception into a
+ *     bare re-raise; documented limitation).
+ *
+ * Declared to return `never` so TypeScript's control-flow analysis knows code
+ * after a `raise` is unreachable.
+ */
+export function raiseError(className?: string, message?: Val): never {
+  throw new SirError(className ?? "RuntimeError", message);
+}
+
+/**
+ * The SIR class name of a caught value.
+ *
+ * A {@link SirError} reports its tag; a plain native `Error` is treated as a
+ * `StandardError` (so `rescue StandardError`/`rescue => e` catches JS runtime
+ * errors too); anything else (a thrown non-error value) is also bucketed as
+ * `StandardError`, the everyday rescuable root.
+ */
+export function classOfThrown(err: unknown): string {
+  if (err instanceof SirError) return err.sirClass;
+  return "StandardError";
+}
+
+/** `true` if `actual` is `target` or any of its registered ancestors. */
+function isAncestorOrSelf(actual: string, target: string): boolean {
+  let cur: string | undefined = actual;
+  const seen = new Set<string>();
+  while (cur !== undefined && !seen.has(cur)) {
+    if (cur === target) return true;
+    seen.add(cur);
+    cur = ANCESTRY[cur];
+  }
+  return false;
+}
+
+/**
+ * Does a caught value match a rescue clause that names `classNames`?
+ *
+ * - An **empty** `classNames` is a bare `rescue` (catch-all) → always `true`.
+ * - `Exception` is Ruby's universal exception root → matches anything.
+ * - Otherwise the value matches if its class equals, or descends from, any
+ *   named class (per the built-in {@link ANCESTRY}; user classes match by exact
+ *   name).
+ *
+ * The emitted `catch` block calls this once per rescue clause, in source order,
+ * running the first matching clause's body and re-`throw`ing if none match.
+ */
+export function rescueMatches(err: unknown, classNames: string[]): boolean {
+  if (classNames.length === 0) return true;
+  const actual = classOfThrown(err);
+  return classNames.some(
+    (name) => name === "Exception" || isAncestorOrSelf(actual, name),
+  );
+}

--- a/code/packages/typescript/sir-runtime-exceptions/tests/exceptions.test.ts
+++ b/code/packages/typescript/sir-runtime-exceptions/tests/exceptions.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  SirError,
+  raiseError,
+  classOfThrown,
+  rescueMatches,
+} from "../src/index.js";
+
+describe("SirError", () => {
+  it("tags the exception with its SIR class name", () => {
+    const e = new SirError("ArgumentError", "bad arg");
+    expect(e.sirClass).toBe("ArgumentError");
+    expect(e.message).toBe("bad arg");
+    expect(e.name).toBe("ArgumentError");
+  });
+
+  it("defaults the message to the class name when none is given", () => {
+    expect(new SirError("RuntimeError").message).toBe("RuntimeError");
+    expect(new SirError("RuntimeError", null).message).toBe("RuntimeError");
+  });
+
+  it("stringifies a non-string message", () => {
+    expect(new SirError("E", 42).message).toBe("42");
+  });
+
+  it("is a real Error and an instanceof SirError", () => {
+    const e = new SirError("E");
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(SirError);
+  });
+});
+
+describe("raiseError", () => {
+  it("throws a SirError of the named class with the message", () => {
+    expect(() => raiseError("TypeError", "nope")).toThrow(SirError);
+    try {
+      raiseError("TypeError", "nope");
+    } catch (e) {
+      expect((e as SirError).sirClass).toBe("TypeError");
+      expect((e as SirError).message).toBe("nope");
+    }
+  });
+
+  it("defaults bare re-raise to RuntimeError", () => {
+    try {
+      raiseError();
+    } catch (e) {
+      expect((e as SirError).sirClass).toBe("RuntimeError");
+    }
+  });
+});
+
+describe("classOfThrown", () => {
+  it("reports a SirError's class tag", () => {
+    expect(classOfThrown(new SirError("KeyError"))).toBe("KeyError");
+  });
+
+  it("buckets native errors and non-errors as StandardError", () => {
+    expect(classOfThrown(new Error("native"))).toBe("StandardError");
+    expect(classOfThrown("a string")).toBe("StandardError");
+    expect(classOfThrown(undefined)).toBe("StandardError");
+  });
+});
+
+describe("rescueMatches", () => {
+  it("empty class list is a catch-all bare rescue", () => {
+    expect(rescueMatches(new SirError("Anything"), [])).toBe(true);
+    expect(rescueMatches("not even an error", [])).toBe(true);
+  });
+
+  it("matches the exact class name", () => {
+    expect(rescueMatches(new SirError("ArgumentError"), ["ArgumentError"])).toBe(
+      true,
+    );
+  });
+
+  it("matches an ancestor via the built-in hierarchy", () => {
+    expect(rescueMatches(new SirError("ArgumentError"), ["StandardError"])).toBe(
+      true,
+    );
+    expect(rescueMatches(new SirError("KeyError"), ["IndexError"])).toBe(true);
+    expect(rescueMatches(new SirError("NoMethodError"), ["NameError"])).toBe(
+      true,
+    );
+  });
+
+  it("Exception is the universal root and matches anything", () => {
+    expect(rescueMatches(new SirError("WhateverError"), ["Exception"])).toBe(
+      true,
+    );
+    expect(rescueMatches(new Error("native"), ["Exception"])).toBe(true);
+  });
+
+  it("StandardError catches native JS errors", () => {
+    expect(rescueMatches(new Error("native"), ["StandardError"])).toBe(true);
+  });
+
+  it("does not match an unrelated class", () => {
+    expect(rescueMatches(new SirError("TypeError"), ["ArgumentError"])).toBe(
+      false,
+    );
+    expect(rescueMatches(new SirError("RuntimeError"), ["KeyError"])).toBe(
+      false,
+    );
+  });
+
+  it("matches when any of several listed classes match", () => {
+    expect(
+      rescueMatches(new SirError("TypeError"), ["KeyError", "TypeError"]),
+    ).toBe(true);
+  });
+
+  it("matches a user class only by exact name (no known ancestry)", () => {
+    expect(rescueMatches(new SirError("MyError"), ["MyError"])).toBe(true);
+    expect(rescueMatches(new SirError("MyError"), ["StandardError"])).toBe(
+      false,
+    );
+  });
+});

--- a/code/packages/typescript/sir-runtime-exceptions/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-exceptions/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-exceptions/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-exceptions/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Q7a — SIR17 exceptions for the TypeScript backend

Makes the TypeScript SIR backend emit the `Exceptions` feature, following the
plan's **translate-first / library-only-for-quirks** rule: `begin/rescue/ensure`
becomes a native `try { … } catch (__exc) { … } finally { … }`, and the two
pieces with no faithful native equivalent come from a new per-concern runtime
package. (Python counterpart Q7b lands separately.)

### New package: `@coding-adventures/sir-runtime-exceptions`
Full standard layout (package.json, tsconfig, vitest.config, BUILD/BUILD_windows,
required_capabilities, README, CHANGELOG). **16 vitest cases @ 100% coverage; `tsc --strict` clean.**
- **`SirError`** — a real `Error` tagged with the Ruby/SIR class name (`sirClass`); message defaults to the class name; prototype fix-up keeps `instanceof` working down-level.
- **`raiseError(className?, message?): never`** — throws a `SirError`; bare call re-raises as a generic `RuntimeError`.
- **`classOfThrown` / `rescueMatches`** — ordered rescue-clause class matching against a curated built-in Ruby ancestry table (`Exception` = universal root; empty list = bare `rescue` catch-all; user classes by exact name).

### Backend (`semantic-ir-to-typescript`)
- `Stmt::TryCatch` → native `try/catch/finally`. The `catch (__exc)` body is an if/else-if chain over `__SirExc.rescueMatches(__exc, [names])` in source order; `rescue Foo => e` binds `const e = __exc`; if no clause matches the original exception is re-`throw`n. `ensure_body` → `finally` (omitted when absent).
- `BuiltinCall("raise", …)` → `__SirExc.raiseError(…)`: a `Const` class operand as a name string + optional message; a non-`Const` first arg (`raise "m"`) → implicit `RuntimeError` with that message; bare `raise` → generic re-raise.
- `collect_assigned_locals` descends into try/rescue/ensure bodies (correct `let`-vs-`const`).
- `uses_exceptions(m)` gates the import; `ACCEPTED_FEATURES += Exceptions`.

### Verification
- `cargo test`: semantic-ir-to-typescript **346**, semantic-ir-to-python **39**, ruby-to-semantic-ir **54** — all green.
- New Ruby→TS + direct-SIR tests: begin/rescue/ensure shape, message-only `raise`, bare-rescue catch-all + rethrow, non-throwing module omits the import.
- **Exec-proof on Node** against the real package: ancestor-matched `rescue` binds the message, `ensure` runs, an unmatched exception propagates.
- `/security-review`: PASSED (codegen escapes all dynamic values via `quote_ts_string`/`sanitize_ident`; runtime has no eval/regex/network/fs, cycle-safe ancestry walk).

### v0 limitation (documented)
User-defined exception-class ancestry is unknown (no SIR exception-class symbol
table), so `rescue StandardError` matches only built-in subclasses and user
classes match by exact name; a bare re-raise becomes a generic `RuntimeError`.
Both await frontend threading of the exception model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
