### PR TITLE
[codex] Add Hue package release coordination summary

### DIFF
--- a/code/packages/rust/hue-core/CHANGELOG.md
+++ b/code/packages/rust/hue-core/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this package will be documented in this file.
   final release/manual-review handoff checks.
 - Hue package release queue summaries that turn release handoff readiness into
   final queue entry checks for publish/release coordination.
+- Hue package release coordination summaries that combine release queue,
+  handoff, acceptance, review, and publish gates for final coordination checks.
 - Hue discovery worker-run projection from generic `MdnsScanResult` envelopes,
   preserving scan parse failures as per-source D23 worker failures.
 - Hue discovery worker-run projection from aggregate `MdnsWorkerScanReport`

--- a/code/packages/rust/hue-core/README.md
+++ b/code/packages/rust/hue-core/README.md
@@ -79,6 +79,8 @@ packages a typed surface for:
   final release/manual-review handoff checks
 - Hue package release queue summaries that turn release handoff readiness into
   final queue entry checks for publish/release coordination
+- Hue package release coordination summaries that combine release queue,
+  handoff, acceptance, review, and publish gates for final coordination checks
 
 ## Dependencies
 

--- a/code/packages/rust/hue-core/src/lib.rs
+++ b/code/packages/rust/hue-core/src/lib.rs
@@ -2438,6 +2438,97 @@ pub fn hue_package_release_queue_summary(
     HuePackageReleaseQueueSummary::from_pairing_plan(plan)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HuePackageReleaseCoordinationSummary {
+    pub release_queue_summary: HuePackageReleaseQueueSummary,
+    pub required_coordination_check_count: usize,
+    pub passed_coordination_check_count: usize,
+    pub blocked_coordination_check_count: usize,
+    pub release_queue_ready: bool,
+    pub release_handoff_ready: bool,
+    pub package_accepted: bool,
+    pub review_queues_clear: bool,
+    pub publish_gate_ready: bool,
+    pub release_coordination_ready: bool,
+}
+
+impl HuePackageReleaseCoordinationSummary {
+    pub fn from_pairing_plan(plan: &HueBridgePairingPlan) -> Self {
+        Self::from_release_queue_summary(hue_package_release_queue_summary(plan))
+    }
+
+    pub fn from_release_queue_summary(
+        release_queue_summary: HuePackageReleaseQueueSummary,
+    ) -> Self {
+        let release_queue_ready = release_queue_summary.is_release_queue_ready();
+        let release_handoff_ready = !release_queue_summary.needs_release_handoff();
+        let package_accepted = !release_queue_summary.needs_package_acceptance();
+        let review_queues_clear = !release_queue_summary
+            .handoff_summary
+            .needs_review_queue_clearance();
+        let publish_gate_ready = !release_queue_summary.needs_publish_gate();
+        let checks = [
+            release_queue_ready,
+            release_handoff_ready,
+            package_accepted,
+            review_queues_clear,
+            publish_gate_ready,
+        ];
+        let passed_coordination_check_count = checks.iter().filter(|ready| **ready).count();
+        let required_coordination_check_count = checks.len();
+        let blocked_coordination_check_count =
+            required_coordination_check_count - passed_coordination_check_count;
+        let release_coordination_ready = blocked_coordination_check_count == 0;
+
+        Self {
+            release_queue_summary,
+            required_coordination_check_count,
+            passed_coordination_check_count,
+            blocked_coordination_check_count,
+            release_queue_ready,
+            release_handoff_ready,
+            package_accepted,
+            review_queues_clear,
+            publish_gate_ready,
+            release_coordination_ready,
+        }
+    }
+
+    pub fn is_release_coordination_ready(self) -> bool {
+        self.release_coordination_ready
+    }
+
+    pub fn has_blocked_coordination_checks(self) -> bool {
+        self.blocked_coordination_check_count > 0
+    }
+
+    pub fn needs_release_queue(self) -> bool {
+        !self.release_queue_ready
+    }
+
+    pub fn needs_release_handoff(self) -> bool {
+        !self.release_handoff_ready
+    }
+
+    pub fn needs_package_acceptance(self) -> bool {
+        !self.package_accepted
+    }
+
+    pub fn needs_review_queue_clearance(self) -> bool {
+        !self.review_queues_clear
+    }
+
+    pub fn needs_publish_gate(self) -> bool {
+        !self.publish_gate_ready
+    }
+}
+
+pub fn hue_package_release_coordination_summary(
+    plan: &HueBridgePairingPlan,
+) -> HuePackageReleaseCoordinationSummary {
+    HuePackageReleaseCoordinationSummary::from_pairing_plan(plan)
+}
+
 fn descriptor_declares_capability(descriptor: &IntegrationDescriptor, capability_id: &str) -> bool {
     descriptor
         .capabilities
@@ -6351,6 +6442,81 @@ mod tests {
         assert!(summary.needs_release_handoff());
         assert!(summary.needs_package_acceptance());
         assert!(summary.needs_lifecycle_completion());
+        assert!(summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_coordination_summary_reports_ready_coordination() {
+        let plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+
+        let summary = hue_package_release_coordination_summary(&plan);
+
+        assert_eq!(
+            summary.release_queue_summary,
+            hue_package_release_queue_summary(&plan)
+        );
+        assert_eq!(summary.required_coordination_check_count, 5);
+        assert_eq!(summary.passed_coordination_check_count, 5);
+        assert_eq!(summary.blocked_coordination_check_count, 0);
+        assert!(summary.release_queue_ready);
+        assert!(summary.release_handoff_ready);
+        assert!(summary.package_accepted);
+        assert!(summary.review_queues_clear);
+        assert!(summary.publish_gate_ready);
+        assert!(summary.release_coordination_ready);
+        assert!(summary.is_release_coordination_ready());
+        assert!(!summary.has_blocked_coordination_checks());
+        assert!(!summary.needs_release_queue());
+        assert!(!summary.needs_release_handoff());
+        assert!(!summary.needs_package_acceptance());
+        assert!(!summary.needs_review_queue_clearance());
+        assert!(!summary.needs_publish_gate());
+    }
+
+    #[test]
+    fn hue_package_release_coordination_summary_routes_blocked_coordination() {
+        let mut plan = hue_pairing_plan_for_discovered_bridge(
+            DiscoveredHueBridge {
+                bridge_id: "001788fffeabcdef".to_string(),
+                address: "https://192.0.2.10".to_string(),
+                hardware_model: Some("BSB002".to_string()),
+                firmware_version: Some("1.60".to_string()),
+            },
+            "chief-of-staff",
+            "desk",
+        );
+        plan.bridge.address = None;
+        plan.registration_request.path = "/wrong/api".to_string();
+        plan.application_key_header = "x-application-key".to_string();
+        plan.event_stream_path = "/wrong/eventstream".to_string();
+        plan.requires_user_presence = false;
+
+        let summary = HuePackageReleaseCoordinationSummary::from_pairing_plan(&plan);
+
+        assert_eq!(summary.required_coordination_check_count, 5);
+        assert_eq!(summary.passed_coordination_check_count, 0);
+        assert_eq!(summary.blocked_coordination_check_count, 5);
+        assert!(!summary.release_queue_ready);
+        assert!(!summary.release_handoff_ready);
+        assert!(!summary.package_accepted);
+        assert!(!summary.review_queues_clear);
+        assert!(!summary.publish_gate_ready);
+        assert!(!summary.release_coordination_ready);
+        assert!(!summary.is_release_coordination_ready());
+        assert!(summary.has_blocked_coordination_checks());
+        assert!(summary.needs_release_queue());
+        assert!(summary.needs_release_handoff());
+        assert!(summary.needs_package_acceptance());
+        assert!(summary.needs_review_queue_clearance());
         assert!(summary.needs_publish_gate());
     }
 }


### PR DESCRIPTION
## Summary
- add Hue package release coordination summaries on top of release queue readiness
- expose helpers for blocked release queue, handoff, acceptance, review, and publish gates
- document the new coordination summary in hue-core README and changelog

## Tests
- cargo fmt --manifest-path code/packages/rust/hue-core/Cargo.toml
- cargo test --manifest-path code/packages/rust/hue-core/Cargo.toml
- git diff --check