### PR TITLE
feat(adj-setcover): B2b — domain-agnostic set-cover library; combinations + defeasance + cache, proven cross-domain

### DIFF
--- a/code/specs/data/adj-setcover/.gitignore
+++ b/code/specs/data/adj-setcover/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+_cache/
+_test_cache/
+_setcover_*.adj

--- a/code/specs/data/adj-setcover/README.md
+++ b/code/specs/data/adj-setcover/README.md
@@ -1,0 +1,71 @@
+# adj-setcover — domain-agnostic minimum-cost set-cover (B2b)
+
+The generic core under MYCIN's drug-regimen deriver, lifted out of medicine so any
+domain can use it. The point of B2: **combination coverage and defeasance are
+domain-general constructs**, not medical ones — so they live here, and medicine is
+just one caller.
+
+You give it a `SetCoverSpec`:
+
+| field | meaning |
+|---|---|
+| `costs` | each element's preference cost (≥ 0) |
+| `requirements` | the things that must be covered |
+| `covers` | element → requirements it covers **alone** |
+| `combinations` | an n-ary **subset** of elements that **jointly** cover a requirement none covers alone |
+| `defeated` | observed facts that **void** a specific coverage edge |
+| `excluded_by` / `exclusions` | tags that remove elements (an allergy, a policy ban) |
+
+and `solve(spec)` emits an adj-lang integer program, runs `adj-lang-cli`
+(`adj-constraint-solver`'s native min-cost set-cover), and returns the cheapest set
+covering every requirement — or reports no cover exists.
+
+## Why it's general (two domains, one library)
+
+`examples/drug_regimen.py` and `examples/security_controls.py` call the **same**
+`setcover.solve`:
+
+```
+$ python3 examples/security_controls.py
+1) Nominal: CONTROL PLAN (cost 6): dlp + edr + mfa + monitoring
+     + combination mfa + monitoring covers credential_theft        # defense-in-depth = n-ary combo
+2) edr has a known bypass (CVE): CONTROL PLAN (cost 7): … + waf     # defeasance re-derives
+3) Re-run nominal: … [cache hit]                                    # content-addressed cache
+
+$ python3 examples/drug_regimen.py
+1) Adult community: REGIMEN (cost 2): ceftriaxone + vancomycin
+     + combination vancomycin + ceftriaxone covers s_pneumoniae_resistant
+2) Severe beta-lactam allergy: NO regimen (infeasible) -> escalate  # exclusion → honest abstention
+```
+
+A combination conferring a capability from a *subset* (drug synergy / defense-in-
+depth) and a defeated edge (drug resistance / a control bypass) are the same
+mechanism in both.
+
+## n-ary combinations scale
+
+A k-element combination is an aux `y = AND(elements)` — **k+1 clauses, linear in k**.
+With `adj-constraint-solver ≥ 0.10` (B2a) those AND-implication clauses stay on the
+scalable SAT path, so combinations scale to a full element set rather than collapsing
+to the LIA enumeration. We only encode **declared** combinations — the system never
+*discovers* new synergies on the fly (that is a cold-path re-grounding that mints a
+new fact set; the warm solve reasons only over the bounded facts it was given).
+
+## Content-addressed caching
+
+`solve(spec, cache_dir=…)` keys the result on `spec.content_hash()` (a stable hash
+of the whole spec). A recurring scenario is an instant cache hit; **editing any fact
+— a cost, an edge, a defeater, an exclusion — changes the hash and re-derives.** So
+the expensive solve runs once per distinct input, and a fact change can never serve
+a stale result (the same property the CAS gives the grounded libraries).
+
+## Files
+
+- `setcover.py` — the library (spec → emit → engine → result + cache). Validates
+  every name against a token regex before emitting (no adj-lang injection); temp
+  file via `mkstemp`; subprocess argv-only.
+- `examples/security_controls.py` — non-medical caller (proof of generality).
+- `examples/drug_regimen.py` — a compact medical caller (the grounded full formulary
+  lives at `../mycin-2026/treatment/antibiotics/`).
+- `test_setcover.py` — emit/hash/validation (no model) + solve/cache/defeasance/
+  infeasible (skips if the CLI isn't built).

--- a/code/specs/data/adj-setcover/examples/drug_regimen.py
+++ b/code/specs/data/adj-setcover/examples/drug_regimen.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""drug_regimen.py — the medical domain through the SAME generic set-cover library.
+
+A compact, self-contained empiric-meningitis formulary expressed as a generic
+`SetCoverSpec` — to show the medical case is just one caller of the domain-agnostic
+library (same constructs as `security_controls.py`). The grounded MYCIN formulary
+lives at code/specs/data/mycin-2026/treatment/antibiotics/ and is richer; this is
+the minimal illustration.
+
+  - organisms      = requirements; drugs = elements (cost = preference tier)
+  - combination    = vancomycin + ceftriaxone JOINTLY cover resistant pneumococcus,
+                     which neither covers alone (the grounded n-ary fact)
+  - defeater       = a culture showing resistance voids that drug's coverage edge
+  - exclusion      = a severe beta-lactam allergy removes every beta-lactam
+
+Run:  python3 drug_regimen.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from setcover import Combination, SetCoverSpec, find_cli, solve  # noqa: E402
+
+COSTS = {"vancomycin": 1, "ceftriaxone": 1, "ampicillin": 1, "cefepime": 2, "moxifloxacin": 4}
+COVERS = {
+    "ceftriaxone": ["n_meningitidis"],
+    "cefepime": ["n_meningitidis", "pseudomonas"],
+    "ampicillin": ["listeria"],
+    "moxifloxacin": ["n_meningitidis"],   # beta-lactam-sparing alternative
+}
+COMBINATIONS = [
+    Combination(("vancomycin", "ceftriaxone"), "s_pneumoniae_resistant"),
+    Combination(("vancomycin", "cefepime"), "s_pneumoniae_resistant"),
+]
+# Every beta-lactam carries the exclusion tag.
+EXCLUDED_BY = {d: ["betalactam_allergy"] for d in ("ceftriaxone", "ampicillin", "cefepime")}
+
+
+def scenario(title: str, requirements, exclusions, cli, cache) -> None:
+    spec = SetCoverSpec(costs=COSTS, requirements=requirements, covers=COVERS,
+                        combinations=COMBINATIONS, excluded_by=EXCLUDED_BY, exclusions=exclusions)
+    res = solve(spec, cli=cli, cache_dir=cache)
+    print("=" * 70 + f"\n{title}\n" + "=" * 70)
+    print(f"  cover: {requirements}" + (f"  | exclusions: {exclusions}" if exclusions else ""))
+    if res.selected is None:
+        print(f"  NO regimen ({res.outcome}) -> escalate / specialist.")
+        return
+    print(f"  REGIMEN (cost {res.cost:.0f}): {' + '.join(res.selected)}"
+          + ("   [cache hit]" if res.cached else ""))
+    for c in res.used_combinations:
+        print(f"    + combination {' + '.join(c.elements)} covers {c.covers}")
+
+
+def main() -> int:
+    cli = find_cli()
+    if cli is None:
+        print("drug_regimen: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    cache = Path(__file__).resolve().parent / "_cache"
+    scenario("1) Adult community (resistant pneumococcus + meningococcus)",
+             ["s_pneumoniae_resistant", "n_meningitidis"], [], cli, cache)
+    scenario("2) Severe beta-lactam allergy — beta-lactam combination unavailable",
+             ["s_pneumoniae_resistant", "n_meningitidis"], ["betalactam_allergy"], cli, cache)
+    print("\nSame generic library as the security-controls planner.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/adj-setcover/examples/security_controls.py
+++ b/code/specs/data/adj-setcover/examples/security_controls.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""security_controls.py — the SAME set-cover library, on a NON-medical domain.
+
+Minimum-cost selection of security controls that cover every threat, using the
+exact same generic `setcover` library that derives a drug regimen — proving the
+constructs (n-ary combination coverage + defeasance) are domain-general, not
+medicine-specific.
+
+  - threats             = the requirements to cover
+  - controls            = the elements (each with an operational-burden cost)
+  - combination         = defense-in-depth: MFA + monitoring JOINTLY cover
+                          credential-theft, which neither covers alone (n-ary)
+  - defeater            = a control with a known bypass (an observed CVE) — its
+                          coverage edge is voided, exactly like a culture showing
+                          a drug is resistant
+
+Run:  python3 security_controls.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from setcover import Combination, SetCoverSpec, find_cli, solve  # noqa: E402
+
+# Operational-burden cost per control (lower = preferred).
+COSTS = {"mfa": 1, "monitoring": 2, "edr": 1, "waf": 2, "dlp": 2}
+# What each control covers ALONE (credential_theft is covered by NO single control).
+COVERS = {"edr": ["malware"], "waf": ["malware"], "dlp": ["data_exfiltration"]}
+# Defense-in-depth: MFA + monitoring together cover credential theft.
+COMBINATIONS = [Combination(("mfa", "monitoring"), "credential_theft")]
+THREATS = ["credential_theft", "malware", "data_exfiltration"]
+
+
+def scenario(title: str, defeated: list[tuple[str, str]], cli, cache_dir) -> None:
+    spec = SetCoverSpec(costs=COSTS, requirements=THREATS, covers=COVERS,
+                        combinations=COMBINATIONS, defeated=defeated)
+    res = solve(spec, cli=cli, cache_dir=cache_dir)
+    print("=" * 70 + f"\n{title}\n" + "=" * 70)
+    if defeated:
+        print(f"  defeated edges (known bypass): {defeated}")
+    if res.selected is None:
+        print(f"  NO control set covers every threat ({res.outcome}) -> escalate.")
+        return
+    print(f"  CONTROL PLAN (cost {res.cost:.0f}): {' + '.join(res.selected)}"
+          + ("   [cache hit]" if res.cached else ""))
+    for c in res.used_combinations:
+        print(f"    + combination {' + '.join(c.elements)} covers {c.covers}")
+
+
+def main() -> int:
+    cli = find_cli()
+    if cli is None:
+        print("security_controls: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    cache = Path(__file__).resolve().parent / "_cache"
+    # A: nominal — malware covered by the cheaper edr.
+    scenario("1) Nominal threat model", [], cli, cache)
+    # B: a CVE bypasses edr (observed) — its malware edge is defeated, so the cover
+    #    re-derives onto the costlier waf. Same defeasance mechanic as drug resistance.
+    scenario("2) edr has a known bypass (CVE) — coverage re-derives", [("edr", "malware")], cli, cache)
+    # C: re-run A to demonstrate the content-addressed cache (instant, identical).
+    scenario("3) Re-run the nominal model (content-addressed cache)", [], cli, cache)
+    print("\nSame generic library as the drug-regimen deriver — combinations + "
+          "defeasance are domain-general.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/adj-setcover/setcover.py
+++ b/code/specs/data/adj-setcover/setcover.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""setcover.py — a DOMAIN-AGNOSTIC minimum-cost set-cover, solved by the ADJ engine.
+
+This is the generic core under MYCIN's drug-regimen deriver, lifted out of medicine
+so any domain can use it. You give it:
+
+  - ELEMENTS (each with a cost + optional exclusion tags),
+  - REQUIREMENTS to cover,
+  - single-element COVERAGE edges (element → requirements it covers alone),
+  - n-ary COMBINATIONS (a *subset* of elements that jointly covers a requirement
+    that none covers alone — e.g. two drugs in synergy, or two security controls
+    in defense-in-depth),
+  - DEFEATERS (observed facts that VOID a specific coverage edge — e.g. a culture
+    showing resistance, or a control with a known bypass),
+  - active EXCLUSIONS (tags that remove elements — e.g. an allergy, or a policy ban),
+
+and it emits an adj-lang integer program, solves it with `adj-lang-cli`
+(`adj-constraint-solver`'s native min-cost set-cover), and returns the cheapest set
+of elements covering every requirement — or reports that no cover exists.
+
+It is **deterministic and pure**, so the result is CONTENT-ADDRESSED CACHED: the key
+is a hash of the whole spec, so a recurring scenario is a cache hit, and editing any
+fact (cost, edge, defeater, …) changes the hash and re-derives. The expensive solve
+runs once per distinct input.
+
+The n-ary combination is a k+1-clause AND-linearization (`y = AND(elements)`); the
+engine (adj-constraint-solver ≥ 0.10) keeps it on the scalable SAT path. Defeasance
+needs no engine support — a defeated edge is simply dropped before emitting.
+
+This module is medicine-agnostic; see `examples/drug_regimen.py` and
+`examples/security_controls.py` for two callers in different domains.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Element/requirement names become adj-lang identifiers, so they must be single
+# lowercase tokens — validated before they ever reach the emitted program.
+TOKEN_RE = re.compile(r"\A[a-z][a-z0-9_]*\Z")
+
+
+@dataclass(frozen=True)
+class Combination:
+    """A set of elements that JOINTLY cover `covers` (n-ary; none covers it alone)."""
+    elements: tuple[str, ...]
+    covers: str
+
+
+@dataclass
+class SetCoverSpec:
+    """A minimum-cost set-cover problem, domain-agnostic."""
+    costs: dict[str, int]                         # element -> preference cost (≥ 0)
+    requirements: list[str]                       # the things to cover
+    covers: dict[str, list[str]]                  # element -> requirements it covers alone
+    combinations: list[Combination] = field(default_factory=list)
+    defeated: list[tuple[str, str]] = field(default_factory=list)  # (element, requirement) edges voided
+    excluded_by: dict[str, list[str]] = field(default_factory=dict)  # element -> exclusion tags
+    exclusions: list[str] = field(default_factory=list)  # active exclusion tags
+
+    def canonical(self) -> str:
+        """A canonical JSON serialization — the cache key derives from this, so it
+        must be stable under dict/list ordering."""
+        return json.dumps({
+            "costs": dict(sorted(self.costs.items())),
+            "requirements": sorted(self.requirements),
+            "covers": {k: sorted(v) for k, v in sorted(self.covers.items())},
+            "combinations": sorted([[sorted(c.elements), c.covers] for c in self.combinations]),
+            "defeated": sorted([list(d) for d in self.defeated]),
+            "excluded_by": {k: sorted(v) for k, v in sorted(self.excluded_by.items())},
+            "exclusions": sorted(self.exclusions),
+        }, separators=(",", ":"))
+
+    def content_hash(self) -> str:
+        return hashlib.sha256(self.canonical().encode()).hexdigest()[:16]
+
+
+@dataclass
+class SolveResult:
+    selected: list[str] | None     # the chosen elements, or None if no cover exists
+    cost: float | None
+    outcome: str                   # "optimal" | "infeasible" | <solver outcome>
+    used_combinations: list[Combination]
+    cached: bool = False
+
+
+def find_cli() -> Path | None:
+    """Locate the built adj-lang-cli (PATH, then the workspace target dirs)."""
+    p = shutil.which("adj-lang-cli")
+    if p:
+        return Path(p)
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        for prof in ("debug", "release"):
+            c = parent / "code/packages/rust/target" / prof / "adj-lang-cli"
+            if c.exists():
+                return c
+    return None
+
+
+def _validate(name: str, kind: str) -> str:
+    if not TOKEN_RE.match(name):
+        raise ValueError(f"unsafe {kind} name {name!r} (must match {TOKEN_RE.pattern})")
+    return name
+
+
+def candidates(spec: SetCoverSpec) -> list[str]:
+    """Elements not removed by an active exclusion tag."""
+    active = set(spec.exclusions)
+    return [e for e in spec.costs
+            if not (set(spec.excluded_by.get(e, [])) & active)]
+
+
+def emit_program(spec: SetCoverSpec) -> tuple[str, dict[str, str], bool]:
+    """Emit the adj-lang integer program. Returns (text, x_var → element, feasible)."""
+    cands = candidates(spec)
+    defeated = {tuple(d) for d in spec.defeated}
+    for e in cands:
+        _validate(e, "element")
+    for r in spec.requirements:
+        _validate(r, "requirement")
+
+    lines: list[str] = []
+    xvar = {e: f"x_{e}" for e in cands}
+    for e in cands:
+        _validate(xvar[e], "selector")
+        lines.append(f"symbol {xvar[e]} : bool")
+
+    # n-ary combinations: an aux `y = AND(members)`, only if every member is a
+    # candidate and the combination's coverage isn't fully defeated.
+    combo_cover: dict[str, list[str]] = {}
+    for i, comb in enumerate(spec.combinations):
+        if not all(m in xvar for m in comb.elements):
+            continue
+        if (("&".join(comb.elements), comb.covers)) in defeated:
+            continue
+        y = f"y_{i}"
+        lines.append(f"symbol {y} : bool")
+        for m in comb.elements:                    # y ≤ x_m  (all required)
+            lines.append(f"constrain {y} <= {xvar[m]}")
+        members = " + ".join(xvar[m] for m in comb.elements)   # y ≥ Σ − (k−1)
+        lines.append(f"constrain {y} - ({members}) >= {1 - len(comb.elements)}")
+        combo_cover.setdefault(comb.covers, []).append(y)
+
+    feasible = True
+    for r in spec.requirements:
+        terms = [xvar[e] for e in cands
+                 if r in spec.covers.get(e, []) and (e, r) not in defeated]
+        terms += combo_cover.get(r, [])
+        if terms:
+            lines.append(f"constrain {' + '.join(terms)} >= 1   % cover {r}")
+        else:
+            feasible = False
+            lines.append(f"constrain 0 >= 1   % UNCOVERABLE: {r}")
+
+    obj_terms = []
+    for e in cands:
+        cost = spec.costs[e]
+        if not isinstance(cost, int) or isinstance(cost, bool) or cost < 0:
+            raise ValueError(f"unsafe cost {cost!r} for {e} (non-negative int required)")
+        obj_terms.append(f"{cost} * {xvar[e]}")
+    lines.append(f"minimize {' + '.join(obj_terms)}")
+    return "\n".join(lines) + "\n", {v: e for e, v in xvar.items()}, feasible
+
+
+def solve(spec: SetCoverSpec, cli: Path | None = None,
+          cache_dir: Path | None = None) -> SolveResult:
+    """Solve the min-cost set-cover. Content-addressed cached: a recurring spec is a
+    cache hit; any change to the spec changes its hash and re-derives."""
+    if cache_dir is not None:
+        cache_dir = Path(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cf = cache_dir / f"{spec.content_hash()}.json"
+        if cf.exists():
+            d = json.loads(cf.read_text())
+            return SolveResult(d["selected"], d["cost"], d["outcome"],
+                               [Combination(tuple(c[0]), c[1]) for c in d["used_combinations"]],
+                               cached=True)
+
+    if cli is None:
+        cli = find_cli()
+    if cli is None:
+        raise RuntimeError("adj-lang-cli not built (cargo build -p adj-lang-cli)")
+
+    program, var_to_elem, _ = emit_program(spec)
+    fd, name = tempfile.mkstemp(suffix=".adj", prefix="_setcover_", dir=Path(__file__).resolve().parent)
+    p = Path(name)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(program)
+        r = subprocess.run([str(cli), str(p)], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"adj-lang-cli exited {r.returncode}: {r.stderr}")
+        out = json.loads(r.stdout) if r.stdout else {}
+    finally:
+        p.unlink(missing_ok=True)
+
+    opt = out.get("optimize", {})
+    if opt.get("outcome") != "optimal":
+        result = SolveResult(None, None, opt.get("outcome", "unknown"), [])
+    else:
+        chosen = sorted(var_to_elem[a["name"]] for a in opt.get("assignments", [])
+                        if a["name"] in var_to_elem and abs(a["value"] - 1) < 1e-9)
+        chosen_set = set(chosen)
+        used = [c for c in spec.combinations if set(c.elements) <= chosen_set]
+        result = SolveResult(chosen, opt.get("value"), "optimal", used)
+
+    if cache_dir is not None:
+        cf.write_text(json.dumps({
+            "selected": result.selected, "cost": result.cost, "outcome": result.outcome,
+            "used_combinations": [[list(c.elements), c.covers] for c in result.used_combinations],
+        }, indent=2) + "\n")
+    return result

--- a/code/specs/data/adj-setcover/test_setcover.py
+++ b/code/specs/data/adj-setcover/test_setcover.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""test_setcover.py — guard the domain-agnostic set-cover library.
+
+Pure checks (no model) cover the emitter, validation, and the content-hash; the
+solve + cache + cross-domain checks run when adj-lang-cli is built (skipped cleanly
+otherwise). CI runs this.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import setcover as sc  # noqa: E402
+
+
+def base_spec() -> sc.SetCoverSpec:
+    # r1 covered only by the combination {a,b}; r2 by single c.
+    return sc.SetCoverSpec(
+        costs={"a": 1, "b": 1, "c": 1, "d": 5},
+        requirements=["r1", "r2"],
+        covers={"c": ["r2"]},
+        combinations=[sc.Combination(("a", "b"), "r1")],
+    )
+
+
+def test_content_hash_is_order_stable() -> None:
+    s1 = base_spec()
+    s2 = sc.SetCoverSpec(
+        costs={"d": 5, "c": 1, "b": 1, "a": 1},   # different dict order
+        requirements=["r2", "r1"],
+        covers={"c": ["r2"]},
+        combinations=[sc.Combination(("a", "b"), "r1")],
+    )
+    assert s1.content_hash() == s2.content_hash(), "hash must be canonical/order-stable"
+    # A material change (a defeater) changes the hash.
+    s3 = base_spec()
+    s3.defeated = [("c", "r2")]
+    assert s3.content_hash() != s1.content_hash()
+
+
+def test_emit_rejects_unsafe_tokens() -> None:
+    bad = sc.SetCoverSpec(costs={"a": 1}, requirements=["r)\nminimize evil"], covers={"a": ["r)\nminimize evil"]})
+    try:
+        sc.emit_program(bad)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on an injection-shaped requirement")
+
+
+def test_emit_is_well_formed() -> None:
+    prog, var_to_elem, feasible = sc.emit_program(base_spec())
+    assert feasible and "minimize" in prog
+    assert "symbol y_0 : bool" in prog, "the {a,b} combination needs an AND aux"
+    assert set(var_to_elem.values()) == {"a", "b", "c", "d"}
+
+
+def test_exclusion_removes_elements() -> None:
+    spec = base_spec()
+    spec.excluded_by = {"c": ["banned"]}
+    spec.exclusions = ["banned"]
+    assert "c" not in sc.candidates(spec)
+
+
+def main() -> int:
+    test_content_hash_is_order_stable()
+    test_emit_rejects_unsafe_tokens()
+    test_emit_is_well_formed()
+    test_exclusion_removes_elements()
+
+    cli = sc.find_cli()
+    if cli is None:
+        print("test_setcover: PASS (emit/hash/validation); solve checks SKIPPED (adj-lang-cli not built)")
+        return 0
+
+    cache = HERE / "_test_cache"
+    shutil.rmtree(cache, ignore_errors=True)
+
+    # Combination is required: r1 only covered by {a,b} → both selected; c for r2.
+    res = sc.solve(base_spec(), cli=cli, cache_dir=cache)
+    assert res.outcome == "optimal" and set(res.selected) == {"a", "b", "c"}, res
+    assert any(c.covers == "r1" for c in res.used_combinations)
+    assert not res.cached
+    # Re-solve → content-addressed cache hit, identical result.
+    res2 = sc.solve(base_spec(), cli=cli, cache_dir=cache)
+    assert res2.cached and set(res2.selected) == {"a", "b", "c"}, res2
+
+    # Defeasance: void c's coverage of r2, and give an alternative d covering r2.
+    spec = base_spec()
+    spec.covers["d"] = ["r2"]
+    spec.defeated = [("c", "r2")]
+    res3 = sc.solve(spec, cli=cli, cache_dir=cache)
+    assert "c" not in (res3.selected or []) and "d" in (res3.selected or []), res3
+
+    # Infeasible: a requirement nothing covers → no cover, reported (not fabricated).
+    bad = sc.SetCoverSpec(costs={"a": 1}, requirements=["unreachable"], covers={})
+    res4 = sc.solve(bad, cli=cli)
+    assert res4.selected is None and res4.outcome == "infeasible", res4
+
+    shutil.rmtree(cache, ignore_errors=True)
+    print("test_setcover: PASS (combination required; cache hit; defeasance re-derives; "
+          "infeasible reported; domain-agnostic)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Stacked on #5752 (B2a) — merge that first.** The generic core under MYCIN's drug-regimen deriver, **lifted out of medicine** — the second half of B2. Combination coverage and defeasance are domain-general, so they live in a domain-agnostic library; medicine is one caller.

## The library (`setcover.py`)
A `SetCoverSpec` — elements+costs, requirements, single coverage edges, **n-ary combinations** (a subset that jointly covers a requirement none covers alone), **defeaters** (observed facts that void a coverage edge), exclusion tags — emits an adj-lang integer program, runs `adj-lang-cli` (the native min-cost set-cover), and returns the cheapest cover or an honest "no cover".

- **Content-addressed cache:** `solve()` keys the result on a stable hash of the whole spec. A recurring scenario is an instant **cache hit**; editing *any* fact (cost, edge, defeater, exclusion) changes the hash and re-derives — a fact change can never serve a stale result (the property the CAS gives the grounded libraries).
- **n-ary combinations** are k+1-clause AND-linearizations (linear in k); with B2a they stay on the scalable SAT path. We encode only **declared** combinations — never discover synergies on the fly (that's a cold-path re-grounding; the warm solve reasons only over its bounded facts).

## Proof of generality — two domains, one library

```
$ python3 examples/security_controls.py          # NON-medical
1) CONTROL PLAN (cost 6): dlp + edr + mfa + monitoring
     + combination mfa + monitoring covers credential_theft     # defense-in-depth = n-ary combo
2) edr has a known bypass (CVE): … + waf                        # defeasance re-derives
3) Re-run nominal: … [cache hit]                                # content-addressed cache

$ python3 examples/drug_regimen.py               # medical, SAME library
1) REGIMEN (cost 2): ceftriaxone + vancomycin
     + combination vancomycin + ceftriaxone covers s_pneumoniae_resistant
2) Severe beta-lactam allergy: NO regimen (infeasible) -> escalate   # exclusion → abstention
```

A combination conferring a capability from a subset (drug synergy / defense-in-depth) and a defeated edge (drug resistance / a control bypass) are the **same mechanism** in both.

## Verification
- `python3 test_setcover.py` → PASS (emit/hash-stability/validation with no model; combination-required, cache-hit, defeasance-re-derives, infeasible-reported with the CLI). Both examples run. ruff clean.
- Security review: **PASSED** — every interpolated name is token-validated (incl. the subtle `combination.covers` path, which is filtered through the validated requirement set); cache is JSON-only (no eval/pickle); subprocess argv-only; mkstemp temp file.

This completes **B2** (with B2a): combination + sensitivity as generic ADJ constructs that work across domains, n-ary, scalable, and cached — exactly the cross-domain invariant you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)