### PR TITLE
feat(mycin-2026): treatment as a solved constraint problem — treat fast and cheap

### DIFF
--- a/code/specs/data/mycin-2026/treatment/README.md
+++ b/code/specs/data/mycin-2026/treatment/README.md
@@ -1,0 +1,74 @@
+# Treatment as a solved constraint problem
+
+The diagnostic layer answers *"how probable is bacterial meningitis?"* But the
+practice of medicine asks a different question — *"do we treat now, and with what?"*
+— and that one is **not** the argmax of the differential. Medicine treats **fast
+and cheap**: missing bacterial meningitis is catastrophic, empirical antibiotics
+are cheap and low-harm, and there is a hard **door-to-antibiotic deadline**. So
+the treatment decision is itself a **constraint problem**, solved by the *same*
+`adj-lang` constraint solver (`symbol` / `constrain` / `solve` / `check`) the
+diagnostic engine already uses — at **0 answer-time model calls**.
+
+```sh
+python3 treatment/treat.py <case_id>        # diagnose, then solve the treatment decision
+python3 treatment/treat.py x --p 0.30       # evaluate the policy at any P(bacterial)
+python3 treatment/test_treatment.py         # CI guard
+```
+
+## The two constraints the solver solves
+
+**(A) Cost break-even** — solve for the probability `p*` at which treating equals
+waiting:
+
+```adj
+symbol p_star : scalar
+observe cost_miss(100)        % harm of MISSING bacterial meningitis (death/disability)
+observe cost_treat(1)         % harm/cost of empirical antibiotics if not bacterial
+constrain p_star * cost_miss = cost_treat
+solve for { p_star }          % -> p_star = 0.01 ; treat iff P(bacterial) >= p_star
+```
+
+Because `cost_miss >> cost_treat`, `p*` is tiny — you treat even at a low
+probability. The numbers are the **policy**, and like the rulebook they are
+auditable, editable inputs, not magic constants.
+
+**(B) Time feasibility** — `check` whether **waiting** for a definitive culture
+result can satisfy the door-to-antibiotic deadline:
+
+```adj
+symbol wait_strategy : scalar
+observe culture_hours(48)     % time to a definitive CSF culture
+observe deadline_hours(1)     % door-to-antibiotic target (IDSA ~1 h)
+constrain wait_strategy = culture_hours
+constrain wait_strategy <= deadline_hours
+check                         % -> UNSAT (IIS core [0,1]) : you CANNOT wait
+```
+
+The solver **proves** the decision cannot be deferred — it must be made now, on
+current evidence.
+
+## The headline: cost+time override the argmax probability
+
+This resolves the honest paradox from the diagnostic layer (the M8
+cost-to-correct finding): after calibration a pre-culture case can be *more
+probably viral* by base rate, yet:
+
+```
+P(bacterial)=0.30  most-probable dx = viral_meningitis
+  -> ACTION: TREAT EMPIRICALLY NOW
+  ^ the cost+time constraints OVERRIDE the argmax probability:
+    viral is more probable, but you treat for bacterial now.
+```
+
+You act on **cost and time**, not on the argmax probability — and the
+recommendation cites the solved `p*` and the binding time constraint (its IIS
+core), so it is auditable end to end, with no model in the decision loop.
+
+## Honest limits
+- The cost/time parameters are an illustrative policy (utility units), not a
+  validated health-economic model; they are explicit inputs precisely so a
+  clinician can audit and edit them.
+- Single empirical regimen, single deadline; antibiotic-choice, resistance, and
+  renal-dose constraints (all natural `constrain`s) are future work.
+- This is a mechanism demonstration on the meningitis differential, not a
+  treatment-authorizing tool.

--- a/code/specs/data/mycin-2026/treatment/test_treatment.py
+++ b/code/specs/data/mycin-2026/treatment/test_treatment.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""test_treatment.py - guard the treatment-as-constraint layer. 0 model calls.
+
+Asserts the SAME constraint solver that diagnoses also makes the treatment
+decision, and that cost+time can override the argmax probability:
+  - cost break-even solves to p* = cost_treat/cost_miss;
+  - waiting for culture within the door-to-antibiotic deadline is UNSAT;
+  - at a probability where viral is MORE probable (P(bacterial) < 0.5) but above
+    p*, the action is still "treat empirically now" (the override);
+  - below p*, treatment is withheld.
+Skips cleanly without adj-lang-cli.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import treat as treat_mod  # noqa: E402
+sys.path.insert(0, str(HERE.parent / "warm"))
+import decide as decide_mod  # noqa: E402
+
+
+def main() -> int:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("test_treatment: SKIPPED (adj-lang-cli not built)")
+        return 0
+
+    # cost break-even = cost_treat / cost_miss.
+    p_star = treat_mod.cost_breakeven(cli)
+    assert abs(p_star - treat_mod.COST_TREAT / treat_mod.COST_MISS) < 1e-9, p_star
+
+    # waiting for culture within the deadline is infeasible (solver proves it).
+    timing = treat_mod.can_wait_for_culture(cli)
+    assert timing.get("outcome") == "unsat", timing
+    assert timing.get("core"), timing
+
+    # OVERRIDE: viral more probable (P=0.30) but above p* -> treat anyway.
+    over = treat_mod.recommend("synthetic", cli, p_override=0.30)
+    assert over["answer_time_model_calls"] == 0
+    assert over["most_probable_dx"] == "viral_meningitis"
+    assert over["action"].startswith("TREAT")
+    assert over["overrides_argmax_probability"] is True, over
+
+    # Below p* -> withhold.
+    low = treat_mod.recommend("synthetic", cli, p_override=p_star / 2)
+    assert not low["treat_threshold_met"], low
+    assert low["action"].startswith("WITHHOLD"), low
+
+    print(f"test_treatment: PASS (p*={p_star}; wait-for-culture UNSAT core={timing['core']}; "
+          f"P=0.30 viral-more-probable -> TREAT overrides argmax; P<p* -> withhold)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/mycin-2026/treatment/treat.py
+++ b/code/specs/data/mycin-2026/treatment/treat.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""treat.py - the treatment decision as a SOLVED constraint problem. 0 model calls.
+
+MYCIN-2026 (treatment layer). The differential gives P(bacterial); the clinical
+ACTION - treat empirically now, or wait for definitive culture - is NOT the
+argmax-posterior. Medicine treats fast and cheap: missing bacterial meningitis is
+catastrophic, empirical antibiotics are cheap and low-harm, and there is a hard
+door-to-antibiotic deadline. So the decision is a constraint problem the SAME
+solver (adj-lang `symbol`/`constrain`/`solve`/`check`) solves:
+
+  (A) COST break-even - solve for the probability p* at which treating equals
+      waiting:  p* * cost_miss = cost_treat  ->  treat iff P(bacterial) >= p*.
+      With cost_miss >> cost_treat, p* is tiny: you treat even at low probability.
+
+  (B) TIME feasibility - check whether WAITING for a definitive culture result can
+      satisfy the door-to-antibiotic deadline:  culture_hours <= deadline_hours.
+      Culture takes ~48 h, the deadline is ~1 h, so this is UNSAT (with an IIS
+      core) - the solver PROVES you cannot defer the decision; it must be made now
+      on current evidence.
+
+This resolves the honest paradox from the diagnostic layer: a pre-culture case can
+be *more probably* viral (by base rate) yet the cost+time-constrained decision is
+"treat empirically for bacterial NOW" - because you act on COST and TIME, not on
+the argmax probability. The recommendation cites the solved p* and the binding
+time constraint, so it is auditable end to end.
+
+Usage:  python3 treat.py <case_id>     (reads ir/<case_id>.json; runs the warm decide)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MYCIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(MYCIN / "warm"))
+import decide as decide_mod  # noqa: E402
+import ir_to_adj as ir_mod  # noqa: E402
+
+IR_DIR = MYCIN / "ir"
+
+# Clinical cost/time parameters (utility units; documented, editable - they are
+# the policy, and like the rulebook they are auditable inputs, not magic numbers).
+COST_MISS = 100   # harm of MISSING bacterial meningitis (death/disability) - large
+COST_TREAT = 1    # harm/cost of empirical antibiotics if not bacterial - small
+DEADLINE_HOURS = 1    # door-to-antibiotic target (IDSA: antibiotics within ~1 h)
+CULTURE_HOURS = 48    # time to a definitive CSF culture result
+
+
+def run_check_or_solve(cli: Path, program: str, key: str) -> dict:
+    p = MYCIN / "treatment" / "_tmp_policy.adj"
+    p.write_text(program)
+    try:
+        r = subprocess.run([str(cli), str(p)], capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+        return json.loads(r.stdout).get(key, {})
+    finally:
+        p.unlink(missing_ok=True)
+
+
+def cost_breakeven(cli: Path) -> float:
+    """Solve p* : p* * cost_miss = cost_treat (the treat-iff threshold)."""
+    prog = (f"symbol p_star : scalar\nobserve cost_miss({COST_MISS})\n"
+            f"observe cost_treat({COST_TREAT})\n"
+            f"constrain p_star * cost_miss = cost_treat\nsolve for {{ p_star }}\n")
+    out = run_check_or_solve(cli, prog, "solve")
+    for a in out.get("assignments", []):
+        if a["name"] == "p_star":
+            return float(a["value"])
+    raise RuntimeError(f"break-even did not solve: {out}")
+
+
+def can_wait_for_culture(cli: Path) -> dict:
+    """Check culture_hours <= deadline_hours. UNSAT => cannot wait (must act now)."""
+    prog = (f"symbol wait_strategy : scalar\nobserve culture_hours({CULTURE_HOURS})\n"
+            f"observe deadline_hours({DEADLINE_HOURS})\n"
+            f"constrain wait_strategy = culture_hours\n"
+            f"constrain wait_strategy <= deadline_hours\ncheck\n")
+    return run_check_or_solve(cli, prog, "check")
+
+
+def recommend(case_id: str, cli: Path, p_override: float | None = None) -> dict:
+    # 1. the differential (warm path, 0 model calls) - or an explicit posterior to
+    # evaluate the policy at any P(bacterial) (e.g. a calibrated value where viral
+    # is more probable, to show the cost+time override).
+    if p_override is not None:
+        p_bacterial = p_override
+        most_probable = "bacterial_meningitis" if p_bacterial >= 0.5 else "viral_meningitis"
+    else:
+        ir = json.loads((IR_DIR / f"{case_id}.json").read_text())
+        observe_adj, _, _ = ir_mod.ir_to_adj(ir, ir_mod.load_domains())
+        dec = decide_mod.decide(case_id, observe_adj, cli)
+        p_bacterial = dec["posteriors"].get("bacterial_meningitis", 0.0)
+        most_probable = dec["leader"]
+
+    # 2. the SOLVED treatment constraints.
+    p_star = cost_breakeven(cli)
+    timing = can_wait_for_culture(cli)
+    must_act_now = timing.get("outcome") == "unsat"   # cannot defer past the deadline
+    cost_says_treat = p_bacterial >= p_star
+
+    treat = cost_says_treat   # treat iff probability clears the cost break-even
+    action = "TREAT EMPIRICALLY NOW" if treat else "WITHHOLD; observe / await results"
+    # The interesting case: probability favors viral, but cost+time force treatment.
+    overrides_argmax = treat and most_probable != "bacterial_meningitis"
+
+    return {
+        "case_id": case_id,
+        "answer_time_model_calls": 0,
+        "p_bacterial": round(p_bacterial, 4),
+        "most_probable_dx": most_probable,
+        "cost_breakeven_p_star": p_star,
+        "treat_threshold_met": cost_says_treat,
+        "time_constraint": {"can_wait_for_culture": not must_act_now,
+                            "check": timing, "deadline_hours": DEADLINE_HOURS,
+                            "culture_hours": CULTURE_HOURS},
+        "must_decide_now": must_act_now,
+        "action": action,
+        "overrides_argmax_probability": overrides_argmax,
+        "justification": (
+            f"P(bacterial)={p_bacterial:.4f} >= cost break-even p*={p_star} "
+            f"(missing bacterial costs {COST_MISS}x empirical treatment), and waiting "
+            f"for culture ({CULTURE_HOURS} h) violates the door-to-antibiotic deadline "
+            f"({DEADLINE_HOURS} h) [time constraint UNSAT, IIS core {timing.get('core')}] "
+            f"-> act now." if treat else
+            f"P(bacterial)={p_bacterial:.4f} < cost break-even p*={p_star}; treatment not indicated."),
+    }
+
+
+def main(argv: list[str]) -> int:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("treat: adj-lang-cli not built (cargo build -p adj-lang-cli)", file=sys.stderr)
+        return 3
+    p_override = None
+    if "--p" in argv:
+        p_override = float(argv[argv.index("--p") + 1])
+    case_id = next((a for a in argv if not a.startswith("--") and a != str(p_override)),
+                   "case_preculture_ambiguous")
+    rec = recommend(case_id, cli, p_override)
+    print(json.dumps(rec, indent=2))
+    print(f"\n  {rec['case_id']}: most-probable dx = {rec['most_probable_dx']} "
+          f"(P(bacterial)={rec['p_bacterial']}) -> ACTION: {rec['action']}")
+    if rec["overrides_argmax_probability"]:
+        print("  ^ the cost+time constraints OVERRIDE the argmax probability: "
+              "viral is more probable, but you treat for bacterial now.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Treatment as a solved constraint problem

The diagnostic layer answers *"how probable is bacterial meningitis?"* But medicine asks *"do we treat now?"* — and that is **not** the argmax of the differential. Medicine treats **fast and cheap**, so the treatment decision is itself a **constraint problem**, solved by the *same* `adj-lang` constraint solver the diagnostic engine already uses — at **0 answer-time model calls**.

> Builds on the merged MYCIN-2026 cold path (M4–M6) + the constraint solver. Built in an isolated git worktree to avoid colliding with concurrent sessions in the shared checkout.

### Two constraints the solver solves
**(A) Cost break-even** — `solve` for `p*` where treating equals waiting:
```adj
constrain p_star * cost_miss = cost_treat   % cost_miss=100, cost_treat=1
solve for { p_star }                        % → p* = 0.01 ; treat iff P(bacterial) ≥ p*
```
Because missing bacterial meningitis costs ~100× empirical antibiotics, `p*` is tiny — you treat even at low probability.

**(B) Time feasibility** — `check` whether *waiting* for culture beats the deadline:
```adj
constrain wait_strategy = culture_hours      % 48 h
constrain wait_strategy <= deadline_hours    % 1 h door-to-antibiotic
check                                        % → UNSAT (IIS core [0,1]): you CANNOT wait
```
The solver **proves** the decision can't be deferred — it must be made now.

### The headline — cost+time override the argmax probability
This resolves the honest paradox from the M8 cost-to-correct proof. At a calibrated `P(bacterial)=0.30`, where viral is *more probable*:
```
most-probable dx = viral_meningitis  →  ACTION: TREAT EMPIRICALLY NOW
  ^ cost+time OVERRIDE the argmax: viral is more probable, but you treat for bacterial now.
```
You act on **cost and time**, not the most-probable label — and the recommendation cites the solved `p*` and the binding time-constraint IIS, so it's auditable end to end with no model in the decision loop.

### Verification
- `python3 treatment/test_treatment.py` → p* = cost_treat/cost_miss; wait-for-culture UNSAT; P=0.30 → TREAT (overrides argmax); below p* → withhold. **ruff clean.**
- `/security-review` → passed (list-arg subprocess, no injection into the generated `.adj`, json-only).
- Honest limits in `treatment/README.md` (illustrative cost/time params, single regimen/deadline — a mechanism demo, not a treatment-authorizing tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)