### PR TITLE
feat(lexer): interpret declarative mode transitions (F10 step 2)

### DIFF
--- a/code/packages/rust/adj-lang/src/_lexer_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_lexer_grammar.rs
@@ -203,5 +203,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/algol-lexer/src/_grammar.rs
+++ b/code/packages/rust/algol-lexer/src/_grammar.rs
@@ -210,5 +210,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/csharp-lexer/src/_grammar.rs
+++ b/code/packages/rust/csharp-lexer/src/_grammar.rs
@@ -632,6 +632,8 @@ mod v_1_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1242,6 +1244,8 @@ mod v_2_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1859,6 +1863,8 @@ mod v_3_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2476,6 +2482,8 @@ mod v_4_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3093,6 +3101,8 @@ mod v_5_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3745,6 +3755,8 @@ mod v_6_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4425,6 +4437,8 @@ mod v_7_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5126,6 +5140,8 @@ mod v_8_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5827,6 +5843,8 @@ mod v_9_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -6528,6 +6546,8 @@ mod v_10_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -7264,6 +7284,8 @@ mod v_11_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -8000,6 +8022,8 @@ mod v_12_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/css-lexer/src/_grammar.rs
+++ b/code/packages/rust/css-lexer/src/_grammar.rs
@@ -337,5 +337,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/dartmouth-basic-lexer/src/_grammar.rs
+++ b/code/packages/rust/dartmouth-basic-lexer/src/_grammar.rs
@@ -197,5 +197,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/excel-lexer/src/_grammar.rs
+++ b/code/packages/rust/excel-lexer/src/_grammar.rs
@@ -336,5 +336,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/fsharp-lexer/src/_grammar.rs
+++ b/code/packages/rust/fsharp-lexer/src/_grammar.rs
@@ -484,6 +484,8 @@ mod v_1_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -926,6 +928,8 @@ mod v_2_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1368,6 +1372,8 @@ mod v_3_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1810,6 +1816,8 @@ mod v_3_1 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2252,6 +2260,8 @@ mod v_4_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2694,6 +2704,8 @@ mod v_4_1 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3136,6 +3148,8 @@ mod v_4_5 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3578,6 +3592,8 @@ mod v_4_6 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4020,6 +4036,8 @@ mod v_4_7 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4462,6 +4480,8 @@ mod v_5 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4904,6 +4924,8 @@ mod v_6 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5346,6 +5368,8 @@ mod v_7 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5788,6 +5812,8 @@ mod v_8 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -6230,6 +6256,8 @@ mod v_9 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -6672,6 +6700,8 @@ mod v_10 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/grammar-tools/CHANGELOG.md
+++ b/code/packages/rust/grammar-tools/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - F10 declarative lexer mode transitions
+
+### Added
+- `ModeTransition` and `TransitionAction` types, plus `start_mode` and
+  `transitions` fields on `TokenGrammar`, implementing the declarative
+  lexer-mode transition table from `F10-declarative-lexer-modes.md`. A
+  grammar can now drive context-sensitive lexing (regex-vs-division,
+  template substitutions) from the `.tokens` file instead of a
+  hand-written host-language callback.
+- `.tokens` DSL: a `start_mode:` directive and a `transitions:` section
+  whose lines read `on TOKENS [in MODE] -> ACTION [, ACTION ...]`
+  (actions: `set-mode`/`push`/`pop`/`enable-skip`/`disable-skip`;
+  `KEYWORD="value"` value-guard form supported).
+- `parse_transition` parser, validation (undefined target/guard modes are
+  rejected; `start_mode` must resolve; `MAX_TRANSITIONS` cap as a DoS
+  guard), and `transitions_src`/`transition_src`/`action_src` codegen in
+  `compiler.rs` (emits the table as pure data, mirroring `groups_src`).
+
+### Changed
+- All compiled `_grammar.rs` artifacts gain the two new fields as trivial
+  defaults (`start_mode: None, transitions: vec![]`); behaviour is
+  byte-identical to before for any grammar that declares no transitions
+  (full F04 backward-compat).
+
+### Notes
+- Interpreting the table in the lexer is a separate change (F10 step 2,
+  `grammar_lexer.rs`). This entry covers the grammar-tools core: types,
+  parse, validation, and codegen.
+
 ## [0.6.0] - LS04 spec dump
 
 ### Added

--- a/code/packages/rust/grammar-tools/src/compiler.rs
+++ b/code/packages/rust/grammar-tools/src/compiler.rs
@@ -54,7 +54,9 @@
 //! ```
 
 use crate::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
-use crate::token_grammar::{PatternGroup, TokenDefinition, TokenGrammar};
+use crate::token_grammar::{
+    ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction,
+};
 
 // ===========================================================================
 // Public API
@@ -96,7 +98,7 @@ pub fn compile_token_grammar(grammar: &TokenGrammar, source_file: &str) -> Strin
 // Call `token_grammar()` instead of reading and parsing the .tokens file.
 
 #[allow(unused_imports)]
-use grammar_tools::token_grammar::{{PatternGroup, TokenDefinition, TokenGrammar}};
+use grammar_tools::token_grammar::{{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction}};
 #[allow(unused_imports)]
 use std::collections::HashMap;
 
@@ -116,6 +118,8 @@ pub fn token_grammar() -> TokenGrammar {{
         context_keywords: {context_kw_src},
         soft_keywords: {soft_kw_src},
         layout_keywords: {layout_kw_src},
+        start_mode: {start_mode_src},
+        transitions: {transitions_src},
     }}
 }}
 ",
@@ -135,6 +139,8 @@ pub fn token_grammar() -> TokenGrammar {{
         context_kw_src = string_vec_src(&grammar.context_keywords),
         soft_kw_src = string_vec_src(&grammar.soft_keywords),
         layout_kw_src = string_vec_src(&grammar.layout_keywords),
+        start_mode_src = option_str_src(&grammar.start_mode),
+        transitions_src = transitions_src(&grammar.transitions, "        "),
     )
 }
 
@@ -310,6 +316,63 @@ fn groups_src(groups: &std::collections::HashMap<String, PatternGroup>, indent: 
         entries = entries.join("\n"),
         indent = indent,
     )
+}
+
+/// Render a `Vec<ModeTransition>` (F10) as a Rust `vec![...]` expression.
+///
+/// Emitted in source order — the slice is already ordered and order is
+/// semantically meaningful (first-matching-rule-wins), so no sort (unlike
+/// `groups_src`, which orders a HashMap for determinism).
+fn transitions_src(ts: &[ModeTransition], indent: &str) -> String {
+    if ts.is_empty() {
+        return "vec![]".to_string();
+    }
+    let inner = format!("{}    ", indent);
+    let items: Vec<String> = ts.iter().map(|t| transition_src(t, &inner)).collect();
+    format!("vec![\n{},\n{}]", items.join(",\n"), indent)
+}
+
+/// Render one `ModeTransition` as a Rust struct expression.
+fn transition_src(t: &ModeTransition, indent: &str) -> String {
+    let on_tokens = string_vec_src(&t.on_tokens);
+    let on_value = option_str_src(&t.on_value);
+    let in_mode = option_str_src(&t.in_mode);
+    let actions = if t.actions.is_empty() {
+        "vec![]".to_string()
+    } else {
+        let items: Vec<String> = t.actions.iter().map(action_src).collect();
+        format!("vec![{}]", items.join(", "))
+    };
+    format!(
+        "{indent}ModeTransition {{\n\
+         {indent}    on_tokens: {on_tokens},\n\
+         {indent}    on_value: {on_value},\n\
+         {indent}    in_mode: {in_mode},\n\
+         {indent}    actions: {actions},\n\
+         {indent}    line_number: {line_number},\n\
+         {indent}}}",
+        indent = indent,
+        on_tokens = on_tokens,
+        on_value = on_value,
+        in_mode = in_mode,
+        actions = actions,
+        line_number = t.line_number,
+    )
+}
+
+/// Render one `TransitionAction` as a Rust expression.
+fn action_src(a: &TransitionAction) -> String {
+    match a {
+        TransitionAction::SetMode(m) => {
+            format!("TransitionAction::SetMode({}.to_string())", rust_string_lit(m))
+        }
+        TransitionAction::Push(g) => {
+            format!("TransitionAction::Push({}.to_string())", rust_string_lit(g))
+        }
+        TransitionAction::Pop => "TransitionAction::Pop".to_string(),
+        TransitionAction::EnableSkip => "TransitionAction::EnableSkip".to_string(),
+        TransitionAction::DisableSkip => "TransitionAction::DisableSkip".to_string(),
+    }
 }
 
 // ===========================================================================
@@ -646,5 +709,39 @@ mod tests {
         let g = parse_parser_grammar("# @version 4\nvalue = NUMBER ;").unwrap();
         let code = compile_parser_grammar(&g, "");
         assert!(code.contains("version: 4"));
+    }
+
+    #[test]
+    fn token_grammar_no_transitions_emits_empty_defaults() {
+        // Backward compat: a grammar without F10 sections emits the two new
+        // fields as trivial defaults.
+        let g = crate::token_grammar::parse_token_grammar("NUMBER = /[0-9]+/").unwrap();
+        let code = compile_token_grammar(&g, "n.tokens");
+        assert!(code.contains("start_mode: None"));
+        assert!(code.contains("transitions: vec![]"));
+    }
+
+    #[test]
+    fn token_grammar_emits_transition_table() {
+        let source = "\
+NAME = /[a-z]+/
+start_mode: div
+group div:
+  SLASH = \"/\"
+transitions:
+  on (NAME | RPAREN) -> set-mode div
+  on KEYWORD=\"return\" -> set-mode default
+";
+        let g = crate::token_grammar::parse_token_grammar(source).unwrap();
+        let code = compile_token_grammar(&g, "js.tokens");
+        // start_mode threads through.
+        assert!(code.contains(r#"start_mode: Some(r#"div"#));
+        // The emitted table references the real types and variants.
+        assert!(code.contains("ModeTransition {"));
+        assert!(code.contains("TransitionAction::SetMode(r#\"div\"#.to_string())"));
+        // on_value guard for the keyword rule.
+        assert!(code.contains(r#"on_value: Some(r#"return"#));
+        // The emitted import line carries the new types.
+        assert!(code.contains("ModeTransition") && code.contains("TransitionAction"));
     }
 }

--- a/code/packages/rust/grammar-tools/src/token_grammar.rs
+++ b/code/packages/rust/grammar-tools/src/token_grammar.rs
@@ -122,6 +122,64 @@ pub struct PatternGroup {
     pub definitions: Vec<TokenDefinition>,
 }
 
+/// One action a [`ModeTransition`] applies to the lexer's mode register after a
+/// token is emitted. See `F10-declarative-lexer-modes.md`.
+///
+/// The lexer keeps a single "active mode" register — the top of its group stack
+/// (F04). These actions mutate it:
+///
+/// - `SetMode(m)` — replace the active mode **without saving** the previous one.
+///   This is the flat flex-style toggle (e.g. JavaScript expression-position vs
+///   operand-position for regex-vs-division). Stack depth is unchanged.
+/// - `Push(g)`    — save the current mode and make `g` active (F04 push). +1 depth.
+/// - `Pop`        — restore the saved mode (F04 pop). No-op at the floor.
+/// - `EnableSkip` / `DisableSkip` — toggle skip-pattern processing, for regions
+///   where whitespace is significant (mirrors F04's `set_skip_enabled`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransitionAction {
+    SetMode(String),
+    Push(String),
+    Pop,
+    EnableSkip,
+    DisableSkip,
+}
+
+/// One declarative lexer mode transition rule, parsed from a `transitions:`
+/// section line of the form `on TOKENS [in MODE] -> ACTION [, ACTION ...]`.
+///
+/// This is pure data — the lexer interprets it after each token is emitted
+/// (first matching rule wins). It replaces the hand-written per-language
+/// `on-token` callback that F04 required for context-sensitive lexing. See
+/// `F10-declarative-lexer-modes.md`.
+///
+/// # Fields
+///
+/// - `on_tokens` — Emitted token type-names that trigger the rule (the *alias*
+///   target if the matched pattern was aliased, e.g. `STRING` not `STRING_DQ`).
+///   The literal `KEYWORD` matches promoted keyword tokens; pair it with
+///   `on_value` to match a specific keyword.
+/// - `on_value` — Optional keyword-value guard, e.g. `Some("return")`. When set,
+///   the rule fires only if the emitted token's value equals this string.
+/// - `in_mode` — Optional active-mode guard. `None` means "in any mode".
+/// - `actions` — Ordered actions applied when the rule fires.
+/// - `line_number` — Source line for diagnostics.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModeTransition {
+    pub on_tokens: Vec<String>,
+    pub on_value: Option<String>,
+    pub in_mode: Option<String>,
+    pub actions: Vec<TransitionAction>,
+    pub line_number: usize,
+}
+
+/// Upper bound on the number of transition rules in one grammar.
+///
+/// A defensive cap so an untrusted `.tokens` file cannot blow up generated-code
+/// size or lexer memory with a pathological transition table. No real grammar
+/// approaches this — JavaScript's full regex/division + template table is a few
+/// dozen rules.
+pub const MAX_TRANSITIONS: usize = 4096;
+
 /// The complete contents of a parsed `.tokens` file.
 ///
 /// # Fields
@@ -223,6 +281,13 @@ pub struct TokenGrammar {
     /// Keywords that introduce a Haskell-style layout context when
     /// `mode == "layout"`.
     pub layout_keywords: Vec<String>,
+    /// The lexer mode (active group) the tokenizer starts in. `None` means
+    /// `"default"`. Set by the `start_mode:` directive. See F10.
+    pub start_mode: Option<String>,
+    /// Declarative lexer mode transition table (F10). Empty means no
+    /// transitions — behaviour is identical to F04 (the lexer never switches
+    /// modes on its own). Set by the `transitions:` section.
+    pub transitions: Vec<ModeTransition>,
 }
 
 // ===========================================================================
@@ -485,6 +550,9 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
     let mut case_sensitive: bool = true;
     let mut error_definitions = Vec::new();
     let mut groups: HashMap<String, PatternGroup> = HashMap::new();
+    // F10 declarative lexer modes.
+    let mut start_mode: Option<String> = None;
+    let mut transitions: Vec<ModeTransition> = Vec::new();
     // Magic comment fields — set by `# @key value` lines.
     let mut version: u32 = 0;
     let mut case_insensitive: bool = false;
@@ -510,6 +578,10 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
             "layout_keywords",
             "context_keywords",
             "soft_keywords",
+            // F10 reserved section/directive names.
+            "transitions",
+            "modes",
+            "start_mode",
         ]
         .iter()
         .copied()
@@ -647,6 +719,14 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
             current_section = String::from("soft_keywords");
             continue;
         }
+        // --- F10: transitions section ---
+        //
+        // The `transitions:` section holds declarative lexer mode transition
+        // rules. Each indented line is `on TOKENS [in MODE] -> ACTION, ...`.
+        if stripped == "transitions:" || stripped == "transitions :" {
+            current_section = String::from("transitions");
+            continue;
+        }
 
         // --- Escapes directive ---
         //
@@ -674,6 +754,25 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
                 });
             }
             mode = Some(mode_value.to_string());
+            continue;
+        }
+
+        // --- F10: start_mode directive ---
+        //
+        // `start_mode: NAME` names the lexer mode (active group) the tokenizer
+        // begins in. Defaults to "default" when omitted. Must be checked BEFORE
+        // the generic token-definition fallthrough, and the name is validated
+        // against declared groups in `validate_token_grammar`.
+        if stripped.starts_with("start_mode:") || stripped.starts_with("start_mode :") {
+            let colon_idx = stripped.find(':').unwrap();
+            let sm_value = stripped[colon_idx + 1..].trim();
+            if sm_value.is_empty() {
+                return Err(TokenGrammarError {
+                    message: "Missing mode name after 'start_mode:'".to_string(),
+                    line_number,
+                });
+            }
+            start_mode = Some(sm_value.to_string());
             continue;
         }
 
@@ -725,6 +824,9 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
                         soft_keywords.push(stripped.to_string());
                     } else if current_section == "reserved" {
                         reserved_keywords.push(stripped.to_string());
+                    } else if current_section == "transitions" {
+                        let rule = parse_transition(stripped, line_number)?;
+                        transitions.push(rule);
                     } else if current_section == "skip" {
                         let defn = parse_definition(stripped, line_number)?;
                         skip_definitions.push(defn);
@@ -792,7 +894,168 @@ pub fn parse_token_grammar(source: &str) -> Result<TokenGrammar, TokenGrammarErr
         context_keywords,
         soft_keywords,
         layout_keywords,
+        start_mode,
+        transitions,
     })
+}
+
+// ===========================================================================
+// F10: transition-rule parser
+// ===========================================================================
+
+/// Parse one `transitions:` line into a [`ModeTransition`].
+///
+/// Grammar of a rule line (keywords are lowercase):
+///
+/// ```text
+/// on TOKENS [in MODE] -> ACTION [, ACTION ...]
+/// ```
+///
+/// where
+/// - `TOKENS` is one token name (`NAME`), an alternation `(A | B | C)`, or the
+///   special `KEYWORD="value"` form for a specific promoted keyword,
+/// - `[in MODE]` is an optional active-mode guard,
+/// - each `ACTION` is `set-mode M` | `push G` | `pop` | `enable-skip` |
+///   `disable-skip`.
+///
+/// # Examples
+///
+/// ```text
+/// on (NAME | NUMBER | RPAREN) -> set-mode div
+/// on KEYWORD="return" -> set-mode default
+/// on TEMPLATE_HEAD in default -> push template, set-mode default
+/// ```
+fn parse_transition(line: &str, line_number: usize) -> Result<ModeTransition, TokenGrammarError> {
+    // Split on the mandatory `->` arrow separating the matcher from the actions.
+    let arrow = line.find("->").ok_or_else(|| TokenGrammarError {
+        message: format!("Transition rule missing '->': '{}'", line),
+        line_number,
+    })?;
+    let head = line[..arrow].trim();
+    let action_str = line[arrow + 2..].trim();
+    if action_str.is_empty() {
+        return Err(TokenGrammarError {
+            message: format!("Transition rule has no actions after '->': '{}'", line),
+            line_number,
+        });
+    }
+
+    // --- Head: `on TOKENS [in MODE]` ---
+    let head = head.strip_prefix("on ").map(str::trim).ok_or_else(|| {
+        TokenGrammarError {
+            message: format!("Transition rule must start with 'on ': '{}'", line),
+            line_number,
+        }
+    })?;
+
+    // Optional `in MODE` guard. We split on the whitespace-delimited ` in `
+    // token so that a token-set like `(A | B)` is not mistaken for the guard.
+    let (tokens_part, in_mode) = match split_in_guard(head) {
+        Some((toks, mode)) => (toks.trim().to_string(), Some(mode.trim().to_string())),
+        None => (head.to_string(), None),
+    };
+
+    // --- Token set, with optional `KEYWORD="value"` form ---
+    let mut on_value: Option<String> = None;
+    let tokens_inner = tokens_part
+        .strip_prefix('(')
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or(&tokens_part);
+    let mut on_tokens = Vec::new();
+    for raw in tokens_inner.split('|') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        // `KEYWORD="value"` — a value-guarded keyword. Only one value guard is
+        // supported per rule (the common case: `on KEYWORD="return"`).
+        if let Some(eq) = item.find('=') {
+            let name = item[..eq].trim();
+            let value_raw = item[eq + 1..].trim();
+            let value = value_raw
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .unwrap_or(value_raw);
+            on_tokens.push(name.to_string());
+            on_value = Some(value.to_string());
+        } else {
+            on_tokens.push(item.to_string());
+        }
+    }
+    if on_tokens.is_empty() {
+        return Err(TokenGrammarError {
+            message: format!("Transition rule has no trigger tokens: '{}'", line),
+            line_number,
+        });
+    }
+
+    // --- Actions: comma-separated ---
+    let mut actions = Vec::new();
+    for raw in action_str.split(',') {
+        let act = raw.trim();
+        if act.is_empty() {
+            continue;
+        }
+        let parsed = if let Some(m) = act.strip_prefix("set-mode ") {
+            TransitionAction::SetMode(m.trim().to_string())
+        } else if let Some(g) = act.strip_prefix("push ") {
+            TransitionAction::Push(g.trim().to_string())
+        } else if act == "pop" {
+            TransitionAction::Pop
+        } else if act == "enable-skip" {
+            TransitionAction::EnableSkip
+        } else if act == "disable-skip" {
+            TransitionAction::DisableSkip
+        } else {
+            return Err(TokenGrammarError {
+                message: format!(
+                    "Unknown transition action '{}' \
+                     (expected set-mode/push/pop/enable-skip/disable-skip)",
+                    act
+                ),
+                line_number,
+            });
+        };
+        actions.push(parsed);
+    }
+    if actions.is_empty() {
+        return Err(TokenGrammarError {
+            message: format!("Transition rule has no valid actions: '{}'", line),
+            line_number,
+        });
+    }
+
+    Ok(ModeTransition {
+        on_tokens,
+        on_value,
+        in_mode,
+        actions,
+        line_number,
+    })
+}
+
+/// Split a transition head on a top-level ` in ` mode guard, ignoring any ` in `
+/// that appears inside a parenthesised token set. Returns
+/// `Some((tokens, mode))` when a guard is present, else `None`.
+fn split_in_guard(head: &str) -> Option<(&str, &str)> {
+    let bytes = head.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b' ' if depth == 0 => {
+                // Check for the literal token ` in ` at a top-level boundary.
+                if head[i..].starts_with(" in ") {
+                    return Some((&head[..i], &head[i + 4..]));
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 // ===========================================================================
@@ -924,6 +1187,58 @@ pub fn validate_token_grammar(grammar: &TokenGrammar) -> Vec<String> {
         let mut group_seen: std::collections::HashMap<String, usize> =
             std::collections::HashMap::new();
         validate_definitions(&group.definitions, &mut group_seen, &mut issues);
+    }
+
+    // F10: validate declarative lexer modes.
+    //
+    // A mode name is valid if it is "default" (the implicit base group) or a
+    // declared group. `set-mode`/`push` targets and `in MODE` guards must all
+    // resolve to a real mode, otherwise the lexer would silently fall back to
+    // the wrong group — a silent-failure hazard we reject up front.
+    let mode_exists = |name: &str| name == "default" || grammar.groups.contains_key(name);
+
+    if let Some(ref sm) = grammar.start_mode {
+        if !mode_exists(sm) {
+            issues.push(format!(
+                "start_mode '{}' is not 'default' or a declared group",
+                sm
+            ));
+        }
+    }
+
+    // Defensive cap so an untrusted grammar cannot blow up codegen/lexer size.
+    if grammar.transitions.len() > MAX_TRANSITIONS {
+        issues.push(format!(
+            "Too many transition rules ({}, max {})",
+            grammar.transitions.len(),
+            MAX_TRANSITIONS
+        ));
+    }
+
+    for rule in &grammar.transitions {
+        if let Some(ref m) = rule.in_mode {
+            if !mode_exists(m) {
+                issues.push(format!(
+                    "Transition guard 'in {}' (line {}) names an undeclared mode",
+                    m, rule.line_number
+                ));
+            }
+        }
+        for action in &rule.actions {
+            match action {
+                TransitionAction::SetMode(m) | TransitionAction::Push(m) => {
+                    if !mode_exists(m) {
+                        issues.push(format!(
+                            "Transition action targets undeclared mode '{}' (line {})",
+                            m, rule.line_number
+                        ));
+                    }
+                }
+                TransitionAction::Pop
+                | TransitionAction::EnableSkip
+                | TransitionAction::DisableSkip => {}
+            }
+        }
     }
 
     issues
@@ -1153,6 +1468,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(!issues.is_empty());
@@ -1183,6 +1500,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(!issues.is_empty());
@@ -1213,6 +1532,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(!issues.is_empty());
@@ -1422,6 +1743,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(issues.iter().any(|i| i.contains("Unknown mode")));
@@ -1617,6 +1940,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(issues.iter().any(|i| i.contains("Invalid regex")));
@@ -1648,6 +1973,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(issues.iter().any(|i| i.contains("Empty pattern group")));
@@ -1916,6 +2243,8 @@ case_sensitive: true,
             layout_keywords: vec![],
             context_keywords: Vec::new(),
             soft_keywords: Vec::new(),
+            start_mode: None,
+            transitions: Vec::new(),
         };
         let issues = validate_token_grammar(&grammar);
         assert!(issues.iter().any(|issue| issue.contains("layout_keywords")));
@@ -1945,5 +2274,150 @@ case_sensitive: true,
         let result = parse_token_grammar(source);
         assert!(result.is_err());
         assert!(result.unwrap_err().message.contains("Reserved group name"));
+    }
+
+    // -----------------------------------------------------------------------
+    // F10: declarative lexer mode transitions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_no_transitions_means_empty_defaults() {
+        // Backward compat: a grammar with no F10 sections parses to the
+        // F04-identical empty defaults.
+        let grammar = parse_token_grammar("NUMBER = /[0-9]+/").unwrap();
+        assert_eq!(grammar.start_mode, None);
+        assert!(grammar.transitions.is_empty());
+    }
+
+    #[test]
+    fn test_parse_start_mode_directive() {
+        let source = "NAME = /[a-z]+/\nstart_mode: div\ngroup div:\n  SLASH = \"/\"\n";
+        let grammar = parse_token_grammar(source).unwrap();
+        assert_eq!(grammar.start_mode.as_deref(), Some("div"));
+    }
+
+    #[test]
+    fn test_start_mode_missing_value_errors() {
+        let result = parse_token_grammar("NAME = /[a-z]+/\nstart_mode:\n");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("start_mode"));
+    }
+
+    #[test]
+    fn test_parse_transition_alternation_to_set_mode() {
+        let source = "\
+NAME = /[a-z]+/
+transitions:
+  on (NAME | NUMBER | RPAREN) -> set-mode div
+";
+        let grammar = parse_token_grammar(source).unwrap();
+        assert_eq!(grammar.transitions.len(), 1);
+        let rule = &grammar.transitions[0];
+        assert_eq!(rule.on_tokens, vec!["NAME", "NUMBER", "RPAREN"]);
+        assert_eq!(rule.on_value, None);
+        assert_eq!(rule.in_mode, None);
+        assert_eq!(rule.actions, vec![TransitionAction::SetMode("div".to_string())]);
+    }
+
+    #[test]
+    fn test_parse_transition_keyword_value_form() {
+        let source = "NAME = /[a-z]+/\ntransitions:\n  on KEYWORD=\"return\" -> set-mode default\n";
+        let grammar = parse_token_grammar(source).unwrap();
+        let rule = &grammar.transitions[0];
+        assert_eq!(rule.on_tokens, vec!["KEYWORD"]);
+        assert_eq!(rule.on_value.as_deref(), Some("return"));
+    }
+
+    #[test]
+    fn test_parse_transition_in_guard_and_multiple_actions() {
+        // The `in MODE` guard must not be confused with a parenthesised token
+        // set, and multiple comma-separated actions are applied in order.
+        let source = "\
+NAME = /[a-z]+/
+group template:
+  TAIL = \"x\"
+transitions:
+  on TEMPLATE_HEAD in default -> push template, set-mode default
+";
+        let grammar = parse_token_grammar(source).unwrap();
+        let rule = &grammar.transitions[0];
+        assert_eq!(rule.on_tokens, vec!["TEMPLATE_HEAD"]);
+        assert_eq!(rule.in_mode.as_deref(), Some("default"));
+        assert_eq!(
+            rule.actions,
+            vec![
+                TransitionAction::Push("template".to_string()),
+                TransitionAction::SetMode("default".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_transition_pop_and_skip_actions() {
+        let source = "\
+NAME = /[a-z]+/
+transitions:
+  on RBRACE -> pop, disable-skip
+  on LBRACE -> enable-skip
+";
+        let grammar = parse_token_grammar(source).unwrap();
+        assert_eq!(
+            grammar.transitions[0].actions,
+            vec![TransitionAction::Pop, TransitionAction::DisableSkip]
+        );
+        assert_eq!(
+            grammar.transitions[1].actions,
+            vec![TransitionAction::EnableSkip]
+        );
+    }
+
+    #[test]
+    fn test_transition_missing_arrow_errors() {
+        let result = parse_token_grammar("NAME = /x/\ntransitions:\n  on NAME set-mode div\n");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("->"));
+    }
+
+    #[test]
+    fn test_transition_unknown_action_errors() {
+        let result = parse_token_grammar("NAME = /x/\ntransitions:\n  on NAME -> teleport\n");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("Unknown transition action"));
+    }
+
+    #[test]
+    fn test_validate_rejects_undefined_target_mode() {
+        // `set-mode div` with no `group div:` declared is a hard validation error.
+        let grammar =
+            parse_token_grammar("NAME = /x/\ntransitions:\n  on NAME -> set-mode div\n").unwrap();
+        let issues = validate_token_grammar(&grammar);
+        assert!(issues.iter().any(|i| i.contains("undeclared mode")));
+    }
+
+    #[test]
+    fn test_validate_accepts_default_and_declared_modes() {
+        let source = "\
+NAME = /[a-z]+/
+start_mode: default
+group div:
+  SLASH = \"/\"
+transitions:
+  on NAME -> set-mode div
+  on KEYWORD=\"return\" -> set-mode default
+";
+        let grammar = parse_token_grammar(source).unwrap();
+        let issues = validate_token_grammar(&grammar);
+        assert!(
+            !issues.iter().any(|i| i.contains("mode")),
+            "unexpected mode issues: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_undefined_start_mode() {
+        let grammar = parse_token_grammar("NAME = /x/\nstart_mode: nope\n").unwrap();
+        let issues = validate_token_grammar(&grammar);
+        assert!(issues.iter().any(|i| i.contains("start_mode")));
     }
 }

--- a/code/packages/rust/haskell-lexer/src/_grammar.rs
+++ b/code/packages/rust/haskell-lexer/src/_grammar.rs
@@ -320,6 +320,8 @@ mod v_1_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -614,6 +616,8 @@ mod v_1_1 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -908,6 +912,8 @@ mod v_1_2 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1202,6 +1208,8 @@ mod v_1_3 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1496,6 +1504,8 @@ mod v_1_4 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1790,6 +1800,8 @@ mod v_98 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2084,6 +2096,8 @@ mod v_2010 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![r#"let"#.to_string(), r#"where"#.to_string(), r#"do"#.to_string(), r#"of"#.to_string()],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/java-lexer/src/_grammar.rs
+++ b/code/packages/rust/java-lexer/src/_grammar.rs
@@ -502,6 +502,8 @@ mod v_1_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -972,6 +974,8 @@ mod v_1_1 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1442,6 +1446,8 @@ mod v_1_4 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1926,6 +1932,8 @@ mod v_5 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2417,6 +2425,8 @@ mod v_7 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2922,6 +2932,8 @@ mod v_8 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3441,6 +3453,8 @@ mod v_10 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3974,6 +3988,8 @@ mod v_14 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4507,6 +4523,8 @@ mod v_17 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5033,6 +5051,8 @@ mod v_21 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/javascript-lexer/src/_grammar.rs
+++ b/code/packages/rust/javascript-lexer/src/_grammar.rs
@@ -490,6 +490,8 @@ mod v_es1 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -967,6 +969,8 @@ mod v_es3 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1444,6 +1448,8 @@ mod v_es5 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1990,6 +1996,8 @@ mod v_es2015 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2550,6 +2558,8 @@ mod v_es2016 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3110,6 +3120,8 @@ mod v_es2017 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3670,6 +3682,8 @@ mod v_es2018 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4230,6 +4244,8 @@ mod v_es2019 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -4832,6 +4848,8 @@ mod v_es2020 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -5455,6 +5473,8 @@ mod v_es2021 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -6085,6 +6105,8 @@ mod v_es2022 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -6722,6 +6744,8 @@ mod v_es2023 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -7359,6 +7383,8 @@ mod v_es2024 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -8003,6 +8029,8 @@ mod v_es2025 {
             context_keywords: vec![r#"as"#.to_string(), r#"async"#.to_string(), r#"await"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"using"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/jsdoc-lexer/src/_grammar.rs
+++ b/code/packages/rust/jsdoc-lexer/src/_grammar.rs
@@ -246,5 +246,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/json-lexer/src/_grammar.rs
+++ b/code/packages/rust/json-lexer/src/_grammar.rs
@@ -112,5 +112,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/lattice-lexer/src/_grammar.rs
+++ b/code/packages/rust/lattice-lexer/src/_grammar.rs
@@ -392,5 +392,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/lexer/CHANGELOG.md
+++ b/code/packages/rust/lexer/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased] — F10 declarative lexer mode transitions
+
+### Added
+- `GrammarLexer` now interprets the declarative mode transition table on a
+  `TokenGrammar` (F10). After each token is emitted it consults the table and
+  may `set-mode` (flat toggle of the active group), `push`/`pop` (F04 nested
+  regions), or toggle skip — enabling context-sensitive lexing (JavaScript
+  regex-vs-division, template substitutions) without a hand-written `on-token`
+  callback. New `apply_transitions` + `transition_key`; start mode from
+  `grammar.start_mode`.
+- **Flat-mode inheritance**: a group reached via `set-mode` inherits the
+  default group's patterns (own patterns take priority), so a JS `div` mode can
+  override `SLASH`/`SLASH_EQUALS` ahead of `REGEX` without duplicating the
+  grammar. `push` targets stay exclusive (F04 region semantics). Derived
+  automatically from the transition table.
+
+### Notes
+- Fully backward compatible: empty transition table ⇒ identical token stream
+  (early-return). Verified by the existing suite + 7 new F10 tests.
+
 ## [0.4.0] — 2026-05-14 — LANG51 string escape improvements
 
 ### Changed

--- a/code/packages/rust/lexer/src/grammar_lexer.rs
+++ b/code/packages/rust/lexer/src/grammar_lexer.rs
@@ -57,7 +57,9 @@ use regex::{Regex, RegexBuilder};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
-use grammar_tools::token_grammar::{TokenGrammar, TokenDefinition};
+use grammar_tools::token_grammar::{
+    ModeTransition, TokenDefinition, TokenGrammar, TransitionAction,
+};
 
 use crate::token::{LexerError, Token, TokenType, string_to_token_type, TOKEN_CONTEXT_KEYWORD};
 
@@ -563,6 +565,21 @@ pub struct GrammarLexer<'a> {
     context_keyword_set: HashSet<String>,
     /// Keywords that introduce Haskell-style layout contexts.
     layout_keyword_set: HashSet<String>,
+    /// F10: declarative lexer mode transition table, cloned from the grammar.
+    /// Empty means no transitions — the lexer never switches modes on its own
+    /// (F04 behaviour). Consulted after each token is emitted; see
+    /// [`apply_transitions`](GrammarLexer::apply_transitions).
+    transitions: Vec<ModeTransition>,
+    /// F10: the mode (active group) the lexer starts in and resets to.
+    /// Resolved from `grammar.start_mode` (default `"default"`).
+    start_mode: String,
+    /// F10: groups that are *flat modes* (reached via `set-mode`) rather than
+    /// *nested regions* (reached via `push`). A flat mode's own patterns are
+    /// tried first, then the default group's patterns are inherited — so a JS
+    /// `div` mode can override `SLASH`/`SLASH_EQUALS` ahead of `REGEX` without
+    /// duplicating the whole grammar. Nested regions (XML `tag`/`cdata`) stay
+    /// exclusive. Derived automatically from the transition table in `new`.
+    inheriting_modes: HashSet<String>,
 }
 
 impl<'a> GrammarLexer<'a> {
@@ -641,6 +658,40 @@ impl<'a> GrammarLexer<'a> {
             .iter()
             .cloned()
             .collect();
+
+        // F10: the mode the lexer starts in. Defaults to "default" (the base
+        // group). Validated upstream by `validate_token_grammar`; if a grammar
+        // names a non-existent start mode we still fall back to "default" so
+        // tokenization never panics on a malformed compiled artifact.
+        let start_mode = match &grammar.start_mode {
+            Some(m) if group_patterns.contains_key(m) || m == "default" => m.clone(),
+            _ => "default".to_string(),
+        };
+
+        // F10: a group targeted by a `set-mode` action is a *flat mode* that
+        // inherits the default patterns; a group targeted only by `push` is a
+        // *nested region* that stays exclusive (F04). `push` targets win the
+        // classification when a group is both (it is then treated as exclusive).
+        let mut set_mode_targets: HashSet<String> = HashSet::new();
+        let mut push_targets: HashSet<String> = HashSet::new();
+        for rule in &grammar.transitions {
+            for action in &rule.actions {
+                match action {
+                    TransitionAction::SetMode(m) => {
+                        set_mode_targets.insert(m.clone());
+                    }
+                    TransitionAction::Push(g) => {
+                        push_targets.insert(g.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let inheriting_modes: HashSet<String> = set_mode_targets
+            .into_iter()
+            .filter(|m| m != "default" && !push_targets.contains(m))
+            .collect();
+
         GrammarLexer {
             chars: source.chars().collect(),
             source: Cow::Borrowed(source),
@@ -657,7 +708,7 @@ impl<'a> GrammarLexer<'a> {
             escape_mode,
             group_patterns,
             group_names,
-            group_stack: vec!["default".to_string()],
+            group_stack: vec![start_mode.clone()],
             on_token: None,
             skip_enabled: true,
             pre_tokenize_hooks: Vec::new(),
@@ -667,6 +718,9 @@ impl<'a> GrammarLexer<'a> {
             bracket_depths: BracketDepths::default(),
             context_keyword_set,
             layout_keyword_set,
+            transitions: grammar.transitions.clone(),
+            start_mode,
+            inheriting_modes,
         }
     }
 
@@ -902,14 +956,133 @@ impl<'a> GrammarLexer<'a> {
         };
         for p in patterns {
             if let Some(m) = p.pattern.find(remaining) {
-                return Some((
-                    p.name.clone(),
-                    p.alias.clone(),
-                    m.as_str().to_string(),
-                ));
+                return Some((p.name.clone(), p.alias.clone(), m.as_str().to_string()));
+            }
+        }
+        // F10: a flat mode (set-mode target) inherits the default patterns —
+        // its own patterns above take priority, the rest fall through here.
+        // Nested regions (push targets) are NOT in `inheriting_modes` and so
+        // remain exclusive, preserving F04 semantics for XML-style grammars.
+        if group_name != "default" && self.inheriting_modes.contains(group_name) {
+            for p in &self.patterns {
+                if let Some(m) = p.pattern.find(remaining) {
+                    return Some((p.name.clone(), p.alias.clone(), m.as_str().to_string()));
+                }
             }
         }
         None
+    }
+
+    // -----------------------------------------------------------------------
+    // F10: declarative mode transitions
+    // -----------------------------------------------------------------------
+
+    /// The name used to match a token against transition rules (F10).
+    ///
+    /// Token identity in a `.tokens` grammar is UPPER_SNAKE (e.g. `NAME`,
+    /// `SLASH`, `RPAREN`). Custom token names that don't map to a built-in
+    /// `TokenType` are carried verbatim in `type_name` (and `KEYWORD` for
+    /// promoted keywords), so those are returned directly. Tokens whose name
+    /// *does* map to a built-in `TokenType` carry `type_name == None` and only
+    /// the enum — so we invert [`string_to_token_type`] to recover the grammar
+    /// name. Anything unrecognised returns `""` and matches no rule.
+    fn transition_key(token: &Token) -> &str {
+        if let Some(name) = token.type_name.as_deref() {
+            return name;
+        }
+        match token.type_ {
+            TokenType::Name => "NAME",
+            TokenType::Number => "NUMBER",
+            TokenType::String => "STRING",
+            TokenType::Keyword => "KEYWORD",
+            TokenType::Plus => "PLUS",
+            TokenType::Minus => "MINUS",
+            TokenType::Star => "STAR",
+            TokenType::Slash => "SLASH",
+            TokenType::Equals => "EQUALS",
+            TokenType::EqualsEquals => "EQUALS_EQUALS",
+            TokenType::LParen => "LPAREN",
+            TokenType::RParen => "RPAREN",
+            TokenType::Comma => "COMMA",
+            TokenType::Colon => "COLON",
+            TokenType::Semicolon => "SEMICOLON",
+            TokenType::LBrace => "LBRACE",
+            TokenType::RBrace => "RBRACE",
+            TokenType::LBracket => "LBRACKET",
+            TokenType::RBracket => "RBRACKET",
+            TokenType::Dot => "DOT",
+            TokenType::Bang => "BANG",
+            TokenType::Newline => "NEWLINE",
+            TokenType::Indent => "INDENT",
+            TokenType::Dedent => "DEDENT",
+            TokenType::Eof => "EOF",
+        }
+    }
+
+    /// Apply the declarative mode transition table after `token` is emitted (F10).
+    ///
+    /// The first rule whose trigger token, optional `in MODE` guard, and
+    /// optional keyword-value guard all match wins; its actions mutate the
+    /// active-mode register (top of `group_stack`) and/or the skip flag:
+    ///
+    /// - `SetMode(m)` — replace the active mode in place (flat toggle, no depth
+    ///   change). This is how regex-vs-division position is tracked.
+    /// - `Push(g)` / `Pop` — F04 nested-region save/restore (templates).
+    /// - `EnableSkip` / `DisableSkip` — toggle `skip_enabled`.
+    ///
+    /// No-op when the table is empty (F04 behaviour).
+    fn apply_transitions(&mut self, token: &Token) {
+        if self.transitions.is_empty() {
+            return;
+        }
+        let key = Self::transition_key(token);
+        let active = self
+            .group_stack
+            .last()
+            .map(|s| s.as_str())
+            .unwrap_or("default")
+            .to_string();
+
+        // Find the first matching rule, cloning its actions so the immutable
+        // borrow of `self.transitions` ends before we mutate `self.group_stack`.
+        let mut matched: Option<Vec<TransitionAction>> = None;
+        for rule in &self.transitions {
+            if !rule.on_tokens.iter().any(|t| t == key) {
+                continue;
+            }
+            if let Some(m) = &rule.in_mode {
+                if m != &active {
+                    continue;
+                }
+            }
+            if let Some(v) = &rule.on_value {
+                if v != &token.value {
+                    continue;
+                }
+            }
+            matched = Some(rule.actions.clone());
+            break;
+        }
+
+        if let Some(actions) = matched {
+            for action in actions {
+                match action {
+                    TransitionAction::SetMode(m) => {
+                        if let Some(top) = self.group_stack.last_mut() {
+                            *top = m;
+                        }
+                    }
+                    TransitionAction::Push(g) => self.group_stack.push(g),
+                    TransitionAction::Pop => {
+                        if self.group_stack.len() > 1 {
+                            self.group_stack.pop();
+                        }
+                    }
+                    TransitionAction::EnableSkip => self.skip_enabled = true,
+                    TransitionAction::DisableSkip => self.skip_enabled = false,
+                }
+            }
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1055,6 +1228,15 @@ impl<'a> GrammarLexer<'a> {
 
                     // Apply suppression: if the callback suppressed this
                     // token, don't add it to the output.
+                    //
+                    // F10: capture the (emitted) main token so the declarative
+                    // table can fire on IT after the callback's own actions —
+                    // not on a callback-synthetic Emit token.
+                    let main_token_for_trans = if ctx.suppressed {
+                        None
+                    } else {
+                        Some(token.clone())
+                    };
                     if !ctx.suppressed {
                         self.bracket_depths.update(&token.value);
                         self.last_emitted_token = Some(token.clone());
@@ -1085,8 +1267,17 @@ impl<'a> GrammarLexer<'a> {
                             }
                         }
                     }
+
+                    // F10: the declarative table is the default; a registered
+                    // callback runs first (above) and the table refines.
+                    if let Some(t) = main_token_for_trans {
+                        self.apply_transitions(&t);
+                    }
                 } else {
                     self.bracket_depths.update(&token.value);
+                    // F10: consult the declarative table before the token is
+                    // moved into `tokens`, so the new mode governs the NEXT match.
+                    self.apply_transitions(&token);
                     self.last_emitted_token = Some(token.clone());
                     tokens.push(token);
                 }
@@ -1109,7 +1300,8 @@ impl<'a> GrammarLexer<'a> {
         });
 
         // Reset group stack and skip_enabled for reuse.
-        self.group_stack = vec!["default".to_string()];
+        // F10: reset to the configured start mode, not the bare "default".
+        self.group_stack = vec![self.start_mode.clone()];
         self.skip_enabled = true;
 
         Ok(tokens)
@@ -2833,5 +3025,133 @@ PLUS = "+""#,
             (TokenType::Keyword, "FROM"),
             (TokenType::Name,    "users"),
         ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // F10: declarative lexer mode transitions
+    // -----------------------------------------------------------------------
+
+    /// A small JS-shaped grammar that exercises regex-vs-division. `default`
+    /// (expression position) lists `REGEX` before `SLASH`; the `div` mode
+    /// (operand position) overrides only the slash tokens and inherits the
+    /// rest from `default`.
+    fn regex_div_grammar() -> TokenGrammar {
+        parse_token_grammar(
+            "\
+NAME = /[a-z]+/
+REGEX = /\\/[a-z]+\\//
+SLASH_EQUALS = \"/=\"
+SLASH = \"/\"
+EQUALS = \"=\"
+PLUS = \"+\"
+
+group div:
+  SLASH_EQUALS = \"/=\"
+  SLASH = \"/\"
+
+start_mode: default
+transitions:
+  on NAME -> set-mode div
+  on (EQUALS | PLUS | SLASH | SLASH_EQUALS | REGEX) -> set-mode default
+",
+        )
+        .unwrap()
+    }
+
+    fn names(tokens: &[Token]) -> Vec<String> {
+        // Use the same canonical UPPER_SNAKE identity the matcher uses.
+        tokens
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| GrammarLexer::transition_key(t).to_string())
+            .collect()
+    }
+
+    #[test]
+    fn f10_division_chain_lexed_as_slashes() {
+        // `a/b/c` in operand position: each `/` is division, not a regex.
+        let g = regex_div_grammar();
+        let toks = GrammarLexer::new("a/b/c", &g).tokenize().unwrap();
+        assert_eq!(
+            names(&toks),
+            vec!["NAME", "SLASH", "NAME", "SLASH", "NAME"]
+        );
+    }
+
+    #[test]
+    fn f10_regex_in_expression_position() {
+        // After `=`, a `/.../`  is a regex literal.
+        let g = regex_div_grammar();
+        let toks = GrammarLexer::new("x=/ab/", &g).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["NAME", "EQUALS", "REGEX"]);
+    }
+
+    #[test]
+    fn f10_flat_mode_inherits_default_patterns() {
+        // In `div` mode a NAME has no override, so it must be matched via
+        // inheritance from the default group. If inheritance were off, the
+        // second identifier would fail to lex.
+        let g = regex_div_grammar();
+        let toks = GrammarLexer::new("ab cd", &g).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["NAME", "NAME"]);
+    }
+
+    #[test]
+    fn f10_slash_equals_override_beats_inherited_regex() {
+        // `a/=b` — in div mode the `/=` override wins over the inherited
+        // `REGEX`/`SLASH` patterns.
+        let g = regex_div_grammar();
+        let toks = GrammarLexer::new("a/=b", &g).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["NAME", "SLASH_EQUALS", "NAME"]);
+    }
+
+    #[test]
+    fn f10_no_transitions_is_backward_compatible() {
+        // The SAME tokens without a transitions table: `REGEX` greedily wins,
+        // so `a/b/c` lexes as NAME REGEX NAME (the pre-F10 behaviour). This
+        // pins that an empty table changes nothing.
+        let g = parse_token_grammar(
+            "NAME = /[a-z]+/\nREGEX = /\\/[a-z]+\\//\nSLASH = \"/\"\n",
+        )
+        .unwrap();
+        let toks = GrammarLexer::new("a/b/c", &g).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["NAME", "REGEX", "NAME"]);
+    }
+
+    #[test]
+    fn f10_push_region_stays_exclusive() {
+        // A `push`ed region is NOT a flat mode: it does NOT inherit default,
+        // preserving F04 exclusivity. Here the `tag` region only knows `WORD`
+        // and `CLOSE`; the default `BANG` is invisible inside it, so a `!`
+        // inside the region is a lex error.
+        let g = parse_token_grammar(
+            "\
+OPEN = \"<\"
+BANG = \"!\"
+group tag:
+  WORD = /[a-z]+/
+  CLOSE = \">\"
+transitions:
+  on OPEN -> push tag
+  on CLOSE -> pop
+",
+        )
+        .unwrap();
+        // Inside the region, `!` (a default token) must NOT match.
+        assert!(GrammarLexer::new("<a!>", &g).tokenize().is_err());
+        // A well-formed region tokenizes; after `>` we pop back to default
+        // where `!` is valid again.
+        let toks = GrammarLexer::new("<ab>!", &g).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["OPEN", "WORD", "CLOSE", "BANG"]);
+    }
+
+    #[test]
+    fn f10_start_mode_is_respected() {
+        // Starting directly in `div` means the first `/` is a division slash.
+        let g = regex_div_grammar();
+        let mut g2 = g.clone();
+        g2.start_mode = Some("div".to_string());
+        let toks = GrammarLexer::new("a/b", &g2).tokenize().unwrap();
+        assert_eq!(names(&toks), vec!["NAME", "SLASH", "NAME"]);
     }
 }

--- a/code/packages/rust/lisp-lexer/src/_grammar.rs
+++ b/code/packages/rust/lisp-lexer/src/_grammar.rs
@@ -91,5 +91,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/macsyma-lexer/src/_grammar.rs
+++ b/code/packages/rust/macsyma-lexer/src/_grammar.rs
@@ -238,5 +238,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/mosaic-lexer/src/_grammar.rs
+++ b/code/packages/rust/mosaic-lexer/src/_grammar.rs
@@ -154,5 +154,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/moslayout-compiler/src/_grammar.rs
+++ b/code/packages/rust/moslayout-compiler/src/_grammar.rs
@@ -213,6 +213,8 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }
 

--- a/code/packages/rust/mosmodel-compiler/src/_grammar.rs
+++ b/code/packages/rust/mosmodel-compiler/src/_grammar.rs
@@ -166,6 +166,8 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }
 

--- a/code/packages/rust/mosstyle-compiler/src/_grammar.rs
+++ b/code/packages/rust/mosstyle-compiler/src/_grammar.rs
@@ -164,6 +164,8 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }
 

--- a/code/packages/rust/nib-lexer/src/_grammar.rs
+++ b/code/packages/rust/nib-lexer/src/_grammar.rs
@@ -266,5 +266,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/oct-lexer/src/_grammar.rs
+++ b/code/packages/rust/oct-lexer/src/_grammar.rs
@@ -238,5 +238,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/prolog-lexer/src/_grammar.rs
+++ b/code/packages/rust/prolog-lexer/src/_grammar.rs
@@ -217,5 +217,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/python-lexer/src/_grammar.rs
+++ b/code/packages/rust/python-lexer/src/_grammar.rs
@@ -682,6 +682,8 @@ mod v_2_7 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1249,6 +1251,8 @@ mod v_3_0 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1823,6 +1827,8 @@ mod v_3_6 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2453,6 +2459,8 @@ mod v_3_8 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3118,6 +3126,8 @@ mod v_3_10 {
             context_keywords: vec![],
             soft_keywords: vec![r#"match"#.to_string(), r#"case"#.to_string(), r#"_"#.to_string()],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3783,6 +3793,8 @@ mod v_3_12 {
             context_keywords: vec![],
             soft_keywords: vec![r#"match"#.to_string(), r#"case"#.to_string(), r#"_"#.to_string(), r#"type"#.to_string()],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/sql-lexer/src/_grammar.rs
+++ b/code/packages/rust/sql-lexer/src/_grammar.rs
@@ -196,5 +196,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/starlark-lexer/src/_grammar.rs
+++ b/code/packages/rust/starlark-lexer/src/_grammar.rs
@@ -441,5 +441,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/toml-lexer/src/_grammar.rs
+++ b/code/packages/rust/toml-lexer/src/_grammar.rs
@@ -266,5 +266,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }

--- a/code/packages/rust/typescript-lexer/src/_grammar.rs
+++ b/code/packages/rust/typescript-lexer/src/_grammar.rs
@@ -523,6 +523,8 @@ mod v_ts1_0 {
             context_keywords: vec![r#"get"#.to_string(), r#"set"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1076,6 +1078,8 @@ mod v_ts2_0 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string(), r#"never"#.to_string(), r#"infer"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1643,6 +1647,8 @@ mod v_ts3_0 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string(), r#"infer"#.to_string(), r#"never"#.to_string(), r#"unknown"#.to_string(), r#"override"#.to_string(), r#"out"#.to_string(), r#"satisfies"#.to_string(), r#"accessor"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2273,6 +2279,8 @@ mod v_ts4_0 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string(), r#"infer"#.to_string(), r#"never"#.to_string(), r#"unknown"#.to_string(), r#"override"#.to_string(), r#"out"#.to_string(), r#"satisfies"#.to_string(), r#"accessor"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -2910,6 +2918,8 @@ mod v_ts5_0 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string(), r#"infer"#.to_string(), r#"never"#.to_string(), r#"unknown"#.to_string(), r#"override"#.to_string(), r#"out"#.to_string(), r#"satisfies"#.to_string(), r#"accessor"#.to_string(), r#"using"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -3554,6 +3564,8 @@ mod v_ts5_8 {
             context_keywords: vec![r#"as"#.to_string(), r#"from"#.to_string(), r#"of"#.to_string(), r#"get"#.to_string(), r#"set"#.to_string(), r#"static"#.to_string(), r#"using"#.to_string(), r#"type"#.to_string(), r#"interface"#.to_string(), r#"namespace"#.to_string(), r#"module"#.to_string(), r#"declare"#.to_string(), r#"abstract"#.to_string(), r#"readonly"#.to_string(), r#"is"#.to_string(), r#"keyof"#.to_string(), r#"asserts"#.to_string(), r#"unique"#.to_string(), r#"infer"#.to_string(), r#"never"#.to_string(), r#"unknown"#.to_string(), r#"override"#.to_string(), r#"out"#.to_string(), r#"satisfies"#.to_string(), r#"accessor"#.to_string()],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/verilog-lexer/src/_grammar.rs
+++ b/code/packages/rust/verilog-lexer/src/_grammar.rs
@@ -410,6 +410,8 @@ mod v_1995 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -802,6 +804,8 @@ mod v_2001 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1194,6 +1198,8 @@ mod v_2005 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/verilog-lexer/src/_grammar_1995.rs
+++ b/code/packages/rust/verilog-lexer/src/_grammar_1995.rs
@@ -383,6 +383,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/verilog-lexer/src/_grammar_2001.rs
+++ b/code/packages/rust/verilog-lexer/src/_grammar_2001.rs
@@ -383,6 +383,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/verilog-lexer/src/_grammar_2005.rs
+++ b/code/packages/rust/verilog-lexer/src/_grammar_2005.rs
@@ -383,6 +383,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/verilog-lexer/src/_grammar_generic.rs
+++ b/code/packages/rust/verilog-lexer/src/_grammar_generic.rs
@@ -383,6 +383,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar.rs
@@ -302,6 +302,8 @@ mod v_1987 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -582,6 +584,8 @@ mod v_1993 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -862,6 +866,8 @@ mod v_2002 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1142,6 +1148,8 @@ mod v_2008 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }
@@ -1422,6 +1430,8 @@ mod v_2019 {
             context_keywords: vec![],
             soft_keywords: vec![],
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         }
     }
 }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_1987.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_1987.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_1993.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_1993.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_2002.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_2002.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_2008.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_2008.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_2019.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_2019.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/vhdl-lexer/src/_grammar_generic.rs
+++ b/code/packages/rust/vhdl-lexer/src/_grammar_generic.rs
@@ -271,6 +271,8 @@ pub fn token_grammar() -> TokenGrammar {
         version: 0,
         case_insensitive: false,
             layout_keywords: vec![],
+            start_mode: None,
+            transitions: vec![],
         context_keywords: vec![],
         soft_keywords: vec![],
     }

--- a/code/packages/rust/xml-lexer/src/_grammar.rs
+++ b/code/packages/rust/xml-lexer/src/_grammar.rs
@@ -204,5 +204,7 @@ pub fn token_grammar() -> TokenGrammar {
         context_keywords: vec![],
         soft_keywords: vec![],
         layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
     }
 }


### PR DESCRIPTION
## What

Wires the F10 transition table into `GrammarLexer` so context-sensitive tokenization is driven by the grammar, not a hand-written callback. **PR-2** of the F10 arc — **stacked on #5662** (PR-1, base branch).

## Changes

- **`apply_transitions`** — after each token is emitted, consult the table (first-matching-rule-wins) and mutate the active-mode register: `set-mode` replaces the top of the group stack in place (flat toggle), `push`/`pop` are F04 nested-region save/restore, `enable-skip`/`disable-skip` toggle the skip flag. Early-returns on an empty table (F04 backward-compat). Composes after a registered `on-token` callback.
- **`transition_key`** — a token's grammar identity is its `type_name` (custom tokens + `KEYWORD`), else the UPPER_SNAKE inverse of `string_to_token_type` for the 25 built-in `TokenType` variants. This is what `on NAME` / `on RPAREN` / `on KEYWORD="return"` match against.
- **`start_mode`** — `group_stack` initialises to / resets to the grammar's start mode.

## Key design refinement discovered here: flat-mode inheritance

A non-default group matches its patterns **exclusively** (correct for XML regions). But a JS `div` mode is nearly identical to `default` — exclusivity would force duplicating the whole grammar. Fix: **a group reached via `set-mode` inherits the default patterns** (own patterns win on priority), so `div` overrides `SLASH`/`SLASH_EQUALS` ahead of `REGEX` without duplication; **`push` targets stay exclusive** (F04 region semantics). Derived automatically from the transition table — no DSL change. (I'll fold this into the F10 spec in PR-0.)

## Tests (7 new; 131 lexer tests pass)

regex-vs-division via inheritance (`a/b/c` → `NAME SLASH NAME SLASH NAME`; `x=/ab/` → `REGEX`), flat-mode inheritance, `/=` override, push-region exclusivity, `start_mode`, and **no-table backward-compat** (`a/b/c` → `NAME REGEX NAME`, the pre-F10 behaviour). closurec + downstream build unchanged.

## Security

Pure index-guarded mutation of `Vec`/strings; action count bounded by `MAX_TRANSITIONS` (PR-1); no `unsafe`, no I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)