### PR TITLE
Add SPICE deck analysis plan selection

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **Deck analysis-plan selector** —
+  `select_deck_analysis_plan()` now resolves one explicit or implicit deck
+  analysis plan with stable ambiguity and invalid-card errors, matching Rust
+  and TypeScript.
+
 - **Deck analysis-plan resolver** —
   `resolve_deck_analyses()` now extracts `.op`, `.dc`, `.ac`, and `.tran`
   analysis cards before `.end` into stable metadata with shared diagnostics,

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -97,7 +97,9 @@ those stable measurement rows.
 `resolve_deck_analyses()` extracts `.op`, `.dc`, `.ac`, and `.tran` cards
 before `.end`, keeps non-analysis active lines, and reports stable diagnostics
 for malformed arguments, unsupported AC sweep modes, invalid sweep intervals,
-and unresolved scalar expressions.
+and unresolved scalar expressions. `select_deck_analysis_plan()` picks one
+explicit card by analysis alias, defaults decks without analysis cards to an
+implicit `.op`, and reports ambiguity before solver dispatch.
 `resolve_deck_outputs()` and `select_deck_output_probes()` extract `.save` and
 scoped or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `format_deck_op_table()`,
@@ -175,6 +177,8 @@ probe lists or malformed `V(node)` / `I(source)` probes.
 `resolve_deck_analyses()` extracts `.op`, `.dc`, `.ac`, and `.tran` cards
 before `.end`, preserves non-analysis active lines, and reports stable
 diagnostics for malformed deck-level analysis controls.
+`select_deck_analysis_plan()` returns one selected or implicit plan for
+downstream deck execution helpers.
 
 ## Controlled source examples
 

--- a/code/packages/python/spice-engine/src/spice_engine/__init__.py
+++ b/code/packages/python/spice-engine/src/spice_engine/__init__.py
@@ -44,6 +44,7 @@ from spice_engine.compatibility import (
     resolve_deck_outputs,
     resolve_deck_parameters,
     resolve_deck_sources,
+    select_deck_analysis_plan,
     select_deck_output_probes,
 )
 from spice_engine.elements import (
@@ -560,6 +561,7 @@ __all__ = [
     "resolve_deck_outputs",
     "resolve_deck_sources",
     "resolve_deck_parameters",
+    "select_deck_analysis_plan",
     "select_deck_output_probes",
     "sens_dc",
     "s_parameters",

--- a/code/packages/python/spice-engine/src/spice_engine/compatibility.py
+++ b/code/packages/python/spice-engine/src/spice_engine/compatibility.py
@@ -806,6 +806,48 @@ def resolve_deck_analyses(netlist: str) -> DeckAnalysisSummary:
     )
 
 
+def select_deck_analysis_plan(
+    netlist: str,
+    analysis: str | None = None,
+) -> DeckAnalysisPlan:
+    """Return one explicit or implicit deck analysis plan for execution."""
+
+    summary = resolve_deck_analyses(netlist)
+    if summary.diagnostics:
+        diagnostic = summary.diagnostics[0]
+        raise ValueError(
+            f"select_deck_analysis_plan: line {diagnostic.line_number}: {diagnostic.message}"
+        )
+
+    requested_analysis = None
+    if analysis is not None:
+        requested_analysis = _normalize_deck_analysis_name(analysis)
+        if requested_analysis is None:
+            raise ValueError(f"select_deck_analysis_plan: unsupported analysis {analysis!r}")
+
+    plans = list(summary.analyses)
+    if requested_analysis is not None:
+        plans = [plan for plan in plans if plan.analysis == requested_analysis]
+        if not plans:
+            raise ValueError(
+                f"select_deck_analysis_plan: no .{requested_analysis} analysis card found"
+            )
+        if len(plans) > 1:
+            raise ValueError(
+                f"select_deck_analysis_plan: multiple .{requested_analysis} analysis cards found"
+            )
+        return plans[0]
+
+    if not plans:
+        return DeckAnalysisPlan(".op", "op", 0)
+    if len(plans) > 1:
+        raise ValueError(
+            "select_deck_analysis_plan: multiple analysis cards found; "
+            "pass analysis to select one"
+        )
+    return plans[0]
+
+
 def compatibility_corpus() -> tuple[CompatibilityDeck, ...]:
     """Return the canonical first release-readiness compatibility corpus."""
 
@@ -2813,6 +2855,19 @@ def _normalize_deck_output_analysis(analysis: str) -> str | None:
     if normalized == "dc":
         return "dc"
     if normalized == "ac":
+        return "ac"
+    if normalized in {"tran", "transient"}:
+        return "tran"
+    return None
+
+
+def _normalize_deck_analysis_name(analysis: str) -> str | None:
+    normalized = analysis.strip().lower().removeprefix(".").replace("_", "-")
+    if normalized in {"op", "dcop", "operating-point", "operatingpoint"}:
+        return "op"
+    if normalized in {"dc", "dc-sweep", "dcsweep"}:
+        return "dc"
+    if normalized in {"ac", "ac-sweep", "acsweep"}:
         return "ac"
     if normalized in {"tran", "transient"}:
         return "tran"

--- a/code/packages/python/spice-engine/tests/test_compatibility.py
+++ b/code/packages/python/spice-engine/tests/test_compatibility.py
@@ -17,6 +17,7 @@ from spice_engine import (
     resolve_deck_outputs,
     resolve_deck_parameters,
     resolve_deck_sources,
+    select_deck_analysis_plan,
     select_deck_output_probes,
 )
 
@@ -640,6 +641,65 @@ def test_resolve_deck_analyses_reports_invalid_cards() -> None:
         "SPICE_DECK_ANALYSIS_SWEEP",
         "SPICE_DECK_ANALYSIS_SWEEP",
     ]
+
+
+def test_select_deck_analysis_plan_defaults_and_selects() -> None:
+    implicit = select_deck_analysis_plan(
+        """
+V1 in 0 DC 1
+R1 in 0 1k
+.end
+"""
+    )
+    assert implicit.directive == ".op"
+    assert implicit.analysis == "op"
+    assert implicit.line_number == 0
+
+    selected = select_deck_analysis_plan(
+        """
+V1 in 0 DC 0
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+""",
+        "transient",
+    )
+    assert selected.directive == ".tran"
+    assert selected.analysis == "tran"
+    assert selected.line_number == 4
+    assert selected.stop_time == pytest.approx(2.0e-3)
+
+
+def test_select_deck_analysis_plan_reports_ambiguous_or_invalid_selection() -> None:
+    with pytest.raises(ValueError, match="multiple analysis cards"):
+        select_deck_analysis_plan(
+            """
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+"""
+        )
+
+    with pytest.raises(ValueError, match=r"multiple \.tran analysis cards"):
+        select_deck_analysis_plan(
+            """
+.tran 1u 2m
+.tran 2u 4m
+.end
+""",
+            ".tran",
+        )
+
+    with pytest.raises(ValueError, match="unsupported analysis"):
+        select_deck_analysis_plan(".op\n.end\n", "noise")
+
+    with pytest.raises(ValueError, match=r"line 2: \.dc step value must be non-zero"):
+        select_deck_analysis_plan(
+            """
+.dc V1 0 1 0
+.end
+"""
+        )
 
 
 def test_resolve_deck_outputs_reports_invalid_cards() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `select_deck_analysis_plan` so callers can choose one explicit or
+  implicit deck analysis plan with stable ambiguity and invalid-card errors,
+  matching Python and TypeScript.
 - Add `resolve_deck_analyses` so `.op`, `.dc`, `.ac`, and `.tran` analysis
   cards are extracted before `.end` into stable metadata with shared
   diagnostics, matching Python and TypeScript.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -151,7 +151,9 @@ stable measurement rows.
 `resolve_deck_analyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, keeps non-analysis active lines, and reports stable diagnostics for
 malformed arguments, unsupported AC sweep modes, invalid sweep intervals, and
-unresolved scalar expressions.
+unresolved scalar expressions. `select_deck_analysis_plan` picks one explicit
+card by analysis alias, defaults decks without analysis cards to an implicit
+`.op`, and reports ambiguity before solver dispatch.
 `resolve_deck_fourier`, `fourier_transient_cards`, and
 `fourier_transient_deck` extract parsed `.four` / `.FOUR` cards before `.end`
 and route transient samples into the existing SPICE-style Fourier result shape
@@ -188,3 +190,5 @@ text table formatters.
 `resolve_deck_analyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, preserves non-analysis active lines, and reports stable diagnostics for
 malformed deck-level analysis controls.
+`select_deck_analysis_plan` returns one selected or implicit plan for
+downstream deck execution helpers.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3862,6 +3862,58 @@ pub fn resolve_deck_analyses(netlist: &str) -> DeckAnalysisSummary {
     }
 }
 
+pub fn select_deck_analysis_plan(
+    netlist: &str,
+    analysis: Option<&str>,
+) -> Result<DeckAnalysisPlan, SpiceError> {
+    let summary = resolve_deck_analyses(netlist);
+    if let Some(diagnostic) = summary.diagnostics.first() {
+        return Err(table_error(
+            "select_deck_analysis_plan",
+            &format!("line {}: {}", diagnostic.line_number, diagnostic.message),
+        ));
+    }
+
+    let requested_analysis = match analysis {
+        Some(value) => Some(normalize_deck_analysis_name(value).ok_or_else(|| {
+            table_error(
+                "select_deck_analysis_plan",
+                &format!("unsupported analysis {value:?}"),
+            )
+        })?),
+        None => None,
+    };
+
+    let mut plans = summary.analyses;
+    if let Some(requested_analysis) = requested_analysis {
+        plans.retain(|plan| plan.analysis == requested_analysis);
+        if plans.is_empty() {
+            return Err(table_error(
+                "select_deck_analysis_plan",
+                &format!("no .{requested_analysis} analysis card found"),
+            ));
+        }
+        if plans.len() > 1 {
+            return Err(table_error(
+                "select_deck_analysis_plan",
+                &format!("multiple .{requested_analysis} analysis cards found"),
+            ));
+        }
+        return Ok(plans.remove(0));
+    }
+
+    if plans.is_empty() {
+        return Ok(implicit_deck_op_analysis_plan());
+    }
+    if plans.len() > 1 {
+        return Err(table_error(
+            "select_deck_analysis_plan",
+            "multiple analysis cards found; pass analysis to select one",
+        ));
+    }
+    Ok(plans.remove(0))
+}
+
 pub fn release_readiness_gates(corpus: &[CompatibilityDeck]) -> ReleaseReadinessReport {
     let mut issues = Vec::new();
     let mut seen_ids = HashSet::new();
@@ -6483,6 +6535,43 @@ fn normalize_deck_output_analysis(analysis: &str) -> Option<&'static str> {
         "ac" => Some("ac"),
         "tran" | "transient" => Some("tran"),
         _ => None,
+    }
+}
+
+fn normalize_deck_analysis_name(analysis: &str) -> Option<&'static str> {
+    match analysis
+        .trim()
+        .trim_start_matches('.')
+        .replace('_', "-")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "op" | "dcop" | "operating-point" | "operatingpoint" => Some("op"),
+        "dc" | "dc-sweep" | "dcsweep" => Some("dc"),
+        "ac" | "ac-sweep" | "acsweep" => Some("ac"),
+        "tran" | "transient" => Some("tran"),
+        _ => None,
+    }
+}
+
+fn implicit_deck_op_analysis_plan() -> DeckAnalysisPlan {
+    DeckAnalysisPlan {
+        directive: ".op".to_string(),
+        analysis: "op".to_string(),
+        line_number: 0,
+        source_name: None,
+        start_value: None,
+        stop_value: None,
+        step_value: None,
+        sweep_kind: None,
+        point_count: None,
+        start_frequency_hz: None,
+        stop_frequency_hz: None,
+        step_time: None,
+        stop_time: None,
+        start_time: None,
+        max_step: None,
+        use_initial_conditions: false,
     }
 }
 

--- a/code/packages/rust/spice-engine/tests/compatibility_tests.rs
+++ b/code/packages/rust/spice-engine/tests/compatibility_tests.rs
@@ -5,7 +5,8 @@ use spice_engine::{
     format_release_readiness_report, release_readiness_gates, resolve_deck_analyses,
     resolve_deck_fourier, resolve_deck_functions, resolve_deck_initial_conditions,
     resolve_deck_measurements, resolve_deck_outputs, resolve_deck_parameters, resolve_deck_sources,
-    select_deck_output_probes, CompatibilityDeck, CompatibilityGoldenValue, CompatibilityOracle,
+    select_deck_analysis_plan, select_deck_output_probes, CompatibilityDeck,
+    CompatibilityGoldenValue, CompatibilityOracle,
 };
 
 #[test]
@@ -905,6 +906,80 @@ fn resolve_deck_analyses_reports_invalid_cards() {
             "SPICE_DECK_ANALYSIS_SWEEP",
         ]
     );
+}
+
+#[test]
+fn select_deck_analysis_plan_defaults_and_selects() {
+    let implicit = select_deck_analysis_plan(
+        "
+V1 in 0 DC 1
+R1 in 0 1k
+.end
+",
+        None,
+    )
+    .unwrap();
+    assert_eq!(implicit.directive, ".op");
+    assert_eq!(implicit.analysis, "op");
+    assert_eq!(implicit.line_number, 0);
+
+    let selected = select_deck_analysis_plan(
+        "
+V1 in 0 DC 0
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+",
+        Some("transient"),
+    )
+    .unwrap();
+    assert_eq!(selected.directive, ".tran");
+    assert_eq!(selected.analysis, "tran");
+    assert_eq!(selected.line_number, 4);
+    assert!((selected.stop_time.unwrap() - 2.0e-3).abs() < 1.0e-12);
+}
+
+#[test]
+fn select_deck_analysis_plan_reports_ambiguous_or_invalid_selection() {
+    let error = select_deck_analysis_plan(
+        "
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+",
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("multiple analysis cards"));
+
+    let error = select_deck_analysis_plan(
+        "
+.tran 1u 2m
+.tran 2u 4m
+.end
+",
+        Some(".tran"),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("multiple .tran analysis cards"));
+
+    let error = select_deck_analysis_plan(".op\n.end\n", Some("noise"))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("unsupported analysis"));
+
+    let error = select_deck_analysis_plan(
+        "
+.dc V1 0 1 0
+.end
+",
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("line 2: .dc step value must be non-zero"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `selectDeckAnalysisPlan` so callers can choose one explicit or implicit
+  deck analysis plan with stable ambiguity and invalid-card errors, matching
+  Python and Rust.
 - Add `resolveDeckAnalyses` so `.op`, `.dc`, `.ac`, and `.tran` analysis
   cards are extracted before `.end` into stable metadata with shared
   diagnostics, matching Python and Rust.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -85,7 +85,9 @@ measurement rows.
 `resolveDeckAnalyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, keeps non-analysis active lines, and reports stable diagnostics for
 malformed arguments, unsupported AC sweep modes, invalid sweep intervals, and
-unresolved scalar expressions.
+unresolved scalar expressions. `selectDeckAnalysisPlan` picks one explicit card
+by analysis alias, defaults decks without analysis cards to an implicit `.op`,
+and reports ambiguity before solver dispatch.
 `resolveDeckOutputs` and `selectDeckOutputProbes` extract `.save` and scoped
 or global `.probe` cards before `.end`, normalize and deduplicate output
 probes in deck order, and feed `formatDeckOpTable`,
@@ -151,3 +153,5 @@ probe lists or malformed `V(node)` / `I(source)` probes.
 `resolveDeckAnalyses` extracts `.op`, `.dc`, `.ac`, and `.tran` cards before
 `.end`, preserves non-analysis active lines, and reports stable diagnostics for
 malformed deck-level analysis controls.
+`selectDeckAnalysisPlan` returns one selected or implicit plan for downstream
+deck execution helpers.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -3135,6 +3135,53 @@ export function resolveDeckAnalyses(netlist: string): DeckAnalysisSummary {
   };
 }
 
+export function selectDeckAnalysisPlan(netlist: string, analysis?: string): DeckAnalysisPlan {
+  const summary = resolveDeckAnalyses(netlist);
+  if (summary.diagnostics.length > 0) {
+    const diagnostic = summary.diagnostics[0];
+    throw invalidElement(
+      "selectDeckAnalysisPlan",
+      `line ${diagnostic.lineNumber}: ${diagnostic.message}`,
+    );
+  }
+
+  const requestedAnalysis = analysis === undefined
+    ? undefined
+    : normalizeDeckAnalysisName(analysis);
+  if (analysis !== undefined && requestedAnalysis === undefined) {
+    throw invalidElement("selectDeckAnalysisPlan", `unsupported analysis ${JSON.stringify(analysis)}`);
+  }
+
+  let plans = [...summary.analyses];
+  if (requestedAnalysis !== undefined) {
+    plans = plans.filter((plan) => plan.analysis === requestedAnalysis);
+    if (plans.length === 0) {
+      throw invalidElement(
+        "selectDeckAnalysisPlan",
+        `no .${requestedAnalysis} analysis card found`,
+      );
+    }
+    if (plans.length > 1) {
+      throw invalidElement(
+        "selectDeckAnalysisPlan",
+        `multiple .${requestedAnalysis} analysis cards found`,
+      );
+    }
+    return plans[0];
+  }
+
+  if (plans.length === 0) {
+    return { directive: ".op", analysis: "op", lineNumber: 0, useInitialConditions: false };
+  }
+  if (plans.length > 1) {
+    throw invalidElement(
+      "selectDeckAnalysisPlan",
+      "multiple analysis cards found; pass analysis to select one",
+    );
+  }
+  return plans[0];
+}
+
 export function releaseReadinessGates(
   corpus: readonly CompatibilityDeck[] = COMPATIBILITY_CORPUS,
 ): ReleaseReadinessReport {
@@ -5313,6 +5360,29 @@ function normalizeDeckOutputAnalysis(analysis: string): DeckOutputSelection["ana
     case "dc":
       return "dc";
     case "ac":
+      return "ac";
+    case "tran":
+    case "transient":
+      return "tran";
+    default:
+      return undefined;
+  }
+}
+
+function normalizeDeckAnalysisName(analysis: string): DeckAnalysisPlan["analysis"] | undefined {
+  switch (analysis.trim().toLowerCase().replace(/^\./, "").replace(/_/g, "-")) {
+    case "op":
+    case "dcop":
+    case "operating-point":
+    case "operatingpoint":
+      return "op";
+    case "dc":
+    case "dc-sweep":
+    case "dcsweep":
+      return "dc";
+    case "ac":
+    case "ac-sweep":
+    case "acsweep":
       return "ac";
     case "tran":
     case "transient":

--- a/code/packages/typescript/spice-engine/tests/compatibility.test.ts
+++ b/code/packages/typescript/spice-engine/tests/compatibility.test.ts
@@ -14,6 +14,7 @@ import {
   resolveDeckOutputs,
   resolveDeckParameters,
   resolveDeckSources,
+  selectDeckAnalysisPlan,
   selectDeckOutputProbes,
 } from "../src/index.js";
 
@@ -679,5 +680,62 @@ R1 in out 1k
       "SPICE_DECK_ANALYSIS_SWEEP",
       "SPICE_DECK_ANALYSIS_SWEEP",
     ]);
+  });
+
+  it("defaults and selects deck analysis plans", () => {
+    const implicit = selectDeckAnalysisPlan(`
+V1 in 0 DC 1
+R1 in 0 1k
+.end
+`);
+    expect(implicit.directive).toBe(".op");
+    expect(implicit.analysis).toBe("op");
+    expect(implicit.lineNumber).toBe(0);
+
+    const selected = selectDeckAnalysisPlan(
+      `
+V1 in 0 DC 0
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+`,
+      "transient",
+    );
+    expect(selected.directive).toBe(".tran");
+    expect(selected.analysis).toBe("tran");
+    expect(selected.lineNumber).toBe(4);
+    expect(selected.stopTime).toBeCloseTo(2.0e-3);
+  });
+
+  it("reports ambiguous or invalid deck analysis plan selection", () => {
+    expect(() =>
+      selectDeckAnalysisPlan(`
+.dc V1 0 5 1
+.tran 1u 2m
+.end
+`),
+    ).toThrow(/multiple analysis cards/);
+
+    expect(() =>
+      selectDeckAnalysisPlan(
+        `
+.tran 1u 2m
+.tran 2u 4m
+.end
+`,
+        ".tran",
+      ),
+    ).toThrow(/multiple \.tran analysis cards/);
+
+    expect(() => selectDeckAnalysisPlan(".op\n.end\n", "noise")).toThrow(
+      /unsupported analysis/,
+    );
+
+    expect(() =>
+      selectDeckAnalysisPlan(`
+.dc V1 0 1 0
+.end
+`),
+    ).toThrow(/line 2: \.dc step value must be non-zero/);
   });
 });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -46,7 +46,8 @@ downstream tools to compare.
      stable scalar rows; parsed transient `.four` deck cards now route harmonic
      analyses over transient outputs with optional `HARMONICS=` and `FROM=`
      controls; parsed `.op`, `.dc`, `.ac`, and `.tran` cards now resolve into
-     shared cross-language analysis-plan metadata before execution.
+     shared cross-language analysis-plan metadata before execution, and callers
+     can select one explicit or implicit plan with stable ambiguity errors.
    - Expand remaining deck-controlled analyses toward full SPICE compatibility
      while keeping unsupported control-flow diagnostics explicit.
 
@@ -375,10 +376,21 @@ downstream tools to compare.
     - This closes the first runnable-analysis metadata foothold while leaving
       actual deck dispatch into solver executions in backlog.
 
+32. Deck analysis-plan selector.
+    - Status: completed in this analysis-plan selection slice.
+    - Python, Rust, and TypeScript now expose matching helpers for selecting one
+      explicit `.op`, `.dc`, `.ac`, or `.tran` analysis plan by normalized
+      analysis alias.
+    - Decks without analysis cards default to an implicit `.op` plan, while
+      decks with multiple candidate cards report stable ambiguity errors before
+      solver dispatch.
+    - This gives deck execution helpers a deterministic single-plan bridge
+      while leaving full selected-plan-to-solver dispatch in backlog.
+
 ## Backlog
 
 1. Deck execution layer.
-   - Convert parsed analysis-plan metadata into runnable solver executions.
+   - Wire selected analysis-plan metadata into runnable solver executions.
    - Expand deck-controlled output-plan integration beyond stable table
      routing toward full SPICE compatibility.
    - Define a deliberate `.control` subset; explicit unsupported-feature


### PR DESCRIPTION
## Summary
- add cross-language deck analysis-plan selectors for choosing one explicit or implicit `.op`/`.dc`/`.ac`/`.tran` plan
- normalize analysis aliases, default decks without analysis cards to implicit `.op`, and report ambiguity/invalid-card errors before dispatch
- document the completed selector slice and leave selected-plan-to-solver execution wiring in backlog

## Verification
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m ruff check code/packages/python/spice-engine/src/spice_engine/compatibility.py code/packages/python/spice-engine/src/spice_engine/__init__.py code/packages/python/spice-engine/tests/test_compatibility.py`
- `PYTHONPATH="$(find code/packages/python -maxdepth 2 -type d -name src | paste -sd: -)" /Users/adhithya/.local/share/mise/installs/python/3.12.13/bin/python3 -m pytest code/packages/python/spice-engine/tests -q --no-cov`
- `npm --prefix code/packages/typescript/spice-engine run build`
- `npm --prefix code/packages/typescript/spice-engine test`
- `cargo test --manifest-path code/packages/rust/spice-engine/Cargo.toml`
- `git diff --check`