### PR TITLE
feat(elixir-lexer): F10 declarative mode transitions — Elixir port

### DIFF
--- a/code/packages/elixir/lexer/CHANGELOG.md
+++ b/code/packages/elixir/lexer/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.4.0 — 2026-06-14
+
+### Added
+
+- **F10 declarative lexer mode transitions**: The lexer now reads `transitions:`
+  and `start_mode:` from the `TokenGrammar` (parsed by the F10 grammar-tools
+  upgrade) and fires mode-switch actions automatically after every emitted token
+  — no `on_token` callback code required for common mode-switching patterns.
+
+  New `State` fields:
+  - `transitions` — list of `mode_transition` maps from `TokenGrammar.transitions`
+  - `inheriting_modes` — MapSet of group names that inherit default patterns
+  - `start_mode` — the mode the lexer starts in (defaults to `"default"`)
+
+  Supported actions per transition rule (first-match-wins):
+  - `{:set_mode, name}` — flat toggle: replace the active group in-place.
+  - `{:push, name}` — nested region: push an exclusive group onto the stack.
+  - `:pop` — close a nested region, restoring the previous group.
+  - `:enable_skip` — resume skip-pattern processing.
+  - `:disable_skip` — suspend skip-pattern processing.
+
+  Guard semantics (all must match for a rule to fire):
+  1. Token type must be in the rule's `on_tokens` list (required).
+  2. If `in_mode` is set, the current active group must match.
+  3. If `on_value` is set, the token's value must match.
+
+- **Flat-mode inheritance** (`compute_inheriting_modes/1`): Groups targeted by
+  `set_mode` (but not `push`) automatically inherit the default group's patterns
+  as a fallthrough. Push targets remain exclusive — only their own patterns apply.
+  This lets a subsidiary mode (e.g., `div_mode`) recognise its own tokens first
+  and fall back to identifiers, numbers, etc. from the default group without
+  duplicating patterns.
+
+- **`start_mode` field** on `State`: when `TokenGrammar.start_mode` is set,
+  the lexer begins in that group (previously always began in `"default"`).
+
+- **F10 transitions coexist with `on_token` callbacks**: transitions fire before
+  the callback, so the callback's `ctx.active_group` already reflects the
+  post-transition mode. Both mechanisms can be active simultaneously.
+
+- **13 new F10 tests** covering: backward compatibility, `set-mode` switching,
+  flat-mode inheritance (set_mode target sees default patterns; push target does
+  not), `in_mode` guard, push/pop nesting, `disable-skip` action, `start_mode`
+  directive, and callback/transition coexistence.
+
 ## 0.3.0 — 2026-04-04
 
 ### Added

--- a/code/packages/elixir/lexer/lib/lexer/grammar_lexer.ex
+++ b/code/packages/elixir/lexer/lib/lexer/grammar_lexer.ex
@@ -295,6 +295,19 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
       # -- Extension: Bracket depth tracking ---
       # Per-type bracket nesting depth counters: %{paren: 0, bracket: 0, brace: 0}
       bracket_depths: %{paren: 0, bracket: 0, brace: 0},
+      # -- F10: Declarative mode transitions ---
+      # List of mode_transition maps parsed from the grammar's `transitions:` section.
+      # Evaluated after every emitted token (first-match-wins). When empty (the
+      # default), mode switching still works via the on_token callback as before.
+      transitions: [],
+      # Set of group names that inherit the default group's patterns as a fallthrough.
+      # A group inherits when it is a `set_mode` target but NOT a `push` target. Push
+      # targets are exclusive — only their own patterns apply, matching the Go impl.
+      inheriting_modes: MapSet.new(),
+      # The mode the lexer starts in. Defaults to "default" when the grammar does not
+      # set `start_mode:`. Used to initialize group_stack; future support for reset
+      # between calls lives here too.
+      start_mode: "default",
       # -- Position tracking ---
       pos: 0,
       line: 1,
@@ -473,6 +486,11 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
     layout_keyword_set =
       MapSet.new(Map.get(grammar, :layout_keywords, []) || [])
 
+    # F10: determine the lexer's starting mode and compute flat-mode inheritance.
+    start_mode = grammar.start_mode || "default"
+    transitions = grammar.transitions || []
+    inheriting_modes = compute_inheriting_modes(transitions)
+
     %State{
       source: source,
       patterns: patterns,
@@ -486,11 +504,14 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
       group_patterns: group_patterns,
       context_keyword_set: context_keyword_set,
       layout_keyword_set: layout_keyword_set,
-      group_stack: ["default"],
+      group_stack: [start_mode],
       on_token: on_token,
       skip_enabled: true,
       last_emitted_token: nil,
-      bracket_depths: %{paren: 0, bracket: 0, brace: 0}
+      bracket_depths: %{paren: 0, bracket: 0, brace: 0},
+      transitions: transitions,
+      inheriting_modes: inheriting_modes,
+      start_mode: start_mode
     }
   end
 
@@ -673,7 +694,8 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
 
     if ch == "\n" do
       token = %Token{type: "NEWLINE", value: "\\n", line: state.line, column: state.column}
-      new_state = %{advance(state) | last_emitted_token: token}
+      # Apply F10 transitions for NEWLINE, then record it as the last emitted token.
+      new_state = state |> apply_transitions(token) |> then(&%{advance(&1) | last_emitted_token: token})
       {:continue, new_state, [token | tokens]}
     else
       # Use the active group's patterns (top of the group stack).
@@ -682,10 +704,27 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
       active_group = List.first(state.group_stack)
       group_pats = Map.get(state.group_patterns, active_group, state.patterns)
 
+      # F10 flat-mode inheritance: groups that are `set_mode` targets (but NOT
+      # `push` targets) inherit the default group's patterns as a fallthrough.
+      # This lets a subsidiary mode recognise its own tokens first and still
+      # fall back to identifiers, numbers, etc. from the default group — no
+      # duplication needed. Push targets remain exclusive.
+      group_pats =
+        if active_group != "default" and MapSet.member?(state.inheriting_modes, active_group) do
+          default_pats = Map.get(state.group_patterns, "default", [])
+          group_pats ++ default_pats
+        else
+          group_pats
+        end
+
       case try_match_token_in_group(remaining, state, group_pats) do
         {:matched, token, new_state} ->
           # Update bracket depth tracking.
           new_state = update_bracket_depth(new_state, token.value)
+
+          # Apply F10 declarative transitions (fires before or alongside the
+          # on_token callback; both can act on the same token independently).
+          new_state = apply_transitions(new_state, token)
 
           # If a callback is registered, invoke it and process the
           # returned actions. The callback receives a read-only context
@@ -815,6 +854,106 @@ defmodule CodingAdventures.Lexer.GrammarLexer do
     new_state = %{new_state | last_emitted_token: last_emitted}
 
     {:continue, new_state, new_tokens}
+  end
+
+  # -- F10: Compute inheriting modes -----------------------------------------
+  #
+  # Returns a MapSet of group names that should inherit the default group's
+  # patterns as a fallthrough (flat-mode inheritance).
+  #
+  # A group qualifies when it is:
+  #   1. A target of at least one `set_mode` action, AND
+  #   2. NOT a target of any `push` action (push targets are exclusive), AND
+  #   3. Not "default" itself.
+  #
+  # The distinction matters because `push` creates a nested, exclusive region —
+  # only the pushed group's own patterns apply there. `set_mode` does a flat
+  # swap: the new mode is conceptually "still the default mode, but with
+  # overrides", so inheriting the default patterns as fallthrough is natural.
+  #
+  # Mirrors `computeInheritingModes` in the Go lexer (grammar_lexer_f10.go).
+
+  defp compute_inheriting_modes(transitions) do
+    # Collect set_mode and push targets from all transition rules.
+    {push_targets, set_mode_targets} =
+      Enum.reduce(transitions, {MapSet.new(), MapSet.new()}, fn rule, {pushes, sets} ->
+        Enum.reduce(rule.actions, {pushes, sets}, fn
+          {:push, target}, {p, s} -> {MapSet.put(p, target), s}
+          {:set_mode, target}, {p, s} -> {p, MapSet.put(s, target)}
+          _, acc -> acc
+        end)
+      end)
+
+    # Inheriting = set_mode targets minus push targets minus "default".
+    set_mode_targets
+    |> MapSet.difference(push_targets)
+    |> MapSet.delete("default")
+  end
+
+  # -- F10: Apply declarative mode transitions --------------------------------
+  #
+  # Called after every emitted token (including NEWLINEs). Walks the transition
+  # table, finds the first rule whose on_tokens / in_mode / on_value guards all
+  # pass, and applies its actions to the state.
+  #
+  # Action semantics:
+  #   {:set_mode, name}  — flat toggle: replace the active group in-place.
+  #   {:push, name}      — push a new group (exclusive nested region).
+  #   :pop               — close the current region; clamp at bottom.
+  #   :enable_skip       — resume skip-pattern processing.
+  #   :disable_skip      — suspend skip-pattern processing.
+  #
+  # Guard semantics (all must match):
+  #   on_tokens  — token.type must be in the list (required).
+  #   in_mode    — if set, the active group must equal the value.
+  #   on_value   — if set, token.value must equal the value.
+  #
+  # First-match-wins: once a rule fires, remaining rules are skipped.
+  #
+  # Returns the updated state (unchanged if no rule matches or transitions = []).
+
+  defp apply_transitions(%State{transitions: []} = state, _token), do: state
+
+  defp apply_transitions(%State{} = state, token) do
+    active = List.first(state.group_stack)
+
+    matching_rule =
+      Enum.find(state.transitions, fn rule ->
+        type_matched = token.type in rule.on_tokens
+        mode_matched = is_nil(rule.in_mode) or rule.in_mode == active
+        value_matched = is_nil(rule.on_value) or rule.on_value == token.value
+        type_matched and mode_matched and value_matched
+      end)
+
+    case matching_rule do
+      nil ->
+        state
+
+      rule ->
+        Enum.reduce(rule.actions, state, fn action, acc ->
+          case action do
+            {:set_mode, target} ->
+              # Replace only the top-of-stack entry, leaving the rest intact.
+              [_top | rest] = acc.group_stack
+              %{acc | group_stack: [target | rest]}
+
+            {:push, target} ->
+              %{acc | group_stack: [target | acc.group_stack]}
+
+            :pop ->
+              case acc.group_stack do
+                [_only] -> acc
+                [_top | rest] -> %{acc | group_stack: rest}
+              end
+
+            :enable_skip ->
+              %{acc | skip_enabled: true}
+
+            :disable_skip ->
+              %{acc | skip_enabled: false}
+          end
+        end)
+    end
   end
 
   # -- Skip pattern matching --------------------------------------------------

--- a/code/packages/elixir/lexer/test/lexer/grammar_lexer_test.exs
+++ b/code/packages/elixir/lexer/test/lexer/grammar_lexer_test.exs
@@ -892,4 +892,325 @@ defmodule CodingAdventures.Lexer.GrammarLexerTest do
       assert Enum.any?(tokens, &(&1.type == "TAG_NAME"))
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # F10: Declarative lexer mode transitions
+  # ---------------------------------------------------------------------------
+  #
+  # F10 adds three concepts on top of the existing group/callback machinery:
+  #
+  # 1. `transitions:` section in the grammar — declarative on-token rules that
+  #    fire automatically, replacing (or augmenting) hand-written callbacks.
+  #
+  # 2. Flat-mode inheritance — groups targeted by `set-mode` (but not `push`)
+  #    inherit the default group's patterns as fallthrough so the author need
+  #    not duplicate common patterns (NAME, NUMBER, etc.) in every mode.
+  #
+  # 3. `start_mode:` directive — the lexer begins in the named group instead
+  #    of "default".
+  #
+  # The tests below exercise each feature independently and in combination.
+
+  describe "F10 — backward compatibility" do
+    test "a grammar with no transitions behaves identically to before" do
+      # This is the most important regression guard: existing grammars that
+      # predate F10 must tokenize identically regardless of whether F10 code
+      # is present on the hot path.
+      {:ok, grammar} =
+        TokenGrammar.parse("""
+        NAME   = /[a-zA-Z_][a-zA-Z_0-9]*/
+        NUMBER = /[0-9]+/
+        PLUS   = "+"
+        """)
+
+      {:ok, tokens} = GrammarLexer.tokenize("a + 1", grammar)
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "PLUS", "NUMBER", "EOF"]
+    end
+  end
+
+  describe "F10 — set-mode action" do
+    # Build a grammar where emitting EQ switches from "default" to "rhs" mode.
+    # The "rhs" group has an RHS_NAME pattern that shadows the default NAME.
+    defp set_mode_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME = /[a-zA-Z_]+/
+        EQ   = "="
+
+        group rhs:
+          RHS_NAME = /[a-zA-Z_]+/
+
+        transitions:
+          on EQ -> set-mode rhs
+        """)
+
+      g
+    end
+
+    test "after trigger token, active group switches to the named mode" do
+      # Tokenize "foo = bar":
+      # - "foo" → NAME (default)
+      # - "="   → EQ, then transition fires → switch to rhs mode
+      # - "bar" → RHS_NAME (rhs mode; rhs pattern shadows default NAME)
+      {:ok, tokens} = GrammarLexer.tokenize("foo = bar", set_mode_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "EQ", "RHS_NAME", "EOF"]
+    end
+
+    test "no switch when no matching token type" do
+      # "foo bar" has no EQ, so no transition fires; both words are NAME.
+      {:ok, tokens} = GrammarLexer.tokenize("foo bar", set_mode_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "NAME", "EOF"]
+    end
+  end
+
+  describe "F10 — flat-mode inheritance" do
+    # A grammar where "div_mode" (set-mode target) has its own SLASH_DIV pattern
+    # but relies on the default group for NAME and NUMBER.  Without flat-mode
+    # inheritance the user would have to duplicate all default patterns inside
+    # "div_mode"; with it, they get them for free as a fallthrough.
+    defp flat_inheritance_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME   = /[a-zA-Z_]+/
+        NUMBER = /[0-9]+/
+        SLASH  = "/"
+
+        group div_mode:
+          SLASH_DIV = "/"
+
+        transitions:
+          on NAME -> set-mode div_mode
+        """)
+
+      g
+    end
+
+    test "set-mode group's own patterns take precedence over inherited defaults" do
+      # "x / y": after emitting NAME("x") we switch to div_mode.
+      # "/" is in div_mode as SLASH_DIV (takes precedence over default SLASH).
+      # "y" is NAME inherited from default (div_mode is a set_mode target).
+      {:ok, tokens} = GrammarLexer.tokenize("x / y", flat_inheritance_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "SLASH_DIV", "NAME", "EOF"]
+    end
+
+    test "numbers are accessible in set-mode group via inheritance" do
+      # "x 42": after switching to div_mode, NUMBER is still available from
+      # the default group via flat-mode inheritance.
+      {:ok, tokens} = GrammarLexer.tokenize("x 42", flat_inheritance_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "NUMBER", "EOF"]
+    end
+  end
+
+  describe "F10 — push target is exclusive (no flat-mode inheritance)" do
+    # "exclusive" is a push target, so it does NOT inherit default patterns.
+    # Only patterns defined inside the group itself are available.
+    defp push_exclusive_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME  = /[a-zA-Z_]+/
+        OPEN  = "{"
+
+        group exclusive:
+          INNER = /[^}]+/
+          CLOSE = "}"
+
+        transitions:
+          on OPEN -> push exclusive
+          on CLOSE -> pop
+        """)
+
+      g
+    end
+
+    test "push target uses only its own patterns — no default fallthrough" do
+      # "outer { inner } outer":
+      # - "outer " → NAME (default)
+      # - "{"      → OPEN (default), push exclusive
+      # - " inner " → INNER (exclusive; /[^}]+/ matches until "}")
+      # - "}"      → CLOSE (exclusive), pop → back to default
+      # - " outer" → NAME (default)
+      {:ok, tokens} = GrammarLexer.tokenize("outer { inner } outer", push_exclusive_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "OPEN", "INNER", "CLOSE", "NAME", "EOF"]
+    end
+
+    test "push and pop restore previous mode correctly" do
+      {:ok, tokens} = GrammarLexer.tokenize("a { b } c", push_exclusive_grammar())
+      types = Enum.map(tokens, & &1.type)
+      # After pop the lexer is back in default → "c" is NAME, not INNER.
+      assert types == ["NAME", "OPEN", "INNER", "CLOSE", "NAME", "EOF"]
+    end
+  end
+
+  describe "F10 — in_mode guard" do
+    # Two transitions both triggered by DOT, but with opposing in_mode guards.
+    # Toggling back and forth between "default" and "member_mode".
+    defp in_mode_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME = /[a-zA-Z_]+/
+        DOT  = "."
+
+        group member_mode:
+          MEMBER = /[a-zA-Z_]+/
+
+        transitions:
+          on DOT in default     -> set-mode member_mode
+          on DOT in member_mode -> set-mode default
+        """)
+
+      g
+    end
+
+    test "in_mode guard ensures only the matching rule fires" do
+      # "a.b.c": DOT in default → switch to member_mode, DOT in member_mode → switch back
+      {:ok, tokens} = GrammarLexer.tokenize("a.b.c", in_mode_grammar())
+      types = Enum.map(tokens, & &1.type)
+      # default: NAME("a"), DOT → switch to member_mode
+      # member_mode: MEMBER("b") inherited-default?, DOT → switch back
+      # default: NAME("c")
+      assert types == ["NAME", "DOT", "MEMBER", "DOT", "NAME", "EOF"]
+    end
+
+    test "rule with in_mode does NOT fire when in a different mode" do
+      # "a.b": starts in default → NAME, then DOT → switch to member_mode → MEMBER
+      # No second dot, so second rule never fires.  Just verify no crash.
+      {:ok, tokens} = GrammarLexer.tokenize("a.b", in_mode_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "DOT", "MEMBER", "EOF"]
+    end
+  end
+
+  describe "F10 — disable-skip action" do
+    # After a TRIGGER (":"), skip is disabled so subsequent whitespace is
+    # emitted as a WS token instead of being silently consumed.
+    defp disable_skip_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        NAME    = /[a-zA-Z_]+/
+        WS      = /[ \\t]+/
+        TRIGGER = ":"
+
+        skip:
+          WS = /[ \\t]+/
+
+        transitions:
+          on TRIGGER -> disable-skip
+        """)
+
+      g
+    end
+
+    test "disable-skip makes whitespace significant after trigger token" do
+      # "word: val":
+      # - "word" → NAME (skip active, spaces consumed)
+      # - ":"    → TRIGGER, disable-skip fires
+      # - " "    → WS (skip now inactive, matched by WS definition)
+      # - "val"  → NAME
+      {:ok, tokens} = GrammarLexer.tokenize("word: val", disable_skip_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "TRIGGER", "WS", "NAME", "EOF"]
+    end
+  end
+
+  describe "F10 — start_mode directive" do
+    # The lexer should begin in "header" mode rather than "default".
+    # "header" has HDR = /[A-Z]+/ which is NOT in the default group.
+    defp start_mode_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME  = /[a-zA-Z_]+/
+        COLON = ":"
+
+        group header:
+          HDR   = /[A-Z]+/
+          COLON = ":"
+
+        start_mode: header
+        """)
+
+      g
+    end
+
+    test "lexer starts in the configured group, not default" do
+      # "HDR:": starts in header mode → "HDR" matches HDR (not NAME), then COLON.
+      # If we were in default mode, /[a-zA-Z_]+/ would match first as NAME.
+      {:ok, tokens} = GrammarLexer.tokenize("HDR:", start_mode_grammar())
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["HDR", "COLON", "EOF"]
+    end
+
+    test "start_mode respects the configured group patterns" do
+      # Verify values are also correct.
+      {:ok, tokens} = GrammarLexer.tokenize("HDR:", start_mode_grammar())
+      [{type, value} | _] = Enum.map(tokens, &{&1.type, &1.value})
+      assert type == "HDR"
+      assert value == "HDR"
+    end
+  end
+
+  describe "F10 — transitions coexist with on_token callbacks" do
+    # Both F10 transitions and an on_token callback can be active simultaneously.
+    # Transitions fire first; the callback then sees the already-updated state.
+    defp combo_grammar do
+      {:ok, g} =
+        TokenGrammar.parse("""
+        skip:
+          WS = /[ \\t]+/
+
+        NAME   = /[a-zA-Z_]+/
+        HASH   = "#"
+
+        group comment_mode:
+          COMMENT_TEXT = /[^\\n]+/
+
+        transitions:
+          on HASH -> push comment_mode
+        """)
+
+      g
+    end
+
+    test "F10 transition fires and callback also fires for the same token" do
+      pid = self()
+
+      callback = fn token, ctx ->
+        if token.type == "HASH" do
+          # When the callback runs, the transition has already fired, so we
+          # are already in comment_mode.
+          send(pid, {:active_group, ctx.active_group})
+        end
+
+        []
+      end
+
+      {:ok, tokens} = GrammarLexer.tokenize("x # comment", combo_grammar(), on_token: callback)
+
+      types = Enum.map(tokens, & &1.type)
+      assert types == ["NAME", "HASH", "COMMENT_TEXT", "EOF"]
+
+      # Verify callback was called and saw the post-transition mode.
+      assert_received {:active_group, "comment_mode"}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Ports F10 declarative lexer mode transitions to the Elixir `GrammarLexer`, mirroring the Go lexer port (PR #5746)
- Includes grammar_tools F10 changes from PR #5741 (stacked; reviewer: once #5741 merges, rebase this onto main and CI will be clean)
- 13 new F10 tests in `grammar_lexer_test.exs`; 67 total, 0 failures

**New in `grammar_lexer.ex`:**
- `compute_inheriting_modes/1` — which `set_mode` target groups inherit default patterns (push targets remain exclusive)
- `apply_transitions/2` — fires after every emitted token; first-match-wins; supports `set_mode`, `push`, `pop`, `enable_skip`, `disable_skip` actions with `on_tokens`/`in_mode`/`on_value` guards
- Flat-mode inheritance — `set_mode` target groups append default patterns as fallthrough in `try_newline_or_token/3`
- `start_mode` — initializes `group_stack` from `grammar.start_mode` rather than always `"default"`
- F10 transitions coexist with `on_token` callbacks: transitions fire first

**Tests (F10 describe blocks):**
- Backward compatibility, `set-mode` switching, flat-mode inheritance, push exclusivity, `in_mode` guard, push/pop nesting, `disable-skip` action, `start_mode` directive, callback+transition coexistence

## Test plan

- [ ] All 67 lexer tests pass (54 pre-existing + 13 new F10)
- [ ] CI green on both ubuntu-latest and macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)