### PR TITLE
refactor(image-codec-dng): wire matrix inversion through image-raw-pipeline (IMG07)

### DIFF
--- a/code/packages/rust/image-codec-dng/CHANGELOG.md
+++ b/code/packages/rust/image-codec-dng/CHANGELOG.md
@@ -5,6 +5,24 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **`color.rs`** — `invert_3x3` now delegates to
+  `image_raw_pipeline::invert_3x3` (IMG07). The previous inline Cramer's rule
+  implementation is replaced by a one-line wrapper so the shared crate owns the
+  canonical implementation. `matrix_multiply` body is rewritten using three
+  `image_raw_pipeline::mat3x3_mul` column-vector calls instead of a triple
+  loop, composing the shared vector primitive. Both public APIs and all 21 unit
+  tests + 2 doc-tests are unchanged.
+
+### Dependencies
+
+- Added `image-raw-pipeline = { path = "../image-raw-pipeline" }` (IMG07)
+
+---
+
 ## [0.1.0] — 2026-05-30
 
 ### Added

--- a/code/packages/rust/image-codec-dng/Cargo.toml
+++ b/code/packages/rust/image-codec-dng/Cargo.toml
@@ -9,3 +9,4 @@ license = "MIT"
 pixel-container = { path = "../pixel-container" }
 paint-instructions = { path = "../paint-instructions" }
 image-codec-tiff = { path = "../image-codec-tiff" }
+image-raw-pipeline = { path = "../image-raw-pipeline" }

--- a/code/packages/rust/image-codec-dng/src/color.rs
+++ b/code/packages/rust/image-codec-dng/src/color.rs
@@ -111,15 +111,17 @@ pub fn wb_from_as_shot_neutral(neutrals: &[f64]) -> [f64; 3] {
 ///
 /// This is O(27) floating-point multiplications for 3×3.
 pub fn matrix_multiply(a: &[[f64; 3]; 3], b: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
-    let mut out = [[0f64; 3]; 3];
-    for i in 0..3 {
-        for j in 0..3 {
-            for k in 0..3 {
-                out[i][j] += a[i][k] * b[k][j];
-            }
-        }
-    }
-    out
+    // Decompose B column-by-column: each column of A×B is mat3x3_mul(A, col_j(B)).
+    // col_j(B) = [B[0][j], B[1][j], B[2][j]]  (B is row-major)
+    let c0 = image_raw_pipeline::mat3x3_mul(a, [b[0][0], b[1][0], b[2][0]]);
+    let c1 = image_raw_pipeline::mat3x3_mul(a, [b[0][1], b[1][1], b[2][1]]);
+    let c2 = image_raw_pipeline::mat3x3_mul(a, [b[0][2], b[1][2], b[2][2]]);
+    // Reassemble: result[i][j] = c_j[i]
+    [
+        [c0[0], c1[0], c2[0]],
+        [c0[1], c1[1], c2[1]],
+        [c0[2], c1[2], c2[2]],
+    ]
 }
 
 // ─── ForwardMatrix path ───────────────────────────────────────────────────────
@@ -192,28 +194,5 @@ pub fn camera_to_srgb_via_forward(forward: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
 /// assert!((inv[0][0] - 1.0).abs() < 1e-9);
 /// ```
 pub fn invert_3x3(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
-    // Determinant by cofactor expansion along the first row.
-    let det = m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
-        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
-        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
-
-    if det.abs() < 1e-10 {
-        return None; // singular matrix
-    }
-
-    let inv_det = 1.0 / det;
-    let mut inv = [[0f64; 3]; 3];
-
-    // Cofactors (note the sign alternation pattern: +, -, +, -, +, -, +, -, +)
-    inv[0][0] = (m[1][1] * m[2][2] - m[1][2] * m[2][1]) * inv_det;
-    inv[0][1] = -(m[0][1] * m[2][2] - m[0][2] * m[2][1]) * inv_det;
-    inv[0][2] = (m[0][1] * m[1][2] - m[0][2] * m[1][1]) * inv_det;
-    inv[1][0] = -(m[1][0] * m[2][2] - m[1][2] * m[2][0]) * inv_det;
-    inv[1][1] = (m[0][0] * m[2][2] - m[0][2] * m[2][0]) * inv_det;
-    inv[1][2] = -(m[0][0] * m[1][2] - m[0][2] * m[1][0]) * inv_det;
-    inv[2][0] = (m[1][0] * m[2][1] - m[1][1] * m[2][0]) * inv_det;
-    inv[2][1] = -(m[0][0] * m[2][1] - m[0][1] * m[2][0]) * inv_det;
-    inv[2][2] = (m[0][0] * m[1][1] - m[0][1] * m[1][0]) * inv_det;
-
-    Some(inv)
+    image_raw_pipeline::invert_3x3(m)
 }


### PR DESCRIPTION
## Summary

- Adds `image-raw-pipeline` as a dependency to `image-codec-dng`
- `invert_3x3` replaced with one-line wrapper over `image_raw_pipeline::invert_3x3`, removing 21 lines of inline Cramer's rule
- `matrix_multiply` rewritten using three `image_raw_pipeline::mat3x3_mul` column-vector calls (`A×B` via per-column decomposition) instead of a triple nested loop

## Test plan

- [x] `cargo test -p image-codec-dng` — 21 unit tests + 2 doc-tests pass unchanged
- [x] `cargo build --workspace` — no new errors (pre-existing `uefi` error unrelated)
- [x] Security review passed

Part of IMG07 image-raw-pipeline refactor series (PR-5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)