### PR TITLE
feat(grammar-tools): F10 declarative lexer modes (Python port)

### DIFF
--- a/code/packages/python/grammar-tools/CHANGELOG.md
+++ b/code/packages/python/grammar-tools/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the grammar-tools package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - F10 declarative lexer mode transitions
+
+### Added
+- `ModeTransition` and `TransitionAction` dataclasses, plus `start_mode` and
+  `transitions` fields on `TokenGrammar`, porting the F10 declarative
+  lexer-mode transition table (`F10-declarative-lexer-modes.md`) from the Rust
+  reference. A `.tokens` grammar can declare context-sensitive lexing
+  (regex-vs-division, template substitutions) as data rather than a callback.
+- `.tokens` parsing: a `start_mode:` directive and a `transitions:` section
+  (`on TOKENS [in MODE] -> ACTION, ...`; actions `set-mode`/`push`/`pop`/
+  `enable-skip`/`disable-skip`; `KEYWORD="value"` guard). Validation rejects
+  undefined target/guard modes and caps rule count (`MAX_TRANSITIONS`).
+- `compile_token_grammar` emits the two new fields (the dataclass reprs are
+  valid constructor source); the generated import line carries the new types.
+
+### Notes
+- Backward compatible: a grammar with no `transitions:`/`start_mode:` parses to
+  empty defaults. Interpreting the table in the Python `lexer` package is a
+  follow-up (mirrors the Rust grammar-tools → lexer split).
+
 ## [0.3.0] - 2026-03-26
 
 ### Added

--- a/code/packages/python/grammar-tools/src/grammar_tools/__init__.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/__init__.py
@@ -35,10 +35,12 @@ from grammar_tools.parser_grammar import (
     validate_parser_grammar,
 )
 from grammar_tools.token_grammar import (
+    ModeTransition,
     PatternGroup,
     TokenDefinition,
     TokenGrammar,
     TokenGrammarError,
+    TransitionAction,
     parse_token_grammar,
     validate_token_grammar,
 )
@@ -52,6 +54,8 @@ __all__ = [
     "TokenDefinition",
     "TokenGrammar",
     "TokenGrammarError",
+    "ModeTransition",
+    "TransitionAction",
     "parse_token_grammar",
     "validate_token_grammar",
     # Parser grammar

--- a/code/packages/python/grammar-tools/src/grammar_tools/compiler.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/compiler.py
@@ -228,6 +228,8 @@ def compile_token_grammar(grammar: TokenGrammar, source_file: str = "") -> str:
         f"{i1}reserved_keywords={grammar.reserved_keywords!r},",
         f"{i1}error_definitions={err_src},",
         f"{i1}groups={groups_src},",
+        f"{i1}start_mode={grammar.start_mode!r},",
+        f"{i1}transitions={grammar.transitions!r},",
         f"{i1}layout_keywords={grammar.layout_keywords!r},",
         ")",
     ])
@@ -242,7 +244,7 @@ def compile_token_grammar(grammar: TokenGrammar, source_file: str = "") -> str:
         "# Downstream packages import TOKEN_GRAMMAR directly instead of\n"
         "# reading and parsing the .tokens file at runtime.\n"
         "\n"
-        "from grammar_tools.token_grammar import PatternGroup, TokenDefinition, TokenGrammar\n"  # noqa: E501
+        "from grammar_tools.token_grammar import ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction\n"  # noqa: E501
         "\n"
         "# fmt: off  # noqa: E501 — generated code may have long lines\n"
         "\n"

--- a/code/packages/python/grammar-tools/src/grammar_tools/token_grammar.py
+++ b/code/packages/python/grammar-tools/src/grammar_tools/token_grammar.py
@@ -163,6 +163,54 @@ class PatternGroup:
     definitions: list[TokenDefinition]
 
 
+@dataclass(frozen=True)
+class TransitionAction:
+    """One action a :class:`ModeTransition` applies to the lexer's mode
+    register after a token is emitted (F10).
+
+    ``kind`` is one of ``"set_mode"``, ``"push"``, ``"pop"``, ``"enable_skip"``,
+    ``"disable_skip"``. ``target`` is the mode/group name for ``set_mode``/
+    ``push`` and ``None`` otherwise.
+
+    - ``set_mode`` replaces the active mode (top of group stack) in place — the
+      flat flex-style toggle used for regex-vs-division.
+    - ``push`` / ``pop`` are the F04 nested-region save/restore (templates).
+    - ``enable_skip`` / ``disable_skip`` toggle skip-pattern processing.
+    """
+
+    kind: str
+    target: str | None = None
+
+
+@dataclass(frozen=True)
+class ModeTransition:
+    """One declarative lexer mode transition rule (F10).
+
+    Parsed from a ``transitions:`` line ``on TOKENS [in MODE] -> ACTION, ...``.
+    Pure data; the lexer interprets it after each token is emitted (first
+    matching rule wins). See ``F10-declarative-lexer-modes.md``.
+
+    Attributes:
+        on_tokens: Emitted token type-names that trigger the rule (alias
+            targets; ``"KEYWORD"`` for promoted keywords).
+        on_value: Optional keyword-value guard (e.g. ``"return"``).
+        in_mode: Optional active-mode guard; ``None`` means "in any mode".
+        actions: Ordered actions applied when the rule fires.
+        line_number: Source line for diagnostics.
+    """
+
+    on_tokens: tuple[str, ...]
+    on_value: str | None
+    in_mode: str | None
+    actions: tuple[TransitionAction, ...]
+    line_number: int
+
+
+#: Upper bound on transition rules per grammar — a DoS guard against a
+#: pathological ``.tokens`` file blowing up codegen/lexer memory.
+MAX_TRANSITIONS = 4096
+
+
 @dataclass
 class TokenGrammar:
     """The complete contents of a parsed .tokens file.
@@ -224,6 +272,13 @@ class TokenGrammar:
     error_definitions: list[TokenDefinition] = field(default_factory=list)
     groups: dict[str, PatternGroup] = field(default_factory=dict)
     case_sensitive: bool = True
+    start_mode: str | None = None
+    """F10: the mode (active group) the lexer starts in. ``None`` means
+    ``"default"``. Set by the ``start_mode:`` directive."""
+    transitions: list[ModeTransition] = field(default_factory=list)
+    """F10: declarative lexer mode transition table. Empty means no
+    transitions — behaviour is identical to F04. Set by the ``transitions:``
+    section."""
     layout_keywords: list[str] = field(default_factory=list)
     """Keywords that introduce a Haskell-style layout context when
     ``mode == "layout"``."""
@@ -461,6 +516,109 @@ def _parse_definition(
         )
 
 
+def _split_in_guard(head: str) -> tuple[str, str | None]:
+    """Split a transition head on a top-level `` in `` mode guard, ignoring
+    any `` in `` inside a parenthesised token set (F10)."""
+    depth = 0
+    i = 0
+    while i < len(head):
+        ch = head[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == " " and depth == 0 and head[i:].startswith(" in "):
+            return head[:i], head[i + 4 :]
+        i += 1
+    return head, None
+
+
+def _parse_transition(line: str, line_number: int) -> ModeTransition:
+    """Parse one ``transitions:`` line into a :class:`ModeTransition` (F10).
+
+    Grammar: ``on TOKENS [in MODE] -> ACTION [, ACTION ...]`` where TOKENS is a
+    name or ``(A | B | C)`` (or ``KEYWORD="value"``) and each ACTION is
+    ``set-mode M`` | ``push G`` | ``pop`` | ``enable-skip`` | ``disable-skip``.
+    """
+    if "->" not in line:
+        raise TokenGrammarError(
+            f"Transition rule missing '->': {line!r}", line_number
+        )
+    head, action_str = (part.strip() for part in line.split("->", 1))
+    if not action_str:
+        raise TokenGrammarError(
+            f"Transition rule has no actions after '->': {line!r}", line_number
+        )
+
+    if not head.startswith("on "):
+        raise TokenGrammarError(
+            f"Transition rule must start with 'on ': {line!r}", line_number
+        )
+    head = head[3:].strip()
+
+    tokens_part, in_mode = _split_in_guard(head)
+    tokens_part = tokens_part.strip()
+    if in_mode is not None:
+        in_mode = in_mode.strip()
+
+    inner = tokens_part
+    if inner.startswith("(") and inner.endswith(")"):
+        inner = inner[1:-1]
+    on_tokens: list[str] = []
+    on_value: str | None = None
+    for raw in inner.split("|"):
+        item = raw.strip()
+        if not item:
+            continue
+        if "=" in item:
+            name_p, value_p = (p.strip() for p in item.split("=", 1))
+            value = value_p
+            if value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
+            on_tokens.append(name_p)
+            on_value = value
+        else:
+            on_tokens.append(item)
+    if not on_tokens:
+        raise TokenGrammarError(
+            f"Transition rule has no trigger tokens: {line!r}", line_number
+        )
+
+    actions: list[TransitionAction] = []
+    for raw in action_str.split(","):
+        act = raw.strip()
+        if not act:
+            continue
+        if act.startswith("set-mode "):
+            actions.append(TransitionAction("set_mode", act[9:].strip()))
+        elif act.startswith("push "):
+            actions.append(TransitionAction("push", act[5:].strip()))
+        elif act == "pop":
+            actions.append(TransitionAction("pop"))
+        elif act == "enable-skip":
+            actions.append(TransitionAction("enable_skip"))
+        elif act == "disable-skip":
+            actions.append(TransitionAction("disable_skip"))
+        else:
+            raise TokenGrammarError(
+                f"Unknown transition action {act!r} (expected set-mode/push/"
+                "pop/enable-skip/disable-skip)",
+                line_number,
+            )
+    if not actions:
+        raise TokenGrammarError(
+            f"Transition rule has no valid actions: {line!r}", line_number
+        )
+
+    return ModeTransition(
+        on_tokens=tuple(on_tokens),
+        on_value=on_value,
+        in_mode=in_mode,
+        actions=tuple(actions),
+        line_number=line_number,
+    )
+
+
 def parse_token_grammar(source: str) -> TokenGrammar:
     """Parse the text of a .tokens file into a TokenGrammar.
 
@@ -582,6 +740,18 @@ def parse_token_grammar(source: str) -> TokenGrammar:
             current_section = None
             continue
 
+        # --- start_mode: directive (F10) ---
+        if stripped.startswith("start_mode:"):
+            sm_value = stripped[11:].strip()
+            if not sm_value:
+                raise TokenGrammarError(
+                    "Missing mode name after 'start_mode:'",
+                    line_number,
+                )
+            grammar.start_mode = sm_value
+            current_section = None
+            continue
+
         # --- Group headers ---
         # Pattern groups are declared with ``group NAME:`` where NAME is
         # a lowercase identifier. All subsequent indented lines belong to
@@ -608,6 +778,9 @@ def parse_token_grammar(source: str) -> TokenGrammar:
                 "layout_keywords",
                 "context_keywords",
                 "soft_keywords",
+                "transitions",
+                "modes",
+                "start_mode",
             }
             if group_name in reserved_names:
                 raise TokenGrammarError(
@@ -655,6 +828,10 @@ def parse_token_grammar(source: str) -> TokenGrammar:
             current_section = "soft_keywords"
             continue
 
+        if stripped in ("transitions:", "transitions :"):
+            current_section = "transitions"
+            continue
+
         # --- Inside a section ---
         if current_section is not None:
             # Sections contain indented lines. A non-indented line exits
@@ -675,6 +852,11 @@ def parse_token_grammar(source: str) -> TokenGrammar:
                 elif current_section == "soft_keywords":
                     if stripped:
                         grammar.soft_keywords.append(stripped)
+                elif current_section == "transitions":
+                    if stripped:
+                        grammar.transitions.append(
+                            _parse_transition(stripped, line_number)
+                        )
                 elif current_section == "skip":
                     # Skip section contains token definitions
                     if "=" not in stripped:
@@ -929,5 +1111,40 @@ def validate_token_grammar(grammar: TokenGrammar) -> list[str]:
         issues.extend(
             _validate_definitions(group.definitions, f"group '{group_name}' token")
         )
+
+    # F10: validate declarative lexer modes. A mode is valid if it is
+    # "default" or a declared group. Undefined targets/guards are rejected so
+    # the lexer never silently falls back to the wrong group.
+    def _mode_exists(name: str) -> bool:
+        return name == "default" or name in grammar.groups
+
+    if grammar.start_mode is not None and not _mode_exists(grammar.start_mode):
+        issues.append(
+            f"start_mode '{grammar.start_mode}' is not 'default' "
+            f"or a declared group"
+        )
+
+    if len(grammar.transitions) > MAX_TRANSITIONS:
+        issues.append(
+            f"Too many transition rules ({len(grammar.transitions)}, "
+            f"max {MAX_TRANSITIONS})"
+        )
+
+    for rule in grammar.transitions:
+        if rule.in_mode is not None and not _mode_exists(rule.in_mode):
+            issues.append(
+                f"Transition guard 'in {rule.in_mode}' (line "
+                f"{rule.line_number}) names an undeclared mode"
+            )
+        for action in rule.actions:
+            if (
+                action.kind in ("set_mode", "push")
+                and action.target is not None
+                and not _mode_exists(action.target)
+            ):
+                issues.append(
+                    f"Transition action targets undeclared mode "
+                    f"'{action.target}' (line {rule.line_number})"
+                )
 
     return issues

--- a/code/packages/python/grammar-tools/tests/test_token_grammar.py
+++ b/code/packages/python/grammar-tools/tests/test_token_grammar.py
@@ -1086,3 +1086,133 @@ class TestMagicComments:
         assert len(grammar.definitions) == 2
         assert grammar.definitions[0].name == "NUMBER"
         assert grammar.definitions[1].name == "PLUS"
+
+
+# ---------------------------------------------------------------------------
+# F10: declarative lexer mode transitions
+# ---------------------------------------------------------------------------
+
+
+def test_f10_no_transitions_is_backward_compatible() -> None:
+    from grammar_tools.token_grammar import parse_token_grammar
+
+    g = parse_token_grammar("NUMBER = /[0-9]+/")
+    assert g.start_mode is None
+    assert g.transitions == []
+
+
+def test_f10_parse_start_mode() -> None:
+    from grammar_tools.token_grammar import parse_token_grammar
+
+    g = parse_token_grammar(
+        'NAME = /[a-z]+/\nstart_mode: div\ngroup div:\n  SLASH = "/"\n'
+    )
+    assert g.start_mode == "div"
+
+
+def test_f10_parse_transition_alternation_and_value_guard() -> None:
+    from grammar_tools.token_grammar import (
+        TransitionAction,
+        parse_token_grammar,
+    )
+
+    src = (
+        "NAME = /[a-z]+/\n"
+        "transitions:\n"
+        "  on (NAME | NUMBER | RPAREN) -> set-mode div\n"
+        '  on KEYWORD="return" -> set-mode default, pop\n'
+    )
+    g = parse_token_grammar(src)
+    assert len(g.transitions) == 2
+    r0, r1 = g.transitions
+    assert r0.on_tokens == ("NAME", "NUMBER", "RPAREN")
+    assert r0.actions == (TransitionAction("set_mode", "div"),)
+    assert r1.on_tokens == ("KEYWORD",)
+    assert r1.on_value == "return"
+    assert r1.actions == (
+        TransitionAction("set_mode", "default"),
+        TransitionAction("pop"),
+    )
+
+
+def test_f10_parse_in_guard() -> None:
+    from grammar_tools.token_grammar import parse_token_grammar
+
+    src = (
+        "NAME = /[a-z]+/\n"
+        "group template:\n  TAIL = /x/\n"
+        "transitions:\n"
+        "  on TEMPLATE_HEAD in default -> push template, set-mode default\n"
+    )
+    g = parse_token_grammar(src)
+    assert g.transitions[0].in_mode == "default"
+
+
+def test_f10_transition_missing_arrow_errors() -> None:
+    import pytest
+
+    from grammar_tools.token_grammar import (
+        TokenGrammarError,
+        parse_token_grammar,
+    )
+
+    with pytest.raises(TokenGrammarError, match="->"):
+        parse_token_grammar("NAME = /x/\ntransitions:\n  on NAME set-mode div\n")
+
+
+def test_f10_transition_unknown_action_errors() -> None:
+    import pytest
+
+    from grammar_tools.token_grammar import (
+        TokenGrammarError,
+        parse_token_grammar,
+    )
+
+    with pytest.raises(TokenGrammarError, match="Unknown transition action"):
+        parse_token_grammar("NAME = /x/\ntransitions:\n  on NAME -> teleport\n")
+
+
+def test_f10_validate_rejects_undefined_target_mode() -> None:
+    from grammar_tools.token_grammar import (
+        parse_token_grammar,
+        validate_token_grammar,
+    )
+
+    g = parse_token_grammar(
+        "NAME = /x/\ntransitions:\n  on NAME -> set-mode div\n"
+    )
+    issues = validate_token_grammar(g)
+    assert any("undeclared mode" in i for i in issues)
+
+
+def test_f10_validate_accepts_declared_modes() -> None:
+    from grammar_tools.token_grammar import (
+        parse_token_grammar,
+        validate_token_grammar,
+    )
+
+    src = (
+        'NAME = /[a-z]+/\nstart_mode: default\ngroup div:\n  SLASH = "/"\n'
+        "transitions:\n"
+        "  on NAME -> set-mode div\n"
+        '  on KEYWORD="return" -> set-mode default\n'
+    )
+    g = parse_token_grammar(src)
+    assert not [i for i in validate_token_grammar(g) if "mode" in i]
+
+
+def test_f10_compiler_round_trips_transitions() -> None:
+    from grammar_tools.compiler import compile_token_grammar
+    from grammar_tools.token_grammar import parse_token_grammar
+
+    src = (
+        'NAME = /[a-z]+/\nstart_mode: default\ngroup div:\n  SLASH = "/"\n'
+        "transitions:\n  on (NAME | RPAREN) -> set-mode div\n"
+    )
+    g = parse_token_grammar(src)
+    code = compile_token_grammar(g, "js.tokens")
+    namespace: dict = {}
+    exec(compile(code, "<generated>", "exec"), namespace)
+    g2 = namespace["TOKEN_GRAMMAR"]
+    assert g2.start_mode == g.start_mode
+    assert g2.transitions == g.transitions


### PR DESCRIPTION
## What

Ports the **grammar-tools half** of F10 to the Python implementation, mirroring the Rust reference ([#5662](https://github.com/adhithyan15/coding-adventures/pull/5662)) and the same grammar-tools → lexer split. First of the all-language ports (PR-4 series).

- `token_grammar.py` — `ModeTransition` + `TransitionAction` dataclasses; `start_mode`/`transitions` fields (with defaults — existing constructors keep working); `start_mode:` directive + `transitions:` section parsing (`on TOKENS [in MODE] -> ACTION, ...`, `KEYWORD="value"` guard, `_split_in_guard`); validation rejecting undefined modes + `MAX_TRANSITIONS` cap.
- `compiler.py` — emits the two fields via dataclass repr (valid constructor source) + imports the new types in generated grammars.
- `__init__.py` — exports the new types.
- **9 new tests** (parse alternation / value guard / in-guard, error cases, undefined-mode rejection, codegen round-trip) — all pass.

## Backward compat

No `transitions:`/`start_mode:` ⇒ empty defaults (verified). Interpreting the table in the Python `lexer` package is the follow-up PR (mirrors Rust [#5663](https://github.com/adhithyan15/coding-adventures/pull/5663)).

## Security

Pure parsing + validation; rule-count DoS cap; no I/O. The two pre-existing ruff findings in `token_grammar.py` (SIM105/E501) are unchanged from `main`; my additions are ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)