### PR TITLE
feat(irc-server-native): Java/JVM native binding + stop-before-serve race fix

### DIFF
--- a/code/packages/java/irc-server-native/.gitignore
+++ b/code/packages/java/irc-server-native/.gitignore
@@ -1,0 +1,3 @@
+gradle-build/
+.gradle/
+build/

--- a/code/packages/java/irc-server-native/BUILD
+++ b/code/packages/java/irc-server-native/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p irc-server-native-jni --release && gradle test

--- a/code/packages/java/irc-server-native/BUILD_windows
+++ b/code/packages/java/irc-server-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p irc-server-native-jni --release && gradle test

--- a/code/packages/java/irc-server-native/CHANGELOG.md
+++ b/code/packages/java/irc-server-native/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-06-14
+
+### Added
+
+- `com.codingadventures.ircserver.IrcServer` — a Java facade for a
+  high-performance IRC server whose IRC and TCP logic run entirely in Rust
+  (`irc-net-reactor` on the home-grown kqueue/epoll reactor). Builder config
+  (`host`, `port`, `serverName`, `motd`, `operPassword`, `maxConnections`) plus
+  `serve` (blocking), `serveBackground`, `stop`, `running`, `localHost` /
+  `localPort` / `localAddr`, and `AutoCloseable` `close`.
+- `irc-server-native-jni` Rust cdylib (via the zero-dependency `jni-bridge`):
+  `nativeNewServer` / `nativeServe` / `nativeServeBackground` / `nativeStop` /
+  `nativeRunning` / `nativeLocalHost` / `nativeLocalPort` / `nativeDisposeServer`
+  over an opaque `long` peer pointer. No callback into the JVM.
+- JUnit 5 real-socket tests: ephemeral address, registration + PING/PONG,
+  channel `PRIVMSG` broadcast between two clients, `running` flips after serve.
+- Gradle build pointing `java.library.path` at the Rust release dir; `BUILD`
+  builds the cdylib then runs `gradle test`.
+
+### Security / robustness
+
+- `serve`/`serveBackground` run the blocking loop on an **owned clone** of the
+  engine (`Clone` over `Arc`s), so the background thread never dangles even
+  though `nativeDisposeServer` frees the peer (mirrors the Python/Ruby/Node
+  bindings).
+- Fixed a **stop-before-serve race** in the shared `stream-reactor` event loop
+  that this binding surfaced: `serve()` reset the stop flag on entry, so a
+  `stop()` arriving before the background serve thread started was silently
+  swallowed and `serve()`/`join()` hung forever. The JVM tests flip
+  `running`→`stop` synchronously, hitting it every run; the fix (don't reset the
+  flag in `serve()`) makes `stop()` reliable for every binding. Added an
+  `irc-net-reactor` regression test (`stop_called_before_serve_starts_is_not_lost`).

--- a/code/packages/java/irc-server-native/README.md
+++ b/code/packages/java/irc-server-native/README.md
@@ -1,0 +1,60 @@
+# irc-server-native (Java / JVM)
+
+A **high-performance IRC server for the JVM** — every line of IRC and TCP logic
+runs in Rust (the [`irc-net-reactor`](../../rust/irc-net-reactor) engine on the
+home-grown `kqueue`/`epoll` reactor). Java only launches and controls the server,
+through a thin JNI layer over the zero-dependency `jni-bridge` (the Rust crate
+[`irc-server-native-jni`](../../rust/irc-server-native-jni)).
+
+## Why
+
+This is the JVM member of a family: one Rust IRC engine, embedded natively in
+every language. Because all logic lives in Rust, the binding is a pure lifecycle
+control surface — **create, serve, stop** — with no callback into Java.
+
+## Usage
+
+```java
+import com.codingadventures.ircserver.IrcServer;
+
+try (IrcServer server = IrcServer.builder().port(6667).build()) {
+    server.serveBackground();                 // returns immediately
+    System.out.println("listening on " + server.localAddr());
+    // ... connect IRC clients to server.localHost():server.localPort() ...
+    server.stop();
+}
+```
+
+`serve()` blocks the calling thread; `serveBackground()` runs the loop on a Rust
+background thread and returns immediately. `IrcServer` is `AutoCloseable` —
+`close()` stops, joins, and frees the native peer.
+
+## API
+
+`IrcServer.builder()` — `host`, `port`, `serverName`, `motd`, `operPassword`,
+`maxConnections`, then `build()`. Instance methods: `serve()`,
+`serveBackground()`, `stop()`, `running()`, `localHost()`, `localPort()`,
+`localAddr()`, `close()`.
+
+## How it's built
+
+`BUILD` runs `cargo build -p irc-server-native-jni --release` (producing
+`libirc_server_native_jni.{so,dylib}`) then `gradle test`. The test JVM is given
+`-Djava.library.path=…/rust/target/release` so `System.loadLibrary` finds the
+addon.
+
+## Lifecycle note
+
+The native peer is a raw pointer behind a `long` handle. Like the repo's
+`conduit` JVM binding, `IrcServer` is single-owner: don't race `close()` against
+other methods on the same instance from another thread.
+
+## Layer position
+
+```
+com.codingadventures.ircserver.IrcServer   (this package — Java facade)
+        ↓ irc_server_native_jni cdylib (jni-bridge; background-thread serve)
+irc-net-reactor   (Rust IRC engine, in-process broadcast)
+        ↓
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+```

--- a/code/packages/java/irc-server-native/build.gradle.kts
+++ b/code/packages/java/irc-server-native/build.gradle.kts
@@ -1,0 +1,50 @@
+// Build configuration for the Java IRC server binding.
+//
+// A thin JNI layer over the Rust `irc_server_native_jni` cdylib, which embeds
+// the all-Rust `irc-net-reactor` IRC engine. The cdylib must be built first:
+//
+//   cargo build --manifest-path ../../rust/Cargo.toml -p irc-server-native-jni --release
+//
+// The BUILD script runs that command before invoking `gradle test`.
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+
+    // Point the JVM's native library search path at the Rust release build.
+    // projectDir = code/packages/java/irc-server-native, so
+    // projectDir.parentFile.parentFile = code/packages, and the Rust workspace
+    // builds into code/packages/rust/target/release.
+    val rustReleaseDir = projectDir.parentFile.parentFile
+        .resolve("rust/target/release")
+        .absolutePath
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/code/packages/java/irc-server-native/required_capabilities.json
+++ b/code/packages/java/irc-server-native/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "required_capabilities": ["rust", "java", "cargo"]
+}

--- a/code/packages/java/irc-server-native/settings.gradle.kts
+++ b/code/packages/java/irc-server-native/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "irc-server-native"

--- a/code/packages/java/irc-server-native/src/main/java/com/codingadventures/ircserver/IrcServer.java
+++ b/code/packages/java/irc-server-native/src/main/java/com/codingadventures/ircserver/IrcServer.java
@@ -1,0 +1,148 @@
+package com.codingadventures.ircserver;
+
+import java.util.List;
+
+/**
+ * A high-performance IRC server for the JVM, backed by the all-Rust
+ * {@code irc-net-reactor} engine (on the home-grown kqueue/epoll reactor).
+ *
+ * <p>Every line of IRC and TCP logic runs in Rust; this class only launches and
+ * controls the server. Usage:
+ *
+ * <pre>{@code
+ * try (IrcServer server = IrcServer.builder().port(6667).build()) {
+ *     server.serveBackground();
+ *     // ... connect IRC clients to server.localHost():server.localPort() ...
+ *     server.stop();
+ * }
+ * }</pre>
+ *
+ * <p>The peer is a raw native pointer; like {@code conduit}'s server, this class
+ * is single-owner. Do not race {@link #close()} against other methods on the
+ * same instance from another thread.
+ */
+public final class IrcServer implements AutoCloseable {
+
+    /** Peer pointer to the Rust {@code NativeServer}; 0 once closed. */
+    private long handle;
+
+    private IrcServer(long handle) {
+        this.handle = handle;
+    }
+
+    /** Start configuring a server. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Run the event loop on the calling thread, blocking until {@link #stop()}. */
+    public void serve() {
+        checkOpen();
+        Native.nativeServe(handle);
+    }
+
+    /** Run the event loop on a background Rust thread; returns immediately. */
+    public void serveBackground() {
+        checkOpen();
+        Native.nativeServeBackground(handle);
+    }
+
+    /** Signal the server to stop and join the background thread. */
+    public void stop() {
+        checkOpen();
+        Native.nativeStop(handle);
+    }
+
+    /** Whether the event loop is currently running. */
+    public boolean running() {
+        checkOpen();
+        return Native.nativeRunning(handle);
+    }
+
+    /** The bound IP address. */
+    public String localHost() {
+        checkOpen();
+        return Native.nativeLocalHost(handle);
+    }
+
+    /** The bound TCP port (useful when port 0 was requested). */
+    public int localPort() {
+        checkOpen();
+        return Native.nativeLocalPort(handle);
+    }
+
+    /** The bound {@code host:port} address. */
+    public String localAddr() {
+        return localHost() + ":" + localPort();
+    }
+
+    @Override
+    public void close() {
+        if (handle != 0) {
+            Native.nativeDisposeServer(handle);
+            handle = 0;
+        }
+    }
+
+    private void checkOpen() {
+        if (handle == 0) {
+            throw new IllegalStateException("server is closed");
+        }
+    }
+
+    /** Fluent configuration for an {@link IrcServer}. */
+    public static final class Builder {
+        private String host = "127.0.0.1";
+        private int port = 6667;
+        private String serverName = "irc.local";
+        private List<String> motd = List.of("Welcome.");
+        private String operPassword = "";
+        private int maxConnections = 1024;
+
+        private Builder() {
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder serverName(String serverName) {
+            this.serverName = serverName;
+            return this;
+        }
+
+        public Builder motd(List<String> motd) {
+            this.motd = (motd == null || motd.isEmpty()) ? List.of("Welcome.") : motd;
+            return this;
+        }
+
+        public Builder operPassword(String operPassword) {
+            this.operPassword = operPassword == null ? "" : operPassword;
+            return this;
+        }
+
+        public Builder maxConnections(int maxConnections) {
+            this.maxConnections = maxConnections;
+            return this;
+        }
+
+        /** Bind the server and return a running-capable handle. */
+        public IrcServer build() {
+            // MOTD lines are joined with newlines for a single JNI string arg;
+            // the Rust side splits them back into lines.
+            String joinedMotd = String.join("\n", motd);
+            long h = Native.nativeNewServer(
+                host, port, serverName, joinedMotd, operPassword, maxConnections);
+            if (h == 0) {
+                throw new IllegalStateException("irc-server-native: failed to bind server");
+            }
+            return new IrcServer(h);
+        }
+    }
+}

--- a/code/packages/java/irc-server-native/src/main/java/com/codingadventures/ircserver/Native.java
+++ b/code/packages/java/irc-server-native/src/main/java/com/codingadventures/ircserver/Native.java
@@ -1,0 +1,53 @@
+package com.codingadventures.ircserver;
+
+/**
+ * JNI bindings to the {@code irc_server_native_jni} Rust cdylib, which embeds the
+ * all-Rust {@code irc-net-reactor} IRC engine. Each {@code native} method maps to
+ * a {@code Java_com_codingadventures_ircserver_Native_*} function in
+ * {@code code/packages/rust/irc-server-native-jni/src/lib.rs}.
+ *
+ * <p>All IRC and TCP logic runs in Rust; the JVM only launches and controls the
+ * server. There is no callback into Java.
+ */
+final class Native {
+
+    static {
+        System.loadLibrary("irc_server_native_jni");
+    }
+
+    private Native() {
+    }
+
+    /**
+     * Bind a server and return its peer pointer (0 on failure, with a Java
+     * exception already thrown). {@code motd} is a single newline-joined string.
+     */
+    static native long nativeNewServer(
+        String host,
+        int port,
+        String serverName,
+        String motd,
+        String operPassword,
+        int maxConnections);
+
+    /** Run the event loop on the calling thread (blocks until stopped). */
+    static native void nativeServe(long server);
+
+    /** Run the event loop on a background Rust thread; returns immediately. */
+    static native void nativeServeBackground(long server);
+
+    /** Signal the loop to stop and join the background thread. */
+    static native void nativeStop(long server);
+
+    /** Whether the loop is currently running. */
+    static native boolean nativeRunning(long server);
+
+    /** The bound IP address. */
+    static native String nativeLocalHost(long server);
+
+    /** The bound TCP port. */
+    static native int nativeLocalPort(long server);
+
+    /** Stop, join, and free the peer. */
+    static native void nativeDisposeServer(long server);
+}

--- a/code/packages/java/irc-server-native/src/test/java/com/codingadventures/ircserver/IrcServerTest.java
+++ b/code/packages/java/irc-server-native/src/test/java/com/codingadventures/ircserver/IrcServerTest.java
@@ -1,0 +1,122 @@
+package com.codingadventures.ircserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests: start the real Rust IRC engine on an ephemeral port and
+ * drive live IRC clients over real TCP sockets.
+ */
+class IrcServerTest {
+
+    private static Socket connect(int port) throws IOException {
+        Socket sock = new Socket();
+        sock.connect(new InetSocketAddress("127.0.0.1", port), 2000);
+        sock.setSoTimeout(300);
+        return sock;
+    }
+
+    private static String recvUntil(Socket sock, String needle) throws IOException {
+        long deadline = System.currentTimeMillis() + 5000;
+        StringBuilder buf = new StringBuilder();
+        byte[] chunk = new byte[4096];
+        InputStream in = sock.getInputStream();
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                int n = in.read(chunk);
+                if (n < 0) {
+                    break;
+                }
+                buf.append(new String(chunk, 0, n, StandardCharsets.UTF_8));
+                if (buf.indexOf(needle) >= 0) {
+                    break;
+                }
+            } catch (java.net.SocketTimeoutException e) {
+                // keep polling until the deadline
+            }
+        }
+        return buf.toString();
+    }
+
+    private static void send(Socket sock, String line) throws IOException {
+        OutputStream out = sock.getOutputStream();
+        out.write(line.getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    private static void register(Socket sock, String nick) throws IOException {
+        send(sock, "NICK " + nick + "\r\nUSER " + nick + " 0 * :" + nick + "\r\n");
+        String welcome = recvUntil(sock, "001");
+        assertTrue(welcome.contains("001"), "expected 001 welcome for " + nick);
+    }
+
+    @Test
+    void reportsEphemeralBoundAddress() {
+        try (IrcServer server = IrcServer.builder().port(0).build()) {
+            assertEquals("127.0.0.1", server.localHost());
+            assertTrue(server.localPort() > 0);
+        }
+    }
+
+    @Test
+    void registrationAndPing() throws IOException, InterruptedException {
+        try (IrcServer server = IrcServer.builder().port(0).serverName("irc.test").build()) {
+            server.serveBackground();
+            Thread.sleep(100);
+            try (Socket alice = connect(server.localPort())) {
+                register(alice, "alice");
+                send(alice, "PING :liveness\r\n");
+                String pong = recvUntil(alice, "PONG");
+                assertTrue(pong.contains("PONG"), "expected PONG, got: " + pong);
+            }
+            server.stop();
+        }
+    }
+
+    @Test
+    void privmsgBroadcastsBetweenClients() throws IOException, InterruptedException {
+        try (IrcServer server = IrcServer.builder().port(0).serverName("irc.test").build()) {
+            server.serveBackground();
+            Thread.sleep(100);
+            try (Socket alice = connect(server.localPort());
+                 Socket bob = connect(server.localPort())) {
+                register(alice, "alice");
+                register(bob, "bob");
+                send(alice, "JOIN #test\r\n");
+                send(bob, "JOIN #test\r\n");
+                recvUntil(alice, "JOIN");
+                recvUntil(bob, "JOIN");
+
+                // Alice speaks; Bob (a different connection) must receive it —
+                // this exercises the Rust engine's in-process mailbox fan-out.
+                send(alice, "PRIVMSG #test :hello bob\r\n");
+                String received = recvUntil(bob, "hello bob");
+                assertTrue(received.contains("PRIVMSG") && received.contains("hello bob"),
+                    "bob should receive alice's broadcast, got: " + received);
+            }
+            server.stop();
+        }
+    }
+
+    @Test
+    void runningFlipsAfterServe() throws InterruptedException {
+        try (IrcServer server = IrcServer.builder().port(0).build()) {
+            assertTrue(!server.running());
+            server.serveBackground();
+            long deadline = System.currentTimeMillis() + 5000;
+            while (!server.running() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10);
+            }
+            assertTrue(server.running());
+            server.stop();
+        }
+    }
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -732,6 +732,7 @@ members = [
     "conduit",
     "conduit-jni",
     "conduit-capi",
+    "irc-server-native-jni",
     "smart-home-core",
     "smart-home-capability-cage",
     "smart-home-discovery",

--- a/code/packages/rust/irc-net-reactor/src/lib.rs
+++ b/code/packages/rust/irc-net-reactor/src/lib.rs
@@ -627,6 +627,27 @@ mod tests {
     }
 
     #[test]
+    fn stop_called_before_serve_starts_is_not_lost() {
+        // A caller may request stop() before the background serve thread has
+        // actually entered the event loop (common via FFI bindings that flip a
+        // "running" flag before spawning the serve thread).  The stop must not be
+        // swallowed — otherwise serve() runs forever and join() hangs.  We loop
+        // to exercise the race repeatedly; a regression would hang this test.
+        for _ in 0..25 {
+            let server = IrcReactorServer::bind(IrcConfig {
+                port: 0,
+                ..IrcConfig::default()
+            })
+            .expect("bind");
+            let background = server.clone();
+            let handle = thread::spawn(move || background.serve());
+            // Stop immediately, without waiting for the loop to start.
+            server.stop();
+            handle.join().expect("server thread").expect("server exit");
+        }
+    }
+
+    #[test]
     fn quit_command_broadcasts_to_channel() {
         let (server, handle, addr) = start_server();
 

--- a/code/packages/rust/irc-server-native-jni/Cargo.toml
+++ b/code/packages/rust/irc-server-native-jni/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "irc-server-native-jni"
+version = "0.1.0"
+edition = "2021"
+description = "JNI native library bridging Java/Kotlin to the all-Rust irc-net-reactor IRC engine"
+publish = false
+
+[lib]
+# cdylib → libirc_server_native_jni.{so,dylib,dll}, loaded via
+# System.loadLibrary("irc_server_native_jni"). The `lib` crate type lets pure-Rust
+# helpers be unit-tested without a JVM.
+crate-type = ["cdylib", "lib"]
+name = "irc_server_native_jni"
+
+[dependencies]
+jni-bridge      = { path = "../jni-bridge" }
+irc-net-reactor = { path = "../irc-net-reactor" }

--- a/code/packages/rust/irc-server-native-jni/src/lib.rs
+++ b/code/packages/rust/irc-server-native-jni/src/lib.rs
@@ -1,0 +1,266 @@
+//! `irc-server-native-jni` — a JNI bridge embedding the all-Rust IRC engine
+//! (`irc-net-reactor`) into the JVM (Java / Kotlin).
+//!
+//! ## Design: control surface only, no callbacks
+//!
+//! All IRC and TCP logic lives in Rust (`irc-net-reactor` on the home-grown
+//! kqueue/epoll reactor).  The JVM only *launches and controls* the server, so
+//! this library exposes a tiny set of `native` methods over an opaque `long`
+//! peer pointer:
+//!
+//! * `nativeNewServer(host, port, serverName, motd, operPassword, maxConnections)`
+//!   → bind, return the peer pointer.
+//! * `nativeServe(ptr)` — run the loop on the calling thread (blocks).
+//! * `nativeServeBackground(ptr)` — run the loop on a spawned thread.
+//! * `nativeStop(ptr)` — signal the loop to stop and join the background thread.
+//! * `nativeRunning` / `nativeLocalHost` / `nativeLocalPort`.
+//! * `nativeDisposeServer(ptr)` — stop, join, and free the peer.
+//!
+//! There is **no per-message callback into the JVM** (unlike `conduit-jni`,
+//! which dispatches HTTP routes to Java handlers), so no thread attachment or
+//! global-reference machinery is needed.
+//!
+//! ## Use-after-free safety
+//!
+//! `serve`/`serveBackground` run the blocking loop on an **owned clone** of the
+//! engine (`IrcReactorServer` is `Clone` over `Arc`s).  So the background thread
+//! never dereferences the peer struct and never dangles, even though
+//! `nativeDisposeServer` frees the peer.  Callers must still not race
+//! `dispose()` against other calls on the same handle from another thread (the
+//! `long` peer is a raw pointer) — the Java facade documents single-owner
+//! lifecycle, exactly as `conduit-jni` does.
+//!
+//! The peer pointer is validated against 0 on every call; a true data race on a
+//! freed peer is the caller's responsibility.
+
+// JNI entry points are `Java_<Pkg>_<Class>_<method>` (not snake_case) and share
+// one uniform safety contract (called by the JVM with a valid peer pointer), so
+// per-function `# Safety` docs would be noise.
+#![allow(non_snake_case, clippy::missing_safety_doc, clippy::unused_unit)]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use irc_net_reactor::{IrcConfig, IrcReactorServer};
+use jni_bridge::{
+    jboolean, jclass, jint, jlong, jni_get_string_utf, jni_new_string_utf, jni_throw_new, jstring,
+    JNIEnv,
+};
+
+/// Return `$ret` if the peer pointer is null (0).
+macro_rules! guard_ptr {
+    ($ptr:expr, $ret:expr) => {
+        if $ptr == 0 {
+            return $ret;
+        }
+    };
+}
+
+/// The Rust state behind the `long` peer pointer.
+struct NativeServer {
+    /// The bound engine.  Kept as a control handle; the serve loop runs a clone.
+    server: Option<IrcReactorServer>,
+    local_host: String,
+    local_port: u16,
+    running: Arc<AtomicBool>,
+    bg: Option<std::thread::JoinHandle<()>>,
+}
+
+// SAFETY: only an owned clone of `IrcReactorServer` (Arc-based, Send) is moved
+// into the background thread; the peer struct itself stays with its owner.
+unsafe impl Send for NativeServer {}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeNewServer(
+    env: *mut JNIEnv,
+    _class: jclass,
+    host: jstring,
+    port: jint,
+    server_name: jstring,
+    motd: jstring,
+    oper_password: jstring,
+    max_connections: jint,
+) -> jlong {
+    let host = jni_get_string_utf(env, host).unwrap_or_else(|| "127.0.0.1".to_string());
+    let port = if (0..=65535).contains(&port) {
+        port as u16
+    } else {
+        jni_throw_new(
+            env,
+            "java/lang/IllegalArgumentException",
+            "port must be between 0 and 65535",
+        );
+        return 0;
+    };
+    let server_name =
+        jni_get_string_utf(env, server_name).unwrap_or_else(|| "irc.local".to_string());
+    // MOTD is passed as a single newline-joined string to avoid marshalling a
+    // String[] across JNI; split it back into lines here.
+    let motd: Vec<String> = jni_get_string_utf(env, motd)
+        .map(|joined| {
+            joined
+                .split('\n')
+                .filter(|line| !line.is_empty())
+                .map(|line| line.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    let oper_password = jni_get_string_utf(env, oper_password).unwrap_or_default();
+    let max_connections = if max_connections >= 1 {
+        max_connections as usize
+    } else {
+        jni_throw_new(
+            env,
+            "java/lang/IllegalArgumentException",
+            "maxConnections must be >= 1",
+        );
+        return 0;
+    };
+
+    let config = IrcConfig {
+        host,
+        port,
+        server_name,
+        motd,
+        oper_password,
+        max_connections,
+    };
+    let server = match IrcReactorServer::bind(config) {
+        Ok(server) => server,
+        Err(e) => {
+            jni_throw_new(
+                env,
+                "java/lang/RuntimeException",
+                &format!("irc_server_native_jni: bind failed: {e}"),
+            );
+            return 0;
+        }
+    };
+
+    let addr = server.local_addr();
+    let native = NativeServer {
+        server: Some(server),
+        local_host: addr.ip().to_string(),
+        local_port: addr.port(),
+        running: Arc::new(AtomicBool::new(false)),
+        bg: None,
+    };
+    Box::into_raw(Box::new(native)) as jlong
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeServe(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) {
+    guard_ptr!(server_ptr, ());
+    let srv = &mut *(server_ptr as *mut NativeServer);
+    if srv.running.load(Ordering::SeqCst) {
+        return; // already serving
+    }
+    let engine = match srv.server.as_ref() {
+        Some(server) => server.clone(),
+        None => return,
+    };
+    srv.running.store(true, Ordering::SeqCst);
+    let _ = engine.serve();
+    srv.running.store(false, Ordering::SeqCst);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeServeBackground(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) {
+    guard_ptr!(server_ptr, ());
+    let srv = &mut *(server_ptr as *mut NativeServer);
+    if srv.running.load(Ordering::SeqCst) {
+        return;
+    }
+    let engine = match srv.server.as_ref() {
+        Some(server) => server.clone(),
+        None => return,
+    };
+    let running = Arc::clone(&srv.running);
+    running.store(true, Ordering::SeqCst);
+    srv.bg = Some(std::thread::spawn(move || {
+        let _ = engine.serve();
+        running.store(false, Ordering::SeqCst);
+    }));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeStop(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) {
+    guard_ptr!(server_ptr, ());
+    let srv = &mut *(server_ptr as *mut NativeServer);
+    if let Some(server) = srv.server.as_ref() {
+        server.stop();
+    }
+    if let Some(handle) = srv.bg.take() {
+        let _ = handle.join();
+    }
+    srv.running.store(false, Ordering::SeqCst);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeRunning(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) -> jboolean {
+    guard_ptr!(server_ptr, 0);
+    let srv = &*(server_ptr as *mut NativeServer);
+    if srv.running.load(Ordering::SeqCst) {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeLocalHost(
+    env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) -> jstring {
+    guard_ptr!(server_ptr, std::ptr::null_mut());
+    let srv = &*(server_ptr as *mut NativeServer);
+    jni_new_string_utf(env, &srv.local_host)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeLocalPort(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) -> jint {
+    guard_ptr!(server_ptr, 0);
+    let srv = &*(server_ptr as *mut NativeServer);
+    srv.local_port as jint
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_ircserver_Native_nativeDisposeServer(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    server_ptr: jlong,
+) {
+    if server_ptr == 0 {
+        return;
+    }
+    let mut srv = Box::from_raw(server_ptr as *mut NativeServer);
+    // Stop and join before the box (and its engine clone) is dropped.
+    if let Some(server) = srv.server.as_ref() {
+        server.stop();
+    }
+    if let Some(handle) = srv.bg.take() {
+        let _ = handle.join();
+    }
+    // `srv` dropped here.
+}

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -325,7 +325,13 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
     }
 
     pub fn serve(&mut self) -> Result<(), PlatformError> {
-        self.stop_flag.store(false, Ordering::SeqCst);
+        // NOTE: we deliberately do NOT reset `stop_flag` here.  The flag starts
+        // `false` at construction, so a reset would be redundant on first serve —
+        // but it would also create a race: a `stop()` that arrives after the
+        // serve thread is spawned but before this loop begins would be silently
+        // erased, leaving the loop running forever (observed via JNI, where the
+        // caller can request stop before the background serve thread starts).
+        // A `stop()` must never be lost, so the flag is honoured as-is.
         let mut events = Vec::new();
         while !self.stop_flag.load(Ordering::SeqCst) {
             self.drain_mailbox()?;

--- a/lessons.md
+++ b/lessons.md
@@ -489,3 +489,10 @@ time. The trust boundary (header_safe, status clamp, UTF-8 validation, panic
 isolation) is audited once. Handlers cross as a C function pointer + opaque `ctx`
 + a `ctx_free` destructor; the host boxes its closure. `crate-type = ["staticlib",
 "cdylib", "lib"]` serves compile-time linkers, FFI loaders, and `cargo test`.
+---
+
+## stream-reactor — never reset a cancellation flag inside the run loop's own entry
+
+**Date:** 2026-06-14
+
+**`StreamReactor::serve()` must NOT reset the stop flag — a `stop()` racing serve startup gets silently swallowed.** The reactor's `serve()` used to do `self.stop_flag.store(false)` at the top. The flag is already `false` at construction, so the reset was redundant on first serve — but it created a race: an FFI binding (JNI/N-API/etc.) that flips a "running" flag and lets the caller request `stop()` *before* the background serve thread enters the loop would have its stop erased, so `serve()` runs forever and `join()` hangs. This was invisible in Python/Ruby because their tests wait for the server to actually be listening before stopping (and Python/Ruby `join` with a timeout); it surfaced in the JVM binding, whose JUnit tests flip running→stop synchronously in one thread, and whose native `join()` has no timeout. **Rule:** a `stop()` request must never be lost — don't reset stop/cancellation flags inside the run loop's own entry. Reset (re-arm) only via an explicit separate operation if a consumer truly needs to re-run. Reproduce FFI hangs single-threaded in pure Rust (spawn serve, `stop()` immediately, `join()`) before blaming the binding; use `sample <pid>`/jstack to see the native thread stuck in `kevent`.


### PR DESCRIPTION
## What

Port 5 of the language-binding arc — embeds the merged `irc-net-reactor` Rust IRC engine in the **JVM** via the zero-dep `jni-bridge`.

```java
try (IrcServer server = IrcServer.builder().port(6667).build()) {
    server.serveBackground();
    // ... connect IRC clients ...
    server.stop();
}
```

All IRC logic stays in Rust; Java only launches/controls the server (no callback into the JVM). `serve`/`serveBackground` run on an **owned clone** of the engine, so the background thread never dangles even though `close()` frees the native peer.

## Engine race fix (the interesting part)

The JVM binding **surfaced a real race** in the shared `stream-reactor`: `serve()` reset the stop flag on entry, so a `stop()` arriving after the serve thread was spawned but **before** the loop began was silently erased — `serve()` ran forever and `join()` hung. The JVM tests flip `running`→`stop` synchronously in one thread (and the native `join()` has no timeout), so they hit it every run; Python/Ruby masked it by waiting for the server to listen and via join-timeouts.

I reproduced the hang in **pure Rust** first (`sample`/jstack showed the thread stuck in `kevent`), fixed it (`serve()` no longer resets the flag — a `stop()` must never be lost), and added a regression test `irc-net-reactor::stop_called_before_serve_starts_is_not_lost`. Downstream consumers (`stream-reactor`, `tcp-runtime`, `embeddable-tcp-server`) all still pass; documented in `lessons.md`. This makes `stop()` reliable for **every** binding.

## Security review

Passed first round — no UAF/double-free/data-race in the JNI peer lifecycle (single-owner contract like `conduit-jni`; `close()` nulls the handle), and the engine fix is verified correct (no in-tree consumer re-serves a stopped reactor).

## Tests

4 JUnit real-socket tests, all green: ephemeral address, registration + PING/PONG, channel `PRIVMSG` broadcast between two clients, `running` flips after serve. `gradle test` BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)