### PR TITLE
perf(tcp-runtime): route TcpMailbox by shard instead of O(N) broadcast (multi-core 1/5)

### DIFF
--- a/code/packages/rust/stream-reactor/CHANGELOG.md
+++ b/code/packages/rust/stream-reactor/CHANGELOG.md
@@ -44,3 +44,22 @@ All notable changes to this package will be documented in this file.
   already-read byte chunk after reads are resumed.
 - Added a regression test proving deferred bytes are not lost across pause and
   resume.
+
+## [0.1.4] - 2026-06-14
+
+### Changed
+
+- **Shard-aware `ConnectionId` allocation.** Each reactor now stamps its shard
+  index into the low `shard_bits` of every `ConnectionId` it allocates
+  (`id = (sequence << shard_bits) | shard_index`), so a multi-reactor mailbox can
+  route a write to the one reactor that owns a connection with pure arithmetic and
+  no shared registry. A lone reactor uses `shard_bits == 0`, leaving ids
+  byte-identical to the previous sequence-counter scheme.
+- Replaced the `StreamReactorOptions::connection_id_seed` shared `AtomicU64` with
+  `shard_index` / `shard_bits` fields. Uniqueness across shards no longer needs a
+  cross-shard atomic on the accept hot path — the shard bits plus each reactor's
+  private sequence are unique by construction.
+
+### Added
+
+- Regression test `connection_ids_encode_the_shard_index_in_their_low_bits`.

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use transport_platform::{
@@ -74,8 +74,15 @@ impl StreamHandlerResult {
 pub struct StreamReactorOptions {
     pub listener: ListenerOptions,
     pub stream: StreamOptions,
-    /// Shared counter used by sharded reactors to allocate unique connection IDs.
-    pub connection_id_seed: Option<Arc<AtomicU64>>,
+    /// This reactor's shard index within a sharded runtime (0 for a lone reactor).
+    /// It is baked into the low bits of every [`ConnectionId`] this reactor hands
+    /// out, so a mailbox can route a write to the one reactor that owns the
+    /// connection using pure arithmetic — no shared registry.  See [`StreamReactor`].
+    pub shard_index: u64,
+    /// Number of low bits reserved for the shard index: `ceil(log2(worker_count))`.
+    /// `0` for a single reactor, which makes [`ConnectionId`]s identical to the
+    /// original unsharded scheme (a sequence counter starting at 1).
+    pub shard_bits: u32,
     pub read_buffer_size: usize,
     pub max_connections: usize,
     pub max_pending_write_bytes: usize,
@@ -87,7 +94,8 @@ impl Default for StreamReactorOptions {
         Self {
             listener: ListenerOptions::default(),
             stream: StreamOptions::default(),
-            connection_id_seed: None,
+            shard_index: 0,
+            shard_bits: 0,
             read_buffer_size: DEFAULT_READ_BUFFER_SIZE,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             max_pending_write_bytes: DEFAULT_MAX_PENDING_WRITE_BYTES,
@@ -100,7 +108,8 @@ impl PartialEq for StreamReactorOptions {
     fn eq(&self, other: &Self) -> bool {
         self.listener == other.listener
             && self.stream == other.stream
-            && self.connection_id_seed.is_some() == other.connection_id_seed.is_some()
+            && self.shard_index == other.shard_index
+            && self.shard_bits == other.shard_bits
             && self.read_buffer_size == other.read_buffer_size
             && self.max_connections == other.max_connections
             && self.max_pending_write_bytes == other.max_pending_write_bytes
@@ -221,6 +230,10 @@ pub struct StreamReactor<P, S = ()> {
     connections: BTreeMap<StreamId, ConnectionState<S>>,
     connection_index: BTreeMap<ConnectionId, StreamId>,
     next_connection_id: u64,
+    /// Low bits stamped into every `ConnectionId` to identify this reactor as the
+    /// owning shard; `shard_bits` is how many low bits are reserved for it.
+    shard_index: u64,
+    shard_bits: u32,
     stop_flag: Arc<AtomicBool>,
     mailbox: StreamMailbox,
     read_buffer_size: usize,
@@ -228,7 +241,6 @@ pub struct StreamReactor<P, S = ()> {
     max_pending_write_bytes: usize,
     poll_timeout: Duration,
     stream_options: StreamOptions,
-    connection_id_seed: Option<Arc<AtomicU64>>,
     state_init: StateInit<S>,
     handler: StatefulHandler<S>,
     on_close: CloseHandler<S>,
@@ -290,6 +302,8 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             connections: BTreeMap::new(),
             connection_index: BTreeMap::new(),
             next_connection_id: 1,
+            shard_index: options.shard_index,
+            shard_bits: options.shard_bits,
             stop_flag: Arc::new(AtomicBool::new(false)),
             mailbox: StreamMailbox::default(),
             read_buffer_size: options.read_buffer_size.max(1),
@@ -297,7 +311,6 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             max_pending_write_bytes: options.max_pending_write_bytes.max(1),
             poll_timeout: options.poll_timeout,
             stream_options: options.stream,
-            connection_id_seed: options.connection_id_seed,
             state_init: Arc::new(init),
             handler: Arc::new(handler),
             on_close: Arc::new(on_close),
@@ -385,13 +398,22 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                     self.platform
                         .set_stream_interest(accepted.stream, StreamInterest::readable())?;
 
-                    let connection_id = if let Some(seed) = &self.connection_id_seed {
-                        ConnectionId(seed.fetch_add(1, Ordering::SeqCst))
-                    } else {
-                        let id = ConnectionId(self.next_connection_id);
-                        self.next_connection_id += 1;
-                        id
-                    };
+                    // Every ConnectionId encodes its owning shard in the low bits:
+                    //
+                    //     id = (sequence << shard_bits) | shard_index
+                    //
+                    // so a `TcpMailbox` can route a write to the one reactor that
+                    // owns the connection with pure arithmetic — no shared registry
+                    // and no cross-shard atomic on the accept hot path.  Uniqueness
+                    // holds because the low `shard_bits` distinguish the shard and
+                    // the high bits carry this reactor's own monotonic sequence.
+                    // For a lone reactor (`shard_bits == 0`, `shard_index == 0`)
+                    // the id is just `sequence`, byte-identical to the original
+                    // unsharded scheme.
+                    let sequence = self.next_connection_id;
+                    self.next_connection_id += 1;
+                    let connection_id =
+                        ConnectionId((sequence << self.shard_bits) | self.shard_index);
                     self.connection_index.insert(connection_id, accepted.stream);
                     self.connections.insert(
                         accepted.stream,
@@ -863,6 +885,57 @@ mod tests {
         stop.stop();
         let result = server.join().expect("server thread");
         assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn connection_ids_encode_the_shard_index_in_their_low_bits() {
+        // Stand a lone reactor up as if it were shard 1 of a 4-shard runtime
+        // (shard_bits = 2).  Every ConnectionId it allocates must carry `1` in its
+        // low two bits and a non-zero sequence in the high bits, so a routed
+        // mailbox can send a write back to exactly this reactor.
+        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let options = StreamReactorOptions {
+            shard_index: 1,
+            shard_bits: 2,
+            ..StreamReactorOptions::default()
+        };
+        let mut reactor = StreamReactor::bind_kqueue_with_state(
+            ("127.0.0.1", 0),
+            options,
+            |_| (),
+            move |info, _, bytes| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.id.0);
+                StreamHandlerResult::write(bytes.to_vec())
+            },
+            |_, _| {},
+        )
+        .expect("bind");
+        let addr = reactor.local_addr();
+        let stop = reactor.stop_handle();
+        let server = thread::spawn(move || reactor.serve());
+
+        for _ in 0..3 {
+            let mut stream = TcpStream::connect(addr).expect("connect");
+            stream.write_all(b"x").expect("write");
+            stream.shutdown(Shutdown::Write).expect("shutdown");
+            let mut echoed = Vec::new();
+            stream.read_to_end(&mut echoed).expect("read echo");
+            assert_eq!(echoed, b"x");
+        }
+
+        stop.stop();
+        server.join().expect("server thread").expect("serve");
+
+        let ids = seen.lock().expect("seen mutex poisoned").clone();
+        assert_eq!(ids.len(), 3, "every connection should be observed");
+        for id in ids {
+            assert_eq!(id & 0b11, 1, "shard index must occupy the low 2 bits: {id}");
+            assert!(id >> 2 >= 1, "the sequence (high bits) must start at 1: {id}");
+        }
     }
 
     #[test]

--- a/code/packages/rust/tcp-runtime/CHANGELOG.md
+++ b/code/packages/rust/tcp-runtime/CHANGELOG.md
@@ -42,3 +42,26 @@ All notable changes to this package will be documented in this file.
 - Added `TcpHandlerResult::defer_read()` so adapters can pause a connection
   and replay the already-read bytes later instead of dropping data or closing
   on backpressure.
+
+## [0.1.4] - 2026-06-14
+
+### Changed
+
+- **`TcpMailbox` now routes instead of broadcasting.** `send` / `send_and_close` /
+  `close` / `pause_reads` / `resume_reads` decode the owning shard from the
+  `ConnectionId` (low `shard_bits`) and enqueue into that one reactor's mailbox,
+  instead of cloning the bytes into every reactor's queue and having non-owners
+  drop them. `resume_all_reads` (which carries no id) still fans out to all
+  reactors. Single-reactor runtimes have `shard_bits == 0`, so routing is a no-op
+  index of `0`.
+- Sharded builders assign each worker a `shard_index` and a shared
+  `shard_bits = ceil(log2(worker_count))`, and no longer create the shared
+  `AtomicU64` connection-id seed (uniqueness now comes from the `ConnectionId`
+  shard encoding).
+
+### Added
+
+- `shard_bits_for(worker_count)` helper and unit test `shard_bits_for_is_ceil_log2`.
+- End-to-end test `sharded_mailbox_routes_replies_through_the_owning_shard`:
+  replies routed only through the mailbox reach the correct connection across a
+  4-shard runtime (a wrong shard mask would hang the client read).

--- a/code/packages/rust/tcp-runtime/src/lib.rs
+++ b/code/packages/rust/tcp-runtime/src/lib.rs
@@ -8,7 +8,6 @@
 //! convenience constructors.
 
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -80,8 +79,12 @@ impl TcpHandlerResult {
 pub struct TcpRuntimeOptions {
     pub listener: ListenerOptions,
     pub stream: StreamOptions,
-    /// Optional shared seed used by sharded runtimes for unique connection IDs.
-    pub connection_id_seed: Option<Arc<AtomicU64>>,
+    /// Shard index / shard-bit width baked into each `ConnectionId` so a
+    /// `TcpMailbox` can route a write to the owning reactor.  Set automatically per
+    /// worker by the sharded builders; both default to `0` for a single runtime
+    /// (which leaves `ConnectionId`s identical to the unsharded scheme).
+    pub shard_index: u64,
+    pub shard_bits: u32,
     pub read_buffer_size: usize,
     pub max_connections: usize,
     pub max_pending_write_bytes: usize,
@@ -94,7 +97,8 @@ impl Default for TcpRuntimeOptions {
         Self {
             listener: defaults.listener,
             stream: defaults.stream,
-            connection_id_seed: None,
+            shard_index: 0,
+            shard_bits: 0,
             read_buffer_size: defaults.read_buffer_size,
             max_connections: defaults.max_connections,
             max_pending_write_bytes: defaults.max_pending_write_bytes,
@@ -107,7 +111,8 @@ impl PartialEq for TcpRuntimeOptions {
     fn eq(&self, other: &Self) -> bool {
         self.listener == other.listener
             && self.stream == other.stream
-            && self.connection_id_seed.is_some() == other.connection_id_seed.is_some()
+            && self.shard_index == other.shard_index
+            && self.shard_bits == other.shard_bits
             && self.read_buffer_size == other.read_buffer_size
             && self.max_connections == other.max_connections
             && self.max_pending_write_bytes == other.max_pending_write_bytes
@@ -122,7 +127,8 @@ impl From<TcpRuntimeOptions> for StreamReactorOptions {
         Self {
             listener: value.listener,
             stream: value.stream,
-            connection_id_seed: value.connection_id_seed,
+            shard_index: value.shard_index,
+            shard_bits: value.shard_bits,
             read_buffer_size: value.read_buffer_size,
             max_connections: value.max_connections,
             max_pending_write_bytes: value.max_pending_write_bytes,
@@ -225,41 +231,58 @@ impl<P, S> Drop for ShardedTcpRuntime<P, S> {
 #[derive(Clone)]
 pub struct TcpMailbox {
     inners: Arc<[StreamMailbox]>,
+    /// Number of low `ConnectionId` bits that name the owning shard — exactly the
+    /// `shard_bits` the reactors were built with (`ceil(log2(worker_count))`).
+    shard_bits: u32,
 }
 
 impl TcpMailbox {
+    /// Map a `ConnectionId` to the index of the reactor that owns it.
+    ///
+    /// The shard index lives in the low `shard_bits` of the id (stamped there at
+    /// accept time), so this is a single mask — no shared lookup table.  A single
+    /// reactor has `shard_bits == 0`, so the mask is `0` and every id routes to
+    /// `inners[0]`.  An out-of-range index (only possible from a stale/foreign id
+    /// that never belonged to this runtime) yields `None` and the command is
+    /// dropped, which is the same safe outcome as routing it to a reactor that
+    /// doesn't know the connection.
+    fn owner_of(&self, connection_id: ConnectionId) -> Option<&StreamMailbox> {
+        let index = (connection_id.0 & ((1u64 << self.shard_bits) - 1)) as usize;
+        self.inners.get(index)
+    }
+
     pub fn send(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
-        let bytes = bytes.into();
-        for inner in self.inners.iter() {
-            inner.send(connection_id, bytes.clone());
+        if let Some(inner) = self.owner_of(connection_id) {
+            inner.send(connection_id, bytes);
         }
     }
 
     pub fn send_and_close(&self, connection_id: ConnectionId, bytes: impl Into<Vec<u8>>) {
-        let bytes = bytes.into();
-        for inner in self.inners.iter() {
-            inner.send_and_close(connection_id, bytes.clone());
+        if let Some(inner) = self.owner_of(connection_id) {
+            inner.send_and_close(connection_id, bytes);
         }
     }
 
     pub fn close(&self, connection_id: ConnectionId) {
-        for inner in self.inners.iter() {
+        if let Some(inner) = self.owner_of(connection_id) {
             inner.close(connection_id);
         }
     }
 
     pub fn pause_reads(&self, connection_id: ConnectionId) {
-        for inner in self.inners.iter() {
+        if let Some(inner) = self.owner_of(connection_id) {
             inner.pause_reads(connection_id);
         }
     }
 
     pub fn resume_reads(&self, connection_id: ConnectionId) {
-        for inner in self.inners.iter() {
+        if let Some(inner) = self.owner_of(connection_id) {
             inner.resume_reads(connection_id);
         }
     }
 
+    /// `resume_all_reads` carries no `ConnectionId`, so it genuinely fans out to
+    /// every reactor — each resumes the connections it owns.
     pub fn resume_all_reads(&self) {
         for inner in self.inners.iter() {
             inner.resume_all_reads();
@@ -267,9 +290,25 @@ impl TcpMailbox {
     }
 
     fn from_mailboxes(mailboxes: Vec<StreamMailbox>) -> Self {
+        let shard_bits = shard_bits_for(mailboxes.len());
         Self {
             inners: Arc::from(mailboxes.into_boxed_slice()),
+            shard_bits,
         }
+    }
+}
+
+/// Low bits needed to name `worker_count` shards: `ceil(log2(worker_count))`.
+///
+/// `worker_count <= 1` → `0` (no bits — the single reactor owns everything and
+/// `ConnectionId`s stay identical to the unsharded scheme).  `2 → 1`, `3 → 2`,
+/// `4 → 2`, `5 → 3`, … (next-power-of-two rounding, so up to `2^bits` shards fit).
+fn shard_bits_for(worker_count: usize) -> u32 {
+    if worker_count <= 1 {
+        0
+    } else {
+        // Bits required to represent the largest shard index, `worker_count - 1`.
+        u64::BITS - (worker_count as u64 - 1).leading_zeros()
     }
 }
 
@@ -427,11 +466,11 @@ where
         options.listener.reuse_port = true;
     }
 
-    let shared_connection_id = if worker_count > 1 {
-        Some(Arc::new(AtomicU64::new(1)))
-    } else {
-        None
-    };
+    // Each reactor stamps its own shard index into the low `shard_bits` of every
+    // ConnectionId it allocates, so the shared mailbox routes a write straight to
+    // the owning reactor.  No cross-shard atomic seed is needed for uniqueness any
+    // more — the shard bits plus each reactor's private sequence are unique.
+    let shard_bits = shard_bits_for(worker_count);
 
     let init: Arc<dyn Fn(TcpConnectionInfo) -> S + Send + Sync> = Arc::new(init);
     let handler: Arc<dyn Fn(TcpConnectionInfo, &mut S, &[u8]) -> TcpHandlerResult + Send + Sync> =
@@ -440,11 +479,10 @@ where
 
     let mut bind_address = address;
     let mut runtimes = Vec::with_capacity(worker_count);
-    for _ in 0..worker_count {
+    for shard_index in 0..worker_count {
         let mut worker_options = options.clone();
-        if let Some(seed) = &shared_connection_id {
-            worker_options.connection_id_seed = Some(Arc::clone(seed));
-        }
+        worker_options.shard_index = shard_index as u64;
+        worker_options.shard_bits = shard_bits;
 
         let init = Arc::clone(&init);
         let handler = Arc::clone(&handler);
@@ -969,7 +1007,7 @@ mod tests {
     use super::*;
     use std::io::{self, Read, Write};
     use std::net::{Shutdown, TcpStream};
-    use std::sync::{Arc, Barrier, Mutex};
+    use std::sync::{Arc, Barrier, Mutex, OnceLock};
     use std::thread;
 
     #[test]
@@ -1211,6 +1249,84 @@ mod tests {
             .read_exact(&mut response)
             .expect("read delayed response");
         assert_eq!(&response, b"delayed");
+
+        stop.stop();
+        let result = server.join().expect("server thread");
+        assert!(result.is_ok(), "server should exit cleanly: {result:?}");
+    }
+
+    #[test]
+    fn shard_bits_for_is_ceil_log2() {
+        // 1 reactor needs no shard bits; otherwise we need enough bits to hold the
+        // largest shard index (worker_count - 1), rounding up to a power of two.
+        assert_eq!(shard_bits_for(0), 0);
+        assert_eq!(shard_bits_for(1), 0);
+        assert_eq!(shard_bits_for(2), 1);
+        assert_eq!(shard_bits_for(3), 2);
+        assert_eq!(shard_bits_for(4), 2);
+        assert_eq!(shard_bits_for(5), 3);
+        assert_eq!(shard_bits_for(8), 3);
+        assert_eq!(shard_bits_for(9), 4);
+        // Every shard index in `0..worker_count` must fit in `shard_bits` bits, so
+        // the low-bit encoding never collides two distinct shards.
+        for worker_count in 1..=64usize {
+            let bits = shard_bits_for(worker_count);
+            assert!((worker_count as u64 - 1) < (1u64 << bits.max(1)) || worker_count == 1);
+            assert!((worker_count as u64) <= (1u64 << bits) || bits == 0);
+        }
+    }
+
+    #[test]
+    fn sharded_mailbox_routes_replies_through_the_owning_shard() {
+        // Replies are sent back ONLY through the routed `TcpMailbox` (not through
+        // `TcpHandlerResult`), so every reply must be routed to the shard that
+        // accepted the connection.  A wrong shard mask would enqueue the reply on a
+        // reactor that never saw the connection — its owner would never write it
+        // and the client read would time out.  So a green run is end-to-end proof
+        // that `ConnectionId` shard-encoding + `TcpMailbox` routing agree.
+        let mailbox_slot: Arc<OnceLock<TcpMailbox>> = Arc::new(OnceLock::new());
+        let mailbox_for_handler = Arc::clone(&mailbox_slot);
+        let mut runtime = TcpRuntime::bind_kqueue_sharded(
+            ("127.0.0.1", 0),
+            TcpRuntimeOptions::default(),
+            4,
+            move |info, bytes| {
+                if let Some(mailbox) = mailbox_for_handler.get() {
+                    mailbox.send(info.id, bytes.to_vec());
+                }
+                TcpHandlerResult::default()
+            },
+        )
+        .expect("bind sharded runtime");
+        let addr = runtime.local_addr();
+        // Publish the mailbox the handlers route through (set before serve starts).
+        mailbox_slot.set(runtime.mailbox()).ok();
+        let stop = runtime.stop_handle();
+        let server = thread::spawn(move || runtime.serve());
+
+        let client_count = 24usize;
+        let barrier = Arc::new(Barrier::new(client_count));
+        let mut clients = Vec::new();
+        for i in 0..client_count {
+            let barrier = Arc::clone(&barrier);
+            clients.push(thread::spawn(move || -> Result<Vec<u8>, String> {
+                barrier.wait();
+                let mut stream = TcpStream::connect(addr).map_err(|e| e.to_string())?;
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .map_err(|e| e.to_string())?;
+                let payload = format!("shard-reply-{i}").into_bytes();
+                stream.write_all(&payload).map_err(|e| e.to_string())?;
+                let mut echoed = vec![0u8; payload.len()];
+                stream.read_exact(&mut echoed).map_err(|e| e.to_string())?;
+                Ok(echoed)
+            }));
+        }
+
+        for (i, client) in clients.into_iter().enumerate() {
+            let echoed = client.join().expect("client thread").expect("client io");
+            assert_eq!(echoed, format!("shard-reply-{i}").into_bytes());
+        }
 
         stop.stop();
         let result = server.join().expect("server thread");

--- a/code/specs/tcp-runtime-roadmap.md
+++ b/code/specs/tcp-runtime-roadmap.md
@@ -311,19 +311,32 @@ well-controlled transport engine.
 The current `tcp-reactor` proves correctness and architecture, but a serious
 runtime needs a scaling story.
 
-Missing pieces:
-
-- one-reactor-per-core or one-reactor-per-shard architecture
-- listener sharding policy
-- connection affinity policy
-- cross-thread wakeups
-- lock-minimal metrics and connection handoff paths
-
-The key decision:
+The key decision (held to):
 
 - keep each connection owned by exactly one reactor thread
 - communicate across reactors with explicit wakeups and queues, not shared
   mutable connection state
+
+Status:
+
+- **Done** — one-reactor-per-shard architecture (`ShardedTcpRuntime`: N reactors
+  on N threads, each with its own kqueue/epoll/IOCP instance).
+- **Done** — listener sharding policy (`SO_REUSEPORT` auto-enabled when
+  `worker_count > 1`; the kernel load-balances accepts across the per-shard
+  listeners).
+- **Done** — connection affinity / routing. Each reactor stamps its shard index
+  into the low `shard_bits` of every `ConnectionId`
+  (`id = (sequence << shard_bits) | shard_index`), so `TcpMailbox` routes an
+  off-reactor write to the one owning reactor with a single mask — no shared
+  registry and no O(N) broadcast. This replaced the earlier shared-`AtomicU64`
+  connection-id seed.
+
+Missing pieces:
+
+- cross-thread wakeups (the wakeup primitive exists in `transport-platform`, but
+  the mailbox does not yet trigger it, so an off-reactor write waits up to the
+  poll timeout before flushing)
+- lock-minimal metrics and connection handoff paths
 
 ### 5. Hardening, observability, and benchmarking
 


### PR DESCRIPTION
## Summary

**PR 1 of 5** toward a true multi-core runtime. The sharded reactor already exists (`ShardedTcpRuntime`: N reactors on N threads, `SO_REUSEPORT`), but `TcpMailbox.send` **broadcast** every off-reactor write into *all* N reactor queues — cloning the bytes N times — and the N−1 non-owners looked the id up, missed, and dropped it. Wasteful for cross-connection fan-out (the IRC broadcast case), and it gets worse the more cores you add.

This routes each write to the **one owning reactor** with pure arithmetic and no shared state.

## How

Encode the owning shard into the `ConnectionId` at allocation time:

```
id = (sequence << shard_bits) | shard_index      // shard_bits = ceil(log2(worker_count))
shard_of(id) = id & ((1 << shard_bits) - 1)
```

- **stream-reactor**: each reactor stamps its `shard_index` into the low bits of every id it hands out; uniqueness holds because the low bits name the shard and the high bits carry that reactor's private monotonic sequence. Replaced `StreamReactorOptions::connection_id_seed` (a shared `AtomicU64` contended on *every accept*) with `shard_index` / `shard_bits`. A lone reactor uses `shard_bits == 0`, so ids stay **byte-identical** to the old scheme — zero overhead, zero behavior change on the single-reactor path.
- **tcp-runtime**: `TcpMailbox` `send`/`send_and_close`/`close`/`pause_reads`/`resume_reads` decode the shard (a single mask) and enqueue into that reactor only — no byte cloning, no broadcast. `resume_all_reads` (no id) still fans out. Sharded builders assign each worker `shard_index` + `shard_bits` and drop the seed.

## Tests

- `connection_ids_encode_the_shard_index_in_their_low_bits` (stream-reactor)
- `shard_bits_for_is_ceil_log2` (tcp-runtime unit)
- `sharded_mailbox_routes_replies_through_the_owning_shard` (tcp-runtime): a 4-shard runtime where replies go back **only** through the routed mailbox — a wrong shard mask would enqueue on a reactor that never saw the connection and hang the client read, so green is end-to-end proof routing + encoding agree.

All existing reactor / sharded / mailbox / IRC / embeddable tests stay green (`cargo test -p stream-reactor -p tcp-runtime -p irc-net-reactor -p embeddable-tcp-server`). Clippy clean. **No new `unsafe`.**

## Security

Reviewed (passed): no integer-shift/overflow reachable from network input (`shard_bits` is build-time-fixed by thread count), `owner_of` is bounds-checked (`inners.get`) so a stale/foreign id is safely dropped — never delivered to a different live connection, and ids remain unique after removing the seed.

Spec `tcp-runtime-roadmap.md` "Multi-core scaling" updated: shard architecture + `SO_REUSEPORT` + connection affinity/routing now **Done**; cross-thread wakeups (PR2) remain the open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)