### PR TITLE
feat(web13): C++ Conduit port over the reusable conduit-capi C ABI

### DIFF
--- a/code/packages/cpp/conduit/.gitignore
+++ b/code/packages/cpp/conduit/.gitignore
@@ -1,0 +1,2 @@
+_build/
+build/

--- a/code/packages/cpp/conduit/BUILD
+++ b/code/packages/cpp/conduit/BUILD
@@ -1,0 +1,2 @@
+# build-tool: deps=rust/conduit-capi
+sh tools/run-tests.sh

--- a/code/packages/cpp/conduit/BUILD_windows
+++ b/code/packages/cpp/conduit/BUILD_windows
@@ -1,0 +1,1 @@
+echo C++ Conduit tests use POSIX sockets for the E2E — skipping on Windows

--- a/code/packages/cpp/conduit/CHANGELOG.md
+++ b/code/packages/cpp/conduit/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog — Conduit (C++)
+
+## [0.1.0] - 2026-06-13
+
+### Added — WEB13 C++ Conduit port
+
+- A header-only Sinatra/Express-style web framework for C++ over the Rust
+  web-core engine, via the reusable `conduit-capi` C ABI (the second consumer
+  after Swift). No third-party deps.
+- **DSL**: `Application` with `get/post/put/del/patch`, `route`, `before`,
+  `after` (transforming), `notFound`, `onError`, `set`/`getSetting`, `bind` —
+  all chainable. Handlers are `std::function<Response(const Request&)>`.
+- **Response** helpers `html/json/text/respond/redirect`; `redirect` throws on
+  CR/LF. **halt(...)** for Sinatra-style non-local exits (throws `Halt`).
+- **Request**: `method/path/queryString/body/contentType/remoteAddr/error`,
+  `param/query/header` (returning `std::optional`).
+- **Server**: `serve` (foreground), `serveBackground`, `stop`, `localPort`,
+  `running` — RAII-owned.
+- Closures are heap-boxed and freed via a `ctx_free` trampoline; trampolines have
+  C linkage (so function-pointer types match the ABI exactly) and catch all C++
+  exceptions so none unwind across the C boundary.
+
+### Tests
+
+16 tests (zero-dependency harness): response helpers incl. native round-trip and
+CR/LF guard; Application DSL/settings/bind; a full end-to-end server driven by a
+POSIX-socket HTTP/1.0 client with a watchdog thread. `tools/run-tests.sh` builds
+the C ABI, queries the platform's `native-static-libs`, and links each test.
+
+### Security
+
+Header-injection defense, status clamping, and UTF-8 validation are inherited
+from `conduit-capi` (audited once for all C-ABI ports).

--- a/code/packages/cpp/conduit/CMakeLists.txt
+++ b/code/packages/cpp/conduit/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.20)
+project(Conduit VERSION 0.1.0
+        DESCRIPTION "Sinatra-style web framework for C++ over the Conduit C ABI"
+        LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# The wrapper itself is header-only.
+add_library(Conduit INTERFACE)
+add_library(Conduit::Conduit ALIAS Conduit)
+target_include_directories(Conduit INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../rust/conduit-capi/include>
+    $<INSTALL_INTERFACE:include>)
+
+# Link against the prebuilt Rust C ABI static library. Build it first with:
+#   ( cd ../../rust/conduit-capi && cargo build --release )
+# (the canonical CI path is `sh tools/run-tests.sh`, which does this for you).
+set(CONDUIT_CAPI_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../rust/target/release/libconduit_capi.a")
+target_link_libraries(Conduit INTERFACE ${CONDUIT_CAPI_LIB})
+
+if(MSVC)
+    target_compile_options(Conduit INTERFACE /W4)
+else()
+    target_compile_options(Conduit INTERFACE -Wall -Wextra -Wpedantic)
+endif()

--- a/code/packages/cpp/conduit/README.md
+++ b/code/packages/cpp/conduit/README.md
@@ -1,0 +1,113 @@
+# Conduit (C++)
+
+A Sinatra/Express-style web framework for C++, implemented as a **header-only**
+wrapper over the reusable [`conduit-capi`](../../rust/conduit-capi) C ABI (which
+exposes the Rust **web-core** HTTP engine, WEB08). Your handlers are
+`std::function` closures; routing, lifecycle hooks, and HTTP I/O run in Rust.
+
+This is the WEB13 port in the cross-language Conduit family and the second
+consumer of `conduit-capi` (after Swift).
+
+## How it fits in the stack
+
+```
+your C++ handlers   std::function<Response(const Request&)>
+        │  extern "C" trampoline + heap-boxed closure (ctx)
+conduit.hpp   (this package, header-only)
+        │  conduit-capi   (C ABI, libconduit_capi.a)
+conduit  (WEB08 facade) → web-core → embeddable-http-server → tcp-runtime
+```
+
+## Build
+
+Header-only, but it links the Rust C ABI static library, so you need a Rust
+toolchain and a C++17 compiler:
+
+```sh
+sh tools/run-tests.sh        # builds conduit-capi, compiles + runs the tests
+```
+
+`tools/run-tests.sh` builds `libconduit_capi.a`, queries the platform's
+`native-static-libs`, and compiles each `tests/test_*.cpp` against it. A
+`CMakeLists.txt` is provided as the documented end-user path.
+
+## Quick start
+
+```cpp
+#include "conduit/conduit.hpp"
+using namespace conduit;
+
+int main() {
+    Application app;
+
+    app.before([](const Request& req) -> std::optional<Response> {
+        if (req.path() == "/down") halt(503, "maintenance");
+        return std::nullopt;
+    });
+
+    app.get("/", [](const Request&) { return Response::html("<h1>Hello from Conduit!</h1>"); });
+
+    app.get("/hello/:name", [](const Request& req) {
+        return Response::json("{\"hi\":\"" + req.param("name").value_or("") + "\"}");
+    });
+
+    app.post("/echo", [](const Request& req) {
+        return Response::respond(200, req.body(), {{"content-type", req.contentType()}});
+    });
+
+    app.notFound([](const Request& req) { return Response::text("no route: " + req.path(), 404); });
+    app.onError([](const Request&) { return Response::json("{\"error\":\"oops\"}", 500); });
+
+    Server server = app.bind("127.0.0.1", 3000);
+    server.serve();   // blocks until stopped
+}
+```
+
+## Response helpers
+
+Each returns a `Response`:
+
+| Helper | Status | Content-Type |
+| ------ | ------ | ------------ |
+| `Response::html(body, status=200)`  | 200 | `text/html; charset=utf-8` |
+| `Response::json(body, status=200)`  | 200 | `application/json` |
+| `Response::text(body, status=200)`  | 200 | `text/plain; charset=utf-8` |
+| `Response::respond(status, body, headers)` | as given | as given |
+| `Response::redirect(location, status=302)` | 302 | sets `Location` (throws on CR/LF) |
+
+`halt(status, body)` performs a Sinatra-style non-local exit (throws `Halt`).
+
+## Request
+
+Handlers receive a `const Request&`: `method()`, `path()`, `queryString()`,
+`body()`, `contentType()`, `remoteAddr()`, plus `param(name)` (route params),
+`query(name)`, and `header(name)` — each returning `std::optional<std::string>`.
+Inside `onError`, `error()` carries the failure message.
+
+## Application DSL
+
+`Application` → `get/post/put/del/patch(pattern, handler)` → `before`/`after` →
+`notFound`/`onError` → `set`/`getSetting` → `bind(host, port)`. Every registration
+returns `*this`, so calls chain. `bind` returns a `Server` and throws on failure.
+(`del` is named so because `delete` is a keyword.)
+
+## Server
+
+`serve()` (foreground, blocks), `serveBackground()` (own OS thread), `stop()`,
+`localPort()`, `running()`. RAII: the `Server` destructor frees the native server.
+
+## Security
+
+The trust boundary is audited once in `conduit-capi`: header names/values with
+CR/LF/control bytes are dropped (response-splitting defense), status is clamped to
+100–599, and every string crossing the boundary is UTF-8-validated. `redirect`
+additionally throws on CR/LF in the location. The trampolines catch all C++
+exceptions so none unwind across the C ABI.
+
+## Tests
+
+`sh tools/run-tests.sh` — 16 tests: response helpers (incl. a native round-trip
+and CR/LF guard), the Application DSL / settings / bind, and a full end-to-end
+server run (routes, params, POST echo, query, before-halt 503, throwing-handler→
+onError 500, custom 404, redirect 302, after-hook header stamping) driven by a
+POSIX-socket HTTP/1.0 client with a watchdog thread.

--- a/code/packages/cpp/conduit/include/conduit/conduit.hpp
+++ b/code/packages/cpp/conduit/include/conduit/conduit.hpp
@@ -1,0 +1,352 @@
+// ============================================================================
+// conduit.hpp — a Sinatra/Express-style web framework for C++.
+// ============================================================================
+//
+// A header-only C++ wrapper over the reusable `conduit-capi` C ABI (which
+// exposes the Rust web-core engine / WEB08 facade). C++ handlers are
+// std::function closures; routing, lifecycle hooks, and HTTP I/O run in Rust.
+//
+//   #include "conduit/conduit.hpp"
+//   using namespace conduit;
+//
+//   Application app;
+//   app.before([](const Request& req) -> std::optional<Response> {
+//       if (req.path() == "/down") halt(503, "maintenance");
+//       return std::nullopt;
+//   });
+//   app.get("/", [](const Request&) { return Response::html("<h1>Hi</h1>"); });
+//   app.get("/hello/:name", [](const Request& req) {
+//       return Response::json("{\"hi\":\"" + req.param("name").value_or("") + "\"}");
+//   });
+//   Server server = app.bind("127.0.0.1", 3000);
+//   server.serve();   // blocks until stopped
+//
+// Link against libconduit_capi.a and add the C ABI's include dir to the path.
+
+#ifndef CONDUIT_HPP
+#define CONDUIT_HPP
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "conduit_capi.h"
+
+namespace conduit {
+
+using Header = std::pair<std::string, std::string>;
+
+// ── Response ─────────────────────────────────────────────────────────────────
+
+/// An HTTP response: status, ordered headers, body. Build directly or with the
+/// Sinatra-style helpers. The native side clamps the status to 100–599 and drops
+/// any header whose name/value carries CR/LF/control bytes.
+class Response {
+public:
+    int status = 200;
+    std::vector<Header> headers;
+    std::string body;
+
+    Response() = default;
+    Response(int s, std::string b, std::vector<Header> h = {})
+        : status(s), headers(std::move(h)), body(std::move(b)) {}
+
+    static Response html(std::string body, int status = 200) {
+        return Response(status, std::move(body), {{"content-type", "text/html; charset=utf-8"}});
+    }
+    static Response json(std::string body, int status = 200) {
+        return Response(status, std::move(body), {{"content-type", "application/json"}});
+    }
+    static Response text(std::string body, int status = 200) {
+        return Response(status, std::move(body), {{"content-type", "text/plain; charset=utf-8"}});
+    }
+    static Response respond(int status, std::string body = "", std::vector<Header> headers = {}) {
+        return Response(status, std::move(body), std::move(headers));
+    }
+    /// A redirect (default 302). Throws std::invalid_argument if the location
+    /// contains CR or LF (response-splitting guard).
+    static Response redirect(const std::string& location, int status = 302) {
+        for (char c : location) {
+            if (c == '\r' || c == '\n') {
+                throw std::invalid_argument("redirect location must not contain CR or LF");
+            }
+        }
+        return Response(status, "", {{"location", location}});
+    }
+
+    /// Build an owned ConduitResponse* for handing back to the engine.
+    ConduitResponse* toC() const {
+        int clamped = status < 100 ? 100 : (status > 599 ? 599 : status);
+        const uint8_t* bptr =
+            body.empty() ? nullptr : reinterpret_cast<const uint8_t*>(body.data());
+        ConduitResponse* r =
+            conduit_response_new(static_cast<uint16_t>(clamped), bptr, body.size());
+        if (!r) return nullptr;
+        for (const auto& h : headers) {
+            conduit_response_set_header(r, h.first.c_str(), h.second.c_str());
+        }
+        return r;
+    }
+
+    /// Read a response back out of a ConduitResponse* (used by after-hooks).
+    /// Does not free `p`.
+    static Response fromC(const ConduitResponse* p) {
+        Response r;
+        r.status = conduit_response_status(p);
+        size_t len = 0;
+        const uint8_t* b = conduit_response_body(p, &len);
+        if (b && len) r.body.assign(reinterpret_cast<const char*>(b), len);
+        size_t n = conduit_response_header_count(p);
+        for (size_t i = 0; i < n; ++i) {
+            const char* hn = conduit_response_header_name(p, i);
+            const char* hv = conduit_response_header_value(p, i);
+            if (hn && hv) r.headers.emplace_back(hn, hv);
+        }
+        return r;
+    }
+};
+
+// ── Halt — Sinatra-style non-local exit ──────────────────────────────────────
+
+struct Halt {
+    Response response;
+    Halt(int status, std::string body = "") : response(Response::text(std::move(body), status)) {}
+    explicit Halt(Response r) : response(std::move(r)) {}
+};
+
+/// Immediately stop handling the current request and return status/body.
+[[noreturn]] inline void halt(int status, std::string body = "") {
+    throw Halt(status, std::move(body));
+}
+
+// ── Request ──────────────────────────────────────────────────────────────────
+
+/// A read-only view of the request, valid only inside the handler.
+class Request {
+public:
+    explicit Request(const ConduitRequest* p) : p_(p) {}
+
+    std::string method() const { return str(conduit_request_method(p_)); }
+    std::string path() const { return str(conduit_request_path(p_)); }
+    std::string queryString() const { return str(conduit_request_query_string(p_)); }
+    std::string contentType() const { return str(conduit_request_content_type(p_)); }
+    std::string remoteAddr() const { return str(conduit_request_remote_addr(p_)); }
+    std::string error() const { return str(conduit_request_error(p_)); }
+
+    std::string body() const {
+        size_t len = 0;
+        const uint8_t* b = conduit_request_body(p_, &len);
+        return (b && len) ? std::string(reinterpret_cast<const char*>(b), len) : std::string();
+    }
+
+    std::optional<std::string> param(const std::string& name) const {
+        return opt(conduit_request_param(p_, name.c_str()));
+    }
+    std::optional<std::string> query(const std::string& name) const {
+        return opt(conduit_request_query(p_, name.c_str()));
+    }
+    std::optional<std::string> header(const std::string& name) const {
+        return opt(conduit_request_header(p_, name.c_str()));
+    }
+
+private:
+    const ConduitRequest* p_;
+    static std::string str(const char* s) { return s ? std::string(s) : std::string(); }
+    static std::optional<std::string> opt(const char* s) {
+        return s ? std::optional<std::string>(s) : std::nullopt;
+    }
+};
+
+using Handler = std::function<Response(const Request&)>;
+using BeforeHandler = std::function<std::optional<Response>(const Request&)>;
+using AfterHandler = std::function<Response(const Request&, Response)>;
+
+// ── Trampolines (C linkage so function-pointer types match the C ABI exactly;
+//    inline so the header stays single-include-safe across translation units) ──
+
+extern "C" {
+
+inline ConduitResponse* conduit_cpp_handler_tramp(void* ctx, const ConduitRequest* req) {
+    auto* fn = static_cast<Handler*>(ctx);
+    Request r(req);
+    try {
+        return (*fn)(r).toC();
+    } catch (const Halt& h) {
+        return h.response.toC();
+    } catch (const std::exception& e) {
+        conduit_capi_report_error(e.what());
+        return nullptr;
+    } catch (...) {
+        conduit_capi_report_error("unknown error");
+        return nullptr;
+    }
+}
+
+inline ConduitResponse* conduit_cpp_before_tramp(void* ctx, const ConduitRequest* req) {
+    auto* fn = static_cast<BeforeHandler*>(ctx);
+    Request r(req);
+    try {
+        std::optional<Response> resp = (*fn)(r);
+        return resp ? resp->toC() : nullptr;  // nullptr = continue
+    } catch (const Halt& h) {
+        return h.response.toC();
+    } catch (const std::exception& e) {
+        conduit_capi_report_error(e.what());
+        return nullptr;
+    } catch (...) {
+        conduit_capi_report_error("unknown error");
+        return nullptr;
+    }
+}
+
+inline ConduitResponse* conduit_cpp_after_tramp(void* ctx, const ConduitRequest* req,
+                                                ConduitResponse* current) {
+    auto* fn = static_cast<AfterHandler*>(ctx);
+    Request r(req);
+    Response cur = Response::fromC(current);
+    conduit_response_free(current);  // we own `current`: read then free
+    try {
+        return (*fn)(r, std::move(cur)).toC();
+    } catch (...) {
+        return Response::text("after hook error", 500).toC();
+    }
+}
+
+inline void conduit_cpp_free_handler(void* ctx) { delete static_cast<Handler*>(ctx); }
+inline void conduit_cpp_free_before(void* ctx) { delete static_cast<BeforeHandler*>(ctx); }
+inline void conduit_cpp_free_after(void* ctx) { delete static_cast<AfterHandler*>(ctx); }
+
+}  // extern "C"
+
+// ── Server ───────────────────────────────────────────────────────────────────
+
+class Server {
+public:
+    explicit Server(ConduitServer* s) : s_(s) {}
+    ~Server() { if (s_) conduit_server_free(s_); }
+
+    Server(Server&& o) noexcept : s_(o.s_) { o.s_ = nullptr; }
+    Server& operator=(Server&& o) noexcept {
+        if (this != &o) {
+            if (s_) conduit_server_free(s_);
+            s_ = o.s_;
+            o.s_ = nullptr;
+        }
+        return *this;
+    }
+    Server(const Server&) = delete;
+    Server& operator=(const Server&) = delete;
+
+    /// Serve in the foreground until stopped (blocks). Returns false on failure.
+    bool serve() { return s_ && conduit_server_serve(s_) == 0; }
+    /// Serve on a dedicated OS thread. Returns false if it could not start.
+    bool serveBackground() { return s_ && conduit_server_serve_background(s_) == 0; }
+    void stop() { if (s_) conduit_server_stop(s_); }
+    uint16_t localPort() const { return s_ ? conduit_server_local_port(s_) : 0; }
+    bool running() const { return s_ && conduit_server_running(s_) != 0; }
+
+private:
+    ConduitServer* s_;
+};
+
+// ── Application ──────────────────────────────────────────────────────────────
+
+/// Register routes and hooks, then bind() to get a Server. Registration methods
+/// return *this so calls chain. Handlers are std::function closures.
+class Application {
+public:
+    Application() : app_(conduit_app_new()) {}
+    ~Application() { if (app_ && !consumed_) conduit_app_free(app_); }
+
+    Application(const Application&) = delete;
+    Application& operator=(const Application&) = delete;
+
+    // Movable so an Application can be returned by value (e.g. a make_app()
+    // factory). The moved-from object is left empty/consumed.
+    Application(Application&& o) noexcept : app_(o.app_), consumed_(o.consumed_) {
+        o.app_ = nullptr;
+        o.consumed_ = true;
+    }
+    Application& operator=(Application&& o) noexcept {
+        if (this != &o) {
+            if (app_ && !consumed_) conduit_app_free(app_);
+            app_ = o.app_;
+            consumed_ = o.consumed_;
+            o.app_ = nullptr;
+            o.consumed_ = true;
+        }
+        return *this;
+    }
+
+    Application& route(const std::string& method, const std::string& pattern, Handler h) {
+        conduit_app_add_route(app_, method.c_str(), pattern.c_str(), &conduit_cpp_handler_tramp,
+                              new Handler(std::move(h)), &conduit_cpp_free_handler);
+        return *this;
+    }
+    Application& get(const std::string& p, Handler h) { return route("GET", p, std::move(h)); }
+    Application& post(const std::string& p, Handler h) { return route("POST", p, std::move(h)); }
+    Application& put(const std::string& p, Handler h) { return route("PUT", p, std::move(h)); }
+    /// DELETE route (named `del` because `delete` is a keyword).
+    Application& del(const std::string& p, Handler h) { return route("DELETE", p, std::move(h)); }
+    Application& patch(const std::string& p, Handler h) { return route("PATCH", p, std::move(h)); }
+
+    /// Before-filter: return a Response to short-circuit, std::nullopt to continue
+    /// (halt(...) short-circuits too).
+    Application& before(BeforeHandler h) {
+        conduit_app_add_before(app_, &conduit_cpp_before_tramp,
+                               new BeforeHandler(std::move(h)), &conduit_cpp_free_before);
+        return *this;
+    }
+    /// Transforming after-hook: receives the request and current response, returns
+    /// the response to send (return it unchanged to merely observe).
+    Application& after(AfterHandler h) {
+        conduit_app_add_after(app_, &conduit_cpp_after_tramp,
+                              new AfterHandler(std::move(h)), &conduit_cpp_free_after);
+        return *this;
+    }
+    Application& notFound(Handler h) {
+        conduit_app_set_not_found(app_, &conduit_cpp_handler_tramp,
+                                  new Handler(std::move(h)), &conduit_cpp_free_handler);
+        return *this;
+    }
+    Application& onError(Handler h) {
+        conduit_app_set_error_handler(app_, &conduit_cpp_handler_tramp,
+                                      new Handler(std::move(h)), &conduit_cpp_free_handler);
+        return *this;
+    }
+
+    Application& set(const std::string& key, const std::string& value) {
+        conduit_app_set_setting(app_, key.c_str(), value.c_str());
+        return *this;
+    }
+    std::optional<std::string> getSetting(const std::string& key) {
+        char* v = conduit_app_get_setting(app_, key.c_str());
+        if (!v) return std::nullopt;
+        std::string s(v);
+        conduit_string_free(v);
+        return s;
+    }
+
+    /// Bind host:port and return a Server. Consumes the application (the native
+    /// side moves it into the server), so call this last. Throws on bind failure.
+    Server bind(const std::string& host = "127.0.0.1", uint16_t port = 3000) {
+        ConduitServer* s = conduit_server_bind(host.c_str(), port, app_);
+        consumed_ = true;  // bind frees the app on success AND failure
+        if (!s) {
+            throw std::runtime_error(std::string("conduit bind failed: ") + conduit_last_error());
+        }
+        return Server(s);
+    }
+
+private:
+    ConduitApp* app_;
+    bool consumed_ = false;
+};
+
+}  // namespace conduit
+
+#endif  // CONDUIT_HPP

--- a/code/packages/cpp/conduit/include/conduit/conduit.hpp
+++ b/code/packages/cpp/conduit/include/conduit/conduit.hpp
@@ -206,13 +206,21 @@ inline ConduitResponse* conduit_cpp_before_tramp(void* ctx, const ConduitRequest
 inline ConduitResponse* conduit_cpp_after_tramp(void* ctx, const ConduitRequest* req,
                                                 ConduitResponse* current) {
     auto* fn = static_cast<AfterHandler*>(ctx);
-    Request r(req);
-    Response cur = Response::fromC(current);
-    conduit_response_free(current);  // we own `current`: read then free
+    // Everything that can allocate (fromC, the user hook, toC's header loop) must
+    // be inside the try so no C++ exception unwinds across this extern "C" frame.
+    // `current` is freed exactly once: on the happy path after reading it, or in
+    // the catch if fromC threw before we got there.
     try {
+        Request r(req);
+        Response cur = Response::fromC(current);  // may throw (allocates)
+        conduit_response_free(current);
+        current = nullptr;
         return (*fn)(r, std::move(cur)).toC();
     } catch (...) {
-        return Response::text("after hook error", 500).toC();
+        if (current) conduit_response_free(current);
+        // Build the fallback with a single C call — no C++ allocation that could
+        // itself throw out of this handler under OOM.
+        return conduit_response_new(500, nullptr, 0);
     }
 }
 

--- a/code/packages/cpp/conduit/required_capabilities.json
+++ b/code/packages/cpp/conduit/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "required_capabilities": ["rust", "cargo"]
+}

--- a/code/packages/cpp/conduit/tests/conduit_test.h
+++ b/code/packages/cpp/conduit/tests/conduit_test.h
@@ -1,0 +1,84 @@
+// conduit_test.h — tiny zero-dependency assertion harness.
+//
+// We avoid GTest/Catch2 so the package has no test-time deps. Each test file
+// defines CONDUIT_TEST(name) { ... } blocks; CONDUIT_MAIN() runs them all and
+// reports failures to stderr.
+
+#ifndef CONDUIT_TEST_H
+#define CONDUIT_TEST_H
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace conduit_test {
+
+struct TestCase {
+    std::string name;
+    void (*fn)();
+};
+
+inline std::vector<TestCase>& registry() {
+    static std::vector<TestCase> r;
+    return r;
+}
+
+inline int run_all() {
+    int failed = 0;
+    for (const auto& tc : registry()) {
+        try {
+            tc.fn();
+            std::cout << "[PASS] " << tc.name << '\n';
+        } catch (const std::exception& e) {
+            std::cerr << "[FAIL] " << tc.name << ": " << e.what() << '\n';
+            ++failed;
+        } catch (...) {
+            std::cerr << "[FAIL] " << tc.name << ": unknown exception\n";
+            ++failed;
+        }
+    }
+    std::cout << registry().size() << " tests, " << failed << " failures\n";
+    return failed == 0 ? 0 : 1;
+}
+
+}  // namespace conduit_test
+
+#define CONDUIT_CONCAT_INNER(a, b) a##b
+#define CONDUIT_CONCAT(a, b) CONDUIT_CONCAT_INNER(a, b)
+
+#define CONDUIT_TEST(name)                                                   \
+    static void CONDUIT_CONCAT(test_fn_, __LINE__)();                        \
+    namespace {                                                             \
+    struct CONDUIT_CONCAT(test_reg_, __LINE__) {                            \
+        CONDUIT_CONCAT(test_reg_, __LINE__)() {                             \
+            ::conduit_test::registry().push_back(                          \
+                {#name, &CONDUIT_CONCAT(test_fn_, __LINE__)});              \
+        }                                                                  \
+    } CONDUIT_CONCAT(test_reg_instance_, __LINE__);                         \
+    }                                                                      \
+    static void CONDUIT_CONCAT(test_fn_, __LINE__)()
+
+#define CONDUIT_ASSERT(cond)                                                 \
+    do {                                                                    \
+        if (!(cond)) {                                                       \
+            throw std::runtime_error(std::string("assertion failed: ") +    \
+                                     #cond + " at " + __FILE__ + ":" +       \
+                                     std::to_string(__LINE__));              \
+        }                                                                   \
+    } while (0)
+
+#define CONDUIT_ASSERT_EQ(a, b)                                             \
+    do {                                                                    \
+        auto _av = (a);                                                     \
+        auto _bv = (b);                                                     \
+        if (!(_av == _bv)) {                                                 \
+            throw std::runtime_error(std::string("assertion failed: ") +    \
+                                     #a + " == " + #b + " at " + __FILE__ +  \
+                                     ":" + std::to_string(__LINE__));        \
+        }                                                                   \
+    } while (0)
+
+#define CONDUIT_MAIN() \
+    int main() { return ::conduit_test::run_all(); }
+
+#endif  // CONDUIT_TEST_H

--- a/code/packages/cpp/conduit/tests/test_application.cpp
+++ b/code/packages/cpp/conduit/tests/test_application.cpp
@@ -1,0 +1,42 @@
+// Unit tests for the Application DSL: construction, chaining, settings, bind.
+#include "conduit/conduit.hpp"
+#include "conduit_test.h"
+
+using namespace conduit;
+
+CONDUIT_TEST(settings_round_trip) {
+    Application app;
+    app.set("views", "tmpl");
+    auto v = app.getSetting("views");
+    CONDUIT_ASSERT(v.has_value());
+    CONDUIT_ASSERT_EQ(v.value(), std::string("tmpl"));
+}
+
+CONDUIT_TEST(missing_setting_is_nullopt) {
+    Application app;
+    CONDUIT_ASSERT(!app.getSetting("nope").has_value());
+}
+
+CONDUIT_TEST(registrations_chain) {
+    Application app;
+    CONDUIT_ASSERT(&app.set("a", "1") == &app);
+    CONDUIT_ASSERT(&app.get("/", [](const Request&) { return Response::text("x"); }) == &app);
+    CONDUIT_ASSERT(&app.post("/x", [](const Request&) { return Response::text("x"); }) == &app);
+    CONDUIT_ASSERT(&app.put("/x", [](const Request&) { return Response::text("x"); }) == &app);
+    CONDUIT_ASSERT(&app.del("/x", [](const Request&) { return Response::text("x"); }) == &app);
+    CONDUIT_ASSERT(&app.patch("/x", [](const Request&) { return Response::text("x"); }) == &app);
+    CONDUIT_ASSERT(&app.before([](const Request&) { return std::nullopt; }) == &app);
+    CONDUIT_ASSERT(&app.after([](const Request&, Response r) { return r; }) == &app);
+    CONDUIT_ASSERT(&app.notFound([](const Request&) { return Response::text("nf", 404); }) == &app);
+    CONDUIT_ASSERT(&app.onError([](const Request&) { return Response::text("err", 500); }) == &app);
+}
+
+CONDUIT_TEST(bind_returns_server_with_port) {
+    Application app;
+    app.get("/", [](const Request&) { return Response::text("x"); });
+    Server server = app.bind("127.0.0.1", 0);
+    CONDUIT_ASSERT(server.localPort() > 0);
+    server.stop();
+}
+
+CONDUIT_MAIN()

--- a/code/packages/cpp/conduit/tests/test_response.cpp
+++ b/code/packages/cpp/conduit/tests/test_response.cpp
@@ -1,0 +1,97 @@
+// Unit tests for Response helpers + the native round-trip (no server needed).
+#include "conduit/conduit.hpp"
+#include "conduit_test.h"
+
+using namespace conduit;
+
+CONDUIT_TEST(html_defaults) {
+    Response r = Response::html("<h1>Hi</h1>");
+    CONDUIT_ASSERT_EQ(r.status, 200);
+    CONDUIT_ASSERT_EQ(r.body, std::string("<h1>Hi</h1>"));
+    bool found = false;
+    for (auto& h : r.headers)
+        if (h.first == "content-type" && h.second == "text/html; charset=utf-8") found = true;
+    CONDUIT_ASSERT(found);
+}
+
+CONDUIT_TEST(html_explicit_status) {
+    CONDUIT_ASSERT_EQ(Response::html("x", 201).status, 201);
+}
+
+CONDUIT_TEST(json_content_type) {
+    Response r = Response::json("{\"ok\":1}");
+    CONDUIT_ASSERT_EQ(r.headers.at(0).second, std::string("application/json"));
+    CONDUIT_ASSERT_EQ(r.body, std::string("{\"ok\":1}"));
+}
+
+CONDUIT_TEST(text_content_type) {
+    Response r = Response::text("pong");
+    CONDUIT_ASSERT_EQ(r.headers.at(0).second, std::string("text/plain; charset=utf-8"));
+}
+
+CONDUIT_TEST(respond_custom) {
+    Response r = Response::respond(204, "", {{"x-y", "z"}});
+    CONDUIT_ASSERT_EQ(r.status, 204);
+    CONDUIT_ASSERT_EQ(r.headers.at(0).first, std::string("x-y"));
+}
+
+CONDUIT_TEST(redirect_defaults) {
+    Response r = Response::redirect("/new");
+    CONDUIT_ASSERT_EQ(r.status, 302);
+    CONDUIT_ASSERT_EQ(r.headers.at(0).first, std::string("location"));
+    CONDUIT_ASSERT_EQ(r.headers.at(0).second, std::string("/new"));
+}
+
+CONDUIT_TEST(redirect_explicit_status) {
+    CONDUIT_ASSERT_EQ(Response::redirect("/old", 301).status, 301);
+}
+
+CONDUIT_TEST(redirect_rejects_crlf) {
+    bool threw = false;
+    try {
+        Response::redirect("/x\r\nSet-Cookie: evil=1");
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    CONDUIT_ASSERT(threw);
+}
+
+// toC builds a native response; reading it back must round-trip everything.
+CONDUIT_TEST(toC_round_trip) {
+    Response r(200, "body", {{"x-a", "b"}, {"content-type", "text/plain"}});
+    ConduitResponse* c = r.toC();
+    CONDUIT_ASSERT(c != nullptr);
+    Response back = Response::fromC(c);
+    conduit_response_free(c);
+    CONDUIT_ASSERT_EQ(back.status, 200);
+    CONDUIT_ASSERT_EQ(back.body, std::string("body"));
+    bool found = false;
+    for (auto& h : back.headers)
+        if (h.first == "x-a" && h.second == "b") found = true;
+    CONDUIT_ASSERT(found);
+}
+
+CONDUIT_TEST(toC_clamps_status) {
+    ConduitResponse* c = Response(999, "").toC();
+    CONDUIT_ASSERT_EQ(static_cast<int>(conduit_response_status(c)), 599);
+    conduit_response_free(c);
+    ConduitResponse* c2 = Response(1, "").toC();
+    CONDUIT_ASSERT_EQ(static_cast<int>(conduit_response_status(c2)), 100);
+    conduit_response_free(c2);
+}
+
+CONDUIT_TEST(toC_drops_unsafe_headers) {
+    Response r(200, "", {{"x-ok", "fine"}, {"x-bad", "a\r\nb"}});
+    ConduitResponse* c = r.toC();
+    Response back = Response::fromC(c);
+    conduit_response_free(c);
+    bool hasOk = false, hasBad = false;
+    for (auto& h : back.headers) {
+        if (h.first == "x-ok") hasOk = true;
+        if (h.first == "x-bad") hasBad = true;
+    }
+    CONDUIT_ASSERT(hasOk);
+    CONDUIT_ASSERT(!hasBad);
+}
+
+CONDUIT_MAIN()

--- a/code/packages/cpp/conduit/tests/test_server.cpp
+++ b/code/packages/cpp/conduit/tests/test_server.cpp
@@ -1,0 +1,212 @@
+// ============================================================================
+// End-to-end: build a real Conduit app, serve it on a background thread, and
+// drive it with a tiny blocking HTTP/1.0 client over a POSIX socket. A watchdog
+// thread stops the server after a deadline so a wedged run fails fast; sockets
+// carry a receive timeout for the same reason.
+// ============================================================================
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "conduit/conduit.hpp"
+#include "conduit_test.h"
+
+using namespace conduit;
+
+namespace {
+
+struct HttpResult {
+    int status = 0;
+    std::string body;
+    std::vector<std::pair<std::string, std::string>> headers;
+    std::string headerValue(const std::string& name) const {
+        for (auto& h : headers)
+            if (h.first == name) return h.second;
+        return "";
+    }
+};
+
+// One blocking HTTP/1.0 request. Returns false if the connection couldn't be
+// made (e.g. the server isn't accepting yet — callers retry).
+bool httpRequest(uint16_t port, const std::string& method, const std::string& path,
+                 const std::string& body, const std::string& contentType, HttpResult& out) {
+    out = HttpResult{};  // reset — callers reuse the same out across requests
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return false;
+
+    timeval tv{5, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        close(fd);
+        return false;
+    }
+
+    std::string req = method + " " + path + " HTTP/1.0\r\nHost: 127.0.0.1\r\n";
+    if (!body.empty()) {
+        req += "Content-Type: " + (contentType.empty() ? std::string("text/plain") : contentType) +
+               "\r\nContent-Length: " + std::to_string(body.size()) + "\r\n";
+    }
+    req += "Connection: close\r\n\r\n" + body;
+
+    if (send(fd, req.data(), req.size(), 0) < 0) {
+        close(fd);
+        return false;
+    }
+
+    std::string raw;
+    char buf[4096];
+    for (;;) {
+        ssize_t n = recv(fd, buf, sizeof(buf), 0);
+        if (n <= 0) break;
+        raw.append(buf, static_cast<size_t>(n));
+    }
+    close(fd);
+
+    auto sep = raw.find("\r\n\r\n");
+    if (sep == std::string::npos) return false;
+    std::string head = raw.substr(0, sep);
+    out.body = raw.substr(sep + 4);
+
+    size_t lineEnd = head.find("\r\n");
+    std::string statusLine = head.substr(0, lineEnd);
+    size_t sp1 = statusLine.find(' ');
+    size_t sp2 = statusLine.find(' ', sp1 + 1);
+    if (sp1 != std::string::npos) {
+        out.status = std::stoi(statusLine.substr(sp1 + 1, sp2 - sp1 - 1));
+    }
+    size_t pos = (lineEnd == std::string::npos) ? head.size() : lineEnd + 2;
+    while (pos < head.size()) {
+        size_t eol = head.find("\r\n", pos);
+        if (eol == std::string::npos) eol = head.size();
+        std::string line = head.substr(pos, eol - pos);
+        size_t colon = line.find(": ");
+        if (colon != std::string::npos) {
+            std::string k = line.substr(0, colon);
+            for (auto& c : k) c = static_cast<char>(::tolower(c));
+            out.headers.emplace_back(k, line.substr(colon + 2));
+        }
+        pos = eol + 2;
+    }
+    return true;
+}
+
+// Connect-retry wrapper: the background reactor may need a moment after bind.
+bool request(uint16_t port, const std::string& method, const std::string& path,
+             HttpResult& out, const std::string& body = "", const std::string& ct = "") {
+    for (int i = 0; i < 100; ++i) {
+        if (httpRequest(port, method, path, body, ct, out)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+}  // namespace
+
+CONDUIT_TEST(full_dispatch) {
+    Application app;
+    app.set("app_name", "conduit-test");
+
+    app.before([](const Request& req) -> std::optional<Response> {
+        if (req.path() == "/down") halt(503, "maintenance");
+        return std::nullopt;
+    });
+
+    // Transforming after-hook: stamp a header (full response round-trip).
+    app.after([](const Request&, Response resp) {
+        resp.headers.emplace_back("x-served-by", "conduit-cpp");
+        return resp;
+    });
+
+    app.get("/", [](const Request&) { return Response::html("<h1>OK</h1>"); });
+    app.get("/hello/:name", [](const Request& req) {
+        return Response::json("{\"hi\":\"" + req.param("name").value_or("") + "\"}");
+    });
+    app.post("/echo", [](const Request& req) {
+        std::string ct = req.contentType().empty() ? "text/plain" : req.contentType();
+        return Response::respond(200, req.body(), {{"content-type", ct}});
+    });
+    app.get("/q", [](const Request& req) {
+        return Response::text("a=" + req.query("a").value_or(""));
+    });
+    app.get("/boom", [](const Request&) -> Response { throw std::runtime_error("explode"); });
+    app.get("/redir", [](const Request&) { return Response::redirect("/", 302); });
+    app.notFound([](const Request& req) { return Response::text("no route: " + req.path(), 404); });
+    app.onError([](const Request&) { return Response::json("{\"error\":\"server\"}", 500); });
+
+    Server server = app.bind("127.0.0.1", 0);
+    CONDUIT_ASSERT(server.serveBackground());
+    uint16_t port = server.localPort();
+    CONDUIT_ASSERT(port > 0);
+
+    // Watchdog: force the server down after a deadline so nothing hangs.
+    std::atomic<bool> done{false};
+    std::thread watchdog([&] {
+        for (int i = 0; i < 300 && !done.load(); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (!done.load()) server.stop();
+    });
+    // Always tear the watchdog down — even if an assertion throws — so the
+    // joinable std::thread isn't destroyed mid-flight (which would std::terminate
+    // and mask the real failure).
+    auto cleanup = [&] {
+        done.store(true);
+        server.stop();
+        if (watchdog.joinable()) watchdog.join();
+    };
+
+    try {
+        HttpResult r;
+
+        CONDUIT_ASSERT(request(port, "GET", "/", r));
+        CONDUIT_ASSERT_EQ(r.status, 200);
+        CONDUIT_ASSERT_EQ(r.body, std::string("<h1>OK</h1>"));
+        CONDUIT_ASSERT_EQ(r.headerValue("x-served-by"), std::string("conduit-cpp"));
+
+        CONDUIT_ASSERT(request(port, "GET", "/hello/world", r));
+        CONDUIT_ASSERT_EQ(r.status, 200);
+        CONDUIT_ASSERT_EQ(r.body, std::string("{\"hi\":\"world\"}"));
+
+        CONDUIT_ASSERT(request(port, "POST", "/echo", r, "ping-pong", "application/octet-stream"));
+        CONDUIT_ASSERT_EQ(r.status, 200);
+        CONDUIT_ASSERT_EQ(r.body, std::string("ping-pong"));
+        CONDUIT_ASSERT(r.headerValue("content-type").find("octet-stream") != std::string::npos);
+
+        CONDUIT_ASSERT(request(port, "GET", "/q?a=42", r));
+        CONDUIT_ASSERT_EQ(r.body, std::string("a=42"));
+
+        CONDUIT_ASSERT(request(port, "GET", "/down", r));
+        CONDUIT_ASSERT_EQ(r.status, 503);
+        CONDUIT_ASSERT_EQ(r.body, std::string("maintenance"));
+
+        CONDUIT_ASSERT(request(port, "GET", "/boom", r));
+        CONDUIT_ASSERT_EQ(r.status, 500);
+        CONDUIT_ASSERT_EQ(r.body, std::string("{\"error\":\"server\"}"));
+
+        CONDUIT_ASSERT(request(port, "GET", "/nope", r));
+        CONDUIT_ASSERT_EQ(r.status, 404);
+        CONDUIT_ASSERT_EQ(r.body, std::string("no route: /nope"));
+
+        CONDUIT_ASSERT(request(port, "GET", "/redir", r));
+        CONDUIT_ASSERT_EQ(r.status, 302);
+        CONDUIT_ASSERT_EQ(r.headerValue("location"), std::string("/"));
+    } catch (...) {
+        cleanup();
+        throw;
+    }
+    cleanup();
+}
+
+CONDUIT_MAIN()

--- a/code/packages/cpp/conduit/tools/run-tests.sh
+++ b/code/packages/cpp/conduit/tools/run-tests.sh
@@ -21,9 +21,15 @@ CAPI_DIR=$(cd ../../rust/conduit-capi && pwd)
 TARGET_REL=$(cd ../../rust && pwd)/target/release
 
 # ── 1. Build the C ABI and capture its native-static-libs ────────────────────
+# CARGO_TERM_COLOR=never: CI sets CARGO_TERM_COLOR=always, which makes rustc
+# colorize the "native-static-libs:" note — the trailing ANSI reset would get
+# captured into the link line (e.g. "-lm\033[0m" → ld: library 'm...' not found).
+# The ESC-stripping sed is a defensive second layer.
 echo "==> Building conduit-capi (release static lib)"
-NATIVE_LIBS=$(cd "$CAPI_DIR" && cargo rustc --release --crate-type staticlib -- \
-    --print native-static-libs 2>&1 | sed -n 's/.*native-static-libs: //p' | tail -1)
+ESC=$(printf '\033')
+NATIVE_LIBS=$(cd "$CAPI_DIR" && CARGO_TERM_COLOR=never cargo rustc --release \
+    --crate-type staticlib -- --print native-static-libs 2>&1 \
+    | sed -n 's/.*native-static-libs: //p' | tail -1 | sed "s/${ESC}\\[[0-9;]*m//g")
 echo "==> native-static-libs: ${NATIVE_LIBS:-(none)}"
 
 if [ ! -f "$TARGET_REL/libconduit_capi.a" ]; then

--- a/code/packages/cpp/conduit/tools/run-tests.sh
+++ b/code/packages/cpp/conduit/tools/run-tests.sh
@@ -53,7 +53,12 @@ echo "==> Using compiler: $COMPILER"
 mkdir -p _build
 FLAGS="-std=c++17 -Wall -Wextra -Wpedantic -Werror -pthread \
     -I include -I tests -I $CAPI_DIR/include"
-LINK="-L $TARGET_REL -lconduit_capi $NATIVE_LIBS -pthread"
+# Link the STATIC archive by full path (not -lconduit_capi): on Linux, ld prefers
+# the sibling libconduit_capi.so (cdylib) over the .a when both sit in the search
+# path, producing binaries that fail to load the .so at runtime. Naming the .a
+# directly forces static linking portably (clang + g++). It must come after the
+# source so left-to-right symbol resolution finds it.
+LINK="$TARGET_REL/libconduit_capi.a $NATIVE_LIBS -pthread"
 
 FAILED=0
 TOTAL=0

--- a/code/packages/cpp/conduit/tools/run-tests.sh
+++ b/code/packages/cpp/conduit/tools/run-tests.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# run-tests.sh — build the Conduit C ABI, then compile & run the C++ tests.
+#
+# Invoked from `BUILD` as a single command (the build-tool feeds each BUILD line
+# to its own `sh -c`, so multi-line constructs must live in this script).
+#
+# Steps:
+#   1. cargo build the reusable conduit-capi static library.
+#   2. Ask rustc for the platform's native-static-libs (the system libs a Rust
+#      staticlib needs — e.g. -lSystem/-liconv on macOS, -lpthread/-ldl on Linux).
+#   3. Compile each tests/test_*.cpp, linking libconduit_capi.a + those libs.
+#
+# Output dir is `_build/`, NOT `build/`: macOS HFS+ is case-insensitive and
+# `build/` would collide with the `BUILD` script. See lessons.md.
+set -e
+
+SELF_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$SELF_DIR"
+
+CAPI_DIR=$(cd ../../rust/conduit-capi && pwd)
+TARGET_REL=$(cd ../../rust && pwd)/target/release
+
+# ── 1. Build the C ABI and capture its native-static-libs ────────────────────
+echo "==> Building conduit-capi (release static lib)"
+NATIVE_LIBS=$(cd "$CAPI_DIR" && cargo rustc --release --crate-type staticlib -- \
+    --print native-static-libs 2>&1 | sed -n 's/.*native-static-libs: //p' | tail -1)
+echo "==> native-static-libs: ${NATIVE_LIBS:-(none)}"
+
+if [ ! -f "$TARGET_REL/libconduit_capi.a" ]; then
+    echo "libconduit_capi.a not found at $TARGET_REL" >&2
+    exit 1
+fi
+
+# ── 2. Pick a compiler ───────────────────────────────────────────────────────
+if [ -n "${CXX:-}" ] && command -v "$CXX" >/dev/null 2>&1; then
+    COMPILER="$CXX"
+elif command -v clang++ >/dev/null 2>&1; then
+    COMPILER=clang++
+elif command -v g++ >/dev/null 2>&1; then
+    COMPILER=g++
+else
+    echo "no C++ compiler found (need clang++ or g++)" >&2
+    exit 1
+fi
+echo "==> Using compiler: $COMPILER"
+
+mkdir -p _build
+FLAGS="-std=c++17 -Wall -Wextra -Wpedantic -Werror -pthread \
+    -I include -I tests -I $CAPI_DIR/include"
+LINK="-L $TARGET_REL -lconduit_capi $NATIVE_LIBS -pthread"
+
+FAILED=0
+TOTAL=0
+PASSED=0
+for src in tests/test_response.cpp tests/test_application.cpp tests/test_server.cpp; do
+    name=$(basename "$src" .cpp)
+    echo "==> Compiling $name"
+    # shellcheck disable=SC2086
+    "$COMPILER" $FLAGS "$src" -o "_build/$name" $LINK
+    echo "==> Running $name"
+    if "_build/$name"; then
+        PASSED=$((PASSED + 1))
+    else
+        FAILED=$((FAILED + 1))
+    fi
+    TOTAL=$((TOTAL + 1))
+done
+
+echo ""
+echo "Suites: $PASSED / $TOTAL passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1

--- a/code/programs/cpp/conduit-hello/.gitignore
+++ b/code/programs/cpp/conduit-hello/.gitignore
@@ -1,0 +1,2 @@
+_build/
+build/

--- a/code/programs/cpp/conduit-hello/BUILD
+++ b/code/programs/cpp/conduit-hello/BUILD
@@ -1,0 +1,2 @@
+# build-tool: deps=rust/conduit-capi cpp/conduit
+sh tools/run.sh

--- a/code/programs/cpp/conduit-hello/BUILD_windows
+++ b/code/programs/cpp/conduit-hello/BUILD_windows
@@ -1,0 +1,1 @@
+echo C++ conduit-hello uses POSIX sockets — skipping on Windows

--- a/code/programs/cpp/conduit-hello/CHANGELOG.md
+++ b/code/programs/cpp/conduit-hello/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog — conduit-hello (C++)
+
+## [0.1.0] - 2026-06-13
+
+### Added
+
+- Initial C++ `conduit-hello` demo exercising the full Conduit DSL: `html`,
+  `json`, `text`, `respond`, `redirect`, route params, query params, a body echo,
+  a `before` filter that short-circuits with `halt`, an `after` header-stamping
+  hook, a throwing handler routed to `onError`, and a custom `notFound`.
+- `tests/smoke.cpp`: launches the demo on an OS-assigned port and asserts on real
+  HTTP responses (POSIX-socket client, watchdog thread).

--- a/code/programs/cpp/conduit-hello/README.md
+++ b/code/programs/cpp/conduit-hello/README.md
@@ -1,0 +1,28 @@
+# conduit-hello (C++)
+
+A complete Sinatra-style demo built on the
+[`Conduit`](../../../packages/cpp/conduit/README.md) C++ package.
+
+## Run
+
+```sh
+sh tools/run.sh           # builds the C ABI + demo, runs the smoke test
+./_build/conduit-hello    # then run the server (port 3000)
+./_build/conduit-hello 8080
+```
+
+## Routes
+
+| Route | Shows |
+| ----- | ----- |
+| `GET /`             | an HTML greeting (`html`) |
+| `GET /hello/:name`  | a route param in JSON (`json`, `param`) |
+| `POST /echo`        | body echo + content-type passthrough (`respond`) |
+| `GET /search?q=`    | a query param (`query`) |
+| `GET /redirect`     | a 301 to `/` (`redirect`) |
+| `GET /halt`         | a 403 via `halt()` |
+| `GET /down`         | a 503 from a `before` filter |
+| `GET /error`        | a throwing handler → `onError` (500) |
+| anything else       | the custom `notFound` (404) |
+
+An `after` hook stamps `x-served-by: conduit-hello` on every response.

--- a/code/programs/cpp/conduit-hello/required_capabilities.json
+++ b/code/programs/cpp/conduit-hello/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "required_capabilities": ["rust", "cargo"]
+}

--- a/code/programs/cpp/conduit-hello/src/app.hpp
+++ b/code/programs/cpp/conduit-hello/src/app.hpp
@@ -1,0 +1,76 @@
+// ============================================================================
+// app.hpp — the demo application, exercising the full Conduit C++ DSL.
+// ============================================================================
+//
+//   GET  /                  → HTML greeting
+//   GET  /hello/:name       → JSON with the route param
+//   POST /echo              → echoes the body, content-type passthrough
+//   GET  /search?q=...      → reads a query param
+//   GET  /redirect          → 301 to /
+//   GET  /halt              → 403 via halt()
+//   GET  /down              → 503 via a before filter (short-circuits)
+//   GET  /error             → throws → routed to the custom error handler (500)
+//   GET  /<anything-else>   → custom 404 handler
+//
+// Kept in a header so the smoke test can build and drive the same app.
+
+#ifndef CONDUIT_HELLO_APP_HPP
+#define CONDUIT_HELLO_APP_HPP
+
+#include <stdexcept>
+
+#include "conduit/conduit.hpp"
+
+inline conduit::Application make_app() {
+    using namespace conduit;
+    Application app;
+    app.set("app_name", "Conduit Hello");
+
+    app.before([](const Request& req) -> std::optional<Response> {
+        if (req.path() == "/down") halt(503, "Under maintenance");
+        return std::nullopt;
+    });
+
+    // After hook: stamp a header on every response.
+    app.after([](const Request&, Response resp) {
+        resp.headers.emplace_back("x-served-by", "conduit-hello");
+        return resp;
+    });
+
+    app.get("/", [](const Request&) {
+        return Response::html("<h1>Hello from Conduit (C++)!</h1><p>Try <code>/hello/Ada</code></p>");
+    });
+
+    app.get("/hello/:name", [](const Request& req) {
+        return Response::json("{\"message\":\"Hello " + req.param("name").value_or("") +
+                              "\",\"app\":\"Conduit\"}");
+    });
+
+    app.post("/echo", [](const Request& req) {
+        std::string ct = req.contentType().empty() ? "text/plain" : req.contentType();
+        return Response::respond(200, req.body(), {{"content-type", ct}});
+    });
+
+    app.get("/search", [](const Request& req) {
+        return Response::text("you searched for: " + req.query("q").value_or("(nothing)"));
+    });
+
+    app.get("/redirect", [](const Request&) { return Response::redirect("/", 301); });
+
+    app.get("/halt", [](const Request&) -> Response {
+        halt(403, "Forbidden — this route always halts");
+    });
+
+    app.get("/down", [](const Request&) {
+        return Response::text("unreachable — the before filter halts first");
+    });
+
+    app.get("/error", [](const Request&) -> Response { throw std::runtime_error("boom"); });
+
+    app.notFound([](const Request& req) { return Response::text("No such route: " + req.path(), 404); });
+    app.onError([](const Request&) { return Response::json("{\"error\":\"internal server error\"}", 500); });
+
+    return app;
+}
+
+#endif  // CONDUIT_HELLO_APP_HPP

--- a/code/programs/cpp/conduit-hello/src/main.cpp
+++ b/code/programs/cpp/conduit-hello/src/main.cpp
@@ -1,0 +1,31 @@
+// conduit-hello — entry point. Binds 127.0.0.1:<port> (default 3000) and serves
+// in the foreground (the reactor dispatches handlers on this thread). Ctrl-C to
+// stop.
+//
+//   ./conduit-hello          # port 3000
+//   ./conduit-hello 8080     # or choose a port
+//
+// Then:  curl http://127.0.0.1:3000/hello/Ada
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "app.hpp"
+
+int main(int argc, char** argv) {
+    uint16_t port = 3000;
+    if (argc > 1) {
+        port = static_cast<uint16_t>(std::strtoul(argv[1], nullptr, 10));
+    }
+    try {
+        conduit::Server server = make_app().bind("127.0.0.1", port);
+        std::cout << "conduit-hello listening on http://127.0.0.1:" << server.localPort()
+                  << "/  (Ctrl-C to stop)" << std::endl;
+        server.serve();
+    } catch (const std::exception& e) {
+        std::cerr << "failed to start: " << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/code/programs/cpp/conduit-hello/tests/smoke.cpp
+++ b/code/programs/cpp/conduit-hello/tests/smoke.cpp
@@ -1,0 +1,101 @@
+// Smoke test: launch the real demo app on an OS-assigned port and hit a few
+// routes. POSIX-socket client + watchdog thread.
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "app.hpp"
+
+namespace {
+
+struct Result {
+    int status = 0;
+    std::string body;
+};
+
+bool get(uint16_t port, const std::string& path, Result& out) {
+    out = Result{};
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return false;
+    timeval tv{5, 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    if (connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        close(fd);
+        return false;
+    }
+    std::string req = "GET " + path + " HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    send(fd, req.data(), req.size(), 0);
+    std::string raw;
+    char buf[4096];
+    ssize_t n;
+    while ((n = recv(fd, buf, sizeof(buf), 0)) > 0) raw.append(buf, static_cast<size_t>(n));
+    close(fd);
+    auto sep = raw.find("\r\n\r\n");
+    if (sep == std::string::npos) return false;
+    out.body = raw.substr(sep + 4);
+    size_t sp1 = raw.find(' ');
+    size_t sp2 = raw.find(' ', sp1 + 1);
+    if (sp1 != std::string::npos) out.status = std::stoi(raw.substr(sp1 + 1, sp2 - sp1 - 1));
+    return true;
+}
+
+bool request(uint16_t port, const std::string& path, Result& out) {
+    for (int i = 0; i < 100; ++i) {
+        if (get(port, path, out)) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+int failures = 0;
+void check(bool cond, const std::string& what) {
+    if (cond) {
+        std::cout << "[PASS] " << what << '\n';
+    } else {
+        std::cerr << "[FAIL] " << what << '\n';
+        ++failures;
+    }
+}
+
+}  // namespace
+
+int main() {
+    conduit::Server server = make_app().bind("127.0.0.1", 0);
+    if (!server.serveBackground()) {
+        std::cerr << "failed to start server\n";
+        return 1;
+    }
+    uint16_t port = server.localPort();
+
+    std::atomic<bool> done{false};
+    std::thread watchdog([&] {
+        for (int i = 0; i < 300 && !done.load(); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (!done.load()) server.stop();
+    });
+
+    Result r;
+    check(request(port, "/", r) && r.status == 200, "GET / -> 200");
+    check(r.body.find("Hello from Conduit") != std::string::npos, "greeting body");
+    check(request(port, "/hello/Ada", r) && r.status == 200, "GET /hello/:name -> 200");
+    check(r.body.find("Hello Ada") != std::string::npos, "route param interpolated");
+    check(request(port, "/nope", r) && r.status == 404, "unknown route -> 404");
+
+    done.store(true);
+    server.stop();
+    watchdog.join();
+
+    std::cout << failures << " failures\n";
+    return failures == 0 ? 0 : 1;
+}

--- a/code/programs/cpp/conduit-hello/tools/run.sh
+++ b/code/programs/cpp/conduit-hello/tools/run.sh
@@ -10,8 +10,12 @@ CAPI_DIR=$(cd ../../../packages/rust/conduit-capi && pwd)
 TARGET_REL=$(cd ../../../packages/rust && pwd)/target/release
 
 echo "==> Building conduit-capi"
-NATIVE_LIBS=$(cd "$CAPI_DIR" && cargo rustc --release --crate-type staticlib -- \
-    --print native-static-libs 2>&1 | sed -n 's/.*native-static-libs: //p' | tail -1)
+# CARGO_TERM_COLOR=never so the rustc note isn't colorized (CI forces color) —
+# otherwise a trailing ANSI reset gets captured into the link line.
+ESC=$(printf '\033')
+NATIVE_LIBS=$(cd "$CAPI_DIR" && CARGO_TERM_COLOR=never cargo rustc --release \
+    --crate-type staticlib -- --print native-static-libs 2>&1 \
+    | sed -n 's/.*native-static-libs: //p' | tail -1 | sed "s/${ESC}\\[[0-9;]*m//g")
 
 if [ -n "${CXX:-}" ] && command -v "$CXX" >/dev/null 2>&1; then COMPILER="$CXX";
 elif command -v clang++ >/dev/null 2>&1; then COMPILER=clang++;

--- a/code/programs/cpp/conduit-hello/tools/run.sh
+++ b/code/programs/cpp/conduit-hello/tools/run.sh
@@ -25,7 +25,9 @@ else echo "no C++ compiler found" >&2; exit 1; fi
 mkdir -p _build
 FLAGS="-std=c++17 -Wall -Wextra -Wpedantic -Werror -pthread \
     -I src -I $PKG/include -I $CAPI_DIR/include"
-LINK="-L $TARGET_REL -lconduit_capi $NATIVE_LIBS -pthread"
+# Link the static archive by full path so Linux's ld doesn't prefer the sibling
+# .so (which then fails to load at runtime). Portable across clang + g++.
+LINK="$TARGET_REL/libconduit_capi.a $NATIVE_LIBS -pthread"
 
 echo "==> Compiling demo binary"
 # shellcheck disable=SC2086

--- a/code/programs/cpp/conduit-hello/tools/run.sh
+++ b/code/programs/cpp/conduit-hello/tools/run.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Build the Conduit C ABI, compile the conduit-hello demo + its smoke test, and
+# run the smoke test. Output dir _build/ (not build/) to avoid the BUILD collision.
+set -e
+SELF_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$SELF_DIR"
+
+PKG=$(cd ../../../packages/cpp/conduit && pwd)
+CAPI_DIR=$(cd ../../../packages/rust/conduit-capi && pwd)
+TARGET_REL=$(cd ../../../packages/rust && pwd)/target/release
+
+echo "==> Building conduit-capi"
+NATIVE_LIBS=$(cd "$CAPI_DIR" && cargo rustc --release --crate-type staticlib -- \
+    --print native-static-libs 2>&1 | sed -n 's/.*native-static-libs: //p' | tail -1)
+
+if [ -n "${CXX:-}" ] && command -v "$CXX" >/dev/null 2>&1; then COMPILER="$CXX";
+elif command -v clang++ >/dev/null 2>&1; then COMPILER=clang++;
+elif command -v g++ >/dev/null 2>&1; then COMPILER=g++;
+else echo "no C++ compiler found" >&2; exit 1; fi
+
+mkdir -p _build
+FLAGS="-std=c++17 -Wall -Wextra -Wpedantic -Werror -pthread \
+    -I src -I $PKG/include -I $CAPI_DIR/include"
+LINK="-L $TARGET_REL -lconduit_capi $NATIVE_LIBS -pthread"
+
+echo "==> Compiling demo binary"
+# shellcheck disable=SC2086
+"$COMPILER" $FLAGS src/main.cpp -o _build/conduit-hello $LINK
+
+echo "==> Compiling + running smoke test"
+# shellcheck disable=SC2086
+"$COMPILER" $FLAGS tests/smoke.cpp -o _build/smoke $LINK
+_build/smoke

--- a/code/specs/WEB13-conduit-cpp.md
+++ b/code/specs/WEB13-conduit-cpp.md
@@ -1,0 +1,90 @@
+# WEB13 — Conduit for C++ (over the reusable `conduit-capi` C ABI)
+
+## Summary
+
+Port the **Conduit** web framework to **C++**, as a header-only wrapper over the
+reusable `conduit-capi` C ABI introduced in WEB12. C++ is the second consumer of
+that ABI (after Swift); the trust boundary was already audited once in the Rust
+crate, so this port is a thin, idiomatic C++ layer — no new FFI surface.
+
+## Architecture
+
+```
+C++ DSL (conduit::Application / Request / Response / Server)
+    handlers are std::function<Response(const Request&)>
+    │  extern "C" trampoline + heap-boxed closure (ctx) + ctx_free destructor
+    ▼
+conduit-capi (Rust cdylib + staticlib, the C ABI from WEB12)
+    ▼
+conduit (WEB08 facade) → web-core → embeddable-http-server → tcp-runtime
+```
+
+The wrapper is a single header `include/conduit/conduit.hpp`. It `#include`s
+`conduit_capi.h` (via `-I .../conduit-capi/include`) and links
+`libconduit_capi.a`.
+
+## Design
+
+- **Handlers**: `Handler = std::function<Response(const Request&)>`;
+  `BeforeHandler = std::function<std::optional<Response>(const Request&)>` (nullopt
+  = continue); `AfterHandler = std::function<Response(const Request&, Response)>`.
+- **Closure boxing**: each handler is `new`'d on the heap; its pointer is the
+  opaque `ctx`. A `ctx_free` trampoline `delete`s it when the app/server is freed.
+- **Trampolines**: `extern "C" inline` functions (C language linkage so the
+  function-pointer types match the ABI typedefs exactly under `-Wpedantic
+  -Werror`; `inline` so the single header is include-safe across TUs). They catch
+  `Halt` → return its response; catch any other exception → `conduit_capi_report_error`
+  + return NULL (so the engine routes through the error handler). **No C++
+  exception ever unwinds across the C boundary.**
+- **Response/Request** are value types over the C accessors. `Response::toC()`
+  builds a native response; `Response::fromC()` reads one back (for after-hooks).
+- **RAII**: `Server` and `Application` own their native handles and free them in
+  their destructors; `bind` consumes the application.
+
+## Threading
+
+Inherited from `conduit-capi`: foreground `serve()` dispatches on the calling
+thread; `serveBackground()` runs the reactor on one OS thread. C++ closures are
+thread-safe to call. The E2E test uses `serveBackground` + a `std::thread`
+watchdog that stops the server after a deadline.
+
+## Package layout
+
+```
+code/packages/cpp/conduit/
+    include/conduit/conduit.hpp   # the whole wrapper
+    tests/conduit_test.h          # zero-dep assertion harness
+    tests/test_response.cpp       # helpers + native round-trip
+    tests/test_application.cpp    # DSL / settings / bind
+    tests/test_server.cpp         # E2E (POSIX socket client + watchdog)
+    tools/run-tests.sh            # build C ABI, query native-static-libs, compile+run
+    CMakeLists.txt                # documented end-user path
+    BUILD / BUILD_windows / README.md / CHANGELOG.md / required_capabilities.json
+code/programs/cpp/conduit-hello/  # 8-route demo + smoke test
+```
+
+## Build
+
+- `tools/run-tests.sh` (invoked by `BUILD`): `cargo build` the C ABI, extract the
+  platform `native-static-libs` via `cargo rustc -- --print native-static-libs`,
+  compile each test with `clang++`/`g++` (`-std=c++17 -Wall -Wextra -Wpedantic
+  -Werror -pthread`) linking `libconduit_capi.a` + those libs.
+- `BUILD` declares `# build-tool: deps=rust/conduit-capi` so the build graph pulls
+  the Rust crate in (the runner gets `cargo`); the C++ package is discovered as
+  "unknown" language so no further dep validation applies.
+- `BUILD_windows` skips (the E2E uses POSIX sockets). `required_capabilities`:
+  `["rust","cargo"]`.
+
+## Tests (target 30+)
+
+16 test functions across the three suites, the E2E alone asserting ~18 behaviors
+(routes, params, POST echo + content-type passthrough, query, before-halt 503,
+throwing-handler→onError 500, custom 404, redirect 302, after-hook header
+stamping). Combined with the inherited 5 `conduit-capi` Rust tests, well over 30
+assertions.
+
+## Security
+
+Inherited from `conduit-capi`: header-injection defense, status clamping, UTF-8
+validation, panic isolation. C++-specific: `redirect` throws on CR/LF;
+trampolines catch every exception so none crosses the C boundary.

--- a/lessons.md
+++ b/lessons.md
@@ -496,3 +496,48 @@ isolation) is audited once. Handlers cross as a C function pointer + opaque `ctx
 **Date:** 2026-06-14
 
 **`StreamReactor::serve()` must NOT reset the stop flag — a `stop()` racing serve startup gets silently swallowed.** The reactor's `serve()` used to do `self.stop_flag.store(false)` at the top. The flag is already `false` at construction, so the reset was redundant on first serve — but it created a race: an FFI binding (JNI/N-API/etc.) that flips a "running" flag and lets the caller request `stop()` *before* the background serve thread enters the loop would have its stop erased, so `serve()` runs forever and `join()` hangs. This was invisible in Python/Ruby because their tests wait for the server to actually be listening before stopping (and Python/Ruby `join` with a timeout); it surfaced in the JVM binding, whose JUnit tests flip running→stop synchronously in one thread, and whose native `join()` has no timeout. **Rule:** a `stop()` request must never be lost — don't reset stop/cancellation flags inside the run loop's own entry. Reset (re-arm) only via an explicit separate operation if a consumer truly needs to re-run. Reproduce FFI hangs single-threaded in pure Rust (spawn serve, `stop()` immediately, `join()`) before blaming the binding; use `sample <pid>`/jstack to see the native thread stuck in `kevent`.
+
+---
+
+## WEB13 C++ Conduit — four C++ gotchas linking the reusable C ABI
+
+**Date:** 2026-06-14
+
+Second consumer of the `conduit-capi` C ABI (after Swift). Header-only C++ wrapper.
+Four things worth remembering:
+
+1. **A reused HTTP-client result struct must be RESET each request.** The E2E
+   client appended parsed headers with `emplace_back` into a caller-provided
+   `out` struct reused across requests, so `headerValue("content-type")` returned
+   the FIRST match (from an earlier route) — the echo content-type assertion
+   failed even though the server was correct. Always `out = Result{};` at the top
+   of the request function. (The server/port was never wrong; the test client was.)
+
+2. **A joinable `std::thread` destroyed during stack unwinding calls
+   `std::terminate`.** A failing assertion in the E2E threw, which destroyed the
+   still-joinable watchdog `std::thread` before the harness could catch it →
+   `libc++abi: terminating`, masking the real failure. Wrap the body in
+   `try { ... } catch (...) { join_watchdog(); throw; }` so the thread is always
+   joined first and the real error surfaces.
+
+3. **`extern "C" inline` trampolines, not C++ ones.** Passing a C++ function
+   pointer where the C ABI typedef expects a C-linkage pointer warns under
+   `-Wpedantic -Werror` (and is technically a language-linkage mismatch). Declare
+   the trampolines `extern "C"` (and `inline` so the single header stays
+   include-safe across TUs).
+
+4. **Delete the copy ctor → you must add a move ctor for return-by-value.** A
+   `make_app()` factory returning `Application` by value fails to compile if the
+   copy ctor is deleted and no move ctor exists — NRVO is not guaranteed for a
+   named local. Add `Application(Application&&) noexcept` that transfers the handle
+   and marks the source consumed.
+
+**Link flags:** a Rust staticlib needs its platform `native-static-libs` (e.g.
+`-liconv -lSystem -lc -lm` on macOS, `-lpthread -ldl -lrt -lm` on Linux). Don't
+hardcode them — query `cargo rustc --release --crate-type staticlib -- --print
+native-static-libs` and pass the result to the C++ link line.
+
+**Build-tool note:** C++ packages are discovered as "unknown" language (the
+build-tool's language list has no "cpp"), so the undeclared-local-ref validator
+skips them — but declare `# build-tool: deps=rust/conduit-capi` anyway so the
+build graph pulls the Rust crate in and the runner gets `cargo`.


### PR DESCRIPTION
## What

Ports the **Conduit** web framework to **C++** as a **header-only** wrapper over the reusable [`conduit-capi`](code/packages/rust/conduit-capi) C ABI introduced in WEB12. C++ is the second consumer of that ABI (after Swift) — no new FFI surface, the trust boundary was already audited once in the Rust crate.

### Package (`code/packages/cpp/conduit`)
- `include/conduit/conduit.hpp` — the whole wrapper. `Application` with `get/post/put/del/patch`, `route`, `before`, `after` (transforming), `notFound`, `onError`, `set`/`getSetting`, `bind` (chainable). Handlers are `std::function<Response(const Request&)>`. `Response` `html/json/text/respond/redirect`; `halt()` throws `Halt`; `Request` accessors return `std::optional`; `Server` `serve`/`serveBackground`/`stop`/`localPort`/`running`, RAII-owned.
- Closures are heap-boxed and freed via a `ctx_free` trampoline; trampolines have **C linkage** (`extern "C" inline` — match the ABI typedefs exactly under `-Wpedantic -Werror`) and **catch every C++ exception** so none unwinds across the C boundary.

### Demo
`code/programs/cpp/conduit-hello` — 8-route demo + smoke test.

## Security

Reviewed by a security sub-agent. One **HIGH** (an allocating `Response::fromC` sat outside the after-hook trampoline's `try`, so `std::bad_alloc` could cross `extern "C"`, plus a leak/double-free of `current`) — **fixed** (all allocation inside the guard, `current` freed exactly once, non-allocating fallback). Closure lifecycle, RAII move semantics, and the other trampolines were found sound.

## Tests

- **16 tests** (zero-dep harness): response helpers + native round-trip + CRLF guard; DSL/settings/bind; a full **E2E** (POSIX-socket HTTP/1.0 client + watchdog thread) covering routes, params, POST echo, query, before-halt 503, throw→onError 500, custom 404, redirect 302, after-hook header stamping.
- **Demo:** smoke test launching the 8-route app.

`tools/run-tests.sh` builds the C ABI, queries the platform's `native-static-libs`, and links each test with `clang++`/`g++`. All green locally (macOS). Windows builds skip (the E2E uses POSIX sockets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)