### PR TITLE
fix(nib-type-checker): handle mul_expr in expression dispatch

### DIFF
--- a/code/packages/typescript/nib-type-checker/CHANGELOG.md
+++ b/code/packages/typescript/nib-type-checker/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.1
+
+- fix: recognise the `mul_expr` precedence level (LANG-FULL N1). The grammar's
+  cascade is `add_expr → mul_expr → bitwise_expr`, but the checker omitted
+  `mul_expr` from its expression rules and dispatch. An enclosing `add_expr`
+  therefore filtered its `mul_expr` operands out and inferred no type, so a body
+  like `a +% b` (or `a * b`) annotated nothing. `mul_expr` now reuses the
+  additive checker (same-type operands, numeric result, BCD restricted to
+  `+%`/`-`). Mirrors the analogous nib-formatter fix (#5713).
+
 ## 0.1.0
 
 - add a TypeScript port of the Nib type checker

--- a/code/packages/typescript/nib-type-checker/package.json
+++ b/code/packages/typescript/nib-type-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/nib-type-checker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Type-checks Nib ASTs and returns annotated ASTs with diagnostics",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/nib-type-checker/src/checker.ts
+++ b/code/packages/typescript/nib-type-checker/src/checker.ts
@@ -24,6 +24,13 @@ const EXPRESSION_RULES = new Set([
   "eq_expr",
   "cmp_expr",
   "add_expr",
+  // The grammar's precedence cascade is add_expr → mul_expr → bitwise_expr,
+  // so multiplicative expressions sit *between* additive and bitwise levels.
+  // `mul_expr` must be recognised as an expression rule; otherwise
+  // `expressionChildren` filters mul_expr operands out of an enclosing
+  // add_expr, leaving it with zero operands and no inferred type (e.g.
+  // `a +% b` would never annotate its `u4` operands).
+  "mul_expr",
   "bitwise_expr",
   "unary_expr",
   "primary",
@@ -523,6 +530,10 @@ export class NibTypeChecker extends GenericTypeChecker<ASTNode> {
         result = this.checkPrimary(node, scope);
         break;
       case "add_expr":
+      // Multiplicative expressions share additive semantics — same-type
+      // operands, numeric result, BCD restricted to '+%'/'-' — so they reuse
+      // the additive checker rather than introducing a parallel code path.
+      case "mul_expr":
         result = this.checkAddExpression(node, scope);
         break;
       case "or_expr":

--- a/code/packages/typescript/nib-type-checker/tests/nib-type-checker.test.ts
+++ b/code/packages/typescript/nib-type-checker/tests/nib-type-checker.test.ts
@@ -30,6 +30,26 @@ describe("nib-type-checker", () => {
     expect(findAnnotatedTypes(result.typedAst)).toContain("u4");
   });
 
+  it("infers types through multiplicative (mul_expr) operators", () => {
+    // Regression for the precedence cascade add_expr → mul_expr → bitwise_expr:
+    // before `mul_expr` was recognised as an expression rule, an enclosing
+    // add_expr filtered its mul_expr operands out and inferred no type, so a
+    // body like `a * b` annotated nothing.
+    const ast = parseNib("fn mul(a: u4, b: u4) -> u4 { return a * b; }");
+    const result = checkNib(ast);
+
+    expect(result.ok).toBe(true);
+    expect(findAnnotatedTypes(result.typedAst)).toContain("u4");
+  });
+
+  it("rejects mismatched operands of a multiplicative operator", () => {
+    const ast = parseNib("fn main() { let x: u4 = 1; let y: bool = true; let z: u4 = x * y; }");
+    const result = checkNib(ast);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((error) => error.message.includes("same type"))).toBe(true);
+  });
+
   it("rejects mismatched let bindings", () => {
     const ast = parseNib("fn main() { let flag: bool = 1; }");
     const result = checkNib(ast);


### PR DESCRIPTION
## What

The Nib type checker never learned about the `mul_expr` precedence level added in LANG-FULL N1. The grammar cascade is now `add_expr → mul_expr → bitwise_expr`, but `mul_expr` was missing from both the `EXPRESSION_RULES` allow-list (consulted by `expressionChildren`) and the rule-dispatch `switch`.

**Effect:** an enclosing `add_expr` filtered its `mul_expr` operands out of `expressionChildren` (not in the allow-list), saw zero operands, inferred no type, and never descended. A well-typed body like `a +% b` or `a * b` annotated nothing, so `findAnnotatedTypes` returned `[]` and the type-checker test failed.

## Fix

- Add `"mul_expr"` to `EXPRESSION_RULES`.
- Route `case "mul_expr"` through the existing `checkAddExpression` — multiplicative expressions share additive semantics (same-type operands, numeric result, BCD restricted to `+%`/`-`), so no parallel code path is needed.
- Regression tests: inference through `*`, and operand-type mismatch rejection.

## Why a standalone PR

This is a **latent bug already on `main`** — independent of any in-flight grammar-tools / F10 work. It only surfaces in CI because grammar-tools PRs pull `nib-type-checker` into the affected-test set. Landing it on its own unblocks every PR touching `grammar-tools`. Directly mirrors the analogous nib-formatter fix (#5713).

🤖 Generated with [Claude Code](https://claude.com/claude-code)