### PR TITLE
feat(mycin-2026): C2 — local-first decomposer; messy input → diagnosis fully on-device

### DIFF
--- a/code/specs/data/mycin-2026/warm/decomposer.py
+++ b/code/specs/data/mycin-2026/warm/decomposer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""decomposer.py - local-first backend selection for the ONE warm-path model call.
+
+MYCIN-2026 C2. The warm path needs exactly one model call: messy clinical prose ->
+typed findings in the closed dictionary (decompose.py defines the prompt + the IR
+shape). This module chooses WHICH local model serves that call, preferring the
+most on-device option so patient data never has to leave the machine (privacy /
+HIPAA by architecture):
+
+    1. the trained MLX SPECIALIST (a small Gemma/Qwen LoRA, the privacy target -
+       runs fully on the doctor's Apple-Silicon machine; see ../train/)
+    2. local OLLAMA (a small instruct model on 127.0.0.1; still on-device)
+    3. (none available) -> raise, with a clear message - never silently degrade.
+
+Every backend returns the SAME IR via the shared prompt + coerce_ir, so the rest
+of the warm path (ir_to_adj -> decide -> voi -> set-cover) is backend-agnostic and
+still runs at 0 ANSWER-TIME model calls. This file only swaps the decompose call.
+
+`decompose_text(prose)` is the live one-shot entry point - messy human input to
+typed IR in one call - which the ER spine (C3) and a live consultation use.
+
+Config (env, all optional):
+    MYCIN_MLX_MODEL    HF id or path of the base (e.g. mlx-community/gemma-3-1b-it-4bit)
+    MYCIN_MLX_ADAPTER  path to the trained LoRA adapter dir (e.g. ../train/adapters)
+    MYCIN_OLLAMA_MODEL ollama model tag (default: qwen2.5:1.5b - the ~1 GB floor)
+
+Usage:
+    python3 decomposer.py "72M, neck stiffness, fever, neutrophilic CSF pleocytosis"
+    python3 decomposer.py --which        # just report which backend is available
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "warm"))
+sys.path.insert(0, str(ROOT / "bench"))
+import decompose as decompose_mod  # noqa: E402  (prompt_for, coerce_ir, ollama, OLLAMA)
+
+DICT = ROOT / "warm" / "dictionary.json"
+OLLAMA_TAGS = "http://127.0.0.1:11434/api/tags"
+DEFAULT_OLLAMA_MODEL = "qwen2.5:1.5b"  # the ~1 GB tolerant-framework floor (BENCH_FINDINGS)
+
+
+# --------------------------------------------------------------------------
+# Backends. Each `*_backend()` returns a `gen(prompt) -> str` callable, or None
+# if that backend is not available right now (no import, no server, no model).
+# --------------------------------------------------------------------------
+
+def mlx_backend() -> tuple[str, "callable"] | None:
+    """The trained on-device specialist, if mlx-lm is importable and a model is
+    configured. Lazy: importing this module never requires mlx."""
+    model = os.environ.get("MYCIN_MLX_MODEL")
+    if not model:
+        return None
+    adapter = os.environ.get("MYCIN_MLX_ADAPTER") or None
+    if adapter and not Path(adapter).exists():
+        return None
+    try:
+        from mlx_lm import generate, load
+        from mlx_lm.sample_utils import make_sampler
+    except ImportError:
+        return None
+    try:
+        m, tok = load(model, adapter_path=adapter)
+    except Exception:  # noqa: BLE001 - model not present / load failed -> unavailable
+        return None
+    sampler = make_sampler(temp=0.0)  # greedy, deterministic
+
+    def gen(prompt: str) -> str:
+        text = tok.apply_chat_template([{"role": "user", "content": prompt}],
+                                       add_generation_prompt=True)
+        out = generate(m, tok, prompt=text, max_tokens=512, sampler=sampler, verbose=False)
+        for stop in ("<end_of_turn>", "<eos>", "<pad>", "<start_of_turn>"):
+            out = out.split(stop)[0]
+        return out.strip()
+
+    label = f"mlx-specialist:{model}" + (f"+{adapter}" if adapter else "")
+    return label, gen
+
+
+def ollama_available() -> bool:
+    """A short-timeout probe of the local Ollama server (no hang if it is down)."""
+    try:
+        with urllib.request.urlopen(OLLAMA_TAGS, timeout=2):
+            return True
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def ollama_backend() -> tuple[str, "callable"] | None:
+    if not ollama_available():
+        return None
+    model = os.environ.get("MYCIN_OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
+    return f"ollama:{model}", (lambda prompt: decompose_mod.ollama(model, prompt))
+
+
+def select_backend() -> tuple[str, "callable"]:
+    """Pick the most on-device backend available, in priority order. Raises with a
+    clear message if none is - we never silently fall back to nothing."""
+    for factory in (mlx_backend, ollama_backend):
+        picked = factory()
+        if picked is not None:
+            return picked
+    raise RuntimeError(
+        "no local decomposer backend available. Set MYCIN_MLX_MODEL (+ "
+        "MYCIN_MLX_ADAPTER) for the on-device specialist, or start Ollama "
+        "(`ollama serve`) with a small model pulled.")
+
+
+# --------------------------------------------------------------------------
+# The live entry point: messy human input -> typed IR, one model call.
+# --------------------------------------------------------------------------
+
+def decompose_text(prose: str, gen: "callable" = None, dictionary: dict = None,
+                   case_id: str = "live") -> dict:
+    """Decompose one messy clinical string into typed IR (the warm path's single
+    model call). `gen` defaults to the selected local backend; pass one to inject
+    a backend (e.g. for tests). Returns the coerced + tolerant-normalized IR."""
+    if dictionary is None:
+        dictionary = json.loads(DICT.read_text())
+    if gen is None:
+        _, gen = select_backend()
+    raw = gen(decompose_mod.prompt_for(prose, dictionary))
+    ir = decompose_mod.coerce_ir(case_id, raw)
+    # Absorb small-model JSON variance the same way the bench does (so a sub-2B
+    # specialist's output maps), if the tolerant normalizer is importable.
+    try:
+        import bench_models as bench
+        if hasattr(bench, "tolerant_findings"):
+            ir["findings"] = bench.tolerant_findings(ir, load_domains()).get("findings", ir["findings"])
+    except Exception:  # noqa: BLE001 - normalization is best-effort, never fatal
+        pass
+    # Small models often emit `inference_justifications` / `discard` as bare
+    # strings (a prose aside) instead of the typed objects the rest of the path
+    # expects. Drop the non-conforming entries here - the decomposer is the layer
+    # that absorbs model-output variance, so ir_to_adj/decide stay strict. (These
+    # prose asides are non-findings and would be discarded anyway.)
+    ir["inference_justifications"] = [j for j in ir["inference_justifications"] if isinstance(j, dict)]
+    ir["discard"] = [d for d in ir["discard"] if isinstance(d, dict)]
+    return ir
+
+
+def load_domains() -> dict:
+    """The dictionary's functor -> value-domain map (for tolerant normalization)."""
+    d = json.loads(DICT.read_text())
+    return {f["functor"]: f["value_domain"] for f in d["findings"]}
+
+
+def main(argv: list[str]) -> int:
+    if "--which" in argv:
+        try:
+            name, _ = select_backend()
+            print(f"decomposer backend: {name}")
+            return 0
+        except RuntimeError as e:
+            print(f"decomposer: {e}", file=sys.stderr)
+            return 1
+    prose = " ".join(a for a in argv if not a.startswith("--"))
+    if not prose:
+        print('usage: decomposer.py "<clinical prose>"  |  --which', file=sys.stderr)
+        return 2
+    try:
+        name, gen = select_backend()
+    except RuntimeError as e:
+        print(f"decomposer: {e}", file=sys.stderr)
+        return 1
+    print(f"[backend: {name}]  (1 on-device model call; data stays local)")
+    ir = decompose_text(prose, gen=gen)
+    print(json.dumps(ir, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-2026/warm/run_live.py
+++ b/code/specs/data/mycin-2026/warm/run_live.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""run_live.py - messy human input -> diagnosis, FULLY LOCAL. The C2 payoff.
+
+One raw clinical string in; a byte-cited differential out. The ONLY model call is
+the on-device decompose (decomposer.py picks the local specialist or local
+Ollama); everything after is the CPU engine over the grounded CAS rulebook at
+0 ANSWER-TIME model calls. So the patient's words never leave the machine - the
+privacy / HIPAA story, demonstrated end to end:
+
+    "72M, fever, stiff neck, neutrophilic CSF, low glucose"
+        |  decomposer.decompose_text   (1 on-device model call)
+        v  typed findings in the closed dictionary
+        |  ir_to_adj -> decide          (0 model calls, CPU, byte-cited)
+        v  differential + the audit trail the physician reviews
+
+This is decision SUPPORT: every line is grounded + overridable; the physician
+makes the call. Run it on real prose; it never sends anything off-device.
+
+Usage:  python3 run_live.py "<clinical prose>"
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "warm"))
+import decide as decide_mod  # noqa: E402
+import decomposer as dc  # noqa: E402
+import ir_to_adj as ir_mod  # noqa: E402
+
+
+def run(prose: str) -> int:
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("run_live: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    try:
+        backend, gen = dc.select_backend()
+    except RuntimeError as e:
+        print(f"run_live: {e}", file=sys.stderr)
+        return 1
+
+    print("=" * 74)
+    print(f"INPUT (messy human prose): {prose}")
+    print(f"[decompose backend: {backend}] - the ONLY model call, on-device")
+    print("=" * 74)
+
+    # [1] the single on-device model call: prose -> typed IR
+    domains = ir_mod.load_domains()
+    ir = dc.decompose_text(prose, gen=gen)
+    observe_adj, kept, dropped = ir_mod.ir_to_adj(ir, domains)
+    print(f"\n[1] DECOMPOSITION  findings: {', '.join(kept) or '(none mapped)'}")
+    if dropped:
+        print(f"    dropped at the vocabulary gate: {[d['term'] for d in dropped]}")
+    if not kept:
+        print("\n    No dictionary findings extracted -> the engine abstains "
+              "(no fabricated diagnosis). Re-phrase or add detail.")
+        return 0
+
+    # [2] the differential - 0 answer-time model calls, byte-cited
+    res = decide_mod.decide("live", observe_adj, cli)
+    print("\n[2] DIFFERENTIAL  (0 answer-time model calls - CPU over the grounded rulebook)")
+    for hyp, p in sorted(res["posteriors"].items(), key=lambda kv: -kv[1]):
+        lead = "  <- leading" if hyp == res["leader"] else ""
+        print(f"    {hyp:24s} P = {p:.4f}{lead}")
+    dec = res["decision"].get("type")
+    print(f"    decision: {dec}  | evidence for leader: {res['n_evidence_for_leader']}")
+
+    print("\n" + "=" * 74)
+    print("PHYSICIAN REVIEW - every line is grounded + overridable; you make the call.")
+    print("answer-time model calls: 0   |   data left the machine: none")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    prose = " ".join(a for a in argv if not a.startswith("--"))
+    if not prose:
+        print('usage: run_live.py "<clinical prose>"', file=sys.stderr)
+        return 2
+    return run(prose)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-2026/warm/test_decomposer.py
+++ b/code/specs/data/mycin-2026/warm/test_decomposer.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""test_decomposer.py - guard local-first backend selection + the live entry point.
+
+Runs with NO model: a stub `gen` is injected so the decompose path is exercised
+deterministically. Backend availability is checked structurally (mlx unavailable
+without config; selection raises when nothing is available). CI runs this.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "warm"))
+import decomposer as dc  # noqa: E402
+
+CANNED = (
+    '{"findings": ['
+    '{"term": "fever(present)", "span": "fever", "type": "stated", "polarity": "affirmed"},'
+    '{"term": "meningismus(present)", "span": "neck stiffness", "type": "stated", "polarity": "affirmed"}'
+    '], "discard": [], "inference_justifications": []}'
+)
+
+
+def test_decompose_text_with_injected_backend() -> None:
+    """The live entry point works with any `gen`, no real model required."""
+    ir = dc.decompose_text("72M with fever and neck stiffness", gen=lambda _p: CANNED)
+    assert ir["case_id"] == "live"
+    terms = {f["term"] if isinstance(f, dict) else f for f in ir["findings"]}
+    assert "fever(present)" in terms, ir["findings"]
+    assert "meningismus(present)" in terms, ir["findings"]
+
+
+def test_decompose_tolerates_unparseable_output() -> None:
+    """A backend that emits junk yields an empty-but-valid IR (abstain, not crash)."""
+    ir = dc.decompose_text("anything", gen=lambda _p: "not json at all")
+    assert ir["findings"] == [] and ir["discard"] == []
+
+
+def test_mlx_backend_unavailable_without_config() -> None:
+    """No MYCIN_MLX_MODEL set -> the MLX backend reports unavailable (not an error)."""
+    saved = os.environ.pop("MYCIN_MLX_MODEL", None)
+    try:
+        assert dc.mlx_backend() is None
+    finally:
+        if saved is not None:
+            os.environ["MYCIN_MLX_MODEL"] = saved
+
+
+def test_select_backend_raises_when_none_available(monkeypatch=None) -> None:
+    """Selection never silently degrades to nothing - it raises with guidance."""
+    orig_mlx, orig_oll = dc.mlx_backend, dc.ollama_backend
+    dc.mlx_backend = lambda: None
+    dc.ollama_backend = lambda: None
+    try:
+        raised = False
+        try:
+            dc.select_backend()
+        except RuntimeError as e:
+            raised = True
+            assert "no local decomposer backend" in str(e)
+        assert raised, "expected RuntimeError when no backend is available"
+    finally:
+        dc.mlx_backend, dc.ollama_backend = orig_mlx, orig_oll
+
+
+def test_load_domains_shape() -> None:
+    domains = dc.load_domains()
+    assert isinstance(domains, dict) and domains, "dictionary functors -> value domains"
+    assert all(isinstance(v, list) for v in domains.values())
+
+
+def main() -> int:
+    test_decompose_text_with_injected_backend()
+    test_decompose_tolerates_unparseable_output()
+    test_mlx_backend_unavailable_without_config()
+    test_select_backend_raises_when_none_available()
+    test_load_domains_shape()
+    print("test_decomposer: PASS (backend selection + live decompose_text; no model required)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Independent PR.** The warm path's **one** model call now prefers the most on-device backend, so the patient's data never has to leave the machine (privacy / HIPAA by architecture) — demonstrated end-to-end with a real ~1 GB local model.

## What it adds

- **`warm/decomposer.py`** — backend selection in priority order:
  1. the trained **MLX specialist** (small Gemma/Qwen LoRA on Apple Silicon — `train/`),
  2. local **Ollama** on `127.0.0.1`,
  3. none → **raise** with guidance (never silently degrade).

  Every backend returns the **same IR** via the shared prompt, so the rest of the warm path is backend-agnostic and still runs at **0 answer-time model calls**. The decomposer is the layer that **absorbs small-model output variance** (tolerant-normalizes findings; drops bare-string `inference_justifications`/`discard` so `ir_to_adj`/`decide` stay strict). Config via env (`MYCIN_MLX_MODEL`/`_ADAPTER`, `MYCIN_OLLAMA_MODEL`; default `qwen2.5:1.5b` — the ~1 GB tolerant-framework floor).
- **`decompose_text(prose)`** — the live one-shot entry point (messy human input → typed IR in one call) the ER spine (C3) and a live consult use.
- **`warm/run_live.py`** — the payoff: one raw clinical string → decompose (1 on-device call) → `ir_to_adj` → `decide` → a byte-cited differential.

## Verified LIVE on-device

```
INPUT: 72M, fever, stiff neck, photophobia. CSF: neutrophil-predominant pleocytosis, low glucose, high protein.
[decompose backend: ollama:qwen2.5:1.5b]  — the ONLY model call, on-device
[1] findings: csf_glucose(low), csf_protein(high), csf_neutrophilic_pleocytosis(high), fever(present), meningismus(present)
[2] bacterial_meningitis P=0.9895  <- leading   (determinate; 0 answer-time model calls)
answer-time model calls: 0   |   data left the machine: none
```

The model's stray diagnostic aside ("consistent with bacterial meningitis") landed in `inference_justifications`, where the framework **discards** it — only typed findings reach the engine.

## Verification
- `python3 warm/test_decomposer.py` → PASS (backend selection + live `decompose_text` with an injected stub; no model required in CI).
- `python3 warm/run_live.py "<prose>"` → live local diagnosis (above).
- ruff clean. Security review: **PASSED** — the closed-dictionary + regex gate between model output and the engine is the key control (a malicious model can't inject adj-lang); MLX model/adapter from operator-set env; Ollama URL hardcoded localhost; output json-parsed never executed.

**Next:** C3 puts `mlx-whisper` voice in front of this (spoken ER input → triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)