### PR TITLE
feat(irc-server-native): Elixir/BEAM native binding for the all-Rust IRC engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,11 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Set up Elixir
-        if: needs.detect.outputs.needs_elixir == 'true'
+        # Elixir NIF packages skip Windows (BEAM import-library linkage isn't
+        # wired up — see each Elixir package's BUILD_windows), and
+        # erlef/setup-beam can't map newer Windows runner images (e.g.
+        # win25-vs2026), so don't install Elixir on Windows at all.
+        if: needs.detect.outputs.needs_elixir == 'true' && runner.os != 'Windows'
         uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.18.4'
@@ -588,7 +592,7 @@ jobs:
           if [ "${{ needs.detect.outputs.needs_swift }}" = "true" ]; then
             echo "Swift: $(swift --version | head -1)"
           fi
-          if [ "${{ needs.detect.outputs.needs_elixir }}" = "true" ]; then
+          if [ "${{ needs.detect.outputs.needs_elixir }}" = "true" ] && [ "$RUNNER_OS" != "Windows" ]; then
             echo "Elixir: $(elixir --version)"
             echo "Mix: $(mix --version)"
           fi

--- a/code/packages/elixir/irc-server-native/.gitignore
+++ b/code/packages/elixir/irc-server-native/.gitignore
@@ -1,0 +1,7 @@
+_build/
+deps/
+priv/*.so
+priv/*.dylib
+native/*/target/
+erl_crash.dump
+cover/

--- a/code/packages/elixir/irc-server-native/BUILD
+++ b/code/packages/elixir/irc-server-native/BUILD
@@ -1,0 +1,14 @@
+# BUILD — coding_adventures_irc_server_native (Elixir IRC server binding)
+#
+# Each non-comment line runs as a SEPARATE subprocess with the working
+# directory reset to the package root, so chain directory changes with &&.
+# cargo, mix, elixir, erlang are expected on PATH (mise shims locally; CI installs them).
+
+# Step 1: build the Rust NIF cdylib.
+cd native/irc_server_native && cargo build --release
+
+# Step 2: copy the platform library into priv/ as irc_server_native.so
+mkdir -p priv && { cp native/irc_server_native/target/release/libirc_server_native.dylib priv/irc_server_native.so 2>/dev/null || cp native/irc_server_native/target/release/libirc_server_native.so priv/irc_server_native.so; }
+
+# Step 3: compile + test.
+mix deps.get --quiet && mix compile && mix test --cover

--- a/code/packages/elixir/irc-server-native/BUILD_windows
+++ b/code/packages/elixir/irc-server-native/BUILD_windows
@@ -1,0 +1,14 @@
+# BUILD — coding_adventures_irc_server_native (Elixir IRC server binding)
+#
+# Each non-comment line runs as a SEPARATE subprocess with the working
+# directory reset to the package root, so chain directory changes with &&.
+# cargo, mix, elixir, erlang are expected on PATH (mise shims locally; CI installs them).
+
+# Step 1: build the Rust NIF cdylib.
+cd native/irc_server_native && cargo build --release
+
+# Step 2: copy the platform library into priv/ as irc_server_native.so
+mkdir -p priv && { cp native/irc_server_native/target/release/libirc_server_native.dylib priv/irc_server_native.so 2>/dev/null || cp native/irc_server_native/target/release/libirc_server_native.so priv/irc_server_native.so; }
+
+# Step 3: compile + test.
+mix deps.get --quiet && mix compile && mix test --cover

--- a/code/packages/elixir/irc-server-native/BUILD_windows
+++ b/code/packages/elixir/irc-server-native/BUILD_windows
@@ -1,14 +1,6 @@
-# BUILD — coding_adventures_irc_server_native (Elixir IRC server binding)
+# BUILD_windows — coding_adventures_irc_server_native
 #
-# Each non-comment line runs as a SEPARATE subprocess with the working
-# directory reset to the package root, so chain directory changes with &&.
-# cargo, mix, elixir, erlang are expected on PATH (mise shims locally; CI installs them).
-
-# Step 1: build the Rust NIF cdylib.
-cd native/irc_server_native && cargo build --release
-
-# Step 2: copy the platform library into priv/ as irc_server_native.so
-mkdir -p priv && { cp native/irc_server_native/target/release/libirc_server_native.dylib priv/irc_server_native.so 2>/dev/null || cp native/irc_server_native/target/release/libirc_server_native.so priv/irc_server_native.so; }
-
-# Step 3: compile + test.
-mix deps.get --quiet && mix compile && mix test --cover
+# Windows NIF support is not yet wired up (the BEAM links against erts.dll in a
+# way that needs explicit import-library linkage). Skip this package on Windows,
+# matching the Elixir conduit package.
+echo "skipped (NIF not yet supported on Windows)"

--- a/code/packages/elixir/irc-server-native/CHANGELOG.md
+++ b/code/packages/elixir/irc-server-native/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-06-14
+
+### Added
+
+- `CodingAdventures.IrcServerNative.Server` — an Elixir facade for a
+  high-performance IRC server whose IRC and TCP logic run entirely in Rust
+  (`irc-net-reactor` on the home-grown kqueue/epoll reactor). API: `new/1`
+  (`:host`, `:port`, `:server_name`, `:motd`, `:oper_password`,
+  `:max_connections`), `serve/1` (dirty I/O, blocking), `serve_background/1`,
+  `stop/1`, `running?/1`, `local_host/1` / `local_port/1` / `local_addr/1`.
+- `irc_server_native` Erlang NIF (Rust cdylib via the zero-dependency
+  `erl-nif-bridge`): a `NativeServer` resource with `new_server` /
+  `server_serve` (dirty I/O) / `server_serve_background` / `server_stop` /
+  `server_running` / `server_local_host` / `server_local_port`. No callback into
+  Elixir — the binding is lifecycle-only. The resource destructor stops and
+  joins the server on GC.
+- `@on_load` NIF loader; `build.rs` linker config; `BUILD` that builds the
+  cdylib, copies it into `priv/`, and runs `mix test --cover` (the pure-stub
+  `Native` module is excluded from coverage).
+- ExUnit real-socket tests (`:gen_tcp`): ephemeral address, `running?` flips
+  after `serve_background`, registration + PING/PONG, channel `PRIVMSG`
+  broadcast between two clients.
+
+### Security / robustness
+
+- `serve`/`serve_background` run the blocking loop on an **owned clone** of the
+  engine (`Clone` over `Arc`s), so the GC destructor's stop+join never races a
+  dangling engine (mirrors the Python/Ruby/Node/Java bindings).

--- a/code/packages/elixir/irc-server-native/README.md
+++ b/code/packages/elixir/irc-server-native/README.md
@@ -1,0 +1,66 @@
+# coding_adventures_irc_server_native (Elixir)
+
+A **high-performance IRC server for the BEAM** — every line of IRC and TCP logic
+runs in Rust (the [`irc-net-reactor`](../../rust/irc-net-reactor) engine on the
+home-grown `kqueue`/`epoll` reactor). Elixir only launches and controls the
+server, through an Erlang NIF built on the zero-dependency `erl-nif-bridge`.
+
+## Why
+
+This is the BEAM member of a family: one Rust IRC engine, embedded natively in
+every language. Because all logic lives in Rust, the binding is a pure lifecycle
+control surface — **create, serve, stop** — with no callback into Elixir.
+
+## Usage
+
+```elixir
+alias CodingAdventures.IrcServerNative.Server
+
+{:ok, server} = Server.new(port: 6667)
+:ok = Server.serve_background(server)   # runs the loop on a Rust thread
+# ... connect IRC clients to Server.local_host(server):Server.local_port(server) ...
+:ok = Server.stop(server)
+```
+
+`serve/1` runs the loop in the calling process (a dirty I/O NIF, so it doesn't
+starve the BEAM schedulers) and blocks until `stop/1`; `serve_background/1` runs
+it on a Rust OS thread and returns immediately.
+
+## API
+
+`CodingAdventures.IrcServerNative.Server`:
+
+| function           | description                                              |
+|--------------------|----------------------------------------------------------|
+| `new(opts)`        | build + bind (`:host`, `:port`, `:server_name`, `:motd`, `:oper_password`, `:max_connections`) |
+| `serve/1`          | run the loop in the calling process (dirty I/O), blocking |
+| `serve_background/1` | run the loop on a Rust thread, returns immediately      |
+| `stop/1`           | signal the loop to stop and join the thread              |
+| `running?/1`       | whether the loop is running                              |
+| `local_host/1` / `local_port/1` / `local_addr/1` | the bound address          |
+
+The server resource is reference-counted by the BEAM; when the last reference is
+garbage-collected, the Rust destructor stops and joins the server.
+
+## How it's built
+
+`BUILD` runs `cargo build --release` in `native/irc_server_native`, copies the
+cdylib into `priv/irc_server_native.so`, then `mix compile` + `mix test`. The NIF
+is loaded with `@on_load` via `:erlang.load_nif/2`.
+
+## Resilience
+
+`serve`/`serve_background` run the blocking loop on an **owned clone** of the
+engine, so the resource destructor (which stops + joins) never races a dangling
+engine. The underlying reactor closes a single connection (never the whole loop)
+when a client resets.
+
+## Layer position
+
+```
+CodingAdventures.IrcServerNative.Server   (this package — Elixir facade)
+        ↓ irc_server_native NIF (erl-nif-bridge; dirty-I/O or background-thread serve)
+irc-net-reactor   (Rust IRC engine, in-process broadcast)
+        ↓
+tcp-runtime → transport-platform → kqueue / epoll / IOCP
+```

--- a/code/packages/elixir/irc-server-native/lib/coding_adventures/irc_server_native/native.ex
+++ b/code/packages/elixir/irc-server-native/lib/coding_adventures/irc_server_native/native.ex
@@ -1,0 +1,50 @@
+defmodule CodingAdventures.IrcServerNative.Native do
+  @moduledoc """
+  NIF stubs for the Rust `irc_server_native` cdylib, which embeds the all-Rust
+  `irc-net-reactor` IRC engine.
+
+  Each function body (`:erlang.nif_error(:not_loaded)`) is replaced at module
+  load by the real Rust function via `@on_load`. The cdylib's `nif_init/0`
+  declares its module as `Elixir.CodingAdventures.IrcServerNative.Native`, which
+  MUST match this module's name exactly or the BEAM refuses to load the NIF.
+
+  All IRC and TCP logic runs in Rust; Elixir only launches and controls the
+  server. There is no callback into Elixir.
+  """
+
+  @on_load :load_nif
+
+  @doc false
+  def load_nif do
+    priv_dir = :code.priv_dir(:coding_adventures_irc_server_native)
+    nif_path = Path.join(priv_dir, "irc_server_native")
+    :erlang.load_nif(to_charlist(nif_path), 0)
+  end
+
+  @doc """
+  Build a server resource bound to `host:port`.
+
+  `motd` is a single newline-joined binary (the Rust side splits it into lines).
+  Returns an opaque resource, or raises `ArgumentError` on bad arguments.
+  """
+  def new_server(_host, _port, _server_name, _motd, _oper_password, _max_connections),
+    do: :erlang.nif_error(:not_loaded)
+
+  @doc "Run the event loop in the calling process, blocking until stopped (dirty I/O)."
+  def server_serve(_server), do: :erlang.nif_error(:not_loaded)
+
+  @doc "Spawn a Rust thread to run the event loop; returns immediately."
+  def server_serve_background(_server), do: :erlang.nif_error(:not_loaded)
+
+  @doc "Signal the loop to stop and join the background thread."
+  def server_stop(_server), do: :erlang.nif_error(:not_loaded)
+
+  @doc "Whether the loop is currently running (boolean)."
+  def server_running(_server), do: :erlang.nif_error(:not_loaded)
+
+  @doc "The bound IP address (binary)."
+  def server_local_host(_server), do: :erlang.nif_error(:not_loaded)
+
+  @doc "The bound TCP port (integer)."
+  def server_local_port(_server), do: :erlang.nif_error(:not_loaded)
+end

--- a/code/packages/elixir/irc-server-native/lib/coding_adventures/irc_server_native/server.ex
+++ b/code/packages/elixir/irc-server-native/lib/coding_adventures/irc_server_native/server.ex
@@ -1,0 +1,86 @@
+defmodule CodingAdventures.IrcServerNative.Server do
+  @moduledoc """
+  A high-performance IRC server for the BEAM, backed by the all-Rust
+  `irc-net-reactor` engine (on the home-grown kqueue/epoll reactor).
+
+  Every line of IRC and TCP logic runs in Rust; this module only launches and
+  controls the server.
+
+      {:ok, server} = CodingAdventures.IrcServerNative.Server.new(port: 0)
+      :ok = CodingAdventures.IrcServerNative.Server.serve_background(server)
+      # ... connect IRC clients to local_host(server):local_port(server) ...
+      :ok = CodingAdventures.IrcServerNative.Server.stop(server)
+
+  The underlying resource is reference-counted by the BEAM; when the last
+  reference is garbage-collected the Rust destructor stops and joins the server.
+  """
+
+  alias CodingAdventures.IrcServerNative.Native
+
+  @enforce_keys [:resource]
+  defstruct [:resource]
+
+  @type t :: %__MODULE__{resource: reference()}
+
+  @default_motd ["Welcome."]
+
+  @doc """
+  Build and bind a server.
+
+  Options: `:host` (default `"127.0.0.1"`), `:port` (default `6667`; `0` picks an
+  ephemeral port), `:server_name` (default `"irc.local"`), `:motd` (list of
+  lines, default `["Welcome."]`), `:oper_password` (default `""`),
+  `:max_connections` (default `1024`).
+  """
+  @spec new(keyword()) :: {:ok, t()}
+  def new(opts \\ []) do
+    host = Keyword.get(opts, :host, "127.0.0.1")
+    port = Keyword.get(opts, :port, 6667)
+    server_name = Keyword.get(opts, :server_name, "irc.local")
+    motd = Keyword.get(opts, :motd, @default_motd)
+    motd = if motd == [], do: @default_motd, else: motd
+    oper_password = Keyword.get(opts, :oper_password, "")
+    max_connections = Keyword.get(opts, :max_connections, 1024)
+
+    resource =
+      Native.new_server(
+        to_string(host),
+        port,
+        to_string(server_name),
+        Enum.map_join(motd, "\n", &to_string/1),
+        to_string(oper_password),
+        max_connections
+      )
+
+    {:ok, %__MODULE__{resource: resource}}
+  end
+
+  @doc "Run the event loop in the calling process, blocking until `stop/1`."
+  @spec serve(t()) :: :ok
+  def serve(%__MODULE__{resource: r}), do: Native.server_serve(r)
+
+  @doc "Run the event loop on a background Rust thread; returns immediately."
+  @spec serve_background(t()) :: :ok
+  def serve_background(%__MODULE__{resource: r}), do: Native.server_serve_background(r)
+
+  @doc "Signal the server to stop and join the background thread."
+  @spec stop(t()) :: :ok
+  def stop(%__MODULE__{resource: r}), do: Native.server_stop(r)
+
+  @doc "Whether the event loop is currently running."
+  @spec running?(t()) :: boolean()
+  def running?(%__MODULE__{resource: r}), do: Native.server_running(r) == true
+
+  @doc "The bound IP address."
+  @spec local_host(t()) :: String.t()
+  def local_host(%__MODULE__{resource: r}), do: Native.server_local_host(r)
+
+  @doc "The bound TCP port (the OS-assigned port when constructed with `port: 0`)."
+  @spec local_port(t()) :: non_neg_integer()
+  def local_port(%__MODULE__{resource: r}), do: Native.server_local_port(r)
+
+  @doc "The bound `host:port` address."
+  @spec local_addr(t()) :: String.t()
+  def local_addr(%__MODULE__{} = server),
+    do: "#{local_host(server)}:#{local_port(server)}"
+end

--- a/code/packages/elixir/irc-server-native/mix.exs
+++ b/code/packages/elixir/irc-server-native/mix.exs
@@ -1,0 +1,32 @@
+defmodule CodingAdventures.IrcServerNative.MixProject do
+  use Mix.Project
+
+  # Wraps the Rust `irc_server_native` cdylib as an Erlang NIF. The shared
+  # library is built EXTERNALLY by BUILD (cargo build + copy into priv/), not by
+  # elixir_make (which causes a chicken-and-egg compile-task error in CI — see
+  # lessons.md).
+
+  def project do
+    [
+      app: :coding_adventures_irc_server_native,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      # The Native module is pure NIF stubs whose bodies are replaced by the Rust
+      # cdylib at load time, so they never execute under coverage instrumentation
+      # (analogous to excluding the .so itself). Exclude it; the real logic lives
+      # in Server, which the end-to-end tests cover.
+      test_coverage: [
+        summary: [threshold: 80],
+        ignore_modules: [CodingAdventures.IrcServerNative.Native]
+      ]
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps, do: []
+end

--- a/code/packages/elixir/irc-server-native/native/irc_server_native/Cargo.toml
+++ b/code/packages/elixir/irc-server-native/native/irc_server_native/Cargo.toml
@@ -1,0 +1,19 @@
+# Erlang NIF cdylib exposing the all-Rust irc-net-reactor IRC engine to Elixir.
+# Loaded via :erlang.load_nif/2. [workspace]-isolated: BUILD does its own
+# `cargo build` from this directory.
+[workspace]
+
+[package]
+name = "irc-server-native-nif"
+version = "0.1.0"
+edition = "2021"
+description = "Erlang NIF exposing the irc-net-reactor IRC engine to Elixir"
+build = "build.rs"
+
+[lib]
+name = "irc_server_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+erl-nif-bridge  = { path = "../../../../rust/erl-nif-bridge" }
+irc-net-reactor = { path = "../../../../rust/irc-net-reactor" }

--- a/code/packages/elixir/irc-server-native/native/irc_server_native/build.rs
+++ b/code/packages/elixir/irc-server-native/native/irc_server_native/build.rs
@@ -1,0 +1,19 @@
+// build.rs — linker flags for the Elixir/Erlang conduit_native NIF
+//
+// Erlang NIFs (.so/.bundle/.dll) are loaded by the BEAM via
+// `:erlang.load_nif/2`. The `enif_*` symbols are provided by the running
+// ERTS runtime, not by a library we link against at build time. We tell
+// the linker to allow undefined symbols and resolve them at dlopen() time.
+//
+// - macOS: explicit `-undefined dynamic_lookup` flag for ld
+// - Linux: ELF allows undefined symbols by default in shared objects
+// - Windows: the BEAM exports erts.dll; not yet wired up here
+
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_os == "macos" {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/code/packages/elixir/irc-server-native/native/irc_server_native/src/lib.rs
+++ b/code/packages/elixir/irc-server-native/native/irc_server_native/src/lib.rs
@@ -1,0 +1,420 @@
+//! `irc_server_native` — an Erlang NIF embedding the all-Rust IRC engine
+//! (`irc-net-reactor`) into the BEAM (Elixir/Erlang).
+//!
+//! ## Design: control surface only, no callbacks
+//!
+//! All IRC and TCP logic lives in Rust (`irc-net-reactor` on the home-grown
+//! kqueue/epoll reactor).  Elixir only *launches and controls* the server, so
+//! this NIF exposes a small set of functions over a single BEAM resource:
+//! `new_server`, `server_serve` (dirty I/O — blocks), `server_serve_background`,
+//! `server_stop`, `server_running`, `server_local_host`, `server_local_port`.
+//!
+//! Unlike `conduit`'s NIF, there is **no per-request dispatch back into Elixir**
+//! (no routes, no dispatcher pid), so the binding is pure lifecycle control.
+//!
+//! ## Use-after-free safety
+//!
+//! The blocking loop runs on an **owned clone** of the engine (`IrcReactorServer`
+//! is `Clone` over `Arc`s).  The resource keeps its own copy as a control handle
+//! (for `stop` and `local_*`), so the background thread never dangles even when
+//! the resource is GC'd — the destructor stops and joins before dropping.
+
+// NIF tables use nul-terminated byte-string literals (`b"...\0"`) for C `char*`
+// fields, matching the `conduit_native` NIF; clippy's c-string-literal lint is noise here.
+#![allow(clippy::manual_c_str_literals)]
+
+use erl_nif_bridge::*;
+use std::ffi::{c_char, c_int, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use irc_net_reactor::{IrcConfig, IrcReactorServer};
+
+/// The mutable interior of a server resource.  A single BEAM resource can be
+/// driven concurrently from multiple Elixir processes, so all access to these
+/// fields — and the `running` check-and-set — happens under [`NativeServer::inner`]'s
+/// `Mutex`; an `AtomicBool` alone would not serialize the field mutations.
+struct ServerInner {
+    /// The bound engine, kept as a control handle; the serve loop runs a clone.
+    server: Option<IrcReactorServer>,
+    bg_thread: Option<std::thread::JoinHandle<()>>,
+}
+
+/// State held inside the BEAM `NativeServer` resource.
+struct NativeServer {
+    inner: Mutex<ServerInner>,
+    /// Shared with the background serve thread, which clears it on exit, so it
+    /// stays an atomic outside the mutex.
+    running: Arc<AtomicBool>,
+    // Immutable after construction — read without locking.
+    local_host: String,
+    local_port: u16,
+}
+
+/// Lock the resource interior, recovering from a poisoned mutex rather than
+/// re-panicking across the NIF boundary (a panic into the BEAM is UB).
+fn lock_inner(srv: &NativeServer) -> std::sync::MutexGuard<'_, ServerInner> {
+    srv.inner
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+// Resource type handle, registered on NIF load.
+static SERVER_RTYPE: OnceLock<usize> = OnceLock::new();
+
+fn server_rtype() -> *mut ErlNifResourceType {
+    *SERVER_RTYPE
+        .get()
+        .expect("irc_server_native NIF not loaded") as *mut ErlNifResourceType
+}
+
+/// GC destructor: stop the loop, join the background thread, then drop the value.
+unsafe extern "C" fn server_dtor(_env: ErlNifEnv, obj: *mut c_void) {
+    let srv_ptr = obj as *mut NativeServer;
+    // The destructor runs only once the last reference is gone, so no NIF call is
+    // touching the resource concurrently. Stop + join (releasing the lock before
+    // the join) then drop the value in place — the BEAM owns the memory.
+    let handle = {
+        let srv = &*srv_ptr;
+        let mut inner = lock_inner(srv);
+        if let Some(server) = inner.server.as_ref() {
+            server.stop();
+        }
+        inner.bg_thread.take()
+    };
+    if let Some(handle) = handle {
+        let _ = handle.join();
+    }
+    std::ptr::drop_in_place(srv_ptr);
+}
+
+unsafe extern "C" fn nif_load(
+    env: ErlNifEnv,
+    _priv: *mut *mut c_void,
+    _info: ERL_NIF_TERM,
+) -> c_int {
+    let module = b"Elixir.CodingAdventures.IrcServerNative.Native\0";
+    let srv_name = b"NativeServer\0";
+    let mut tried = 0;
+    let srv_rt = enif_open_resource_type(
+        env,
+        module.as_ptr() as *const _,
+        srv_name.as_ptr() as *const _,
+        Some(server_dtor),
+        ERL_NIF_RT_CREATE,
+        &mut tried,
+    );
+    if srv_rt.is_null() {
+        return 1;
+    }
+    let _ = SERVER_RTYPE.set(srv_rt as usize);
+    0
+}
+
+unsafe fn argv_slice<'a>(argv: *const ERL_NIF_TERM, argc: c_int) -> &'a [ERL_NIF_TERM] {
+    if argv.is_null() || argc <= 0 {
+        return &[];
+    }
+    std::slice::from_raw_parts(argv, argc as usize)
+}
+
+// ── new_server(host, port, server_name, motd, oper_password, max_connections) ──
+
+unsafe extern "C" fn nif_new_server(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 6 {
+        return badarg(env);
+    }
+
+    let host = match binary_to_string(env, args[0]) {
+        Some(s) => s,
+        None => return badarg(env),
+    };
+    let port = match get_i64(env, args[1]) {
+        Some(v) if (0..=65535).contains(&v) => v as u16,
+        _ => return badarg(env),
+    };
+    let server_name = match binary_to_string(env, args[2]) {
+        Some(s) => s,
+        None => return badarg(env),
+    };
+    // MOTD arrives as a single newline-joined binary; split it back into lines.
+    let motd: Vec<String> = match binary_to_string(env, args[3]) {
+        Some(joined) => joined
+            .split('\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| line.to_string())
+            .collect(),
+        None => return badarg(env),
+    };
+    let oper_password = match binary_to_string(env, args[4]) {
+        Some(s) => s,
+        None => return badarg(env),
+    };
+    let max_connections = match get_i64(env, args[5]) {
+        Some(v) if v >= 1 => v as usize,
+        _ => return badarg(env),
+    };
+
+    let config = IrcConfig {
+        host,
+        port,
+        server_name,
+        motd,
+        oper_password,
+        max_connections,
+    };
+    let server = match IrcReactorServer::bind(config) {
+        Ok(server) => server,
+        Err(_) => return badarg(env),
+    };
+    let addr = server.local_addr();
+    let native = NativeServer {
+        local_host: addr.ip().to_string(),
+        local_port: addr.port(),
+        running: Arc::new(AtomicBool::new(false)),
+        inner: Mutex::new(ServerInner {
+            server: Some(server),
+            bg_thread: None,
+        }),
+    };
+    wrap_resource::<NativeServer>(env, server_rtype(), native)
+}
+
+// ── server_serve(server) — blocks (dirty I/O scheduler) ──────────────────────
+
+unsafe extern "C" fn nif_server_serve(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    let srv = &*srv_ptr;
+    // Clone the engine and flip `running` under the lock, then release it BEFORE
+    // the blocking serve — otherwise a concurrent server_stop could never take
+    // the lock to signal us, deadlocking.
+    let engine = {
+        let inner = lock_inner(srv);
+        if srv.running.load(Ordering::SeqCst) {
+            return atom(env, "ok");
+        }
+        match inner.server.as_ref() {
+            Some(server) => {
+                srv.running.store(true, Ordering::SeqCst);
+                server.clone()
+            }
+            None => return badarg(env),
+        }
+    };
+    let _ = engine.serve();
+    srv.running.store(false, Ordering::SeqCst);
+    atom(env, "ok")
+}
+
+// ── server_serve_background(server) — spawn a thread, return immediately ──────
+
+unsafe extern "C" fn nif_server_serve_background(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    let srv = &*srv_ptr;
+    let mut inner = lock_inner(srv);
+    if srv.running.load(Ordering::SeqCst) {
+        return atom(env, "ok");
+    }
+    let engine = match inner.server.as_ref() {
+        Some(server) => server.clone(),
+        None => return badarg(env),
+    };
+    let running = Arc::clone(&srv.running);
+    running.store(true, Ordering::SeqCst);
+    let handle = std::thread::spawn(move || {
+        let _ = engine.serve();
+        running.store(false, Ordering::SeqCst);
+    });
+    inner.bg_thread = Some(handle);
+    atom(env, "ok")
+}
+
+unsafe extern "C" fn nif_server_stop(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    let srv = &*srv_ptr;
+    // Signal stop and take the join handle under the lock, then release it before
+    // joining (the background thread never touches the lock, so this can't deadlock).
+    let handle = {
+        let mut inner = lock_inner(srv);
+        if let Some(server) = inner.server.as_ref() {
+            server.stop();
+        }
+        inner.bg_thread.take()
+    };
+    if let Some(handle) = handle {
+        let _ = handle.join();
+    }
+    srv.running.store(false, Ordering::SeqCst);
+    atom(env, "ok")
+}
+
+unsafe extern "C" fn nif_server_running(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    let running = (*srv_ptr).running.load(Ordering::SeqCst);
+    atom(env, if running { "true" } else { "false" })
+}
+
+unsafe extern "C" fn nif_server_local_host(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    str_to_binary(env, &(*srv_ptr).local_host)
+}
+
+unsafe extern "C" fn nif_server_local_port(
+    env: ErlNifEnv,
+    argc: c_int,
+    argv: *const ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
+    let args = argv_slice(argv, argc);
+    if args.len() != 1 {
+        return badarg(env);
+    }
+    let srv_ptr = match unwrap_resource::<NativeServer>(env, args[0], server_rtype()) {
+        Some(p) => p,
+        None => return badarg(env),
+    };
+    make_i64(env, (*srv_ptr).local_port as i64)
+}
+
+// ── NIF entry table ──────────────────────────────────────────────────────────
+
+// `server_serve` is dirty I/O (flags = 2 = ERL_NIF_DIRTY_JOB_IO_BOUND) because it
+// blocks for the server's lifetime; everything else runs on a normal scheduler.
+struct FuncTable([ErlNifFunc; 7]);
+unsafe impl Sync for FuncTable {}
+
+static FUNCS: FuncTable = FuncTable([
+    ErlNifFunc {
+        name: b"new_server\0".as_ptr() as *const _,
+        arity: 6,
+        fptr: nif_new_server,
+        flags: 0,
+    },
+    ErlNifFunc {
+        name: b"server_serve\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_serve,
+        flags: 2,
+    },
+    ErlNifFunc {
+        name: b"server_serve_background\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_serve_background,
+        flags: 0,
+    },
+    ErlNifFunc {
+        name: b"server_stop\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_stop,
+        flags: 0,
+    },
+    ErlNifFunc {
+        name: b"server_running\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_running,
+        flags: 0,
+    },
+    ErlNifFunc {
+        name: b"server_local_host\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_local_host,
+        flags: 0,
+    },
+    ErlNifFunc {
+        name: b"server_local_port\0".as_ptr() as *const _,
+        arity: 1,
+        fptr: nif_server_local_port,
+        flags: 0,
+    },
+]);
+
+static MODULE_NAME_BYTES: &[u8] = b"Elixir.CodingAdventures.IrcServerNative.Native\0";
+static VM_VARIANT_BYTES: &[u8] = b"beam.vanilla\0";
+static MIN_ERTS_BYTES: &[u8] = b"erts-13.0\0";
+
+struct NifEntry(ErlNifEntry);
+unsafe impl Sync for NifEntry {}
+
+static NIF_ENTRY: NifEntry = NifEntry(ErlNifEntry {
+    major: ERL_NIF_MAJOR_VERSION,
+    minor: ERL_NIF_MINOR_VERSION,
+    name: MODULE_NAME_BYTES.as_ptr() as *const c_char,
+    num_of_funcs: 7,
+    funcs: FUNCS.0.as_ptr(),
+    load: Some(nif_load),
+    reload: None,
+    upgrade: None,
+    unload: None,
+    vm_variant: VM_VARIANT_BYTES.as_ptr() as *const c_char,
+    options: 0,
+    sizeof_ErlNifResourceTypeInit: 0,
+    min_erts: MIN_ERTS_BYTES.as_ptr() as *const c_char,
+});
+
+/// The BEAM resolves this symbol when `:erlang.load_nif/2` loads the library.
+///
+/// # Safety
+/// Called once by the BEAM loader.
+#[no_mangle]
+pub unsafe extern "C" fn nif_init() -> *const ErlNifEntry {
+    &NIF_ENTRY.0
+}

--- a/code/packages/elixir/irc-server-native/required_capabilities.json
+++ b/code/packages/elixir/irc-server-native/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "required_capabilities": ["rust", "elixir", "cargo"]
+}

--- a/code/packages/elixir/irc-server-native/test/irc_server_native_test.exs
+++ b/code/packages/elixir/irc-server-native/test/irc_server_native_test.exs
@@ -1,0 +1,108 @@
+defmodule CodingAdventures.IrcServerNative.ServerTest do
+  use ExUnit.Case, async: false
+
+  alias CodingAdventures.IrcServerNative.Server
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  defp connect(port) do
+    {:ok, sock} =
+      :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false, packet: :raw], 2000)
+
+    sock
+  end
+
+  defp recv_until(sock, needle, deadline \\ nil) do
+    deadline = deadline || System.monotonic_time(:millisecond) + 5000
+    recv_until(sock, needle, deadline, "")
+  end
+
+  defp recv_until(sock, needle, deadline, acc) do
+    cond do
+      String.contains?(acc, needle) ->
+        acc
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        acc
+
+      true ->
+        case :gen_tcp.recv(sock, 0, 300) do
+          {:ok, data} -> recv_until(sock, needle, deadline, acc <> data)
+          {:error, :timeout} -> recv_until(sock, needle, deadline, acc)
+          {:error, _} -> acc
+        end
+    end
+  end
+
+  defp register(sock, nick) do
+    :ok = :gen_tcp.send(sock, "NICK #{nick}\r\nUSER #{nick} 0 * :#{nick}\r\n")
+    welcome = recv_until(sock, "001")
+    assert String.contains?(welcome, "001"), "expected 001 welcome for #{nick}"
+  end
+
+  defp start_server do
+    {:ok, server} = Server.new(port: 0, server_name: "irc.test")
+    :ok = Server.serve_background(server)
+    # wait until running
+    Enum.reduce_while(1..200, nil, fn _, _ ->
+      if Server.running?(server), do: {:halt, :ok}, else: (Process.sleep(5); {:cont, nil})
+    end)
+
+    server
+  end
+
+  # ── tests ──────────────────────────────────────────────────────────────────
+
+  test "reports the ephemeral bound address" do
+    {:ok, server} = Server.new(port: 0)
+    assert Server.local_host(server) == "127.0.0.1"
+    assert Server.local_port(server) > 0
+    assert Server.local_addr(server) == "127.0.0.1:#{Server.local_port(server)}"
+  end
+
+  test "running? flips after serve_background" do
+    {:ok, server} = Server.new(port: 0)
+    refute Server.running?(server)
+    :ok = Server.serve_background(server)
+    Enum.reduce_while(1..200, nil, fn _, _ ->
+      if Server.running?(server), do: {:halt, :ok}, else: (Process.sleep(5); {:cont, nil})
+    end)
+
+    assert Server.running?(server)
+    :ok = Server.stop(server)
+  end
+
+  test "registration and PING/PONG" do
+    server = start_server()
+    sock = connect(Server.local_port(server))
+    register(sock, "alice")
+    :ok = :gen_tcp.send(sock, "PING :liveness\r\n")
+    pong = recv_until(sock, "PONG")
+    assert String.contains?(pong, "PONG")
+    :gen_tcp.close(sock)
+    :ok = Server.stop(server)
+  end
+
+  test "PRIVMSG broadcasts between two clients" do
+    server = start_server()
+    alice = connect(Server.local_port(server))
+    bob = connect(Server.local_port(server))
+    register(alice, "alice")
+    register(bob, "bob")
+    :ok = :gen_tcp.send(alice, "JOIN #test\r\n")
+    :ok = :gen_tcp.send(bob, "JOIN #test\r\n")
+    recv_until(alice, "JOIN")
+    recv_until(bob, "JOIN")
+
+    # Alice speaks; Bob (a different connection) must receive it — exercises the
+    # Rust engine's in-process mailbox fan-out.
+    :ok = :gen_tcp.send(alice, "PRIVMSG #test :hello bob\r\n")
+    received = recv_until(bob, "hello bob")
+    assert String.contains?(received, "PRIVMSG")
+    assert String.contains?(received, "hello bob")
+
+    :gen_tcp.close(alice)
+    :gen_tcp.close(bob)
+    :ok = Server.stop(server)
+  end
+end

--- a/code/packages/elixir/irc-server-native/test/test_helper.exs
+++ b/code/packages/elixir/irc-server-native/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## What

Port 6 of the language-binding arc — embeds the `irc-net-reactor` Rust IRC engine in the **BEAM** via the zero-dep `erl-nif-bridge`.

```elixir
alias CodingAdventures.IrcServerNative.Server
{:ok, server} = Server.new(port: 6667)
:ok = Server.serve_background(server)
:ok = Server.stop(server)
```

All IRC logic stays in Rust; Elixir only launches/controls the server (no callback into Elixir). `serve/1` is a dirty-I/O NIF (blocks the calling process without starving schedulers); `serve_background/1` runs the loop on a Rust thread. The `NativeServer` resource is reference-counted by the BEAM; its destructor stops and joins on GC.

## Security review (MEDIUM, fixed)

A single BEAM resource can be driven concurrently from multiple Elixir processes, and the `running` AtomicBool's check-and-set did **not** serialize the non-atomic `server`/`bg_thread` field mutations — a data race (UB) on concurrent `serve_background`/`stop`. Fixed by guarding the mutable interior with a `Mutex` (the running check-and-set is now atomic with the field access); `serve`/`stop`/the destructor release the lock before the blocking serve / the join to avoid deadlock. Re-review passed.

## Tests

4 ExUnit real-socket tests (`:gen_tcp`), all green: ephemeral address, `running?` flips after `serve_background`, registration + PING/PONG, channel `PRIVMSG` broadcast between two clients. 90% coverage (the pure-stub `Native` module is excluded — its bodies are replaced by the Rust NIF at load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)