### PR TITLE
feat(web10): Kotlin Conduit port — reuses the Java JNI cdylib

### DIFF
--- a/code/packages/kotlin/conduit/.gitignore
+++ b/code/packages/kotlin/conduit/.gitignore
@@ -1,0 +1,3 @@
+gradle-build/
+.gradle/
+build/

--- a/code/packages/kotlin/conduit/BUILD
+++ b/code/packages/kotlin/conduit/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p conduit-jni --release && gradle test

--- a/code/packages/kotlin/conduit/BUILD_windows
+++ b/code/packages/kotlin/conduit/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p conduit-jni --release && gradle test

--- a/code/packages/kotlin/conduit/CHANGELOG.md
+++ b/code/packages/kotlin/conduit/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.1.0 — 2026-06-14
+
+Initial release. Kotlin port (WEB10) of the Conduit web framework — a thin
+idiomatic DSL over the Java package, reusing the WEB09 `conduit_jni` cdylib
+with no new native code.
+
+### Added
+- `conduit { }` builder DSL with trailing-lambda routes and filters.
+- Top-level response helpers (`html`, `json`, `text`, `respond`, `halt`,
+  `redirect`) and `Request` extension properties (`req.path`, `req["name"]`, …).
+- `ConduitApp` lifecycle wrapper (`serve`/`serveBackground`/`stop`/`localPort`/
+  `running`, `AutoCloseable`).
+- Kotlin/JUnit5 tests incl. an end-to-end HTTP suite (class-level 30s timeout).
+- Depends on `com.codingadventures:conduit` via a Gradle composite build.

--- a/code/packages/kotlin/conduit/README.md
+++ b/code/packages/kotlin/conduit/README.md
@@ -1,0 +1,58 @@
+# conduit (Kotlin)
+
+An idiomatic Kotlin DSL for the Conduit web framework — **WEB10** in the series.
+Unlike every other port, it ships **no new native code**: it reuses the WEB09
+`conduit_jni` cdylib by depending on the Java `conduit` package. Java and Kotlin
+share one JVM, the native library loads once, and a Kotlin handler lambda
+`{ req -> ... }` is SAM-converted into the Java `ConduitHandler`, so it crosses
+the JNI boundary exactly like a Java lambda.
+
+## Quick start
+
+```kotlin
+import com.codingadventures.conduitkt.*
+
+val app = conduit {
+    before { if (it.path == "/down") halt(503, "Maintenance") else null }
+    get("/")            { html("<h1>Hello from Conduit (Kotlin)!</h1>") }
+    get("/hello/:name") { json("""{"message":"Hello ${it["name"]}"}""") }
+    post("/echo")       { respond(200, it.body, mapOf("content-type" to it.contentType)) }
+    notFound            { html("<h1>Not Found: ${it.path}</h1>", 404) }
+    onError             { json("""{"error":"Internal Server Error"}""", 500) }
+    set("app_name", "Conduit Hello (Kotlin)")
+}
+
+app.serve("127.0.0.1", 3000)   // blocks until stopped
+```
+
+## DSL
+
+- `conduit { … }` builds an app; `get/post/put/delete/patch(pattern) { … }`,
+  `before/after/notFound/onError { … }`, `set(k, v)`.
+- Response helpers: `html`, `json`, `text`, `respond`, `halt`, `redirect`.
+- `Request` extension properties: `req.method`, `req.path`, `req.body`,
+  `req.contentType`, `req.queryString`, `req.error`, and `req["name"]` for
+  route params. `param`/`queryParam`/`header`/`params()` carry over from Java.
+- `app.serve(host, port)` (blocks), `app.serveBackground(...)`, `app.stop()`,
+  `app.localPort()`, `app.running()`; `ConduitApp` is `AutoCloseable`.
+
+## How it fits
+
+```
+Kotlin DSL (conduitkt) → Java conduit package (WEB09, unchanged) →
+conduit_jni cdylib → conduit (WEB08) → web-core → kqueue/epoll/IOCP
+```
+
+All native dispatch, JNI threading, marshaling, and security hardening are
+inherited from WEB09.
+
+## Building
+
+```sh
+cargo build --manifest-path ../../rust/Cargo.toml -p conduit-jni --release
+gradle test
+```
+
+The build sets `-Djava.library.path` to the Rust release output and pulls the
+Java package in via a Gradle composite build (`includeBuild` in
+`settings.gradle.kts`).

--- a/code/packages/kotlin/conduit/build.gradle.kts
+++ b/code/packages/kotlin/conduit/build.gradle.kts
@@ -1,0 +1,62 @@
+// Build configuration for the Kotlin Conduit web framework (WEB10).
+//
+// This package ships NO new Rust — it reuses the WEB09 `conduit_jni` cdylib
+// through a dependency on the Java `conduit` package (pulled in as a Gradle
+// composite build; see settings.gradle.kts). Tests still require the cdylib
+// to exist, so the BUILD script runs:
+//
+//   cargo build --manifest-path ../../rust/Cargo.toml -p conduit-jni --release
+//
+// before `gradle test`.
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    application
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    // The Java Conduit package — substituted by the composite build. It carries
+    // the native cdylib loader and the Application/Server/Request/Response API.
+    api("com.codingadventures:conduit")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// Point the JVM's native library search path at the Rust release output so the
+// Java package's `System.loadLibrary("conduit_jni")` resolves. projectDir =
+// code/packages/kotlin/conduit; up two = code/packages; then rust/target/release.
+val rustReleaseDir = projectDir.parentFile.parentFile
+    .resolve("rust/target/release")
+    .absolutePath
+
+// The bundled 8-route demo (ConduitHello.kt) — run with `gradle run`.
+application {
+    mainClass.set("com.codingadventures.conduitkt.ConduitHelloKt")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+    testLogging { events("passed", "skipped", "failed") }
+}
+
+tasks.named<JavaExec>("run") {
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+}

--- a/code/packages/kotlin/conduit/required_capabilities.json
+++ b/code/packages/kotlin/conduit/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "required_capabilities": ["rust", "kotlin", "java", "cargo"]
+}

--- a/code/packages/kotlin/conduit/settings.gradle.kts
+++ b/code/packages/kotlin/conduit/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "conduit-kotlin"
+
+// Reuse the Java Conduit package (and its native cdylib) as a composite build.
+// Gradle substitutes the `com.codingadventures:conduit` dependency with it.
+includeBuild("../../java/conduit")

--- a/code/packages/kotlin/conduit/src/main/kotlin/com/codingadventures/conduitkt/Conduit.kt
+++ b/code/packages/kotlin/conduit/src/main/kotlin/com/codingadventures/conduitkt/Conduit.kt
@@ -1,0 +1,214 @@
+/**
+ * Conduit — idiomatic Kotlin DSL over the Java Conduit web framework (WEB10).
+ *
+ * Ships no native code: it reuses the WEB09 `conduit_jni` cdylib through the
+ * Java `conduit` package. A Kotlin handler lambda `{ req -> ... }` is
+ * SAM-converted by the compiler into the Java [ConduitHandler] functional
+ * interface, so it crosses the JNI boundary exactly like a Java lambda.
+ *
+ * ```kotlin
+ * import com.codingadventures.conduitkt.*
+ *
+ * val app = conduit {
+ *     before { if (it.path == "/down") halt(503, "Maintenance") else null }
+ *     get("/")            { html("<h1>Hello from Conduit (Kotlin)!</h1>") }
+ *     get("/hello/:name") { json("""{"message":"Hello ${it.param("name")}"}""") }
+ *     post("/echo")       { respond(200, it.body, mapOf("content-type" to it.contentType)) }
+ *     notFound            { html("<h1>Not Found: ${it.path}</h1>", 404) }
+ *     onError             { json("""{"error":"Internal Server Error"}""", 500) }
+ *     set("app_name", "Conduit Hello (Kotlin)")
+ * }
+ *
+ * app.serve("127.0.0.1", 3000)   // blocks until stopped
+ * ```
+ */
+package com.codingadventures.conduitkt
+
+import com.codingadventures.conduit.Application
+import com.codingadventures.conduit.ConduitHandler
+import com.codingadventures.conduit.Responses
+import com.codingadventures.conduit.Server
+
+// Re-export the Java request/response types under Kotlin-friendly names so
+// users only import from this package.
+typealias Request = com.codingadventures.conduit.Request
+typealias Response = com.codingadventures.conduit.Response
+typealias HaltException = com.codingadventures.conduit.HaltException
+
+// ── Ergonomic extension properties on Request ───────────────────────────────
+//
+// The Java accessors are zero-arg methods (path(), method(), …). Kotlin sees
+// those as functions; these extension properties expose them as `req.path`.
+
+/** HTTP method, e.g. `"GET"`. */
+val Request.method: String get() = method()
+
+/** Request path without the query string. */
+val Request.path: String get() = path()
+
+/** Raw query string without the leading `?`. */
+val Request.queryString: String get() = queryString()
+
+/** Raw request body as a UTF-8 string. */
+val Request.body: String get() = body()
+
+/** Value of the `Content-Type` header, or `""`. */
+val Request.contentType: String get() = contentType()
+
+/** Remote peer IP address. */
+val Request.remoteAddr: String get() = remoteAddr()
+
+/** Error message — non-empty only inside the error handler. */
+val Request.error: String get() = error()
+
+/** Look up a route param with `req["name"]`. Returns `null` if absent. */
+operator fun Request.get(name: String): String? = param(name)
+
+// ── Response helpers (top-level, mirror Responses) ──────────────────────────
+
+/** `200 text/html` response (status overridable). */
+fun html(body: String, status: Int = 200): Response = Responses.html(body, status)
+
+/** `application/json` response from pre-serialized JSON text. */
+fun json(body: String, status: Int = 200): Response = Responses.json(body, status)
+
+/** `text/plain` response. */
+fun text(body: String, status: Int = 200): Response = Responses.text(body, status)
+
+/** Arbitrary response with explicit headers. */
+fun respond(status: Int, body: String, headers: Map<String, String> = emptyMap()): Response =
+    Responses.respond(status, body, headers)
+
+/** A halt response — return it from a filter/handler to short-circuit. */
+fun halt(status: Int, body: String): Response = Responses.halt(status, body)
+
+/** A redirect to [location] (default `302`). Rejects CR/LF in the location. */
+fun redirect(location: String, status: Int = 302): Response = Responses.redirect(location, status)
+
+// ── DSL builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Receiver for the [conduit] builder block. Each method registers on the
+ * underlying Java [Application]. Handlers are Kotlin lambdas, SAM-converted to
+ * [ConduitHandler].
+ */
+class ConduitBuilder internal constructor(@PublishedApi internal val app: Application) {
+    fun get(pattern: String, handler: (Request) -> Response?) {
+        app.get(pattern, ConduitHandler { handler(it) })
+    }
+
+    fun post(pattern: String, handler: (Request) -> Response?) {
+        app.post(pattern, ConduitHandler { handler(it) })
+    }
+
+    fun put(pattern: String, handler: (Request) -> Response?) {
+        app.put(pattern, ConduitHandler { handler(it) })
+    }
+
+    fun delete(pattern: String, handler: (Request) -> Response?) {
+        app.delete(pattern, ConduitHandler { handler(it) })
+    }
+
+    fun patch(pattern: String, handler: (Request) -> Response?) {
+        app.patch(pattern, ConduitHandler { handler(it) })
+    }
+
+    /** Register a route for an arbitrary HTTP method. */
+    fun route(method: String, pattern: String, handler: (Request) -> Response?) {
+        app.route(method, pattern, ConduitHandler { handler(it) })
+    }
+
+    /** Before filter — return a [Response] to short-circuit, `null` to continue. */
+    fun before(handler: (Request) -> Response?) {
+        app.before(ConduitHandler { handler(it) })
+    }
+
+    /** After filter — return a [Response] to replace, `null` to keep the prior one. */
+    fun after(handler: (Request) -> Response?) {
+        app.after(ConduitHandler { handler(it) })
+    }
+
+    /** Custom not-found handler. */
+    fun notFound(handler: (Request) -> Response?) {
+        app.notFound(ConduitHandler { handler(it) })
+    }
+
+    /** Error handler — message available via `req.error`. */
+    fun onError(handler: (Request) -> Response?) {
+        app.onError(ConduitHandler { handler(it) })
+    }
+
+    /** Store a string setting. */
+    fun set(key: String, value: String) {
+        app.set(key, value)
+    }
+
+    /** Read a string setting, or `null`. */
+    fun getSetting(key: String): String? = app.getSetting(key)
+}
+
+/**
+ * Build a [ConduitApp] with the given DSL block.
+ *
+ * The returned app owns a native peer; bind it with [ConduitApp.serve] /
+ * [ConduitApp.serveBackground]. Use it in a `use { }` block (it is
+ * [AutoCloseable]) or close it explicitly.
+ */
+fun conduit(block: ConduitBuilder.() -> Unit): ConduitApp {
+    val app = Application()
+    ConduitBuilder(app).apply(block)
+    return ConduitApp(app)
+}
+
+// ── App + server lifecycle ──────────────────────────────────────────────────
+
+/**
+ * A built Conduit application. Wraps the Java [Application] and the bound
+ * [Server]. Binding happens lazily on the first [serve]/[serveBackground].
+ */
+class ConduitApp internal constructor(private val application: Application) : AutoCloseable {
+    private var server: Server? = null
+
+    /**
+     * Read a setting registered in the builder. Valid before the app is bound
+     * to a server (binding consumes the underlying Java application).
+     */
+    fun getSetting(key: String): String? = application.getSetting(key)
+
+    /** Bind to [host]:[port] and serve on the calling thread (blocks until stopped). */
+    fun serve(host: String = "127.0.0.1", port: Int = 3000) {
+        bind(host, port).serve()
+    }
+
+    /** Bind and serve on a background thread; returns this for chaining/tests. */
+    fun serveBackground(host: String = "127.0.0.1", port: Int = 0): ConduitApp {
+        bind(host, port).serveBackground()
+        return this
+    }
+
+    /** The bound TCP port (valid after a serve/serveBackground call). */
+    fun localPort(): Int = requireServer().localPort()
+
+    /** Whether the server thread is active. */
+    fun running(): Boolean = server?.running() ?: false
+
+    /** Signal the server to stop. */
+    fun stop() {
+        server?.stop()
+    }
+
+    private fun bind(host: String, port: Int): Server {
+        check(server == null) { "server already bound" }
+        return Server.bind(application, host, port).also { server = it }
+    }
+
+    private fun requireServer(): Server =
+        server ?: error("server not bound — call serve()/serveBackground() first")
+
+    override fun close() {
+        server?.close()
+        // If never bound, the Java Application still owns a native peer; close it.
+        if (server == null) application.close()
+        server = null
+    }
+}

--- a/code/packages/kotlin/conduit/src/main/kotlin/com/codingadventures/conduitkt/ConduitHello.kt
+++ b/code/packages/kotlin/conduit/src/main/kotlin/com/codingadventures/conduitkt/ConduitHello.kt
@@ -1,0 +1,61 @@
+/**
+ * Conduit demo (Kotlin) — the canonical eight-route example, mirroring the
+ * Ruby/Python/Lua/TypeScript/Elixir/Rust/Java `conduit-hello` demos.
+ *
+ * It lives in the framework package (rather than a separate program) because
+ * the Kotlin package is itself a Gradle composite build over the Java package,
+ * and a second `conduit`-named composite for a standalone demo would collide on
+ * Gradle's directory-derived build path. Run it with `gradle run`.
+ *
+ * ```
+ *   GET  /              HTML home
+ *   GET  /hello/:name   JSON greeting using a route param
+ *   POST /echo          echoes the request body
+ *   GET  /redirect      301 to /
+ *   GET  /halt          halt(403, "Forbidden")
+ *   GET  /down          before-filter halt(503)
+ *   GET  /error         throws → routes to the error handler (500)
+ *   (any)/missing       custom not-found handler (404)
+ * ```
+ */
+package com.codingadventures.conduitkt
+
+/** Build the demo application. Pure — easy to test. */
+fun demoApp(): ConduitApp = conduit {
+    before { if (it.path == "/down") halt(503, "Under maintenance") else null }
+    get("/") {
+        html(
+            """
+            <!DOCTYPE html>
+            <html><head><title>Conduit Hello</title></head>
+            <body>
+              <h1>Hello from Conduit (Kotlin)!</h1>
+              <p>Try <a href="/hello/Adhithya">/hello/Adhithya</a>.</p>
+            </body></html>
+            """.trimIndent(),
+        )
+    }
+    get("/hello/:name") { json("""{"message":"Hello ${it["name"]}"}""") }
+    post("/echo") { respond(200, it.body, mapOf("content-type" to it.contentType)) }
+    get("/redirect") { redirect("/", 301) }
+    get("/halt") { halt(403, "Forbidden") }
+    get("/error") { throw RuntimeException("Something went wrong!") }
+    notFound { html("<h1>Not Found: ${it.path}</h1>", 404) }
+    onError { json("""{"error":"Internal Server Error","detail":"${it.error}"}""", 500) }
+    set("app_name", "Conduit Hello (Kotlin)")
+}
+
+fun main(args: Array<String>) {
+    var host = "127.0.0.1"
+    var port = 3000
+    var i = 0
+    while (i < args.size - 1) {
+        when (args[i]) {
+            "--host" -> host = args[i + 1]
+            "--port" -> port = args[i + 1].toInt()
+        }
+        i++
+    }
+    println("Conduit Hello listening on http://$host:$port")
+    demoApp().serve(host, port)
+}

--- a/code/packages/kotlin/conduit/src/test/kotlin/com/codingadventures/conduitkt/ConduitHelloTest.kt
+++ b/code/packages/kotlin/conduit/src/test/kotlin/com/codingadventures/conduitkt/ConduitHelloTest.kt
@@ -1,0 +1,116 @@
+package com.codingadventures.conduitkt
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Integration tests for the bundled 8-route demo ([demoApp]) over real HTTP —
+ * the Kotlin equivalent of the other ports' `conduit-hello` test suites.
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class ConduitHelloTest {
+
+    private lateinit var app: ConduitApp
+    private var port = 0
+    private val client = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+
+    @BeforeTest
+    fun start() {
+        app = demoApp()
+        app.serveBackground("127.0.0.1", 0)
+        Thread.sleep(150)
+        port = app.localPort()
+    }
+
+    @AfterTest
+    fun stop() {
+        app.stop()
+        app.close()
+    }
+
+    private fun get(path: String): HttpResponse<String> =
+        client.send(
+            HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+                .timeout(Duration.ofSeconds(5)).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun post(path: String, body: String): HttpResponse<String> =
+        client.send(
+            HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+                .timeout(Duration.ofSeconds(5))
+                .header("content-type", "text/plain")
+                .POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    @Test fun root() {
+        val r = get("/")
+        assertEquals(200, r.statusCode())
+        assertContains(r.body(), "Hello from Conduit")
+        assertContains(r.body(), "/hello/Adhithya")
+    }
+
+    @Test fun helloParam() = assertContains(get("/hello/Adhithya").body(), "Hello Adhithya")
+
+    @Test fun echo() {
+        val r = post("/echo", "ping=pong")
+        assertEquals(200, r.statusCode())
+        assertEquals("ping=pong", r.body())
+    }
+
+    @Test fun echoEmpty() = assertEquals("", post("/echo", "").body())
+
+    @Test fun redirect() {
+        val r = get("/redirect")
+        assertEquals(301, r.statusCode())
+        assertEquals("/", r.headers().firstValue("location").orElse(""))
+    }
+
+    @Test fun halt() {
+        val r = get("/halt")
+        assertEquals(403, r.statusCode())
+        assertEquals("Forbidden", r.body())
+    }
+
+    @Test fun down() {
+        val r = get("/down")
+        assertEquals(503, r.statusCode())
+        assertEquals("Under maintenance", r.body())
+    }
+
+    @Test fun error() {
+        val r = get("/error")
+        assertEquals(500, r.statusCode())
+        assertContains(r.body(), "Internal Server Error")
+        assertContains(r.body(), "Something went wrong")
+    }
+
+    @Test fun missing() {
+        val r = get("/missing")
+        assertEquals(404, r.statusCode())
+        assertContains(r.body(), "Not Found: /missing")
+    }
+
+    @Test fun anyUnknownIs404() = assertEquals(404, get("/a/b/c").statusCode())
+
+    @Test fun localPortAssigned() = assertTrue(port > 0)
+
+    @Test fun appNameSetting() {
+        demoApp().use { assertEquals("Conduit Hello (Kotlin)", it.getSetting("app_name")) }
+    }
+}

--- a/code/packages/kotlin/conduit/src/test/kotlin/com/codingadventures/conduitkt/ConduitKtTest.kt
+++ b/code/packages/kotlin/conduit/src/test/kotlin/com/codingadventures/conduitkt/ConduitKtTest.kt
@@ -1,0 +1,156 @@
+package com.codingadventures.conduitkt
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Tests for the Kotlin Conduit DSL. The response-helper and builder paths are
+ * exercised directly; the request handling is verified end-to-end over real
+ * HTTP (the Java `Request` constructor is package-private, so the lazy-map
+ * parsing is covered through the running server rather than in isolation).
+ *
+ * A 30s class-level timeout surfaces any hung server/dispatch as a clear
+ * failure instead of stalling CI (same hardening as the Java port).
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class ConduitKtTest {
+
+    private var appHandle: ConduitApp? = null
+
+    @AfterTest
+    fun tearDown() {
+        appHandle?.let {
+            it.stop()
+            it.close()
+        }
+        appHandle = null
+    }
+
+    private val client: HttpClient = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+
+    private fun start(block: ConduitBuilder.() -> Unit): Int {
+        val app = conduit(block)
+        appHandle = app
+        app.serveBackground("127.0.0.1", 0)
+        Thread.sleep(150)
+        return app.localPort()
+    }
+
+    private fun get(port: Int, path: String): HttpResponse<String> =
+        client.send(
+            HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+                .timeout(Duration.ofSeconds(5)).GET().build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun post(port: Int, path: String, body: String): HttpResponse<String> =
+        client.send(
+            HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+                .timeout(Duration.ofSeconds(5))
+                .header("content-type", "text/plain")
+                .POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    // ── Response-helper unit tests (no server) ──────────────────────────────
+
+    @Test
+    fun htmlHelper() {
+        val r = html("<h1>Hi</h1>")
+        assertEquals(200, r.status())
+        assertEquals("<h1>Hi</h1>", r.body())
+        assertEquals("text/html; charset=utf-8", r.headers()["content-type"])
+    }
+
+    @Test
+    fun jsonAndTextAndRespondHelpers() {
+        assertEquals("application/json", json("{}").headers()["content-type"])
+        assertEquals(201, text("x", 201).status())
+        val r = respond(204, "", mapOf("x-y" to "z"))
+        assertEquals("z", r.headers()["x-y"])
+    }
+
+    @Test
+    fun haltAndRedirectHelpers() {
+        assertEquals(403, halt(403, "no").status())
+        val r = redirect("/new", 301)
+        assertEquals(301, r.status())
+        assertEquals("/new", r.headers()["location"])
+    }
+
+    // ── E2E tests ────────────────────────────────────────────────────────────
+
+    @Test
+    fun routesRespond() {
+        val port = start {
+            before { if (it.path == "/down") halt(503, "Maintenance") else null }
+            get("/") { html("<h1>OK</h1>") }
+            get("/ping") { text("pong") }
+            get("/hello/:name") { json("""{"hi":"${it["name"]}"}""") }
+            get("/search") { text("q=${it.queryParams()["q"]}") }
+            post("/echo") { respond(200, it.body, mapOf("content-type" to it.contentType)) }
+            get("/old") { redirect("/new") }
+            get("/forbidden") { halt(403, "Forbidden") }
+            get("/boom") { throw RuntimeException("kaboom") }
+            notFound { html("Not Found: ${it.path}", 404) }
+            onError { json("""{"error":"${it.error}"}""", 500) }
+        }
+
+        assertEquals("<h1>OK</h1>", get(port, "/").body())
+        assertEquals("pong", get(port, "/ping").body())
+        assertContains(get(port, "/hello/Ada").body(), "Ada")
+        assertContains(get(port, "/search?q=hello").body(), "hello")
+        assertEquals("hello world", post(port, "/echo", "hello world").body())
+
+        val down = get(port, "/down")
+        assertEquals(503, down.statusCode())
+        assertEquals("Maintenance", down.body())
+
+        val old = get(port, "/old")
+        assertEquals(302, old.statusCode())
+        assertEquals("/new", old.headers().firstValue("location").orElse(""))
+
+        assertEquals(403, get(port, "/forbidden").statusCode())
+
+        val boom = get(port, "/boom")
+        assertEquals(500, boom.statusCode())
+        assertContains(boom.body(), "kaboom")
+
+        val missing = get(port, "/missing")
+        assertEquals(404, missing.statusCode())
+        assertContains(missing.body(), "Not Found: /missing")
+    }
+
+    @Test
+    fun serverMetadataAndRunning() {
+        val app = conduit { get("/") { text("ok") } }
+        appHandle = app
+        app.serveBackground("127.0.0.1", 0)
+        Thread.sleep(150)
+        assertTrue(app.localPort() > 0)
+        assertTrue(app.running())
+        app.stop()
+        assertFalse(app.running())
+    }
+
+    @Test
+    fun settingsReadableBeforeBind() {
+        conduit { set("app_name", "Conduit KT") }.use {
+            assertEquals("Conduit KT", it.getSetting("app_name"))
+        }
+    }
+}

--- a/code/specs/WEB10-conduit-kotlin.md
+++ b/code/specs/WEB10-conduit-kotlin.md
@@ -1,0 +1,127 @@
+# WEB10 — Kotlin Conduit (JVM, reuses the Java cdylib)
+
+## Overview
+
+A Kotlin port of the Conduit web framework. Unlike every other port, WEB10
+ships **no new Rust** — it reuses the WEB09 `conduit_jni` cdylib unchanged by
+depending on the Java `conduit` package. The Kotlin layer is a thin,
+idiomatic DSL: trailing-lambda routes, extension properties on `Request`, and
+top-level response helpers.
+
+This is possible because Java and Kotlin share one JVM. The native library is
+loaded once (by the Java `Native` class's static initializer); a Kotlin
+lambda `{ req -> ... }` is **SAM-converted** by the Kotlin compiler into the
+Java `ConduitHandler` functional interface, so it crosses the JNI boundary
+exactly like a Java lambda.
+
+```kotlin
+import com.codingadventures.conduitkt.*
+
+val app = conduit {
+    before { if (it.path == "/down") halt(503, "Maintenance") else null }
+    get("/")            { html("<h1>Hello from Conduit (Kotlin)!</h1>") }
+    get("/hello/:name") { json("""{"message":"Hello ${it.param("name")}"}""") }
+    post("/echo")       { respond(200, it.body, mapOf("content-type" to it.contentType)) }
+    notFound            { html("<h1>Not Found: ${it.path}</h1>", 404) }
+    onError             { json("""{"error":"Internal Server Error"}""", 500) }
+    set("app_name", "Conduit Hello (Kotlin)")
+}
+
+app.serve("127.0.0.1", 3000)   // blocks until stopped
+```
+
+## Why no new cdylib?
+
+The `conduit_jni` symbols are named `Java_com_codingadventures_conduit_Native_*`
+— tied to the Java `Native` class. Giving Kotlin its own native methods would
+require either recompiling the cdylib with Kotlin-specific JNI symbol names or
+a second cdylib. Both contradict "reuse unchanged." Instead, the Kotlin
+package **depends on** `com.codingadventures:conduit` (the Java package) and
+drives its `Application`/`Server` through a Kotlin-friendly surface. The
+native dispatch, threading, marshaling, and security hardening are all
+inherited from WEB09.
+
+## Architecture
+
+```
+Kotlin DSL (com.codingadventures.conduitkt)
+    conduit { }, get/post/..., extension props, html/json/text/halt/redirect
+    │  (Kotlin SAM conversion → Java ConduitHandler)
+    ▼
+Java conduit package (Application, Server, Request, Response, Native)   ← WEB09, unchanged
+    ▼
+conduit_jni cdylib → conduit (WEB08) → web-core → … → kqueue/epoll/IOCP
+```
+
+## DSL surface
+
+| Kotlin | Delegates to |
+|--------|--------------|
+| `conduit { … }` | builds a Java `Application` via a `ConduitBuilder` receiver |
+| `get/post/put/delete/patch(pattern) { handler }` | `Application.get(...)` etc. (trailing lambda) |
+| `before { } / after { } / notFound { } / onError { }` | the Java filters/handlers |
+| `set(key, value)` / `getSetting(key)` | `Application.set` / `getSetting` |
+| `app.serve(host, port)` / `app.serveBackground(...)` / `app.stop()` | wraps `Server.bind` + serve |
+| `html/json/text(body, status=200)` | `Responses.html/json/text` |
+| `respond(status, body, headers)` | `Responses.respond` |
+| `halt(status, body)` / `redirect(location, status=302)` | `Responses.halt/redirect` |
+
+### Ergonomic extensions on `Request`
+
+The Java accessors are methods (`path()`, `method()`, `body()`, …). Kotlin
+extension properties expose them as properties — `req.path`, `req.method`,
+`req.body`, `req.contentType`, `req.queryString`, `req.error` — plus a
+`req["name"]` operator for route params. `param`, `queryParam`, `header`, and
+the maps remain as-is (already Kotlin-friendly).
+
+### `Server` lifecycle
+
+`conduit { }` returns a small `ConduitApp` holding the Java `Application`.
+`ConduitApp.serve(host, port)` binds a `Server`, serves (blocking);
+`serveBackground` returns the `Server` for tests; `localPort`, `running`, and
+`stop`/`close` delegate. `ConduitApp` is `AutoCloseable`.
+
+## Package layout
+
+```
+code/packages/kotlin/conduit/
+├── BUILD                 # cargo build conduit-jni (idempotent) + gradle test
+├── BUILD_windows
+├── CHANGELOG.md
+├── README.md
+├── build.gradle.kts      # kotlin("jvm") 2.1.20, Java 21; depends on com.codingadventures:conduit
+├── settings.gradle.kts   # includeBuild("../../java/conduit")
+├── required_capabilities.json   # ["rust","kotlin","java","cargo"]
+└── src/
+    ├── main/kotlin/com/codingadventures/conduitkt/Conduit.kt
+    └── test/kotlin/com/codingadventures/conduitkt/ConduitKtTest.kt
+
+code/programs/kotlin/conduit-hello/   # 8-route demo + integration tests
+```
+
+The native library path (`-Djava.library.path=<rust/target/release>`) is set
+in `build.gradle.kts` exactly as in the Java package, so
+`System.loadLibrary("conduit_jni")` resolves.
+
+## Tests (target: 30+)
+
+- DSL unit tests (no server): builder registers routes/filters/settings;
+  response helpers; `Request` extension properties (constructed via the Java
+  package-private path is not accessible from Kotlin, so these are covered via
+  the E2E suite instead).
+- E2E suite via `java.net.http.HttpClient` over a real server on port 0,
+  mirroring WEB09's `ServerTest`: `/`, `/hello/:name`, POST `/echo`,
+  before-filter halt(503), redirect(302), notFound(404), onError(500), query
+  params, server metadata. Class-level `@Timeout(30s)` (same hardening as
+  WEB09).
+- `conduit-hello`: 8-route demo + integration tests.
+
+## Out of scope
+
+- New Rust / cdylib changes — entirely inherited from WEB09.
+- Binary bodies (UTF-8 strings, as in every port).
+
+## Future
+
+The same JVM-reuse trick means a Scala or Clojure port would also be a thin
+wrapper over the Java cdylib, should those languages join the repo.

--- a/code/specs/WEB10-conduit-kotlin.md
+++ b/code/specs/WEB10-conduit-kotlin.md
@@ -93,11 +93,22 @@ code/packages/kotlin/conduit/
 ├── settings.gradle.kts   # includeBuild("../../java/conduit")
 ├── required_capabilities.json   # ["rust","kotlin","java","cargo"]
 └── src/
-    ├── main/kotlin/com/codingadventures/conduitkt/Conduit.kt
-    └── test/kotlin/com/codingadventures/conduitkt/ConduitKtTest.kt
-
-code/programs/kotlin/conduit-hello/   # 8-route demo + integration tests
+    ├── main/kotlin/com/codingadventures/conduitkt/Conduit.kt        # DSL + helpers
+    ├── main/kotlin/com/codingadventures/conduitkt/ConduitHello.kt   # bundled 8-route demo (gradle run)
+    └── test/kotlin/com/codingadventures/conduitkt/
+        ├── ConduitKtTest.kt        # DSL + E2E
+        └── ConduitHelloTest.kt     # demo integration tests
 ```
+
+### Deviation: the demo is bundled, not a separate program
+
+The other ports ship a standalone `conduit-hello` program. Kotlin can't: the
+Kotlin package is itself a Gradle **composite build** over the Java `conduit`
+package, and a separate `conduit-hello` build would transitively include both
+`java/conduit` and `kotlin/conduit` — two directories named `conduit`, which
+collide on Gradle's directory-derived build path (`:conduit`). So the canonical
+8-route demo (`ConduitHello.kt`, `gradle run`) and its integration tests live
+inside the package instead. Functionally identical; one fewer Gradle build.
 
 The native library path (`-Djava.library.path=<rust/target/release>`) is set
 in `build.gradle.kts` exactly as in the Java package, so


### PR DESCRIPTION
**WEB10** — Kotlin port of Conduit. Uniquely, this ships **no new Rust and no new native code**: it reuses the WEB09 `conduit_jni` cdylib by depending on the Java `conduit` package (Gradle composite build). Java + Kotlin share one JVM; the native lib loads once; and Kotlin **SAM-converts** `{ req -> ... }` lambdas into the Java `ConduitHandler`, so they cross the JNI boundary exactly like Java lambdas.

## The Kotlin layer (thin, idiomatic)
```kotlin
val app = conduit {
    before { if (it.path == "/down") halt(503, "Maintenance") else null }
    get("/")            { html("<h1>Hello from Conduit (Kotlin)!</h1>") }
    get("/hello/:name") { json("""{"message":"Hello ${it["name"]}"}""") }
    post("/echo")       { respond(200, it.body, mapOf("content-type" to it.contentType)) }
    notFound            { html("<h1>Not Found: ${it.path}</h1>", 404) }
    onError             { json("""{"error":"Internal Server Error"}""", 500) }
}
app.serve("127.0.0.1", 3000)
```
- `conduit { }` builder, trailing-lambda routes/filters, `set`/`getSetting`.
- Top-level `html`/`json`/`text`/`respond`/`halt`/`redirect`.
- `Request` extension properties (`req.path`, `req.method`, `req.body`, …) + `req["name"]` param operator.
- `ConduitApp` lifecycle (`serve`/`serveBackground`/`stop`/`localPort`/`running`, `AutoCloseable`).

## Deviation: bundled demo
The standard standalone `conduit-hello` program would transitively `includeBuild` both `java/conduit` and `kotlin/conduit` — two dirs named `conduit` that collide on Gradle's directory-derived build path (`:conduit`). So the canonical 8-route demo (`ConduitHello.kt`, `gradle run`) and its integration tests live **inside the package**. Functionally identical; documented in the spec.

## Security
No native code, no new untrusted-input handling — FFI, dispatch, marshaling, and the CR/LF header-injection defenses are all inherited unchanged from the already-reviewed WEB09. `redirect()` delegates to Java's CRLF-rejecting helper; `ConduitApp` bind/close are null-guarded (no double-free).

## Test plan
- [x] 18 tests green via composite build (12 demo integration over real HTTP + 6 DSL/E2E)
- [x] cargo build conduit-jni + gradle test pass locally
- [x] Class-level `@Timeout(30s)` hardening (as WEB09)
- [ ] CI green

## Next in the series
Perl (WEB11, `perl-bridge`), then Swift/C++/Go/C#/F#/Dart/Haskell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)