### PR TITLE
fix(nib-formatter): handle mul_expr in expression dispatch

### DIFF
--- a/code/packages/typescript/nib-formatter/CHANGELOG.md
+++ b/code/packages/typescript/nib-formatter/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.1.1
+
+- fix a latent crash on multiplicative (`mul_expr`) expressions: the Nib
+  precedence cascade is `add_expr → mul_expr → bitwise_expr → unary_expr`,
+  but the formatter's expression dispatch (`EXPRESSION_RULES` set and the
+  `printExpression` switch) never listed `mul_expr`. Any program containing
+  a `*`, `/`, `*%`, or `/?` operator parsed to an `add_expr` whose only
+  operand was an unrecognised `mul_expr` node, so the printer threw
+  `Malformed add_expr: expected at least one operand`. The `mul_expr` rule
+  was added to the grammar in #5677 (N1, `*` and `/`); this wires the
+  formatter to match. Surfaced when an unrelated `grammar-tools` change
+  pulled `nib-formatter` back into the affected-package test set (its tests
+  only re-run when a transitive dependency changes).
+- add regression tests for `a * b` and the mixed `a + b * c` precedence
+  chain so the dispatch gap cannot silently reopen.
+
 ## 0.1.0
 
 - add the initial `@coding-adventures/nib-formatter` TypeScript package

--- a/code/packages/typescript/nib-formatter/package.json
+++ b/code/packages/typescript/nib-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/nib-formatter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Format Nib source into canonical layout using the shared document algebra stack.",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/nib-formatter/src/index.ts
+++ b/code/packages/typescript/nib-formatter/src/index.ts
@@ -49,6 +49,7 @@ const EXPRESSION_RULES = new Set([
   "eq_expr",
   "cmp_expr",
   "add_expr",
+  "mul_expr",
   "bitwise_expr",
   "unary_expr",
   "primary",
@@ -520,6 +521,7 @@ function printExpression(node: ASTNode): Doc {
     case "eq_expr":
     case "cmp_expr":
     case "add_expr":
+    case "mul_expr":
     case "bitwise_expr":
       return printInfixExpression(node);
     case "unary_expr":

--- a/code/packages/typescript/nib-formatter/tests/nib-formatter.test.ts
+++ b/code/packages/typescript/nib-formatter/tests/nib-formatter.test.ts
@@ -73,6 +73,25 @@ describe("formatNib()", () => {
     );
   });
 
+  it("formats multiplicative (mul_expr) operators canonically", () => {
+    // Regression for the precedence cascade add_expr → mul_expr →
+    // bitwise_expr → unary_expr: the printer must recognise `mul_expr`
+    // as an infix-expression rule. Before this was wired, `a * b` parsed
+    // to an add_expr whose only operand was a mul_expr node, and the
+    // printer threw "Malformed add_expr: expected at least one operand".
+    expect(formatNib("fn main(){return a*b;}")).toBe(
+      "fn main() {\n  return a * b;\n}",
+    );
+  });
+
+  it("respects mul-over-add precedence when printing a mixed chain", () => {
+    // `a + b * c` — the `b * c` mul_expr nests inside the add_expr without
+    // needing parentheses, exactly as the precedence cascade implies.
+    expect(formatNib("fn main(){return a+b*c;}")).toBe(
+      "fn main() {\n  return a + b * c;\n}",
+    );
+  });
+
   it("uses the shared infix-chain printer for longer operator chains", () => {
     expect(formatNib("fn main(){return a+b+c;}")).toBe(
       "fn main() {\n  return a +\n    b +\n    c;\n}",


### PR DESCRIPTION
## Summary

Fixes a latent crash in `@coding-adventures/nib-formatter` on any Nib
program containing a multiplicative operator (`*`, `/`, `*%`, `/?`).

The Nib grammar precedence cascade is
`add_expr → mul_expr → bitwise_expr → unary_expr`
([`nib.grammar` L293–309](https://github.com/adhithyan15/coding-adventures/blob/main/code/grammars/nib.grammar#L293)),
but the formatter's expression dispatch never listed `mul_expr` — it was
absent from both the `EXPRESSION_RULES` set and the `printExpression`
switch. As a result, any expression with a `*`/`/` parsed to an
`add_expr` whose only operand was an unrecognised `mul_expr` node, and
`printInfixExpression` threw:

```
Error: Malformed add_expr: expected at least one operand
```

The fix wires `mul_expr` into both dispatch points, routing it to the
existing generic `printInfixExpression` — `mul_expr` is structurally a
sibling of the infix levels already handled (`add_expr`, `bitwise_expr`,
`cmp_expr`, …) with the same operand/operator shape.

### Why this was latent
The `mul_expr` rule was added to the grammar in
[#5677](https://github.com/adhithyan15/coding-adventures/pull/5677)
(N1, Nib `*` and `/`); the formatter was never updated to match. The
build tool only re-runs `nib-formatter`'s tests when one of its
(transitive) dependencies changes — and nothing had since #5677. An
unrelated `grammar-tools` change in a separate branch pulled
`nib-formatter` back into the affected-package set, which is how the
crash surfaced. This fix is independent and lands on its own.

## Test plan
- [x] `nib-formatter` suite: **23/23 pass** (was 21 — failed 13/21
      before this fix, now +2 regression tests for `a * b` and the mixed
      `a + b * c` precedence chain)
- [x] `tsc --noEmit` — clean (only sibling-package missing-module noise
      from uninstalled local deps; none in `nib-formatter/src`)
- [x] `/security-review` — PASS (two literal string additions; no new
      attack surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)