### PR TITLE
feat(irc-server-native): Python native binding for the all-Rust IRC engine

### DIFF
--- a/code/packages/python/irc-server-native/BUILD
+++ b/code/packages/python/irc-server-native/BUILD
@@ -1,0 +1,17 @@
+set -e
+
+# Step 1: Build the Rust cdylib extension (all IRC + TCP logic lives in Rust).
+# cargo, python3, and uv are in PATH (mise shims locally; GitHub Actions on CI).
+cd ext/irc_server_native && cargo build --release && cd ../..
+
+# Step 2: Copy the built cdylib into the Python package directory under the
+# platform-specific extension suffix (e.g. .cpython-313-darwin.so).  Each BUILD
+# line runs in its own shell, so a Python one-liner does the glob + copy atomically.
+python3 -c "import sysconfig, glob, shutil, sys; ext = sysconfig.get_config_var('EXT_SUFFIX'); libs = glob.glob('ext/irc_server_native/target/release/libirc_server_native.*'); src = next((l for l in libs if l.endswith(('.so', '.dylib', '.dll'))), None); sys.exit('ERROR: Rust extension build failed -- no libirc_server_native found') if src is None else shutil.copy(src, 'src/coding_adventures/irc_server_native/irc_server_native' + ext)"
+
+# Step 3: Create a virtual environment and install the package in editable mode.
+uv venv --quiet --clear
+uv pip install -e ".[dev]" --quiet
+
+# Step 4: Run the test suite.
+.venv/bin/python -m pytest tests/ -v

--- a/code/packages/python/irc-server-native/CHANGELOG.md
+++ b/code/packages/python/irc-server-native/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-06-13
+
+### Added
+
+- `IrcServer` — a Python facade for a high-performance IRC server whose IRC and
+  TCP logic run entirely in Rust (`irc-net-reactor` on the home-grown
+  kqueue/epoll reactor). Control surface: `serve` (GIL released around the
+  blocking loop), `stop` (callable from another thread), `local_host` /
+  `local_port`, `running`, `dispose`.
+- `irc_server_native` C extension (Rust cdylib via the zero-dependency
+  `python-bridge`): `server_new` / `server_serve` / `server_stop` /
+  `server_local_host` / `server_local_port` / `server_running` /
+  `server_dispose` over an opaque `PyCapsule` handle. No per-message callback
+  into Python — the binding is lifecycle-only.
+- `build.rs` linker configuration for the Python C extension (macOS
+  `-undefined dynamic_lookup`, Linux `--allow-shlib-undefined`, Windows
+  `python3` import lib).
+- `BUILD` that compiles the cdylib, copies it under the platform `EXT_SUFFIX`,
+  and runs the test suite.
+- Tests: facade unit tests against a fake native module (argument coercion,
+  MOTD default, lifecycle delegation, introspection) plus real end-to-end tests
+  that start the Rust engine on an ephemeral port and drive two live IRC clients
+  through registration, PING/PONG, and channel `PRIVMSG` broadcast.

--- a/code/packages/python/irc-server-native/README.md
+++ b/code/packages/python/irc-server-native/README.md
@@ -1,0 +1,73 @@
+# coding-adventures-irc-server-native
+
+A **high-performance IRC server for Python** — every line of IRC and TCP logic
+runs in Rust (the [`irc-net-reactor`](../../rust/irc-net-reactor) engine on the
+home-grown `kqueue`/`epoll` reactor). Python only launches and controls the
+server, through a thin native extension built on the zero-dependency
+`python-bridge` (no PyO3).
+
+## Why
+
+This is the Python member of a family: one Rust IRC engine, embedded natively in
+every language. Because all logic lives in Rust, the binding is a pure lifecycle
+control surface — **create, serve, stop** — with no per-message callback into
+Python (and therefore none of the GIL-re-acquisition complexity that a
+callback-based framework like `conduit` needs).
+
+## Usage
+
+```python
+from coding_adventures.irc_server_native import IrcServer
+
+server = IrcServer(host="127.0.0.1", port=6667, server_name="irc.example")
+server.serve()   # blocks until another thread calls server.stop()
+```
+
+Bind an ephemeral port and read it back (handy for tests):
+
+```python
+import threading
+
+server = IrcServer(host="127.0.0.1", port=0)
+port = server.local_port()
+threading.Thread(target=server.serve, daemon=True).start()
+# ... connect IRC clients to 127.0.0.1:port ...
+server.stop()
+```
+
+Point an IRC client (irssi, WeeChat, `nc`) at the host/port, register with
+`NICK`/`USER`, `JOIN #channel`, and chat — the broadcast fan-out to other
+channel members happens entirely in Rust.
+
+## API
+
+| method                | description                                            |
+|-----------------------|--------------------------------------------------------|
+| `IrcServer(host, port, server_name, motd, oper_password, max_connections)` | build + bind |
+| `serve()`             | run the event loop, blocking (the GIL is released)     |
+| `stop()`              | signal the loop to stop (safe from another thread)     |
+| `local_host()` / `local_port()` | the bound address (real port after `port=0`)  |
+| `running()`           | whether the loop is currently running                  |
+| `dispose()`           | free the listener now (must be stopped first)          |
+
+## How it's built
+
+The `BUILD` script compiles the Rust cdylib in `ext/irc_server_native`, copies it
+into the package under the platform's extension suffix, then installs and tests:
+
+```
+cd ext/irc_server_native && cargo build --release
+# copy target/release/libirc_server_native.* → src/.../irc_server_native<EXT_SUFFIX>
+uv venv && uv pip install -e ".[dev]"
+pytest
+```
+
+## Layer position
+
+```
+coding_adventures.irc_server_native.IrcServer   (this package — Python facade)
+        ↓ irc_server_native C extension (python-bridge, GIL released on serve)
+irc-net-reactor   (Rust IRC engine, in-process broadcast)
+        ↓
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+```

--- a/code/packages/python/irc-server-native/ext/irc_server_native/Cargo.toml
+++ b/code/packages/python/irc-server-native/ext/irc_server_native/Cargo.toml
@@ -1,0 +1,23 @@
+# irc_server_native — Python C extension wrapping the Rust IRC engine.
+#
+# All IRC + TCP logic lives in `irc-net-reactor` (Rust, on the home-grown
+# kqueue/epoll reactor).  This crate is a thin control surface: create the
+# server, run it (releasing the GIL around the blocking event loop), stop it.
+# There is NO per-message callback into Python — unlike `conduit`, the host
+# language only launches and controls the server.
+#
+# crate-type = ["cdylib"]: emit a shared library Python can `import`.
+
+[package]
+name = "irc-server-native-python"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "irc_server_native"
+
+[dependencies]
+irc-net-reactor = { path = "../../../../rust/irc-net-reactor" }
+python-bridge   = { path = "../../../../rust/python-bridge" }

--- a/code/packages/python/irc-server-native/ext/irc_server_native/build.rs
+++ b/code/packages/python/irc-server-native/ext/irc_server_native/build.rs
@@ -1,0 +1,47 @@
+// build.rs — linker configuration for the Python C extension cdylib.
+//
+// Python C extensions (.so / .pyd) are loaded via dlopen() by the Python
+// interpreter at import time. The Python C API symbols (Py_IncRef, PyDict_New,
+// etc.) are provided by the running Python process rather than being linked
+// into our .so at build time.
+//
+// On macOS (Mach-O), we must pass `-undefined dynamic_lookup` to the linker
+// so it does not fail on unresolved Python symbols during the `cargo build`
+// phase. The dynamic linker resolves them at runtime when Python loads the
+// extension with `dlopen()`.
+//
+// On Linux (ELF), shared libraries may have undefined symbols by default
+// (the dynamic linker resolves them at load time), so no extra flag is needed.
+// We still pass --allow-shlib-undefined to be explicit.
+//
+// On Windows (.pyd), the extension must link against python3X.lib (the import
+// library), which is found via the PYTHON_LIB_PATH environment variable.
+
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    match target_os.as_str() {
+        "macos" => {
+            // Tell the macOS linker to defer resolution of all undefined symbols
+            // to load time. This is the standard approach for Python .so extensions.
+            println!("cargo:rustc-link-arg=-undefined");
+            println!("cargo:rustc-link-arg=dynamic_lookup");
+        }
+        "linux" => {
+            // ELF .so files allow undefined symbols by default, but we can be
+            // explicit about it to suppress any linker warnings.
+            println!("cargo:rustc-link-arg=-Wl,--allow-shlib-undefined");
+        }
+        "windows" => {
+            // On Windows we need to link against the Python import library.
+            // The library is typically at: Python3X\libs\python3X.lib.
+            // We look for it via PYTHON_LIB_PATH or fall back to a common location.
+            if let Ok(lib_path) = std::env::var("PYTHON_LIB_PATH") {
+                println!("cargo:rustc-link-search={lib_path}");
+            }
+            // Link against python3 (the version-agnostic import lib for stable ABI).
+            println!("cargo:rustc-link-lib=python3");
+        }
+        _ => {}
+    }
+}

--- a/code/packages/python/irc-server-native/ext/irc_server_native/src/lib.rs
+++ b/code/packages/python/irc-server-native/ext/irc_server_native/src/lib.rs
@@ -1,0 +1,435 @@
+//! `irc_server_native` — a Python C extension that embeds the all-Rust IRC
+//! engine (`irc-net-reactor`) and exposes a tiny lifecycle control surface.
+//!
+//! ## Design: control surface only, no callbacks
+//!
+//! All IRC and TCP logic lives in Rust (`irc-net-reactor` on the home-grown
+//! kqueue/epoll reactor).  Python's only job is to *launch and control* the
+//! server, so this module exposes exactly five module-level functions over an
+//! opaque [`PyCapsule`] handle:
+//!
+//! | function                       | meaning                                    |
+//! |--------------------------------|--------------------------------------------|
+//! | `server_new(host, port, name, motd, oper_password, max_connections)` | build + bind, return a capsule |
+//! | `server_serve(capsule)`        | run the event loop, **releasing the GIL**  |
+//! | `server_stop(capsule)`         | signal the loop to stop (callable from another thread) |
+//! | `server_local_host(capsule)` / `server_local_port(capsule)` | the bound address |
+//! | `server_running(capsule)`      | is the loop currently running?             |
+//! | `server_dispose(capsule)`      | drop the engine (must be stopped first)    |
+//!
+//! Unlike `conduit`, there is **no per-request dispatch back into Python**, so
+//! none of the `PyGILState_Ensure`/TSFN machinery is needed — just a single
+//! `PyEval_SaveThread`/`PyEval_RestoreThread` around the blocking `serve()`.
+//!
+//! ## GIL discipline
+//!
+//! `server_serve` releases the GIL with `PyEval_SaveThread` before calling the
+//! blocking `IrcReactorServer::serve()` and re-acquires it with
+//! `PyEval_RestoreThread` afterward.  This lets a *different* Python thread call
+//! `server_stop` (which only touches the thread-safe stop handle) while the
+//! event loop runs — the standard "serve on one thread, stop from another"
+//! pattern, identical to how `conduit` drives `web-core`.
+
+use std::ffi::{c_char, c_long, c_void, CString};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use irc_net_reactor::{IrcConfig, IrcReactorServer};
+use python_bridge::{
+    method_def_sentinel, py_false, py_none, py_true, runtime_error_class, str_from_py, str_to_py,
+    vec_str_from_py, PyErr_Clear, PyErr_SetString, PyLong_FromLong, PyMethodDef, PyModuleDef,
+    PyModuleDef_Base, PyModule_Create2, PyObjectPtr, PyTuple_GetItem, METH_VARARGS,
+    PYTHON_API_VERSION,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C API symbols not re-exported by python-bridge — declared inline (stable ABI).
+// ─────────────────────────────────────────────────────────────────────────────
+//
+//   PyEval_SaveThread    → release the GIL; returns a *mut PyThreadState.
+//   PyEval_RestoreThread → re-acquire the GIL from a saved thread state.
+//   PyCapsule_New        → wrap a raw C pointer with a destructor.
+//   PyCapsule_GetPointer → recover the raw pointer from a capsule.
+//   PyLong_AsLong        → Python int → C long (-1 + set error on failure).
+//   PyErr_Occurred       → non-null if a Python exception is currently set.
+#[allow(non_snake_case)]
+extern "C" {
+    fn PyEval_SaveThread() -> *mut c_void;
+    fn PyEval_RestoreThread(state: *mut c_void);
+    fn PyCapsule_New(
+        pointer: *mut c_void,
+        name: *const c_char,
+        destructor: Option<unsafe extern "C" fn(PyObjectPtr)>,
+    ) -> PyObjectPtr;
+    fn PyCapsule_GetPointer(capsule: PyObjectPtr, name: *const c_char) -> *mut c_void;
+    fn PyLong_AsLong(o: PyObjectPtr) -> c_long;
+    fn PyErr_Occurred() -> PyObjectPtr;
+}
+
+/// The capsule's type name — `PyCapsule_GetPointer` checks it on every recovery,
+/// so a capsule from a different module can never be mistaken for ours.
+const CAPSULE_NAME: &[u8] = b"irc_server_native.server\0";
+
+/// The boxed state behind the capsule.  `running` mirrors the engine's serve
+/// state so `server_dispose` can refuse to drop a live server.
+struct PyIrcServer {
+    server: Option<IrcReactorServer>,
+    running: Arc<AtomicBool>,
+}
+
+/// Called by Python when the capsule is garbage-collected: reconstruct and drop
+/// the `Box`, which drops the `IrcReactorServer` (closing the listener).  Python
+/// holds the GIL here, so this is safe.
+unsafe extern "C" fn capsule_destructor(capsule: PyObjectPtr) {
+    let ptr = PyCapsule_GetPointer(capsule, CAPSULE_NAME.as_ptr() as *const c_char);
+    if !ptr.is_null() {
+        drop(Box::from_raw(ptr as *mut PyIrcServer));
+    }
+}
+
+/// Recover the `*mut PyIrcServer` from a capsule, setting a Python error and
+/// returning null on mismatch.
+unsafe fn get_state(capsule: PyObjectPtr) -> *mut PyIrcServer {
+    let ptr = PyCapsule_GetPointer(capsule, CAPSULE_NAME.as_ptr() as *const c_char);
+    if ptr.is_null() {
+        // PyCapsule_GetPointer already set a TypeError on mismatch.
+        return ptr::null_mut();
+    }
+    ptr as *mut PyIrcServer
+}
+
+/// Set a `RuntimeError` from a Rust string (falls back to a static message if
+/// the string contains an interior NUL).
+///
+/// Clears any pending exception first: a too-short argument tuple leaves an
+/// `IndexError` set by `PyTuple_GetItem`, and we want our `RuntimeError` to be
+/// the single, clean exception the caller sees rather than chaining onto it.
+unsafe fn set_runtime_error(message: String) {
+    PyErr_Clear();
+    let c_msg =
+        CString::new(message).unwrap_or_else(|_| CString::new("irc_server_native error").unwrap());
+    PyErr_SetString(runtime_error_class(), c_msg.as_ptr());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// server_new(host, port, server_name, motd, oper_password, max_connections)
+// ─────────────────────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn server_new(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let host_py = PyTuple_GetItem(args, 0);
+    let port_py = PyTuple_GetItem(args, 1);
+    let name_py = PyTuple_GetItem(args, 2);
+    let motd_py = PyTuple_GetItem(args, 3);
+    let oper_py = PyTuple_GetItem(args, 4);
+    let max_py = PyTuple_GetItem(args, 5);
+
+    if [host_py, port_py, name_py, motd_py, oper_py, max_py]
+        .iter()
+        .any(|p| p.is_null())
+    {
+        set_runtime_error(
+            "server_new requires (host, port, server_name, motd, oper_password, max_connections)"
+                .to_string(),
+        );
+        return ptr::null_mut();
+    }
+
+    let Some(host) = str_from_py(host_py) else {
+        set_runtime_error("host must be a string".to_string());
+        return ptr::null_mut();
+    };
+    let Some(server_name) = str_from_py(name_py) else {
+        set_runtime_error("server_name must be a string".to_string());
+        return ptr::null_mut();
+    };
+    let Some(oper_password) = str_from_py(oper_py) else {
+        set_runtime_error("oper_password must be a string".to_string());
+        return ptr::null_mut();
+    };
+    let Some(motd) = vec_str_from_py(motd_py) else {
+        set_runtime_error("motd must be a list of strings".to_string());
+        return ptr::null_mut();
+    };
+
+    // Port: validate the 0–65535 range explicitly.  PyLong_AsLong returns -1 on
+    // a non-integer and sets an error, which we surface rather than mask.
+    let port_raw = PyLong_AsLong(port_py);
+    if !PyErr_Occurred().is_null() {
+        return ptr::null_mut();
+    }
+    if !(0..=65535).contains(&port_raw) {
+        set_runtime_error(format!("port must be between 0 and 65535, got {port_raw}"));
+        return ptr::null_mut();
+    }
+    let port = port_raw as u16;
+
+    let max_raw = PyLong_AsLong(max_py);
+    if !PyErr_Occurred().is_null() {
+        return ptr::null_mut();
+    }
+    if max_raw < 1 {
+        set_runtime_error(format!("max_connections must be >= 1, got {max_raw}"));
+        return ptr::null_mut();
+    }
+    let max_connections = max_raw as usize;
+
+    let config = IrcConfig {
+        host,
+        port,
+        server_name,
+        motd,
+        oper_password,
+        max_connections,
+    };
+
+    let server = match IrcReactorServer::bind(config) {
+        Ok(server) => server,
+        Err(err) => {
+            set_runtime_error(format!("failed to bind IRC server: {err}"));
+            return ptr::null_mut();
+        }
+    };
+
+    let state = Box::new(PyIrcServer {
+        server: Some(server),
+        running: Arc::new(AtomicBool::new(false)),
+    });
+    PyCapsule_New(
+        Box::into_raw(state) as *mut c_void,
+        CAPSULE_NAME.as_ptr() as *const c_char,
+        Some(capsule_destructor),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// server_serve(capsule) — blocks, releasing the GIL
+// ─────────────────────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn server_serve(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_serve(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+
+    // Hold an OWNED clone of the engine across the blocking call rather than a
+    // raw pointer into the boxed state.  `IrcReactorServer` is `Clone` over
+    // `Arc`s, so this clone keeps the runtime alive even if another thread calls
+    // `server_dispose` (which only drops the box's stored copy) while we serve —
+    // closing a use-after-free window that a raw pointer would leave open.  We
+    // also flip `running` to true *before* releasing the GIL, so `server_dispose`
+    // (which runs only with the GIL held) always observes the running state and
+    // refuses to dispose a live server.
+    let server = match (*state).server.as_ref() {
+        Some(server) => server.clone(),
+        None => {
+            set_runtime_error("server has been disposed".to_string());
+            return ptr::null_mut();
+        }
+    };
+
+    (*state).running.store(true, Ordering::SeqCst);
+    let thread_state = PyEval_SaveThread();
+    let result = server.serve();
+    PyEval_RestoreThread(thread_state);
+    (*state).running.store(false, Ordering::SeqCst);
+
+    match result {
+        Ok(()) => py_none(),
+        Err(err) => {
+            set_runtime_error(format!("IRC server error: {err}"));
+            ptr::null_mut()
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// server_stop(capsule)
+// ─────────────────────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn server_stop(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_stop(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+    match (*state).server.as_ref() {
+        Some(server) => {
+            server.stop();
+            py_none()
+        }
+        None => {
+            set_runtime_error("server has been disposed".to_string());
+            ptr::null_mut()
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// server_local_host / server_local_port / server_running / server_dispose
+// ─────────────────────────────────────────────────────────────────────────────
+
+unsafe extern "C" fn server_local_host(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_local_host(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+    match (*state).server.as_ref() {
+        Some(server) => str_to_py(&server.local_addr().ip().to_string()),
+        None => {
+            set_runtime_error("server has been disposed".to_string());
+            ptr::null_mut()
+        }
+    }
+}
+
+unsafe extern "C" fn server_local_port(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_local_port(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+    match (*state).server.as_ref() {
+        Some(server) => PyLong_FromLong(server.local_addr().port() as c_long),
+        None => {
+            set_runtime_error("server has been disposed".to_string());
+            ptr::null_mut()
+        }
+    }
+}
+
+unsafe extern "C" fn server_running(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_running(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+    if (*state).running.load(Ordering::SeqCst) {
+        py_true()
+    } else {
+        py_false()
+    }
+}
+
+unsafe extern "C" fn server_dispose(_module: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr {
+    let capsule = PyTuple_GetItem(args, 0);
+    if capsule.is_null() {
+        set_runtime_error("server_dispose(capsule)".to_string());
+        return ptr::null_mut();
+    }
+    let state = get_state(capsule);
+    if state.is_null() {
+        return ptr::null_mut();
+    }
+    if (*state).running.load(Ordering::SeqCst) {
+        set_runtime_error("cannot dispose a running server; call stop() first".to_string());
+        return ptr::null_mut();
+    }
+    // Drop the engine now (closing the listener) rather than waiting for GC.
+    (*state).server.take();
+    py_none()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module definition
+// ─────────────────────────────────────────────────────────────────────────────
+
+static mut MODULE_METHODS: [PyMethodDef; 8] = [
+    PyMethodDef {
+        ml_name: c"server_new".as_ptr(),
+        ml_meth: Some(server_new),
+        ml_flags: METH_VARARGS,
+        ml_doc:
+            c"server_new(host, port, server_name, motd, oper_password, max_connections) -> capsule"
+                .as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_serve".as_ptr(),
+        ml_meth: Some(server_serve),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_serve(capsule) -> None  # blocks; releases the GIL".as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_stop".as_ptr(),
+        ml_meth: Some(server_stop),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_stop(capsule) -> None".as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_local_host".as_ptr(),
+        ml_meth: Some(server_local_host),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_local_host(capsule) -> str".as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_local_port".as_ptr(),
+        ml_meth: Some(server_local_port),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_local_port(capsule) -> int".as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_running".as_ptr(),
+        ml_meth: Some(server_running),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_running(capsule) -> bool".as_ptr(),
+    },
+    PyMethodDef {
+        ml_name: c"server_dispose".as_ptr(),
+        ml_meth: Some(server_dispose),
+        ml_flags: METH_VARARGS,
+        ml_doc: c"server_dispose(capsule) -> None".as_ptr(),
+    },
+    method_def_sentinel(),
+];
+
+static mut MODULE_DEF: PyModuleDef = PyModuleDef {
+    m_base: PyModuleDef_Base {
+        ob_base: [0u8; std::mem::size_of::<usize>() * 2],
+        m_init: None,
+        m_index: 0,
+        m_copy: ptr::null_mut(),
+    },
+    m_name: c"irc_server_native".as_ptr(),
+    m_doc: c"Native control surface for the all-Rust irc-net-reactor IRC engine".as_ptr(),
+    m_size: -1,
+    m_methods: ptr::null_mut(), // set in PyInit_ below
+    m_slots: ptr::null_mut(),
+    m_traverse: ptr::null_mut(),
+    m_clear: ptr::null_mut(),
+    m_free: ptr::null_mut(),
+};
+
+/// Module initializer — Python calls this when the extension is imported.
+///
+/// # Safety
+/// Called exactly once by the CPython import machinery with the GIL held.
+#[no_mangle]
+pub unsafe extern "C" fn PyInit_irc_server_native() -> PyObjectPtr {
+    #[allow(static_mut_refs)]
+    {
+        MODULE_DEF.m_methods = MODULE_METHODS.as_mut_ptr();
+    }
+    PyModule_Create2(&raw mut MODULE_DEF, PYTHON_API_VERSION)
+}

--- a/code/packages/python/irc-server-native/pyproject.toml
+++ b/code/packages/python/irc-server-native/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "coding-adventures-irc-server-native"
+version = "0.1.0"
+description = "High-performance IRC server for Python, backed by the all-Rust irc-net-reactor engine"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Adhithya Rajasekaran" }]
+readme = "README.md"
+keywords = ["irc", "server", "rust", "native", "reactor", "kqueue", "epoll"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Communications :: Chat :: Internet Relay Chat",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Rust",
+    "License :: OSI Approved :: MIT License",
+]
+
+[project.urls]
+Homepage = "https://github.com/adhithyan15/coding-adventures"
+Repository = "https://github.com/adhithyan15/coding-adventures"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/coding_adventures"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "ANN"]
+ignore = ["ANN401"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["ANN"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=coding_adventures.irc_server_native --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+source = ["src/coding_adventures/irc_server_native"]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+omit = ["*/irc_server_native/irc_server_native*"]

--- a/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/__init__.py
+++ b/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/__init__.py
@@ -1,0 +1,18 @@
+"""coding_adventures.irc_server_native — a high-performance IRC server for Python.
+
+All IRC and TCP logic runs in Rust (the ``irc-net-reactor`` engine on the
+home-grown kqueue/epoll reactor).  Python only *launches and controls* the
+server — there is no per-message callback into Python, so the API is tiny:
+
+    from coding_adventures.irc_server_native import IrcServer
+
+    server = IrcServer(host="127.0.0.1", port=6667)
+    server.serve()   # blocks (GIL released) until server.stop()
+
+See :class:`IrcServer` for the full control surface.
+"""
+
+from .server import IrcServer
+
+__all__ = ["IrcServer"]
+__version__ = "0.1.0"

--- a/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/server.py
+++ b/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/server.py
@@ -31,7 +31,11 @@ def _load_native() -> Any:
         from . import irc_server_native  # type: ignore[import]
 
         return irc_server_native
-    except ImportError:
+    except ImportError:  # pragma: no cover - env-specific fallback
+        # Defensive: load the cdylib directly by path when the normal package
+        # import misses it (its filename carries a platform/ABI tag).  Only one
+        # of these two branches runs in any given environment, so this one is
+        # excluded from coverage rather than chased with an unportable test.
         import importlib.util
         import os
 

--- a/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/server.py
+++ b/code/packages/python/irc-server-native/src/coding_adventures/irc_server_native/server.py
@@ -1,0 +1,147 @@
+"""IrcServer — the Python control surface for the Rust IRC engine.
+
+``IrcServer`` is a thin facade over the ``irc_server_native`` C extension, which
+in turn embeds the all-Rust ``irc-net-reactor`` engine.  Because every line of
+IRC and TCP logic lives in Rust, this class only needs to *create*, *run*, and
+*stop* the server — it never handles a message itself.
+
+Typical usage::
+
+    server = IrcServer(host="127.0.0.1", port=6667, server_name="irc.example")
+    server.serve()          # blocks until another thread calls server.stop()
+
+For tests, run ``serve()`` on a background thread and call ``stop()`` after
+assertions; read the OS-assigned port with ``local_port()`` when binding to 0.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _load_native() -> Any:
+    """Import the compiled ``irc_server_native`` extension.
+
+    Done lazily (not at module import time) so that ``import
+    coding_adventures.irc_server_native`` succeeds on a machine without the
+    compiled ``.so`` — the extension only has to exist by the time an
+    :class:`IrcServer` is actually constructed (i.e. after the BUILD script ran).
+    """
+    try:
+        from . import irc_server_native  # type: ignore[import]
+
+        return irc_server_native
+    except ImportError:
+        import importlib.util
+        import os
+
+        pkg_dir = os.path.dirname(__file__)
+        candidate = next(
+            (
+                os.path.join(pkg_dir, f)
+                for f in os.listdir(pkg_dir)
+                if f.startswith("irc_server_native") and f.endswith(".so")
+            ),
+            None,
+        )
+        spec = importlib.util.spec_from_file_location(
+            "irc_server_native", candidate or ""
+        )
+        if spec is None or spec.origin is None or spec.loader is None:
+            raise ImportError(  # noqa: B904
+                "irc_server_native extension not found. "
+                "Run the BUILD script first to compile the Rust extension."
+            )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+class IrcServer:
+    """A high-performance IRC server backed by the Rust ``irc-net-reactor`` engine.
+
+    Parameters
+    ----------
+    host:
+        Bind address. ``"127.0.0.1"`` is loopback; ``"0.0.0.0"`` listens on all
+        interfaces (reachable from other machines — use deliberately).
+    port:
+        TCP port. ``0`` asks the OS for a free ephemeral port, then readable via
+        :meth:`local_port`.
+    server_name:
+        Hostname advertised in the ``001`` welcome and as the message prefix.
+    motd:
+        Message of the Day lines. Defaults to ``["Welcome."]``.
+    oper_password:
+        Password for the ``OPER`` command. Empty string (default) disables OPER.
+    max_connections:
+        Maximum simultaneous connections.
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 6667,
+        server_name: str = "irc.local",
+        motd: list[str] | None = None,
+        oper_password: str = "",
+        max_connections: int = 1024,
+        *,
+        _native: Any = None,
+    ) -> None:
+        # ``_native`` is an injection seam for tests: pass a fake module exposing
+        # the same server_* functions to exercise this facade without the .so.
+        native = _native if _native is not None else _load_native()
+        motd_lines = list(motd) if motd else ["Welcome."]
+
+        self._native = native
+        self._capsule = native.server_new(
+            str(host),
+            int(port),
+            str(server_name),
+            [str(line) for line in motd_lines],
+            str(oper_password),
+            int(max_connections),
+        )
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    def serve(self) -> None:
+        """Run the event loop, blocking until :meth:`stop` is called.
+
+        The Rust extension releases the GIL around the blocking loop, so another
+        Python thread (or a signal handler) can call :meth:`stop`.
+        """
+        self._native.server_serve(self._capsule)
+
+    def stop(self) -> None:
+        """Signal the event loop to stop; a blocked :meth:`serve` returns.
+
+        Safe to call from any thread, and idempotent.
+        """
+        self._native.server_stop(self._capsule)
+
+    def dispose(self) -> None:
+        """Release the server's listener now (the server must be stopped first).
+
+        Disposing is optional — the engine is also freed when this object is
+        garbage-collected — but it frees the bound port deterministically.
+        """
+        self._native.server_dispose(self._capsule)
+
+    # ── Introspection ────────────────────────────────────────────────────────
+
+    def running(self) -> bool:
+        """Whether the event loop is currently running."""
+        return bool(self._native.server_running(self._capsule))
+
+    def local_host(self) -> str:
+        """The bound IP address as a string."""
+        return str(self._native.server_local_host(self._capsule))
+
+    def local_port(self) -> int:
+        """The bound TCP port (the OS-assigned port when constructed with ``port=0``).
+
+        Read this after constructing with ``port=0`` to learn the chosen port.
+        """
+        return int(self._native.server_local_port(self._capsule))

--- a/code/packages/python/irc-server-native/tests/test_irc_server_native.py
+++ b/code/packages/python/irc-server-native/tests/test_irc_server_native.py
@@ -1,0 +1,250 @@
+"""Tests for the Python IRC server binding.
+
+Two layers:
+
+* **Facade tests** drive ``IrcServer`` against a fake native module, exercising
+  the Python wrapper logic (argument coercion, delegation) with no compiled
+  extension required — so coverage holds even where the native smoke test skips.
+* **End-to-end tests** start the real Rust engine on an ephemeral port and run
+  two live IRC clients through registration and channel broadcast.  They skip
+  cleanly if the compiled ``irc_server_native`` extension is not present.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+
+import pytest
+
+from coding_adventures.irc_server_native import IrcServer
+from coding_adventures.irc_server_native.server import _load_native
+
+
+def _native_available() -> bool:
+    try:
+        _load_native()
+        return True
+    except Exception:
+        return False
+
+
+NATIVE = _native_available()
+requires_native = pytest.mark.skipif(
+    not NATIVE, reason="irc_server_native extension not compiled"
+)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Facade tests — fake native module, no .so needed
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class FakeNative:
+    """Records calls so the facade's delegation and coercion can be asserted."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.capsule = object()
+        self._running = False
+        self.host = "127.0.0.1"
+        self.port = 6667
+
+    def server_new(self, host, port, server_name, motd, oper_password, max_connections):
+        self.calls.append(
+            ("new", host, port, server_name, motd, oper_password, max_connections)
+        )
+        return self.capsule
+
+    def server_serve(self, capsule):
+        self.calls.append(("serve", capsule))
+        self._running = True
+
+    def server_stop(self, capsule):
+        self.calls.append(("stop", capsule))
+        self._running = False
+
+    def server_dispose(self, capsule):
+        self.calls.append(("dispose", capsule))
+
+    def server_running(self, capsule):
+        self.calls.append(("running", capsule))
+        return self._running
+
+    def server_local_host(self, capsule):
+        return self.host
+
+    def server_local_port(self, capsule):
+        return self.port
+
+
+def test_new_coerces_arguments_and_defaults_motd():
+    fake = FakeNative()
+    IrcServer(host=0xC0A8, port="6667", server_name=123, _native=fake)  # type: ignore[arg-type]
+    kind, host, port, name, motd, oper, maxc = fake.calls[0]
+    assert kind == "new"
+    assert host == str(0xC0A8)  # coerced to str
+    assert port == 6667  # coerced to int
+    assert name == "123"  # coerced to str
+    assert motd == ["Welcome."]  # default applied
+    assert oper == ""  # default empty
+    assert maxc == 1024  # default
+
+
+def test_new_passes_through_explicit_motd_and_oper():
+    fake = FakeNative()
+    IrcServer(
+        motd=["one", "two"],
+        oper_password="s3cret",
+        max_connections=42,
+        _native=fake,
+    )
+    _, _, _, _, motd, oper, maxc = fake.calls[0]
+    assert motd == ["one", "two"]
+    assert oper == "s3cret"
+    assert maxc == 42
+
+
+def test_lifecycle_methods_delegate_to_native():
+    fake = FakeNative()
+    server = IrcServer(_native=fake)
+    assert server.running() is False
+    server.serve()
+    assert server.running() is True
+    server.stop()
+    assert server.running() is False
+    server.dispose()
+    assert ("serve", fake.capsule) in fake.calls
+    assert ("stop", fake.capsule) in fake.calls
+    assert ("dispose", fake.capsule) in fake.calls
+
+
+def test_introspection_returns_native_values():
+    fake = FakeNative()
+    fake.host = "0.0.0.0"
+    fake.port = 9999
+    server = IrcServer(_native=fake)
+    assert server.local_host() == "0.0.0.0"
+    assert server.local_port() == 9999
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# End-to-end tests — the real Rust engine over real sockets
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _recv_until(sock: socket.socket, needle: str, timeout: float = 5.0) -> str:
+    sock.settimeout(0.3)
+    deadline = time.time() + timeout
+    buf = b""
+    while time.time() < deadline:
+        try:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+            if needle.encode() in buf:
+                break
+        except TimeoutError:
+            continue
+    return buf.decode("utf-8", "replace")
+
+
+def _connect(port: int) -> socket.socket:
+    last: Exception | None = None
+    for _ in range(40):
+        try:
+            return socket.create_connection(("127.0.0.1", port), timeout=1.0)
+        except OSError as exc:  # noqa: PERF203
+            last = exc
+            time.sleep(0.01)
+    raise AssertionError(f"could not connect to server: {last}")
+
+
+def _register(sock: socket.socket, nick: str) -> None:
+    sock.sendall(f"NICK {nick}\r\nUSER {nick} 0 * :{nick}\r\n".encode())
+    welcome = _recv_until(sock, "001")
+    assert "001" in welcome, f"expected 001 welcome for {nick}, got: {welcome!r}"
+
+
+@pytest.fixture()
+def running_server():
+    server = IrcServer(host="127.0.0.1", port=0, server_name="irc.test")
+    port = server.local_port()
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+    try:
+        yield server, port
+    finally:
+        server.stop()
+        thread.join(timeout=5)
+
+
+@requires_native
+def test_local_addr_reports_ephemeral_port():
+    server = IrcServer(host="127.0.0.1", port=0)
+    assert server.local_host() == "127.0.0.1"
+    assert server.local_port() > 0
+    server.dispose()
+
+
+@requires_native
+def test_registration_and_ping(running_server):
+    _server, port = running_server
+    alice = _connect(port)
+    try:
+        _register(alice, "alice")
+        alice.sendall(b"PING :liveness\r\n")
+        pong = _recv_until(alice, "PONG")
+        assert "PONG" in pong, f"expected PONG, got: {pong!r}"
+    finally:
+        alice.close()
+
+
+@requires_native
+def test_privmsg_broadcasts_between_clients(running_server):
+    _server, port = running_server
+    alice = _connect(port)
+    bob = _connect(port)
+    try:
+        _register(alice, "alice")
+        _register(bob, "bob")
+        alice.sendall(b"JOIN #test\r\n")
+        bob.sendall(b"JOIN #test\r\n")
+        _recv_until(alice, "JOIN")
+        _recv_until(bob, "JOIN")
+
+        # Alice speaks; Bob (a different connection) must receive it — this
+        # exercises the Rust engine's in-process mailbox fan-out.
+        alice.sendall(b"PRIVMSG #test :hello bob\r\n")
+        received = _recv_until(bob, "hello bob")
+        assert "PRIVMSG" in received and "hello bob" in received, (
+            f"bob should receive alice's broadcast, got: {received!r}"
+        )
+    finally:
+        alice.close()
+        bob.close()
+
+
+@requires_native
+def test_running_flag_tracks_serve(running_server):
+    server, _port = running_server
+    # Give the background serve() a moment to flip the flag.
+    deadline = time.time() + 5
+    while not server.running() and time.time() < deadline:
+        time.sleep(0.01)
+    assert server.running() is True
+
+
+@requires_native
+def test_dispose_refused_while_running(running_server):
+    # Disposing a live server must be refused — the native layer frees the engine
+    # in dispose(), and allowing that mid-serve() would be a use-after-free.
+    server, _port = running_server
+    deadline = time.time() + 5
+    while not server.running() and time.time() < deadline:
+        time.sleep(0.01)
+    assert server.running() is True
+    with pytest.raises(RuntimeError):
+        server.dispose()


### PR DESCRIPTION
## What

PR 2 of the arc to embed one high-performance Rust IRC server in every language. This adds **`irc-server-native`** for Python: a thin native extension over the [`irc-net-reactor`](https://github.com/adhithyan15/coding-adventures/tree/main/code/packages/rust/irc-net-reactor) engine (merged in PR 1), built on the zero-dep `python-bridge` (no PyO3).

```python
from coding_adventures.irc_server_native import IrcServer
server = IrcServer(host="127.0.0.1", port=6667)
server.serve()   # blocks (GIL released) until server.stop()
```

## Why it's simpler than conduit

`conduit` calls back into Python for every HTTP route, so it needs `PyGILState_Ensure`/TSFN machinery. Here **all IRC logic stays in Rust** — Python only launches and controls the server. So the binding is a pure lifecycle control surface (`server_new`/`serve`/`stop`/`local_*`/`running`/`dispose`) over an opaque `PyCapsule`, with a single `PyEval_SaveThread`/`PyEval_RestoreThread` around the blocking event loop.

## Security review (HIGH, fixed)

The review caught a real **use-after-free**: `server_dispose` frees the engine, and there was a window after `PyEval_SaveThread()` but before the `running` flag was set where another thread could dispose the engine that `serve()` was about to dereference. Fixed by (1) holding an **owned clone** of the engine across `serve()` — `IrcReactorServer` is `Clone` over `Arc`s, so the runtime stays alive even if the stored copy is dropped — and (2) setting `running=true` **before** releasing the GIL so `dispose` always refuses a live server. Added a regression test. Passed review in 2 rounds.

## Tests

9 tests, 95% coverage: facade unit tests against a fake native module (no `.so` needed, so coverage holds where the native smoke test skips) + real end-to-end tests that start the Rust engine and drive two live IRC clients through registration, PING/PONG, channel `PRIVMSG` **broadcast**, and the dispose-while-running guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)