### PR TITLE
Add Z-Wave controller readiness summary

### DIFF
--- a/code/packages/rust/zwave-core/CHANGELOG.md
+++ b/code/packages/rust/zwave-core/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
   shape diagnostics.
 - Command-class and Serial API frame batch summaries for supervisor coverage
   views.
+- Z-Wave controller readiness summaries that combine node, command-class,
+  Serial API, security, and Long Range region signals.
 
 ## [0.1.0] - 2026-05-06
 

--- a/code/packages/rust/zwave-core/README.md
+++ b/code/packages/rust/zwave-core/README.md
@@ -12,6 +12,8 @@ Current scope:
 - command-class payload frame parse/encode for short and extended class ids
 - command-class frame summaries plus Serial API per-frame and batch summaries
   for supervisor views
+- controller readiness summaries that combine node, command-class, Serial API,
+  security, and Long Range region signals
 - Serial API SOF/ACK/NAK/CAN constants
 - Serial API request/response frame parse and encode
 - checksum validation

--- a/code/packages/rust/zwave-core/src/lib.rs
+++ b/code/packages/rust/zwave-core/src/lib.rs
@@ -493,6 +493,85 @@ pub fn summarize_serial_frames<'a>(
     SerialFrameBatchSummary::from_frames(frames)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZWaveControllerReadinessSummary {
+    pub network: ZWaveNetworkSummary,
+    pub command_frames: CommandClassFrameSummary,
+    pub serial_frames: SerialFrameBatchSummary,
+    pub has_nodes: bool,
+    pub has_command_class_coverage: bool,
+    pub has_serial_requests: bool,
+    pub has_serial_responses: bool,
+    pub has_security_coverage: bool,
+    pub long_range_region_mismatch: bool,
+}
+
+impl ZWaveControllerReadinessSummary {
+    pub fn from_summaries(
+        network: ZWaveNetworkSummary,
+        command_frames: CommandClassFrameSummary,
+        serial_frames: SerialFrameBatchSummary,
+    ) -> Self {
+        let has_nodes = network.has_nodes();
+        let has_command_class_coverage =
+            network.command_class_entries > 0 || !command_frames.is_empty();
+        let has_serial_requests = serial_frames.has_requests();
+        let has_serial_responses = serial_frames.has_responses();
+        let has_security_coverage =
+            network.has_security() || command_frames.has_security_2_frames();
+        let long_range_region_mismatch =
+            network.has_long_range_nodes() && !network.supports_long_range;
+
+        Self {
+            network,
+            command_frames,
+            serial_frames,
+            has_nodes,
+            has_command_class_coverage,
+            has_serial_requests,
+            has_serial_responses,
+            has_security_coverage,
+            long_range_region_mismatch,
+        }
+    }
+
+    pub fn is_ready(self) -> bool {
+        self.has_nodes
+            && self.has_command_class_coverage
+            && self.has_serial_requests
+            && self.has_serial_responses
+            && !self.long_range_region_mismatch
+    }
+
+    pub fn needs_node_discovery(self) -> bool {
+        !self.has_nodes
+    }
+
+    pub fn needs_command_class_interview(self) -> bool {
+        self.has_nodes && !self.has_command_class_coverage
+    }
+
+    pub fn needs_serial_probe(self) -> bool {
+        !self.has_serial_requests
+    }
+
+    pub fn waiting_for_serial_response(self) -> bool {
+        self.has_serial_requests && !self.has_serial_responses
+    }
+
+    pub fn needs_region_review(self) -> bool {
+        self.long_range_region_mismatch
+    }
+}
+
+pub fn summarize_zwave_controller_readiness(
+    network: ZWaveNetworkSummary,
+    command_frames: CommandClassFrameSummary,
+    serial_frames: SerialFrameBatchSummary,
+) -> ZWaveControllerReadinessSummary {
+    ZWaveControllerReadinessSummary::from_summaries(network, command_frames, serial_frames)
+}
+
 pub fn serial_checksum(bytes_after_sof_before_checksum: &[u8]) -> u8 {
     bytes_after_sof_before_checksum
         .iter()
@@ -746,6 +825,70 @@ mod tests {
         assert!(summary.has_extended_command_classes());
         assert!(summary.has_security_2_frames());
         assert!(!summary.is_empty());
+    }
+
+    #[test]
+    fn controller_readiness_summary_marks_ready_controller_surface() {
+        let network = ZWaveNetworkSummary::from_parts(
+            RegionProfile::UnitedStatesLongRange,
+            [
+                NodeId::classic(2).unwrap(),
+                NodeId::long_range(2_001).unwrap(),
+            ],
+            [CommandClassId::SWITCH_BINARY],
+        );
+        let security2 = CommandClassFrame::new(CommandClassId::SECURITY_2, 0x02, vec![0x01]);
+        let command_frames = summarize_command_class_frames([&security2]);
+        let request = SerialFrame::new(SerialFrameType::Request, 0x13, vec![0x02, 0x25, 0x01]);
+        let response = SerialFrame::new(SerialFrameType::Response, 0x02, vec![0x01]);
+        let serial_frames = summarize_serial_frames([&request, &response]);
+
+        let readiness =
+            summarize_zwave_controller_readiness(network, command_frames, serial_frames);
+
+        assert_eq!(
+            readiness,
+            ZWaveControllerReadinessSummary {
+                network,
+                command_frames,
+                serial_frames,
+                has_nodes: true,
+                has_command_class_coverage: true,
+                has_serial_requests: true,
+                has_serial_responses: true,
+                has_security_coverage: true,
+                long_range_region_mismatch: false,
+            }
+        );
+        assert!(readiness.is_ready());
+        assert!(!readiness.needs_node_discovery());
+        assert!(!readiness.needs_command_class_interview());
+        assert!(!readiness.needs_serial_probe());
+        assert!(!readiness.waiting_for_serial_response());
+        assert!(!readiness.needs_region_review());
+    }
+
+    #[test]
+    fn controller_readiness_summary_flags_blocked_controller_surface() {
+        let network = ZWaveNetworkSummary::from_parts(
+            RegionProfile::UnitedStates,
+            [NodeId::long_range(2_001).unwrap()],
+            std::iter::empty::<CommandClassId>(),
+        );
+        let command_frames = CommandClassFrameSummary::default();
+        let request = SerialFrame::new(SerialFrameType::Request, 0x13, vec![0x02, 0x25, 0x01]);
+        let serial_frames = summarize_serial_frames([&request]);
+
+        let readiness =
+            summarize_zwave_controller_readiness(network, command_frames, serial_frames);
+
+        assert!(!readiness.is_ready());
+        assert!(!readiness.needs_node_discovery());
+        assert!(readiness.needs_command_class_interview());
+        assert!(!readiness.needs_serial_probe());
+        assert!(readiness.waiting_for_serial_response());
+        assert!(readiness.needs_region_review());
+        assert!(!readiness.has_security_coverage);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a Z-Wave controller readiness rollup derived from existing network, command-class, and Serial API summaries
- expose readiness predicates for node discovery, command-class interview, serial probe/response, and Long Range region review
- document the new readiness helper in zwave-core README and changelog

## Tests
- cargo fmt --manifest-path code/packages/rust/zwave-core/Cargo.toml
- cargo test --manifest-path code/packages/rust/zwave-core/Cargo.toml -- --nocapture
- git diff --check