### PR TITLE
feat(adj-constraint-solver): B2a — general boolean-clause recognizer; n-ary combinations scale (0.10.0)

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.10.0] - 2026-06-14 — general boolean-clause recognizer (n-ary combinations scale)
+
+### Added / Changed
+
+- **The SAT set-cover path now accepts ANY single-clause boolean constraint**, not
+  just at-least-one covering (`Σ xᵢ ≥ 1`). A new `classify_clause` recognizes a
+  `{−1,+1}`-coefficient constraint as a clause iff, after normalizing to `≥`, the
+  bound equals `1 − |negatives|` (it excludes exactly one assignment). This covers:
+  at-least-one covering, **the two implications of an AND-linearization**
+  (`¬y ∨ dᵢ` and `y ∨ ¬d₁ … ∨ ¬dₖ`), and `{0,1}` bounds; a true cardinality
+  constraint (`≥ 2 of …`) is still deferred to LIA.
+- **Why it matters:** an **n-ary combination** (a requirement covered only by a
+  *subset* of selected elements — e.g. vancomycin + ceftriaxone covering resistant
+  pneumococcus, which neither covers alone) is modeled by an aux boolean `y = AND(…)`,
+  whose two defining constraints are exactly those implication clauses. Before, a
+  combination-laden cover hit one of those constraints, failed the narrow `Σx ≥ 1`
+  match, and fell back to the LIA enumeration (the ~24-selector ceiling). Now the
+  whole combination cover stays on the **scalable SAT path**, so combinations scale
+  to a full formulary — and each k-element combination is just k+1 clauses, linear
+  in k. Defeasance (a covering edge voided by an observed fact) is an emit-time
+  concern (the defeated element is dropped from the clause) and needs no engine change.
+- +2 tests: a 3-element combination cover (all three selected) routes through SAT;
+  a combination is **not** paid for when a single agent already covers the
+  requirement.
+
+### Unchanged
+
+- Behavior-preserving for every prior case (all 54 earlier tests pass; the existing
+  covering, fractional-relaxation, scale, uncoverable, and scalar tests are
+  unchanged). `b = rk − lk` now uses `checked_sub` (defers to LIA on overflow rather
+  than wrapping). General-integer / `maximize` / `: scalar` paths untouched.
+
 ## [0.9.0] - 2026-06-14 — SAT-scaled set-cover (a full-formulary feasibility oracle)
 
 ### Added

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/README.md
+++ b/code/packages/rust/adj-constraint-solver/README.md
@@ -129,17 +129,25 @@ N ≲ 21). The integer path is **opt-in via the declared sort** — `: scalar` /
 
 ### Scaling set-cover — the SAT oracle
 
-For a **pure-boolean** minimum-cost set-cover (every constraint an at-least-one
-covering clause `Σ xᵢ ≥ 1`, all selectors `: bool`), `optimize` routes the
-binary-search feasibility probes to the DPLL `SatTactic` instead of LIA's bounded
-enumeration. The cost bound `Σ wᵢ·xᵢ ≤ K` at each probe is a **Sinz sequential
-at-most-k** encoding (verified exact vs brute force). Same optimum as the LIA
-path; the difference is reach: LIA tops out around **24 selectors**, the SAT
-oracle handles a **full hospital formulary (100+ candidate drugs)** — 123 drugs
-in ~15 s, where LIA could not run at all. (Plain DPLL, so an adversarial cycle
-cover still slows past ~30–50; a real per-patient candidate set of ~10–30 drugs is
-sub-second. A CDCL/PB-native solver would lift the worst case — the oracle
-interface is already in place for that swap.)
+For a **pure-boolean** minimum-cost set-cover (all selectors `: bool`, every
+constraint reducible to a single CNF clause), `optimize` routes the binary-search
+feasibility probes to the DPLL `SatTactic` instead of LIA's bounded enumeration.
+The cost bound `Σ wᵢ·xᵢ ≤ K` at each probe is a **Sinz sequential at-most-k**
+encoding (verified exact vs brute force). Same optimum as the LIA path; the
+difference is reach: LIA tops out around **24 selectors**, the SAT oracle handles
+a **full hospital formulary (100+ candidate drugs)** — 123 drugs in ~15 s, where
+LIA could not run at all. (Plain DPLL, so an adversarial cycle cover still slows
+past ~30–50; a real per-patient candidate set of ~10–30 drugs is sub-second. A
+CDCL/PB-native solver would lift the worst case — the oracle interface is already
+in place for that swap.)
+
+The clause recognizer (`classify_clause`) accepts **any** `{−1,+1}`-coefficient
+constraint that is a single clause — at-least-one covering (`Σ xᵢ ≥ 1`), `{0,1}`
+bounds, and the two implications of an **AND-linearization** (`¬y ∨ dᵢ`,
+`y ∨ ¬d₁ … ∨ ¬dₖ`). That last one is what makes an **n-ary combination** — a
+requirement satisfied only by a *subset* of selected elements (`y = AND(d₁…dₖ)`) —
+stay on the scalable SAT path; each k-element combination is just k+1 clauses,
+linear in k. A genuine cardinality constraint (`≥ 2 of …`) is still deferred to LIA.
 
 ## Where it fits
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -1476,10 +1476,94 @@ fn sinz_at_most(literals: &[String], k: i128) -> (Vec<Predicate>, Vec<String>) {
     (cl, aux)
 }
 
-/// View the (substituted) constraints as a pure-boolean SET-COVER: each must be an
-/// at-least-one covering clause (`Σ cᵢxᵢ ≥ 1`, all `cᵢ ≥ 1`) or a trivially-true
-/// boolean bound (`x ≥ 0`, `x ≤ 1`). Returns the covering clauses, or `None` if any
-/// constraint isn't of that shape (so the caller falls back to the LIA path).
+/// How a boolean linear constraint relates to a single CNF clause.
+enum ClauseKind {
+    /// Equivalent to this disjunction of literals.
+    Clause(Predicate),
+    /// Trivially satisfied (e.g. a `{0,1}` bound) — contributes nothing.
+    AlwaysTrue,
+    /// Unsatisfiable on its own (e.g. `0 ≥ 1`, an uncoverable requirement).
+    AlwaysFalse,
+    /// A genuine cardinality/general constraint — not a single clause.
+    NotAClause,
+}
+
+/// Negate every coefficient of a linear form.
+fn negate_map(
+    c: &std::collections::BTreeMap<String, i128>,
+) -> Option<std::collections::BTreeMap<String, i128>> {
+    // checked: an i128::MIN coefficient declines (→ NotAClause) rather than panic/wrap.
+    c.iter()
+        .map(|(k, v)| v.checked_neg().map(|n| (k.clone(), n)))
+        .collect()
+}
+
+/// Recognize `Σ cᵢxᵢ (op) b` over booleans as a single clause. After normalizing to
+/// `Σ aᵢxᵢ ≥ B`, a `{−1,+1}`-coefficient constraint is a clause **iff** its threshold
+/// excludes exactly one assignment — `B == 1 − |negatives|` (the clause is false only
+/// when every positive literal is 0 and every negative literal is 1). This recognizes:
+/// at-least-one covering (`Σx ≥ 1`), the two implications of an AND-linearization used
+/// for n-ary combinations (`¬y ∨ dᵢ` and `y ∨ ¬d₁ … ∨ ¬dₖ`), and `{0,1}` bounds. A
+/// true cardinality constraint (`≥ 2 of …`) is `NotAClause`, so the caller defers to LIA.
+fn classify_clause(c: &std::collections::BTreeMap<String, i128>, op: RelOp, b: i128) -> ClauseKind {
+    // Normalize to `Σ aᵢxᵢ ≥ bound`.
+    let (coeffs, bound) = match op {
+        RelOp::Ge => (c.clone(), b),
+        RelOp::Gt => match b.checked_add(1) {
+            Some(x) => (c.clone(), x),
+            None => return ClauseKind::NotAClause,
+        },
+        RelOp::Le => match (negate_map(c), b.checked_neg()) {
+            (Some(m), Some(x)) => (m, x),
+            _ => return ClauseKind::NotAClause,
+        },
+        RelOp::Lt => match (
+            negate_map(c),
+            b.checked_sub(1).and_then(|x| x.checked_neg()),
+        ) {
+            (Some(m), Some(x)) => (m, x),
+            _ => return ClauseKind::NotAClause,
+        },
+        RelOp::Eq | RelOp::Ne => return ClauseKind::NotAClause,
+    };
+    if coeffs.is_empty() {
+        return if bound <= 0 {
+            ClauseKind::AlwaysTrue
+        } else {
+            ClauseKind::AlwaysFalse
+        };
+    }
+    if !coeffs.values().all(|v| matches!(v, 1 | -1)) {
+        return ClauseKind::NotAClause; // not a ±1 clause (total over i128; no abs() panic)
+    }
+    let n_neg = coeffs.values().filter(|v| **v < 0).count() as i128;
+    let p_pos = coeffs.values().filter(|v| **v > 0).count() as i128;
+    if bound <= -n_neg {
+        return ClauseKind::AlwaysTrue; // min possible LHS already meets it
+    }
+    if bound > p_pos {
+        return ClauseKind::AlwaysFalse; // max possible LHS can't meet it
+    }
+    if bound == 1 - n_neg {
+        let lits = coeffs
+            .iter()
+            .map(|(v, co)| {
+                if *co > 0 {
+                    Predicate::Var(v.clone())
+                } else {
+                    Predicate::Not(Box::new(Predicate::Var(v.clone())))
+                }
+            })
+            .collect();
+        return ClauseKind::Clause(Predicate::Or(lits));
+    }
+    ClauseKind::NotAClause // a true cardinality constraint
+}
+
+/// View the (substituted) constraints as a pure-boolean clausal system (a set-cover,
+/// possibly with n-ary combination AND-linearizations and defeasance). Each constraint
+/// must reduce to a single CNF clause or a trivial bound. Returns the clauses, or
+/// `None` if any constraint isn't clausal (so the caller falls back to the LIA path).
 fn as_clausal_cover(
     subbed: &[(ComputeExpr, RelOp, ComputeExpr)],
     bool_set: &HashSet<&str>,
@@ -1494,24 +1578,15 @@ fn as_clausal_cover(
             *c.entry(v).or_insert(0) -= w;
         }
         c.retain(|_, w| *w != 0);
-        let b = rk - lk;
+        let b = rk.checked_sub(lk)?;
         if !c.keys().all(|v| bool_set.contains(v.as_str())) {
             return None;
         }
-        let pos_sum: i128 = c.values().filter(|w| **w > 0).sum();
-        match op {
-            // Σ cᵢxᵢ ≥ 1 with every cᵢ ≥ 1  ⇔  at least one xᵢ true  → an Or clause.
-            RelOp::Ge if b == 1 && !c.is_empty() && c.values().all(|w| *w >= 1) => {
-                clauses.push(Predicate::Or(
-                    c.keys().map(|v| Predicate::Var(v.clone())).collect(),
-                ));
-            }
-            // An empty LHS with b ≥ 1 (e.g. `0 ≥ 1`) is an uncoverable organism.
-            RelOp::Ge if c.is_empty() && b >= 1 => clauses.push(Predicate::Bool(false)),
-            // Trivially-true boolean bounds.
-            RelOp::Ge if b <= 0 && c.values().all(|w| *w >= 0) => {}
-            RelOp::Le if b >= pos_sum && c.values().all(|w| *w >= 0) => {}
-            _ => return None,
+        match classify_clause(&c, *op, b) {
+            ClauseKind::Clause(p) => clauses.push(p),
+            ClauseKind::AlwaysTrue => {}
+            ClauseKind::AlwaysFalse => clauses.push(Predicate::Bool(false)),
+            ClauseKind::NotAClause => return None,
         }
     }
     Some(clauses)
@@ -3004,6 +3079,53 @@ mod tests {
             .join(" + ");
         let (value, _) = expect_int_optimum(&optimize_src(&src));
         assert_eq!(value, n as i128 / 2, "cycle cover min = n/2");
+    }
+
+    #[test]
+    fn nary_combination_cover_routes_through_sat() {
+        // A requirement coverable ONLY by the 3-element combination {a,b,c} (an AND
+        // linearized with aux `y`), plus a single-drug requirement `e`. The optimum
+        // must select a,b,c (for the combination) + e. The combination's implication
+        // clauses (`¬y ∨ a`, `y ∨ ¬a ∨ ¬b ∨ ¬c`) are ±1 clauses the generalized
+        // recognizer accepts, so this scalable boolean cover goes through the SAT path.
+        let out = optimize_src(
+            "symbol a : bool\nsymbol b : bool\nsymbol c : bool\nsymbol e : bool\nsymbol y : bool\n\
+             constrain y <= a\nconstrain y <= b\nconstrain y <= c\n\
+             constrain y - (a + b + c) >= -2\n\
+             constrain y >= 1\nconstrain e >= 1\n\
+             minimize a + b + c + e",
+        );
+        let (value, selected) = expect_int_optimum(&out);
+        assert_eq!(
+            value, 4,
+            "a+b+c+e all chosen for the combination + single cover"
+        );
+        for v in ["a", "b", "c", "e"] {
+            assert!(
+                selected.contains(&v.to_string()),
+                "{v} must be selected: {selected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn combination_is_only_taken_when_a_requirement_needs_it() {
+        // If the requirement `e` is coverable directly AND the combination is not
+        // forced, the optimizer must NOT pay for the combination. Here nothing forces
+        // `y`, so the optimum is just `e` (cost 1), leaving a,b,c unselected.
+        let out = optimize_src(
+            "symbol a : bool\nsymbol b : bool\nsymbol c : bool\nsymbol e : bool\nsymbol y : bool\n\
+             constrain y <= a\nconstrain y <= b\nconstrain y <= c\n\
+             constrain y - (a + b + c) >= -2\n\
+             constrain e + y >= 1\n\
+             minimize a + b + c + e",
+        );
+        let (value, selected) = expect_int_optimum(&out);
+        assert_eq!(
+            value, 1,
+            "cover via the single agent, not the 3-drug combination"
+        );
+        assert_eq!(selected, vec!["e".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
**First half of B2 (combination + sensitivity), kept generic.** The SAT set-cover path no longer matches only `Σx ≥ 1` covering — a new `classify_clause` recognizes **any** `{−1,+1}`-coefficient boolean constraint that is a single CNF clause: after normalizing to `≥`, it's a clause iff the bound equals `1 − |negatives|` (it excludes exactly one assignment). That covers at-least-one covering, `{0,1}` bounds, **and the two implications of an AND-linearization** (`¬y ∨ dᵢ`, `y ∨ ¬d₁ … ∨ ¬dₖ`).

## Why it matters — and why it's domain-general

An **n-ary combination** — a requirement covered only by a *subset* of selected elements (vancomycin + ceftriaxone covering resistant pneumococcus, which neither covers alone; or in any domain, MFA + monitoring jointly mitigating a threat) — is modeled by an aux boolean `y = AND(d₁…dₖ)`, whose defining constraints are exactly those implication clauses.

Before, a combination-laden cover failed the narrow match and **fell back to LIA's ~24-selector ceiling**. Now the whole cover stays on the **scalable SAT path**, and each k-element combination is just **k+1 clauses (linear in k)** — so n-ary combinations scale to a full formulary. A genuine cardinality constraint (`≥ 2 of …`) is still deferred to LIA. Defeasance (a covering edge voided by an observed fact) needs no engine change — the defeated element is dropped from the clause at emit time (that's B2b).

## Verification
- The real MYCIN combination set-cover (vanc+ceftriaxone) now routes through SAT and is **identical** (adult → vanc+ceftriaxone cost 2; over-50 → +ampicillin cost 3); `native_setcover.py` + its test still agree with the Python deriver.
- Behavior-preserving for every prior shape — all 54 earlier tests pass + 2 new combination tests (a 3-element combination cover selects all three; a combination is *not* paid for when a single agent suffices).
- `cargo fmt`. Security review: threshold logic verified **sound** (no constraint misclassified into a wrong optimum). Two LOW findings **fixed** — coefficient negation is now checked (`i128::MIN` declines to `NotAClause`), and the ±1 test uses `matches!(v, 1 | -1)` (total over i128, no debug panic).

**Next (B2b):** the domain-agnostic set-cover *library* — generic spec (elements/costs/requirements/single edges/n-ary combination hyperedges/defeaters), content-addressed solve cache, MYCIN adapter, and a non-medical worked example (security controls) to prove cross-domain generality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)