### PR TITLE
feat(mycin-2026): A2 — bacteremia/sepsis (MYCIN's primary domain): reason from the source, cover the blood

### DIFF
--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/README.md
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/README.md
@@ -1,0 +1,62 @@
+# Bacteremia / sepsis (A2) — reason from the source, then cover the blood
+
+Bacteremia (organisms in the bloodstream) was **MYCIN's primary domain**. Its
+signature diagnostic move was to infer the likely organism from the **portal of
+entry** and host factors, then recommend empiric coverage. This package does that
+on our substrate — and it is the *same machinery* as the meningitis vertical (A1)
+pointed at a different site, with **no new engine**: that generalization is the
+point of A2.
+
+```
+source + host factors ──► source-id differential ──► significant set ──► set-cover ──► regimen
+        (portal of entry)   (which bloodstream bug?)   (cover these)       (bsi-formulary)
+```
+
+## Reasoning from the portal of entry (`source-id.adj`)
+
+| source | organisms it implies |
+|---|---|
+| urinary | enteric gram-negative bacilli (lead), Enterococcus, Pseudomonas |
+| intravascular line | CoNS (lead), S. aureus, Candida (skin flora) |
+| intra-abdominal | enteric GNB + anaerobes + Enterococcus (polymicrobial) |
+| skin / soft tissue | S. aureus, group A strep |
+| respiratory | pneumococcus, Klebsiella |
+| host: neutropenia | + Pseudomonas, Candida (anti-pseudomonal coverage matters) |
+| host: injection drug use | + S. aureus (right-sided endocarditis) |
+| host: prosthetic material | + CoNS (indolent device infection) |
+
+## What the deriver produces (0 model calls)
+
+| scenario | significant set | derived empiric regimen |
+|---|---|---|
+| Urosepsis | GNB, Enterococcus, S. aureus | piperacillin-tazobactam + vancomycin |
+| Central-line BSI | S. aureus, CoNS, GNB | piperacillin-tazobactam + vancomycin |
+| **Intra-abdominal** | GNB, anaerobes, Enterococcus | **piperacillin-tazobactam alone** (covers all three) |
+| SSTI + injection drug use | S. aureus, GNB | piperacillin-tazobactam + vancomycin |
+| Febrile neutropenia, source unknown | GNB, Pseudomonas, S. aureus | piperacillin-tazobactam (anti-pseudomonal) + vancomycin |
+| Intra-abdominal + **severe β-lactam allergy** | GNB, anaerobes, Enterococcus | **NO REGIMEN → escalate / specialist** (honest abstention) |
+
+The intra-abdominal case shows the set-cover picking a single broad agent over
+multiple narrow ones; the β-lactam-allergy case shows it **abstaining** when this
+formulary has no non-β-lactam that covers enteric gram-negatives (a real gap —
+aztreonam / fluoroquinolone / aminoglycoside would be the specialist call), rather
+than fabricating a regimen.
+
+## Files
+- `source-vocab.adj` — controlled vocabulary (bloodstream organisms + source/host
+  findings), importable CAS library; names align with the formulary tokens.
+- `source-id.adj` — the source→organism differential rulebook.
+- `bsi-formulary.json` — systemic empiric formulary (no CSF-penetration filter —
+  bloodstream, not CNS). Coverage **authored-illustrative**, clearly marked **not
+  yet spider-grounded**; a future formulary-spider pass grounds + gates it exactly
+  as it did the meningitis formulary (which corrected three hand-authored errors).
+- `identify_bsi.py` — runs the differential, the significant set, and a **generic**
+  minimum-cost set-cover (B1 will lift this into the engine as a native, proof-DAG-
+  producing `select`). `python3 identify_bsi.py`.
+- `test_identify_bsi.py` — guards the behavior; 0 answer-time model calls.
+
+## Honesty boundary
+The likelihood ratios and formulary coverage are authored from standard guidance
+(IDSA bloodstream / sepsis / SSTI / cIAI, Surviving Sepsis) and are **not yet
+spider-grounded** — the same authored→grounded path the meningitis side already
+walked. Decision-support only; every premise is one CAS edit overridable.

--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/bsi-formulary.json
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/bsi-formulary.json
@@ -1,0 +1,45 @@
+{
+  "_doc": "Empiric BACTEREMIA / SEPSIS formulary — systemic antibacterial (+ antifungal) FACTS, not regimens. Each drug carries what it COVERS (bloodstream pathogens), contraindications, and a preference TIER (first-line=1 … reserve=5). The regimen is DERIVED by minimum-cost SET-COVER over the organisms the source-id differential keeps in play (identify_bsi.py) — so it generalizes across sources with no new rules. Unlike the meningitis formulary there is no CSF-penetration filter (this is bloodstream, not CNS). Coverage facts are AUTHORED-ILLUSTRATIVE from standard references (IDSA bloodstream/sepsis/SSTI/cIAI guidance, Surviving Sepsis, Sanford) and are NOT yet spider-grounded — a future formulary-spider pass grounds + gates them exactly as it did the meningitis formulary (which corrected three hand-authored errors). Tiers encode empiric preference among valid options; both are one CAS edit from a grounded value. domain: empiric community/healthcare-associated bacteremia.",
+  "drugs": {
+    "piperacillin_tazobactam": {
+      "covers": ["enteric_gnb", "pseudomonas", "anaerobes", "enterococcus", "strep_pyogenes", "s_pneumoniae"],
+      "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 1,
+      "source": "IDSA/Surviving Sepsis: anti-pseudomonal beta-lactam/beta-lactamase-inhibitor, broad gram-negative + anaerobe + enterococcal (faecalis) coverage"
+    },
+    "cefepime": {
+      "covers": ["enteric_gnb", "pseudomonas", "strep_pyogenes", "s_pneumoniae"],
+      "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 2,
+      "source": "IDSA neutropenic fever: anti-pseudomonal cephalosporin (no anaerobic/enterococcal coverage)"
+    },
+    "ceftriaxone": {
+      "covers": ["enteric_gnb", "strep_pyogenes", "s_pneumoniae"],
+      "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 1,
+      "source": "3rd-gen cephalosporin: non-pseudomonal gram-negative + streptococcal (community sepsis)"
+    },
+    "meropenem": {
+      "covers": ["enteric_gnb", "pseudomonas", "anaerobes", "enterococcus", "strep_pyogenes", "s_pneumoniae"],
+      "betalactam": true, "contraindications": ["betalactam_allergy_severe"], "tier": 3,
+      "source": "Carbapenem (reserve): very broad incl. ESBL gram-negatives, anaerobes; Enterococcus faecalis"
+    },
+    "vancomycin": {
+      "covers": ["s_aureus", "coag_neg_staph", "enterococcus", "strep_pyogenes", "s_pneumoniae"],
+      "betalactam": false, "contraindications": [], "tier": 1,
+      "source": "Empiric gram-positive coverage incl. MRSA, CoNS, most enterococci (not VRE)"
+    },
+    "metronidazole": {
+      "covers": ["anaerobes"],
+      "betalactam": false, "contraindications": [], "tier": 1,
+      "source": "Anaerobic coverage (pairs with a non-anaerobic gram-negative agent, e.g. cefepime/ceftriaxone)"
+    },
+    "micafungin": {
+      "covers": ["candida"],
+      "betalactam": false, "contraindications": [], "tier": 2,
+      "source": "IDSA candidiasis: echinocandin, first-line empiric candidemia"
+    },
+    "daptomycin": {
+      "covers": ["s_aureus", "coag_neg_staph", "enterococcus", "strep_pyogenes"],
+      "betalactam": false, "contraindications": [], "tier": 3,
+      "source": "Gram-positive incl. MRSA + VRE (reserve; NOT for pulmonary source — inactivated by surfactant)"
+    }
+  }
+}

--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/identify_bsi.py
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/identify_bsi.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""identify_bsi.py — bacteremia: identify the organism from the SOURCE, then cover it.
+
+MYCIN-2026 A2. Bacteremia was MYCIN's primary domain, and its signature move was
+to reason from the portal of entry: a urinary source implies enteric gram-negative
+rods; a central line implies skin flora (CoNS, S. aureus, Candida); an
+intra-abdominal source implies gram-negatives + anaerobes + Enterococcus; and so
+on. This is the SAME machinery as the meningitis vertical (A1) pointed at a
+different site — proving the substrate generalizes across infection sites with no
+new engine:
+
+    source + host factors ──► source-id differential ──► significant set ──► set-cover ──► regimen
+
+The set-cover here is GENERIC (no CSF-penetration filter — this is bloodstream,
+not CNS): minimum preference-cost set of drugs whose union covers every organism
+still in play. 0 answer-time model calls.
+
+Usage:  python3 identify_bsi.py    (runs the demo scenarios)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from itertools import combinations
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MYCIN = HERE.parent.parent
+sys.path.insert(0, str(MYCIN / "warm"))
+import decide as decide_mod  # noqa: E402  (find_cli only)
+
+FORMULARY = json.loads((HERE / "bsi-formulary.json").read_text())
+DRUGS = FORMULARY["drugs"]
+
+# Leader is always kept; others kept if still materially in play.
+IN_PLAY_SHARE = 0.12
+# A finding term/value is a single lowercase identifier (closed vocabulary). We
+# validate before composing the .adj program so an externally-sourced finding can
+# never inject extra rulebook directives (same boundary discipline as decide.py).
+TOKEN_RE = re.compile(r"\A[a-z][a-z0-9_]*\Z")
+
+
+def run_differential(cli: Path, findings: dict[str, str]) -> list[dict]:
+    """Compose a case (import the rulebook + observe findings), run the CLI, return
+    the ranked organisms. The case file is created with mkstemp (O_EXCL, 0600,
+    unpredictable name) next to source-id.adj so the relative import resolves."""
+    lines = ['import "source-id.adj"']
+    for f, v in findings.items():
+        if not (TOKEN_RE.match(f) and TOKEN_RE.match(v)):
+            raise ValueError(f"unsafe finding token {f!r}={v!r} (must match {TOKEN_RE.pattern})")
+        lines.append(f"observe {f}({v})")
+    fd, name = tempfile.mkstemp(suffix=".adj", prefix="_tmp_bsi_", dir=HERE)
+    case = Path(name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write("\n".join(lines) + "\n")
+        r = subprocess.run([str(cli), str(case)], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"adj-lang-cli exited {r.returncode}: {r.stderr}")
+        out = json.loads(r.stdout)
+    finally:
+        case.unlink(missing_ok=True)
+    return out.get("ranked", [])
+
+
+def significant_set(ranked: list[dict]) -> list[str]:
+    """Leader + every organism still materially in play (share ≥ threshold)."""
+    if not ranked:
+        return []
+    keep = [ranked[0]["hypothesis"]]
+    keep += [r["hypothesis"] for r in ranked[1:] if r.get("normalized_share", 0) >= IN_PLAY_SHARE]
+    return keep
+
+
+def min_cost_cover(drugs: dict, organisms: list[str], exclusions: set[str]) -> list[str] | None:
+    """GENERIC minimum preference-cost (then fewest-drug) set-cover. Candidates are
+    drugs not contraindicated for this patient; returns None if no set covers all
+    organisms. Tiny formulary → exhaustive subset search is instant. (B1 will lift
+    this into the engine as a native, proof-DAG-producing `select` construct.)"""
+    cands = [d for d, f in drugs.items() if not (set(f.get("contraindications", [])) & exclusions)]
+    need = set(organisms)
+    best, best_key = None, None
+    for k in range(1, len(cands) + 1):
+        for combo in combinations(cands, k):
+            cov = set().union(*(drugs[d]["covers"] for d in combo)) if combo else set()
+            if need <= cov:
+                key = (sum(drugs[d]["tier"] for d in combo), len(combo))
+                if best_key is None or key < best_key:
+                    best, best_key = list(combo), key
+    return best
+
+
+def identify_and_treat(cli: Path, title: str, findings: dict[str, str],
+                       exclusions: set[str]) -> None:
+    print("=" * 78 + f"\n{title}\n" + "=" * 78)
+    print(f"  findings: {', '.join(f'{k}={v}' for k, v in findings.items())}")
+    ranked = run_differential(cli, findings)
+    print("  ORGANISM DIFFERENTIAL (which bloodstream pathogen?):")
+    for r in ranked[:6]:
+        mark = "  <- leading" if r is ranked[0] else ""
+        print(f"    {r['hypothesis']:18s} P={r['posterior']:.3f}  share={r['normalized_share']:.3f}{mark}")
+    sig = significant_set(ranked)
+    print(f"  SIGNIFICANT SET (cover these): {sig}")
+    cover = min_cost_cover(DRUGS, sig, exclusions)
+    if cover is None:
+        print(f"  NO REGIMEN covers {sig} under exclusions {sorted(exclusions)} -> escalate / specialist.\n")
+        return
+    print(f"  DERIVED EMPIRIC REGIMEN: {' + '.join(cover)}")
+    for d in cover:
+        covered = sorted(set(DRUGS[d]["covers"]) & set(sig))
+        print(f"    - {d:24s} covers {covered}")
+    print()
+
+
+def main() -> int:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("identify_bsi: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    print("formulary: bsi-formulary.json (authored-illustrative; not yet spider-grounded)\n")
+
+    identify_and_treat(cli, "1) Urinary source (urosepsis)",
+                       {"infection_source": "urinary"}, set())
+    identify_and_treat(cli, "2) Central-line-associated bloodstream infection",
+                       {"infection_source": "intravascular_line"}, set())
+    identify_and_treat(cli, "3) Intra-abdominal source (polymicrobial)",
+                       {"infection_source": "intraabdominal"}, set())
+    identify_and_treat(cli, "4) Skin/soft-tissue source in an injection drug user",
+                       {"infection_source": "skin_soft_tissue", "injection_drug_use": "present"}, set())
+    identify_and_treat(cli, "5) Febrile neutropenia, source unknown — anti-pseudomonal needed",
+                       {"infection_source": "unknown", "neutropenia": "present"}, set())
+    identify_and_treat(cli, "6) Intra-abdominal source, SEVERE beta-lactam allergy — cover re-derives",
+                       {"infection_source": "intraabdominal"}, {"betalactam_allergy_severe"})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/source-id.adj
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/source-id.adj
@@ -1,0 +1,129 @@
+% ============================================================================
+% source-id — WHICH bacterium in the blood? The bacteremia organism-identification
+% rulebook, reasoning from the PORTAL OF ENTRY. Importable CAS library.
+% ============================================================================
+% MYCIN-2026 A2. A differential over the common bloodstream pathogens, driven by
+% the source of infection (the strong signal) plus host factors. Magnitudes are
+% authored from standard references (IDSA bloodstream / sepsis guidance; Surviving
+% Sepsis; standard microbiology) and are clearly marked NOT yet spider-grounded
+% (`trust consensus`/`empirical`) — one CAS edit from a grounded value, the same
+% honesty boundary the meningitis rulebook and formulary carry.
+%
+% Use:  import "source-id.adj"  then add observe lines; the ? queries are here.
+
+import "source-vocab.adj"
+
+rulebook source_id {
+    use bacteremia_vocab
+
+    % ===================== Base priors (source-unknown bacteremia) =====================
+    % Rough community bloodstream-isolate frequencies; the differential normalizes.
+    prior 0.22 for s_aureus
+        source "S. aureus a leading bloodstream isolate (standard microbiology)"
+        trust consensus
+    prior 0.25 for enteric_gnb
+        source "Enterobacterales the leading gram-negative bloodstream isolates"
+        trust consensus
+    prior 0.10 for coag_neg_staph
+        source "CoNS common (often line-related / contaminant) (standard microbiology)"
+        trust consensus
+    prior 0.08 for enterococcus
+        source "Enterococcus a common nosocomial bloodstream isolate"
+        trust consensus
+    prior 0.07 for s_pneumoniae
+        source "Pneumococcal bacteremia (community)"
+        trust consensus
+    prior 0.05 for pseudomonas
+        source "Pseudomonas (healthcare-associated / neutropenic)"
+        trust consensus
+    prior 0.04 for strep_pyogenes
+        source "Group A strep bacteremia (skin/soft-tissue)"
+        trust consensus
+    prior 0.05 for anaerobes
+        source "Anaerobic bacteremia (intra-abdominal)"
+        trust consensus
+    prior 0.03 for candida
+        source "Candidemia (line / gut translocation / neutropenia)"
+        trust consensus
+
+    % ===================== Source → organism (the strong signal) =====================
+    % Urinary: enteric GNB dominate; Enterococcus and Pseudomonas also.
+    contributes 14 from infection_source(urinary) to enteric_gnb
+        source "Urinary source → Enterobacterales (E. coli leading uropathogen)"
+        trust empirical
+    contributes 4 from infection_source(urinary) to enterococcus
+        source "Enterococcal urinary source (esp. healthcare-associated)"
+        trust empirical
+    contributes 2 from infection_source(urinary) to pseudomonas
+        source "Pseudomonas urinary source (catheter / healthcare)"
+        trust empirical
+
+    % Intravascular line: skin flora — CoNS, then S. aureus, then Candida.
+    contributes 12 from infection_source(intravascular_line) to coag_neg_staph
+        source "Central-line-associated bloodstream infection: CoNS leading (IDSA CLABSI)"
+        trust empirical
+    contributes 8 from infection_source(intravascular_line) to s_aureus
+        source "CLABSI: S. aureus (IDSA intravascular catheter guidance)"
+        trust empirical
+    contributes 4 from infection_source(intravascular_line) to candida
+        source "Catheter-related candidemia (IDSA candidiasis guidance)"
+        trust empirical
+
+    % Intra-abdominal: polymicrobial — enteric GNB + anaerobes + Enterococcus.
+    contributes 9 from infection_source(intraabdominal) to enteric_gnb
+        source "Intra-abdominal source → enteric GNB (IDSA cIAI)"
+        trust empirical
+    contributes 9 from infection_source(intraabdominal) to anaerobes
+        source "Intra-abdominal source → anaerobes incl. B. fragilis (IDSA cIAI)"
+        trust empirical
+    contributes 4 from infection_source(intraabdominal) to enterococcus
+        source "Enterococcus in complicated intra-abdominal infection"
+        trust empirical
+
+    % Skin / soft tissue: S. aureus and group A strep.
+    contributes 12 from infection_source(skin_soft_tissue) to s_aureus
+        source "Skin/soft-tissue source → S. aureus (IDSA SSTI)"
+        trust empirical
+    contributes 6 from infection_source(skin_soft_tissue) to strep_pyogenes
+        source "Skin/soft-tissue source → group A strep (IDSA SSTI)"
+        trust empirical
+
+    % Respiratory: pneumococcus, then enteric GNB (Klebsiella).
+    contributes 9 from infection_source(respiratory) to s_pneumoniae
+        source "Pneumonia source → pneumococcal bacteremia"
+        trust empirical
+    contributes 3 from infection_source(respiratory) to enteric_gnb
+        source "Gram-negative pneumonia (Klebsiella) bacteremia"
+        trust empirical
+
+    % ===================== Host factors =====================
+    % Neutropenia: anti-pseudomonal coverage matters; GNB + Candida risk.
+    contributes 6 from neutropenia(present) to pseudomonas
+        source "Febrile neutropenia → Pseudomonas (IDSA neutropenic fever)"
+        trust empirical
+    contributes 3 from neutropenia(present) to enteric_gnb
+        source "Febrile neutropenia → gram-negative bacteremia"
+        trust empirical
+    contributes 3 from neutropenia(present) to candida
+        source "Prolonged neutropenia → candidemia"
+        trust empirical
+    % IV drug use: S. aureus (right-sided endocarditis).
+    contributes 8 from injection_drug_use(present) to s_aureus
+        source "Injection drug use → S. aureus bacteremia / endocarditis"
+        trust empirical
+    % Prosthetic material: CoNS (indolent device infection).
+    contributes 6 from prosthetic_material(present) to coag_neg_staph
+        source "Prosthetic material → CoNS device infection"
+        trust empirical
+}
+
+% The differential: rank the competing bloodstream organisms by posterior.
+? s_aureus
+? coag_neg_staph
+? enteric_gnb
+? pseudomonas
+? enterococcus
+? strep_pyogenes
+? s_pneumoniae
+? anaerobes
+? candida

--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/source-vocab.adj
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/source-vocab.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% source-vocab — controlled vocabulary for ORGANISM IDENTIFICATION in
+% bacteremia / sepsis, reasoning from the PORTAL OF ENTRY. Importable CAS library.
+% ============================================================================
+% MYCIN-2026 A2. Bacteremia (organisms in the blood) was MYCIN's *primary* domain.
+% Its central diagnostic move was to infer the likely organism from the SOURCE /
+% portal of entry plus host factors, then recommend empiric coverage. This is the
+% same machinery as the meningitis organism-id (A1) pointed at a different site —
+% proving the substrate generalizes across infection sites with NO new engine.
+%
+% Same closed-vocabulary discipline: the decomposer is constrained to these
+% `surface` forms and the compiler rejects any term not defined here. Organism
+% names align with the bacteremia formulary's tokens (bsi-formulary.json).
+%
+% Use:  import "source-vocab.adj"  then  use bacteremia_vocab
+
+dictionary bacteremia_vocab {
+
+    % ======================== Hypotheses (the organisms) ========================
+    define s_aureus : hypothesis
+        surface "Staphylococcus aureus", "staph aureus", "MRSA", "MSSA"
+    define coag_neg_staph : hypothesis
+        surface "coagulase-negative staphylococcus", "CoNS", "Staphylococcus epidermidis"
+    define enteric_gnb : hypothesis
+        surface "enteric gram-negative bacilli", "E. coli", "Escherichia coli",
+                "Klebsiella", "Enterobacter", "gram-negative rods"
+    define pseudomonas : hypothesis
+        surface "Pseudomonas aeruginosa", "pseudomonas", "non-fermenting gram-negative rod"
+    define enterococcus : hypothesis
+        surface "Enterococcus", "enterococci", "Enterococcus faecalis", "VRE"
+    define strep_pyogenes : hypothesis
+        surface "Streptococcus pyogenes", "group A strep", "beta-hemolytic strep"
+    define s_pneumoniae : hypothesis
+        surface "Streptococcus pneumoniae", "pneumococcus", "pneumococcal bacteremia"
+    define anaerobes : hypothesis
+        surface "anaerobes", "Bacteroides", "Bacteroides fragilis", "anaerobic organisms"
+    define candida : hypothesis
+        surface "Candida", "candidemia", "yeast", "fungemia"
+
+    % ======================== Findings ==========================
+    % --- The portal of entry / source (the dominant determinant). ---
+    define infection_source : finding values [
+            urinary, intravascular_line, intraabdominal,
+            skin_soft_tissue, respiratory, unknown]
+        surface "urinary source", "urosepsis", "pyelonephritis", "UTI source",
+                "central line", "catheter-related", "intravascular catheter",
+                "intra-abdominal", "perforated viscus", "biliary source", "peritonitis",
+                "skin and soft tissue", "cellulitis", "wound infection",
+                "pneumonia", "respiratory source", "lung source",
+                "no clear source", "source unknown", "cryptogenic"
+
+    % --- Host factors that shift the organism distribution. ---
+    define neutropenia : finding values [present, absent]
+        surface "neutropenic", "neutropenia", "ANC < 500", "post-chemotherapy nadir",
+                "not neutropenic"
+    define injection_drug_use : finding values [present, absent]
+        surface "injection drug use", "IVDU", "people who inject drugs", "no IV drug use"
+    define prosthetic_material : finding values [present, absent]
+        surface "prosthetic valve", "prosthetic joint", "indwelling hardware",
+                "vascular graft", "no prosthetic material"
+    define healthcare_associated : finding values [present, absent]
+        surface "healthcare-associated", "hospital-acquired", "recent hospitalization",
+                "recent antibiotics", "nursing facility", "community-acquired"
+}

--- a/code/specs/data/mycin-2026/diagnosis/bacteremia/test_identify_bsi.py
+++ b/code/specs/data/mycin-2026/diagnosis/bacteremia/test_identify_bsi.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""test_identify_bsi.py — guard bacteremia source→organism→cover. 0 model calls.
+
+Asserts the source drives the organism differential, the significant set maps onto
+the bacteremia formulary and derives a sensible empiric regimen, and that a severe
+beta-lactam allergy with gram-negative needs ABSTAINS (no fabricated regimen).
+Skips the CLI checks if adj-lang-cli is not built. CI runs this.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MYCIN = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(MYCIN / "warm"))
+import decide as decide_mod  # noqa: E402
+import identify_bsi as bsi  # noqa: E402
+
+
+def test_cover_pure() -> None:
+    """Generic set-cover: picks lowest-tier covering set; abstains when impossible."""
+    drugs = {
+        "broad": {"covers": ["gnb", "anaerobe"], "tier": 1, "contraindications": ["allergy"]},
+        "narrow_a": {"covers": ["gnb"], "tier": 1, "contraindications": []},
+        "narrow_b": {"covers": ["anaerobe"], "tier": 1, "contraindications": []},
+    }
+    # One broad drug (tier 1) beats two narrow (tier 1+1) by fewest-drugs tiebreak.
+    assert bsi.min_cost_cover(drugs, ["gnb", "anaerobe"], set()) == ["broad"]
+    # Exclude the broad one → must use the two narrow agents.
+    cover = bsi.min_cost_cover(drugs, ["gnb", "anaerobe"], {"allergy"})
+    assert cover is not None and set(cover) == {"narrow_a", "narrow_b"}, cover
+    # No drug covers 'mrsa' → abstain.
+    assert bsi.min_cost_cover(drugs, ["mrsa"], set()) is None
+
+
+def test_token_validation() -> None:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        return
+    try:
+        bsi.run_differential(cli, {"infection_source": "urinary)\nobserve x("})
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on an injection-shaped finding token")
+
+
+def main() -> int:
+    test_cover_pure()
+    test_token_validation()
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("test_identify_bsi: PASS (pure checks); CLI checks SKIPPED (adj-lang-cli not built)")
+        return 0
+
+    # Urinary source → enteric GNB leads.
+    ranked = bsi.run_differential(cli, {"infection_source": "urinary"})
+    assert ranked[0]["hypothesis"] == "enteric_gnb", ranked[0]
+
+    # Central line → S. aureus / CoNS dominate the top of the differential.
+    ranked = bsi.run_differential(cli, {"infection_source": "intravascular_line"})
+    top2 = {ranked[0]["hypothesis"], ranked[1]["hypothesis"]}
+    assert top2 == {"s_aureus", "coag_neg_staph"}, top2
+
+    # Intra-abdominal → piperacillin-tazobactam alone covers GNB + anaerobes + enterococcus.
+    ranked = bsi.run_differential(cli, {"infection_source": "intraabdominal"})
+    sig = bsi.significant_set(ranked)
+    assert {"enteric_gnb", "anaerobes"} <= set(sig), sig
+    cover = bsi.min_cost_cover(bsi.DRUGS, sig, set())
+    assert cover == ["piperacillin_tazobactam"], cover
+
+    # Same source + severe beta-lactam allergy → no GN coverage left → abstain.
+    assert bsi.min_cost_cover(bsi.DRUGS, sig, {"betalactam_allergy_severe"}) is None
+
+    print("test_identify_bsi: PASS (source drives the organism; pip-tazo covers the "
+          "intra-abdominal triad; severe beta-lactam allergy abstains; 0 model calls)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Independent PR** (own rulebook + formulary; no dependency on #5708/#5715) — mergeable in parallel.

## What this is

Bacteremia was **MYCIN's primary domain**, and its signature move was to infer the organism from the **portal of entry** + host factors, then cover it. This is the **same machinery** as the meningitis vertical (A1) pointed at a different site — **no new engine**. That generalization across infection sites is the point of A2.

```
source + host factors → source-id differential → significant set → set-cover → empiric regimen
```

## Reasoning from the portal of entry (`source-id.adj`)

urinary → enteric GNB; central line → CoNS / S. aureus / Candida; intra-abdominal → GNB + anaerobes + Enterococcus; skin/soft-tissue → S. aureus / group A strep; respiratory → pneumococcus; neutropenia → + Pseudomonas/Candida; injection drug use → + S. aureus.

## What it derives (0 model calls)

| scenario | significant set | regimen |
|---|---|---|
| Urosepsis | GNB, Enterococcus, S. aureus | pip-tazo + vancomycin |
| Central-line BSI | S. aureus, CoNS, GNB | pip-tazo + vancomycin |
| **Intra-abdominal** | GNB, anaerobes, Enterococcus | **pip-tazo alone** (one broad agent covers all three) |
| SSTI + injection drug use | S. aureus, GNB | pip-tazo + vancomycin |
| Febrile neutropenia, unknown source | GNB, Pseudomonas, S. aureus | pip-tazo (anti-pseudomonal) + vancomycin |
| Intra-abdominal + **severe β-lactam allergy** | GNB, anaerobes, Enterococcus | **NO REGIMEN → escalate / specialist** (honest abstention) |

The β-lactam-allergy case **abstains** because no non-β-lactam in this formulary covers enteric gram-negatives (a real gap — aztreonam / fluoroquinolone / aminoglycoside is the specialist call), rather than fabricating.

## Honesty boundary
LRs + formulary coverage are **authored-illustrative** from standard guidance (IDSA bloodstream/sepsis/SSTI/cIAI, Surviving Sepsis), clearly marked **not yet spider-grounded** — the same authored→grounded path the meningitis side already walked (where the spider corrected 3 hand-authored errors). The set-cover is **generic** (no domain-specific filter); B1 will lift it into the engine as a native `select`.

## Verification
- `python3 diagnosis/bacteremia/identify_bsi.py` reproduces the table.
- `python3 diagnosis/bacteremia/test_identify_bsi.py` → PASS; 0 answer-time model calls; skips if CLI unbuilt.
- ruff clean. Security review: **PASSED** (mkstemp O_EXCL temp file + TOKEN_RE finding validation; set-cover bounded to the static formulary).

Decision-support only — every premise grounded/authored + overridable; the physician makes the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)