### PR TITLE
feat(transport-platform): cross-thread WakeHandle — off-reactor sends flush in ms (multi-core 2/5)

### DIFF
--- a/code/packages/rust/kqueue/CHANGELOG.md
+++ b/code/packages/rust/kqueue/CHANGELOG.md
@@ -14,3 +14,12 @@ All notable changes to this package will be documented in this file.
 
 - widened the wrapper to expose timer and user-event filters for higher
   transport layers such as `transport-platform`
+
+## [0.1.1] - 2026-06-14
+
+### Added
+
+- `Kqueue::try_clone` — duplicates the queue descriptor, yielding a second handle
+  to the same kernel queue. Because `apply` takes `&self` and `kevent` is
+  thread-safe, the clone can trigger an `EVFILT_USER` wakeup from another thread
+  on a queue a different thread is blocked in `wait` on (cross-thread reactor wake).

--- a/code/packages/rust/kqueue/src/lib.rs
+++ b/code/packages/rust/kqueue/src/lib.rs
@@ -320,6 +320,17 @@ mod imp {
             Ok(Self { fd })
         }
 
+        /// Duplicate this kqueue's descriptor, yielding a second handle to the
+        /// *same* kernel queue.  Because `apply` takes `&self` and the kernel's
+        /// `kevent` is thread-safe, the clone can be moved to another thread and
+        /// used to trigger an `EVFILT_USER` wakeup on a queue another thread is
+        /// blocked in `wait` on — the basis for a cross-thread reactor wakeup.
+        pub fn try_clone(&self) -> io::Result<Self> {
+            Ok(Self {
+                fd: self.fd.try_clone()?,
+            })
+        }
+
         pub fn apply(&self, change: KqueueChange) -> io::Result<()> {
             self.apply_all(&[change])
         }

--- a/code/packages/rust/stream-reactor/CHANGELOG.md
+++ b/code/packages/rust/stream-reactor/CHANGELOG.md
@@ -63,3 +63,18 @@ All notable changes to this package will be documented in this file.
 ### Added
 
 - Regression test `connection_ids_encode_the_shard_index_in_their_low_bits`.
+
+## [0.1.5] - 2026-06-14
+
+### Added
+
+- **Cross-thread reactor wakeup.** Each reactor registers a wakeup at construction
+  and hands its `StreamMailbox` a `WakeHandle`; `StreamMailbox::push` fires it
+  after enqueuing, so an off-reactor write interrupts `poll` and flushes in
+  milliseconds instead of waiting out the poll timeout (default 10 ms). Best-effort
+  and non-fatal: on platforms whose wakeup can't be shared across threads, the
+  mailbox simply has no handle and the reactor drains on its next poll as before.
+- Tests: `off_reactor_mailbox_write_wakes_the_reactor_immediately` (a 30 s poll
+  timeout proves the wake fires — a dropped wake fails the test, not just slows it)
+  and `concurrent_off_reactor_wakes_do_not_corrupt_the_reactor` (8 threads hammer
+  the wake while clients echo). Both pass under ThreadSanitizer.

--- a/code/packages/rust/stream-reactor/src/lib.rs
+++ b/code/packages/rust/stream-reactor/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use transport_platform::{
     BindAddress, CloseKind, ListenerId, ListenerOptions, PlatformError, PlatformEvent, ReadOutcome,
-    StreamId, StreamInterest, StreamOptions, TransportPlatform, WriteOutcome,
+    StreamId, StreamInterest, StreamOptions, TransportPlatform, WakeHandle, WriteOutcome,
 };
 
 const DEFAULT_MAX_CONNECTIONS: usize = 1_024;
@@ -131,6 +131,11 @@ impl StopHandle {
 #[derive(Clone, Default)]
 pub struct StreamMailbox {
     commands: Arc<Mutex<VecDeque<StreamMailboxCommand>>>,
+    /// Optional cross-thread trigger that interrupts the owning reactor's `poll`
+    /// the instant a command is enqueued, so an off-reactor write flushes without
+    /// waiting for the poll timeout.  `None` on platforms whose wakeup primitive
+    /// can't be shared across threads (the reactor then drains on its next poll).
+    wake: Option<WakeHandle>,
 }
 
 impl StreamMailbox {
@@ -167,10 +172,19 @@ impl StreamMailbox {
     }
 
     fn push(&self, command: StreamMailboxCommand) {
+        // Enqueue *first*, then wake: the reactor, once interrupted, must already
+        // see the command in the queue.  (`serve` drains at both the top and
+        // bottom of every poll cycle, so a wake that races mid-cycle is still
+        // caught.)
         self.commands
             .lock()
             .expect("stream mailbox mutex poisoned")
             .push_back(command);
+        if let Some(wake) = &self.wake {
+            // Best-effort: a failed wake just means the reactor flushes on its
+            // next poll timeout instead of immediately — never a lost command.
+            let _ = wake.wake();
+        }
     }
 
     fn drain(&self) -> Vec<StreamMailboxCommand> {
@@ -295,6 +309,21 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                 PlatformError::ProviderFault(format!("enable listener interest: {error}"))
             })?;
 
+        // Register a wakeup and grab a cross-thread handle for the mailbox, so an
+        // off-reactor write can interrupt `poll` and flush at once instead of
+        // waiting out the poll timeout.  Best-effort: if the platform can't create
+        // a wakeup or can't share it across threads (the default `wake_handle`
+        // returns `Unsupported`, e.g. on Windows), the mailbox just has no handle
+        // and the reactor drains on its next poll timeout exactly as before.
+        let wake = match platform.create_wakeup() {
+            Ok(wakeup) => platform.wake_handle(wakeup).ok(),
+            Err(_) => None,
+        };
+        let mailbox = StreamMailbox {
+            commands: Arc::new(Mutex::new(VecDeque::new())),
+            wake,
+        };
+
         Ok(Self {
             platform,
             listener,
@@ -305,7 +334,7 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
             shard_index: options.shard_index,
             shard_bits: options.shard_bits,
             stop_flag: Arc::new(AtomicBool::new(false)),
-            mailbox: StreamMailbox::default(),
+            mailbox,
             read_buffer_size: options.read_buffer_size.max(1),
             max_connections: options.max_connections.max(1),
             max_pending_write_bytes: options.max_pending_write_bytes.max(1),
@@ -376,6 +405,10 @@ impl<P: TransportPlatform, S: Send + 'static> StreamReactor<P, S> {
                         }
                         _ => {}
                     },
+                    // A mailbox wakeup: its only job is to break us out of `poll`.
+                    // The mailbox drain at the bottom of this loop iteration does
+                    // the actual work, so there is nothing to handle here.
+                    PlatformEvent::Wakeup { .. } => {}
                     _ => {}
                 }
             }
@@ -936,6 +969,124 @@ mod tests {
             assert_eq!(id & 0b11, 1, "shard index must occupy the low 2 bits: {id}");
             assert!(id >> 2 >= 1, "the sequence (high bits) must start at 1: {id}");
         }
+    }
+
+    #[test]
+    fn off_reactor_mailbox_write_wakes_the_reactor_immediately() {
+        // Give the reactor a deliberately huge poll timeout (30s).  Without a
+        // cross-thread wakeup, a mailbox write enqueued from another thread would
+        // sit until the next socket event or that timeout — so the client's 3s
+        // read would fail.  The wake handle interrupts `poll` at once, so the
+        // write flushes in milliseconds.  A regression that drops the wake makes
+        // this test fail (the read times out), not merely run slow.
+        let seen = Arc::new(Mutex::new(Vec::<ConnectionId>::new()));
+        let seen_in_handler = Arc::clone(&seen);
+        let options = StreamReactorOptions {
+            poll_timeout: Duration::from_secs(30),
+            ..StreamReactorOptions::default()
+        };
+        let mut reactor = StreamReactor::bind_kqueue_with_state(
+            ("127.0.0.1", 0),
+            options,
+            |_| (),
+            move |info, _, _| {
+                seen_in_handler
+                    .lock()
+                    .expect("seen mutex poisoned")
+                    .push(info.id);
+                StreamHandlerResult::default() // do not reply from the handler
+            },
+            |_, _| {},
+        )
+        .expect("bind");
+        let addr = reactor.local_addr();
+        let mailbox = reactor.mailbox();
+        let stop = reactor.stop_handle();
+        let server = thread::spawn(move || reactor.serve());
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client
+            .set_read_timeout(Some(Duration::from_secs(3)))
+            .expect("read timeout");
+        client.write_all(b"ping").expect("write");
+
+        let mut id = None;
+        for _ in 0..300 {
+            if let Some(first) = seen.lock().expect("seen mutex poisoned").first().copied() {
+                id = Some(first);
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let id = id.expect("handler should observe the connection");
+
+        let start = std::time::Instant::now();
+        mailbox.send(id, b"pong".to_vec());
+        let mut buf = [0u8; 4];
+        client
+            .read_exact(&mut buf)
+            .expect("off-reactor write should arrive promptly");
+        assert_eq!(&buf, b"pong");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "wake should flush in ms, took {:?}",
+            start.elapsed()
+        );
+
+        stop.stop();
+        // The reactor is back in its 30s poll; wake it so it sees the stop flag.
+        mailbox.resume_all_reads();
+        server.join().expect("server thread").expect("serve");
+    }
+
+    #[test]
+    fn concurrent_off_reactor_wakes_do_not_corrupt_the_reactor() {
+        // Hammer the cross-thread wake from many threads while the reactor serves
+        // real clients.  This exercises the duplicated-fd wake handle for data
+        // races / use-after-free and is the test to run under ThreadSanitizer.
+        let mut reactor = StreamReactor::bind_kqueue(("127.0.0.1", 0), |_, bytes| {
+            StreamHandlerResult::write(bytes.to_vec())
+        })
+        .expect("bind");
+        let addr = reactor.local_addr();
+        let mailbox = reactor.mailbox();
+        let stop = reactor.stop_handle();
+        let server = thread::spawn(move || reactor.serve());
+
+        // 8 threads each firing thousands of wakes (resume_all_reads enqueues a
+        // command and wakes; send targets mostly-unknown ids, drained and dropped).
+        let wakers: Vec<_> = (0..8)
+            .map(|_| {
+                let mailbox = mailbox.clone();
+                thread::spawn(move || {
+                    for n in 0..2000u64 {
+                        mailbox.resume_all_reads();
+                        // Target ids far above any real connection's sequence so a
+                        // speculative send is always dropped (id miss) rather than
+                        // injecting bytes into a live client's stream.
+                        mailbox.send(ConnectionId(1_000_000 + n), b"x".to_vec());
+                    }
+                })
+            })
+            .collect();
+
+        // Meanwhile real clients must still echo correctly.
+        for i in 0..12 {
+            let mut stream = TcpStream::connect(addr).expect("connect");
+            let payload = format!("client-{i}").into_bytes();
+            stream.write_all(&payload).expect("write");
+            stream.shutdown(Shutdown::Write).expect("shutdown");
+            let mut echoed = Vec::new();
+            stream.read_to_end(&mut echoed).expect("read echo");
+            assert_eq!(echoed, payload);
+        }
+
+        for waker in wakers {
+            waker.join().expect("waker thread");
+        }
+        stop.stop();
+        mailbox.resume_all_reads(); // break the final poll
+        server.join().expect("server thread").expect("serve");
     }
 
     #[test]

--- a/code/packages/rust/transport-platform/CHANGELOG.md
+++ b/code/packages/rust/transport-platform/CHANGELOG.md
@@ -27,3 +27,17 @@ All notable changes to this package will be documented in this file.
 - Windows listeners now use exclusive address ownership instead of mapping the
   cross-platform `reuse_address` flag onto Winsock's unsafe TCP listener
   `SO_REUSEADDR` semantics
+
+## [0.1.1] - 2026-06-14
+
+### Added
+
+- `WakeHandle` — a `Send + Sync`, cloneable, thread-safe trigger for a platform's
+  wakeup, and a `TransportPlatform::wake_handle(wakeup)` method that returns one.
+  Unlike `wake(&mut self)` (which lives on the reactor-owned platform), a
+  `WakeHandle` owns a thread-safe clone of the underlying OS primitive, so an
+  off-reactor producer can interrupt the reactor's `poll` the instant it has work.
+  - kqueue: duplicates the kqueue fd and re-issues `EVFILT_USER` + `NOTE_TRIGGER`.
+  - epoll: duplicates the wakeup `eventfd` and `write`s the counter.
+  - Default impl returns `Unsupported`; Windows/IOCP uses it for now (callers fall
+    back to the poll timeout), so no platform is broken — they just wake later.

--- a/code/packages/rust/transport-platform/src/lib.rs
+++ b/code/packages/rust/transport-platform/src/lib.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, IoSlice};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -240,6 +241,48 @@ pub enum WriteOutcome {
     Closed,
 }
 
+/// A thread-safe trigger for one platform's wakeup, callable from *any* thread.
+///
+/// `create_wakeup` registers a wakeup with the platform and `wake(&mut self)`
+/// fires it — but that lives on the platform, which is owned by the single
+/// reactor thread.  A `WakeHandle` decouples the *firing* from the `&mut self`
+/// platform: it owns a thread-safe clone of the underlying OS primitive (a
+/// duplicated kqueue fd, a duplicated `eventfd`, …), so an off-reactor producer
+/// (e.g. a mailbox on another thread) can interrupt the reactor's `poll` the
+/// instant it enqueues work, instead of waiting for the poll timeout.
+///
+/// Obtain one from [`TransportPlatform::wake_handle`].  It is cheap to clone
+/// (the trigger is reference-counted).
+#[derive(Clone)]
+pub struct WakeHandle {
+    trigger: Arc<dyn Fn() -> Result<(), PlatformError> + Send + Sync>,
+}
+
+impl WakeHandle {
+    /// Build a handle from a backend-specific trigger closure.  Crate-internal:
+    /// only the platform backends construct these.
+    pub(crate) fn from_trigger(
+        trigger: impl Fn() -> Result<(), PlatformError> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            trigger: Arc::new(trigger),
+        }
+    }
+
+    /// Fire the wakeup.  Safe to call from any thread.  A failure here is
+    /// non-fatal to the caller: the reactor will still drain on its next poll
+    /// timeout, so producers typically ignore the result.
+    pub fn wake(&self) -> Result<(), PlatformError> {
+        (self.trigger)()
+    }
+}
+
+impl fmt::Debug for WakeHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WakeHandle").finish_non_exhaustive()
+    }
+}
+
 pub trait TransportPlatform {
     fn native_event_provider(&self) -> NativeEventProvider {
         NativeEventProvider::ReadinessProbe
@@ -302,6 +345,20 @@ pub trait TransportPlatform {
     fn create_wakeup(&mut self) -> Result<WakeupId, PlatformError>;
 
     fn wake(&mut self, wakeup: WakeupId) -> Result<(), PlatformError>;
+
+    /// Return a thread-safe [`WakeHandle`] that fires `wakeup` from any thread.
+    ///
+    /// The default returns [`PlatformError::Unsupported`]; backends that can
+    /// safely share their wakeup primitive across threads (kqueue, epoll)
+    /// override it.  A caller that gets `Unsupported` simply forgoes the
+    /// low-latency wake and relies on the reactor's poll timeout instead — so
+    /// this never breaks a platform, it only makes cross-thread sends flush a
+    /// little later there.
+    fn wake_handle(&self, _wakeup: WakeupId) -> Result<WakeHandle, PlatformError> {
+        Err(PlatformError::Unsupported(
+            "cross-thread wake handle not supported by this platform",
+        ))
+    }
 
     fn poll(
         &mut self,
@@ -838,6 +895,28 @@ pub mod bsd {
                     .with_fflags(kqueue::note_trigger()),
             )?;
             Ok(())
+        }
+
+        fn wake_handle(&self, wakeup: WakeupId) -> Result<WakeHandle, PlatformError> {
+            // The user event must already be registered (via `create_wakeup`);
+            // capture its ident/token and a *duplicate* of the kqueue fd so the
+            // returned handle can re-issue the NOTE_TRIGGER from another thread.
+            let state = self
+                .wakeups
+                .get(&wakeup)
+                .ok_or(PlatformError::InvalidResource)?;
+            let ident = state.ident;
+            let token = wakeup.0;
+            let queue = self.queue.try_clone().map_err(PlatformError::from)?;
+            Ok(WakeHandle::from_trigger(move || {
+                queue
+                    .apply(
+                        kqueue::KqueueChange::user(ident, token)
+                            .with_flags(kqueue::EventFlags::ENABLE | kqueue::EventFlags::CLEAR)
+                            .with_fflags(kqueue::note_trigger()),
+                    )
+                    .map_err(PlatformError::from)
+            }))
         }
 
         fn poll(
@@ -1480,6 +1559,40 @@ pub mod linux {
                 .get(&wakeup)
                 .ok_or(PlatformError::InvalidResource)?;
             Self::write_counter_fd(&state.fd, 1)
+        }
+
+        fn wake_handle(&self, wakeup: WakeupId) -> Result<WakeHandle, PlatformError> {
+            // Duplicate the eventfd so the handle can post a wake from another
+            // thread.  A wake is a single `write` of the counter value `1`; the
+            // eventfd is registered with the epoll instance, so the write makes a
+            // blocked `epoll_wait` return.  The fd is `EFD_NONBLOCK`, so a full
+            // counter (after 2^64-1 unread wakes — effectively never) returns
+            // `EAGAIN`, which we treat as "a wake is already pending" = success.
+            let state = self
+                .wakeups
+                .get(&wakeup)
+                .ok_or(PlatformError::InvalidResource)?;
+            let fd = state.fd.try_clone().map_err(PlatformError::from)?;
+            Ok(WakeHandle::from_trigger(move || {
+                let value: u64 = 1;
+                let written = unsafe {
+                    libc::write(
+                        fd.as_raw_fd(),
+                        (&value as *const u64).cast(),
+                        std::mem::size_of::<u64>(),
+                    )
+                };
+                if written == -1 {
+                    let error = io::Error::last_os_error();
+                    if error.kind() == io::ErrorKind::WouldBlock {
+                        Ok(())
+                    } else {
+                        Err(PlatformError::from(error))
+                    }
+                } else {
+                    Ok(())
+                }
+            }))
         }
 
         fn poll(

--- a/code/specs/tcp-runtime-roadmap.md
+++ b/code/specs/tcp-runtime-roadmap.md
@@ -330,12 +330,17 @@ Status:
   off-reactor write to the one owning reactor with a single mask — no shared
   registry and no O(N) broadcast. This replaced the earlier shared-`AtomicU64`
   connection-id seed.
+- **Done** — cross-thread wakeups. `transport-platform` exposes a `Send + Sync`
+  `WakeHandle` (a duplicated kqueue fd / `eventfd`); each reactor hands one to its
+  mailbox, which fires it on enqueue so an off-reactor write interrupts `poll` and
+  flushes in milliseconds instead of waiting the poll timeout. macOS/Linux only so
+  far; Windows/IOCP falls back to the poll timeout (a follow-up). Validated under
+  ThreadSanitizer.
 
 Missing pieces:
 
-- cross-thread wakeups (the wakeup primitive exists in `transport-platform`, but
-  the mailbox does not yet trigger it, so an off-reactor write waits up to the
-  poll timeout before flushing)
+- IOCP cross-thread wake (share the completion port so `PostQueuedCompletionStatus`
+  can fire from a `WakeHandle`)
 - lock-minimal metrics and connection handoff paths
 
 ### 5. Hardening, observability, and benchmarking

--- a/lessons.md
+++ b/lessons.md
@@ -600,3 +600,34 @@ file or directory`. Fix: add a `tools/run-tests.sh` that runs `cargo build
 `sh tools/run-tests.sh` from the BUILD file. The deps= hint still fires in
 the normal build (making the cargo step a fast no-op); CodeQL gets the Rust
 lib on demand. Surfaced in PR #5739.
+
+## tcp-runtime — cross-thread reactor wakeup + running ThreadSanitizer locally
+
+**Date:** 2026-06-14
+
+Multi-core PR2: a `Send + Sync` `WakeHandle` lets an off-reactor mailbox interrupt
+the reactor's `poll` immediately instead of waiting the 10 ms poll timeout. Two
+durable lessons:
+
+1. **Decouple the cross-thread trigger from the `&mut self` platform.** The
+   platform's `wake(&mut self)` is owned by the reactor thread; producers are on
+   other threads. The fix is a handle that owns a *duplicated* OS primitive
+   (`Kqueue::try_clone` of the kqueue fd; `OwnedFd::try_clone` of the `eventfd`)
+   and re-issues the trigger via a `&self` syscall (`kevent`/`write`, both
+   thread-safe). Give the trait a **default `wake_handle` returning
+   `Unsupported`** so a backend that can't share its primitive (IOCP, today) keeps
+   working — callers just fall back to the poll timeout. Never make the whole
+   reactor depend on a capability one platform lacks.
+
+2. **Running ThreadSanitizer on this repo needs `-Zbuild-std`.** Plain
+   `RUSTFLAGS="-Zsanitizer=thread" cargo +nightly test` fails with "mixing
+   `-Zsanitizer` will cause an ABI mismatch" because the prebuilt std/deps weren't
+   compiled with the sanitizer. Rebuild everything from source:
+   ```
+   rustup +nightly component add rust-src
+   RUSTFLAGS="-Zsanitizer=thread" cargo +nightly test -Zbuild-std \
+     -p stream-reactor --lib --target aarch64-apple-darwin <test-filter>
+   ```
+   The `--target` is required (build-std needs an explicit target). A clean TSan
+   run on the wake stress test (8 threads firing `wake()` while the reactor
+   drains) is the canonical check for the new cross-thread `unsafe` fd sharing.


### PR DESCRIPTION
## Summary

**PR 2 of 5** toward a multi-core runtime. After PR1 routes an off-reactor write to the *one* owning reactor, this makes that write **flush immediately** instead of waiting up to the 10 ms poll timeout.

The wakeup primitive already existed in the platform trait (`create_wakeup`/`wake`/`PlatformEvent::Wakeup`; kqueue `EVFILT_USER`, epoll `eventfd`) — but `wake(&mut self)` lives on the reactor-owned platform, while producers are on other threads, and the reactor never even created a wakeup. So a queued write sat until the next `poll` return.

## How

A `Send + Sync` **`WakeHandle`** that owns a thread-safe clone of the OS primitive, decoupled from `&mut self`:

- **transport-platform**: new `WakeHandle` (Arc'd trigger closure + `wake(&self)`) and `TransportPlatform::wake_handle(wakeup)`. kqueue duplicates the kqueue fd (new `Kqueue::try_clone`) and re-issues `EVFILT_USER | NOTE_TRIGGER`; epoll duplicates the wakeup `eventfd` and writes the counter — both `&self`, thread-safe syscalls. The **default impl returns `Unsupported`**, so Windows/IOCP keeps working unchanged (falls back to the poll timeout) — no platform broken.
- **stream-reactor**: each reactor registers a wakeup at construction and hands its `StreamMailbox` the handle; `push` fires it **after** enqueuing (enqueue-then-wake; `serve` drains at the top and bottom of every poll cycle, so a racing wake is never lost). Best-effort throughout — a failed/absent wake just defers to the poll timeout, never drops a command.

## Tests

- `off_reactor_mailbox_write_wakes_the_reactor_immediately`: a **30 s** poll timeout, so a dropped wake **fails** the test (client read times out) rather than just running slow — proves the wake actually fires.
- `concurrent_off_reactor_wakes_do_not_corrupt_the_reactor`: 8 threads hammer the cross-thread wake while real clients echo.

Both pass under **ThreadSanitizer** (`RUSTFLAGS=-Zsanitizer=thread` + `-Zbuild-std`; incantation recorded in `lessons.md`), validating the new cross-thread `unsafe` fd sharing. All existing reactor / tcp-runtime / IRC / embeddable tests stay green; clippy clean.

## Security

Reviewed (passed): the epoll `unsafe libc::write` mirrors the existing trusted `write_counter_fd` (correct ptr/len, owned dup'd fd valid for the closure's life); `WakeHandle: Send + Sync` is compiler-enforced (`OwnedFd`/`Kqueue` are `Send+Sync`, `kevent`/eventfd `write` are kernel-atomic); both wakeup primitives are level-latched so no lost-wakeup; the dup'd fd keeps the kernel object alive so a late wake after reactor drop is harmless (no UAF).

Spec `tcp-runtime-roadmap.md`: cross-thread wakeups now **Done**; IOCP cross-thread wake (share the completion port) is the remaining follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)