### PR TITLE
feat(web11): Perl Conduit port (XS/perl-bridge) — spec + WIP

### DIFF
--- a/code/packages/rust/perl-bridge/src/lib.rs
+++ b/code/packages/rust/perl-bridge/src/lib.rs
@@ -232,6 +232,24 @@ extern "C" {
     fn raw_croak_message(msg: *const c_char) -> !;
     #[link_name = "perl_bridge_warn_message"]
     fn raw_warn_message(msg: *const c_char);
+    // -- Conduit (WEB11) additions ----------------------------------------
+    #[link_name = "perl_bridge_call_coderef"]
+    fn raw_call_coderef(
+        coderef: *mut SV,
+        argv: *const *mut SV,
+        argc: c_int,
+        err_out: *mut *mut c_char,
+    ) -> *mut SV;
+    #[link_name = "perl_bridge_newHV"]
+    fn raw_newHV() -> *mut HV;
+    #[link_name = "perl_bridge_hv_store"]
+    fn raw_hv_store(hv: *mut HV, key: *const c_char, klen: c_int, val: *mut SV);
+    #[link_name = "perl_bridge_newRV_inc"]
+    fn raw_newRV_inc(sv: *mut SV) -> *mut SV;
+    #[link_name = "perl_bridge_get_context"]
+    fn raw_get_context() -> *mut c_void;
+    #[link_name = "perl_bridge_set_context"]
+    fn raw_set_context(ctx: *mut c_void);
     #[link_name = "perl_bridge_xsub_frame"]
     fn raw_xsub_frame(frame: *mut XsubFrame);
     #[link_name = "perl_bridge_xsub_return"]
@@ -462,6 +480,102 @@ pub unsafe fn die(msg: &str) -> ! {
 pub unsafe fn warn(msg: &str) {
     let c_msg = CString::new(msg).unwrap_or_else(|_| CString::new("(error in warn)").unwrap());
     raw_warn_message(c_msg.as_ptr());
+}
+
+// ---------------------------------------------------------------------------
+// Conduit (WEB11) helpers — coderef calls, hashes, thread context
+// ---------------------------------------------------------------------------
+//
+// These power the Perl Conduit port: calling Perl handler subs from Rust I/O
+// threads, building the env hash, and binding the interpreter context on a
+// non-Perl thread. See `code/specs/WEB11-conduit-perl.md`.
+
+/// Result of calling a Perl coderef.
+pub enum CallResult {
+    /// The sub returned a value (an SV the caller now owns — `SvREFCNT_dec`
+    /// it when done).
+    Ok(*mut SV),
+    /// The sub returned nothing (empty list).
+    Empty,
+    /// The sub died; carries the stringified `$@`.
+    Died(String),
+}
+
+/// Call a Perl coderef with the given SV arguments under `G_SCALAR | G_EVAL`.
+///
+/// Returns [`CallResult`]. On death the `$@` string is captured and the Perl
+/// error state is cleared. The caller MUST hold the interpreter lock (Perl is
+/// single-threaded) and have bound the interpreter context for the current
+/// thread via [`set_context`] when running on a non-Perl thread.
+///
+/// # Safety
+/// `coderef` must be a valid Perl coderef SV; each `args` element a valid SV.
+pub unsafe fn call_coderef(coderef: *mut SV, args: &[*mut SV]) -> CallResult {
+    let mut err: *mut c_char = std::ptr::null_mut();
+    let result = raw_call_coderef(
+        coderef,
+        args.as_ptr(),
+        args.len() as c_int,
+        &mut err,
+    );
+    if !err.is_null() {
+        let msg = std::ffi::CStr::from_ptr(err).to_string_lossy().into_owned();
+        // The shim allocated this with malloc; free it with the matching free.
+        extern "C" {
+            fn free(ptr: *mut c_void);
+        }
+        free(err as *mut c_void);
+        return CallResult::Died(msg);
+    }
+    if result.is_null() {
+        CallResult::Empty
+    } else {
+        CallResult::Ok(result)
+    }
+}
+
+/// Create a new empty Perl hash (HV).
+///
+/// # Safety
+/// Must be called with a valid interpreter context.
+pub unsafe fn new_hv() -> *mut HV {
+    raw_newHV()
+}
+
+/// Store `val` under `key` in `hv`. The hash takes ownership of `val`'s
+/// reference count (do not `SvREFCNT_dec` it afterwards).
+///
+/// # Safety
+/// `hv` must be a valid HV; `val` a valid SV.
+pub unsafe fn hv_store(hv: *mut HV, key: &str, val: *mut SV) {
+    // hv_store copies the key bytes; no NUL-termination required, we pass len.
+    raw_hv_store(hv, key.as_ptr() as *const c_char, key.len() as c_int, val);
+}
+
+/// Make a reference to `sv` (incrementing its refcount) — e.g. a hashref from
+/// an HV cast to `*mut SV`.
+///
+/// # Safety
+/// `sv` must be a valid SV/HV/AV pointer.
+pub unsafe fn new_rv_inc(sv: *mut SV) -> *mut SV {
+    raw_newRV_inc(sv)
+}
+
+/// Capture the current Perl interpreter context (on the main Perl thread).
+///
+/// Returns null on a non-`MULTIPLICITY` build (single global interpreter),
+/// where [`set_context`] is a no-op.
+pub unsafe fn get_context() -> *mut c_void {
+    raw_get_context()
+}
+
+/// Bind `ctx` as the interpreter for the current OS thread before any Perl API
+/// use from a non-Perl (web-core I/O) thread. No-op on non-`MULTIPLICITY`.
+///
+/// # Safety
+/// `ctx` must be a context previously returned by [`get_context`].
+pub unsafe fn set_context(ctx: *mut c_void) {
+    raw_set_context(ctx);
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/perl-bridge/src/perl_bridge_shim.c
+++ b/code/packages/rust/perl-bridge/src/perl_bridge_shim.c
@@ -160,3 +160,100 @@ void perl_bridge_xs_boot_finish(I32 ax) {
     dTHX;
     Perl_xs_boot_epilog(aTHX_ ax);
 }
+
+/* ── Conduit (WEB11) additions: coderef calls, hashes, thread context ─────── */
+
+/*
+ * Call a Perl coderef with `argc` SV* arguments under G_SCALAR | G_EVAL.
+ *
+ * Returns the result SV (reference count incremented — the caller owns it), or
+ * NULL if the sub died. On death, *err_out is set to a malloc'd NUL-terminated
+ * copy of $@ stringified (the caller must free() it); on success *err_out is
+ * left NULL. The arguments are passed through unchanged (mortalised copies are
+ * pushed so the callee can't disturb the caller's refcounts).
+ *
+ * Must be called while holding the interpreter lock (Perl is single-threaded).
+ */
+SV *perl_bridge_call_coderef(SV *coderef, SV **argv, int argc, char **err_out) {
+    dTHX;
+    dSP;
+    int i;
+    SV *result = NULL;
+    *err_out = NULL;
+
+    ENTER;
+    SAVETMPS;
+    PUSHMARK(SP);
+    for (i = 0; i < argc; i++) {
+        XPUSHs(sv_2mortal(newSVsv(argv[i])));
+    }
+    PUTBACK;
+
+    int count = call_sv(coderef, G_SCALAR | G_EVAL);
+
+    SPAGAIN;
+
+    SV *errsv = ERRSV; /* $@ */
+    if (SvTRUE(errsv)) {
+        STRLEN len;
+        const char *msg = SvPV(errsv, len);
+        char *copy = (char *)malloc(len + 1);
+        if (copy != NULL) {
+            memcpy(copy, msg, len);
+            copy[len] = '\0';
+        }
+        *err_out = copy;
+        for (i = 0; i < count; i++) {
+            (void)POPs;
+        }
+        result = NULL;
+    } else if (count > 0) {
+        /* Copy the topmost return value so it survives FREETMPS. */
+        result = newSVsv(POPs);
+    } else {
+        result = NULL;
+    }
+
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+    return result;
+}
+
+HV *perl_bridge_newHV(void) {
+    dTHX;
+    return newHV();
+}
+
+/* Store `val` under `key` (length `klen`). Takes ownership of `val`'s refcount
+ * (hv_store does not increment), matching newSV* producers. */
+void perl_bridge_hv_store(HV *hv, const char *key, I32 klen, SV *val) {
+    dTHX;
+    (void)hv_store(hv, key, klen, val, 0);
+}
+
+SV *perl_bridge_newRV_inc(SV *value) {
+    dTHX;
+    return newRV_inc(value);
+}
+
+/* Capture the current interpreter context (aTHX) on the main Perl thread.
+ * On a non-MULTIPLICITY build there is a single global interpreter and this
+ * returns NULL (set_context is then a no-op). */
+void *perl_bridge_get_context(void) {
+#ifdef MULTIPLICITY
+    return (void *)PERL_GET_CONTEXT;
+#else
+    return NULL;
+#endif
+}
+
+/* Bind `ctx` as the interpreter for the current OS thread before any Perl API
+ * use from a non-Perl (web-core I/O) thread. No-op on non-MULTIPLICITY. */
+void perl_bridge_set_context(void *ctx) {
+#ifdef MULTIPLICITY
+    PERL_SET_CONTEXT((PerlInterpreter *)ctx);
+#else
+    (void)ctx;
+#endif
+}

--- a/code/specs/WEB11-conduit-perl.md
+++ b/code/specs/WEB11-conduit-perl.md
@@ -1,0 +1,164 @@
+# WEB11 — Perl Conduit (XS / perl-bridge port)
+
+## Overview
+
+A Perl port of the Conduit web framework, wrapping the Rust `web-core` engine
+(via the WEB08 `conduit` facade) through an XS native library built on the
+`perl-bridge` crate. Handlers are plain Perl subs; routing, lifecycle hooks,
+and HTTP I/O run in Rust. This closes the original-plan gap (Perl was the last
+language from the first port sweep without a Conduit).
+
+```perl
+use CodingAdventures::Conduit;
+
+my $app = CodingAdventures::Conduit->new;
+
+$app->before(sub { my $req = shift; $req->path eq '/down' ? halt(503, 'Maintenance') : undef });
+$app->get('/',            sub { html('<h1>Hello from Conduit!</h1>') });
+$app->get('/hello/:name', sub { my $req = shift; json(qq({"message":"Hello @{[$req->param('name')]}"})) });
+$app->post('/echo',       sub { my $req = shift; respond(200, $req->body, { 'content-type' => $req->content_type }) });
+$app->not_found(sub { my $req = shift; html('<h1>Not Found: ' . $req->path . '</h1>', 404) });
+$app->on_error(sub { json('{"error":"Internal Server Error"}', 500) });
+
+my $server = $app->bind('127.0.0.1', 3000);
+$server->serve;   # blocks until stopped
+```
+
+## Architecture
+
+```
+Perl DSL (CodingAdventures::Conduit, ::Request, ::Response)
+    handlers are subs; html/json/text/respond/halt/redirect helpers
+    │  Perl coderef ⇄ Rust (perl-bridge: call_coderef + interpreter lock)
+    ▼
+Conduit (Rust XS cdylib, src/lib.rs)  ← boot_CodingAdventures__Conduit
+    new_app / add_route / new_server / serve / serve_background / stop ...
+    ▼
+conduit (WEB08 facade) → web-core → embeddable-http-server → tcp-runtime → kqueue/epoll/IOCP
+```
+
+### The threading crux
+
+`web-core` dispatches HTTP requests on background Rust I/O threads. The Perl
+interpreter is **not** thread-safe — a `PerlInterpreter`'s data structures may
+only be touched by one OS thread at a time. Two concerns:
+
+1. **Serialization.** Every dispatch acquires an `Arc<Mutex<()>>` (the "Perl
+   interpreter lock", the exact analog of the Lua port's lock) before calling
+   any Perl API. Perl code runs one-at-a-time even though requests arrive
+   concurrently.
+
+2. **Interpreter context.** Perl finds its interpreter via the `dTHX` macro,
+   which on a `MULTIPLICITY`/`ithreads` build reads thread-local storage. A
+   web-core I/O thread (not created by Perl) has no TLS context, so we capture
+   the interpreter at `new_server` time (on the main Perl thread) and
+   `PERL_SET_CONTEXT` it on each dispatch thread under the lock. On a
+   non-`MULTIPLICITY` build the interpreter is a single global and the
+   set-context is a harmless no-op; the lock alone suffices.
+
+`serve()` blocks the calling (Perl) thread; `serve_background()` spawns a Rust
+thread for tests. Same lifecycle as every other port.
+
+## Required additions to `perl-bridge`
+
+`perl-bridge` covers SV scalars, arrays (AV), refs, and error croak/warn — but
+not calling Perl coderefs, hashes, or thread context. WEB11 adds (Rust
+wrappers + C shim, each `dTHX`-wrapped):
+
+| Addition | Purpose |
+|----------|---------|
+| `perl_bridge_call_coderef(cv, argv, argc, *err_out) -> *SV` | Call a Perl sub with SV args under `G_SCALAR|G_EVAL`; returns the result SV; on `die`, writes a malloc'd error string to `*err_out` and returns NULL. Encapsulates the full PUSHMARK/PUTBACK/call_sv/SPAGAIN stack dance. |
+| `perl_bridge_newHV() -> *HV` | Build the env hash. |
+| `perl_bridge_hv_store(hv, key, klen, val)` | Populate the env hash. |
+| `perl_bridge_newRV_inc(sv) -> *SV` | Make a hashref/arrayref to pass to handlers. |
+| `perl_bridge_get_context() -> *PerlInterpreter` | Capture `aTHX` on the main thread (no-op→NULL on non-MULTIPLICITY). |
+| `perl_bridge_set_context(interp)` | `PERL_SET_CONTEXT` on a dispatch thread (`#ifdef MULTIPLICITY`). |
+
+All existing perl-bridge tests must still pass (additive change only).
+
+## Marshaling
+
+### Request → Perl
+
+The Rust side builds a flat Perl **env hashref** (CGI/PSGI-style string→string)
+and passes it to a thin Perl wrapper sub (installed by `CodingAdventures::Conduit`)
+that constructs a `Request` object and calls the user's handler. Nested maps
+cross as percent-encoded `k=v&k2=v2` strings (route params, query params,
+headers), parsed lazily on the Perl side with `URI::Escape`-free hand decoding
+— exactly like the Java port. Keys:
+
+```
+REQUEST_METHOD, PATH_INFO, QUERY_STRING, REMOTE_ADDR,
+conduit.route_params, conduit.query_params, conduit.headers,
+conduit.body, conduit.content_type, conduit.content_length,
+conduit.error        # only for the error handler
+```
+
+Building a flat hash needs only `newHV`/`hv_store`/`newSVpv` — no nested
+HV/AV construction from Rust.
+
+### Response → Rust
+
+A handler returns a Conduit response: an arrayref `[status, body, headers_enc]`
+produced by the `html`/`json`/`text`/`respond`/`halt`/`redirect` helpers, where
+`headers_enc` is the same percent-encoded `k=v&…` form. Rust reads the AV's
+three scalars (`av_fetch` ×3) — no HV iteration. Status is clamped to 100–599;
+header names/values with CR/LF or other control chars are dropped (defense
+against response splitting), re-checked on the Rust side.
+
+`undef` from a before filter means "continue".
+
+## Halt protocol
+
+`halt(status, body)` and `redirect(location, status)` return a response
+arrayref (the common path). For a non-local Sinatra-style halt, a handler may
+`die` with a `CodingAdventures::Conduit::HaltError` object; the Rust dispatch
+runs under `G_EVAL`, inspects `$@`, and converts a blessed `HaltError` into a
+response. Any other `die` routes to the registered `on_error` handler (its
+message available via `$req->error`).
+
+## Package layout
+
+```
+code/packages/perl/conduit/
+├── BUILD                  # cargo build + copy .so to lib/auto/... + prove
+├── BUILD_windows
+├── CHANGELOG.md
+├── README.md
+├── Makefile.PL
+├── Cargo.toml             # cdylib "Conduit"; deps perl-bridge, conduit, web-core
+├── build.rs               # -undefined dynamic_lookup on macOS; perl DLL on Windows
+├── required_capabilities.json   # ["rust","perl","cargo"]
+├── src/lib.rs             # XS boot + native subs (new_app/add_route/new_server/serve/…)
+└── lib/CodingAdventures/
+    ├── Conduit.pm         # Application + DSL + response helpers + Server
+    ├── Conduit/Request.pm # Request object over the env hash
+    └── Conduit/Native.pm  # DynaLoader bootstrap of the cdylib
+└── t/
+    ├── 01_response.t      # html/json/text/respond/halt/redirect shapes
+    ├── 02_request.t       # env → Request, percent decoding, param/query/header
+    ├── 03_application.t   # route/filter/handler/setting registration
+    └── 04_server.t        # E2E over real TCP via IO::Socket / HTTP::Tiny
+
+code/programs/perl/conduit-hello/   # 8-route demo + tests
+```
+
+## Tests (target: 30+)
+
+- Response/Request/Application unit tests (no server).
+- `04_server.t` E2E: bind on port 0, `serve_background`, fire HTTP via a tiny
+  socket client (no non-core deps), assert `/`, `/hello/:name`, POST `/echo`,
+  before-filter halt(503), redirect(302), not_found(404), on_error(500), query
+  params, server metadata. A wall-clock guard (`alarm`) bounds any hang.
+- `conduit-hello`: 8-route demo + integration tests.
+
+## Out of scope
+
+- Binary response bodies (UTF-8 strings, as in every port).
+- Perl `ithreads` user threads — the framework serializes via the interpreter
+  lock; it does not run handlers on multiple Perl threads.
+
+## Future
+
+The percent-encoded marshaling + `call_coderef` pattern is reusable for any
+future single-interpreter dynamic-language port.


### PR DESCRIPTION
WEB11 — Perl port of Conduit (the last first-sweep language without one). XS cdylib over web-core via the WEB08 facade, built on perl-bridge. Handlers are Perl subs.

## Threading crux
web-core dispatches on Rust I/O threads; the Perl interpreter isn't thread-safe. Dispatch acquires an Arc<Mutex<()>> interpreter lock (Lua-port analog) and PERL_SET_CONTEXTs the interpreter captured at new_server time (no-op on non-MULTIPLICITY builds with a single global interpreter).

## perl-bridge additions (additive)
- call_coderef — the PUSHMARK/call_sv/SPAGAIN stack dance + G_EVAL $@ capture
- newHV/hv_store/newRV_inc — build the env hashref
- get_context/set_context — background-thread interpreter context

## Marshaling (mirrors Java port)
Flat env hashref; nested maps as percent-encoded k=v& strings; response as arrayref [status, body, headers_enc] (3 scalars, no HV iteration). Status clamped 100-599; CR/LF/control chars dropped from headers.

Spec-first; implementation follows on this branch. Demo + 30+ tests (prove, core-only socket client, alarm hang guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)