### PR TITLE
Add smart-home activation attestation tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -410,6 +410,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_COMPLIANCE_TOOL_ID: &str =
     "smart_home.list_integration_activation_compliance";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_COMPLIANCE_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_compliance_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID: &str =
+    "smart_home.list_integration_activation_attestations";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_attestation_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -950,6 +954,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_COMPLIANCE_SUMMARY_TOOL_ID => {
                     let query = integration_activation_compliance_query(&arguments)?;
                     Ok(get_integration_activation_compliance_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID => {
+                    let query = integration_activation_attestation_query(&arguments)?;
+                    Ok(list_integration_activation_attestations_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_attestation_query(&arguments)?;
+                    Ok(get_integration_activation_attestation_summary_output_handler_output(query))
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -3069,6 +3081,35 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation compliance summary",
             "Return compact D23A activation compliance counts by verdict, evidence kind, owner lane, exception, reviewer, blocker, and compliance readiness.",
             integration_activation_compliance_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID,
+            "List smart-home integration activation attestations",
+            "List Chief-facing D23A activation attestation records that turn compliance checklist rows into signer lane, evidence kind, exception, and activation signoff posture.",
+            integration_activation_attestation_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_attestations", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec!["activation_attestations", "summary", "count", "catalog_count"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation attestation summary",
+            "Return compact D23A activation attestation counts by status, signer lane, evidence kind, reviewer requirement, exception requirement, blocker, and signoff readiness.",
+            integration_activation_attestation_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -6912,6 +6953,321 @@ fn activation_compliance_evidence_kind(focus: IntegrationActivationGuardrailKind
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntegrationActivationAttestationStatus {
+    Accepted,
+    Conditional,
+    ExceptionRequested,
+    Rejected,
+}
+
+impl IntegrationActivationAttestationStatus {
+    fn from_compliance_verdict(verdict: IntegrationActivationComplianceVerdict) -> Self {
+        match verdict {
+            IntegrationActivationComplianceVerdict::Compliant => Self::Accepted,
+            IntegrationActivationComplianceVerdict::Conditional => Self::Conditional,
+            IntegrationActivationComplianceVerdict::ExceptionRequired => Self::ExceptionRequested,
+            IntegrationActivationComplianceVerdict::NonCompliant => Self::Rejected,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Conditional => "conditional",
+            Self::ExceptionRequested => "exception_requested",
+            Self::Rejected => "rejected",
+        }
+    }
+
+    fn is_ready(self) -> bool {
+        matches!(self, Self::Accepted | Self::Conditional)
+    }
+
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Rejected)
+    }
+
+    fn requires_attention(self) -> bool {
+        matches!(self, Self::ExceptionRequested | Self::Rejected)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationAttestationRecord {
+    sequence: usize,
+    attestation_id: String,
+    source_compliance_id: String,
+    source_governance_id: String,
+    source_assurance_id: String,
+    source_guardrail_id: String,
+    status: IntegrationActivationAttestationStatus,
+    compliance_verdict: IntegrationActivationComplianceVerdict,
+    governance_decision: IntegrationActivationGovernanceDecision,
+    assurance_status: IntegrationActivationAssuranceStatus,
+    focus: IntegrationActivationGuardrailKind,
+    signer_lane: IntegrationActivationResponseOwnerLane,
+    owner_lane: IntegrationActivationResponseOwnerLane,
+    attestation_kind: String,
+    evidence_kind: String,
+    control_objective: String,
+    evidence_label: String,
+    recommended_view: IntegrationActivationPlaybookView,
+    title: String,
+    summary: String,
+    priority: u8,
+    integration_ids: Vec<IntegrationId>,
+    required_tier: PrivilegeTier,
+    policy_surface: Option<IntegrationPolicySurface>,
+    reviewer_required: bool,
+    exception_required: bool,
+    signoff_required: bool,
+    attestation_ready: bool,
+    blocks_activation: bool,
+    requires_attention: bool,
+}
+
+impl IntegrationActivationAttestationRecord {
+    fn from_compliance_record(
+        sequence: usize,
+        record: &IntegrationActivationComplianceRecord,
+    ) -> Self {
+        let status =
+            IntegrationActivationAttestationStatus::from_compliance_verdict(record.verdict);
+        let signoff_required = record.reviewer_required
+            || record.exception_required
+            || record.required_tier == PrivilegeTier::HumanApproval;
+        let blocks_activation = record.blocks_activation || status.is_blocked();
+        let requires_attention =
+            record.requires_attention || status.requires_attention() || signoff_required;
+
+        Self {
+            sequence,
+            attestation_id: format!("activation-attestation-{sequence}"),
+            source_compliance_id: record.compliance_id.clone(),
+            source_governance_id: record.source_governance_id.clone(),
+            source_assurance_id: record.source_assurance_id.clone(),
+            source_guardrail_id: record.source_guardrail_id.clone(),
+            status,
+            compliance_verdict: record.verdict,
+            governance_decision: record.governance_decision,
+            assurance_status: record.assurance_status,
+            focus: record.focus,
+            signer_lane: record.owner_lane,
+            owner_lane: record.owner_lane,
+            attestation_kind: activation_attestation_kind(record.focus).to_string(),
+            evidence_kind: record.evidence_kind.clone(),
+            control_objective: record.control_objective.clone(),
+            evidence_label: record.evidence_label.clone(),
+            recommended_view: record.recommended_view,
+            title: record.title.clone(),
+            summary: record.summary.clone(),
+            priority: record.priority,
+            integration_ids: record.integration_ids.clone(),
+            required_tier: record.required_tier,
+            policy_surface: record.policy_surface,
+            reviewer_required: record.reviewer_required,
+            exception_required: record.exception_required,
+            signoff_required,
+            attestation_ready: status.is_ready() && !blocks_activation,
+            blocks_activation,
+            requires_attention,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationAttestationSummary {
+    total_records: usize,
+    unique_integrations: usize,
+    records_requiring_attention: usize,
+    blocked_records: usize,
+    accepted_records: usize,
+    conditional_records: usize,
+    exception_requested_records: usize,
+    rejected_records: usize,
+    incident_attestations: usize,
+    policy_attestations: usize,
+    dependency_attestations: usize,
+    readiness_gap_attestations: usize,
+    platform_signer_records: usize,
+    integration_signer_records: usize,
+    security_signer_records: usize,
+    reviewer_signer_records: usize,
+    verification_signer_records: usize,
+    audit_signer_records: usize,
+    reviewer_required_records: usize,
+    exception_required_records: usize,
+    signoff_required_records: usize,
+    human_approval_records: usize,
+    attestation_ready_records: usize,
+    first_attention_priority: Option<u8>,
+    first_blocked_priority: Option<u8>,
+    first_signoff_priority: Option<u8>,
+    highest_policy_tier: PrivilegeTier,
+    overall_status: IntegrationActivationHealthStatus,
+}
+
+impl IntegrationActivationAttestationSummary {
+    fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationAttestationRecord>,
+    ) -> Self {
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            accepted_records: 0,
+            conditional_records: 0,
+            exception_requested_records: 0,
+            rejected_records: 0,
+            incident_attestations: 0,
+            policy_attestations: 0,
+            dependency_attestations: 0,
+            readiness_gap_attestations: 0,
+            platform_signer_records: 0,
+            integration_signer_records: 0,
+            security_signer_records: 0,
+            reviewer_signer_records: 0,
+            verification_signer_records: 0,
+            audit_signer_records: 0,
+            reviewer_required_records: 0,
+            exception_required_records: 0,
+            signoff_required_records: 0,
+            human_approval_records: 0,
+            attestation_ready_records: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_signoff_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for record in records {
+            summary.total_records += 1;
+            for integration_id in &record.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            if record.requires_attention {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, record.priority);
+            }
+            if record.blocks_activation {
+                summary.blocked_records += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, record.priority);
+            }
+            if record.reviewer_required {
+                summary.reviewer_required_records += 1;
+            }
+            if record.exception_required {
+                summary.exception_required_records += 1;
+            }
+            if record.signoff_required {
+                summary.signoff_required_records += 1;
+                summary.first_signoff_priority =
+                    min_optional_priority(summary.first_signoff_priority, record.priority);
+            }
+            if record.required_tier == PrivilegeTier::HumanApproval {
+                summary.human_approval_records += 1;
+            }
+            if record.attestation_ready {
+                summary.attestation_ready_records += 1;
+            }
+            match record.status {
+                IntegrationActivationAttestationStatus::Accepted => summary.accepted_records += 1,
+                IntegrationActivationAttestationStatus::Conditional => {
+                    summary.conditional_records += 1
+                }
+                IntegrationActivationAttestationStatus::ExceptionRequested => {
+                    summary.exception_requested_records += 1
+                }
+                IntegrationActivationAttestationStatus::Rejected => summary.rejected_records += 1,
+            }
+            match record.focus {
+                IntegrationActivationGuardrailKind::Incident => summary.incident_attestations += 1,
+                IntegrationActivationGuardrailKind::PolicyRisk => summary.policy_attestations += 1,
+                IntegrationActivationGuardrailKind::Dependency => {
+                    summary.dependency_attestations += 1
+                }
+                IntegrationActivationGuardrailKind::ReadinessGap => {
+                    summary.readiness_gap_attestations += 1
+                }
+            }
+            match record.signer_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Audit => summary.audit_signer_records += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(record.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.total_records == 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else if summary.rejected_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.exception_requested_records > 0 || summary.signoff_required_records > 0 {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else {
+            IntegrationActivationHealthStatus::Ready
+        };
+        summary
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0 || self.signoff_required_records > 0
+    }
+
+    fn is_empty(&self) -> bool {
+        self.total_records == 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntegrationActivationAttestationQuery {
+    compliance: IntegrationActivationComplianceQuery,
+    status: Option<IntegrationActivationAttestationStatus>,
+    focus: Option<IntegrationActivationGuardrailKind>,
+    signer_lane: Option<IntegrationActivationResponseOwnerLane>,
+    attestation_kind: Option<String>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    reviewer_required: Option<bool>,
+    exception_required: Option<bool>,
+    signoff_required: Option<bool>,
+    attestation_ready: Option<bool>,
+    attestation_limit: Option<usize>,
+}
+
+fn activation_attestation_kind(focus: IntegrationActivationGuardrailKind) -> &'static str {
+    match focus {
+        IntegrationActivationGuardrailKind::Incident => "incident_closure",
+        IntegrationActivationGuardrailKind::PolicyRisk => "policy_privilege",
+        IntegrationActivationGuardrailKind::Dependency => "dependency_prerequisite",
+        IntegrationActivationGuardrailKind::ReadinessGap => "platform_readiness",
+    }
+}
+
 fn min_optional_priority(current: Option<u8>, priority: u8) -> Option<u8> {
     Some(current.map_or(priority, |existing| existing.min(priority)))
 }
@@ -8052,6 +8408,43 @@ fn integration_activation_compliance_query(
         reviewer_required: optional_bool(arguments, "reviewer_required")?,
         exception_required: optional_bool(arguments, "exception_required")?,
         compliance_limit: optional_u64(arguments, "compliance_limit")?
+            .or(optional_u64(arguments, "record_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_attestation_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationAttestationQuery, ToolCallError> {
+    let status = optional_string(arguments, "attestation_status")?
+        .or(optional_string(arguments, "status")?)
+        .map(|label| parse_activation_attestation_status(&label))
+        .transpose()?;
+    let focus = optional_string(arguments, "attestation_focus")?
+        .or(optional_string(arguments, "focus")?)
+        .map(|label| parse_activation_guardrail_kind(&label))
+        .transpose()?;
+    let signer_lane = optional_string(arguments, "signer_lane")?
+        .or(optional_string(arguments, "attestation_owner_lane")?)
+        .or(optional_string(arguments, "owner_lane")?)
+        .map(|label| parse_activation_response_owner_lane(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationAttestationQuery {
+        compliance: integration_activation_compliance_query(arguments)?,
+        status,
+        focus,
+        signer_lane,
+        attestation_kind: optional_string(arguments, "attestation_kind")?,
+        requires_attention: optional_bool(arguments, "attestation_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "attestation_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        reviewer_required: optional_bool(arguments, "reviewer_required")?,
+        exception_required: optional_bool(arguments, "exception_required")?,
+        signoff_required: optional_bool(arguments, "signoff_required")?,
+        attestation_ready: optional_bool(arguments, "attestation_ready")?,
+        attestation_limit: optional_u64(arguments, "attestation_limit")?
             .or(optional_u64(arguments, "record_limit")?)
             .map(|value| value as usize),
     })
@@ -9627,6 +10020,56 @@ fn integration_activation_compliance_for_query(
         records.retain(|record| record.exception_required == exception_required);
     }
     if let Some(limit) = query.compliance_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
+}
+
+fn integration_activation_attestations_for_query(
+    query: &IntegrationActivationAttestationQuery,
+) -> (Vec<IntegrationActivationAttestationRecord>, usize) {
+    let (compliance_records, catalog_count) =
+        integration_activation_compliance_for_query(&query.compliance);
+    let mut records: Vec<_> = compliance_records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| {
+            IntegrationActivationAttestationRecord::from_compliance_record(index + 1, record)
+        })
+        .collect();
+
+    if let Some(status) = query.status {
+        records.retain(|record| record.status == status);
+    }
+    if let Some(focus) = query.focus {
+        records.retain(|record| record.focus == focus);
+    }
+    if let Some(signer_lane) = query.signer_lane {
+        records.retain(|record| record.signer_lane == signer_lane);
+    }
+    if let Some(attestation_kind) = &query.attestation_kind {
+        records.retain(|record| record.attestation_kind == *attestation_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.blocks_activation == blocked);
+    }
+    if let Some(reviewer_required) = query.reviewer_required {
+        records.retain(|record| record.reviewer_required == reviewer_required);
+    }
+    if let Some(exception_required) = query.exception_required {
+        records.retain(|record| record.exception_required == exception_required);
+    }
+    if let Some(signoff_required) = query.signoff_required {
+        records.retain(|record| record.signoff_required == signoff_required);
+    }
+    if let Some(attestation_ready) = query.attestation_ready {
+        records.retain(|record| record.attestation_ready == attestation_ready);
+    }
+    if let Some(limit) = query.attestation_limit {
         records.truncate(limit);
     }
 
@@ -13301,6 +13744,84 @@ fn get_integration_activation_compliance_summary_output_handler_output(
             (
                 "reviewer_required_records",
                 integer(summary.reviewer_required_records as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn list_integration_activation_attestations_output_handler_output(
+    query: IntegrationActivationAttestationQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_attestations_for_query(&query);
+    let summary = IntegrationActivationAttestationSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_attestations",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_attestation_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_attestation_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_attestations"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "signoff_required_records",
+                integer(summary.signoff_required_records as i64),
+            ),
+            (
+                "exception_required_records",
+                integer(summary.exception_required_records as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_attestation_summary_output_handler_output(
+    query: IntegrationActivationAttestationQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_attestations_for_query(&query);
+    let summary = IntegrationActivationAttestationSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_attestation_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_attestation_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "signoff_required_records",
+                integer(summary.signoff_required_records as i64),
+            ),
+            (
+                "exception_required_records",
+                integer(summary.exception_required_records as i64),
             ),
             ("blocked_records", integer(summary.blocked_records as i64)),
             ("overall_status", string(summary.overall_status.as_str())),
@@ -25628,6 +26149,205 @@ fn integration_activation_compliance_summary_json(
     ])
 }
 
+fn activation_attestation_record_json(
+    record: &IntegrationActivationAttestationRecord,
+) -> JsonValue {
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        ("attestation_id", string(&record.attestation_id)),
+        ("source_compliance_id", string(&record.source_compliance_id)),
+        ("source_governance_id", string(&record.source_governance_id)),
+        ("source_assurance_id", string(&record.source_assurance_id)),
+        ("source_guardrail_id", string(&record.source_guardrail_id)),
+        ("status", string(record.status.as_str())),
+        (
+            "compliance_verdict",
+            string(record.compliance_verdict.as_str()),
+        ),
+        (
+            "governance_decision",
+            string(record.governance_decision.as_str()),
+        ),
+        ("assurance_status", string(record.assurance_status.as_str())),
+        ("focus", string(record.focus.as_str())),
+        ("signer_lane", string(record.signer_lane.as_str())),
+        ("owner_lane", string(record.owner_lane.as_str())),
+        ("attestation_kind", string(&record.attestation_kind)),
+        ("evidence_kind", string(&record.evidence_kind)),
+        ("control_objective", string(&record.control_objective)),
+        ("evidence_label", string(&record.evidence_label)),
+        ("recommended_view", string(record.recommended_view.as_str())),
+        ("title", string(&record.title)),
+        ("summary", string(&record.summary)),
+        ("priority", integer(record.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                record
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(record.integration_ids.len() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(record.required_tier)),
+        ),
+        (
+            "policy_surface",
+            record
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "reviewer_required",
+            JsonValue::Bool(record.reviewer_required),
+        ),
+        (
+            "exception_required",
+            JsonValue::Bool(record.exception_required),
+        ),
+        ("signoff_required", JsonValue::Bool(record.signoff_required)),
+        (
+            "attestation_ready",
+            JsonValue::Bool(record.attestation_ready),
+        ),
+        (
+            "blocks_activation",
+            JsonValue::Bool(record.blocks_activation),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention),
+        ),
+    ])
+}
+
+fn integration_activation_attestation_summary_json(
+    summary: &IntegrationActivationAttestationSummary,
+) -> JsonValue {
+    object([
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        ("accepted_records", integer(summary.accepted_records as i64)),
+        (
+            "conditional_records",
+            integer(summary.conditional_records as i64),
+        ),
+        (
+            "exception_requested_records",
+            integer(summary.exception_requested_records as i64),
+        ),
+        ("rejected_records", integer(summary.rejected_records as i64)),
+        (
+            "incident_attestations",
+            integer(summary.incident_attestations as i64),
+        ),
+        (
+            "policy_attestations",
+            integer(summary.policy_attestations as i64),
+        ),
+        (
+            "dependency_attestations",
+            integer(summary.dependency_attestations as i64),
+        ),
+        (
+            "readiness_gap_attestations",
+            integer(summary.readiness_gap_attestations as i64),
+        ),
+        (
+            "platform_signer_records",
+            integer(summary.platform_signer_records as i64),
+        ),
+        (
+            "integration_signer_records",
+            integer(summary.integration_signer_records as i64),
+        ),
+        (
+            "security_signer_records",
+            integer(summary.security_signer_records as i64),
+        ),
+        (
+            "reviewer_signer_records",
+            integer(summary.reviewer_signer_records as i64),
+        ),
+        (
+            "verification_signer_records",
+            integer(summary.verification_signer_records as i64),
+        ),
+        (
+            "audit_signer_records",
+            integer(summary.audit_signer_records as i64),
+        ),
+        (
+            "reviewer_required_records",
+            integer(summary.reviewer_required_records as i64),
+        ),
+        (
+            "exception_required_records",
+            integer(summary.exception_required_records as i64),
+        ),
+        (
+            "signoff_required_records",
+            integer(summary.signoff_required_records as i64),
+        ),
+        (
+            "human_approval_records",
+            integer(summary.human_approval_records as i64),
+        ),
+        (
+            "attestation_ready_records",
+            integer(summary.attestation_ready_records as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_signoff_priority",
+            summary
+                .first_signoff_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -28943,6 +29663,31 @@ fn parse_activation_compliance_verdict(
     }
 }
 
+fn parse_activation_attestation_status(
+    label: &str,
+) -> Result<IntegrationActivationAttestationStatus, ToolCallError> {
+    match label {
+        "accepted" | "accept" | "compliant" | "approved" | "approve" | "clear" | "pass"
+        | "passed" | "ready" | "ok" => Ok(IntegrationActivationAttestationStatus::Accepted),
+        "conditional" | "condition" | "monitor" | "watch" | "observe" => {
+            Ok(IntegrationActivationAttestationStatus::Conditional)
+        }
+        "exception_requested"
+        | "exception_required"
+        | "exception"
+        | "deferred"
+        | "defer"
+        | "needs_review"
+        | "review"
+        | "attention" => Ok(IntegrationActivationAttestationStatus::ExceptionRequested),
+        "rejected" | "reject" | "non_compliant" | "noncompliant" | "blocked" | "blocker"
+        | "hold" => Ok(IntegrationActivationAttestationStatus::Rejected),
+        _ => Err(validation_error(format!(
+            "unknown activation attestation status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -31047,6 +31792,64 @@ fn integration_activation_compliance_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_attestation_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_compliance_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new(
+            "attestation_status",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("status", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("attestation_focus", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("signer_lane", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "attestation_owner_lane",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new("attestation_kind", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "attestation_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "attestation_blocked",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "reviewer_required",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "exception_required",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("signoff_required", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new(
+            "attestation_ready",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "attestation_limit",
+            JsonSchema::Integer,
+        ));
+        push_if_absent(SchemaProperty::new("record_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -31191,7 +31994,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 147);
+        assert_eq!(definitions.len(), 149);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -31317,6 +32120,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_COMPLIANCE_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID));
@@ -31612,7 +32421,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_GOVERNANCE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            139
+            141
         );
         assert_eq!(
             export
@@ -32154,11 +32963,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(147))
+            Some(&integer(149))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(139))
+            Some(&integer(141))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -38336,6 +39145,138 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_attestations_request = request(
+            "call-list-integration-activation-attestations",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("signoff_required", JsonValue::Bool(true)),
+                ("attestation_limit", integer(3)),
+            ]),
+            5_073,
+        );
+        let list_activation_attestations_trace =
+            tool_runtime.invoke_with_events(&list_activation_attestations_request);
+        assert!(list_activation_attestations_trace.result.ok);
+        assert_eq!(
+            list_activation_attestations_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_attestations_output = list_activation_attestations_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_attestation_count =
+            integer_value(field(list_activation_attestations_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_attestation_count));
+        let activation_attestation_summary =
+            field(list_activation_attestations_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_attestation_summary, "total_records"),
+            Some(&integer(activation_attestation_count))
+        );
+        assert!(
+            integer_value(
+                field(activation_attestation_summary, "signoff_required_records").unwrap()
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_attestation_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_attestation = array_item(
+            field(
+                list_activation_attestations_output,
+                "activation_attestations",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            field(activation_attestation, "signoff_required"),
+            Some(&JsonValue::Bool(true))
+        );
+        assert!(field(activation_attestation, "source_compliance_id").is_some());
+        assert!(field(activation_attestation, "attestation_kind").is_some());
+        assert!(field(activation_attestation, "signer_lane").is_some());
+
+        let activation_attestation_summary_request = request(
+            "call-integration-activation-attestation-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("attestation_blocked", JsonValue::Bool(true)),
+            ]),
+            5_074,
+        );
+        let activation_attestation_summary_trace =
+            tool_runtime.invoke_with_events(&activation_attestation_summary_request);
+        assert!(activation_attestation_summary_trace.result.ok);
+        assert_eq!(
+            activation_attestation_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_attestation_summary_output = activation_attestation_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_attestation_rollup =
+            field(activation_attestation_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_attestation_rollup, "blocked_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_attestation_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -40296,6 +41237,14 @@ mod tests {
             activation_compliance_summary_request,
             activation_compliance_summary_trace,
         );
+        journal.record_trace(
+            list_activation_attestations_request,
+            list_activation_attestations_trace,
+        );
+        journal.record_trace(
+            activation_attestation_summary_request,
+            activation_attestation_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -40369,9 +41318,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 147);
-        assert_eq!(journal_summary.completed_count, 147);
-        assert_eq!(journal.audit_records().len(), 147);
+        assert_eq!(journal_summary.invocation_count, 149);
+        assert_eq!(journal_summary.completed_count, 149);
+        assert_eq!(journal.audit_records().len(), 149);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1545,6 +1545,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationGovernanceSummary,
     ListIntegrationActivationCompliance,
     GetIntegrationActivationComplianceSummary,
+    ListIntegrationActivationAttestations,
+    GetIntegrationActivationAttestationSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1886,6 +1888,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationComplianceSummary => {
                 read_tool("smart_home.get_integration_activation_compliance_summary")
+            }
+            Self::ListIntegrationActivationAttestations => {
+                read_tool("smart_home.list_integration_activation_attestations")
+            }
+            Self::GetIntegrationActivationAttestationSummary => {
+                read_tool("smart_home.get_integration_activation_attestation_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2614,6 +2622,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationGovernanceSummary,
         SmartHomeTool::ListIntegrationActivationCompliance,
         SmartHomeTool::GetIntegrationActivationComplianceSummary,
+        SmartHomeTool::ListIntegrationActivationAttestations,
+        SmartHomeTool::GetIntegrationActivationAttestationSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3456,7 +3466,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 147);
+        assert_eq!(catalog.len(), 149);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4051,6 +4061,14 @@ mod tests {
             == "smart_home.get_integration_activation_compliance_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_attestations"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_attestation_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -4058,15 +4076,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 147);
-        assert_eq!(summary.read_tools, 139);
+        assert_eq!(summary.total_tools, 149);
+        assert_eq!(summary.read_tools, 141);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 139);
+        assert_eq!(summary.read_only_tier_tools, 141);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 147);
+        assert_eq!(summary.total_required_capabilities, 149);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home tool catalog entries for activation attestation list and summary reads
- project Chief activation compliance records into signer-lane attestation records with status, evidence kind, signoff, blocker, and readiness posture
- cover the new attestation tools in Chief bridge definitions, handlers, JSON output, schema, and runtime end-to-end assertions

## Validation
- cargo fmt -p smart-home-core -p chief-of-staff-smart-home-tools -- --check
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Cargo.lock generated under code/packages/rust was removed before commit.