### PR TITLE
feat(irc-net-reactor): all-Rust IRC engine on the home-grown reactor with broadcast

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -514,6 +514,7 @@ members = [
     "irc-framing",
     "irc-server",
     "irc-net-stdlib",
+    "irc-net-reactor",
     "url-parser",
     "closure-emitter",
     "closure-pass-collapse-properties",

--- a/code/packages/rust/irc-net-reactor/BUILD
+++ b/code/packages/rust/irc-net-reactor/BUILD
@@ -1,0 +1,1 @@
+cargo test -p irc-net-reactor -- --nocapture

--- a/code/packages/rust/irc-net-reactor/CHANGELOG.md
+++ b/code/packages/rust/irc-net-reactor/CHANGELOG.md
@@ -20,9 +20,16 @@ All notable changes to this package will be documented in this file.
 - `bind` / `local_addr` / `serve` / `stop` / `is_running` control surface,
   mirroring `mini-redis`'s `MiniRedisServer` shape so language bindings can follow
   the proven `conduit` embedding pattern.
+- **Hostile-client resilience**: each reactor callback is wrapped in
+  `catch_unwind` so a panic inside `IRCServer` on a crafted message closes only
+  the offending connection instead of crashing the single event-loop thread
+  (which would drop every connected client); the shared `IRCServer` mutex is
+  locked poison-tolerantly (`into_inner` recovery) so one contained failure does
+  not permanently brick state for everyone else.
 - Real-socket integration tests covering registration (001 welcome), PING/PONG,
-  channel `PRIVMSG` broadcast to a different connection, `QUIT` broadcast on
-  disconnect, config defaults, and double-`serve` rejection.
+  channel `PRIVMSG` broadcast to a different connection, graceful `QUIT`-command
+  broadcast, abrupt-disconnect `QUIT` broadcast, poisoned-mutex recovery, config
+  defaults, and double-`serve` rejection.
 
 ### Notes
 

--- a/code/packages/rust/irc-net-reactor/CHANGELOG.md
+++ b/code/packages/rust/irc-net-reactor/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-06-13
+
+### Added
+
+- `IrcReactorServer` — an all-Rust IRC server engine that hosts the pure
+  `irc_server::IRCServer` state machine on the home-grown `tcp-runtime` reactor
+  (`kqueue` on macOS/BSD, `epoll` on Linux, IOCP/WSAPoll on Windows).
+- `IrcConfig` — runtime configuration (`host`, `port`, `server_name`, `motd`,
+  `oper_password`, `max_connections`); `port = 0` binds an ephemeral port.
+- In-process **broadcast** via the runtime's `TcpMailbox`: each
+  `irc_server::Response` is serialized and delivered to its target connection by
+  id, so one client's `PRIVMSG` reaches other channel members' sockets. This is
+  the first server in the repo to use the mailbox for genuine fan-out.
+- Per-connection `Framer` state for CRLF line reassembly; lossy UTF-8 decoding;
+  silent skipping of unparseable lines (RFC-traditional behaviour).
+- `bind` / `local_addr` / `serve` / `stop` / `is_running` control surface,
+  mirroring `mini-redis`'s `MiniRedisServer` shape so language bindings can follow
+  the proven `conduit` embedding pattern.
+- Real-socket integration tests covering registration (001 welcome), PING/PONG,
+  channel `PRIVMSG` broadcast to a different connection, `QUIT` broadcast on
+  disconnect, config defaults, and double-`serve` rejection.
+
+### Notes
+
+- Reuses `irc-server`, `irc-proto`, and `irc-framing` unchanged — only the
+  transport layer is new.
+- See `code/specs/irc-net-reactor.md` for the full design and the native-binding
+  roadmap (Python/Ruby/Node first; JVM/Swift/Elixir/Perl later).

--- a/code/packages/rust/irc-net-reactor/Cargo.toml
+++ b/code/packages/rust/irc-net-reactor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "irc-net-reactor"
+version = "0.1.0"
+edition = "2021"
+description = "All-Rust IRC server engine hosted on the home-grown tcp-runtime reactor (kqueue/epoll/IOCP) with in-process broadcast"
+authors = ["coding-adventures"]
+license = "MIT"
+
+[dependencies]
+irc-proto = { path = "../irc-proto" }
+irc-framing = { path = "../irc-framing" }
+irc-server = { path = "../irc-server" }
+tcp-runtime = { path = "../tcp-runtime" }
+transport-platform = { path = "../transport-platform" }
+
+[dev-dependencies]

--- a/code/packages/rust/irc-net-reactor/README.md
+++ b/code/packages/rust/irc-net-reactor/README.md
@@ -1,0 +1,85 @@
+# irc-net-reactor
+
+An **all-Rust IRC server engine** hosted on this repository's home-grown TCP
+runtime (`tcp-runtime` → `transport-platform` → raw `kqueue`/`epoll`/IOCP), with
+in-process broadcast via the runtime's `TcpMailbox`.
+
+This is the engine that the per-language native bindings
+(`python-bridge`/`ruby-bridge`/`node-bridge` wrappers) embed to give every
+language a high-performance IRC server without re-implementing any IRC logic.
+
+## Where it sits in the stack
+
+```
+irc-server (state machine) + irc-proto + irc-framing      ← reused unchanged
+        ↓ wired by
+irc-net-reactor   (THIS CRATE: IRCServer on tcp-runtime, broadcast via TcpMailbox)
+        ↓ runs on
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+        ↑ embedded via per-language native bridge (create / serve / stop)
+   python-bridge   node-bridge   ruby-bridge   …
+```
+
+See [`code/specs/irc-net-reactor.md`](../../../specs/irc-net-reactor.md) for the
+full design, including the broadcast mechanism and concurrency model.
+
+## Why a reactor instead of threads
+
+`irc-net-stdlib` spends one OS thread (and its multi-MB stack) per connection.
+`irc-net-reactor` uses a single event-loop thread that the kernel wakes only when
+a socket is readable — the reactor pattern behind nginx, Redis, and Node.js. The
+IRC *logic* is unchanged; only the transport differs.
+
+## The broadcast mechanism
+
+IRC must write one client's message to *other* clients' sockets. The reactor's
+`TcpMailbox.send(connection_id, bytes)` targets **any** connection by id, from
+any thread. `IRCServer` returns a `Vec<Response>` where each response names its
+target connection; the engine serializes each message and hands it to the
+mailbox. Replies to the sender and fan-out to channel members share one path.
+
+## Usage
+
+```rust
+use irc_net_reactor::{IrcConfig, IrcReactorServer};
+
+let server = IrcReactorServer::bind(IrcConfig {
+    host: "127.0.0.1".to_string(),
+    port: 6667,
+    server_name: "irc.local".to_string(),
+    motd: vec!["Welcome.".to_string()],
+    oper_password: String::new(),
+    max_connections: 1024,
+})?;
+
+println!("listening on {}", server.local_addr());
+server.serve()?; // blocks until server.stop() is called from another thread
+# Ok::<(), std::io::Error>(())
+```
+
+`port = 0` binds an OS-assigned ephemeral port, readable afterwards via
+`local_addr()` — convenient for tests.
+
+## Testing
+
+```
+cargo test -p irc-net-reactor
+```
+
+The integration tests drive two real `TcpStream` clients through registration,
+channel `PRIVMSG` **broadcast** (one client sees another's message — the fan-out
+proof), `QUIT` broadcast on disconnect, and `PING`/`PONG`.
+
+## Platform support
+
+| OS                | Event backend |
+|-------------------|---------------|
+| macOS / *BSD      | `kqueue`      |
+| Linux             | `epoll`       |
+| Windows           | IOCP / WSAPoll|
+
+## Limitations
+
+- Plaintext only (no TLS), matching the rest of the `irc-net-*` family.
+- No IRC-level per-client backpressure beyond the runtime's
+  `max_pending_write_bytes` cap. See the spec for details.

--- a/code/packages/rust/irc-net-reactor/src/lib.rs
+++ b/code/packages/rust/irc-net-reactor/src/lib.rs
@@ -53,11 +53,28 @@
 //! single reactor thread the mutex is essentially uncontended; the design also
 //! stays correct under a future sharded runtime because mailbox sends are
 //! themselves thread-safe.
+//!
+//! ## Resilience to a hostile client (panic isolation)
+//!
+//! The reactor runs the connection callbacks inline on its single event-loop
+//! thread with no `catch_unwind` of its own, so an unhandled panic inside a
+//! callback would tear down the **entire** server — every connected client, not
+//! just the offender.  To keep one malicious or malformed message from becoming
+//! a whole-server denial of service we apply two safeguards here:
+//!
+//! 1. **Panic containment** — each callback is wrapped in `catch_unwind`; a
+//!    panic that escapes `IRCServer` is caught and turned into "close just this
+//!    connection," leaving every other client untouched.
+//! 2. **Poison tolerance** — a panic while the `IRCServer` mutex is held poisons
+//!    it; we recover the guard with `into_inner()` instead of re-panicking, so a
+//!    single contained failure does not permanently brick the shared state for
+//!    everyone else.
 
 use std::io;
 use std::net::SocketAddr;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use irc_framing::Framer;
 use irc_proto::{parse, serialize, ParseError};
@@ -199,7 +216,10 @@ impl IrcReactorServer {
         let mut runtime = self
             .runtime
             .lock()
-            .expect("irc-net-reactor runtime mutex poisoned")
+            // Recover rather than re-panic if a prior holder panicked: this mutex
+            // only guards the runtime handoff and is never touched on the remote
+            // data path, but recovering keeps `serve` callable regardless.
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take()
             .ok_or_else(|| {
                 io::Error::new(
@@ -230,8 +250,21 @@ impl IrcReactorServer {
 // Connection callbacks — the bridge between the reactor and IRCServer
 //
 // These are free functions (rather than inline closures) so the three
-// platform-specific `build_runtime` variants can share one implementation.
+// platform-specific `build_runtime` variants can share one implementation.  The
+// macro that wires them into the reactor wraps each in `catch_unwind`, so a
+// panic inside `IRCServer` closes only the offending connection instead of
+// crashing the shared event-loop thread.
 // ──────────────────────────────────────────────────────────────────────────────
+
+/// Lock the shared `IRCServer`, recovering the guard if the mutex was poisoned
+/// by an earlier (contained) panic.  Re-panicking on a poisoned mutex would turn
+/// one bad message into a permanent outage for every client, so we deliberately
+/// keep serving with the recovered state instead.
+fn lock_server(server: &Mutex<IRCServer>) -> MutexGuard<'_, IRCServer> {
+    server
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 /// A new connection opened: tell the IRC state machine, deliver any responses
 /// (normally none until the client registers), and hand back a fresh `Framer`
@@ -243,10 +276,7 @@ fn handle_connect(
 ) -> Framer {
     // The peer's IP becomes the host part of the client's `nick!user@host` mask.
     let host = info.peer_addr.ip().to_string();
-    let responses = {
-        let mut server = server.lock().expect("IRCServer mutex poisoned");
-        server.on_connect(ConnId(info.id.0), &host)
-    };
+    let responses = lock_server(server).on_connect(ConnId(info.id.0), &host);
     deliver(mailbox, responses);
     Framer::new()
 }
@@ -275,10 +305,7 @@ fn handle_data(
             Err(ParseError(_)) => continue,
         };
 
-        let responses = {
-            let mut server = server.lock().expect("IRCServer mutex poisoned");
-            server.on_message(ConnId(info.id.0), &msg)
-        };
+        let responses = lock_server(server).on_message(ConnId(info.id.0), &msg);
         deliver(mailbox, responses);
     }
 
@@ -295,10 +322,7 @@ fn handle_close(
     info: TcpConnectionInfo,
     _framer: Framer,
 ) {
-    let responses = {
-        let mut server = server.lock().expect("IRCServer mutex poisoned");
-        server.on_disconnect(ConnId(info.id.0))
-    };
+    let responses = lock_server(server).on_disconnect(ConnId(info.id.0));
     deliver(mailbox, responses);
 }
 
@@ -346,14 +370,36 @@ macro_rules! bind_with {
         let close_server = Arc::clone(&$server);
         let close_mailbox = Arc::clone(&$mailbox);
 
+        // Each callback is wrapped in `catch_unwind` so that a panic inside
+        // `IRCServer` (on some crafted message) is contained to the offending
+        // connection rather than unwinding into — and killing — the reactor's
+        // single event-loop thread.  `AssertUnwindSafe` is sound here: on a
+        // caught panic the shared `IRCServer` mutex may be poisoned, but
+        // `lock_server` recovers it, so observing post-panic state is acceptable.
         $bind(
             (host.as_str(), $config.port),
             runtime_options($config),
-            move |info| handle_connect(&connect_server, &connect_mailbox, info),
-            move |info, framer, bytes| {
-                handle_data(&data_server, &data_mailbox, info, framer, bytes)
+            move |info| {
+                catch_unwind(AssertUnwindSafe(|| {
+                    handle_connect(&connect_server, &connect_mailbox, info)
+                }))
+                // A panic during connect setup: hand back a fresh framer and let
+                // the connection proceed (it has no IRC state yet).
+                .unwrap_or_else(|_| Framer::new())
             },
-            move |info, framer| handle_close(&close_server, &close_mailbox, info, framer),
+            move |info, framer, bytes| {
+                catch_unwind(AssertUnwindSafe(|| {
+                    handle_data(&data_server, &data_mailbox, info, framer, bytes)
+                }))
+                // A panic while handling this client's data closes *only* this
+                // connection; every other client keeps running.
+                .unwrap_or_else(|_| TcpHandlerResult::close())
+            },
+            move |info, framer| {
+                let _ = catch_unwind(AssertUnwindSafe(|| {
+                    handle_close(&close_server, &close_mailbox, info, framer)
+                }));
+            },
         )
     }};
 }
@@ -602,6 +648,32 @@ mod tests {
 
         server.stop();
         handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn lock_server_recovers_from_a_poisoned_mutex() {
+        // A panic while the IRCServer lock is held poisons the mutex.  The
+        // resilience contract is that the next lock recovers the state and keeps
+        // serving, rather than re-panicking and bricking the server for everyone.
+        let server = Mutex::new(IRCServer::new("irc.local", vec!["hi".to_string()], ""));
+
+        // Poison the mutex deliberately, swallowing the panic (and its noisy
+        // default hook) so the test output stays clean.
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = server.lock().unwrap();
+            panic!("boom while holding the IRCServer lock");
+        }));
+        std::panic::set_hook(prev_hook);
+        assert!(server.is_poisoned(), "mutex should be poisoned");
+
+        // lock_server hands back a usable guard, and the recovered server still works.
+        let responses = lock_server(&server).on_connect(ConnId(1), "127.0.0.1");
+        assert!(
+            responses.is_empty(),
+            "on_connect returns no immediate responses"
+        );
     }
 
     #[test]

--- a/code/packages/rust/irc-net-reactor/src/lib.rs
+++ b/code/packages/rust/irc-net-reactor/src/lib.rs
@@ -1,0 +1,640 @@
+//! # irc-net-reactor — an all-Rust IRC server on the home-grown reactor
+//!
+//! This crate hosts the pure [`irc_server::IRCServer`] state machine directly on
+//! the repository's home-grown TCP runtime (`tcp-runtime` →
+//! `transport-platform` → raw `kqueue`/`epoll`/IOCP).  Every line of logic —
+//! transport *and* IRC protocol — lives in Rust.  Higher-level language bindings
+//! (`python-bridge`, `ruby-bridge`, `node-bridge`, …) embed this engine and
+//! expose only a three-call control surface: create, serve, stop.
+//!
+//! ## How it differs from `irc-net-stdlib`
+//!
+//! `irc-net-stdlib` (Level 1) dedicates one blocking OS thread to every
+//! connection.  `irc-net-reactor` (this crate) uses a single event-loop thread
+//! that the kernel wakes only when a socket is readable — the reactor pattern
+//! behind nginx, Redis, and Node.js.  The IRC *logic* is byte-for-byte the same
+//! (`irc-server`, `irc-proto`, `irc-framing` are reused unchanged); only the
+//! transport changes.
+//!
+//! ## The broadcast problem and how the mailbox solves it
+//!
+//! IRC is a *broadcast* protocol.  When Alice sends `PRIVMSG #chan :hi`, the
+//! bytes must be written to Bob's and Carol's sockets — connections *other than*
+//! the one that produced the data.  A naive request/response handler (like
+//! `mini-redis`) can only write back to the connection it is currently serving.
+//!
+//! The reactor solves this with the [`tcp_runtime::TcpMailbox`].  `mailbox.send(
+//! connection_id, bytes)` enqueues a write to **any** connection by id, from any
+//! thread.  `IRCServer` already returns a `Vec<Response>` where each
+//! [`irc_server::Response`] names its own target `conn_id`; we simply serialize
+//! each message and hand it to the mailbox.  Replies to the sender and fan-out
+//! to other members travel the exact same path.
+//!
+//! ## Wiring diagram
+//!
+//! ```text
+//!   TCP bytes
+//!     ↓  (kqueue/epoll readiness)
+//!   tcp-runtime read callback ──→ per-connection Framer.feed()
+//!     ↓  Framer.frames()  → b"PRIVMSG #chan :hi"
+//!   irc_proto::parse() → Message
+//!     ↓
+//!   IRCServer::on_message(conn_id, &msg) → Vec<Response>   (under a Mutex)
+//!     ↓  for each Response: irc_proto::serialize(&msg)
+//!   TcpMailbox.send(target_conn_id, wire_bytes)   ← fan-out to OTHER sockets
+//!     ↓
+//!   TCP bytes on the wire
+//! ```
+//!
+//! ## Concurrency
+//!
+//! `irc-server` documents itself as *not* thread-safe, so a single
+//! `Arc<Mutex<IRCServer>>` serializes every state mutation.  With the default
+//! single reactor thread the mutex is essentially uncontended; the design also
+//! stays correct under a future sharded runtime because mailbox sends are
+//! themselves thread-safe.
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use irc_framing::Framer;
+use irc_proto::{parse, serialize, ParseError};
+use irc_server::{ConnId, IRCServer, Response};
+use tcp_runtime::{
+    ConnectionId, PlatformError, StopHandle, TcpConnectionInfo, TcpHandlerResult, TcpMailbox,
+    TcpRuntime, TcpRuntimeOptions,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Platform type alias
+//
+// `tcp-runtime` is generic over the OS event backend.  We pick the right one per
+// target so the rest of the crate is platform-agnostic.  The per-connection
+// state parameter is `Framer` — each socket gets its own line reassembler.
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+type IrcRuntime = TcpRuntime<transport_platform::bsd::KqueueTransportPlatform, Framer>;
+
+#[cfg(target_os = "linux")]
+type IrcRuntime = TcpRuntime<transport_platform::linux::EpollTransportPlatform, Framer>;
+
+#[cfg(target_os = "windows")]
+type IrcRuntime = TcpRuntime<transport_platform::windows::WindowsTransportPlatform, Framer>;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Runtime configuration for an [`IrcReactorServer`].
+///
+/// `port = 0` lets the OS assign a free ephemeral port — handy for tests, which
+/// then read the real port back via [`IrcReactorServer::local_addr`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IrcConfig {
+    /// Bind address, e.g. `"127.0.0.1"` (loopback) or `"0.0.0.0"` (all interfaces).
+    pub host: String,
+    /// TCP port to listen on; `0` requests an OS-assigned ephemeral port.
+    pub port: u16,
+    /// Server name shown in the `001` welcome and as the prefix of server messages.
+    pub server_name: String,
+    /// Message of the Day lines (RFC 1459 §4.1 requires at least one).
+    pub motd: Vec<String>,
+    /// Password for the `OPER` command; an empty string disables `OPER`.
+    pub oper_password: String,
+    /// Maximum number of simultaneous connections.
+    pub max_connections: usize,
+}
+
+impl Default for IrcConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 6667,
+            server_name: "irc.local".to_string(),
+            motd: vec!["Welcome.".to_string()],
+            oper_password: String::new(),
+            max_connections: TcpRuntimeOptions::default().max_connections,
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// The server
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// An IRC server running entirely in Rust on the home-grown reactor.
+///
+/// `bind` constructs the engine and binds the listener eagerly (so the port is
+/// known immediately).  `serve` then runs the blocking event loop until `stop`
+/// is called.  The handle is cheap to [`Clone`]; clones share the same
+/// underlying runtime and stop signal, which lets one clone `serve()` on a
+/// background thread while another calls `stop()`.
+#[derive(Clone)]
+pub struct IrcReactorServer {
+    runtime: Arc<Mutex<Option<IrcRuntime>>>,
+    local_addr: SocketAddr,
+    stop_handle: StopHandle,
+    serving: Arc<AtomicBool>,
+}
+
+impl IrcReactorServer {
+    /// Build the engine, bind the listener, and wire the IRC state machine onto
+    /// the reactor.  The listener is bound here, so [`local_addr`](Self::local_addr)
+    /// is valid as soon as this returns — before [`serve`](Self::serve) is called.
+    pub fn bind(config: IrcConfig) -> io::Result<Self> {
+        // The IRC brain.  Shared (behind a Mutex) by all three reactor callbacks.
+        let server = Arc::new(Mutex::new(IRCServer::new(
+            &config.server_name,
+            config.motd.clone(),
+            &config.oper_password,
+        )));
+
+        // The mailbox is how callbacks fan out to *other* connections.  It only
+        // exists *after* the runtime is built, yet the callbacks (which need it)
+        // are moved *into* the build.  A `OnceLock` breaks this cycle: callbacks
+        // capture an empty cell now, and we publish the mailbox into it the
+        // instant `bind` returns — strictly before `serve` accepts any
+        // connection, so the cell is always populated when a callback fires.
+        let mailbox_cell: Arc<OnceLock<TcpMailbox>> = Arc::new(OnceLock::new());
+
+        let runtime = build_runtime(&config, Arc::clone(&server), Arc::clone(&mailbox_cell))
+            .map_err(into_io_error)?;
+
+        let local_addr = runtime.local_addr();
+        let stop_handle = runtime.stop_handle();
+
+        // Publish the mailbox.  `set` only fails if already set, which cannot
+        // happen here — we own the sole writer.
+        let _ = mailbox_cell.set(runtime.mailbox());
+
+        Ok(Self {
+            runtime: Arc::new(Mutex::new(Some(runtime))),
+            local_addr,
+            stop_handle,
+            serving: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    /// The socket address the listener is bound to.  After `bind` with `port = 0`
+    /// this reports the OS-assigned port.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// Run the event loop.  Blocks the calling thread until [`stop`](Self::stop)
+    /// is invoked (from a signal handler, another thread, or a test).
+    ///
+    /// The runtime is consumed on first `serve`; a second call returns an error
+    /// rather than racing two event loops on one listener.
+    pub fn serve(&self) -> io::Result<()> {
+        let mut runtime = self
+            .runtime
+            .lock()
+            .expect("irc-net-reactor runtime mutex poisoned")
+            .take()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "irc-net-reactor server is already serving or has already served",
+                )
+            })?;
+
+        self.serving.store(true, Ordering::SeqCst);
+        let result = runtime.serve().map_err(into_io_error);
+        self.serving.store(false, Ordering::SeqCst);
+        result
+    }
+
+    /// Signal the event loop to stop; a blocked [`serve`](Self::serve) returns.
+    /// Safe to call from any thread, and idempotent.
+    pub fn stop(&self) {
+        self.stop_handle.stop();
+    }
+
+    /// Whether the event loop is currently running.
+    pub fn is_running(&self) -> bool {
+        self.serving.load(Ordering::SeqCst)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Connection callbacks — the bridge between the reactor and IRCServer
+//
+// These are free functions (rather than inline closures) so the three
+// platform-specific `build_runtime` variants can share one implementation.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A new connection opened: tell the IRC state machine, deliver any responses
+/// (normally none until the client registers), and hand back a fresh `Framer`
+/// to become this connection's per-socket line reassembler.
+fn handle_connect(
+    server: &Mutex<IRCServer>,
+    mailbox: &OnceLock<TcpMailbox>,
+    info: TcpConnectionInfo,
+) -> Framer {
+    // The peer's IP becomes the host part of the client's `nick!user@host` mask.
+    let host = info.peer_addr.ip().to_string();
+    let responses = {
+        let mut server = server.lock().expect("IRCServer mutex poisoned");
+        server.on_connect(ConnId(info.id.0), &host)
+    };
+    deliver(mailbox, responses);
+    Framer::new()
+}
+
+/// Raw bytes arrived: reassemble complete lines, parse each, run it through the
+/// IRC state machine, and fan out the resulting responses through the mailbox.
+fn handle_data(
+    server: &Mutex<IRCServer>,
+    mailbox: &OnceLock<TcpMailbox>,
+    info: TcpConnectionInfo,
+    framer: &mut Framer,
+    bytes: &[u8],
+) -> TcpHandlerResult {
+    framer.feed(bytes);
+
+    for raw_line in framer.frames() {
+        // IRC is nominally ASCII but UTF-8 is universally accepted.  Lossy
+        // decoding substitutes U+FFFD for bad bytes rather than dropping the
+        // connection over a single stray byte.
+        let line = String::from_utf8_lossy(&raw_line).into_owned();
+
+        let msg = match parse(&line) {
+            Ok(msg) => msg,
+            // Malformed or empty line — skip silently, as IRC servers
+            // traditionally ignore garbage rather than disconnecting.
+            Err(ParseError(_)) => continue,
+        };
+
+        let responses = {
+            let mut server = server.lock().expect("IRCServer mutex poisoned");
+            server.on_message(ConnId(info.id.0), &msg)
+        };
+        deliver(mailbox, responses);
+    }
+
+    // All writes (including replies to this very sender) are delivered through
+    // the mailbox above, so the handler itself queues nothing.
+    TcpHandlerResult::default()
+}
+
+/// A connection closed: let the state machine clean up and broadcast the QUIT to
+/// every channel the client was in.
+fn handle_close(
+    server: &Mutex<IRCServer>,
+    mailbox: &OnceLock<TcpMailbox>,
+    info: TcpConnectionInfo,
+    _framer: Framer,
+) {
+    let responses = {
+        let mut server = server.lock().expect("IRCServer mutex poisoned");
+        server.on_disconnect(ConnId(info.id.0))
+    };
+    deliver(mailbox, responses);
+}
+
+/// Serialize each [`Response`] and enqueue it to its target connection.
+///
+/// The connection id inside each `Response` may be *any* connection — this is
+/// exactly where IRC broadcast happens.  If the mailbox is not yet published
+/// (impossible in practice, since connections are only accepted after `bind`
+/// publishes it) the responses are simply dropped rather than panicking.
+fn deliver(mailbox: &OnceLock<TcpMailbox>, responses: Vec<Response>) {
+    let Some(mailbox) = mailbox.get() else {
+        return;
+    };
+    for response in responses {
+        let wire = serialize(&response.msg);
+        mailbox.send(ConnectionId(response.conn_id.0), wire);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Platform-specific binding
+//
+// The only difference between platforms is which `bind_*_with_state` constructor
+// we call.  Each wires the same three callbacks.
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn runtime_options(config: &IrcConfig) -> TcpRuntimeOptions {
+    TcpRuntimeOptions {
+        // At least one connection slot, even if a caller passes 0.
+        max_connections: config.max_connections.max(1),
+        ..TcpRuntimeOptions::default()
+    }
+}
+
+/// Build the three reactor callbacks, each carrying its own clones of the shared
+/// `IRCServer` and mailbox cell, and bind the runtime.
+macro_rules! bind_with {
+    ($bind:path, $config:expr, $server:expr, $mailbox:expr) => {{
+        let host = $config.host.clone();
+
+        let connect_server = Arc::clone(&$server);
+        let connect_mailbox = Arc::clone(&$mailbox);
+        let data_server = Arc::clone(&$server);
+        let data_mailbox = Arc::clone(&$mailbox);
+        let close_server = Arc::clone(&$server);
+        let close_mailbox = Arc::clone(&$mailbox);
+
+        $bind(
+            (host.as_str(), $config.port),
+            runtime_options($config),
+            move |info| handle_connect(&connect_server, &connect_mailbox, info),
+            move |info, framer, bytes| {
+                handle_data(&data_server, &data_mailbox, info, framer, bytes)
+            },
+            move |info, framer| handle_close(&close_server, &close_mailbox, info, framer),
+        )
+    }};
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn build_runtime(
+    config: &IrcConfig,
+    server: Arc<Mutex<IRCServer>>,
+    mailbox: Arc<OnceLock<TcpMailbox>>,
+) -> Result<IrcRuntime, PlatformError> {
+    bind_with!(TcpRuntime::bind_kqueue_with_state, config, server, mailbox)
+}
+
+#[cfg(target_os = "linux")]
+fn build_runtime(
+    config: &IrcConfig,
+    server: Arc<Mutex<IRCServer>>,
+    mailbox: Arc<OnceLock<TcpMailbox>>,
+) -> Result<IrcRuntime, PlatformError> {
+    bind_with!(TcpRuntime::bind_epoll_with_state, config, server, mailbox)
+}
+
+#[cfg(target_os = "windows")]
+fn build_runtime(
+    config: &IrcConfig,
+    server: Arc<Mutex<IRCServer>>,
+    mailbox: Arc<OnceLock<TcpMailbox>>,
+) -> Result<IrcRuntime, PlatformError> {
+    bind_with!(TcpRuntime::bind_windows_with_state, config, server, mailbox)
+}
+
+/// Translate a transport-layer [`PlatformError`] into a standard [`io::Error`]
+/// so callers (and the language bindings) only deal with `io::Result`.
+fn into_io_error(error: PlatformError) -> io::Error {
+    use io::ErrorKind;
+
+    let kind = match error {
+        PlatformError::AddressInUse => ErrorKind::AddrInUse,
+        PlatformError::AddressNotAvailable => ErrorKind::AddrNotAvailable,
+        PlatformError::PermissionDenied => ErrorKind::PermissionDenied,
+        PlatformError::ConnectionRefused => ErrorKind::ConnectionRefused,
+        PlatformError::ConnectionReset => ErrorKind::ConnectionReset,
+        PlatformError::BrokenPipe => ErrorKind::BrokenPipe,
+        PlatformError::TimedOut => ErrorKind::TimedOut,
+        PlatformError::Interrupted => ErrorKind::Interrupted,
+        PlatformError::InvalidResource => ErrorKind::InvalidInput,
+        PlatformError::ResourceClosed => ErrorKind::BrokenPipe,
+        PlatformError::Unsupported(_) => ErrorKind::Unsupported,
+        PlatformError::Io(_) | PlatformError::ProviderFault(_) => ErrorKind::Other,
+    };
+
+    io::Error::new(kind, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{ErrorKind, Read, Write};
+    use std::net::{Shutdown, TcpStream};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    /// Start a server on an OS-assigned port, serving on a background thread.
+    fn start_server() -> (
+        IrcReactorServer,
+        thread::JoinHandle<io::Result<()>>,
+        SocketAddr,
+    ) {
+        let server = IrcReactorServer::bind(IrcConfig {
+            port: 0,
+            ..IrcConfig::default()
+        })
+        .expect("server binds");
+        let addr = server.local_addr();
+        let background = server.clone();
+        let handle = thread::spawn(move || background.serve());
+        (server, handle, addr)
+    }
+
+    fn connect(addr: SocketAddr) -> TcpStream {
+        let mut last_error = None;
+        for _ in 0..40 {
+            match TcpStream::connect(addr) {
+                Ok(stream) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_millis(200)))
+                        .expect("set read timeout");
+                    return stream;
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                    thread::sleep(Duration::from_millis(10));
+                }
+            }
+        }
+        panic!("server did not accept connections in time: {last_error:?}");
+    }
+
+    /// Read from `stream` until the accumulated text contains `needle` or a
+    /// deadline elapses.  Returns everything read so the caller can assert on it.
+    fn read_until(stream: &mut TcpStream, needle: &str) -> String {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 4096];
+        while Instant::now() < deadline {
+            match stream.read(&mut chunk) {
+                Ok(0) => break, // peer closed
+                Ok(n) => {
+                    buffer.extend_from_slice(&chunk[..n]);
+                    if String::from_utf8_lossy(&buffer).contains(needle) {
+                        break;
+                    }
+                }
+                Err(err) if matches!(err.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+        String::from_utf8_lossy(&buffer).into_owned()
+    }
+
+    /// Register a client (NICK + USER) and wait for the `001` welcome numeric.
+    fn register(stream: &mut TcpStream, nick: &str) {
+        let line = format!("NICK {nick}\r\nUSER {nick} 0 * :{nick}\r\n");
+        stream
+            .write_all(line.as_bytes())
+            .expect("write registration");
+        let welcome = read_until(stream, "001");
+        assert!(
+            welcome.contains("001"),
+            "expected 001 welcome for {nick}, got: {welcome:?}"
+        );
+    }
+
+    #[test]
+    fn registration_yields_welcome() {
+        let (server, handle, addr) = start_server();
+        let mut alice = connect(addr);
+        register(&mut alice, "alice");
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn ping_gets_pong() {
+        let (server, handle, addr) = start_server();
+        let mut alice = connect(addr);
+        register(&mut alice, "alice");
+
+        alice.write_all(b"PING :liveness\r\n").expect("write ping");
+        let pong = read_until(&mut alice, "PONG");
+        assert!(pong.contains("PONG"), "expected PONG, got: {pong:?}");
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn privmsg_broadcasts_to_other_channel_member() {
+        let (server, handle, addr) = start_server();
+
+        // Two independent clients register and join the same channel.
+        let mut alice = connect(addr);
+        let mut bob = connect(addr);
+        register(&mut alice, "alice");
+        register(&mut bob, "bob");
+
+        alice.write_all(b"JOIN #test\r\n").expect("alice joins");
+        bob.write_all(b"JOIN #test\r\n").expect("bob joins");
+        // Make sure both are in the channel before the broadcast.
+        let _ = read_until(&mut alice, "JOIN");
+        let _ = read_until(&mut bob, "JOIN");
+
+        // Alice speaks; Bob must receive it (fan-out through the mailbox to a
+        // DIFFERENT connection than the sender).
+        alice
+            .write_all(b"PRIVMSG #test :hello bob\r\n")
+            .expect("alice privmsg");
+        let received = read_until(&mut bob, "hello bob");
+        assert!(
+            received.contains("PRIVMSG") && received.contains("hello bob"),
+            "bob should have received alice's broadcast, got: {received:?}"
+        );
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn quit_command_broadcasts_to_channel() {
+        let (server, handle, addr) = start_server();
+
+        let mut alice = connect(addr);
+        let mut bob = connect(addr);
+        register(&mut alice, "alice");
+        register(&mut bob, "bob");
+        alice.write_all(b"JOIN #test\r\n").expect("alice joins");
+        bob.write_all(b"JOIN #test\r\n").expect("bob joins");
+        let _ = read_until(&mut bob, "JOIN");
+
+        // Alice sends a graceful IRC QUIT; the server broadcasts it to channel peers.
+        alice
+            .write_all(b"QUIT :leaving now\r\n")
+            .expect("alice quits");
+        let quit = read_until(&mut bob, "QUIT");
+        assert!(
+            quit.contains("QUIT") && quit.contains("leaving now"),
+            "bob should see alice's QUIT broadcast, got: {quit:?}"
+        );
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn abrupt_disconnect_broadcasts_quit() {
+        let (server, handle, addr) = start_server();
+
+        let mut alice = connect(addr);
+        let mut bob = connect(addr);
+        register(&mut alice, "alice");
+        register(&mut bob, "bob");
+        alice.write_all(b"JOIN #test\r\n").expect("alice joins");
+        bob.write_all(b"JOIN #test\r\n").expect("bob joins");
+        let _ = read_until(&mut bob, "JOIN");
+
+        // Simulate a client vanishing without an IRC QUIT.  `shutdown(Write)`
+        // sends a clean FIN (unlike `drop` with unread data, which can RST), so
+        // the reactor observes a graceful half-close and runs its close callback
+        // → `IRCServer::on_disconnect` → QUIT broadcast to remaining members.
+        alice
+            .shutdown(Shutdown::Write)
+            .expect("half-close alice's write side");
+        let quit = read_until(&mut bob, "QUIT");
+        assert!(
+            quit.contains("QUIT"),
+            "bob should see alice's QUIT after an abrupt disconnect, got: {quit:?}"
+        );
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
+    fn config_defaults_are_sane() {
+        let config = IrcConfig::default();
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 6667);
+        assert_eq!(config.server_name, "irc.local");
+        assert!(!config.motd.is_empty());
+        assert!(config.oper_password.is_empty());
+        assert!(config.max_connections >= 1);
+    }
+
+    #[test]
+    fn second_serve_is_rejected() {
+        let (server, handle, _addr) = start_server();
+
+        // Wait until the background thread has actually entered serve() and taken
+        // the runtime.  Without this we'd race: whichever serve() locks the mutex
+        // first takes the runtime and blocks, and the loser errors — so the test
+        // could otherwise block the main thread forever instead of erroring.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !server.is_running() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(server.is_running(), "background serve never started");
+
+        // The background thread now owns the runtime; a second serve on this
+        // handle must error rather than racing two event loops.
+        let err = server.serve().expect_err("second serve must fail");
+        assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+}

--- a/code/specs/irc-net-reactor.md
+++ b/code/specs/irc-net-reactor.md
@@ -1,0 +1,171 @@
+# irc-net-reactor — Level 3: All-Rust IRC engine on the home-grown reactor
+
+## Overview
+
+`irc-net-reactor` is the layer that finally puts the IRC server on the
+**home-grown high-performance TCP runtime** we built from scratch
+(`tcp-runtime` → `transport-platform` → raw `kqueue`/`epoll`/IOCP), with **every
+line of logic in Rust**.
+
+Where `irc-net-stdlib` (Level 1) spends one OS thread per connection and
+`irc-net-selectors` (Level 2) leans on the language's stdlib selector,
+`irc-net-reactor` runs the IRC state machine directly on the native event loop
+that the rest of this repository's networking stack is built on — the same
+engine that powers `mini-redis` and `conduit`/`web-core`.
+
+Crucially, this crate is also the **engine that every language embeds natively**.
+A Python, Ruby, or Node program does not re-implement IRC; it loads a thin native
+extension (via the repo's zero-dependency `python-bridge`/`ruby-bridge`/
+`node-bridge`) that wraps `IrcReactorServer` and exposes a three-call control
+surface: **create, serve, stop**. All the IRC and TCP work happens in Rust.
+
+```
+irc-server (state machine) + irc-proto + irc-framing      ← reused unchanged
+        ↓ wired by
+irc-net-reactor   (THIS SPEC: IRCServer on tcp-runtime, broadcast via TcpMailbox)
+        ↓ runs on
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+        ↑ embedded via per-language native bridge (create / serve / stop)
+   python-bridge   node-bridge   ruby-bridge   … (jni / objc / erl-nif / perl later)
+```
+
+---
+
+## Why a new layer
+
+The reactor (`tcp-runtime`) already exists and is proven by `mini-redis`. But
+`mini-redis` is a strictly **per-connection request/response** server: each
+connection only ever writes back to itself. IRC is fundamentally a **broadcast**
+server — when one client sends `PRIVMSG #chan`, the bytes must reach *other*
+clients' sockets.
+
+The reactor supports this natively: `TcpRuntime::mailbox()` returns a
+`TcpMailbox` whose `send(connection_id, bytes)` targets **any** connection id,
+not just the one currently being handled. `irc-net-reactor` is the first server
+in the repo to use the mailbox for genuine fan-out.
+
+---
+
+## Engine design
+
+Per-connection state is an `irc_framing::Framer` (TCP delivers a byte stream;
+the framer reassembles CRLF-terminated IRC lines). One global
+`Arc<Mutex<IRCServer>>` holds the channel/nick state — `irc-server` documents
+itself as *not* thread-safe, so the transport serializes all access behind the
+mutex. The `TcpMailbox` is captured by the connection callbacks through an
+`Arc<OnceLock<TcpMailbox>>` that is filled immediately after `bind` and before
+`serve` — connections are only accepted inside `serve`, so the cell is always
+populated when a callback fires.
+
+The three reactor callbacks map one-to-one onto the three `IRCServer` methods,
+and every outbound `Response{conn_id, msg}` is delivered uniformly through the
+mailbox (`serialize(msg)` → `mailbox.send(conn_id, …)`), including replies to the
+sender. This single delivery path is what makes broadcast and direct replies the
+same code:
+
+| Reactor callback                | IRC action                                   |
+|---------------------------------|----------------------------------------------|
+| `init(info) -> Framer`          | `IRCServer::on_connect(id, peer_ip)`; new `Framer` |
+| `handler(info, framer, bytes)`  | feed framer → `parse` each line → `IRCServer::on_message` → deliver |
+| `on_close(info, framer)`        | `IRCServer::on_disconnect(id)` → deliver (QUIT broadcast) |
+
+Unparseable lines are skipped silently (RFC-traditional behaviour), exactly as
+`irc-net-stdlib`'s Rust driver does. Bytes are decoded with lossy UTF-8 so a
+single bad byte never drops a connection.
+
+---
+
+## Public API
+
+```rust
+pub struct IrcConfig {
+    pub host: String,           // bind address, e.g. "127.0.0.1"
+    pub port: u16,              // 0 = OS-assigned ephemeral port (tests)
+    pub server_name: String,    // shown in 001 welcome + message prefixes
+    pub motd: Vec<String>,      // Message of the Day lines
+    pub oper_password: String,  // OPER password; "" disables OPER
+    pub max_connections: usize, // connection cap
+}
+
+pub struct IrcReactorServer { /* runtime, local_addr, stop_handle, serving */ }
+
+impl IrcReactorServer {
+    pub fn bind(config: IrcConfig) -> std::io::Result<Self>; // binds the listener eagerly
+    pub fn local_addr(&self) -> std::net::SocketAddr;        // real port after bind
+    pub fn serve(&self) -> std::io::Result<()>;              // blocks on kqueue/epoll/IOCP
+    pub fn stop(&self);                                      // unblocks serve()
+    pub fn is_running(&self) -> bool;
+}
+```
+
+This mirrors `mini-redis`'s `MiniRedisServer` shape (`new`/`serve`/`stop`/
+`address`/`is_running`) so the native bindings can follow the proven `conduit`
+embedding pattern.
+
+---
+
+## Native embedding (the point of "all logic in Rust")
+
+Each language ships a `*-native` package wrapping `IrcReactorServer`:
+
+- `server_new(config) -> handle` — build + bind, wrap the boxed engine
+  (PyCapsule / N-API external / Ruby TypedData).
+- `server_serve(handle)` — **release the GIL** (Python `PyEval_SaveThread`),
+  **release the GVL** (Ruby `rb_thread_call_without_gvl`), or run on a
+  **background thread** (Node, per the N-API single-thread rule) around the
+  blocking `engine.serve()`.
+- `server_stop(handle)` — `StopHandle::stop`.
+- `server_local_addr(handle)` — for ephemeral-port tests.
+- `server_dispose(handle)` — drop the engine.
+
+Because all logic is in Rust, there is **no per-message callback into the host
+language** — unlike `conduit`, which dispatches each HTTP route to a language
+handler. That makes these bindings strictly simpler (no TSFN, no GIL
+re-acquisition for dispatch).
+
+Proven binding templates first: **Python**, **Ruby**, **Node/TypeScript**
+(mirroring the three existing `conduit` packages). Java/Kotlin (`jni-bridge`),
+Swift (`objc-bridge`), Elixir (`erl-nif-bridge`), and Perl (`perl-bridge`) have
+bridge crates but no example native package yet, so they follow as their own
+later PRs.
+
+---
+
+## Concurrency & ordering
+
+- `event_loop_threads` defaults to 1 (single reactor thread): connection
+  callbacks are serialized, so the `IRCServer` mutex is never contended and
+  per-connection frame ordering is trivially preserved.
+- `TcpMailbox` sends are themselves thread-safe, so a future sharded variant
+  remains correct (the mutex still serializes state mutation; the mailbox
+  serializes writes per connection).
+
+---
+
+## Known limitations
+
+- **Backpressure**: writes are enqueued on the mailbox without IRC-level flow
+  control. A pathologically slow reader can accumulate queued bytes up to the
+  runtime's `max_pending_write_bytes`, after which the runtime drops/closes per
+  its own policy. Adequate for a teaching IRC server; finer per-client
+  backpressure is future work.
+- **TLS**: none — this is plaintext IRC (port 6667 semantics), matching the rest
+  of the `irc-net-*` family.
+
+---
+
+## Testing
+
+Real-socket integration tests (modelled on `mini-redis`'s test harness): bind on
+port 0, `serve()` on a background thread, connect two `TcpStream` clients, and
+assert:
+
+1. **Registration** — NICK/USER yields the 001 welcome burst.
+2. **Broadcast** — both clients `JOIN #test`; client A `PRIVMSG`s; **client B
+   receives it** (the fan-out proof, exercising `TcpMailbox.send` to a
+   non-sender connection).
+3. **QUIT broadcast** — a client disconnects; remaining members see the QUIT.
+4. **PING/PONG** — liveness round-trip.
+
+The per-language bindings each repeat the broadcast scenario against a server
+started from that language, proving the native control surface end to end.


### PR DESCRIPTION
## What

PR 1 of the arc to run a **high-performance IRC server entirely in Rust** and embed it natively in every language. This adds `irc-net-reactor`: a new Rust crate that hosts the existing `irc-server` state machine directly on our home-grown `tcp-runtime` reactor (`kqueue`/`epoll`/IOCP), with **in-process broadcast**.

Everything — TCP transport *and* IRC protocol — runs in Rust. Later PRs wrap this engine via the zero-dep `python-bridge`/`ruby-bridge`/`node-bridge` so each language gets the same server with a thin `create`/`serve`/`stop` control surface (no IRC logic re-implemented per language).

## The interesting bit: broadcast

`mini-redis` proved the reactor for request/response, but IRC must write one client's `PRIVMSG` to **other** clients' sockets. The reactor's `TcpMailbox.send(connection_id, bytes)` targets *any* connection by id; each `irc-server` `Response` already names its target connection, so we serialize and hand it to the mailbox. Replies to the sender and channel fan-out share one path. This is the first server in the repo to use the mailbox for genuine fan-out.

## Resilience (from security review)

The reactor runs callbacks inline on its single event-loop thread with no `catch_unwind`, so a panic inside `IRCServer` on a crafted message would crash the whole server and poison the shared mutex — a one-client DoS for everyone. Fixed with two safeguards: each callback is wrapped in `catch_unwind` (a panic closes only the offending connection), and the shared `IRCServer` mutex is locked poison-tolerantly (`into_inner` recovery).

## Reuse

`irc-server`, `irc-proto`, `irc-framing` are reused **unchanged** — only the transport layer is new. Mirrors `mini-redis`'s `bind`/`serve`/`stop` shape so the bindings can follow the proven `conduit` embedding pattern.

## Tests

8 real-socket integration tests: registration (001), PING/PONG, channel `PRIVMSG` broadcast to a different connection (the fan-out proof), graceful `QUIT`-command broadcast, abrupt-disconnect `QUIT` broadcast, poisoned-mutex recovery, config defaults, double-`serve` rejection. `cargo build --workspace` clean (pre-existing unrelated `uefi` freestanding-crate failure aside). Security review passed in 2 rounds.

Spec: `code/specs/irc-net-reactor.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)