### PR TITLE
feat(img07): image-raw-pipeline — shared RAW colour pipeline crate

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -384,6 +384,7 @@ members = [
     "qr-code",
     "data-matrix",
     "pdf417",
+    "image-raw-pipeline",
     "image-codec-gif",
     "image-codec-bmp",
     "image-codec-ico",

--- a/code/packages/rust/image-raw-pipeline/BUILD
+++ b/code/packages/rust/image-raw-pipeline/BUILD
@@ -1,0 +1,1 @@
+cargo test -p image-raw-pipeline -- --nocapture

--- a/code/packages/rust/image-raw-pipeline/CHANGELOG.md
+++ b/code/packages/rust/image-raw-pipeline/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — image-raw-pipeline
+
+---
+
+## [0.1.0] — 2026-06-13
+
+### Added
+
+- **`srgb_gamma(linear: f64) -> f64`** — IEC 61966-2-1 EOTF. Linear segment
+  for L ≤ 0.0031308; power segment (1.055 × L^(1/2.4) − 0.055) otherwise.
+
+- **`srgb_decode(encoded: f64) -> f64`** — Inverse EOTF. Linear segment for
+  V ≤ 0.04045; power segment otherwise. Satisfies `srgb_decode(srgb_gamma(x)) ≈ x`.
+
+- **`mat3x3_mul(m: &[[f64;3];3], v: [f64;3]) -> [f64;3]`** — 3×3 ×
+  column-vector multiply, stack-allocated, called once per pixel in the RAW
+  pipeline without any heap allocation.
+
+- **`invert_3x3(m: &[[f64;3];3]) -> Option<[[f64;3];3]>`** — Analytic 3×3
+  inversion via Cramer's rule. Returns `None` for singular matrices
+  (`|det| < 1e-12`). Used by `image-codec-dng` for ForwardMatrix inversion.
+
+- **`apply_color_pipeline`** — Full four-stage RAW development pipeline:
+  black-level subtraction → normalisation → white balance → colour matrix →
+  sRGB gamma. Replaces identical implementations in `image-codec-tiff`,
+  `image-codec-raf`, and `image-codec-rw2`.
+
+- **43 tests** (40 unit + 3 doc-tests): sRGB gamma at boundary/midpoint/
+  endpoints; round-trip encode↔decode; mat3x3_mul identity/swap/scaling;
+  invert_3x3 identity/diagonal/self-inverse/singular/M×inv(M)=I; pipeline
+  identity/black-level/white-level/WB-saturation/channel-swap/multi-pixel.
+
+[0.1.0]: https://github.com/adhithyan15/coding-adventures/tree/feat/img07-image-raw-pipeline

--- a/code/packages/rust/image-raw-pipeline/Cargo.toml
+++ b/code/packages/rust/image-raw-pipeline/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "image-raw-pipeline"
+version = "0.1.0"
+edition = "2021"
+description = "IMG07: Shared RAW colour development pipeline — sRGB gamma, 3×3 matrix ops, and apply_color_pipeline used by all RAW codec crates (TIFF/DNG/CR2/NEF/ARW/RAF/ORF/RW2)"
+license = "MIT"
+
+[dependencies]

--- a/code/packages/rust/image-raw-pipeline/README.md
+++ b/code/packages/rust/image-raw-pipeline/README.md
@@ -1,0 +1,77 @@
+# image-raw-pipeline
+
+Shared RAW colour development pipeline for all camera RAW image codecs.
+
+Extracts the sRGB gamma function, 3×3 matrix operations, and the four-stage
+RAW colour development pipeline that were previously duplicated across
+`image-codec-tiff`, `image-codec-raf`, and `image-codec-rw2`.
+
+## API
+
+```rust
+use image_raw_pipeline::{
+    srgb_gamma, srgb_decode,
+    mat3x3_mul, invert_3x3,
+    apply_color_pipeline,
+};
+
+// sRGB gamma (IEC 61966-2-1): linear light → display encoding.
+let display = srgb_gamma(0.5); // ≈ 0.735
+
+// Inverse: display encoding → linear light.
+let linear = srgb_decode(display); // ≈ 0.5
+
+// 3×3 × column-vector (per-pixel, no heap allocation).
+let cam_to_srgb = [[1.392, -0.418, 0.026],
+                   [-0.254, 1.614, -0.360],
+                   [0.068, -0.584, 1.516]];
+let rgb = mat3x3_mul(&cam_to_srgb, [0.5, 0.5, 0.5]);
+
+// 3×3 inversion (per-file, used by DNG ForwardMatrix path).
+let inv = invert_3x3(&cam_to_srgb).expect("matrix should be invertible");
+
+// Full RAW pipeline: normalize → white balance → colour matrix → gamma.
+let raw_pixels: Vec<(u16, u16, u16)> = vec![(40000, 20000, 18000)];
+let srgb = apply_color_pipeline(
+    &raw_pixels,
+    512,        // black level
+    4095,       // white level (12-bit sensor)
+    [2.1, 1.0, 1.7], // daylight white balance
+    cam_to_srgb,
+);
+// → Vec<(u8, u8, u8)> in sRGB
+```
+
+## Four-stage pipeline
+
+```
+raw u16 sensor values
+  │
+  ▼ 1. Black-level subtraction + normalization  → [0.0, 1.0]
+  │
+  ▼ 2. White balance (multiply per channel)
+  │
+  ▼ 3. Camera-to-sRGB colour matrix (3×3 f64)
+  │
+  ▼ 4. sRGB gamma (IEC 61966-2-1)
+  │
+  ▼ u8 sRGB output
+```
+
+## Zero dependencies
+
+All math is elementary scalar arithmetic on stack-allocated arrays.
+No heap allocation per pixel in `mat3x3_mul` or `apply_color_pipeline`.
+
+## Spec
+
+See [`code/specs/IMG07-image-raw-pipeline.md`](../../../../specs/IMG07-image-raw-pipeline.md).
+
+## Consumers
+
+| Crate | Uses |
+|-------|------|
+| `image-codec-tiff` | `apply_color_pipeline`, `srgb_gamma` |
+| `image-codec-raf`  | `apply_color_pipeline`, `srgb_gamma` |
+| `image-codec-rw2`  | `apply_color_pipeline`, `srgb_gamma` |
+| `image-codec-dng`  | `invert_3x3`, `mat3x3_mul` |

--- a/code/packages/rust/image-raw-pipeline/src/gamma.rs
+++ b/code/packages/rust/image-raw-pipeline/src/gamma.rs
@@ -1,0 +1,204 @@
+// # gamma.rs — sRGB Transfer Functions
+//
+// The IEC 61966-2-1 standard (sRGB) defines a piecewise transfer function
+// that maps linear-light values to display-encoded values and vice-versa.
+//
+// ## Why piecewise?
+//
+// A pure power law (L^(1/2.2)) would require infinite derivative at L=0,
+// which amplifies noise in very dark values. The linear segment near black
+// has finite slope (12.92) and avoids this problem. The crossover point
+// is chosen so the two pieces join smoothly (same value and same
+// first derivative at the transition).
+//
+// ## The constants (do not change these)
+//
+// - 0.0031308  — linear/power crossover in linear light
+// - 0.04045    — the same point in display encoding (12.92 × 0.0031308)
+// - 12.92      — slope of the linear segment
+// - 1.055      — gain of the power segment
+// - 0.055      — offset of the power segment  (continuity constraint)
+// - 2.4        — inverse gamma (reciprocal of ~0.4167)
+//
+// The exponent 1/2.4 ≈ 0.4167 is slightly higher than the nominal sRGB
+// "gamma 2.2" because the linear segment effectively lowers the overall
+// perceptual exponent. In practice: γ_eff ≈ 2.2 when the linear segment
+// is included.
+
+/// Apply the sRGB EOTF: convert linear light `linear ∈ [0, 1]` to
+/// display-encoded value `∈ [0, 1]`.
+///
+/// Fixed points: `srgb_gamma(0.0) == 0.0` and `srgb_gamma(1.0) == 1.0`.
+/// Values outside [0, 1] are handled gracefully (not clamped here — the
+/// caller decides whether to clamp before or after the gamma step).
+///
+/// # Formula (IEC 61966-2-1)
+///
+/// ```text
+/// V = 12.92 × L                  if L ≤ 0.0031308
+/// V = 1.055 × L^(1/2.4) − 0.055 if L > 0.0031308
+/// ```
+#[inline]
+pub fn srgb_gamma(linear: f64) -> f64 {
+    if linear <= 0.0031308 {
+        12.92 * linear
+    } else {
+        1.055 * linear.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// Invert the sRGB EOTF: convert display-encoded value `encoded ∈ [0, 1]`
+/// back to linear light.
+///
+/// Round-trip: `srgb_decode(srgb_gamma(x)) ≈ x` for `x ∈ [0, 1]`
+/// (within f64 floating-point rounding).
+///
+/// # Formula (IEC 61966-2-1)
+///
+/// ```text
+/// L = V / 12.92                     if V ≤ 0.04045
+/// L = ((V + 0.055) / 1.055)^2.4    if V > 0.04045
+/// ```
+#[inline]
+pub fn srgb_decode(encoded: f64) -> f64 {
+    if encoded <= 0.04045 {
+        encoded / 12.92
+    } else {
+        ((encoded + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── srgb_gamma ────────────────────────────────────────────────────────
+
+    #[test]
+    fn gamma_zero_is_zero() {
+        assert!((srgb_gamma(0.0)).abs() < 1e-15);
+    }
+
+    #[test]
+    fn gamma_one_is_one() {
+        // Fixed point: both endpoints map to themselves.
+        assert!((srgb_gamma(1.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn gamma_linear_segment_exact() {
+        // Values at and below 0.0031308 use V = 12.92 × L.
+        let x = 0.001;
+        let expected = 12.92 * x;
+        assert!((srgb_gamma(x) - expected).abs() < 1e-15);
+    }
+
+    #[test]
+    fn gamma_at_crossover_point() {
+        // At exactly 0.0031308 the linear formula applies.
+        let x = 0.0031308;
+        let expected = 12.92 * x;
+        assert!((srgb_gamma(x) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn gamma_above_crossover_uses_power_law() {
+        // Just above 0.0031308 the power formula applies.
+        let x = 0.004_f64;
+        let expected = 1.055 * x.powf(1.0 / 2.4) - 0.055;
+        assert!((srgb_gamma(x) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn gamma_midpoint_is_approximately_0735() {
+        // From reference sRGB tables: gamma(0.5) ≈ 0.7354.
+        let v = srgb_gamma(0.5);
+        assert!(v > 0.73 && v < 0.74, "gamma(0.5) expected ~0.735, got {}", v);
+    }
+
+    #[test]
+    fn gamma_is_monotone_increasing() {
+        // Sample 100 points and verify strict ordering.
+        let mut prev = srgb_gamma(0.0);
+        for i in 1..=100 {
+            let x = i as f64 / 100.0;
+            let v = srgb_gamma(x);
+            assert!(v > prev, "gamma not monotone at x={}", x);
+            prev = v;
+        }
+    }
+
+    #[test]
+    fn gamma_negative_input() {
+        // Negative linear light: linear segment gives negative output (not clamped).
+        let v = srgb_gamma(-0.01);
+        assert!(v < 0.0);
+    }
+
+    // ── srgb_decode ───────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_zero_is_zero() {
+        assert!(srgb_decode(0.0).abs() < 1e-15);
+    }
+
+    #[test]
+    fn decode_one_is_one() {
+        assert!((srgb_decode(1.0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn decode_linear_segment_exact() {
+        // V ≤ 0.04045 → L = V / 12.92.
+        let v = 0.02;
+        let expected = v / 12.92;
+        assert!((srgb_decode(v) - expected).abs() < 1e-15);
+    }
+
+    #[test]
+    fn decode_at_crossover_point() {
+        // At exactly 0.04045 the linear formula applies.
+        let v = 0.04045;
+        let expected = v / 12.92;
+        assert!((srgb_decode(v) - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn decode_above_crossover_uses_power_law() {
+        let v = 0.05;
+        let expected = ((v + 0.055) / 1.055_f64).powf(2.4);
+        assert!((srgb_decode(v) - expected).abs() < 1e-12);
+    }
+
+    // ── Round-trip ────────────────────────────────────────────────────────
+
+    #[test]
+    fn round_trip_gamma_then_decode() {
+        // For all x in [0, 1]: decode(gamma(x)) ≈ x.
+        for i in 0..=50 {
+            let x = i as f64 / 50.0;
+            let roundtrip = srgb_decode(srgb_gamma(x));
+            assert!(
+                (roundtrip - x).abs() < 1e-10,
+                "round-trip failed at x={}: got {}",
+                x, roundtrip
+            );
+        }
+    }
+
+    #[test]
+    fn round_trip_decode_then_gamma() {
+        // For all v in [0, 1]: gamma(decode(v)) ≈ v.
+        for i in 0..=50 {
+            let v = i as f64 / 50.0;
+            let roundtrip = srgb_gamma(srgb_decode(v));
+            assert!(
+                (roundtrip - v).abs() < 1e-10,
+                "round-trip failed at v={}: got {}",
+                v, roundtrip
+            );
+        }
+    }
+}

--- a/code/packages/rust/image-raw-pipeline/src/lib.rs
+++ b/code/packages/rust/image-raw-pipeline/src/lib.rs
@@ -1,0 +1,36 @@
+// # image-raw-pipeline — Shared RAW Colour Development Pipeline
+//
+// ## What this crate provides
+//
+// Camera RAW formats (TIFF, DNG, CR2, NEF, ARW, RAF, ORF, RW2) all require
+// the same four-stage colour pipeline to turn raw sensor values into a
+// displayable sRGB image. Before this crate, that pipeline was duplicated
+// in three separate `color.rs` files across the RAW codec crates. This crate
+// extracts the canonical implementation.
+//
+// ## Exported API
+//
+// | Function | Description |
+// |----------|-------------|
+// | `srgb_gamma(linear)` | Apply IEC 61966-2-1 EOTF: linear → display-encoded |
+// | `srgb_decode(encoded)` | Inverse EOTF: display-encoded → linear light |
+// | `mat3x3_mul(m, v)` | 3×3 × column-vector, no heap allocation |
+// | `invert_3x3(m)` | Analytic 3×3 inversion via Cramer's rule |
+// | `apply_color_pipeline(…)` | Full 4-stage RAW development: normalize → WB → matrix → gamma |
+//
+// ## Dependency policy
+//
+// Zero external dependencies. All math is elementary scalar arithmetic on
+// stack-allocated `[f64;3]` arrays and `[[f64;3];3]` matrices.
+//
+// ## Spec
+//
+// See `code/specs/IMG07-image-raw-pipeline.md`.
+
+pub mod gamma;
+pub mod matrix;
+pub mod pipeline;
+
+pub use gamma::{srgb_gamma, srgb_decode};
+pub use matrix::{mat3x3_mul, invert_3x3};
+pub use pipeline::apply_color_pipeline;

--- a/code/packages/rust/image-raw-pipeline/src/matrix.rs
+++ b/code/packages/rust/image-raw-pipeline/src/matrix.rs
@@ -1,0 +1,284 @@
+// # matrix.rs — 3×3 Matrix Operations for Colour Science
+//
+// Colour pipelines in camera RAW development use 3×3 matrices to transform
+// between different RGB colour spaces. Two primitives suffice for all RAW
+// codec needs:
+//
+// - `mat3x3_mul`: apply a 3×3 matrix to a column vector (per pixel, hot path)
+// - `invert_3x3`: invert a 3×3 matrix (per image, cold path)
+//
+// ## Why not the `matrix` crate?
+//
+// The repo's `matrix` crate stores data as `Vec<Vec<f64>>` — one heap
+// allocation per matrix and per column vector. For per-pixel use (millions
+// of calls per image), heap allocation per call is unacceptable. For the
+// one-time-per-file inversion, it would be fine, but keeping zero external
+// dependencies avoids coupling the RAW codec layer to general-purpose matrix
+// algebra infrastructure.
+//
+// Instead we use:
+// - Plain Rust arrays `[[f64;3];3]` and `[f64;3]` — stack-allocated, zero
+//   indirection, trivially copy-able.
+// - Cramer's rule for inversion — exactly 9 cofactors × 1 determinant, all
+//   scalar ops, no loops over variable sizes.
+//
+// ## Row-major convention
+//
+// `m[row][col]`. Matrix-vector product: `out[i] = Σ_j m[i][j] * v[j]`.
+//
+// ## Cramer's rule for 3×3 inversion
+//
+// For M = [[a,b,c],[d,e,f],[g,h,k]], the inverse is:
+//
+//   det(M) = a(ek - fh) - b(dk - fg) + c(dh - eg)
+//
+//   inv(M) = (1/det) × C^T
+//
+// where C is the cofactor matrix:
+//
+//   C[0][0] =  (ek - fh),  C[0][1] = -(dk - fg),  C[0][2] =  (dh - eg)
+//   C[1][0] = -(bk - ch),  C[1][1] =  (ak - cg),  C[1][2] = -(ah - bg)
+//   C[2][0] =  (bf - ce),  C[2][1] = -(af - cd),  C[2][2] =  (ae - bd)
+//
+// The transpose C^T swaps row/col indices, so inv[i][j] = C[j][i] / det.
+
+/// Multiply a 3×3 row-major matrix `m` by column vector `v`.
+///
+/// Output: `out[i] = m[i][0]*v[0] + m[i][1]*v[1] + m[i][2]*v[2]`
+///
+/// Called once per pixel in `apply_color_pipeline` — no heap allocation.
+///
+/// # Example
+///
+/// ```
+/// use image_raw_pipeline::mat3x3_mul;
+///
+/// // Identity matrix leaves the vector unchanged.
+/// let id = [[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]];
+/// let v  = [3.0, 5.0, 7.0];
+/// let out = mat3x3_mul(&id, v);
+/// assert_eq!(out, v);
+/// ```
+#[inline]
+pub fn mat3x3_mul(m: &[[f64; 3]; 3], v: [f64; 3]) -> [f64; 3] {
+    [
+        m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+        m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+        m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+    ]
+}
+
+/// Analytically invert a 3×3 matrix using Cramer's rule.
+///
+/// Returns `None` if `|det(M)| < 1e-12` (singular or near-singular).
+///
+/// For a non-singular M: `M × inv(M) = I` (identity), up to floating-point
+/// rounding error on the order of machine epsilon (~1e-15 for f64).
+///
+/// # Example
+///
+/// ```
+/// use image_raw_pipeline::{mat3x3_mul, invert_3x3};
+///
+/// let m = [[2.0,0.0,0.0],[0.0,3.0,0.0],[0.0,0.0,4.0]];
+/// let inv = invert_3x3(&m).unwrap();
+///
+/// // Verify M × inv(M) ≈ identity.
+/// let e0 = mat3x3_mul(&m, mat3x3_mul(&inv, [1.0, 0.0, 0.0]));
+/// assert!((e0[0] - 1.0).abs() < 1e-10);
+/// assert!(e0[1].abs() < 1e-10);
+/// assert!(e0[2].abs() < 1e-10);
+/// ```
+pub fn invert_3x3(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
+    // Unpack for readability (mirrors the Cramer's rule derivation above).
+    let [a, b, c] = m[0];
+    let [d, e, f] = m[1];
+    let [g, h, k] = m[2];
+
+    // 2×2 minors needed for cofactors (computed once, reused twice each).
+    let ek_fh = e * k - f * h; // minor for a
+    let dk_fg = d * k - f * g; // minor for b
+    let dh_eg = d * h - e * g; // minor for c
+    let bk_ch = b * k - c * h; // minor for d
+    let ak_cg = a * k - c * g; // minor for e
+    let ah_bg = a * h - b * g; // minor for f
+    let bf_ce = b * f - c * e; // minor for g
+    let af_cd = a * f - c * d; // minor for h
+    let ae_bd = a * e - b * d; // minor for k
+
+    // Determinant via expansion along the first row.
+    let det = a * ek_fh - b * dk_fg + c * dh_eg;
+    if det.abs() < 1e-12 {
+        return None; // singular or near-singular
+    }
+
+    let inv_det = 1.0 / det;
+
+    // Inverse = (1/det) × C^T  (cofactor matrix, transposed).
+    //
+    // Layout: inv[row][col] = C[col][row] / det
+    //         (the transpose swaps the two indices)
+    Some([
+        [ ek_fh * inv_det, -bk_ch * inv_det,  bf_ce * inv_det],
+        [-dk_fg * inv_det,  ak_cg * inv_det, -af_cd * inv_det],
+        [ dh_eg * inv_det, -ah_bg * inv_det,  ae_bd * inv_det],
+    ])
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── mat3x3_mul ────────────────────────────────────────────────────────
+
+    #[test]
+    fn mul_identity_leaves_vector_unchanged() {
+        let id = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let v = [3.0_f64, 5.0, 7.0];
+        let out = mat3x3_mul(&id, v);
+        assert_eq!(out, v);
+    }
+
+    #[test]
+    fn mul_zero_matrix_gives_zero() {
+        let z = [[0.0_f64; 3]; 3];
+        let v = [1.0, 2.0, 3.0];
+        assert_eq!(mat3x3_mul(&z, v), [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn mul_channel_swap_rb() {
+        // Swap R and B: [[0,0,1],[0,1,0],[1,0,0]]
+        let swap = [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]];
+        let v = [1.0_f64, 2.0, 3.0]; // R=1, G=2, B=3
+        let out = mat3x3_mul(&swap, v);
+        assert_eq!(out, [3.0, 2.0, 1.0]); // R and B swapped
+    }
+
+    #[test]
+    fn mul_known_example() {
+        // [[1,2,3],[4,5,6],[7,8,9]] × [1,0,0] = [1,4,7]
+        let m = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
+        let out = mat3x3_mul(&m, [1.0, 0.0, 0.0]);
+        assert!((out[0] - 1.0).abs() < 1e-12);
+        assert!((out[1] - 4.0).abs() < 1e-12);
+        assert!((out[2] - 7.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mul_scaling_matrix() {
+        let scale = [[2.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 4.0]];
+        let v = [1.0_f64, 1.0, 1.0];
+        let out = mat3x3_mul(&scale, v);
+        assert!((out[0] - 2.0).abs() < 1e-12);
+        assert!((out[1] - 3.0).abs() < 1e-12);
+        assert!((out[2] - 4.0).abs() < 1e-12);
+    }
+
+    // ── invert_3x3 ────────────────────────────────────────────────────────
+
+    #[test]
+    fn invert_identity_gives_identity() {
+        let id = [[1.0_f64, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        let inv = invert_3x3(&id).unwrap();
+        for r in 0..3 {
+            for c in 0..3 {
+                let expected = if r == c { 1.0 } else { 0.0 };
+                assert!((inv[r][c] - expected).abs() < 1e-12,
+                    "inv[{}][{}] = {}, expected {}", r, c, inv[r][c], expected);
+            }
+        }
+    }
+
+    #[test]
+    fn invert_diagonal_matrix() {
+        // Diagonal matrix [[2,0,0],[0,3,0],[0,0,4]] inverts to [[0.5,0,0],[0,1/3,0],[0,0,0.25]].
+        let m = [[2.0_f64, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 4.0]];
+        let inv = invert_3x3(&m).unwrap();
+        assert!((inv[0][0] - 0.5).abs() < 1e-12);
+        assert!((inv[1][1] - 1.0/3.0).abs() < 1e-12);
+        assert!((inv[2][2] - 0.25).abs() < 1e-12);
+        // Off-diagonal must be zero.
+        for r in 0..3 {
+            for c in 0..3 {
+                if r != c {
+                    assert!(inv[r][c].abs() < 1e-12, "off-diag [{}][{}] != 0", r, c);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn invert_channel_swap_is_self_inverse() {
+        // The R↔B swap matrix is its own inverse (applying it twice = identity).
+        let swap = [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]];
+        let inv = invert_3x3(&swap).unwrap();
+        for r in 0..3 {
+            for c in 0..3 {
+                assert!((inv[r][c] - swap[r][c]).abs() < 1e-12,
+                    "swap matrix not self-inverse at [{r}][{c}]");
+            }
+        }
+    }
+
+    #[test]
+    fn invert_singular_returns_none() {
+        // Zero matrix has det = 0 — must return None.
+        let zero = [[0.0_f64; 3]; 3];
+        assert!(invert_3x3(&zero).is_none());
+    }
+
+    #[test]
+    fn invert_rank_deficient_returns_none() {
+        // All rows the same → linearly dependent → det = 0.
+        let m = [[1.0_f64, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 2.0, 3.0]];
+        assert!(invert_3x3(&m).is_none());
+    }
+
+    #[test]
+    fn m_times_inv_m_equals_identity() {
+        // M × inv(M) = I for a typical camera colour matrix.
+        let m = [
+            [ 1.392, -0.418,  0.026],
+            [-0.254,  1.614, -0.360],
+            [ 0.068, -0.584,  1.516],
+        ];
+        let inv = invert_3x3(&m).unwrap();
+        // Check each basis vector: M × inv(M) × e_i ≈ e_i.
+        for i in 0..3 {
+            let mut e = [0.0_f64; 3];
+            e[i] = 1.0;
+            let result = mat3x3_mul(&m, mat3x3_mul(&inv, e));
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((result[j] - expected).abs() < 1e-8,
+                    "M×inv(M) failed: [{}][{}] = {}, expected {}",
+                    i, j, result[j], expected);
+            }
+        }
+    }
+
+    #[test]
+    fn inv_m_times_m_equals_identity() {
+        // inv(M) × M = I (check the other direction too).
+        let m = [
+            [1.318, -0.398, 0.080],
+            [-0.213, 1.586, -0.373],
+            [0.047, -0.474, 1.427],
+        ];
+        let inv = invert_3x3(&m).unwrap();
+        for i in 0..3 {
+            let mut e = [0.0_f64; 3];
+            e[i] = 1.0;
+            let result = mat3x3_mul(&inv, mat3x3_mul(&m, e));
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!((result[j] - expected).abs() < 1e-8,
+                    "inv(M)×M failed: [{}][{}] = {}, expected {}",
+                    i, j, result[j], expected);
+            }
+        }
+    }
+}

--- a/code/packages/rust/image-raw-pipeline/src/pipeline.rs
+++ b/code/packages/rust/image-raw-pipeline/src/pipeline.rs
@@ -1,0 +1,287 @@
+// # pipeline.rs — RAW Colour Development Pipeline
+//
+// Camera sensor data is not RGB in the sRGB sense. The Bayer array captures
+// light through coloured filters, and the resulting 16-bit values are in a
+// camera-specific native colour space with a non-zero "black level" pedestal.
+// Four steps turn raw sensor values into a displayable sRGB image:
+//
+// ## Step-by-step
+//
+// ### 1. Black-level subtraction and normalisation
+//
+// Sensors have a "dark current" — they output non-zero values even when no
+// light hits them. The black level is the value corresponding to absolute
+// darkness. Subtracting it and normalising by the white level maps the
+// sensor's dynamic range to [0.0, 1.0]:
+//
+// ```text
+// effective_white = white_level - black_level   (at least 1 to avoid ÷0)
+// r_norm = saturating_sub(r_raw, black_level) as f64 / effective_white
+// ```
+//
+// `saturating_sub` ensures negative results clamp to 0 rather than wrapping.
+//
+// ### 2. White balance
+//
+// The scene illuminant (sun, tungsten, LED, etc.) shifts the colour of
+// everything in the frame. White balance multipliers correct this by
+// boosting the channels that the illuminant suppressed:
+//
+// ```text
+// r_wb = r_norm * wb[0]
+// g_wb = g_norm * wb[1]
+// b_wb = b_norm * wb[2]
+// ```
+//
+// For daylight, red and blue are typically boosted (wb[0] > 1, wb[2] > 1)
+// while green is kept at 1.0 (green is the reference channel in most
+// camera colour science).
+//
+// ### 3. Camera-to-sRGB colour matrix
+//
+// Camera sensors use their own native primaries (determined by the physical
+// dye filters). A 3×3 matrix converts from camera-native linear RGB to
+// standard linear sRGB primaries (IEC 61966-2-1 primary chromaticities):
+//
+// ```text
+// [r', g', b'] = color_matrix × [r_wb, g_wb, b_wb]
+// ```
+//
+// This matrix is camera-specific. RAW codec callers supply it from the
+// camera manufacturer's calibration data (TIFF ColorMatrix tag, DNG
+// ColorMatrix1/ForwardMatrix1, etc.). The identity matrix is valid when
+// the camera is already calibrated to sRGB primaries.
+//
+// After the matrix multiply, each channel is clamped to [0.0, 1.0] to
+// prevent negative values or values above 1 from corrupting the gamma step.
+//
+// ### 4. sRGB gamma
+//
+// Linear light values are physically accurate but perceptually non-uniform
+// — equal steps in linear light don't look equally spaced to the human
+// eye. The sRGB transfer function (IEC 61966-2-1) maps linear light to
+// display encoding that monitors decode correctly:
+//
+// ```text
+// r_out = srgb_gamma(r') * 255, rounded and clamped to [0, 255]
+// ```
+
+use crate::gamma::srgb_gamma;
+use crate::matrix::mat3x3_mul;
+
+/// Apply the full four-stage RAW colour development pipeline.
+///
+/// # Parameters
+///
+/// - `pixels` — linear RGB triples from demosaicing or multi-channel reads.
+///   Values are 16-bit unsigned, range [0, 65535].
+/// - `black_level` — sensor pedestal (absolute darkness level). Subtracted
+///   before normalisation. Commonly 512 for 12-bit sensors, 4096 for 14-bit.
+/// - `white_level` — sensor saturation point (full-scale value). Typically
+///   `(1 << bits) - 1`: 4095 for 12-bit, 16383 for 14-bit. Pass `u32::MAX`
+///   to treat 65535 as full scale.
+/// - `wb` — white balance multipliers [R, G, B]. Neutral = [1.0, 1.0, 1.0].
+/// - `color_matrix` — 3×3 camera-to-sRGB colour matrix, row-major.
+///   Identity = already in sRGB colour space.
+///
+/// # Returns
+///
+/// One `(R, G, B)` u8 triple per input pixel, in sRGB.
+///
+/// # Example
+///
+/// ```
+/// use image_raw_pipeline::apply_color_pipeline;
+///
+/// // Identity pipeline: pure white (65535, 65535, 65535) → (255, 255, 255).
+/// let white = vec![(65535u16, 65535, 65535)];
+/// let id_matrix = [[1.0f64,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]];
+/// let out = apply_color_pipeline(&white, 0, 65535, [1.0, 1.0, 1.0], id_matrix);
+/// assert_eq!(out[0], (255, 255, 255));
+/// ```
+pub fn apply_color_pipeline(
+    pixels:       &[(u16, u16, u16)],
+    black_level:  u32,
+    white_level:  u32,
+    wb:           [f64; 3],
+    color_matrix: [[f64; 3]; 3],
+) -> Vec<(u8, u8, u8)> {
+    // Effective white: the range from black to saturation.
+    // Clamp to at least 1 to avoid division by zero for degenerate inputs.
+    let effective_white = (white_level.saturating_sub(black_level) as f64).max(1.0);
+
+    pixels.iter().map(|&(r_raw, g_raw, b_raw)| {
+        // Stage 1: subtract black level, normalise to [0, 1].
+        let r_norm = (r_raw as u32).saturating_sub(black_level) as f64 / effective_white;
+        let g_norm = (g_raw as u32).saturating_sub(black_level) as f64 / effective_white;
+        let b_norm = (b_raw as u32).saturating_sub(black_level) as f64 / effective_white;
+
+        // Stage 2: white balance — multiply per channel.
+        let r_wb = r_norm * wb[0];
+        let g_wb = g_norm * wb[1];
+        let b_wb = b_norm * wb[2];
+
+        // Stage 3: camera-to-sRGB colour matrix.
+        let [r2, g2, b2] = mat3x3_mul(&color_matrix, [r_wb, g_wb, b_wb]);
+
+        // Clamp to [0, 1] after the matrix — prevents gamma of negative values.
+        let r2 = r2.clamp(0.0, 1.0);
+        let g2 = g2.clamp(0.0, 1.0);
+        let b2 = b2.clamp(0.0, 1.0);
+
+        // Stage 4: sRGB gamma + scale to u8.
+        let to_u8 = |v: f64| (srgb_gamma(v) * 255.0).round().clamp(0.0, 255.0) as u8;
+        (to_u8(r2), to_u8(g2), to_u8(b2))
+    }).collect()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id_matrix() -> [[f64; 3]; 3] {
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    }
+
+    fn neutral_wb() -> [f64; 3] { [1.0, 1.0, 1.0] }
+
+    // ── Identity pipeline ─────────────────────────────────────────────────
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let out = apply_color_pipeline(&[], 0, 65535, neutral_wb(), id_matrix());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn pure_white_maps_to_255() {
+        let out = apply_color_pipeline(
+            &[(65535, 65535, 65535)], 0, 65535, neutral_wb(), id_matrix()
+        );
+        assert_eq!(out[0], (255, 255, 255));
+    }
+
+    #[test]
+    fn pure_black_maps_to_0() {
+        let out = apply_color_pipeline(
+            &[(0, 0, 0)], 0, 65535, neutral_wb(), id_matrix()
+        );
+        assert_eq!(out[0], (0, 0, 0));
+    }
+
+    #[test]
+    fn black_level_subtraction() {
+        // black_level=32768, white_level=65535
+        // Input (32768, 32768, 32768) → after subtraction: (0, 0, 0) → output (0,0,0)
+        let out = apply_color_pipeline(
+            &[(32768, 32768, 32768)], 32768, 65535, neutral_wb(), id_matrix()
+        );
+        assert_eq!(out[0], (0, 0, 0));
+    }
+
+    #[test]
+    fn below_black_level_clamps_to_zero() {
+        // Input below black level: saturating_sub → 0.
+        let out = apply_color_pipeline(
+            &[(100, 100, 100)], 512, 4095, neutral_wb(), id_matrix()
+        );
+        assert_eq!(out[0], (0, 0, 0));
+    }
+
+    #[test]
+    fn white_level_normalization_12bit() {
+        // For a 12-bit sensor: black=0, white=4095.
+        // Input (4095, 4095, 4095) = full scale → should map to (255, 255, 255).
+        let out = apply_color_pipeline(
+            &[(4095, 4095, 4095)], 0, 4095, neutral_wb(), id_matrix()
+        );
+        assert_eq!(out[0], (255, 255, 255));
+    }
+
+    // ── White balance ─────────────────────────────────────────────────────
+
+    #[test]
+    fn wb_boost_red_to_saturation() {
+        // WB multiplier 2.0 on R: half-scale input (32768) × 2.0 = 1.0 → 255.
+        let out = apply_color_pipeline(
+            &[(32768, 32768, 32768)], 0, 65535,
+            [2.0, 1.0, 1.0], id_matrix()
+        );
+        // Red should saturate to 255; green/blue at half-scale (~188 after gamma).
+        assert_eq!(out[0].0, 255, "Red should saturate");
+        assert!(out[0].1 < 200, "Green should not saturate: {}", out[0].1);
+    }
+
+    #[test]
+    fn wb_neutral_midgrey_gives_same_rgb() {
+        // Neutral WB + identity matrix: R=G=B=half-scale → all channels equal.
+        let out = apply_color_pipeline(
+            &[(32768, 32768, 32768)], 0, 65535, neutral_wb(), id_matrix()
+        );
+        let (r, g, b) = out[0];
+        assert_eq!(r, g, "R != G for neutral midgrey");
+        assert_eq!(g, b, "G != B for neutral midgrey");
+    }
+
+    // ── Colour matrix ─────────────────────────────────────────────────────
+
+    #[test]
+    fn color_matrix_swaps_r_and_b() {
+        // Matrix [[0,0,1],[0,1,0],[1,0,0]] swaps R and B.
+        // Input: pure red (65535, 0, 0) → after swap: (0, 0, 65535) = pure blue.
+        let swap = [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]];
+        let out = apply_color_pipeline(
+            &[(65535, 0, 0)], 0, 65535, neutral_wb(), swap
+        );
+        assert_eq!(out[0].0, 0,   "R should be 0 after R↔B swap");
+        assert_eq!(out[0].1, 0,   "G should be 0 after R↔B swap");
+        assert_eq!(out[0].2, 255, "B should be 255 after R↔B swap");
+    }
+
+    #[test]
+    fn color_matrix_identity_preserves_channels() {
+        let out = apply_color_pipeline(
+            &[(65535, 0, 0)], 0, 65535, neutral_wb(), id_matrix()
+        );
+        // Pure red stays pure red.
+        assert_eq!(out[0].0, 255);
+        assert_eq!(out[0].1, 0);
+        assert_eq!(out[0].2, 0);
+    }
+
+    #[test]
+    fn pipeline_multiple_pixels() {
+        let pixels = vec![
+            (65535_u16, 0, 0),     // red
+            (0, 65535, 0),         // green
+            (0, 0, 65535),         // blue
+        ];
+        let out = apply_color_pipeline(&pixels, 0, 65535, neutral_wb(), id_matrix());
+        assert_eq!(out[0], (255, 0, 0));
+        assert_eq!(out[1], (0, 255, 0));
+        assert_eq!(out[2], (0, 0, 255));
+    }
+
+    #[test]
+    fn pipeline_clamps_wb_overexposure_to_255() {
+        // WB multiplier 3.0 on an already-bright pixel: still clamps to 255, not >255.
+        let out = apply_color_pipeline(
+            &[(50000, 50000, 50000)], 0, 65535,
+            [3.0, 3.0, 3.0], id_matrix()
+        );
+        assert_eq!(out[0], (255, 255, 255));
+    }
+
+    #[test]
+    fn pipeline_large_image_no_panic() {
+        // 1000 pixels — verify no panic and correct length.
+        let pixels: Vec<(u16, u16, u16)> = (0..1000).map(|i| {
+            let v = ((i * 65) % 65535) as u16;
+            (v, v, v)
+        }).collect();
+        let out = apply_color_pipeline(&pixels, 0, 65535, neutral_wb(), id_matrix());
+        assert_eq!(out.len(), 1000);
+    }
+}

--- a/code/specs/IMG07-image-raw-pipeline.md
+++ b/code/specs/IMG07-image-raw-pipeline.md
@@ -1,0 +1,207 @@
+# IMG07 — Shared RAW Colour Pipeline
+
+## Overview
+
+Camera RAW formats (TIFF, DNG, CR2, NEF, ARW, RAF, ORF, RW2) all require
+the same four-stage colour pipeline to convert raw sensor values into a
+displayable sRGB image:
+
+```
+raw u16 sensor values
+  │
+  ▼ 1. Black-level subtraction + normalization  [0, white_level] → [0.0, 1.0]
+  │
+  ▼ 2. White balance                            multiply per channel
+  │
+  ▼ 3. Camera-to-sRGB colour matrix             3×3 f64 multiply
+  │
+  ▼ 4. sRGB gamma (IEC 61966-2-1)              linear light → display encoding
+  │
+  ▼ u8 sRGB output (clamp, scale, round)
+```
+
+Before this crate existed, the sRGB gamma formula and full pipeline were
+duplicated in `image-codec-tiff/src/color.rs`, `image-codec-raf/src/color.rs`,
+and `image-codec-rw2/src/color.rs`. IMG07 extracts them into one canonical
+implementation that all RAW codec crates depend on.
+
+Additionally, `image-codec-dng` needed to invert a 3×3 matrix to convert
+between DNG's ForwardMatrix (camera→XYZ) and the ColorMatrix (XYZ→camera)
+paths. That `invert_3x3` and the underlying `mat3x3_mul` primitive now live
+here too.
+
+## Motivation: why a shared crate?
+
+The IEC 61966-2-1 transfer function has specific threshold constants
+(0.0031308, 0.04045, 12.92, 1.055, 0.055, 2.4). Any of these could be
+slightly wrong in a hand-typed duplicate. Extracting to one place:
+
+- eliminates three copies of the same arithmetic
+- gives a single test harness for sRGB correctness
+- makes it trivial to add future RAW codecs without re-implementing gamma
+
+## Function specifications
+
+### `srgb_gamma(linear: f64) -> f64`
+
+Apply the sRGB EOTF (electro-optical transfer function) — converts a
+linear-light scalar in [0, 1] to a display-encoded scalar in [0, 1].
+
+The IEC 61966-2-1 standard (sRGB) specifies:
+
+```
+V = 12.92 × L                     if L ≤ 0.0031308  (linear segment)
+V = 1.055 × L^(1/2.4) − 0.055    if L > 0.0031308  (power segment)
+```
+
+Both endpoints are fixed points: `srgb_gamma(0.0) == 0.0` and
+`srgb_gamma(1.0) == 1.0`.
+
+### `srgb_decode(encoded: f64) -> f64`
+
+Inverse of `srgb_gamma` — converts a display-encoded value back to
+linear light. Defined by IEC 61966-2-1 as:
+
+```
+L = V / 12.92                     if V ≤ 0.04045
+L = ((V + 0.055) / 1.055)^2.4    if V > 0.04045
+```
+
+Round-trip property: `srgb_decode(srgb_gamma(x)) ≈ x` within float
+rounding error for `x ∈ [0, 1]`.
+
+### `mat3x3_mul(m: &[[f64;3];3], v: [f64;3]) -> [f64;3]`
+
+Multiply a 3×3 row-major matrix by a column vector.
+
+```
+[out[0]]   [m[0][0]  m[0][1]  m[0][2]]   [v[0]]
+[out[1]] = [m[1][0]  m[1][1]  m[1][2]] × [v[1]]
+[out[2]]   [m[2][0]  m[2][1]  m[2][2]]   [v[2]]
+```
+
+This is 9 multiplications and 6 additions — fast enough to run per pixel
+without any heap allocation. Used in `apply_color_pipeline` for the
+camera-to-sRGB matrix step, and available for DNG's ForwardMatrix path.
+
+### `invert_3x3(m: &[[f64;3];3]) -> Option<[[f64;3];3]>`
+
+Analytically invert a 3×3 matrix via Cramer's rule (cofactor expansion).
+
+Returns `None` if `|det(M)| < 1e-12` (singular or near-singular matrix).
+
+The inverse satisfies `mat3x3_mul(&inv, mat3x3_mul(&m, v)) ≈ v` for any
+column vector `v`, up to floating-point rounding.
+
+Used by `image-codec-dng` to convert between the ForwardMatrix (camera →
+XYZ D50) and ColorMatrix (XYZ → camera) representations when only one is
+available in the DNG metadata.
+
+### `apply_color_pipeline`
+
+```rust
+pub fn apply_color_pipeline(
+    pixels:       &[(u16, u16, u16)],
+    black_level:  u32,
+    white_level:  u32,
+    wb:           [f64; 3],
+    color_matrix: [[f64; 3]; 3],
+) -> Vec<(u8, u8, u8)>
+```
+
+Apply the full four-stage RAW development pipeline to a slice of 16-bit
+linear RGB triples (one per pixel, from demosaicing or direct multi-channel
+reads):
+
+**Stage 1 — Normalize.**
+
+```
+r_norm = (r_raw.saturating_sub(black_level) as f64) / effective_white
+```
+
+`effective_white = white_level as f64 - black_level as f64` (clamped to 1.0
+to avoid division by zero). After subtraction, values are clamped to [0.0, 1.0].
+
+**Stage 2 — White balance.**
+
+```
+r_wb = r_norm * wb[0]
+g_wb = g_norm * wb[1]
+b_wb = b_norm * wb[2]
+```
+
+White balance multipliers compensate for the scene illuminant. Daylight WB
+typically has `wb[0] > 1` (boost red) and `wb[2] > 1` (boost blue).
+
+**Stage 3 — Colour matrix.**
+
+```
+[r', g', b'] = color_matrix × [r_wb, g_wb, b_wb]
+```
+
+Converts camera-native linear RGB to standard linear sRGB primaries.
+Each RAW codec supplies a camera-specific matrix (or the identity matrix
+for RGB sensors already calibrated to sRGB).
+
+After the matrix multiply, each channel is clamped to [0.0, 1.0].
+
+**Stage 4 — sRGB gamma.**
+
+```
+r_out = srgb_gamma(r')
+```
+
+Applied independently to each channel. Converts linear light to the
+perceptual encoding that monitors display correctly.
+
+**Output.**
+
+Each channel is scaled by 255, rounded, and clamped to [0, 255] as u8.
+
+## Crate layout
+
+```
+image-raw-pipeline/
+  Cargo.toml       (no dependencies — zero-dep)
+  BUILD            (cargo test -p image-raw-pipeline -- --nocapture)
+  README.md
+  CHANGELOG.md
+  src/
+    lib.rs         (re-exports + module-level documentation)
+    gamma.rs       (srgb_gamma, srgb_decode)
+    matrix.rs      (mat3x3_mul, invert_3x3)
+    pipeline.rs    (apply_color_pipeline)
+```
+
+## Dependencies
+
+**None.** All math is elementary scalar arithmetic. The `matrix` crate
+was considered for `invert_3x3`, but its `Vec<Vec<f64>>` representation
+heap-allocates for each 3×3 operation. Since inversion happens once per
+RAW file decode (not per pixel), either approach is fine — but zero deps
+is simpler and avoids adding to the workspace's dep graph.
+
+## Test requirements
+
+≥ 30 unit tests, targeting ≥ 95% line coverage:
+
+- `srgb_gamma`: output at 0.0, 1.0, linear segment boundary (0.0031308),
+  below/above boundary, midpoint (~0.5 → ~0.735)
+- `srgb_decode`: output at 0.0, 1.0, linear segment boundary (0.04045),
+  round-trip with srgb_gamma
+- `mat3x3_mul`: identity matrix, zero matrix, channel-swap matrix, known
+  vector example
+- `invert_3x3`: identity matrix self-inverse, diagonal matrix, singular
+  matrix returns None, `M × inv(M) = I` check
+- `apply_color_pipeline`: empty input, identity pipeline (black and white
+  inputs), WB multiplier boosts a channel to saturation, colour matrix
+  swaps R and B, black level subtraction, white level normalization
+
+## Consumers after this crate lands
+
+| Crate | What changes |
+|-------|-------------|
+| `image-codec-tiff` | `color.rs` delegates `apply_color_pipeline` and removes private `apply_srgb_gamma` |
+| `image-codec-raf`  | `color.rs` delegates `apply_color_pipeline` and removes private `srgb_gamma` |
+| `image-codec-rw2`  | `color.rs` delegates `apply_color_pipeline` and removes private `srgb_gamma` |
+| `image-codec-dng`  | `color.rs` uses `invert_3x3` and `mat3x3_mul` instead of inline copies |


### PR DESCRIPTION
## Summary

- Extracts the sRGB gamma function, 3×3 matrix operations, and the four-stage RAW colour development pipeline that were duplicated across `image-codec-tiff`, `image-codec-raf`, and `image-codec-rw2` into a new shared `image-raw-pipeline` crate.
- Adds IMG07 spec at `code/specs/IMG07-image-raw-pipeline.md`.
- Zero external dependencies — all math is elementary scalar arithmetic on stack-allocated arrays.

**New public API:**
| Function | Description |
|----------|-------------|
| `srgb_gamma(linear: f64) -> f64` | IEC 61966-2-1 EOTF: linear → display-encoded |
| `srgb_decode(encoded: f64) -> f64` | Inverse EOTF |
| `mat3x3_mul(m, v)` | 3×3 × column-vector, no heap allocation |
| `invert_3x3(m)` | Analytic Cramer's rule inversion, returns `None` if singular |
| `apply_color_pipeline(…)` | Full 4-stage RAW pipeline: normalize → WB → matrix → gamma |

**43 tests pass** (40 unit + 3 doc-tests).

## Architectural context

Before this PR, the sRGB gamma formula and the complete colour pipeline were independently implemented in three codec crates:
- `image-codec-tiff/src/color.rs` (`apply_srgb_gamma` + `apply_color_pipeline`)
- `image-codec-raf/src/color.rs` (`srgb_gamma` + `apply_color_pipeline`)
- `image-codec-rw2/src/color.rs` (`srgb_gamma` + `apply_color_pipeline`)

And `image-codec-dng` had inline `invert_3x3` + `matrix_multiply` functions that bypassed the `matrix` crate.

This PR is the foundation. Follow-up PRs will wire each codec through the shared crate:
- PR-2: `feat/img07-wire-tiff`
- PR-3: `feat/img07-wire-raf`
- PR-4: `feat/img07-wire-rw2`
- PR-5: `feat/img07-wire-dng`

## Test plan
- [x] `cargo test -p image-raw-pipeline` → 43 tests pass
- [x] `cargo build --workspace` (run in CI)
- [x] Security review: PASSED — no vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)