### PR TITLE
refactor(image-codec-raf): wire colour pipeline through image-raw-pipeline (IMG07 PR-3)

### DIFF
--- a/code/packages/rust/image-codec-raf/CHANGELOG.md
+++ b/code/packages/rust/image-codec-raf/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — image-codec-raf
 
+## [Unreleased]
+
+### Changed
+
+- **`color.rs`** — `apply_color_pipeline` now delegates to
+  `image_raw_pipeline::apply_color_pipeline` (IMG07). Pre-computes `black_avg`
+  (average of the four CFA-plane levels) and normalised WB multipliers before
+  calling the shared crate. Removes the private `linear_to_srgb_u8` helper —
+  now handled by `image_raw_pipeline::srgb_gamma`. All 19 tests unchanged.
+
+---
+
 ## [0.1.0] — 2026-05-29
 
 Initial release implementing the IC14 Fujifilm RAF image codec.

--- a/code/packages/rust/image-codec-raf/Cargo.toml
+++ b/code/packages/rust/image-codec-raf/Cargo.toml
@@ -7,3 +7,4 @@ description = "Fujifilm RAF (RAW image Format) encoder and decoder using PixelCo
 [dependencies]
 pixel-container = { path = "../pixel-container" }
 paint-instructions = { path = "../paint-instructions" }
+image-raw-pipeline = { path = "../image-raw-pipeline" }

--- a/code/packages/rust/image-codec-raf/src/color.rs
+++ b/code/packages/rust/image-codec-raf/src/color.rs
@@ -95,89 +95,23 @@ pub fn apply_color_pipeline(
     wb: [u32; 3],
     color_matrix: [[f64; 3]; 3],
 ) -> Vec<(u8, u8, u8)> {
-    // ── Step 1: compute the average black level across the four CFA planes ──
-    // The four planes are [R, G1, G2, B].  In practice G1 ≈ G2, so averaging
-    // all four is a reasonable approximation.
+    // Average the four CFA-plane black levels [R, G1, G2, B].
+    // G1 ≈ G2 in practice, so averaging is a reasonable approximation.
     let black_avg = ((black_level[0] as u64
         + black_level[1] as u64
         + black_level[2] as u64
         + black_level[3] as u64) / 4) as u32;
 
-    // ── Step 2: normalise WB multipliers so G = 1.0 ─────────────────────────
-    let g_wb = wb[1] as f64;
-    let wb_r = if g_wb > 0.0 { wb[0] as f64 / g_wb } else { 1.0 };
-    let wb_g = 1.0_f64;
-    let wb_b = if g_wb > 0.0 { wb[2] as f64 / g_wb } else { 1.0 };
+    // Normalise WB so G = 1.0; the shared pipeline expects pre-normalised [f64;3].
+    let wb_norm = normalise_wb(wb);
 
-    // ── Step 3: dynamic range denominator ───────────────────────────────────
-    // After black-level subtraction the maximum value is `white_level − black_avg`.
-    // Guard against the degenerate case where white == black.
-    let range = if white_level > black_avg {
-        (white_level - black_avg) as f64
-    } else {
-        4095.0 // fallback: assume 12-bit range
-    };
-
-    rgb.into_iter().map(|(r_raw, g_raw, b_raw)| {
-        // ── subtract black level (floor at 0 to avoid underflow) ────────────
-        let r_ped = (r_raw as u32).saturating_sub(black_avg) as f64;
-        let g_ped = (g_raw as u32).saturating_sub(black_avg) as f64;
-        let b_ped = (b_raw as u32).saturating_sub(black_avg) as f64;
-
-        // ── normalise to [0, 1] ──────────────────────────────────────────────
-        let r_lin = (r_ped / range).clamp(0.0, 1.0);
-        let g_lin = (g_ped / range).clamp(0.0, 1.0);
-        let b_lin = (b_ped / range).clamp(0.0, 1.0);
-
-        // ── apply white balance ──────────────────────────────────────────────
-        let r_wb = (r_lin * wb_r).clamp(0.0, 1.0);
-        let g_wb2 = (g_lin * wb_g).clamp(0.0, 1.0);
-        let b_wb = (b_lin * wb_b).clamp(0.0, 1.0);
-
-        // ── apply 3×3 colour matrix ──────────────────────────────────────────
-        // Each output channel is a dot product of [r_wb, g_wb, b_wb] with the
-        // corresponding row of the colour matrix.
-        let r_srgb = color_matrix[0][0] * r_wb
-                   + color_matrix[0][1] * g_wb2
-                   + color_matrix[0][2] * b_wb;
-        let g_srgb = color_matrix[1][0] * r_wb
-                   + color_matrix[1][1] * g_wb2
-                   + color_matrix[1][2] * b_wb;
-        let b_srgb = color_matrix[2][0] * r_wb
-                   + color_matrix[2][1] * g_wb2
-                   + color_matrix[2][2] * b_wb;
-
-        // ── apply sRGB gamma and convert to u8 ──────────────────────────────
-        let r8 = linear_to_srgb_u8(r_srgb);
-        let g8 = linear_to_srgb_u8(g_srgb);
-        let b8 = linear_to_srgb_u8(b_srgb);
-
-        (r8, g8, b8)
-    }).collect()
-}
-
-// ── private helper ────────────────────────────────────────────────────────────
-
-/// Convert a linear-light value in `[0, 1]` to an sRGB gamma-encoded u8.
-///
-/// The sRGB transfer function (IEC 61966-2-1):
-///
-/// ```text
-/// y = 12.92 × x                   for x ≤ 0.0031308
-/// y = 1.055 × x^(1/2.4) − 0.055  for x >  0.0031308
-/// ```
-///
-/// Input is clamped to `[0, 1]` before applying the curve.
-#[inline]
-fn linear_to_srgb_u8(x: f64) -> u8 {
-    let x = x.clamp(0.0, 1.0);
-    let y = if x <= 0.003_130_8 {
-        12.92 * x
-    } else {
-        1.055 * x.powf(1.0 / 2.4) - 0.055
-    };
-    // Scale [0, 1] → [0, 255] with rounding.
-    (y * 255.0 + 0.5).min(255.0) as u8
+    image_raw_pipeline::apply_color_pipeline(
+        &rgb,
+        black_avg,
+        white_level,
+        wb_norm,
+        color_matrix,
+    )
 }
 
 /// Normalise raw WB multipliers [R, G, B] so that G = 1.0.


### PR DESCRIPTION
## Summary

- Adds `image-raw-pipeline` as a dependency in `image-codec-raf/Cargo.toml`
- Replaces the inline 4-stage colour pipeline body in `color.rs` with delegation to `image_raw_pipeline::apply_color_pipeline`
- Pre-computes `black_avg` (average of four CFA-plane black levels) and normalised WB multipliers (via existing `normalise_wb`) before calling the shared crate
- Removes the private `linear_to_srgb_u8` helper — now handled by `image_raw_pipeline::srgb_gamma`
- All 19 existing tests pass unchanged

## Test plan

- [x] `cargo test -p image-codec-raf` — 19/19 green
- [x] Security review passed (no findings)
- [ ] CI green on this PR

## Context

Part of the IMG07 arc. PR-1 (image-raw-pipeline crate) merged as #5680. PR-2 (wire-tiff) open as #5685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)