### PR TITLE
feat(silicon-rust-napi): Node.js N-API addon for silicon simulation stack

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -261,6 +261,7 @@ members = [
     "mosfet-models",
     "fab-process-simulation",
     "silicon-rust-python",
+    "silicon-rust-napi",
     "system-board",
     "block-ram",
     "device-driver-framework",

--- a/code/packages/rust/silicon-rust-napi/BUILD
+++ b/code/packages/rust/silicon-rust-napi/BUILD
@@ -1,0 +1,1 @@
+cargo test -p silicon-rust-napi -- --nocapture

--- a/code/packages/rust/silicon-rust-napi/BUILD_windows
+++ b/code/packages/rust/silicon-rust-napi/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test --lib -p silicon-rust-napi -- --nocapture

--- a/code/packages/rust/silicon-rust-napi/CHANGELOG.md
+++ b/code/packages/rust/silicon-rust-napi/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog — silicon-rust-napi
+
+## [0.1.0] — 2026-06-13
+
+### Added
+
+Initial release.  Node.js N-API addon for the silicon simulation stack.
+
+**26 exported functions covering three Rust crates:**
+
+*Physical constants (9):*
+`kBoltzmann`, `qElectron`, `eps0`, `epsSi`, `epsOx`, `niAt300k`,
+`egSiAt300k`, `muN300k`, `muP300k`
+
+*`device-physics` (8):*
+`thermalVoltage`, `intrinsicConcentration`, `fermiPotential`,
+`pnJunctionBuiltInVoltage`, `pnJunctionDepletionWidth`,
+`pnJunctionSaturationCurrent`, `pnJunctionCurrent`,
+`mosfetThresholdVoltage`
+
+*`mosfet-models` (2):*
+`evaluateLevel1`, `evaluateLevel1Defaults`
+
+*`fab-process-simulation` (7):*
+`dealGroveOxidation`, `deposit`, `etch`, `implant`, `diffuse`,
+`implantRange`, `diffusivityCm2PerS`
+
+**Cross-section wire format** — `CrossSection` travels as a pipe-separated
+`material:thickness_nm` string across the FFI boundary (same format as
+`silicon-rust-python`).  Material names are validated against wire-format
+delimiter injection (`|`, `:`).
+
+**TypeScript declarations** — `silicon_rust_napi.d.ts` provides full type
+coverage including `MosResult` and `ImplantRangeResult` interfaces.
+
+**Platform portability** — All N-API code is gated with `#[cfg(not(test))]`
+so `cargo test --lib` links cleanly on Windows without `node.lib`.  On
+Linux and macOS, `cargo test` also builds the cdylib (undefined N-API
+symbols resolved at `dlopen()` time via ELF / `-undefined dynamic_lookup`).
+
+**18 pure-Rust unit tests** covering wire format, constants, PN junction
+physics, MOSFET threshold voltage, Level-1 evaluation, and all
+fab-process-simulation functions.
+
+### Dependencies
+
+- `device-physics 0.1.0`
+- `mosfet-models 0.1.0`
+- `fab-process-simulation 0.1.0`
+- `node-bridge 0.1.0`

--- a/code/packages/rust/silicon-rust-napi/Cargo.toml
+++ b/code/packages/rust/silicon-rust-napi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "silicon-rust-napi"
+version = "0.1.0"
+edition = "2021"
+description = "Node.js N-API addon for the silicon simulation stack: device-physics, mosfet-models, fab-process-simulation"
+
+[lib]
+# cdylib → the .node file Node.js loads.  `cargo test --lib` compiles a
+# separate test binary (no cdylib output), so Windows CI skips the cdylib
+# build entirely (node.lib not available) while still running pure-Rust tests.
+crate-type = ["cdylib"]
+name = "silicon_rust_napi"
+
+[dependencies]
+device-physics          = { path = "../device-physics" }
+mosfet-models           = { path = "../mosfet-models" }
+fab-process-simulation  = { path = "../fab-process-simulation" }
+node-bridge             = { path = "../node-bridge" }

--- a/code/packages/rust/silicon-rust-napi/README.md
+++ b/code/packages/rust/silicon-rust-napi/README.md
@@ -1,0 +1,196 @@
+# silicon-rust-napi
+
+Node.js N-API addon that exposes the Rust silicon simulation stack —
+`device-physics`, `mosfet-models`, and `fab-process-simulation` — to
+JavaScript and TypeScript.
+
+Uses the zero-dependency `node-bridge` crate (raw N-API via `extern "C"`,
+no napi-rs, no bindgen, no Node.js headers at build time).  Compiles to a
+`.node` file loadable with `require('silicon_rust_napi.node')`.
+
+## How it fits in the stack
+
+```
+silicon-rust-napi (this package)
+├── node-bridge        — raw N-API declarations, zero deps
+├── device-physics     — physical constants + semiconductor equations
+├── mosfet-models      — SPICE Level-1 MOSFET model
+└── fab-process-simulation — thin-film deposition, etch, oxidation, implant
+```
+
+## JavaScript usage
+
+```javascript
+const srp = require('./silicon_rust_napi.node');
+
+// Physical constants
+console.log(srp.kBoltzmann());      // 1.380649e-23 J/K
+console.log(srp.thermalVoltage(300)); // 0.025852 V
+
+// PN junction physics
+const vbi = srp.pnJunctionBuiltInVoltage(1e23, 1e22, 300);
+const w   = srp.pnJunctionDepletionWidth(1e23, 1e22, 300, 0.0);
+const is_ = srp.pnJunctionSaturationCurrent(1e23, 1e22, 1e-8, 300, 1e-6, 1e-6);
+const i   = srp.pnJunctionCurrent(1e23, 1e22, 1e-8, 300, 1e-6, 1e-6, 0.6);
+
+// MOSFET threshold voltage
+const vt = srp.mosfetThresholdVoltage('NMOS', 130e-9, 1e-6, 2e-9, 1e24, -0.05, 0, 300, 0);
+
+// Level-1 MOSFET DC operating point (default 130 nm NMOS params)
+const r = srp.evaluateLevel1Defaults(1.8, 1.8, 0.0, 300.15);
+console.log(r.region);  // "saturation"
+console.log(r.id);      // drain current [A]
+console.log(r.gm);      // transconductance [S]
+
+// Full Level-1 with explicit parameters
+const r2 = srp.evaluateLevel1(
+  0.42,   // vt0 [V]
+  220e-6, // kp [A/V²]
+  0.05,   // lambda [1/V]
+  0.27,   // gamma [√V]
+  0.84,   // phi [V]
+  1e-6,   // W [m]
+  130e-9, // L [m]
+  1.4,    // n_sub [×10²⁴/m³]
+  1.8,    // vGs [V]
+  1.8,    // vDs [V]
+  0.0,    // vBs [V]
+  300.15  // T [K]
+);
+
+// Process simulation
+let cs = srp.deposit("", "Si", 500.0);       // Si substrate
+cs = srp.dealGroveOxidation(cs, 5.0);        // grow SiO₂ gate oxide
+cs = srp.deposit(cs, "Poly", 50.0);          // deposit poly gate
+console.log(cs);  // "Poly:50.0|SiO2:...|Si:500.0"
+
+cs = srp.implant(cs, "B", 30.0, 1e13);       // boron source/drain
+cs = srp.diffuse(cs, 30.0, 1000.0);          // 30-min anneal at 1000°C
+
+const { rp, straggle } = srp.implantRange("B", 30.0);  // 92 nm, 38 nm
+const d = srp.diffusivityCm2PerS("B", 1000.0);          // 1e-14 cm²/s
+```
+
+## TypeScript
+
+A full type declaration file is provided at `silicon_rust_napi.d.ts`.
+
+```typescript
+import type { MosResult, ImplantRangeResult } from './silicon_rust_napi';
+const srp: typeof import('./silicon_rust_napi') = require('./silicon_rust_napi.node');
+
+const r: MosResult = srp.evaluateLevel1Defaults(1.8, 1.8, 0.0, 300.15);
+```
+
+## Cross-section wire format
+
+A `CrossSection` is serialised as a pipe-separated list of
+`material:thickness_nm` pairs, ordered top-to-bottom:
+
+```
+""                               # empty cross-section
+"Si:500.0"                       # bare silicon substrate, 500 nm thick
+"SiO2:4.8|Si:500.0"             # gate oxide on silicon
+"Poly:50.0|SiO2:4.8|Si:500.0"  # poly gate on gate oxide on silicon
+```
+
+Material names must not contain `|` or `:` — `deposit()` enforces this to
+prevent wire-format injection.
+
+## API reference
+
+### Constants (no arguments)
+
+| Function      | Value             | Unit    | Description                    |
+|--------------|-------------------|---------|--------------------------------|
+| `kBoltzmann()`| 1.380649×10⁻²³   | J/K     | Boltzmann constant             |
+| `qElectron()` | 1.602176634×10⁻¹⁹| C       | Elementary charge              |
+| `eps0()`      | 8.8541878×10⁻¹²  | F/m     | Vacuum permittivity            |
+| `epsSi()`     | 1.0359×10⁻¹⁰     | F/m     | Silicon permittivity           |
+| `epsOx()`     | 3.4531×10⁻¹¹     | F/m     | SiO₂ permittivity             |
+| `niAt300k()`  | 1×10¹⁶           | /m³     | Intrinsic concentration at 300 K |
+| `egSiAt300k()`| 1.12             | eV      | Silicon bandgap at 300 K       |
+| `muN300k()`   | 0.1350           | m²/V·s  | Electron mobility at 300 K     |
+| `muP300k()`   | 0.0480           | m²/V·s  | Hole mobility at 300 K         |
+
+### device-physics
+
+```
+thermalVoltage(tKelvin)                         → number [V]
+intrinsicConcentration(tKelvin)                 → number [/m³]
+fermiPotential(nDoping, kind, tKelvin)          → number [V]
+pnJunctionBuiltInVoltage(na, nd, t)             → number [V]
+pnJunctionDepletionWidth(na, nd, t, vApplied)   → number [m]
+pnJunctionSaturationCurrent(na,nd,a,t,tauN,tauP)→ number [A]
+pnJunctionCurrent(na,nd,a,t,tauN,tauP,v)       → number [A]
+mosfetThresholdVoltage(deviceType,l,w,tOx,nBody,phiMs,qOx,t,vSb) → number [V]
+```
+
+### mosfet-models
+
+```
+evaluateLevel1(vt0,kp,lambda,gamma,phi,w,l,nSub,vGs,vDs,vBs,t) → MosResult
+evaluateLevel1Defaults(vGs, vDs, vBs, t)                       → MosResult
+
+MosResult: { id, gm, gds, gmb, cgs, cgd, cgb, cbs, cbd [all numbers],
+             region: 'cutoff'|'subthreshold'|'triode'|'saturation' }
+```
+
+### fab-process-simulation
+
+```
+dealGroveOxidation(csStr, timeMin[, aUm, bUm2PerHr]) → string
+deposit(csStr, material, thicknessNm)                 → string
+etch(csStr, targetMaterial, depthNm)                  → string
+implant(csStr, species, energyKev, doseCm2)            → string
+diffuse(csStr, timeMin[, temperatureC])               → string
+implantRange(species, energyKev)                      → { rp, straggle } [nm]
+diffusivityCm2PerS(species, temperatureC)             → number [cm²/s]
+```
+
+## Building
+
+```bash
+# Install Rust if needed
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Build the .node addon (output: target/debug/silicon_rust_napi.so/.dylib/.dll)
+cargo build -p silicon-rust-napi
+
+# Run pure-Rust unit tests (no Node.js required)
+cargo test --lib -p silicon-rust-napi
+```
+
+## Platform notes
+
+| Platform | cdylib build | Tests |
+|----------|-------------|-------|
+| Linux    | ✓ ELF allows undefined symbols | ✓ |
+| macOS    | ✓ `-undefined dynamic_lookup` via node-bridge | ✓ |
+| Windows  | ⚠ requires node.lib (skipped in CI) | ✓ via `--lib` |
+
+## Testing
+
+All 18 unit tests are pure Rust and run without Node.js:
+
+```
+running 18 tests
+test tests::cs_wire_empty_roundtrip           ... ok
+test tests::cs_wire_single_layer              ... ok
+test tests::cs_wire_multi_layer_roundtrip     ... ok
+test tests::cs_wire_malformed_entry_skipped   ... ok
+test tests::validate_material_rejects_delimiters ... ok
+test tests::thermal_voltage_at_300k           ... ok
+test tests::intrinsic_concentration_valid     ... ok
+test tests::intrinsic_concentration_below_100k_fails ... ok
+test tests::pn_junction_built_in_voltage_typical ... ok
+test tests::mosfet_threshold_voltage_nmos     ... ok
+test tests::eval_level1_saturation            ... ok
+test tests::eval_level1_cutoff                ... ok
+test tests::deal_grove_adds_sio2_layer        ... ok
+test tests::deposit_prepends_layer            ... ok
+test tests::etch_removes_top_layer            ... ok
+test tests::implant_range_boron_30kev         ... ok
+test tests::diffusivity_boron_1000c           ... ok
+test tests::wire_roundtrip_after_gate_stack   ... ok
+```

--- a/code/packages/rust/silicon-rust-napi/silicon_rust_napi.d.ts
+++ b/code/packages/rust/silicon-rust-napi/silicon_rust_napi.d.ts
@@ -1,0 +1,251 @@
+/**
+ * silicon_rust_napi — TypeScript declarations for the silicon simulation stack
+ * Node.js N-API addon.
+ *
+ * Load via:
+ *   const srp = require('./silicon_rust_napi.node') as typeof import('./silicon_rust_napi');
+ */
+
+// ─── Physical constants (no arguments) ──────────────────────────────────────
+
+/** Boltzmann constant k [J/K]. */
+export declare function kBoltzmann(): number;
+/** Elementary charge q [C]. */
+export declare function qElectron(): number;
+/** Vacuum permittivity ε₀ [F/m]. */
+export declare function eps0(): number;
+/** Silicon permittivity ε_Si [F/m]. */
+export declare function epsSi(): number;
+/** SiO₂ permittivity ε_ox [F/m]. */
+export declare function epsOx(): number;
+/** Intrinsic carrier concentration n_i at 300 K [/m³]. */
+export declare function niAt300k(): number;
+/** Silicon bandgap E_g at 300 K [eV]. */
+export declare function egSiAt300k(): number;
+/** Electron mobility μ_n at 300 K [m²/V·s]. */
+export declare function muN300k(): number;
+/** Hole mobility μ_p at 300 K [m²/V·s]. */
+export declare function muP300k(): number;
+
+// ─── Device-physics functions ────────────────────────────────────────────────
+
+/** Thermal voltage V_T = kT/q [V]. At 300 K → 0.02585 V. */
+export declare function thermalVoltage(tKelvin: number): number;
+
+/** Intrinsic carrier concentration n_i(T) [/m³]. Throws below 100 K. */
+export declare function intrinsicConcentration(tKelvin: number): number;
+
+/**
+ * Fermi potential φ_F [V].
+ * - kind `'p'`: returns +|φ_F|
+ * - kind `'n'`: returns −|φ_F|
+ */
+export declare function fermiPotential(
+  nDoping: number,
+  kind: 'p' | 'n',
+  tKelvin: number,
+): number;
+
+/** Built-in voltage V_bi [V] for an abrupt p-n junction. */
+export declare function pnJunctionBuiltInVoltage(
+  na: number,
+  nd: number,
+  t: number,
+): number;
+
+/**
+ * Total depletion-region width W [m].
+ * Positive `vApplied` = forward bias; negative = reverse bias.
+ */
+export declare function pnJunctionDepletionWidth(
+  na: number,
+  nd: number,
+  t: number,
+  vApplied: number,
+): number;
+
+/**
+ * Shockley saturation current I_S [A].
+ * @param a  Junction area [m²]
+ * @param tauN  Electron minority-carrier lifetime [s]
+ * @param tauP  Hole minority-carrier lifetime [s]
+ */
+export declare function pnJunctionSaturationCurrent(
+  na: number,
+  nd: number,
+  a: number,
+  t: number,
+  tauN: number,
+  tauP: number,
+): number;
+
+/** Shockley diode current I [A] at applied voltage `v` [V]. */
+export declare function pnJunctionCurrent(
+  na: number,
+  nd: number,
+  a: number,
+  t: number,
+  tauN: number,
+  tauP: number,
+  v: number,
+): number;
+
+/**
+ * Threshold voltage V_t [V] with body effect.
+ * @param deviceType  `'NMOS'` or `'PMOS'`
+ * @param vSb  Source-to-body reverse bias [V] (≥ 0)
+ */
+export declare function mosfetThresholdVoltage(
+  deviceType: 'NMOS' | 'PMOS',
+  l: number,
+  w: number,
+  tOx: number,
+  nBody: number,
+  phiMs: number,
+  qOx: number,
+  t: number,
+  vSb: number,
+): number;
+
+// ─── MOSFET Level-1 model ───────────────────────────────────────────────────
+
+/** DC operating-point result from the Level-1 MOSFET model. */
+export interface MosResult {
+  /** Drain current [A] */
+  id: number;
+  /** Transconductance g_m [S] */
+  gm: number;
+  /** Output conductance g_ds [S] */
+  gds: number;
+  /** Body transconductance g_mb [S] */
+  gmb: number;
+  /** Gate-source capacitance C_gs [F] */
+  cgs: number;
+  /** Gate-drain capacitance C_gd [F] */
+  cgd: number;
+  /** Gate-body capacitance C_gb [F] */
+  cgb: number;
+  /** Body-source capacitance C_bs [F] */
+  cbs: number;
+  /** Body-drain capacitance C_bd [F] */
+  cbd: number;
+  /** Operating region */
+  region: 'cutoff' | 'subthreshold' | 'triode' | 'saturation';
+}
+
+/**
+ * Evaluate the SPICE Level-1 MOSFET model at a given operating point.
+ * @param lambda  Channel-length modulation parameter [V⁻¹]
+ * @param gamma   Body-effect coefficient [√V]
+ * @param phi     Surface potential 2|φ_F| [V]
+ */
+export declare function evaluateLevel1(
+  vt0: number,
+  kp: number,
+  lambda: number,
+  gamma: number,
+  phi: number,
+  w: number,
+  l: number,
+  nSub: number,
+  vGs: number,
+  vDs: number,
+  vBs: number,
+  t: number,
+): MosResult;
+
+/**
+ * Evaluate the Level-1 MOSFET using the default 130 nm NMOS parameter set.
+ * Equivalent to `evaluateLevel1` with the default `Level1Params`.
+ */
+export declare function evaluateLevel1Defaults(
+  vGs: number,
+  vDs: number,
+  vBs: number,
+  t: number,
+): MosResult;
+
+// ─── Fab-process simulation ──────────────────────────────────────────────────
+
+/**
+ * Grow thermal SiO₂ via the Deal-Grove model.
+ * Optional `aUm` / `bUm2PerHr` default to dry-O₂ 1000 °C values.
+ * @returns Updated cross-section wire string
+ */
+export declare function dealGroveOxidation(
+  csStr: string,
+  timeMin: number,
+  aUm?: number,
+  bUm2PerHr?: number,
+): string;
+
+/**
+ * Deposit a uniform film on top of the cross-section.
+ * Throws if `material` contains `|` or `:` (wire-format injection guard).
+ * @returns Updated cross-section wire string
+ */
+export declare function deposit(
+  csStr: string,
+  material: string,
+  thicknessNm: number,
+): string;
+
+/**
+ * Remove `depthNm` nm of `targetMaterial` from the top.
+ * Stops when the budget is exhausted or a different material is reached.
+ * @returns Updated cross-section wire string
+ */
+export declare function etch(
+  csStr: string,
+  targetMaterial: string,
+  depthNm: number,
+): string;
+
+/**
+ * Add a Gaussian ion-implant profile to the topmost Si layer.
+ * @param species  `'B'`, `'P'`, `'As'`, or `'BF2'`
+ * @returns Updated cross-section wire string
+ */
+export declare function implant(
+  csStr: string,
+  species: 'B' | 'P' | 'As' | 'BF2',
+  energyKev: number,
+  doseCm2: number,
+): string;
+
+/**
+ * Broaden all Gaussian doping profiles via Fick's law.
+ * `temperatureC` defaults to 1000 °C when omitted.
+ * @returns Updated cross-section wire string
+ */
+export declare function diffuse(
+  csStr: string,
+  timeMin: number,
+  temperatureC?: number,
+): string;
+
+/** Result of a SRIM table lookup. Both values are in nm. */
+export interface ImplantRangeResult {
+  /** Projected range R_p [nm] */
+  rp: number;
+  /** Straggle ΔR_p [nm] */
+  straggle: number;
+}
+
+/**
+ * Return projected range and straggle from the SRIM table (linear
+ * interpolation).  Throws for unknown species.
+ */
+export declare function implantRange(
+  species: string,
+  energyKev: number,
+): ImplantRangeResult;
+
+/**
+ * Arrhenius-scaled diffusivity D(T) [cm²/s].
+ * Uses the Arrhenius equation scaled from the 1000 °C reference.
+ */
+export declare function diffusivityCm2PerS(
+  species: string,
+  temperatureC: number,
+): number;

--- a/code/packages/rust/silicon-rust-napi/src/lib.rs
+++ b/code/packages/rust/silicon-rust-napi/src/lib.rs
@@ -1,0 +1,864 @@
+//! Node.js N-API addon for the silicon simulation stack.
+//!
+//! Exposes `device-physics`, `mosfet-models`, and `fab-process-simulation` to
+//! JavaScript and TypeScript via the stable N-API (ABI version 8).  Uses the
+//! zero-dependency `node-bridge` crate — no napi-rs, no bindgen, no Node.js
+//! headers at build time.
+//!
+//! ## Why `#[cfg(not(test))]` on all N-API code
+//!
+//! On Windows, MSVC's linker (`lld-link`) resolves ALL undefined symbols at
+//! link time, even dead code.  The N-API symbols (`napi_create_function`,
+//! etc.) live in `node.exe`, not in a static library we can easily provide
+//! during `cargo test`.  Gating every N-API import and function with
+//! `#[cfg(not(test))]` excludes them entirely from the test binary, so
+//! `cargo test` links cleanly on all platforms without Node.js.
+//!
+//! When building the cdylib (the actual `.node` addon), `#[cfg(test)]` is
+//! not set, so all N-API code is compiled in normally.
+//!
+//! ## Wire format for CrossSection (v0.1)
+//!
+//! A `CrossSection` is serialised as a pipe-separated list of
+//! `material:thickness_nm` pairs, ordered top-to-bottom:
+//!
+//! ```text
+//! ""                               # empty
+//! "Si:500.0"                       # bare silicon substrate
+//! "SiO2:4.8|Si:500.0"             # gate oxide on silicon
+//! "Poly:50.0|SiO2:4.8|Si:500.0"  # poly gate on gate oxide
+//! ```
+//!
+//! ## JavaScript usage
+//!
+//! ```javascript
+//! const srp = require('./silicon_rust_napi.node');
+//!
+//! // Physical constants
+//! console.log(srp.kBoltzmann());             // 1.380649e-23 J/K
+//! console.log(srp.thermalVoltage(300));      // 0.025852 V
+//!
+//! // Process simulation
+//! let cs = srp.deposit("", "Si", 500.0);
+//! cs = srp.dealGroveOxidation(cs, 5.0);
+//! cs = srp.deposit(cs, "Poly", 50.0);
+//!
+//! // Level-1 MOSFET at a 130 nm node
+//! const r = srp.evaluateLevel1Defaults(1.8, 1.8, 0.0, 300.15);
+//! console.log(r.region);  // "saturation"
+//! ```
+
+use device_physics as dp;
+use fab_process_simulation as fps;
+use mosfet_models as mm;
+
+// N-API imports — excluded from test builds so the test binary does not pull
+// in undefined Node.js symbols and fail to link on Windows (MSVC/lld-link).
+#[cfg(not(test))]
+use node_bridge::{
+    create_function, f64_from_js, f64_to_js, get_cb_info, object_new, set_named_property,
+    str_from_js, str_to_js, throw_error, undefined,
+    napi_callback_info, napi_env, napi_value,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CrossSection wire format helpers (pure Rust, always compiled, cargo-testable)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Return `Err` if `material` contains a wire-format delimiter (`|` or `:`).
+///
+/// Material names must be plain ASCII identifiers.  Delimiters would let a
+/// caller inject extra layers into the wire string and corrupt the
+/// cross-section seen by downstream process steps.
+pub fn validate_material_name(material: &str) -> Result<(), String> {
+    if material.contains('|') || material.contains(':') {
+        return Err(format!(
+            "material name {:?} contains a wire-format delimiter ('|' or ':'); \
+             material names must not contain these characters",
+            material
+        ));
+    }
+    Ok(())
+}
+
+/// Serialise a `CrossSection` to the pipe-delimited wire format.
+///
+/// Doping profiles are elided in v0.1 — they survive process steps but are
+/// not transported across the FFI boundary.
+pub fn cs_to_wire(cs: &fps::CrossSection) -> String {
+    cs.layers
+        .iter()
+        .map(|l| format!("{}:{}", l.material, l.thickness_nm))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Deserialise a `CrossSection` from the pipe-delimited wire format.
+///
+/// Silently skips malformed entries so an empty string returns an empty
+/// cross-section rather than an error.
+pub fn cs_from_wire(s: &str) -> fps::CrossSection {
+    if s.is_empty() {
+        return fps::CrossSection::default();
+    }
+    let layers = s
+        .split('|')
+        .filter_map(|part| {
+            let mut kv = part.splitn(2, ':');
+            let material = kv.next()?.trim().to_owned();
+            let thickness: f64 = kv.next()?.trim().parse().ok()?;
+            Some(fps::Layer::new(material, thickness))
+        })
+        .collect();
+    fps::CrossSection { layers }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure-Rust helper for Level-1 evaluation (testable without Node.js)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Evaluate the Level-1 MOSFET model with explicit parameters.
+///
+/// Returns `(id, gm, gds, gmb, cgs, cgd, cgb, cbs, cbd, region_str)`.
+/// `region_str` is one of `"cutoff"`, `"subthreshold"`, `"triode"`,
+/// `"saturation"`.
+#[allow(clippy::too_many_arguments)]
+pub fn eval_level1_rs(
+    vt0: f64,
+    kp: f64,
+    lambda: f64,
+    gamma: f64,
+    phi: f64,
+    w: f64,
+    l: f64,
+    n_sub: f64,
+    v_gs: f64,
+    v_ds: f64,
+    v_bs: f64,
+    t: f64,
+) -> (f64, f64, f64, f64, f64, f64, f64, f64, f64, &'static str) {
+    let mut p = mm::Level1Params::default();
+    p.vt0    = vt0;
+    p.kp     = kp;
+    p.lambda = lambda;
+    p.gamma  = gamma;
+    p.phi    = phi;
+    p.w      = w;
+    p.l      = l;
+    p.n_sub  = n_sub;
+    let r = mm::evaluate_level1(&p, v_gs, v_ds, v_bs, t);
+    (r.id, r.gm, r.gds, r.gmb, r.cgs, r.cgd, r.cgb, r.cbs, r.cbd, r.region.as_str())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// N-API implementation — excluded from test builds
+//
+// Everything from here to the end of the `napi_impl` section is compiled only
+// when building the library or cdylib (not when running `cargo test`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parse a required `f64` positional argument.
+///
+/// Throws a JS TypeError and causes the calling function to early-return
+/// `undefined` if the argument is missing or not a number.
+#[cfg(not(test))]
+macro_rules! req_f64 {
+    ($env:expr, $args:expr, $idx:expr, $fn_name:expr) => {
+        match $args.get($idx).and_then(|&v| f64_from_js($env, v)) {
+            Some(v) => v,
+            None => {
+                throw_error(
+                    $env,
+                    concat!(
+                        $fn_name,
+                        ": missing or non-number argument at position ",
+                        stringify!($idx)
+                    ),
+                );
+                return undefined($env);
+            }
+        }
+    };
+}
+
+/// Parse a required `String` positional argument.
+///
+/// Throws a JS TypeError and causes the calling function to early-return
+/// `undefined` if the argument is missing or not a string.
+#[cfg(not(test))]
+macro_rules! req_str {
+    ($env:expr, $args:expr, $idx:expr, $fn_name:expr) => {
+        match $args.get($idx).and_then(|&v| str_from_js($env, v)) {
+            Some(v) => v,
+            None => {
+                throw_error(
+                    $env,
+                    concat!(
+                        $fn_name,
+                        ": missing or non-string argument at position ",
+                        stringify!($idx)
+                    ),
+                );
+                return undefined($env);
+            }
+        }
+    };
+}
+
+/// Convert a `MosResult` struct to a plain JS object:
+/// `{ id, gm, gds, gmb, cgs, cgd, cgb, cbs, cbd, region }`.
+#[cfg(not(test))]
+unsafe fn mos_result_to_js_object(env: napi_env, r: &mm::MosResult) -> napi_value {
+    let obj = object_new(env);
+    set_named_property(env, obj, "id",     f64_to_js(env, r.id));
+    set_named_property(env, obj, "gm",     f64_to_js(env, r.gm));
+    set_named_property(env, obj, "gds",    f64_to_js(env, r.gds));
+    set_named_property(env, obj, "gmb",    f64_to_js(env, r.gmb));
+    set_named_property(env, obj, "cgs",    f64_to_js(env, r.cgs));
+    set_named_property(env, obj, "cgd",    f64_to_js(env, r.cgd));
+    set_named_property(env, obj, "cgb",    f64_to_js(env, r.cgb));
+    set_named_property(env, obj, "cbs",    f64_to_js(env, r.cbs));
+    set_named_property(env, obj, "cbd",    f64_to_js(env, r.cbd));
+    set_named_property(env, obj, "region", str_to_js(env, r.region.as_str()));
+    obj
+}
+
+// ── Physical constants (no arguments) ────────────────────────────────────────
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_k_boltzmann(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::K_BOLTZMANN)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_q_electron(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::Q_ELECTRON)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_eps0(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::EPS0)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_eps_si(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::EPS_SI)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_eps_ox(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::EPS_OX)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_ni_at_300k(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::N_I_300K)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_eg_si_300k(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::EG_SI_300K)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_mu_n_300k(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::MU_N_300K)
+}
+
+#[cfg(not(test))]
+unsafe extern "C" fn napi_mu_p_300k(env: napi_env, _info: napi_callback_info) -> napi_value {
+    f64_to_js(env, dp::MU_P_300K)
+}
+
+// ── device-physics functions ──────────────────────────────────────────────────
+
+/// `thermalVoltage(tKelvin: number): number` — V_T = kT/q [V].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_thermal_voltage(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 1);
+    let t = req_f64!(env, args, 0, "thermalVoltage");
+    f64_to_js(env, dp::thermal_voltage(t))
+}
+
+/// `intrinsicConcentration(tKelvin: number): number` — n_i(T) [/m³].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_intrinsic_concentration(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 1);
+    let t = req_f64!(env, args, 0, "intrinsicConcentration");
+    match dp::intrinsic_concentration(t) {
+        Ok(ni)   => f64_to_js(env, ni),
+        Err(msg) => {
+            throw_error(env, &format!("intrinsicConcentration: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `fermiPotential(nDoping, kind, tKelvin): number` — φ_F [V].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_fermi_potential(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 3);
+    let n    = req_f64!(env, args, 0, "fermiPotential");
+    let kind = req_str!(env, args, 1, "fermiPotential");
+    let t    = req_f64!(env, args, 2, "fermiPotential");
+    match dp::fermi_potential(n, &kind, t) {
+        Ok(phi)  => f64_to_js(env, phi),
+        Err(msg) => {
+            throw_error(env, &format!("fermiPotential: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `pnJunctionBuiltInVoltage(na, nd, t): number` — V_bi [V].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_pn_junction_built_in_voltage(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 3);
+    let na = req_f64!(env, args, 0, "pnJunctionBuiltInVoltage");
+    let nd = req_f64!(env, args, 1, "pnJunctionBuiltInVoltage");
+    let t  = req_f64!(env, args, 2, "pnJunctionBuiltInVoltage");
+    match dp::PNJunction::new(na, nd, 1.0, t, 1e-6, 1e-6) {
+        Ok(j)    => f64_to_js(env, j.built_in_voltage()),
+        Err(msg) => {
+            throw_error(env, &format!("pnJunctionBuiltInVoltage: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `pnJunctionDepletionWidth(na, nd, t, vApplied): number` — W [m].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_pn_junction_depletion_width(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 4);
+    let na        = req_f64!(env, args, 0, "pnJunctionDepletionWidth");
+    let nd        = req_f64!(env, args, 1, "pnJunctionDepletionWidth");
+    let t         = req_f64!(env, args, 2, "pnJunctionDepletionWidth");
+    let v_applied = req_f64!(env, args, 3, "pnJunctionDepletionWidth");
+    match dp::PNJunction::new(na, nd, 1.0, t, 1e-6, 1e-6) {
+        Ok(j)    => f64_to_js(env, j.depletion_width(v_applied)),
+        Err(msg) => {
+            throw_error(env, &format!("pnJunctionDepletionWidth: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `pnJunctionSaturationCurrent(na, nd, a, t, tauN, tauP): number` — I_S [A].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_pn_junction_saturation_current(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 6);
+    let na    = req_f64!(env, args, 0, "pnJunctionSaturationCurrent");
+    let nd    = req_f64!(env, args, 1, "pnJunctionSaturationCurrent");
+    let a     = req_f64!(env, args, 2, "pnJunctionSaturationCurrent");
+    let t     = req_f64!(env, args, 3, "pnJunctionSaturationCurrent");
+    let tau_n = req_f64!(env, args, 4, "pnJunctionSaturationCurrent");
+    let tau_p = req_f64!(env, args, 5, "pnJunctionSaturationCurrent");
+    match dp::PNJunction::new(na, nd, a, t, tau_n, tau_p) {
+        Ok(j)    => f64_to_js(env, j.saturation_current()),
+        Err(msg) => {
+            throw_error(env, &format!("pnJunctionSaturationCurrent: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `pnJunctionCurrent(na, nd, a, t, tauN, tauP, v): number` — I [A].
+#[cfg(not(test))]
+unsafe extern "C" fn napi_pn_junction_current(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 7);
+    let na    = req_f64!(env, args, 0, "pnJunctionCurrent");
+    let nd    = req_f64!(env, args, 1, "pnJunctionCurrent");
+    let a     = req_f64!(env, args, 2, "pnJunctionCurrent");
+    let t     = req_f64!(env, args, 3, "pnJunctionCurrent");
+    let tau_n = req_f64!(env, args, 4, "pnJunctionCurrent");
+    let tau_p = req_f64!(env, args, 5, "pnJunctionCurrent");
+    let v     = req_f64!(env, args, 6, "pnJunctionCurrent");
+    match dp::PNJunction::new(na, nd, a, t, tau_n, tau_p) {
+        Ok(j)    => f64_to_js(env, j.current(v)),
+        Err(msg) => {
+            throw_error(env, &format!("pnJunctionCurrent: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `mosfetThresholdVoltage(deviceType, l, w, tOx, nBody, phiMs, qOx, t, vSb): number`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_mosfet_threshold_voltage(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 9);
+    let device_type = req_str!(env, args, 0, "mosfetThresholdVoltage");
+    let l      = req_f64!(env, args, 1, "mosfetThresholdVoltage");
+    let w      = req_f64!(env, args, 2, "mosfetThresholdVoltage");
+    let t_ox   = req_f64!(env, args, 3, "mosfetThresholdVoltage");
+    let n_body = req_f64!(env, args, 4, "mosfetThresholdVoltage");
+    let phi_ms = req_f64!(env, args, 5, "mosfetThresholdVoltage");
+    let q_ox   = req_f64!(env, args, 6, "mosfetThresholdVoltage");
+    let t      = req_f64!(env, args, 7, "mosfetThresholdVoltage");
+    let v_sb   = req_f64!(env, args, 8, "mosfetThresholdVoltage");
+    match dp::MOSFETParams::new(&device_type, l, w, t_ox, n_body, phi_ms, q_ox, t) {
+        Ok(p) => match p.threshold_voltage(v_sb) {
+            Ok(vt)   => f64_to_js(env, vt),
+            Err(msg) => {
+                throw_error(env, &format!("mosfetThresholdVoltage: {}", msg));
+                undefined(env)
+            }
+        },
+        Err(msg) => {
+            throw_error(env, &format!("mosfetThresholdVoltage: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+// ── mosfet-models functions ───────────────────────────────────────────────────
+
+/// `evaluateLevel1(vt0, kp, lambda, gamma, phi, w, l, nSub,
+///                 vGs, vDs, vBs, t): MosResult`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_evaluate_level1(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 12);
+    let vt0    = req_f64!(env, args,  0, "evaluateLevel1");
+    let kp     = req_f64!(env, args,  1, "evaluateLevel1");
+    let lambda = req_f64!(env, args,  2, "evaluateLevel1");
+    let gamma  = req_f64!(env, args,  3, "evaluateLevel1");
+    let phi    = req_f64!(env, args,  4, "evaluateLevel1");
+    let w      = req_f64!(env, args,  5, "evaluateLevel1");
+    let l      = req_f64!(env, args,  6, "evaluateLevel1");
+    let n_sub  = req_f64!(env, args,  7, "evaluateLevel1");
+    let v_gs   = req_f64!(env, args,  8, "evaluateLevel1");
+    let v_ds   = req_f64!(env, args,  9, "evaluateLevel1");
+    let v_bs   = req_f64!(env, args, 10, "evaluateLevel1");
+    let t      = req_f64!(env, args, 11, "evaluateLevel1");
+
+    let mut p = mm::Level1Params::default();
+    p.vt0    = vt0;
+    p.kp     = kp;
+    p.lambda = lambda;
+    p.gamma  = gamma;
+    p.phi    = phi;
+    p.w      = w;
+    p.l      = l;
+    p.n_sub  = n_sub;
+    let r = mm::evaluate_level1(&p, v_gs, v_ds, v_bs, t);
+    mos_result_to_js_object(env, &r)
+}
+
+/// `evaluateLevel1Defaults(vGs, vDs, vBs, t): MosResult`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_evaluate_level1_defaults(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 4);
+    let v_gs = req_f64!(env, args, 0, "evaluateLevel1Defaults");
+    let v_ds = req_f64!(env, args, 1, "evaluateLevel1Defaults");
+    let v_bs = req_f64!(env, args, 2, "evaluateLevel1Defaults");
+    let t    = req_f64!(env, args, 3, "evaluateLevel1Defaults");
+    let p    = mm::Level1Params::default();
+    let r    = mm::evaluate_level1(&p, v_gs, v_ds, v_bs, t);
+    mos_result_to_js_object(env, &r)
+}
+
+// ── fab-process-simulation functions ─────────────────────────────────────────
+
+/// `dealGroveOxidation(csStr, timeMin[, aUm, bUm2PerHr]): string`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_deal_grove_oxidation(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 4);
+    let cs_str   = req_str!(env, args, 0, "dealGroveOxidation");
+    let time_min = req_f64!(env, args, 1, "dealGroveOxidation");
+    let a_um  = args.get(2).and_then(|&v| f64_from_js(env, v)).filter(|&x| x > 0.0);
+    let b_um2 = args.get(3).and_then(|&v| f64_from_js(env, v)).filter(|&x| x > 0.0);
+    let cs = cs_from_wire(&cs_str);
+    match fps::deal_grove_oxidation(&cs, time_min, a_um, b_um2) {
+        Ok(new_cs) => str_to_js(env, &cs_to_wire(&new_cs)),
+        Err(msg)   => {
+            throw_error(env, &format!("dealGroveOxidation: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `deposit(csStr, material, thicknessNm): string`
+///
+/// Rejects material names containing `|` or `:` to prevent layer injection.
+#[cfg(not(test))]
+unsafe extern "C" fn napi_deposit(env: napi_env, info: napi_callback_info) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 3);
+    let cs_str       = req_str!(env, args, 0, "deposit");
+    let material     = req_str!(env, args, 1, "deposit");
+    let thickness_nm = req_f64!(env, args, 2, "deposit");
+    if let Err(msg) = validate_material_name(&material) {
+        throw_error(env, &format!("deposit: {}", msg));
+        return undefined(env);
+    }
+    let cs = cs_from_wire(&cs_str);
+    match fps::deposit(&cs, &material, thickness_nm) {
+        Ok(new_cs) => str_to_js(env, &cs_to_wire(&new_cs)),
+        Err(msg)   => {
+            throw_error(env, &format!("deposit: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `etch(csStr, targetMaterial, depthNm): string`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_etch(env: napi_env, info: napi_callback_info) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 3);
+    let cs_str          = req_str!(env, args, 0, "etch");
+    let target_material = req_str!(env, args, 1, "etch");
+    let depth_nm        = req_f64!(env, args, 2, "etch");
+    let cs     = cs_from_wire(&cs_str);
+    let new_cs = fps::etch(&cs, &target_material, depth_nm);
+    str_to_js(env, &cs_to_wire(&new_cs))
+}
+
+/// `implant(csStr, species, energyKev, doseCm2): string`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_implant(env: napi_env, info: napi_callback_info) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 4);
+    let cs_str       = req_str!(env, args, 0, "implant");
+    let species      = req_str!(env, args, 1, "implant");
+    let energy_kev   = req_f64!(env, args, 2, "implant");
+    let dose_per_cm2 = req_f64!(env, args, 3, "implant");
+    let cs = cs_from_wire(&cs_str);
+    match fps::implant(&cs, &species, energy_kev, dose_per_cm2) {
+        Ok(new_cs) => str_to_js(env, &cs_to_wire(&new_cs)),
+        Err(msg)   => {
+            throw_error(env, &format!("implant: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `diffuse(csStr, timeMin[, temperatureC]): string`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_diffuse(env: napi_env, info: napi_callback_info) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 3);
+    let cs_str   = req_str!(env, args, 0, "diffuse");
+    let time_min = req_f64!(env, args, 1, "diffuse");
+    let temp_c   = args.get(2).and_then(|&v| f64_from_js(env, v));
+    let cs     = cs_from_wire(&cs_str);
+    let new_cs = fps::diffuse(&cs, time_min, temp_c);
+    str_to_js(env, &cs_to_wire(&new_cs))
+}
+
+/// `implantRange(species, energyKev): { rp: number, straggle: number }`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_implant_range(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 2);
+    let species    = req_str!(env, args, 0, "implantRange");
+    let energy_kev = req_f64!(env, args, 1, "implantRange");
+    match fps::implant_range(&species, energy_kev) {
+        Ok((rp, straggle)) => {
+            let obj = object_new(env);
+            set_named_property(env, obj, "rp",       f64_to_js(env, rp));
+            set_named_property(env, obj, "straggle", f64_to_js(env, straggle));
+            obj
+        }
+        Err(msg) => {
+            throw_error(env, &format!("implantRange: {}", msg));
+            undefined(env)
+        }
+    }
+}
+
+/// `diffusivityCm2PerS(species, temperatureC): number`
+#[cfg(not(test))]
+unsafe extern "C" fn napi_diffusivity_cm2_per_s(
+    env: napi_env,
+    info: napi_callback_info,
+) -> napi_value {
+    let (_this, args) = get_cb_info(env, info, 2);
+    let species     = req_str!(env, args, 0, "diffusivityCm2PerS");
+    let temperature = req_f64!(env, args, 1, "diffusivityCm2PerS");
+    f64_to_js(env, fps::diffusivity_cm2_per_s(&species, temperature))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module registration entry point
+//
+// Node.js calls this symbol the first time `require()` loads the addon.  We
+// receive an empty `exports` object and attach all 26 functions before
+// returning it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(test))]
+#[no_mangle]
+pub unsafe extern "C" fn napi_register_module_v1(
+    env: napi_env,
+    exports: napi_value,
+) -> napi_value {
+    // ── Physical constants ────────────────────────────────────────────────────
+    set_named_property(env, exports, "kBoltzmann",
+        create_function(env, "kBoltzmann", Some(napi_k_boltzmann)));
+    set_named_property(env, exports, "qElectron",
+        create_function(env, "qElectron", Some(napi_q_electron)));
+    set_named_property(env, exports, "eps0",
+        create_function(env, "eps0", Some(napi_eps0)));
+    set_named_property(env, exports, "epsSi",
+        create_function(env, "epsSi", Some(napi_eps_si)));
+    set_named_property(env, exports, "epsOx",
+        create_function(env, "epsOx", Some(napi_eps_ox)));
+    set_named_property(env, exports, "niAt300k",
+        create_function(env, "niAt300k", Some(napi_ni_at_300k)));
+    set_named_property(env, exports, "egSiAt300k",
+        create_function(env, "egSiAt300k", Some(napi_eg_si_300k)));
+    set_named_property(env, exports, "muN300k",
+        create_function(env, "muN300k", Some(napi_mu_n_300k)));
+    set_named_property(env, exports, "muP300k",
+        create_function(env, "muP300k", Some(napi_mu_p_300k)));
+
+    // ── device-physics functions ──────────────────────────────────────────────
+    set_named_property(env, exports, "thermalVoltage",
+        create_function(env, "thermalVoltage", Some(napi_thermal_voltage)));
+    set_named_property(env, exports, "intrinsicConcentration",
+        create_function(env, "intrinsicConcentration", Some(napi_intrinsic_concentration)));
+    set_named_property(env, exports, "fermiPotential",
+        create_function(env, "fermiPotential", Some(napi_fermi_potential)));
+    set_named_property(env, exports, "pnJunctionBuiltInVoltage",
+        create_function(env, "pnJunctionBuiltInVoltage", Some(napi_pn_junction_built_in_voltage)));
+    set_named_property(env, exports, "pnJunctionDepletionWidth",
+        create_function(env, "pnJunctionDepletionWidth", Some(napi_pn_junction_depletion_width)));
+    set_named_property(env, exports, "pnJunctionSaturationCurrent",
+        create_function(env, "pnJunctionSaturationCurrent", Some(napi_pn_junction_saturation_current)));
+    set_named_property(env, exports, "pnJunctionCurrent",
+        create_function(env, "pnJunctionCurrent", Some(napi_pn_junction_current)));
+    set_named_property(env, exports, "mosfetThresholdVoltage",
+        create_function(env, "mosfetThresholdVoltage", Some(napi_mosfet_threshold_voltage)));
+
+    // ── mosfet-models functions ───────────────────────────────────────────────
+    set_named_property(env, exports, "evaluateLevel1",
+        create_function(env, "evaluateLevel1", Some(napi_evaluate_level1)));
+    set_named_property(env, exports, "evaluateLevel1Defaults",
+        create_function(env, "evaluateLevel1Defaults", Some(napi_evaluate_level1_defaults)));
+
+    // ── fab-process-simulation functions ─────────────────────────────────────
+    set_named_property(env, exports, "dealGroveOxidation",
+        create_function(env, "dealGroveOxidation", Some(napi_deal_grove_oxidation)));
+    set_named_property(env, exports, "deposit",
+        create_function(env, "deposit", Some(napi_deposit)));
+    set_named_property(env, exports, "etch",
+        create_function(env, "etch", Some(napi_etch)));
+    set_named_property(env, exports, "implant",
+        create_function(env, "implant", Some(napi_implant)));
+    set_named_property(env, exports, "diffuse",
+        create_function(env, "diffuse", Some(napi_diffuse)));
+    set_named_property(env, exports, "implantRange",
+        create_function(env, "implantRange", Some(napi_implant_range)));
+    set_named_property(env, exports, "diffusivityCm2PerS",
+        create_function(env, "diffusivityCm2PerS", Some(napi_diffusivity_cm2_per_s)));
+
+    exports
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — pure Rust, no Node.js required
+//
+// N-API code is excluded from test builds via `#[cfg(not(test))]` on all
+// N-API imports and functions.  `cargo test` compiles and links cleanly on all
+// platforms (Linux, macOS, Windows) without needing Node.js or node.lib.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── CrossSection wire format ─────────────────────────────────────────────
+
+    #[test]
+    fn cs_wire_empty_roundtrip() {
+        let cs = cs_from_wire("");
+        assert!(cs.layers.is_empty());
+        assert_eq!(cs_to_wire(&cs), "");
+    }
+
+    #[test]
+    fn cs_wire_single_layer() {
+        let cs = cs_from_wire("Si:500.0");
+        assert_eq!(cs.layers.len(), 1);
+        assert_eq!(cs.layers[0].material, "Si");
+        assert!((cs.layers[0].thickness_nm - 500.0).abs() < 1e-9);
+        let s = cs_to_wire(&cs);
+        assert!(s.starts_with("Si:500"), "got: {s}");
+    }
+
+    #[test]
+    fn cs_wire_multi_layer_roundtrip() {
+        let input = "Poly:50.0|SiO2:4.8|Si:500.0";
+        let cs = cs_from_wire(input);
+        assert_eq!(cs.layers.len(), 3);
+        assert_eq!(cs.layers[0].material, "Poly");
+        assert_eq!(cs.layers[1].material, "SiO2");
+        assert_eq!(cs.layers[2].material, "Si");
+        let s = cs_to_wire(&cs);
+        assert!(s.contains("Poly"),   "missing Poly in: {s}");
+        assert!(s.contains("SiO2"),   "missing SiO2 in: {s}");
+        assert!(s.contains("Si:500"), "missing Si:500 in: {s}");
+    }
+
+    #[test]
+    fn cs_wire_malformed_entry_skipped() {
+        let cs = cs_from_wire("Si:500.0|bad_entry|SiO2:4.8");
+        assert_eq!(cs.layers.len(), 2, "malformed entry must be skipped");
+    }
+
+    #[test]
+    fn validate_material_rejects_delimiters() {
+        assert!(validate_material_name("Si").is_ok());
+        assert!(validate_material_name("SiO2").is_ok());
+        assert!(validate_material_name("Poly|extra").is_err());
+        assert!(validate_material_name("bad:name").is_err());
+    }
+
+    // ── device-physics ───────────────────────────────────────────────────────
+
+    #[test]
+    fn thermal_voltage_at_300k() {
+        let vt = dp::thermal_voltage(300.0);
+        assert!((vt - 0.025852).abs() < 1e-5, "V_T={vt}");
+    }
+
+    #[test]
+    fn intrinsic_concentration_valid() {
+        let ni = dp::intrinsic_concentration(300.0).unwrap();
+        assert!(ni > 1e15 && ni < 1e17, "n_i={ni}");
+    }
+
+    #[test]
+    fn intrinsic_concentration_below_100k_fails() {
+        assert!(dp::intrinsic_concentration(50.0).is_err());
+    }
+
+    #[test]
+    fn pn_junction_built_in_voltage_typical() {
+        let j = dp::PNJunction::new(1e23, 1e22, 1.0, 300.0, 1e-6, 1e-6).unwrap();
+        let vbi = j.built_in_voltage();
+        assert!(vbi > 0.6 && vbi < 1.1, "V_bi={vbi}");
+    }
+
+    #[test]
+    fn mosfet_threshold_voltage_nmos() {
+        let p = dp::MOSFETParams::new("NMOS", 130e-9, 1e-6, 2e-9, 1e24, -0.05, 0.0, 300.0)
+            .unwrap();
+        let vt = p.threshold_voltage(0.0).unwrap();
+        assert!(vt > 0.5 && vt < 1.6, "V_t={vt}");
+    }
+
+    // ── mosfet-models ────────────────────────────────────────────────────────
+
+    #[test]
+    fn eval_level1_saturation() {
+        let (id, gm, gds, _gmb, _cgs, _cgd, _cgb, _cbs, _cbd, region) =
+            eval_level1_rs(0.42, 220e-6, 0.05, 0.27, 0.84, 1e-6, 130e-9, 1.4,
+                           1.8, 1.8, 0.0, 300.15);
+        assert_eq!(region, "saturation");
+        assert!(id  > 0.0,  "Id must be positive");
+        assert!(gm  > 0.0,  "gm must be positive");
+        assert!(gds >= 0.0, "gds must be non-negative");
+    }
+
+    #[test]
+    fn eval_level1_cutoff() {
+        let (id, _gm, _gds, _gmb, _cgs, _cgd, _cgb, _cbs, _cbd, region) =
+            eval_level1_rs(0.42, 220e-6, 0.05, 0.27, 0.84, 1e-6, 130e-9, 1.4,
+                           0.0, 1.8, 0.0, 300.15);
+        assert!(id >= 0.0);
+        assert!(
+            region == "cutoff" || region == "subthreshold",
+            "region={region}"
+        );
+    }
+
+    // ── fab-process-simulation ───────────────────────────────────────────────
+
+    #[test]
+    fn deal_grove_adds_sio2_layer() {
+        let cs_in  = cs_from_wire("Si:500.0");
+        let cs_out = fps::deal_grove_oxidation(&cs_in, 5.0, None, None).unwrap();
+        assert_eq!(cs_out.layers[0].material, "SiO2");
+        assert!(cs_out.layers[0].thickness_nm > 0.0);
+    }
+
+    #[test]
+    fn deposit_prepends_layer() {
+        let cs_in  = cs_from_wire("Si:500.0");
+        let cs_out = fps::deposit(&cs_in, "Poly", 50.0).unwrap();
+        assert_eq!(cs_out.layers[0].material, "Poly");
+        assert_eq!(cs_out.layers[1].material, "Si");
+    }
+
+    #[test]
+    fn etch_removes_top_layer() {
+        let cs_in  = cs_from_wire("Poly:50.0|Si:500.0");
+        let cs_out = fps::etch(&cs_in, "Poly", 50.0);
+        assert_eq!(cs_out.layers.len(), 1);
+        assert_eq!(cs_out.layers[0].material, "Si");
+    }
+
+    #[test]
+    fn implant_range_boron_30kev() {
+        let (rp, straggle) = fps::implant_range("B", 30.0).unwrap();
+        assert!((rp       - 92.0).abs() < 1e-6, "rp={rp}");
+        assert!((straggle - 38.0).abs() < 1e-6, "straggle={straggle}");
+    }
+
+    #[test]
+    fn diffusivity_boron_1000c() {
+        let d = fps::diffusivity_cm2_per_s("B", 1000.0);
+        assert!((d - 1e-14).abs() < 1e-20, "D={d}");
+    }
+
+    #[test]
+    fn wire_roundtrip_after_gate_stack() {
+        let cs   = cs_from_wire("Si:500.0");
+        let cs   = fps::deal_grove_oxidation(&cs, 5.0, None, None).unwrap();
+        let cs   = fps::deposit(&cs, "Poly", 50.0).unwrap();
+        let wire = cs_to_wire(&cs);
+        let cs2  = cs_from_wire(&wire);
+        assert_eq!(cs.layers.len(), cs2.layers.len());
+        for (a, b) in cs.layers.iter().zip(cs2.layers.iter()) {
+            assert_eq!(a.material, b.material);
+            assert!(
+                (a.thickness_nm - b.thickness_nm).abs() < 1e-6,
+                "thickness mismatch: {} vs {}",
+                a.thickness_nm,
+                b.thickness_nm
+            );
+        }
+    }
+}

--- a/code/specs/silicon-rust-napi.md
+++ b/code/specs/silicon-rust-napi.md
@@ -1,0 +1,194 @@
+# silicon-rust-napi — Node.js N-API bindings for the silicon simulation stack
+
+## Overview
+
+`silicon-rust-napi` is a Node.js native addon that exposes `device-physics`,
+`mosfet-models`, and `fab-process-simulation` to JavaScript and TypeScript.
+It uses the zero-dependency `node-bridge` crate (raw N-API, no napi-rs) and
+compiles to a `.node` file loadable with `require('silicon_rust_napi')`.
+
+The API surface mirrors `silicon-rust-python` — the same 26 functions are
+available, with JavaScript naming conventions (camelCase) instead of Python's
+snake_case.
+
+## Cross-section wire format
+
+A `CrossSection` travels as a pipe-separated string of `material:thickness_nm`
+pairs, identical to the Python binding.
+
+```
+""                               # empty cross-section
+"Si:500.0"                       # bare silicon substrate
+"SiO2:4.8|Si:500.0"             # gate oxide on silicon
+"Poly:50.0|SiO2:4.8|Si:500.0"  # poly gate on gate oxide
+```
+
+## Public API
+
+### Physical constants (no arguments)
+
+| JS name        | Value            | Unit    | Description                  |
+|---------------|------------------|---------|------------------------------|
+| `kBoltzmann()`| 1.380649×10⁻²³  | J/K     | Boltzmann constant           |
+| `qElectron()` | 1.602176634×10⁻¹⁹| C      | Elementary charge            |
+| `eps0()`      | 8.8541878×10⁻¹² | F/m     | Vacuum permittivity          |
+| `epsSi()`     | 1.0359×10⁻¹⁰    | F/m     | Silicon permittivity         |
+| `epsOx()`     | 3.4531×10⁻¹¹    | F/m     | SiO₂ permittivity           |
+| `niAt300k()`  | 1×10¹⁶          | /m³     | Intrinsic concentration at 300 K |
+| `egSiAt300k()`| 1.12            | eV      | Silicon bandgap at 300 K     |
+| `muN300k()`   | 0.1350          | m²/V/s  | Electron mobility at 300 K   |
+| `muP300k()`   | 0.0480          | m²/V/s  | Hole mobility at 300 K       |
+
+### Device-physics functions
+
+```typescript
+thermalVoltage(tKelvin: number): number
+// V_T = kT/q [V]. At 300 K → ~0.02585 V.
+
+intrinsicConcentration(tKelvin: number): number
+// Intrinsic carrier concentration n_i(T) [/m³]. Throws below 100 K.
+
+fermiPotential(nDoping: number, kind: 'p' | 'n', tKelvin: number): number
+// Fermi potential φ_F [V]. +|φ_F| for p-type, −|φ_F| for n-type.
+
+pnJunctionBuiltInVoltage(na: number, nd: number, t: number): number
+// Built-in voltage V_bi [V] for an abrupt p-n junction.
+
+pnJunctionDepletionWidth(na: number, nd: number, t: number, vApplied: number): number
+// Total depletion-region width W [m]. Positive vApplied = forward bias.
+
+pnJunctionSaturationCurrent(
+  na: number, nd: number, a: number,
+  t: number, tauN: number, tauP: number
+): number
+// Shockley saturation current I_S [A]. a = junction area [m²].
+
+pnJunctionCurrent(
+  na: number, nd: number, a: number,
+  t: number, tauN: number, tauP: number, v: number
+): number
+// Shockley diode current I [A] at applied voltage v [V].
+
+mosfetThresholdVoltage(
+  deviceType: 'NMOS' | 'PMOS',
+  l: number, w: number, tOx: number,
+  nBody: number, phiMs: number, qOx: number,
+  t: number, vSb: number
+): number
+// Threshold voltage V_t [V] with body effect. vSb ≥ 0.
+```
+
+### MOSFET Level-1 model
+
+```typescript
+interface MosResult {
+  id: number;    // Drain current [A]
+  gm: number;    // Transconductance [S]
+  gds: number;   // Output conductance [S]
+  gmb: number;   // Body transconductance [S]
+  cgs: number;   // Gate-source capacitance [F]
+  cgd: number;   // Gate-drain capacitance [F]
+  cgb: number;   // Gate-body capacitance [F]
+  cbs: number;   // Body-source capacitance [F]
+  cbd: number;   // Body-drain capacitance [F]
+  region: 'cutoff' | 'subthreshold' | 'triode' | 'saturation';
+}
+
+evaluateLevel1(
+  vt0: number, kp: number, lambda: number, gamma: number, phi: number,
+  w: number, l: number, nSub: number,
+  vGs: number, vDs: number, vBs: number, t: number
+): MosResult
+
+evaluateLevel1Defaults(vGs: number, vDs: number, vBs: number, t: number): MosResult
+// Same as evaluateLevel1 using default 130 nm NMOS parameter set.
+```
+
+### Fab-process simulation functions
+
+```typescript
+dealGroveOxidation(
+  csStr: string, timeMin: number,
+  aUm?: number, bUm2PerHr?: number
+): string
+// Grow thermal SiO₂ via Deal-Grove. Optional A/B use dry-O₂ 1000°C defaults.
+
+deposit(csStr: string, material: string, thicknessNm: number): string
+// Deposit a uniform film on top of the cross-section.
+
+etch(csStr: string, targetMaterial: string, depthNm: number): string
+// Remove depthNm nm of targetMaterial from the top.
+
+implant(
+  csStr: string, species: 'B' | 'P' | 'As' | 'BF2',
+  energyKev: number, doseCm2: number
+): string
+// Add a Gaussian ion-implant profile to the topmost Si layer.
+
+diffuse(csStr: string, timeMin: number, temperatureC?: number): string
+// Broaden all Gaussian doping profiles (Fick's law). Default temp: 1000 °C.
+
+interface ImplantRangeResult { rp: number; straggle: number; }
+implantRange(species: string, energyKev: number): ImplantRangeResult
+// Return { rp, straggle } (both in nm) from the SRIM table.
+
+diffusivityCm2PerS(species: string, temperatureC: number): number
+// Arrhenius-scaled diffusivity D(T) [cm²/s].
+```
+
+## Architecture
+
+```
+Node.js process
+└── require('silicon_rust_napi')   → loads silicon_rust_napi.node (.so/.dylib/.dll)
+    └── napi_register_module_v1()  → registers 26 JS functions via N-API
+        ├── node-bridge             (raw extern "C" N-API declarations)
+        ├── device-physics          (pure Rust physics)
+        ├── mosfet-models           (Level-1 MOSFET model)
+        └── fab-process-simulation  (process step library)
+```
+
+N-API symbols (`napi_create_function`, etc.) are resolved at `dlopen()` time:
+- macOS: `-undefined dynamic_lookup` (emitted by `node-bridge`'s `build.rs`)
+- Linux: ELF allows undefined symbols in shared objects by default
+- Windows: requires `node.lib`; skipped in CI via `BUILD_windows`
+
+## JavaScript usage example
+
+```javascript
+const srp = require('./silicon_rust_napi.node');
+
+// Physical constants
+console.log(srp.kBoltzmann());     // 1.380649e-23
+console.log(srp.thermalVoltage(300)); // 0.025852
+
+// PN junction
+const vbi = srp.pnJunctionBuiltInVoltage(1e23, 1e22, 300);
+const w   = srp.pnJunctionDepletionWidth(1e23, 1e22, 300, 0.0);
+
+// Level-1 MOSFET
+const r = srp.evaluateLevel1Defaults(1.8, 1.8, 0.0, 300.15);
+console.log(r.region, r.id);  // "saturation" 1.23e-4
+
+// Process simulation
+let cs = srp.deposit("", "Si", 500.0);
+cs = srp.dealGroveOxidation(cs, 5.0);
+cs = srp.deposit(cs, "Poly", 50.0);
+const { rp, straggle } = srp.implantRange("B", 30.0);
+```
+
+## Testing
+
+`cargo test -p silicon-rust-napi` runs all 15 pure-Rust unit tests without
+Node.js. N-API code is dead-stripped from the test binary.
+
+## Files
+
+| File                         | Purpose                                     |
+|-----------------------------|---------------------------------------------|
+| `Cargo.toml`                | crate metadata, cdylib + lib, dependencies  |
+| `src/lib.rs`                | N-API callbacks + module registration       |
+| `silicon_rust_napi.d.ts`    | TypeScript type declarations                |
+| `BUILD` / `BUILD_windows`   | `cargo test` invocations for CI             |
+| `README.md`                 | User-facing documentation                   |
+| `CHANGELOG.md`              | Version history                             |


### PR DESCRIPTION
## Summary

- Adds `silicon-rust-napi`, a zero-dependency Node.js N-API addon exposing 26 functions from `device-physics`, `mosfet-models`, and `fab-process-simulation` to JavaScript/TypeScript
- Uses `node-bridge` crate (raw `extern "C"` N-API, no napi-rs/bindgen, no Node.js headers at build time)
- Provides full TypeScript declarations in `silicon_rust_napi.d.ts`

## Key implementation details

- All N-API code gated with `#[cfg(not(test))]` so `cargo test --lib` links cleanly on Windows without `node.lib` (MSVC requires all symbols resolved, including dead code)
- `BUILD_windows` uses `--lib` flag to skip cdylib build on Windows CI; Linux/macOS build the full cdylib
- Material name injection guard: `deposit()` rejects `|` and `:` in material names to prevent wire-format injection
- CrossSection wire format identical to `silicon-rust-python` (`"Poly:50.0|SiO2:4.8|Si:500.0"`)
- 18 pure-Rust unit tests, all passing on all platforms without Node.js

## Test plan

- [x] `cargo test --lib -p silicon-rust-napi` — 18/18 pass on Windows
- [x] Security review passed (one pre-existing MEDIUM in `node-bridge`'s `check_status` panic behavior, tracked separately)
- [ ] CI: `build (ubuntu-latest)`, `build (macos-latest)`, `build (windows-latest)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)