### PR TITLE
Add Hue package lifecycle summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this package will be documented in this file.
   release, and runtime/pairing review gates.
 - Hue package publish-gate summaries that route blocked handoffs to catalog,
   release, or runtime/pairing review queues.
+- Hue package lifecycle summaries that count release, spec, catalog, handoff,
+  and publish stages as one ordered package readiness view.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -68,6 +68,8 @@ packages a typed surface for:
   release, and runtime/pairing review gates
 - Hue package publish-gate summaries that route blocked handoffs to catalog,
   release, or runtime/pairing review queues
+- Hue package lifecycle summaries that count release, spec, catalog, handoff,
+  and publish stages as one ordered package readiness view
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -2031,6 +2031,93 @@ pub fn hue_package_publish_gate_summary(
     HuePackagePublishGateSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageLifecycleSummary {
+    pub publish_gate: HuePackagePublishGateSummary,
+    pub required_lifecycle_stage_count: usize,
+    pub passed_lifecycle_stage_count: usize,
+    pub blocked_lifecycle_stage_count: usize,
+    pub release_ready: bool,
+    pub spec_ready: bool,
+    pub catalog_ready: bool,
+    pub handoff_accepted: bool,
+    pub publish_ready: bool,
+    pub lifecycle_complete: bool,
+}
+
+impl HuePackageLifecycleSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_publish_gate(hue_package_publish_gate_summary(plan))
+    }
+
+    pub fn from_publish_gate(publish_gate: HuePackagePublishGateSummary) -> Self {
+        let catalog_readiness = publish_gate.handoff_summary.gap_summary.catalog_readiness;
+        let spec_summary = catalog_readiness.spec_summary;
+        let release_ready = spec_summary.release_readiness.is_release_ready();
+        let spec_ready = spec_summary.is_spec_ready();
+        let catalog_ready = catalog_readiness.is_catalog_ready();
+        let handoff_accepted = publish_gate.handoff_accepted;
+        let publish_ready = publish_gate.is_publish_ready();
+        let stages = [
+            release_ready,
+            spec_ready,
+            catalog_ready,
+            handoff_accepted,
+            publish_ready,
+        ];
+        let passed_lifecycle_stage_count = stages.iter().filter(|ready| **ready).count();
+        let required_lifecycle_stage_count = stages.len();
+        let blocked_lifecycle_stage_count =
+            required_lifecycle_stage_count - passed_lifecycle_stage_count;
+        let lifecycle_complete = blocked_lifecycle_stage_count == 0;
+
+        Self {
+            publish_gate,
+            required_lifecycle_stage_count,
+            passed_lifecycle_stage_count,
+            blocked_lifecycle_stage_count,
+            release_ready,
+            spec_ready,
+            catalog_ready,
+            handoff_accepted,
+            publish_ready,
+            lifecycle_complete,
+        }
+    }
+
+    pub fn is_lifecycle_complete(self) -> bool {
+        self.lifecycle_complete
+    }
+
+    pub fn has_blocked_lifecycle_stages(self) -> bool {
+        self.blocked_lifecycle_stage_count > 0
+    }
+
+    pub fn needs_release_stage(self) -> bool {
+        !self.release_ready
+    }
+
+    pub fn needs_spec_stage(self) -> bool {
+        !self.spec_ready
+    }
+
+    pub fn needs_catalog_stage(self) -> bool {
+        !self.catalog_ready
+    }
+
+    pub fn needs_handoff_stage(self) -> bool {
+        !self.handoff_accepted
+    }
+
+    pub fn needs_publish_stage(self) -> bool {
+        !self.publish_ready
+    }
+}
+
+pub fn hue_package_lifecycle_summary(plan: &HueBridgePairingPlan) -> HuePackageLifecycleSummary {
+    HuePackageLifecycleSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -5586,5 +5673,80 @@ mod tests {
         assert!(summary.needs_catalog_spec_queue());
         assert!(summary.needs_release_queue());
         assert!(summary.needs_runtime_pairing_queue());
+    }
+
+    #[test]
+    fn hue_package_lifecycle_summary_marks_complete_package_lifecycle() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_lifecycle_summary(&plan);
+
+        assert_eq!(
+            summary.publish_gate,
+            hue_package_publish_gate_summary(&plan)
+        );
+        assert_eq!(summary.required_lifecycle_stage_count, 5);
+        assert_eq!(summary.passed_lifecycle_stage_count, 5);
+        assert_eq!(summary.blocked_lifecycle_stage_count, 0);
+        assert!(summary.release_ready);
+        assert!(summary.spec_ready);
+        assert!(summary.catalog_ready);
+        assert!(summary.handoff_accepted);
+        assert!(summary.publish_ready);
+        assert!(summary.lifecycle_complete);
+        assert!(summary.is_lifecycle_complete());
+        assert!(!summary.has_blocked_lifecycle_stages());
+        assert!(!summary.needs_release_stage());
+        assert!(!summary.needs_spec_stage());
+        assert!(!summary.needs_catalog_stage());
+        assert!(!summary.needs_handoff_stage());
+        assert!(!summary.needs_publish_stage());
+    }
+
+    #[test]
+    fn hue_package_lifecycle_summary_counts_blocked_lifecycle_stages() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageLifecycleSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_lifecycle_stage_count, 5);
+        assert_eq!(summary.passed_lifecycle_stage_count, 0);
+        assert_eq!(summary.blocked_lifecycle_stage_count, 5);
+        assert!(!summary.release_ready);
+        assert!(!summary.spec_ready);
+        assert!(!summary.catalog_ready);
+        assert!(!summary.handoff_accepted);
+        assert!(!summary.publish_ready);
+        assert!(!summary.lifecycle_complete);
+        assert!(!summary.is_lifecycle_complete());
+        assert!(summary.has_blocked_lifecycle_stages());
+        assert!(summary.needs_release_stage());
+        assert!(summary.needs_spec_stage());
+        assert!(summary.needs_catalog_stage());
+        assert!(summary.needs_handoff_stage());
+        assert!(summary.needs_publish_stage());
     }
 }


### PR DESCRIPTION
## Summary
- add HuePackageLifecycleSummary over the release/spec/catalog/handoff/publish package gates
- expose lifecycle stage counts and helpers for blocked release, spec, catalog, handoff, and publish stages
- document the lifecycle summary in hue-core README and changelog

## Tests
- cargo fmt --manifest-path code/packages/rust/hue-core/Cargo.toml
- cargo test --manifest-path code/packages/rust/hue-core/Cargo.toml
- git diff --check