### PR TITLE
feat(irc-server-native): Ruby native binding + reactor RST hardening

### DIFF
--- a/code/packages/ruby/irc-server-native/BUILD
+++ b/code/packages/ruby/irc-server-native/BUILD
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake compile && bundle exec rake test

--- a/code/packages/ruby/irc-server-native/BUILD_windows
+++ b/code/packages/ruby/irc-server-native/BUILD_windows
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake compile && bundle exec rake test

--- a/code/packages/ruby/irc-server-native/CHANGELOG.md
+++ b/code/packages/ruby/irc-server-native/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-06-14
+
+### Added
+
+- `CodingAdventures::IrcServerNative::IrcServer` — a Ruby facade for a
+  high-performance IRC server whose IRC and TCP logic run entirely in Rust
+  (`irc-net-reactor` on the home-grown kqueue/epoll reactor). Control surface:
+  `serve` (GVL released around the blocking loop), `start` (background thread),
+  `stop` (callable from another thread), `close`, `local_host` / `local_port` /
+  `local_addr`, `running?`.
+- `irc_server_native` C extension (Rust cdylib via the zero-dependency
+  `ruby-bridge`): `NativeServer` with `initialize` / `serve` / `stop` /
+  `dispose` / `running?` / `local_host` / `local_port`, plus an `Error` class.
+  No per-message callback into Ruby — the binding is lifecycle-only.
+- `extconf.rb` + `build_config.rb` + `Rakefile` that compile the cdylib via
+  cargo and install it into `lib/` under the platform `DLEXT`; `build.rs`
+  carries the macOS `dynamic_lookup` and Windows libruby link configuration.
+- `BUILD` / `BUILD_windows`: `bundle install && rake compile && rake test`.
+- End-to-end tests (minitest, real TCP sockets): registration, PING/PONG,
+  channel `PRIVMSG` broadcast between two clients, `QUIT` broadcast, and the
+  native dispose-while-running guard.
+
+### Security / robustness
+
+- `serve` runs on an **owned clone** of the engine and sets the `running` flag
+  before releasing the GVL, so a concurrent `dispose` cannot cause a
+  use-after-free (mirrors the Python binding's hardening).
+- Hardened the shared `stream-reactor` event loop (used by every binding): a
+  per-connection read or write error (e.g. `ECONNRESET` from a client that
+  vanished) now closes only that connection and runs its close callback, instead
+  of propagating out of `serve` and tearing down the whole event loop. This bug
+  was surfaced by the Ruby broadcast test (a client closing with unread data
+  sends a TCP RST). Added an `irc-net-reactor` regression test
+  (`server_survives_a_client_connection_reset`).

--- a/code/packages/ruby/irc-server-native/Gemfile
+++ b/code/packages/ruby/irc-server-native/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/irc-server-native/README.md
+++ b/code/packages/ruby/irc-server-native/README.md
@@ -1,0 +1,79 @@
+# coding_adventures_irc_server_native
+
+A **high-performance IRC server for Ruby** — every line of IRC and TCP logic
+runs in Rust (the [`irc-net-reactor`](../../rust/irc-net-reactor) engine on the
+home-grown `kqueue`/`epoll` reactor). Ruby only launches and controls the
+server, through a native extension built on the zero-dependency `ruby-bridge`
+(no Magnus / rb-sys abstractions).
+
+## Why
+
+This is the Ruby member of a family: one Rust IRC engine, embedded natively in
+every language. Because all logic lives in Rust, the binding is a pure lifecycle
+control surface — **create, serve, stop** — with no per-message callback into
+Ruby.
+
+## Usage
+
+```ruby
+require "coding_adventures_irc_server_native"
+
+server = CodingAdventures::IrcServerNative::IrcServer.new(port: 6667)
+server.serve   # blocks until another thread calls server.stop
+```
+
+Bind an ephemeral port and serve on a background thread (handy for tests):
+
+```ruby
+server = CodingAdventures::IrcServerNative::IrcServer.new(port: 0)
+server.start                       # serves on a background thread
+puts "listening on #{server.local_addr}"
+# ... connect IRC clients to server.local_host:server.local_port ...
+server.close                       # stop + join + release the listener
+```
+
+Point an IRC client (irssi, WeeChat, `nc`) at the host/port, register with
+`NICK`/`USER`, `JOIN #channel`, and chat — the broadcast fan-out to other
+channel members happens entirely in Rust.
+
+## API
+
+`CodingAdventures::IrcServerNative::IrcServer`:
+
+| method                        | description                                        |
+|-------------------------------|----------------------------------------------------|
+| `new(host:, port:, server_name:, motd:, oper_password:, max_connections:)` | build + bind |
+| `serve`                       | run the event loop, blocking (the GVL is released) |
+| `start`                       | serve on a background thread, returns once running |
+| `stop`                        | signal the loop to stop (safe from another thread) |
+| `close`                       | stop, join the thread, release the listener        |
+| `local_host` / `local_port` / `local_addr` | the bound address                    |
+| `running?`                    | whether the loop is currently running              |
+
+The lower-level `CodingAdventures::IrcServerNative::NativeServer` is the raw C
+extension class; most users want the `IrcServer` facade above.
+
+## How it's built
+
+`rake compile` runs `cargo build --release` in `ext/irc_server_native` (via the
+generated Makefile) and copies the cdylib into `lib/` under Ruby's `DLEXT`
+(`.so`/`.bundle`/`.dll`). The `BUILD` script is `bundle install && rake compile
+&& rake test`.
+
+## Resilience
+
+The native `serve` releases the GVL around the blocking loop and runs on an
+**owned clone** of the engine, so a concurrent `dispose` cannot free the engine
+out from under it. The underlying reactor closes a single connection (and never
+the whole loop) when a client resets — so one crashed or hostile client can't
+take the server down.
+
+## Layer position
+
+```
+CodingAdventures::IrcServerNative::IrcServer        (this gem — Ruby facade)
+        ↓ irc_server_native C extension (ruby-bridge, GVL released on serve)
+irc-net-reactor   (Rust IRC engine, in-process broadcast)
+        ↓
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+```

--- a/code/packages/ruby/irc-server-native/Rakefile
+++ b/code/packages/ruby/irc-server-native/Rakefile
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+require "rbconfig"
+require_relative "ext/irc_server_native/build_config"
+
+DLEXT = RbConfig::CONFIG["DLEXT"]
+EXT_DIR = File.expand_path("ext/irc_server_native", __dir__)
+LIB_DIR = File.expand_path("lib", __dir__)
+
+CARGO_LIB = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libirc_server_native.dylib"
+            when /mingw|mswin|cygwin/
+              "irc_server_native.dll"
+            else
+              "libirc_server_native.so"
+            end
+
+TARGET = "irc_server_native.#{DLEXT}"
+
+desc "Compile the Rust native extension"
+task :compile do
+  cd EXT_DIR do
+    sh(*IrcServerNativeBuildConfig.cargo_build_command)
+  end
+
+  src = File.join(IrcServerNativeBuildConfig.target_release_dir(EXT_DIR), CARGO_LIB)
+  dst = File.join(LIB_DIR, TARGET)
+  mkdir_p LIB_DIR
+  cp src, dst
+  puts "Installed #{TARGET} to lib/"
+end
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+task test: :compile
+
+desc "Remove build artifacts"
+task :clean do
+  cd EXT_DIR do
+    sh(*IrcServerNativeBuildConfig.cargo_clean_command) if File.exist?("Cargo.toml")
+  end
+  rm_f Dir[File.join(LIB_DIR, "irc_server_native.*")]
+end
+
+task default: :test

--- a/code/packages/ruby/irc-server-native/coding_adventures_irc_server_native.gemspec
+++ b/code/packages/ruby/irc-server-native/coding_adventures_irc_server_native.gemspec
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "lib/coding_adventures/irc_server_native/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "coding_adventures_irc_server_native"
+  spec.version       = CodingAdventures::IrcServerNative::VERSION
+  spec.authors       = ["Adhithya Rajasekaran"]
+  spec.summary       = "High-performance IRC server for Ruby, backed by the all-Rust irc-net-reactor engine"
+  spec.description   = "A native extension that embeds the irc-net-reactor Rust IRC engine (on the " \
+                       "home-grown kqueue/epoll reactor) via ruby-bridge. Ruby launches and controls " \
+                       "the server; all IRC and TCP logic runs in Rust."
+  spec.homepage      = "https://github.com/adhithyan15/coding-adventures"
+  spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.0.0"
+
+  spec.files         = Dir[
+    "lib/**/*.rb",
+    "ext/**/*.{rb,rs,toml}",
+    "README.md",
+    "CHANGELOG.md"
+  ]
+  spec.require_paths = ["lib"]
+  spec.extensions    = ["ext/irc_server_native/extconf.rb"]
+
+  spec.metadata = {
+    "source_code_uri" => "https://github.com/adhithyan15/coding-adventures",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+end

--- a/code/packages/ruby/irc-server-native/ext/irc_server_native/Cargo.toml
+++ b/code/packages/ruby/irc-server-native/ext/irc_server_native/Cargo.toml
@@ -1,0 +1,23 @@
+# irc_server_native — Ruby C extension wrapping the Rust IRC engine.
+#
+# All IRC + TCP logic lives in `irc-net-reactor` (Rust, on the home-grown
+# kqueue/epoll reactor).  This crate is a thin control surface: create the
+# server, run it (releasing the GVL around the blocking event loop), stop it.
+# There is NO per-message callback into Ruby — the host language only launches
+# and controls the server.
+#
+# crate-type = ["cdylib"]: emit a shared library Ruby can `require`.
+
+[package]
+name = "irc-server-native-ruby"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+name = "irc_server_native"
+
+[dependencies]
+irc-net-reactor = { path = "../../../../rust/irc-net-reactor" }
+ruby-bridge = { path = "../../../../rust/ruby-bridge" }

--- a/code/packages/ruby/irc-server-native/ext/irc_server_native/build.rs
+++ b/code/packages/ruby/irc-server-native/ext/irc_server_native/build.rs
@@ -1,0 +1,146 @@
+use std::path::PathBuf;
+
+fn main() {
+    match std::env::var("CARGO_CFG_TARGET_OS")
+        .unwrap_or_default()
+        .as_str()
+    {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => link_ruby_on_windows(),
+        _ => {}
+    }
+}
+
+fn link_ruby_on_windows() {
+    let Some(ruby) = find_ruby() else {
+        return;
+    };
+    let (Some(bin_dir), Some(lib_dir), Some(so_name)) = (
+        get_ruby_config(&ruby, "bindir"),
+        get_ruby_config(&ruby, "libdir"),
+        get_ruby_config(&ruby, "RUBY_SO_NAME"),
+    ) else {
+        return;
+    };
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    println!("cargo:rustc-link-search=native={lib_dir}");
+    println!("cargo:rustc-link-search=native={bin_dir}");
+
+    if target_env == "msvc" {
+        if generate_msvc_lib(&format!("{so_name}.dll"), &so_name, &out_dir) {
+            println!("cargo:rustc-link-search=native={out_dir}");
+            println!("cargo:rustc-link-lib={so_name}");
+        } else {
+            println!("cargo:rustc-link-lib=dylib={so_name}");
+        }
+        println!("cargo:rustc-cdylib-link-arg=/FORCE:UNRESOLVED");
+    } else if let Some(import_library) = get_ruby_config(&ruby, "LIBRUBY") {
+        let import_library = PathBuf::from(lib_dir).join(import_library);
+        println!("cargo:rustc-cdylib-link-arg={}", import_library.display());
+    } else {
+        println!("cargo:rustc-link-lib=dylib={so_name}");
+    }
+}
+
+fn generate_msvc_lib(dll_name: &str, so_name: &str, out_dir: &str) -> bool {
+    let symbols: &[(&str, bool)] = &[
+        ("rb_define_module", false),
+        ("rb_define_module_under", false),
+        ("rb_define_class_under", false),
+        ("rb_define_method", false),
+        ("rb_define_singleton_method", false),
+        ("rb_define_module_function", false),
+        ("rb_define_alloc_func", false),
+        ("rb_path2class", false),
+        ("rb_utf8_str_new", false),
+        ("rb_string_value_cstr", false),
+        ("rb_ary_new", false),
+        ("rb_ary_push", false),
+        ("rb_ary_entry", false),
+        ("rb_intern", false),
+        ("rb_funcallv", false),
+        ("rb_num2long", false),
+        ("rb_int2inum", false),
+        ("rb_float_new", false),
+        ("rb_num2dbl", false),
+        ("rb_hash_new", false),
+        ("rb_hash_aset", false),
+        ("rb_data_object_wrap", false),
+        ("rb_check_typeddata", false),
+        ("rb_raise", false),
+        ("rb_str_strlen", false),
+        ("rb_thread_call_without_gvl", false),
+        ("rb_thread_call_with_gvl", false),
+        ("rb_protect", false),
+        ("rb_errinfo", false),
+        ("rb_set_errinfo", false),
+        ("rb_cObject", true),
+        ("rb_eStandardError", true),
+        ("rb_eArgError", true),
+        ("rb_eRuntimeError", true),
+    ];
+
+    let def_path = PathBuf::from(out_dir).join(format!("{so_name}.def"));
+    let mut def_content = format!("LIBRARY {dll_name}\nEXPORTS\n");
+    for (sym, is_data) in symbols {
+        if *is_data {
+            def_content.push_str(&format!("    {sym} DATA\n"));
+        } else {
+            def_content.push_str(&format!("    {sym}\n"));
+        }
+    }
+    if std::fs::write(&def_path, def_content).is_err() {
+        return false;
+    }
+
+    let lib_path = PathBuf::from(out_dir).join(format!("{so_name}.lib"));
+    for program in ["lib.exe", "lib"] {
+        let result = std::process::Command::new(program)
+            .args([
+                &format!("/def:{}", def_path.display()),
+                &format!("/out:{}", lib_path.display()),
+                "/machine:x64",
+                "/nologo",
+            ])
+            .output();
+        if matches!(result, Ok(output) if output.status.success() && lib_path.exists()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn get_ruby_config(ruby: &str, key: &str) -> Option<String> {
+    let script = format!("require 'rbconfig'; print RbConfig::CONFIG['{key}']");
+    let output = std::process::Command::new(ruby)
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn find_ruby() -> Option<String> {
+    for finder in ["where", "which"] {
+        if let Ok(output) = std::process::Command::new(finder).arg("ruby").output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}

--- a/code/packages/ruby/irc-server-native/ext/irc_server_native/build_config.rb
+++ b/code/packages/ruby/irc-server-native/ext/irc_server_native/build_config.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Cross-platform cargo invocation for the irc_server_native extension.
+# Mirrors conduit's build_config: on Windows MinGW it routes cargo through
+# `ridk exec` and targets the right triple; everywhere else it just runs cargo.
+
+require "rbconfig"
+
+module IrcServerNativeBuildConfig
+  module_function
+
+  def cargo_build_command
+    cargo_runner + ["build", "--release"] + rust_target_args
+  end
+
+  def cargo_clean_command
+    cargo_runner + ["clean"]
+  end
+
+  def cargo_make_command
+    (cargo_runner + ["build", "--release"] + rust_target_args).join(" ")
+  end
+
+  def target_release_dir(ext_dir)
+    target = rust_target
+    return File.join(ext_dir, "target", "release") if target.nil?
+
+    File.join(ext_dir, "target", target, "release")
+  end
+
+  def rust_target_args
+    target = rust_target
+    target.nil? ? [] : ["--target", target]
+  end
+
+  def rust_target
+    unless ENV["IRC_SERVER_NATIVE_RUST_TARGET"].to_s.empty?
+      return ENV["IRC_SERVER_NATIVE_RUST_TARGET"]
+    end
+
+    case host_os
+    when /mingw|cygwin/
+      case host_cpu
+      when /x64|x86_64/ then "x86_64-pc-windows-gnu"
+      when /i\d86|x86/ then "i686-pc-windows-gnu"
+      end
+    when /mswin|msvc/
+      case host_cpu
+      when /x64|x86_64/ then "x86_64-pc-windows-msvc"
+      when /i\d86|x86/ then "i686-pc-windows-msvc"
+      end
+    end
+  end
+
+  def cargo_runner
+    if ruby_mingw? && ridk_available?
+      ["ridk", "exec", "cargo"]
+    else
+      ["cargo"]
+    end
+  end
+
+  def ruby_mingw?
+    host_os.match?(/mingw|cygwin/)
+  end
+
+  def host_os
+    RbConfig::CONFIG["host_os"].to_s
+  end
+
+  def host_cpu
+    RbConfig::CONFIG["host_cpu"].to_s
+  end
+
+  def ridk_available?
+    if @ridk_available.nil?
+      @ridk_available = system("ridk", "version", out: File::NULL, err: File::NULL)
+    end
+    @ridk_available
+  end
+end

--- a/code/packages/ruby/irc-server-native/ext/irc_server_native/extconf.rb
+++ b/code/packages/ruby/irc-server-native/ext/irc_server_native/extconf.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# extconf.rb — generate a Makefile that builds the extension via cargo.
+#
+# Standard Ruby extensions use mkmf to compile C; we skip it and write a
+# Makefile that runs `cargo build --release` and copies the resulting cdylib
+# into lib/ under Ruby's platform-specific DLEXT (.so/.bundle/.dll).
+
+require "rbconfig"
+require_relative "build_config"
+
+dlext = RbConfig::CONFIG["DLEXT"]
+cargo_lib = case RbConfig::CONFIG["host_os"]
+            when /darwin/
+              "libirc_server_native.dylib"
+            when /mingw|mswin|cygwin/
+              "irc_server_native.dll"
+            else
+              "libirc_server_native.so"
+            end
+
+target = "irc_server_native.#{dlext}"
+lib_dir = File.expand_path("../../lib", __dir__)
+target_dir = IrcServerNativeBuildConfig.target_release_dir(File.expand_path(__dir__))
+cargo_command = IrcServerNativeBuildConfig.cargo_make_command
+
+File.write("Makefile", <<~MAKEFILE)
+  CARGO_DIR = #{File.expand_path(__dir__)}
+  TARGET_DIR = #{target_dir}
+  CARGO = #{cargo_command}
+  CARGO_LIB = $(TARGET_DIR)/#{cargo_lib}
+  INSTALL_DIR = #{lib_dir}
+  TARGET = $(INSTALL_DIR)/#{target}
+
+  all: $(TARGET)
+
+  $(TARGET): $(CARGO_LIB)
+  \t@mkdir -p $(INSTALL_DIR)
+  \tcp $(CARGO_LIB) $(TARGET)
+
+  $(CARGO_LIB): src/lib.rs Cargo.toml
+  \tcd $(CARGO_DIR) && $(CARGO)
+
+  clean:
+  \tcd $(CARGO_DIR) && #{IrcServerNativeBuildConfig.cargo_clean_command.join(" ")}
+  \trm -f $(TARGET)
+
+  install: $(TARGET)
+
+  .PHONY: all clean install
+MAKEFILE
+
+puts "Makefile generated; will build via `cargo build --release`"

--- a/code/packages/ruby/irc-server-native/ext/irc_server_native/src/lib.rs
+++ b/code/packages/ruby/irc-server-native/ext/irc_server_native/src/lib.rs
@@ -1,0 +1,299 @@
+//! `irc_server_native` — a Ruby C extension that embeds the all-Rust IRC engine
+//! (`irc-net-reactor`) and exposes a small lifecycle control surface.
+//!
+//! ## Design: control surface only, no callbacks
+//!
+//! All IRC and TCP logic lives in Rust (`irc-net-reactor` on the home-grown
+//! kqueue/epoll reactor).  Ruby's only job is to *launch and control* the
+//! server, so `CodingAdventures::IrcServerNative::Server` exposes:
+//!
+//! | method         | meaning                                                 |
+//! |----------------|---------------------------------------------------------|
+//! | `new(host, port, server_name, motd, oper_password, max_connections)` | build + bind |
+//! | `serve`        | run the event loop, **releasing the GVL**               |
+//! | `stop`         | signal the loop to stop (callable from another thread)  |
+//! | `local_host` / `local_port` | the bound address                          |
+//! | `running?`     | is the loop currently running?                          |
+//! | `dispose`      | drop the engine (must be stopped first)                 |
+//!
+//! Unlike `conduit`, there is no per-request dispatch back into Ruby.
+//!
+//! ## GVL discipline and resilience
+//!
+//! `serve` releases the GVL via `rb_thread_call_without_gvl` around the blocking
+//! `IrcReactorServer::serve()`, so a *different* Ruby thread can call `stop`
+//! (which only touches the thread-safe stop handle) while the loop runs.
+//!
+//! Two safety measures mirror the Python binding:
+//!
+//! * `serve` runs on an **owned clone** of the engine (cheap — `IrcReactorServer`
+//!   is `Clone` over `Arc`s), so even if another thread disposed the stored copy
+//!   the runtime stays alive: no use-after-free.
+//! * the `running` flag is set to true **before** the GVL is released, and
+//!   `dispose` (which runs only with the GVL held) refuses to free a live server.
+
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use irc_net_reactor::{IrcConfig, IrcReactorServer};
+use ruby_bridge::{
+    bool_to_rb, define_alloc_func, define_class_under, define_method_raw, define_module,
+    define_module_under, nil_value, object_class, raise_arg_error, raise_error, rb_num2long,
+    standard_error_class, str_from_rb, str_to_rb, unwrap_data_mut, usize_to_rb, vec_str_from_rb,
+    wrap_data, VALUE,
+};
+
+// `rb_thread_call_without_gvl` is part of the stable Ruby C API but is not
+// wrapped by ruby-bridge (its function-pointer signature is use-site specific).
+extern "C" {
+    fn rb_thread_call_without_gvl(
+        func: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+        data1: *mut c_void,
+        unblock: Option<unsafe extern "C" fn(*mut c_void)>,
+        data2: *mut c_void,
+    ) -> *mut c_void;
+}
+
+/// The custom exception class raised on server errors, set up in `Init_`.
+static mut SERVER_ERROR: VALUE = 0;
+
+fn raise_server_error(message: &str) -> ! {
+    // SAFETY: SERVER_ERROR is assigned once in Init_irc_server_native before any
+    // method can run, and only read thereafter.
+    let class = unsafe { SERVER_ERROR };
+    raise_error(class, message)
+}
+
+/// The Rust state wrapped inside each Ruby `Server` object.  `running` mirrors
+/// the engine's serve state so `dispose` can refuse to free a live server.
+struct RubyIrcServer {
+    server: Option<IrcReactorServer>,
+    running: Arc<AtomicBool>,
+}
+
+/// Ruby allocates the object (empty) before calling `initialize`.
+unsafe extern "C" fn server_alloc(klass: VALUE) -> VALUE {
+    wrap_data(
+        klass,
+        RubyIrcServer {
+            server: None,
+            running: Arc::new(AtomicBool::new(false)),
+        },
+    )
+}
+
+// ── argument helpers ───────────────────────────────────────────────────────
+
+fn string_from_rb(value: VALUE, message: &str) -> String {
+    str_from_rb(value).unwrap_or_else(|| raise_arg_error(message))
+}
+
+fn usize_from_rb(value: VALUE, message: &str) -> usize {
+    // rb_num2long raises a Ruby TypeError itself if `value` is not numeric.
+    let number = unsafe { rb_num2long(value) };
+    if number < 0 {
+        raise_arg_error(message);
+    }
+    number as usize
+}
+
+fn u16_from_rb(value: VALUE, message: &str) -> u16 {
+    let number = usize_from_rb(value, message);
+    if number > u16::MAX as usize {
+        raise_arg_error(message);
+    }
+    number as u16
+}
+
+// ── initialize ─────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+extern "C" fn server_initialize(
+    self_val: VALUE,
+    host_val: VALUE,
+    port_val: VALUE,
+    name_val: VALUE,
+    motd_val: VALUE,
+    oper_val: VALUE,
+    max_val: VALUE,
+) -> VALUE {
+    let host = string_from_rb(host_val, "host must be a String");
+    let port = u16_from_rb(port_val, "port must be between 0 and 65535");
+    let server_name = string_from_rb(name_val, "server_name must be a String");
+    let motd = vec_str_from_rb(motd_val);
+    let oper_password = string_from_rb(oper_val, "oper_password must be a String");
+    let max_connections = usize_from_rb(max_val, "max_connections must be >= 1");
+    if max_connections < 1 {
+        raise_arg_error("max_connections must be >= 1");
+    }
+
+    let config = IrcConfig {
+        host,
+        port,
+        server_name,
+        motd,
+        oper_password,
+        max_connections,
+    };
+
+    let server = match IrcReactorServer::bind(config) {
+        Ok(server) => server,
+        Err(err) => raise_server_error(&format!("failed to bind IRC server: {err}")),
+    };
+
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    slot.server = Some(server);
+    self_val
+}
+
+// ── serve (GVL released) ─────────────────────────────────────────────────────
+
+/// Carries the owned engine clone and the result across the GVL boundary.
+struct ServeCall {
+    server: IrcReactorServer,
+    ok: bool,
+    error: Option<String>,
+}
+
+/// Runs with the GVL released.  Touches only the owned clone — never the Ruby
+/// object — so it cannot race `stop`/`dispose` (which run with the GVL held).
+unsafe extern "C" fn serve_without_gvl(data: *mut c_void) -> *mut c_void {
+    let call = &mut *(data as *mut ServeCall);
+    match call.server.serve() {
+        Ok(()) => call.ok = true,
+        Err(err) => {
+            call.ok = false;
+            call.error = Some(format!("IRC server error: {err}"));
+        }
+    }
+    ptr::null_mut()
+}
+
+extern "C" fn server_serve(self_val: VALUE) -> VALUE {
+    // Clone the engine and grab the running flag while we (implicitly) hold the
+    // GVL, then release it for the blocking run.  The owned clone keeps the
+    // runtime alive even if another thread disposes the stored copy.
+    let (server, running) = {
+        let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+        let server = match slot.server.as_ref() {
+            Some(server) => server.clone(),
+            None => raise_server_error("server has been disposed"),
+        };
+        (server, Arc::clone(&slot.running))
+    };
+
+    // Set running BEFORE releasing the GVL so `dispose` always observes it.
+    running.store(true, Ordering::SeqCst);
+    let mut call = ServeCall {
+        server,
+        ok: false,
+        error: None,
+    };
+    unsafe {
+        rb_thread_call_without_gvl(
+            serve_without_gvl,
+            &mut call as *mut ServeCall as *mut c_void,
+            None,
+            ptr::null_mut(),
+        );
+    }
+    running.store(false, Ordering::SeqCst);
+
+    if call.ok {
+        nil_value()
+    } else {
+        let message = call
+            .error
+            .take()
+            .unwrap_or_else(|| "IRC server error".to_string());
+        // Drop the owned clone before the longjmp in raise_* skips destructors.
+        drop(call);
+        raise_server_error(&message);
+    }
+}
+
+// ── stop / dispose / running? / local_host / local_port ──────────────────────
+
+extern "C" fn server_stop(self_val: VALUE) -> VALUE {
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    match slot.server.as_ref() {
+        Some(server) => {
+            server.stop();
+            nil_value()
+        }
+        None => raise_server_error("server has been disposed"),
+    }
+}
+
+extern "C" fn server_dispose(self_val: VALUE) -> VALUE {
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    if slot.running.load(Ordering::SeqCst) {
+        raise_server_error("cannot dispose a running server; call stop first");
+    }
+    slot.server.take();
+    nil_value()
+}
+
+extern "C" fn server_running(self_val: VALUE) -> VALUE {
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    bool_to_rb(slot.running.load(Ordering::SeqCst))
+}
+
+extern "C" fn server_local_host(self_val: VALUE) -> VALUE {
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    match slot.server.as_ref() {
+        Some(server) => str_to_rb(&server.local_addr().ip().to_string()),
+        None => raise_server_error("server has been disposed"),
+    }
+}
+
+extern "C" fn server_local_port(self_val: VALUE) -> VALUE {
+    let slot = unsafe { unwrap_data_mut::<RubyIrcServer>(self_val) };
+    match slot.server.as_ref() {
+        Some(server) => usize_to_rb(server.local_addr().port() as usize),
+        None => raise_server_error("server has been disposed"),
+    }
+}
+
+// ── module init ──────────────────────────────────────────────────────────────
+
+/// Entry point — Ruby calls this when the extension is `require`d.
+///
+/// # Safety
+/// Called once by the Ruby loader on the main thread.
+#[no_mangle]
+pub extern "C" fn Init_irc_server_native() {
+    let coding_adventures = define_module("CodingAdventures");
+    let module = define_module_under(coding_adventures, "IrcServerNative");
+
+    let error_class = define_class_under(module, "Error", standard_error_class());
+    // SAFETY: assigned once here before any method can run.
+    unsafe { SERVER_ERROR = error_class };
+
+    let server_class = define_class_under(module, "NativeServer", object_class());
+    define_alloc_func(server_class, server_alloc);
+    define_method_raw(
+        server_class,
+        "initialize",
+        server_initialize as *const c_void,
+        6,
+    );
+    define_method_raw(server_class, "serve", server_serve as *const c_void, 0);
+    define_method_raw(server_class, "stop", server_stop as *const c_void, 0);
+    define_method_raw(server_class, "dispose", server_dispose as *const c_void, 0);
+    define_method_raw(server_class, "running?", server_running as *const c_void, 0);
+    define_method_raw(
+        server_class,
+        "local_host",
+        server_local_host as *const c_void,
+        0,
+    );
+    define_method_raw(
+        server_class,
+        "local_port",
+        server_local_port as *const c_void,
+        0,
+    );
+}

--- a/code/packages/ruby/irc-server-native/lib/coding_adventures/irc_server_native/server.rb
+++ b/code/packages/ruby/irc-server-native/lib/coding_adventures/irc_server_native/server.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrcServerNative
+    # IrcServer — the Ruby control surface for the Rust IRC engine.
+    #
+    # A thin, ergonomic wrapper over the native +NativeServer+ class, which
+    # embeds the all-Rust +irc-net-reactor+ engine.  Every line of IRC and TCP
+    # logic runs in Rust; this class only creates, runs, and stops the server.
+    #
+    # Typical usage:
+    #
+    #   server = CodingAdventures::IrcServerNative::IrcServer.new(port: 6667)
+    #   server.serve            # blocks until another thread calls #stop
+    #
+    # Or run it in the background and stop after assertions (e.g. in tests):
+    #
+    #   server = CodingAdventures::IrcServerNative::IrcServer.new(port: 0)
+    #   server.start            # serves on a background thread
+    #   # ... connect IRC clients to server.local_host:server.local_port ...
+    #   server.close
+    class IrcServer
+      DEFAULT_HOST = "127.0.0.1"
+      DEFAULT_PORT = 6667
+      DEFAULT_SERVER_NAME = "irc.local"
+      DEFAULT_MOTD = ["Welcome."].freeze
+      DEFAULT_MAX_CONNECTIONS = 1024
+
+      def initialize(host: DEFAULT_HOST, port: DEFAULT_PORT, server_name: DEFAULT_SERVER_NAME,
+                     motd: nil, oper_password: "", max_connections: DEFAULT_MAX_CONNECTIONS)
+        motd_lines = (motd && !motd.empty? ? motd : DEFAULT_MOTD).map(&:to_s)
+        @native = NativeServer.new(
+          host.to_s,
+          Integer(port),
+          server_name.to_s,
+          motd_lines,
+          oper_password.to_s,
+          Integer(max_connections)
+        )
+        @thread = nil
+        @closed = false
+      end
+
+      # Run the event loop, blocking until #stop is called.  The native layer
+      # releases the GVL, so another Ruby thread can call #stop.
+      def serve
+        ensure_open
+        @native.serve
+      end
+
+      # Serve on a background thread and return once the loop is running.
+      def start
+        ensure_open
+        raise Error, "server thread is already running" if @thread&.alive?
+
+        @thread = Thread.new { @native.serve }
+        wait_until_running
+        @thread
+      end
+
+      # Signal the event loop to stop; a blocked #serve returns.
+      def stop
+        return if @closed
+
+        @native.stop
+      end
+
+      # Join the background serve thread (if any).
+      def wait(timeout = nil)
+        @thread&.join(timeout)
+      end
+
+      # Stop the server, wait for the background thread, and release the listener.
+      def close
+        return if @closed
+
+        stop
+        wait(5)
+        @native.dispose
+        @closed = true
+      end
+
+      def running?
+        !@closed && @native.running?
+      end
+
+      def local_host
+        @native.local_host
+      end
+
+      def local_port
+        @native.local_port
+      end
+
+      # The bound "host:port" address.
+      def local_addr
+        "#{local_host}:#{local_port}"
+      end
+
+      private
+
+      def ensure_open
+        raise Error, "server is closed" if @closed
+      end
+
+      def wait_until_running
+        100.times do
+          return if @native.running?
+          raise Error, "server thread exited before listening" unless @thread.alive?
+
+          sleep 0.01
+        end
+        raise Error, "server did not start listening in time"
+      end
+    end
+  end
+end

--- a/code/packages/ruby/irc-server-native/lib/coding_adventures/irc_server_native/version.rb
+++ b/code/packages/ruby/irc-server-native/lib/coding_adventures/irc_server_native/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CodingAdventures
+  module IrcServerNative
+    VERSION = "0.1.0"
+  end
+end

--- a/code/packages/ruby/irc-server-native/lib/coding_adventures_irc_server_native.rb
+++ b/code/packages/ruby/irc-server-native/lib/coding_adventures_irc_server_native.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "coding_adventures/irc_server_native/version"
+
+# Load the compiled native extension (lib/irc_server_native.{so,bundle,dll}),
+# which runs Init_irc_server_native and defines
+# CodingAdventures::IrcServerNative::NativeServer + ::Error.
+require "irc_server_native"
+
+require_relative "coding_adventures/irc_server_native/server"

--- a/code/packages/ruby/irc-server-native/test/irc_server_native_test.rb
+++ b/code/packages/ruby/irc-server-native/test/irc_server_native_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "socket"
+require "coding_adventures_irc_server_native"
+
+# End-to-end tests: start the real Rust IRC engine on an ephemeral port and
+# drive live IRC clients over real TCP sockets.
+class IrcServerNativeTest < Minitest::Test
+  Error = CodingAdventures::IrcServerNative::Error
+  IrcServer = CodingAdventures::IrcServerNative::IrcServer
+  NativeServer = CodingAdventures::IrcServerNative::NativeServer
+
+  def setup
+    @server = IrcServer.new(host: "127.0.0.1", port: 0, server_name: "irc.test")
+    @server.start
+    @port = @server.local_port
+  end
+
+  def teardown
+    @server&.close
+  end
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def recv_until(sock, needle, timeout: 5.0)
+    deadline = Time.now + timeout
+    buf = +""
+    while Time.now < deadline
+      next unless IO.select([sock], nil, nil, 0.3)
+
+      begin
+        buf << sock.read_nonblock(4096)
+      rescue IO::WaitReadable
+        next
+      rescue EOFError
+        break
+      end
+      break if buf.include?(needle)
+    end
+    buf
+  end
+
+  def connect
+    TCPSocket.new("127.0.0.1", @port)
+  end
+
+  def register(sock, nick)
+    sock.write("NICK #{nick}\r\nUSER #{nick} 0 * :#{nick}\r\n")
+    welcome = recv_until(sock, "001")
+    assert_includes welcome, "001", "expected 001 welcome for #{nick}"
+  end
+
+  # ── tests ──────────────────────────────────────────────────────────────────
+
+  def test_local_addr_and_running
+    assert_equal "127.0.0.1", @server.local_host
+    assert_operator @server.local_port, :>, 0
+    assert @server.running?
+    assert_equal "127.0.0.1:#{@port}", @server.local_addr
+  end
+
+  def test_registration_and_ping
+    alice = connect
+    register(alice, "alice")
+    alice.write("PING :liveness\r\n")
+    pong = recv_until(alice, "PONG")
+    assert_includes pong, "PONG"
+  ensure
+    alice&.close
+  end
+
+  def test_privmsg_broadcasts_between_clients
+    alice = connect
+    bob = connect
+    register(alice, "alice")
+    register(bob, "bob")
+    alice.write("JOIN #test\r\n")
+    bob.write("JOIN #test\r\n")
+    recv_until(alice, "JOIN")
+    recv_until(bob, "JOIN")
+
+    # Alice speaks; Bob (a different connection) must receive it — exercises the
+    # Rust engine's in-process mailbox fan-out.
+    alice.write("PRIVMSG #test :hello bob\r\n")
+    received = recv_until(bob, "hello bob")
+    assert_includes received, "PRIVMSG"
+    assert_includes received, "hello bob"
+  ensure
+    alice&.close
+    bob&.close
+  end
+
+  def test_quit_broadcasts_to_channel
+    alice = connect
+    bob = connect
+    register(alice, "alice")
+    register(bob, "bob")
+    alice.write("JOIN #test\r\n")
+    bob.write("JOIN #test\r\n")
+    recv_until(bob, "JOIN")
+
+    alice.write("QUIT :leaving now\r\n")
+    quit = recv_until(bob, "QUIT")
+    assert_includes quit, "QUIT"
+  ensure
+    alice&.close
+    bob&.close
+  end
+
+  # The native dispose frees the engine; doing so mid-serve would be a
+  # use-after-free, so it must be refused while the loop is running.
+  def test_native_dispose_refused_while_running
+    native = NativeServer.new("127.0.0.1", 0, "irc.test", ["hi"], "", 1024)
+    thread = Thread.new { native.serve }
+    100.times { break if native.running?; sleep 0.01 }
+    assert native.running?, "native server should be running"
+
+    err = assert_raises(Error) { native.dispose }
+    assert_match(/running/, err.message)
+  ensure
+    native&.stop
+    thread&.join(5)
+    native&.dispose
+  end
+end

--- a/code/packages/rust/irc-net-reactor/src/lib.rs
+++ b/code/packages/rust/irc-net-reactor/src/lib.rs
@@ -596,6 +596,37 @@ mod tests {
     }
 
     #[test]
+    fn server_survives_a_client_connection_reset() {
+        // A client that vanishes with unread data in its socket buffer triggers
+        // a TCP RST.  The reactor must close only that connection and keep
+        // serving everyone else — a single hostile/crashed client must never
+        // take the whole server down.  (Regression: the read path used to
+        // propagate ECONNRESET out of serve(), killing the event loop.)
+        let (server, handle, addr) = start_server();
+
+        let mut alice = connect(addr);
+        let mut bob = connect(addr);
+        register(&mut alice, "alice");
+        register(&mut bob, "bob");
+
+        // Make the server send Alice data she never reads, then drop her socket
+        // with that data still buffered → the OS sends an RST on close.
+        alice.write_all(b"JOIN #test\r\n").expect("alice joins");
+        drop(alice);
+
+        // Bob must still be served: the event loop survived Alice's reset.
+        bob.write_all(b"PING :still-alive\r\n").expect("bob pings");
+        let pong = read_until(&mut bob, "PONG");
+        assert!(
+            pong.contains("PONG"),
+            "server should keep serving bob after alice's RST, got: {pong:?}"
+        );
+
+        server.stop();
+        handle.join().expect("server thread").expect("server exit");
+    }
+
+    #[test]
     fn quit_command_broadcasts_to_channel() {
         let (server, handle, addr) = start_server();
 

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -533,8 +533,8 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             if close_now || state.read_paused || state.close_when_flushed || state.peer_closed {
                 break;
             }
-            match self.platform.read(stream, &mut buffer)? {
-                ReadOutcome::Read(n) => {
+            match self.platform.read(stream, &mut buffer) {
+                Ok(ReadOutcome::Read(n)) => {
                     let chunk = &buffer[..n];
                     match self.apply_read_chunk(&mut state, chunk) {
                         ReadChunkOutcome::Applied => {}
@@ -552,9 +552,18 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                         break;
                     }
                 }
-                ReadOutcome::WouldBlock => break,
-                ReadOutcome::Closed => {
+                Ok(ReadOutcome::WouldBlock) => break,
+                Ok(ReadOutcome::Closed) => {
                     state.peer_closed = true;
+                    break;
+                }
+                // A per-connection read error (e.g. ECONNRESET from a client that
+                // vanished) must close ONLY this connection and run its close
+                // callback — never propagate out of `serve` and tear down the
+                // whole event loop. Otherwise a single hostile or crashed client
+                // would take every other connection down with it.
+                Err(_) => {
+                    close_now = true;
                     break;
                 }
             }
@@ -596,12 +605,19 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
 
         let mut close_now = false;
         while !state.pending_write.is_empty() {
-            match self.platform.write(stream, &state.pending_write)? {
-                WriteOutcome::Wrote(n) => {
+            match self.platform.write(stream, &state.pending_write) {
+                Ok(WriteOutcome::Wrote(n)) => {
                     state.pending_write.drain(..n);
                 }
-                WriteOutcome::WouldBlock => break,
-                WriteOutcome::Closed => {
+                Ok(WriteOutcome::WouldBlock) => break,
+                Ok(WriteOutcome::Closed) => {
+                    close_now = true;
+                    break;
+                }
+                // A per-connection write error (e.g. broken pipe to a client that
+                // vanished) closes ONLY this connection — like the read path, it
+                // must never tear down the event loop for everyone else.
+                Err(_) => {
                     close_now = true;
                     break;
                 }


### PR DESCRIPTION
## What

PR 3 of the arc to embed one high-performance Rust IRC server in every language. This adds **`irc-server-native`** for Ruby (via the zero-dep `ruby-bridge`, no Magnus), and hardens the shared reactor against a real availability bug the Ruby test surfaced.

```ruby
require "coding_adventures_irc_server_native"
server = CodingAdventures::IrcServerNative::IrcServer.new(port: 6667)
server.serve   # blocks (GVL released) until server.stop
```

All IRC logic stays in Rust; Ruby only launches and controls the server. `serve` releases the GVL via `rb_thread_call_without_gvl`, so another thread can `stop`.

## Reactor robustness fix (the interesting part)

The Ruby broadcast test surfaced a genuine availability bug in the shared `stream-reactor` event loop: a **per-connection read/write error** (e.g. `ECONNRESET` from a client that vanished with unread data — *common*, since IRC pushes unsolicited data and clients close with data still buffered) propagated out of `serve()` via `?` and **tore down the entire event loop**, taking every other connected client down. A single crashed or hostile client could DoS the whole server.

Fixed: such per-connection errors now close only that connection (and run its close callback) instead of killing the loop. Added a regression test `irc-net-reactor::server_survives_a_client_connection_reset` (one client RSTs, the server keeps serving everyone else). Downstream consumers — `tcp-runtime`, `embeddable-tcp-server` — still pass.

This bug latently affected the Python binding too; this fix makes all bindings robust.

## Security review (passed, 1 round)

- `serve` runs on an **owned clone** of the engine and sets `running=true` before releasing the GVL, so a concurrent `dispose` can't free the engine mid-serve (same UAF hardening as the Python binding).
- Returns use `nil_value()`/`bool_to_rb()`, never the raw `QNIL` constant (which can SIGSEGV per repo lessons).
- The reactor fix runs `on_close` exactly once per connection; no double-close, no infinite repoll, no masking of genuinely fatal errors.

## Tests

minitest real-socket tests: registration, PING/PONG, channel `PRIVMSG` broadcast between two clients, `QUIT` broadcast, native dispose-while-running guard. Stable across repeated runs. Build mirrors conduit's proven cross-platform Ruby setup (`extconf.rb` + `build_config.rb` + `build.rs`, incl. Windows libruby linking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)