### PR TITLE
Add Z-Wave projection readiness summary

### DIFF
--- a/code/packages/rust/zwave-command-classes/CHANGELOG.md
+++ b/code/packages/rust/zwave-command-classes/CHANGELOG.md
@@ -22,4 +22,6 @@ All notable changes to this package will be documented in this file.
 - Command-class interview descriptors that expose state-query commands and D23
   capability projection for supported classes.
 - Command-class projection summaries for D23 command and sensor surface checks.
+- Command-class projection readiness summaries for command-class inventory,
+  projected capability, command, sensor, and observe-only surface gates.
 - D23 capability and state-delta mapping for common reports.

--- a/code/packages/rust/zwave-command-classes/README.md
+++ b/code/packages/rust/zwave-command-classes/README.md
@@ -22,6 +22,8 @@ Included surfaces:
 - value-report encoding for fixture, simulator, and parser round-trip coverage
 - Z-Wave level/boolean/door-lock normalization helpers
 - command-class projection summaries for D23 command and sensor surface checks
+- command-class projection readiness summaries for command-class inventory,
+  projected capability, command, sensor, and observe-only surface gates
 - D23 capability projection for common command classes
 - D23 `StateDelta` projection for common value reports
 

--- a/code/packages/rust/zwave-command-classes/src/lib.rs
+++ b/code/packages/rust/zwave-command-classes/src/lib.rs
@@ -494,6 +494,100 @@ impl CommandClassProjectionSummary {
     pub fn has_sensor_surface(self) -> bool {
         self.sensor_command_classes > 0
     }
+
+    pub fn has_observe_only_surface(self) -> bool {
+        self.observe_only_capabilities > 0
+    }
+
+    pub fn readiness(self) -> CommandClassProjectionReadinessSummary {
+        CommandClassProjectionReadinessSummary::from_summary(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandClassProjectionReadinessSummary {
+    pub projection_summary: CommandClassProjectionSummary,
+    pub required_projection_check_count: usize,
+    pub passed_projection_check_count: usize,
+    pub missing_projection_check_count: usize,
+    pub command_classes_present: bool,
+    pub capability_projection_ready: bool,
+    pub command_surface_ready: bool,
+    pub sensor_surface_ready: bool,
+    pub observe_only_surface_ready: bool,
+    pub projection_ready: bool,
+}
+
+impl CommandClassProjectionReadinessSummary {
+    pub fn from_command_classes<I>(command_classes: I) -> Self
+    where
+        I: IntoIterator<Item = CommandClassId>,
+    {
+        Self::from_summary(CommandClassProjectionSummary::from_command_classes(
+            command_classes,
+        ))
+    }
+
+    pub fn from_summary(projection_summary: CommandClassProjectionSummary) -> Self {
+        let command_classes_present = projection_summary.unique_command_classes > 0;
+        let capability_projection_ready = projection_summary.has_projected_capabilities();
+        let command_surface_ready = projection_summary.has_command_surface();
+        let sensor_surface_ready = projection_summary.has_sensor_surface();
+        let observe_only_surface_ready = projection_summary.has_observe_only_surface();
+        let checks = [
+            command_classes_present,
+            capability_projection_ready,
+            command_surface_ready,
+            sensor_surface_ready,
+            observe_only_surface_ready,
+        ];
+        let passed_projection_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_projection_check_count = checks.len();
+        let missing_projection_check_count =
+            required_projection_check_count - passed_projection_check_count;
+        let projection_ready = missing_projection_check_count == 0;
+
+        Self {
+            projection_summary,
+            required_projection_check_count,
+            passed_projection_check_count,
+            missing_projection_check_count,
+            command_classes_present,
+            capability_projection_ready,
+            command_surface_ready,
+            sensor_surface_ready,
+            observe_only_surface_ready,
+            projection_ready,
+        }
+    }
+
+    pub fn is_projection_ready(self) -> bool {
+        self.projection_ready
+    }
+
+    pub fn has_missing_projection_checks(self) -> bool {
+        self.missing_projection_check_count > 0
+    }
+
+    pub fn needs_command_class_inventory(self) -> bool {
+        !self.command_classes_present
+    }
+
+    pub fn needs_capability_projection(self) -> bool {
+        !self.capability_projection_ready
+    }
+
+    pub fn needs_command_surface(self) -> bool {
+        !self.command_surface_ready
+    }
+
+    pub fn needs_sensor_surface(self) -> bool {
+        !self.sensor_surface_ready
+    }
+
+    pub fn needs_observe_only_surface(self) -> bool {
+        !self.observe_only_surface_ready
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1860,6 +1954,65 @@ mod tests {
         assert!(!empty.has_projected_capabilities());
         assert!(!empty.has_command_surface());
         assert!(!empty.has_sensor_surface());
+    }
+
+    #[test]
+    fn command_class_projection_readiness_marks_mixed_surface_ready() {
+        let summary = CommandClassProjectionSummary::from_command_classes([
+            CommandClassId::SWITCH_BINARY,
+            CommandClassId::DOOR_LOCK,
+            CommandClassId::BATTERY,
+            COMMAND_CLASS_METER,
+            COMMAND_CLASS_NOTIFICATION,
+        ]);
+
+        let readiness = summary.readiness();
+
+        assert_eq!(readiness.projection_summary, summary);
+        assert_eq!(readiness.required_projection_check_count, 5);
+        assert_eq!(readiness.passed_projection_check_count, 5);
+        assert_eq!(readiness.missing_projection_check_count, 0);
+        assert!(readiness.command_classes_present);
+        assert!(readiness.capability_projection_ready);
+        assert!(readiness.command_surface_ready);
+        assert!(readiness.sensor_surface_ready);
+        assert!(readiness.observe_only_surface_ready);
+        assert!(readiness.projection_ready);
+        assert!(readiness.is_projection_ready());
+        assert!(!readiness.has_missing_projection_checks());
+        assert!(!readiness.needs_command_class_inventory());
+        assert!(!readiness.needs_capability_projection());
+        assert!(!readiness.needs_command_surface());
+        assert!(!readiness.needs_sensor_surface());
+        assert!(!readiness.needs_observe_only_surface());
+    }
+
+    #[test]
+    fn command_class_projection_readiness_routes_sparse_inventory_gaps() {
+        let basic_only = CommandClassProjectionReadinessSummary::from_command_classes([
+            CommandClassId::BASIC,
+            CommandClassId::BASIC,
+        ]);
+
+        assert_eq!(basic_only.required_projection_check_count, 5);
+        assert_eq!(basic_only.passed_projection_check_count, 1);
+        assert_eq!(basic_only.missing_projection_check_count, 4);
+        assert!(basic_only.command_classes_present);
+        assert!(!basic_only.capability_projection_ready);
+        assert!(!basic_only.command_surface_ready);
+        assert!(!basic_only.sensor_surface_ready);
+        assert!(!basic_only.observe_only_surface_ready);
+        assert!(!basic_only.projection_ready);
+        assert!(!basic_only.needs_command_class_inventory());
+        assert!(basic_only.needs_capability_projection());
+        assert!(basic_only.needs_command_surface());
+        assert!(basic_only.needs_sensor_surface());
+        assert!(basic_only.needs_observe_only_surface());
+
+        let empty = CommandClassProjectionReadinessSummary::from_command_classes([]);
+        assert_eq!(empty.passed_projection_check_count, 0);
+        assert!(empty.needs_command_class_inventory());
+        assert!(empty.has_missing_projection_checks());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add CommandClassProjectionReadinessSummary over D23 command-class projection rollups
- expose helpers for missing inventory, capability projection, command, sensor, and observe-only surfaces
- document the new readiness summary in zwave-command-classes README and changelog

## Tests
- cargo fmt --manifest-path code/packages/rust/zwave-command-classes/Cargo.toml
- cargo test --manifest-path code/packages/rust/zwave-command-classes/Cargo.toml -- --nocapture
- git diff --check