### PR TITLE
Add Zigbee APS frame readiness summary

### DIFF
--- a/code/packages/rust/zigbee-aps/CHANGELOG.md
+++ b/code/packages/rust/zigbee-aps/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this package will be documented in this file.
 
 - `ApsFrameBatchSummary` for payload-free APS frame-stream delivery, profile,
   cluster, security, ack-request, and payload-volume rollups.
+- `ApsFrameBatchReadinessSummary` for application-delivery, home-automation,
+  cluster, and payload capture readiness checks.
 - `ApsFrameSummary` for payload-free APS routing, delivery, profile, and
   cluster read models.
 - `ApsCommandFrame`, `ApsCommandId`, and `ApsCommandSummary` for APS command

--- a/code/packages/rust/zigbee-aps/README.md
+++ b/code/packages/rust/zigbee-aps/README.md
@@ -16,6 +16,8 @@ boundary:
   supervision
 - frame-batch summary counts for delivery modes, profile/cluster families,
   security, ack requests, and payload volume
+- frame-batch readiness summaries for application-delivery, home-automation,
+  cluster, and payload capture checks
 - binding summary counts for source endpoint shape and cluster coverage
 - binding readiness summaries for application-source, destination, cluster, and
   source-endpoint hygiene checks

--- a/code/packages/rust/zigbee-aps/src/lib.rs
+++ b/code/packages/rust/zigbee-aps/src/lib.rs
@@ -358,6 +358,106 @@ impl ApsFrameBatchSummary {
     pub fn carries_payloads(self) -> bool {
         self.payload_bytes > 0
     }
+
+    pub fn has_application_delivery(self) -> bool {
+        self.unicast_frames > 0 || self.group_frames > 0
+    }
+
+    pub fn has_home_automation_context(self) -> bool {
+        self.home_automation_frames > 0
+    }
+
+    pub fn has_cluster_context(self) -> bool {
+        self.general_cluster_frames > 0 || self.measurement_and_sensing_frames > 0
+    }
+
+    pub fn readiness(self) -> ApsFrameBatchReadinessSummary {
+        ApsFrameBatchReadinessSummary::from_summary(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApsFrameBatchReadinessSummary {
+    pub batch_summary: ApsFrameBatchSummary,
+    pub required_check_count: usize,
+    pub passed_check_count: usize,
+    pub missing_check_count: usize,
+    pub frames_present: bool,
+    pub data_frames_present: bool,
+    pub application_delivery_ready: bool,
+    pub home_automation_context_ready: bool,
+    pub cluster_context_ready: bool,
+    pub payload_context_ready: bool,
+    pub frame_batch_ready: bool,
+}
+
+impl ApsFrameBatchReadinessSummary {
+    pub fn from_summary(batch_summary: ApsFrameBatchSummary) -> Self {
+        let frames_present = !batch_summary.is_empty();
+        let data_frames_present = batch_summary.data_frames > 0;
+        let application_delivery_ready = batch_summary.has_application_delivery();
+        let home_automation_context_ready = batch_summary.has_home_automation_context();
+        let cluster_context_ready = batch_summary.has_cluster_context();
+        let payload_context_ready = batch_summary.carries_payloads();
+        let checks = [
+            frames_present,
+            data_frames_present,
+            application_delivery_ready,
+            home_automation_context_ready,
+            cluster_context_ready,
+            payload_context_ready,
+        ];
+        let passed_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_check_count = checks.len();
+        let missing_check_count = required_check_count - passed_check_count;
+        let frame_batch_ready = missing_check_count == 0;
+
+        Self {
+            batch_summary,
+            required_check_count,
+            passed_check_count,
+            missing_check_count,
+            frames_present,
+            data_frames_present,
+            application_delivery_ready,
+            home_automation_context_ready,
+            cluster_context_ready,
+            payload_context_ready,
+            frame_batch_ready,
+        }
+    }
+
+    pub fn is_frame_batch_ready(self) -> bool {
+        self.frame_batch_ready
+    }
+
+    pub fn has_missing_checks(self) -> bool {
+        self.missing_check_count > 0
+    }
+
+    pub fn needs_frames(self) -> bool {
+        !self.frames_present
+    }
+
+    pub fn needs_data_frames(self) -> bool {
+        !self.data_frames_present
+    }
+
+    pub fn needs_application_delivery(self) -> bool {
+        !self.application_delivery_ready
+    }
+
+    pub fn needs_home_automation_context(self) -> bool {
+        !self.home_automation_context_ready
+    }
+
+    pub fn needs_cluster_context(self) -> bool {
+        !self.cluster_context_ready
+    }
+
+    pub fn needs_payload_context(self) -> bool {
+        !self.payload_context_ready
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1433,6 +1533,95 @@ mod tests {
         assert_eq!(summary.payload_bytes, 4);
         assert!(summary.has_ack_requests());
         assert!(!summary.has_secured_frames());
+    }
+
+    #[test]
+    fn aps_frame_batch_readiness_summary_marks_application_capture_ready() {
+        let unicast = ApsFrame::unicast_data(
+            Endpoint(1),
+            Endpoint(2),
+            ClusterId::ON_OFF,
+            ProfileId::HOME_AUTOMATION,
+            7,
+            vec![0x01],
+        );
+        let group = ApsFrame {
+            frame_control: ApsFrameControl {
+                delivery_mode: DeliveryMode::Group,
+                ..ApsFrameControl::data_unicast()
+            },
+            addressing: ApsAddressing::Group {
+                group: GroupAddress(0x1234),
+                source_endpoint: Endpoint(3),
+            },
+            cluster_id: ClusterId::TEMPERATURE_MEASUREMENT,
+            profile_id: ProfileId::HOME_AUTOMATION,
+            counter: 8,
+            payload: vec![0x02, 0x03],
+        };
+        let summary = ApsFrameBatchSummary::from_frames([&unicast, &group]);
+
+        let readiness = summary.readiness();
+
+        assert_eq!(readiness.batch_summary, summary);
+        assert_eq!(readiness.required_check_count, 6);
+        assert_eq!(readiness.passed_check_count, 6);
+        assert_eq!(readiness.missing_check_count, 0);
+        assert!(readiness.frames_present);
+        assert!(readiness.data_frames_present);
+        assert!(readiness.application_delivery_ready);
+        assert!(readiness.home_automation_context_ready);
+        assert!(readiness.cluster_context_ready);
+        assert!(readiness.payload_context_ready);
+        assert!(readiness.frame_batch_ready);
+        assert!(readiness.is_frame_batch_ready());
+        assert!(!readiness.has_missing_checks());
+        assert!(!readiness.needs_frames());
+        assert!(!readiness.needs_data_frames());
+        assert!(!readiness.needs_application_delivery());
+        assert!(!readiness.needs_home_automation_context());
+        assert!(!readiness.needs_cluster_context());
+        assert!(!readiness.needs_payload_context());
+    }
+
+    #[test]
+    fn aps_frame_batch_readiness_summary_routes_sparse_capture_gaps() {
+        let command_only = ApsFrameSummary {
+            frame_type: ApsFrameType::Command,
+            delivery_mode: DeliveryMode::Broadcast,
+            profile_kind: ProfileKind::ZigbeeDeviceProfile,
+            cluster_kind: ClusterKind::ManufacturerSpecific,
+            source_endpoint: Endpoint::ZDO,
+            destination_endpoint: Some(Endpoint(255)),
+            group: None,
+            counter: 1,
+            payload_len: 0,
+            ack_request: false,
+            security: false,
+        };
+
+        let readiness = ApsFrameBatchSummary::from_summaries([command_only]).readiness();
+
+        assert_eq!(readiness.required_check_count, 6);
+        assert_eq!(readiness.passed_check_count, 1);
+        assert_eq!(readiness.missing_check_count, 5);
+        assert!(readiness.frames_present);
+        assert!(!readiness.data_frames_present);
+        assert!(!readiness.application_delivery_ready);
+        assert!(!readiness.home_automation_context_ready);
+        assert!(!readiness.cluster_context_ready);
+        assert!(!readiness.payload_context_ready);
+        assert!(!readiness.frame_batch_ready);
+        assert!(!readiness.needs_frames());
+        assert!(readiness.needs_data_frames());
+        assert!(readiness.needs_application_delivery());
+        assert!(readiness.needs_home_automation_context());
+        assert!(readiness.needs_cluster_context());
+        assert!(readiness.needs_payload_context());
+
+        let empty = ApsFrameBatchSummary::empty().readiness();
+        assert_eq!(empty.passed_check_count, 0);
+        assert!(empty.needs_frames());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add ApsFrameBatchReadinessSummary over APS frame batch rollups
- expose helpers for missing frame, data, application-delivery, home-automation, cluster, and payload capture checks
- document the new readiness summary in zigbee-aps README and changelog

## Tests
- cargo fmt --manifest-path code/packages/rust/zigbee-aps/Cargo.toml
- cargo test --manifest-path code/packages/rust/zigbee-aps/Cargo.toml -- --nocapture
- git diff --check