### PR TITLE
Add smart-home activation evidence ledger tools

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -414,6 +414,10 @@ pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_ATTESTATIONS_TOOL_ID: &str =
     "smart_home.list_integration_activation_attestations";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID: &str =
     "smart_home.get_integration_activation_attestation_summary";
+pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_TOOL_ID: &str =
+    "smart_home.list_integration_activation_evidence_ledger";
+pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_SUMMARY_TOOL_ID: &str =
+    "smart_home.get_integration_activation_evidence_ledger_summary";
 pub const SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID: &str =
     "smart_home.list_integration_activation_risk";
 pub const SMART_HOME_GET_INTEGRATION_ACTIVATION_RISK_SUMMARY_TOOL_ID: &str =
@@ -962,6 +966,18 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID => {
                     let query = integration_activation_attestation_query(&arguments)?;
                     Ok(get_integration_activation_attestation_summary_output_handler_output(query))
+                }
+                SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_TOOL_ID => {
+                    let query = integration_activation_evidence_ledger_query(&arguments)?;
+                    Ok(list_integration_activation_evidence_ledger_output_handler_output(query))
+                }
+                SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_SUMMARY_TOOL_ID => {
+                    let query = integration_activation_evidence_ledger_query(&arguments)?;
+                    Ok(
+                        get_integration_activation_evidence_ledger_summary_output_handler_output(
+                            query,
+                        ),
+                    )
                 }
                 SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID => {
                     let query = integration_activation_risk_query(&arguments)?;
@@ -3110,6 +3126,40 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
             "Get smart-home integration activation attestation summary",
             "Return compact D23A activation attestation counts by status, signer lane, evidence kind, reviewer requirement, exception requirement, blocker, and signoff readiness.",
             integration_activation_attestation_query_schema(),
+            object_schema(
+                vec![SchemaProperty::new("summary", JsonSchema::Any)],
+                vec!["summary"],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_TOOL_ID,
+            "List smart-home integration activation evidence ledger",
+            "List Chief-facing D23A activation evidence ledger rows that connect attestation signoff posture back to compliance, governance, assurance, and guardrail evidence source IDs.",
+            integration_activation_evidence_ledger_query_schema(),
+            object_schema(
+                vec![
+                    SchemaProperty::new("activation_evidence_ledger", JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    }),
+                    SchemaProperty::new("summary", JsonSchema::Any),
+                    SchemaProperty::new("count", JsonSchema::Integer),
+                    SchemaProperty::new("catalog_count", JsonSchema::Integer),
+                ],
+                vec![
+                    "activation_evidence_ledger",
+                    "summary",
+                    "count",
+                    "catalog_count",
+                ],
+                false,
+            ),
+        ),
+        read_definition(
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_SUMMARY_TOOL_ID,
+            "Get smart-home integration activation evidence ledger summary",
+            "Return compact D23A activation evidence ledger counts by status, evidence kind, source coverage, signer lane, blocker, and evidence readiness.",
+            integration_activation_evidence_ledger_query_schema(),
             object_schema(
                 vec![SchemaProperty::new("summary", JsonSchema::Any)],
                 vec!["summary"],
@@ -7268,6 +7318,342 @@ fn activation_attestation_kind(focus: IntegrationActivationGuardrailKind) -> &'s
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntegrationActivationEvidenceLedgerStatus {
+    Complete,
+    Conditional,
+    ExceptionPending,
+    Blocked,
+}
+
+impl IntegrationActivationEvidenceLedgerStatus {
+    fn from_attestation(record: &IntegrationActivationAttestationRecord) -> Self {
+        if record.blocks_activation
+            || record.status == IntegrationActivationAttestationStatus::Rejected
+        {
+            Self::Blocked
+        } else if record.exception_required
+            || record.status == IntegrationActivationAttestationStatus::ExceptionRequested
+        {
+            Self::ExceptionPending
+        } else if record.signoff_required
+            || record.reviewer_required
+            || record.status == IntegrationActivationAttestationStatus::Conditional
+        {
+            Self::Conditional
+        } else {
+            Self::Complete
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Conditional => "conditional",
+            Self::ExceptionPending => "exception_pending",
+            Self::Blocked => "blocked",
+        }
+    }
+
+    fn is_ready(self) -> bool {
+        matches!(self, Self::Complete)
+    }
+
+    fn is_blocked(self) -> bool {
+        matches!(self, Self::Blocked)
+    }
+
+    fn requires_attention(self) -> bool {
+        matches!(
+            self,
+            Self::Conditional | Self::ExceptionPending | Self::Blocked
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationEvidenceLedgerRecord {
+    sequence: usize,
+    ledger_id: String,
+    evidence_package_id: String,
+    source_attestation_id: String,
+    source_compliance_id: String,
+    source_governance_id: String,
+    source_assurance_id: String,
+    source_guardrail_id: String,
+    ledger_status: IntegrationActivationEvidenceLedgerStatus,
+    attestation_status: IntegrationActivationAttestationStatus,
+    compliance_verdict: IntegrationActivationComplianceVerdict,
+    evidence_kind: String,
+    attestation_kind: String,
+    control_objective: String,
+    evidence_label: String,
+    focus: IntegrationActivationGuardrailKind,
+    signer_lane: IntegrationActivationResponseOwnerLane,
+    owner_lane: IntegrationActivationResponseOwnerLane,
+    recommended_view: IntegrationActivationPlaybookView,
+    title: String,
+    summary: String,
+    priority: u8,
+    integration_ids: Vec<IntegrationId>,
+    required_tier: PrivilegeTier,
+    policy_surface: Option<IntegrationPolicySurface>,
+    reviewer_required: bool,
+    exception_required: bool,
+    signoff_required: bool,
+    evidence_ready: bool,
+    blocks_activation: bool,
+    requires_attention: bool,
+}
+
+impl IntegrationActivationEvidenceLedgerRecord {
+    fn from_attestation_record(
+        sequence: usize,
+        record: &IntegrationActivationAttestationRecord,
+    ) -> Self {
+        let ledger_status = IntegrationActivationEvidenceLedgerStatus::from_attestation(record);
+        let evidence_ready = ledger_status.is_ready() && record.attestation_ready;
+        let requires_attention =
+            record.requires_attention || ledger_status.requires_attention() || !evidence_ready;
+
+        Self {
+            sequence,
+            ledger_id: format!("activation-evidence-ledger-{sequence}"),
+            evidence_package_id: format!("activation-evidence-package-{sequence}"),
+            source_attestation_id: record.attestation_id.clone(),
+            source_compliance_id: record.source_compliance_id.clone(),
+            source_governance_id: record.source_governance_id.clone(),
+            source_assurance_id: record.source_assurance_id.clone(),
+            source_guardrail_id: record.source_guardrail_id.clone(),
+            ledger_status,
+            attestation_status: record.status,
+            compliance_verdict: record.compliance_verdict,
+            evidence_kind: record.evidence_kind.clone(),
+            attestation_kind: record.attestation_kind.clone(),
+            control_objective: record.control_objective.clone(),
+            evidence_label: record.evidence_label.clone(),
+            focus: record.focus,
+            signer_lane: record.signer_lane,
+            owner_lane: record.owner_lane,
+            recommended_view: record.recommended_view,
+            title: record.title.clone(),
+            summary: record.summary.clone(),
+            priority: record.priority,
+            integration_ids: record.integration_ids.clone(),
+            required_tier: record.required_tier,
+            policy_surface: record.policy_surface,
+            reviewer_required: record.reviewer_required,
+            exception_required: record.exception_required,
+            signoff_required: record.signoff_required,
+            evidence_ready,
+            blocks_activation: record.blocks_activation || ledger_status.is_blocked(),
+            requires_attention,
+        }
+    }
+
+    fn has_source_lineage(&self) -> bool {
+        !self.source_attestation_id.is_empty()
+            && !self.source_compliance_id.is_empty()
+            && !self.source_governance_id.is_empty()
+            && !self.source_assurance_id.is_empty()
+            && !self.source_guardrail_id.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IntegrationActivationEvidenceLedgerSummary {
+    total_records: usize,
+    unique_integrations: usize,
+    records_requiring_attention: usize,
+    blocked_records: usize,
+    complete_records: usize,
+    conditional_records: usize,
+    exception_pending_records: usize,
+    evidence_ready_records: usize,
+    source_linked_records: usize,
+    incident_evidence_records: usize,
+    policy_evidence_records: usize,
+    dependency_evidence_records: usize,
+    readiness_gap_evidence_records: usize,
+    platform_signer_records: usize,
+    integration_signer_records: usize,
+    security_signer_records: usize,
+    reviewer_signer_records: usize,
+    verification_signer_records: usize,
+    audit_signer_records: usize,
+    reviewer_required_records: usize,
+    exception_required_records: usize,
+    signoff_required_records: usize,
+    human_approval_records: usize,
+    first_attention_priority: Option<u8>,
+    first_blocked_priority: Option<u8>,
+    first_incomplete_priority: Option<u8>,
+    highest_policy_tier: PrivilegeTier,
+    overall_status: IntegrationActivationHealthStatus,
+}
+
+impl IntegrationActivationEvidenceLedgerSummary {
+    fn from_records<'a>(
+        records: impl IntoIterator<Item = &'a IntegrationActivationEvidenceLedgerRecord>,
+    ) -> Self {
+        let mut summary = Self {
+            total_records: 0,
+            unique_integrations: 0,
+            records_requiring_attention: 0,
+            blocked_records: 0,
+            complete_records: 0,
+            conditional_records: 0,
+            exception_pending_records: 0,
+            evidence_ready_records: 0,
+            source_linked_records: 0,
+            incident_evidence_records: 0,
+            policy_evidence_records: 0,
+            dependency_evidence_records: 0,
+            readiness_gap_evidence_records: 0,
+            platform_signer_records: 0,
+            integration_signer_records: 0,
+            security_signer_records: 0,
+            reviewer_signer_records: 0,
+            verification_signer_records: 0,
+            audit_signer_records: 0,
+            reviewer_required_records: 0,
+            exception_required_records: 0,
+            signoff_required_records: 0,
+            human_approval_records: 0,
+            first_attention_priority: None,
+            first_blocked_priority: None,
+            first_incomplete_priority: None,
+            highest_policy_tier: PrivilegeTier::ReadOnly,
+            overall_status: IntegrationActivationHealthStatus::Empty,
+        };
+        let mut integration_ids = BTreeSet::new();
+
+        for record in records {
+            summary.total_records += 1;
+            for integration_id in &record.integration_ids {
+                integration_ids.insert(integration_id.clone());
+            }
+            if record.requires_attention {
+                summary.records_requiring_attention += 1;
+                summary.first_attention_priority =
+                    min_optional_priority(summary.first_attention_priority, record.priority);
+            }
+            if record.blocks_activation {
+                summary.blocked_records += 1;
+                summary.first_blocked_priority =
+                    min_optional_priority(summary.first_blocked_priority, record.priority);
+            }
+            if !record.evidence_ready {
+                summary.first_incomplete_priority =
+                    min_optional_priority(summary.first_incomplete_priority, record.priority);
+            }
+            if record.evidence_ready {
+                summary.evidence_ready_records += 1;
+            }
+            if record.has_source_lineage() {
+                summary.source_linked_records += 1;
+            }
+            if record.reviewer_required {
+                summary.reviewer_required_records += 1;
+            }
+            if record.exception_required {
+                summary.exception_required_records += 1;
+            }
+            if record.signoff_required {
+                summary.signoff_required_records += 1;
+            }
+            if record.required_tier == PrivilegeTier::HumanApproval {
+                summary.human_approval_records += 1;
+            }
+            match record.ledger_status {
+                IntegrationActivationEvidenceLedgerStatus::Complete => {
+                    summary.complete_records += 1
+                }
+                IntegrationActivationEvidenceLedgerStatus::Conditional => {
+                    summary.conditional_records += 1
+                }
+                IntegrationActivationEvidenceLedgerStatus::ExceptionPending => {
+                    summary.exception_pending_records += 1
+                }
+                IntegrationActivationEvidenceLedgerStatus::Blocked => {}
+            }
+            match record.focus {
+                IntegrationActivationGuardrailKind::Incident => {
+                    summary.incident_evidence_records += 1
+                }
+                IntegrationActivationGuardrailKind::PolicyRisk => {
+                    summary.policy_evidence_records += 1
+                }
+                IntegrationActivationGuardrailKind::Dependency => {
+                    summary.dependency_evidence_records += 1
+                }
+                IntegrationActivationGuardrailKind::ReadinessGap => {
+                    summary.readiness_gap_evidence_records += 1
+                }
+            }
+            match record.signer_lane {
+                IntegrationActivationResponseOwnerLane::Platform => {
+                    summary.platform_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Integration => {
+                    summary.integration_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Security => {
+                    summary.security_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Reviewer => {
+                    summary.reviewer_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Verification => {
+                    summary.verification_signer_records += 1
+                }
+                IntegrationActivationResponseOwnerLane::Audit => summary.audit_signer_records += 1,
+            }
+            summary.highest_policy_tier = summary.highest_policy_tier.max(record.required_tier);
+        }
+
+        summary.unique_integrations = integration_ids.len();
+        summary.overall_status = if summary.total_records == 0 {
+            IntegrationActivationHealthStatus::Empty
+        } else if summary.blocked_records > 0 {
+            IntegrationActivationHealthStatus::Blocked
+        } else if summary.exception_pending_records > 0
+            || summary.conditional_records > 0
+            || summary.signoff_required_records > 0
+        {
+            IntegrationActivationHealthStatus::NeedsReview
+        } else {
+            IntegrationActivationHealthStatus::Ready
+        };
+        summary
+    }
+
+    fn has_blockers(&self) -> bool {
+        self.blocked_records > 0
+    }
+
+    fn requires_attention(&self) -> bool {
+        self.records_requiring_attention > 0
+            || self.exception_pending_records > 0
+            || self.signoff_required_records > 0
+    }
+
+    fn is_empty(&self) -> bool {
+        self.total_records == 0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IntegrationActivationEvidenceLedgerQuery {
+    attestations: IntegrationActivationAttestationQuery,
+    ledger_status: Option<IntegrationActivationEvidenceLedgerStatus>,
+    evidence_kind: Option<String>,
+    requires_attention: Option<bool>,
+    blocked: Option<bool>,
+    evidence_ready: Option<bool>,
+    ledger_limit: Option<usize>,
+}
+
 fn min_optional_priority(current: Option<u8>, priority: u8) -> Option<u8> {
     Some(current.map_or(priority, |existing| existing.min(priority)))
 }
@@ -8445,6 +8831,30 @@ fn integration_activation_attestation_query(
         signoff_required: optional_bool(arguments, "signoff_required")?,
         attestation_ready: optional_bool(arguments, "attestation_ready")?,
         attestation_limit: optional_u64(arguments, "attestation_limit")?
+            .or(optional_u64(arguments, "record_limit")?)
+            .map(|value| value as usize),
+    })
+}
+
+fn integration_activation_evidence_ledger_query(
+    arguments: &JsonValue,
+) -> Result<IntegrationActivationEvidenceLedgerQuery, ToolCallError> {
+    let ledger_status = optional_string(arguments, "ledger_status")?
+        .or(optional_string(arguments, "evidence_status")?)
+        .map(|label| parse_activation_evidence_ledger_status(&label))
+        .transpose()?;
+
+    Ok(IntegrationActivationEvidenceLedgerQuery {
+        attestations: integration_activation_attestation_query(arguments)?,
+        ledger_status,
+        evidence_kind: optional_string(arguments, "ledger_evidence_kind")?
+            .or(optional_string(arguments, "evidence_kind")?),
+        requires_attention: optional_bool(arguments, "ledger_requires_attention")?
+            .or(optional_bool(arguments, "requires_attention")?),
+        blocked: optional_bool(arguments, "ledger_blocked")?
+            .or(optional_bool(arguments, "blocked")?),
+        evidence_ready: optional_bool(arguments, "evidence_ready")?,
+        ledger_limit: optional_u64(arguments, "ledger_limit")?
             .or(optional_u64(arguments, "record_limit")?)
             .map(|value| value as usize),
     })
@@ -10070,6 +10480,41 @@ fn integration_activation_attestations_for_query(
         records.retain(|record| record.attestation_ready == attestation_ready);
     }
     if let Some(limit) = query.attestation_limit {
+        records.truncate(limit);
+    }
+
+    (records, catalog_count)
+}
+
+fn integration_activation_evidence_ledger_for_query(
+    query: &IntegrationActivationEvidenceLedgerQuery,
+) -> (Vec<IntegrationActivationEvidenceLedgerRecord>, usize) {
+    let (attestation_records, catalog_count) =
+        integration_activation_attestations_for_query(&query.attestations);
+    let mut records: Vec<_> = attestation_records
+        .iter()
+        .enumerate()
+        .map(|(index, record)| {
+            IntegrationActivationEvidenceLedgerRecord::from_attestation_record(index + 1, record)
+        })
+        .collect();
+
+    if let Some(status) = query.ledger_status {
+        records.retain(|record| record.ledger_status == status);
+    }
+    if let Some(evidence_kind) = &query.evidence_kind {
+        records.retain(|record| record.evidence_kind == *evidence_kind);
+    }
+    if let Some(requires_attention) = query.requires_attention {
+        records.retain(|record| record.requires_attention == requires_attention);
+    }
+    if let Some(blocked) = query.blocked {
+        records.retain(|record| record.blocks_activation == blocked);
+    }
+    if let Some(evidence_ready) = query.evidence_ready {
+        records.retain(|record| record.evidence_ready == evidence_ready);
+    }
+    if let Some(limit) = query.ledger_limit {
         records.truncate(limit);
     }
 
@@ -13822,6 +14267,84 @@ fn get_integration_activation_attestation_summary_output_handler_output(
             (
                 "exception_required_records",
                 integer(summary.exception_required_records as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn list_integration_activation_evidence_ledger_output_handler_output(
+    query: IntegrationActivationEvidenceLedgerQuery,
+) -> ToolHandlerOutput {
+    let (records, catalog_count) = integration_activation_evidence_ledger_for_query(&query);
+    let summary = IntegrationActivationEvidenceLedgerSummary::from_records(records.iter());
+    let count = records.len();
+
+    ToolHandlerOutput::new(object([
+        (
+            "activation_evidence_ledger",
+            JsonValue::Array(
+                records
+                    .iter()
+                    .map(activation_evidence_ledger_record_json)
+                    .collect(),
+            ),
+        ),
+        (
+            "summary",
+            integration_activation_evidence_ledger_summary_json(&summary),
+        ),
+        ("count", integer(count as i64)),
+        ("catalog_count", integer(catalog_count as i64)),
+    ]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("list_integration_activation_evidence_ledger"),
+            ),
+            ("records", integer(count as i64)),
+            (
+                "evidence_ready_records",
+                integer(summary.evidence_ready_records as i64),
+            ),
+            (
+                "source_linked_records",
+                integer(summary.source_linked_records as i64),
+            ),
+            ("blocked_records", integer(summary.blocked_records as i64)),
+            ("overall_status", string(summary.overall_status.as_str())),
+        ]),
+    )
+}
+
+fn get_integration_activation_evidence_ledger_summary_output_handler_output(
+    query: IntegrationActivationEvidenceLedgerQuery,
+) -> ToolHandlerOutput {
+    let (records, _) = integration_activation_evidence_ledger_for_query(&query);
+    let summary = IntegrationActivationEvidenceLedgerSummary::from_records(records.iter());
+
+    ToolHandlerOutput::new(object([(
+        "summary",
+        integration_activation_evidence_ledger_summary_json(&summary),
+    )]))
+    .with_event(
+        ToolEventKind::Progress,
+        object([
+            (
+                "operation",
+                string("get_integration_activation_evidence_ledger_summary"),
+            ),
+            ("total_records", integer(summary.total_records as i64)),
+            (
+                "evidence_ready_records",
+                integer(summary.evidence_ready_records as i64),
+            ),
+            (
+                "source_linked_records",
+                integer(summary.source_linked_records as i64),
             ),
             ("blocked_records", integer(summary.blocked_records as i64)),
             ("overall_status", string(summary.overall_status.as_str())),
@@ -26348,6 +26871,213 @@ fn integration_activation_attestation_summary_json(
     ])
 }
 
+fn activation_evidence_ledger_record_json(
+    record: &IntegrationActivationEvidenceLedgerRecord,
+) -> JsonValue {
+    object([
+        ("sequence", integer(record.sequence as i64)),
+        ("ledger_id", string(&record.ledger_id)),
+        ("evidence_package_id", string(&record.evidence_package_id)),
+        (
+            "source_attestation_id",
+            string(&record.source_attestation_id),
+        ),
+        ("source_compliance_id", string(&record.source_compliance_id)),
+        ("source_governance_id", string(&record.source_governance_id)),
+        ("source_assurance_id", string(&record.source_assurance_id)),
+        ("source_guardrail_id", string(&record.source_guardrail_id)),
+        ("ledger_status", string(record.ledger_status.as_str())),
+        (
+            "attestation_status",
+            string(record.attestation_status.as_str()),
+        ),
+        (
+            "compliance_verdict",
+            string(record.compliance_verdict.as_str()),
+        ),
+        ("evidence_kind", string(&record.evidence_kind)),
+        ("attestation_kind", string(&record.attestation_kind)),
+        ("control_objective", string(&record.control_objective)),
+        ("evidence_label", string(&record.evidence_label)),
+        ("focus", string(record.focus.as_str())),
+        ("signer_lane", string(record.signer_lane.as_str())),
+        ("owner_lane", string(record.owner_lane.as_str())),
+        ("recommended_view", string(record.recommended_view.as_str())),
+        ("title", string(&record.title)),
+        ("summary", string(&record.summary)),
+        ("priority", integer(record.priority as i64)),
+        (
+            "integration_ids",
+            JsonValue::Array(
+                record
+                    .integration_ids
+                    .iter()
+                    .map(|integration_id| string(integration_id.as_str()))
+                    .collect(),
+            ),
+        ),
+        (
+            "integration_count",
+            integer(record.integration_ids.len() as i64),
+        ),
+        (
+            "required_tier",
+            string(privilege_tier_label(record.required_tier)),
+        ),
+        (
+            "policy_surface",
+            record
+                .policy_surface
+                .map(|surface| string(surface.as_str()))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "reviewer_required",
+            JsonValue::Bool(record.reviewer_required),
+        ),
+        (
+            "exception_required",
+            JsonValue::Bool(record.exception_required),
+        ),
+        ("signoff_required", JsonValue::Bool(record.signoff_required)),
+        ("evidence_ready", JsonValue::Bool(record.evidence_ready)),
+        (
+            "blocks_activation",
+            JsonValue::Bool(record.blocks_activation),
+        ),
+        (
+            "requires_attention",
+            JsonValue::Bool(record.requires_attention),
+        ),
+        (
+            "has_source_lineage",
+            JsonValue::Bool(record.has_source_lineage()),
+        ),
+    ])
+}
+
+fn integration_activation_evidence_ledger_summary_json(
+    summary: &IntegrationActivationEvidenceLedgerSummary,
+) -> JsonValue {
+    object([
+        ("total_records", integer(summary.total_records as i64)),
+        (
+            "unique_integrations",
+            integer(summary.unique_integrations as i64),
+        ),
+        (
+            "records_requiring_attention",
+            integer(summary.records_requiring_attention as i64),
+        ),
+        ("blocked_records", integer(summary.blocked_records as i64)),
+        ("complete_records", integer(summary.complete_records as i64)),
+        (
+            "conditional_records",
+            integer(summary.conditional_records as i64),
+        ),
+        (
+            "exception_pending_records",
+            integer(summary.exception_pending_records as i64),
+        ),
+        (
+            "evidence_ready_records",
+            integer(summary.evidence_ready_records as i64),
+        ),
+        (
+            "source_linked_records",
+            integer(summary.source_linked_records as i64),
+        ),
+        (
+            "incident_evidence_records",
+            integer(summary.incident_evidence_records as i64),
+        ),
+        (
+            "policy_evidence_records",
+            integer(summary.policy_evidence_records as i64),
+        ),
+        (
+            "dependency_evidence_records",
+            integer(summary.dependency_evidence_records as i64),
+        ),
+        (
+            "readiness_gap_evidence_records",
+            integer(summary.readiness_gap_evidence_records as i64),
+        ),
+        (
+            "platform_signer_records",
+            integer(summary.platform_signer_records as i64),
+        ),
+        (
+            "integration_signer_records",
+            integer(summary.integration_signer_records as i64),
+        ),
+        (
+            "security_signer_records",
+            integer(summary.security_signer_records as i64),
+        ),
+        (
+            "reviewer_signer_records",
+            integer(summary.reviewer_signer_records as i64),
+        ),
+        (
+            "verification_signer_records",
+            integer(summary.verification_signer_records as i64),
+        ),
+        (
+            "audit_signer_records",
+            integer(summary.audit_signer_records as i64),
+        ),
+        (
+            "reviewer_required_records",
+            integer(summary.reviewer_required_records as i64),
+        ),
+        (
+            "exception_required_records",
+            integer(summary.exception_required_records as i64),
+        ),
+        (
+            "signoff_required_records",
+            integer(summary.signoff_required_records as i64),
+        ),
+        (
+            "human_approval_records",
+            integer(summary.human_approval_records as i64),
+        ),
+        (
+            "first_attention_priority",
+            summary
+                .first_attention_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_blocked_priority",
+            summary
+                .first_blocked_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "first_incomplete_priority",
+            summary
+                .first_incomplete_priority
+                .map(|priority| integer(priority as i64))
+                .unwrap_or(JsonValue::Null),
+        ),
+        (
+            "highest_policy_tier",
+            string(privilege_tier_label(summary.highest_policy_tier)),
+        ),
+        ("overall_status", string(summary.overall_status.as_str())),
+        ("is_empty", JsonValue::Bool(summary.is_empty())),
+        ("has_blockers", JsonValue::Bool(summary.has_blockers())),
+        (
+            "requires_attention",
+            JsonValue::Bool(summary.requires_attention()),
+        ),
+    ])
+}
+
 fn activation_risk_json(risk: &IntegrationActivationRiskItem) -> JsonValue {
     object([
         ("risk_kind", string(risk.kind.as_str())),
@@ -29688,6 +30418,26 @@ fn parse_activation_attestation_status(
     }
 }
 
+fn parse_activation_evidence_ledger_status(
+    label: &str,
+) -> Result<IntegrationActivationEvidenceLedgerStatus, ToolCallError> {
+    match label {
+        "complete" | "completed" | "ready" | "accepted" | "clear" | "ok" => {
+            Ok(IntegrationActivationEvidenceLedgerStatus::Complete)
+        }
+        "conditional" | "condition" | "monitor" | "watch" | "review" => {
+            Ok(IntegrationActivationEvidenceLedgerStatus::Conditional)
+        }
+        "exception_pending" | "exception" | "exception_required" | "pending_exception"
+        | "needs_exception" => Ok(IntegrationActivationEvidenceLedgerStatus::ExceptionPending),
+        "blocked" | "blocker" | "rejected" | "reject" | "hold" | "non_compliant"
+        | "noncompliant" => Ok(IntegrationActivationEvidenceLedgerStatus::Blocked),
+        _ => Err(validation_error(format!(
+            "unknown activation evidence ledger status `{label}`"
+        ))),
+    }
+}
+
 fn parse_activation_risk_kind(label: &str) -> Result<IntegrationActivationRiskKind, ToolCallError> {
     match label {
         "policy_tier" | "tier" | "required_tier" => Ok(IntegrationActivationRiskKind::PolicyTier),
@@ -31850,6 +32600,40 @@ fn integration_activation_attestation_query_schema() -> JsonSchema {
     schema
 }
 
+fn integration_activation_evidence_ledger_query_schema() -> JsonSchema {
+    let mut schema = integration_activation_attestation_query_schema();
+    if let JsonSchema::Object {
+        properties,
+        required: _,
+        allow_unknown_fields: _,
+    } = &mut schema
+    {
+        let mut push_if_absent = |property: SchemaProperty| {
+            if !properties
+                .iter()
+                .any(|existing| existing.name == property.name)
+            {
+                properties.push(property);
+            }
+        };
+        push_if_absent(SchemaProperty::new("ledger_status", JsonSchema::String));
+        push_if_absent(SchemaProperty::new("evidence_status", JsonSchema::String));
+        push_if_absent(SchemaProperty::new(
+            "ledger_evidence_kind",
+            JsonSchema::String,
+        ));
+        push_if_absent(SchemaProperty::new(
+            "ledger_requires_attention",
+            JsonSchema::Boolean,
+        ));
+        push_if_absent(SchemaProperty::new("ledger_blocked", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new("evidence_ready", JsonSchema::Boolean));
+        push_if_absent(SchemaProperty::new("ledger_limit", JsonSchema::Integer));
+        push_if_absent(SchemaProperty::new("record_limit", JsonSchema::Integer));
+    }
+    schema
+}
+
 fn integration_activation_risk_query_schema() -> JsonSchema {
     let mut schema = integration_activation_candidate_query_schema(true);
     if let JsonSchema::Object {
@@ -31994,7 +32778,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 149);
+        assert_eq!(definitions.len(), 151);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -32126,6 +32910,12 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_ATTESTATION_SUMMARY_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_SUMMARY_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID));
@@ -32421,7 +33211,7 @@ mod tests {
             .contains(&SMART_HOME_GET_INTEGRATION_ACTIVATION_GOVERNANCE_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            141
+            143
         );
         assert_eq!(
             export
@@ -32963,11 +33753,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(149))
+            Some(&integer(151))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(141))
+            Some(&integer(143))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),
@@ -39277,6 +40067,144 @@ mod tests {
             Some(&JsonValue::Bool(true))
         );
 
+        let list_activation_evidence_ledger_request = request(
+            "call-list-integration-activation-evidence-ledger",
+            SMART_HOME_LIST_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("ledger_requires_attention", JsonValue::Bool(true)),
+                ("ledger_limit", integer(3)),
+            ]),
+            5_075,
+        );
+        let list_activation_evidence_ledger_trace =
+            tool_runtime.invoke_with_events(&list_activation_evidence_ledger_request);
+        assert!(list_activation_evidence_ledger_trace.result.ok);
+        assert_eq!(
+            list_activation_evidence_ledger_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let list_activation_evidence_ledger_output = list_activation_evidence_ledger_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_evidence_ledger_count =
+            integer_value(field(list_activation_evidence_ledger_output, "count").unwrap()).unwrap();
+        assert!((1..=3).contains(&activation_evidence_ledger_count));
+        let activation_evidence_ledger_summary =
+            field(list_activation_evidence_ledger_output, "summary").unwrap();
+        assert_eq!(
+            field(activation_evidence_ledger_summary, "total_records"),
+            Some(&integer(activation_evidence_ledger_count))
+        );
+        assert!(
+            integer_value(
+                field(
+                    activation_evidence_ledger_summary,
+                    "records_requiring_attention",
+                )
+                .unwrap()
+            )
+            .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_evidence_ledger_summary, "requires_attention"),
+            Some(&JsonValue::Bool(true))
+        );
+        let activation_evidence_ledger = array_item(
+            field(
+                list_activation_evidence_ledger_output,
+                "activation_evidence_ledger",
+            )
+            .unwrap(),
+            0,
+        )
+        .unwrap();
+        assert!(field(activation_evidence_ledger, "ledger_id").is_some());
+        assert!(field(activation_evidence_ledger, "evidence_package_id").is_some());
+        assert!(field(activation_evidence_ledger, "source_attestation_id").is_some());
+        assert!(field(activation_evidence_ledger, "source_compliance_id").is_some());
+        assert!(field(activation_evidence_ledger, "source_governance_id").is_some());
+        assert_eq!(
+            field(activation_evidence_ledger, "has_source_lineage"),
+            Some(&JsonValue::Bool(true))
+        );
+
+        let activation_evidence_ledger_summary_request = request(
+            "call-integration-activation-evidence-ledger-summary",
+            SMART_HOME_GET_INTEGRATION_ACTIVATION_EVIDENCE_LEDGER_SUMMARY_TOOL_ID,
+            object([
+                ("priority_at_or_before", integer(2)),
+                (
+                    "available_primitives",
+                    JsonValue::Array(vec![
+                        string("normalized_model"),
+                        string("discovery_index"),
+                        string("command_mapping"),
+                        string("capability_policy"),
+                        string("supervision"),
+                    ]),
+                ),
+                (
+                    "allowed_capability_ids",
+                    JsonValue::Array(vec![string("smart_home.read")]),
+                ),
+                (
+                    "enabled_integrations",
+                    JsonValue::Array(vec![string("mqtt")]),
+                ),
+                ("ledger_blocked", JsonValue::Bool(true)),
+            ]),
+            5_076,
+        );
+        let activation_evidence_ledger_summary_trace =
+            tool_runtime.invoke_with_events(&activation_evidence_ledger_summary_request);
+        assert!(activation_evidence_ledger_summary_trace.result.ok);
+        assert_eq!(
+            activation_evidence_ledger_summary_trace
+                .summary()
+                .progress_event_count,
+            1
+        );
+        let activation_evidence_ledger_summary_output = activation_evidence_ledger_summary_trace
+            .result
+            .output
+            .as_ref()
+            .unwrap();
+        let activation_evidence_ledger_rollup =
+            field(activation_evidence_ledger_summary_output, "summary").unwrap();
+        assert!(
+            integer_value(field(activation_evidence_ledger_rollup, "blocked_records").unwrap())
+                .unwrap()
+                >= 1
+        );
+        assert_eq!(
+            field(activation_evidence_ledger_rollup, "has_blockers"),
+            Some(&JsonValue::Bool(true))
+        );
+
         let list_activation_risk_request = request(
             "call-list-integration-activation-risk",
             SMART_HOME_LIST_INTEGRATION_ACTIVATION_RISK_TOOL_ID,
@@ -41245,6 +42173,14 @@ mod tests {
             activation_attestation_summary_request,
             activation_attestation_summary_trace,
         );
+        journal.record_trace(
+            list_activation_evidence_ledger_request,
+            list_activation_evidence_ledger_trace,
+        );
+        journal.record_trace(
+            activation_evidence_ledger_summary_request,
+            activation_evidence_ledger_summary_trace,
+        );
         journal.record_trace(list_activation_risk_request, list_activation_risk_trace);
         journal.record_trace(
             activation_risk_summary_request,
@@ -41318,9 +42254,9 @@ mod tests {
         journal.record_trace(supervision_tick_request, supervision_tick_trace);
 
         let journal_summary = journal.summary();
-        assert_eq!(journal_summary.invocation_count, 149);
-        assert_eq!(journal_summary.completed_count, 149);
-        assert_eq!(journal.audit_records().len(), 149);
+        assert_eq!(journal_summary.invocation_count, 151);
+        assert_eq!(journal_summary.completed_count, 151);
+        assert_eq!(journal.audit_records().len(), 151);
 
         let runtime = runtime.borrow();
         assert_eq!(runtime.optimistic_state_count(), 0);

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1547,6 +1547,8 @@ pub enum SmartHomeTool {
     GetIntegrationActivationComplianceSummary,
     ListIntegrationActivationAttestations,
     GetIntegrationActivationAttestationSummary,
+    ListIntegrationActivationEvidenceLedger,
+    GetIntegrationActivationEvidenceLedgerSummary,
     ListIntegrationActivationRisk,
     GetIntegrationActivationRiskSummary,
     ListIntegrationActivationDependencies,
@@ -1894,6 +1896,12 @@ impl SmartHomeTool {
             }
             Self::GetIntegrationActivationAttestationSummary => {
                 read_tool("smart_home.get_integration_activation_attestation_summary")
+            }
+            Self::ListIntegrationActivationEvidenceLedger => {
+                read_tool("smart_home.list_integration_activation_evidence_ledger")
+            }
+            Self::GetIntegrationActivationEvidenceLedgerSummary => {
+                read_tool("smart_home.get_integration_activation_evidence_ledger_summary")
             }
             Self::ListIntegrationActivationRisk => {
                 read_tool("smart_home.list_integration_activation_risk")
@@ -2624,6 +2632,8 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetIntegrationActivationComplianceSummary,
         SmartHomeTool::ListIntegrationActivationAttestations,
         SmartHomeTool::GetIntegrationActivationAttestationSummary,
+        SmartHomeTool::ListIntegrationActivationEvidenceLedger,
+        SmartHomeTool::GetIntegrationActivationEvidenceLedgerSummary,
         SmartHomeTool::ListIntegrationActivationRisk,
         SmartHomeTool::GetIntegrationActivationRiskSummary,
         SmartHomeTool::ListIntegrationActivationDependencies,
@@ -3466,7 +3476,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 149);
+        assert_eq!(catalog.len(), 151);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_integrations"
@@ -4069,6 +4079,14 @@ mod tests {
             == "smart_home.get_integration_activation_attestation_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.list_integration_activation_evidence_ledger"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_integration_activation_evidence_ledger_summary"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -4076,15 +4094,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 149);
-        assert_eq!(summary.read_tools, 141);
+        assert_eq!(summary.total_tools, 151);
+        assert_eq!(summary.read_tools, 143);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 141);
+        assert_eq!(summary.read_only_tier_tools, 143);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 149);
+        assert_eq!(summary.total_required_capabilities, 151);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add shared smart-home tool catalog entries for activation evidence ledger list and summary reads
- project Chief activation attestation rows into evidence ledger records with source lineage back to compliance, governance, assurance, and guardrail IDs
- cover the new evidence ledger handlers, JSON output, schema, and runtime journal flow in the Chief smart-home bridge

## Validation
- cargo fmt -p smart-home-core -p chief-of-staff-smart-home-tools -- --check
- cargo test -p smart-home-core
- cargo test -p smart-home-integration-catalog
- cargo test -p hue-core
- cargo test -p smart-home-runtime
- cargo test -p smart-home-testkit
- cargo test -p smart-home-local-http
- cargo test -p smart-home-discovery
- cargo test -p chief-of-staff-smart-home-tools
- cargo test -p smart-home-runtime discover_tool -- --nocapture
- sh BUILD in smart-home-core, smart-home-integration-catalog, hue-core, smart-home-runtime, smart-home-testkit, smart-home-local-http, smart-home-discovery, chief-of-staff-smart-home-tools

Cargo.lock generated under code/packages/rust was removed before commit.