### PR TITLE
feat(lexer): interpret declarative mode transitions (F10 Python port)

### DIFF
--- a/code/packages/python/lexer/CHANGELOG.md
+++ b/code/packages/python/lexer/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the lexer package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — F10 declarative lexer mode transitions
+
+### Added
+- `GrammarLexer` now interprets the declarative mode-transition table on a
+  `TokenGrammar` (F10), the Python port of the Rust `grammar_lexer.rs`
+  interpreter. After each token is emitted it consults the table and may
+  `set-mode` (flat toggle of the active group), `push`/`pop` (F04 nested
+  regions), or toggle skip — enabling context-sensitive lexing
+  (JavaScript regex-vs-division, template substitutions) without a
+  hand-written `on-token` callback. New `_apply_transitions` +
+  `_transition_key`; start mode read from `grammar.start_mode`.
+- **Flat-mode inheritance**: a group reached via `set-mode` inherits the
+  default group's patterns (its own patterns take priority), so a JS `div`
+  mode can override `SLASH`/`SLASH_EQUALS` ahead of `REGEX` without
+  duplicating the grammar. `push` targets stay exclusive (F04 region
+  semantics). Derived automatically from the transition table
+  (`_inheriting_modes`).
+
+### Notes
+- Fully backward compatible: a grammar with no `transitions:` table yields
+  an identical token stream (every F10 helper early-returns / stays inert).
+  Verified by the existing suite + 7 new F10 tests. Mirrors the Rust port
+  (PR #5663); the grammar-tools data model (`ModeTransition` /
+  `TransitionAction`) landed in PR #5668.
+
 ## [0.3.1] - 2026-03-31
 
 ### Fixed

--- a/code/packages/python/lexer/src/lexer/grammar_lexer.py
+++ b/code/packages/python/lexer/src/lexer/grammar_lexer.py
@@ -453,9 +453,50 @@ class GrammarLexer:
                     self._alias_map[defn.name] = defn.alias
             self._group_patterns[group_name] = compiled
 
-        # The group stack. Bottom is always "default". Top is the active
-        # group whose patterns are tried during token matching.
-        self._group_stack: list[str] = ["default"]
+        # --- F10: declarative lexer mode transitions ---
+        # A ``.tokens`` grammar may declare a ``transitions:`` table plus a
+        # ``start_mode:``. The table is pure data (``ModeTransition`` /
+        # ``TransitionAction``); the lexer interprets it after every token
+        # (see ``_apply_transitions``) to switch the active mode — enabling
+        # context-sensitive lexing (JavaScript regex-vs-division) WITHOUT a
+        # hand-written ``on-token`` callback. Empty table ⇒ behaviour identical
+        # to F04 (every helper early-returns / stays inert).
+        self._transitions = list(getattr(grammar, "transitions", []) or [])
+
+        # The mode the lexer starts in. Defaults to "default" (the base group).
+        # If a grammar names a mode with no group, fall back to "default" so
+        # tokenization never crashes on a malformed compiled artifact (the
+        # validator rejects this upstream; this is defence in depth).
+        start_mode = getattr(grammar, "start_mode", None)
+        if start_mode and (
+            start_mode in self._group_patterns or start_mode == "default"
+        ):
+            self._start_mode = start_mode
+        else:
+            self._start_mode = "default"
+
+        # A group reached via ``set-mode`` is a FLAT MODE that inherits the
+        # default group's patterns (its own patterns win on priority); a group
+        # reached only via ``push`` stays EXCLUSIVE (F04 nested-region
+        # semantics). ``push`` wins the classification when a group is both.
+        # Derived once from the table so ``_try_match_token_in_group`` can fall
+        # through to the default patterns for flat modes.
+        set_mode_targets: set[str] = set()
+        push_targets: set[str] = set()
+        for rule in self._transitions:
+            for action in rule.actions:
+                if action.kind == "set_mode" and action.target:
+                    set_mode_targets.add(action.target)
+                elif action.kind == "push" and action.target:
+                    push_targets.add(action.target)
+        self._inheriting_modes: frozenset[str] = frozenset(
+            m for m in set_mode_targets if m != "default" and m not in push_targets
+        )
+
+        # The group stack. Bottom is the configured start mode (F10); "default"
+        # for grammars without a ``start_mode:``. Top is the active group whose
+        # patterns are tried during token matching.
+        self._group_stack: list[str] = [self._start_mode]
 
         # On-token callback â€” None means no callback (zero overhead).
         self._on_token: (
@@ -762,7 +803,15 @@ class GrammarLexer:
                     # Apply skip toggle if the callback changed it.
                     if ctx._skip_enabled is not None:
                         self._skip_enabled = ctx._skip_enabled
+
+                    # F10: the declarative table is the default; a registered
+                    # callback runs first (above) and the table refines, so the
+                    # resulting mode governs the NEXT token match.
+                    self._apply_transitions(token)
                 else:
+                    # F10: consult the declarative table so the new mode governs
+                    # the NEXT match. No-op when the grammar has no transitions.
+                    self._apply_transitions(token)
                     tokens.append(token)
                     self._last_emitted_token = token
                 continue
@@ -791,7 +840,8 @@ class GrammarLexer:
         ))
 
         # Reset state for reuse (in case tokenize is called again).
-        self._group_stack = ["default"]
+        # F10: reset to the configured start mode, not the bare "default".
+        self._group_stack = [self._start_mode]
         self._skip_enabled = True
         self._last_emitted_token = None
         self._bracket_depths = {"paren": 0, "bracket": 0, "brace": 0}
@@ -1162,6 +1212,16 @@ class GrammarLexer:
         remaining = self._source[self._pos:]
         patterns = self._group_patterns.get(group_name, self._patterns)
 
+        # F10: a flat mode (a ``set-mode`` target) inherits the default group's
+        # patterns. Its own patterns take priority (tried first below); the rest
+        # fall through by appending the default patterns. Nested ``push`` regions
+        # are NOT in ``_inheriting_modes`` and so stay exclusive (F04 / XML).
+        if (
+            group_name != "default"
+            and group_name in self._inheriting_modes
+        ):
+            patterns = list(patterns) + self._group_patterns["default"]
+
         for token_name, pattern in patterns:
             match = pattern.match(remaining)
             if match:
@@ -1265,6 +1325,72 @@ class GrammarLexer:
                 return token
 
         return None
+
+    # -- F10: declarative mode transitions ------------------------------------
+
+    @staticmethod
+    def _transition_key(token: Token) -> str:
+        """Return the grammar token NAME used to match transition rules (F10).
+
+        Token identity in a ``.tokens`` grammar is UPPER_SNAKE (``NAME``,
+        ``SLASH``, ``RPAREN``, ``KEYWORD``, ...). A matched token's ``type`` is
+        either a string (custom token names and promoted ``KEYWORD``) — returned
+        verbatim — or a ``TokenType`` enum member whose ``.name`` is already the
+        UPPER_SNAKE grammar name (unlike Rust's CamelCase variants, so no
+        inverse table is needed here).
+        """
+        ttype = token.type
+        if isinstance(ttype, str):
+            return ttype
+        # TokenType enum member — its name is the UPPER_SNAKE grammar key.
+        return ttype.name
+
+    def _apply_transitions(self, token: Token) -> None:
+        """Apply the declarative mode-transition table after ``token`` is emitted.
+
+        The first rule whose trigger token-name, optional ``in MODE`` guard, and
+        optional keyword-value guard all match wins; its actions mutate the
+        active-mode register (top of ``_group_stack``) and/or the skip flag:
+
+        - ``set_mode`` — replace the active mode in place (flat toggle, no depth
+          change). This is how JS regex-vs-division position is tracked.
+        - ``push`` / ``pop`` — F04 nested-region save/restore (templates).
+        - ``enable_skip`` / ``disable_skip`` — toggle skip processing.
+
+        No-op when the table is empty (behaviour identical to F04).
+        """
+        if not self._transitions:
+            return
+        key = self._transition_key(token)
+        active = self._group_stack[-1] if self._group_stack else "default"
+
+        matched_actions = None
+        for rule in self._transitions:
+            if key not in rule.on_tokens:
+                continue
+            if rule.in_mode is not None and rule.in_mode != active:
+                continue
+            if rule.on_value is not None and rule.on_value != token.value:
+                continue
+            matched_actions = rule.actions
+            break
+
+        if matched_actions is None:
+            return
+        for action in matched_actions:
+            if action.kind == "set_mode":
+                if self._group_stack and action.target is not None:
+                    self._group_stack[-1] = action.target
+            elif action.kind == "push":
+                if action.target is not None:
+                    self._group_stack.append(action.target)
+            elif action.kind == "pop":
+                if len(self._group_stack) > 1:
+                    self._group_stack.pop()
+            elif action.kind == "enable_skip":
+                self._skip_enabled = True
+            elif action.kind == "disable_skip":
+                self._skip_enabled = False
 
     def _advance(self) -> None:
         """Move position forward by one character, tracking line and column.

--- a/code/packages/python/lexer/tests/test_grammar_lexer.py
+++ b/code/packages/python/lexer/tests/test_grammar_lexer.py
@@ -1902,3 +1902,109 @@ class TestCaseInsensitiveKeywords:
         tok = non_eof[0]
         assert _token_type_name(tok) == "STRING"
         assert tok.value == "Ada"
+
+
+# ============================================================================
+# F10 — declarative lexer mode transitions (regex-vs-division)
+# ============================================================================
+#
+# These mirror the Rust `grammar_lexer.rs` F10 suite. A flat `div` mode is
+# entered after value-producing tokens (where `/` is DIVISION); operators
+# return to `default` (where `/` starts a REGEX). The `div` mode inherits the
+# default patterns, overriding only the slash tokens.
+
+
+def _f10_regex_div_grammar() -> TokenGrammar:
+    """A minimal regex-vs-division grammar with a flat `div` mode."""
+    return parse_token_grammar(
+        "NAME = /[a-z]+/\n"
+        "REGEX = /\\/[a-z]+\\//\n"
+        'SLASH_EQUALS = "/="\n'
+        'SLASH = "/"\n'
+        'EQUALS = "="\n'
+        'PLUS = "+"\n'
+        "\n"
+        "group div:\n"
+        '  SLASH_EQUALS = "/="\n'
+        '  SLASH = "/"\n'
+        "\n"
+        "start_mode: default\n"
+        "transitions:\n"
+        "  on NAME -> set-mode div\n"
+        "  on (EQUALS | PLUS | SLASH | SLASH_EQUALS | REGEX) -> set-mode default\n"
+    )
+
+
+def _names(tokens: list[Token]) -> list[str]:
+    """The grammar token names (UPPER_SNAKE), excluding EOF."""
+    return [_token_type_name(t) for t in tokens if _token_type_name(t) != "EOF"]
+
+
+class TestF10ModeTransitions:
+    """Declarative mode transitions interpreted by the GrammarLexer."""
+
+    def test_division_chain_lexed_as_slashes(self) -> None:
+        # `a/b/c` in operand position: each `/` is division, not a regex.
+        grammar = _f10_regex_div_grammar()
+        toks = grammar_tokenize("a/b/c", grammar)
+        assert _names(toks) == ["NAME", "SLASH", "NAME", "SLASH", "NAME"]
+
+    def test_regex_in_expression_position(self) -> None:
+        # After `=`, a `/.../` is a regex literal.
+        grammar = _f10_regex_div_grammar()
+        toks = grammar_tokenize("x=/ab/", grammar)
+        assert _names(toks) == ["NAME", "EQUALS", "REGEX"]
+
+    def test_flat_mode_inherits_default_patterns(self) -> None:
+        # In `div` mode a NAME has no override, so it must be matched via
+        # inheritance from the default group. If inheritance were off the
+        # second identifier would fail to lex.
+        grammar = _f10_regex_div_grammar()
+        toks = grammar_tokenize("ab cd", grammar)
+        assert _names(toks) == ["NAME", "NAME"]
+
+    def test_slash_equals_override_beats_inherited_regex(self) -> None:
+        # `a/=b` — in div mode the `/=` override wins over inherited REGEX/SLASH.
+        grammar = _f10_regex_div_grammar()
+        toks = grammar_tokenize("a/=b", grammar)
+        assert _names(toks) == ["NAME", "SLASH_EQUALS", "NAME"]
+
+    def test_no_transitions_is_backward_compatible(self) -> None:
+        # The SAME tokens without a transitions table: REGEX greedily wins, so
+        # `a/b/c` lexes as NAME REGEX NAME (the pre-F10 behaviour).
+        grammar = parse_token_grammar(
+            "NAME = /[a-z]+/\n"
+            "REGEX = /\\/[a-z]+\\//\n"
+            'SLASH = "/"\n'
+        )
+        toks = grammar_tokenize("a/b/c", grammar)
+        assert _names(toks) == ["NAME", "REGEX", "NAME"]
+
+    def test_push_region_stays_exclusive(self) -> None:
+        # A `push`ed region is NOT a flat mode: it does NOT inherit default,
+        # preserving F04 exclusivity. The `tag` region only knows WORD/CLOSE;
+        # the default BANG is invisible inside it.
+        grammar = parse_token_grammar(
+            'OPEN = "<"\n'
+            'BANG = "!"\n'
+            "group tag:\n"
+            "  WORD = /[a-z]+/\n"
+            '  CLOSE = ">"\n'
+            "transitions:\n"
+            "  on OPEN -> push tag\n"
+            "  on CLOSE -> pop\n"
+        )
+        # Inside the region, `!` (a default token) must NOT match.
+        with pytest.raises(LexerError):
+            grammar_tokenize("<a!>", grammar)
+        # A well-formed region tokenizes; after `>` we pop back to default
+        # where `!` is valid again.
+        toks = grammar_tokenize("<ab>!", grammar)
+        assert _names(toks) == ["OPEN", "WORD", "CLOSE", "BANG"]
+
+    def test_start_mode_is_respected(self) -> None:
+        # Starting directly in `div` means the first `/` is a division slash.
+        grammar = _f10_regex_div_grammar()
+        grammar.start_mode = "div"
+        toks = grammar_tokenize("a/b", grammar)
+        assert _names(toks) == ["NAME", "SLASH", "NAME"]


### PR DESCRIPTION
## What

PR-4b of the **F10 declarative lexer mode transitions** arc — the Python port of the Rust `grammar_lexer.rs` interpreter ([#5663](https://github.com/adhithyan15/coding-adventures/pull/5663)). The grammar-tools Python data model (`ModeTransition` / `TransitionAction` / `start_mode` / `transitions`) already landed in [#5668](https://github.com/adhithyan15/coding-adventures/pull/5668); this wires the `lexer` package to interpret it.

## How

`GrammarLexer` now:
- reads `start_mode` from the grammar and starts its group stack there (defaults to `"default"`; falls back safely if the mode names no group — defence in depth beyond upstream validation);
- after each emitted token, calls `_apply_transitions` — first matching rule wins (token-name + optional `in MODE` + optional keyword-value guards); `set_mode` replaces the top of the group stack (flat toggle), `push`/`pop` are F04 nested regions, `enable_skip`/`disable_skip` toggle skip;
- classifies `set-mode` targets as **flat modes** that inherit the default group's patterns (own patterns win on priority) via `_inheriting_modes`, while `push` targets stay **exclusive** (F04 / XML region semantics).

`_transition_key` is simpler than Rust's: Python's `TokenType` enum members are already `UPPER_SNAKE`, so a built-in token's key is `type.name`; custom / `KEYWORD` tokens (string `type`) are returned verbatim — no inverse table needed.

## Backward compatibility

An empty `transitions:` table early-returns, so grammars without F10 produce **identical** token streams. Verified by the full existing suite.

## Verification

- **231 passed, zero regressions** in the lexer suite.
- **+7 F10 tests** mirroring the Rust suite: regex-vs-division chain, expression-position regex, flat-mode inheritance, `/=` override beats inherited REGEX, no-transitions backward-compat, push-region exclusivity, `start_mode` respected.
- `ruff` clean — net contribution adds no new lint violations (the file's pre-existing E501s are untouched).
- `/security-review`: **PASSED** (no vulnerabilities; pure token-state logic, no eval/regex-from-input, `pop` can't underflow the stack, all `[-1]` accesses guarded).

## Remaining in the arc

PR-4c…f port the same interpreter to Ruby / TypeScript / Go / Elixir (grammar-tools + lexer each). All mechanical replication of the Rust/Python reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)