### PR TITLE
feat(mycin-2026): end-to-end interactive MYCIN consultation — 1976 parity (B3 + live sensitivity)

### DIFF
--- a/code/specs/data/mycin-2026/MYCIN-1976-PARITY.md
+++ b/code/specs/data/mycin-2026/MYCIN-1976-PARITY.md
@@ -1,0 +1,74 @@
+# MYCIN-2026 — parity with the 1976 MYCIN, end to end
+
+`mycin_consult.py` is the program that runs MYCIN-2026 the way the 1976 MYCIN
+actually ran: an **interactive consultation** that gathers findings by asking the
+most decision-relevant question, reaches a diagnosis it can explain, recommends
+**culture-directed** therapy, and does it all at **0 answer-time model calls** (the
+only model touch is the upstream decompose; here the inputs are clinician-entered
+data, exactly as MYCIN took them).
+
+## The flow (a real session)
+
+```
+[1] PRESENT ILLNESS: fever, neck stiffness            (sparse intake)
+[2] CONSULTATION  (value-of-information drives the questions)
+  ? csf_culture      Δmargin −0.875  → unavailable; noted
+  ? csf_gram_stain   Δmargin −0.729  → positive
+  ? csf_protein      Δmargin −0.192  → high
+  ? csf_lactate      Δmargin +0.024  → high
+[3] DIAGNOSIS: bacterial_meningitis P=0.9986  (determinate; 3 corroborating findings)
+[4] THERAPY
+    EMPIRIC: ampicillin + ceftriaxone + vancomycin (cost 3)
+    CULTURE BACK — ampicillin-resistant Listeria:
+    CULTURE-DIRECTED: ceftriaxone + meropenem + vancomycin (cost 5)   # ampicillin dropped, re-derived
+answer-time model calls across the whole consultation: 0
+```
+
+## What this closes — the last two 1976 behaviors
+
+1. **The interactive consultation loop.** MYCIN's signature UX was a dialogue: it
+   asked for the datum it most needed, took the answer, and re-derived. We already
+   had the value-of-information *ranking* (`warm/voi.py`); this drives the **Q&A loop**
+   on top of it — ask the highest-VOI unobserved finding, record the answer (or note
+   it unavailable and move on), re-derive, and stop once the diagnosis is determinate
+   with enough corroborating evidence or no remaining question would change it. Each
+   question is justified by its VOI (the **WHY**), and the diagnosis cites its
+   contributing findings (the **HOW**).
+2. **Live sensitivity ingestion.** MYCIN refined empiric therapy with culture
+   results. `native_setcover.py` now takes `defeated` (drug, organism) edges — an
+   in-vitro **resistant** result voids that coverage edge (and any combination whose
+   member is resistant), so the regimen **re-derives** around it. This wires the B2
+   defeasance construct into the live therapy step.
+
+## Full 1976 capability map (now)
+
+| MYCIN (1976) | MYCIN-2026 | status |
+|---|---|---|
+| production rules + backward chaining | grounded adj-lang rulebooks (CAS) | ✅ |
+| certainty factors for uncertainty | calibrated probabilistic LR engine | ✅ beyond |
+| identify the significant organism(s) | organism-id differential (A1) + source→organism (A2) | ✅ |
+| interactive consultation (Q&A) | **VOI-driven dialogue loop (this)** | ✅ |
+| explanation: WHY / HOW | VOI justification + proof DAG / audit trail | ✅ |
+| therapy: fewest drugs, by preference, dosed | minimum-cost set-cover + dose-window UNSAT | ✅ beyond |
+| combination therapy | n-ary combination coverage (B2) | ✅ |
+| **culture sensitivity directs therapy** | **defeasance in the live therapy (this)** | ✅ |
+| domain = bacteremia + meningitis | both | ✅ |
+
+**Beyond 1976:** byte-grounded provenance + an adversarial write gate (it caught
+real hand-authored errors), a content-addressed *correctable* knowledge base,
+local small-model decomposition of messy/spoken input, FHIR chart ingestion, dose
+infeasibility (no safe dose), and 0-answer-time-model-call CPU inference.
+
+**Remaining is breadth, not capability:** more organisms / sites / sub-populations
+(e.g. peds/neonatal priors — the organism-id uses adult-community priors today).
+That is an expansion track; the *mechanisms* are all present and demonstrated.
+
+## Run it
+
+```sh
+python3 mycin_consult.py                 # scripted (answers from the case oracle)
+python3 mycin_consult.py --ask           # interactive (prompts you per question)
+```
+
+Decision-support only — every question, finding, and drug is grounded and
+overridable; the physician makes the call.

--- a/code/specs/data/mycin-2026/mycin_consult.py
+++ b/code/specs/data/mycin-2026/mycin_consult.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""mycin_consult.py — the interactive MYCIN consultation, end to end, 1976-faithful.
+
+This is the program that ties MYCIN-2026 together the way the 1976 MYCIN actually
+ran: an interactive dialogue that gathers findings, reaches a diagnosis, recommends
+culture-directed therapy, and can explain WHY it asked and HOW it concluded — all
+at 0 answer-time model calls (the only model touch is the upstream decompose; here
+the inputs are clinician-entered data, exactly as MYCIN took them).
+
+  [1] PRESENT ILLNESS   the findings known at intake
+  [2] CONSULTATION      MYCIN's hallmark Q&A loop — value-of-information picks the
+                        single most decision-relevant unobserved finding, asks for
+                        it, records the answer, and RE-DERIVES; repeat until the
+                        diagnosis is settled or no remaining question would change
+                        it. Each question is justified by its VOI (the WHY).
+  [3] DIAGNOSIS         the differential + the decision, with the contributing
+                        evidence (the HOW — the proof, byte-cited in the rulebook).
+  [4] THERAPY           empiric minimum-cost cover of the likely organisms, then
+                        CULTURE-DIRECTED refinement: an in-vitro sensitivity
+                        (resistant drug→organism) defeases that coverage edge and
+                        the regimen RE-DERIVES around it.
+  [5] REVIEW            every line grounded + overridable; the physician decides.
+
+Two MYCIN behaviors this closes vs the rest of the stack: the interactive
+consultation LOOP (we already had the VOI ranking; this drives the dialogue on top
+of it) and LIVE sensitivity ingestion into therapy.
+
+Usage:
+  python3 mycin_consult.py [case]            # scripted (answers from the case oracle)
+  python3 mycin_consult.py [case] --ask      # interactive (prompts you per question)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+MYCIN = Path(__file__).resolve().parent
+sys.path.insert(0, str(MYCIN / "warm"))
+sys.path.insert(0, str(MYCIN / "treatment" / "antibiotics"))
+import decide as decide_mod  # noqa: E402
+import derive_regimen as reg  # noqa: E402  (formulary facts, for the WHY of each drug)
+import ir_to_adj as ir_mod  # noqa: E402  (the closed-vocabulary domains)
+import native_setcover as abx  # noqa: E402  (sensitivity-aware set-cover therapy)
+import voi as voi_mod  # noqa: E402
+
+# Stop asking once the diagnosis is determinate with enough corroborating evidence,
+# or once no remaining question would move the differential, or after this many Qs.
+EVIDENCE_STOP = 3
+MAX_QUESTIONS = 10
+EPS = 0.01  # a question whose |Δmargin| is below this won't change the call
+
+
+# Scripted consultation cases: sparse intake + an ORACLE the clinician answers from
+# (so the dialogue is deterministic + CI-testable), the empiric organism set, and an
+# optional culture sensitivity that arrives after empiric therapy.
+CASES = {
+    "adult_bacterial": {
+        "vignette": "Adult, acutely unwell: fever and neck stiffness at intake; "
+                    "CSF studies pending.",
+        "intake": ["fever(present)", "meningismus(present)"],
+        "oracle": {  # the findings the clinician can supply WHEN ASKED
+            "csf_gram_stain": "positive",
+            "csf_neutrophilic_pleocytosis": "high",
+            "csf_glucose": "low",
+            "csf_protein": "high",
+            "csf_lactate": "high",
+            "serum_procalcitonin": "high",
+            "csf_lymphocytic_pleocytosis": "normal",
+        },
+        "organisms": "over_50_or_immunocompromised",  # empiric cover incl. listeria
+        # Culture comes back: the Listeria isolate is ampicillin-resistant → that
+        # coverage edge is defeated and the regimen must re-derive.
+        "sensitivities": [("ampicillin", "listeria")],
+        "gold": "bacterial_meningitis",
+    },
+}
+
+
+def margin(res: dict) -> float:
+    post = sorted(res["posteriors"].values(), reverse=True)
+    return post[0] - post[1] if len(post) >= 2 else post[0]
+
+
+def ask_finding(functor: str, oracle: dict, interactive: bool) -> str | None:
+    """Obtain the value of `functor` — interactively from the user, or from the
+    case oracle. Returns the value, or None if the datum is unavailable."""
+    if interactive:
+        ans = input(f"    ? {functor} = ").strip()
+        return ans or None
+    return oracle.get(functor)
+
+
+def consult(cli, case: dict, interactive: bool = False) -> dict:
+    bar = "=" * 78
+    print(bar + f"\nMYCIN-2026 CONSULTATION\n  {case['vignette']}\n" + bar)
+
+    # The closed vocabulary — every answer is validated against it before it can
+    # reach the engine (an answer from input()/the oracle is otherwise untrusted;
+    # this upholds the same gate ir_to_adj enforces on the decompose path).
+    domains = ir_mod.load_domains()  # functor -> set(legal values)
+    observed = list(case["intake"])
+    asked = {t.split("(")[0] for t in observed}
+    dialogue = []
+    print(f"\n[1] PRESENT ILLNESS: {', '.join(observed)}")
+
+    print("\n[2] CONSULTATION  (value-of-information drives the questions; 0 model calls)")
+    res = None
+    for _ in range(MAX_QUESTIONS):
+        observe_adj = "".join(f"observe {t}\n" for t in observed)
+        res = decide_mod.decide("session", observe_adj, cli)
+        rows = voi_mod.voi("session", observe_adj, set(observed), cli)
+        # Settled? determinate with enough evidence, or nothing left that would move it.
+        next_q = next((r for r in rows if r["order"].split("(")[0] not in asked), None)
+        determinate = res["decision"].get("type") == "determinate"
+        if determinate and (res["n_evidence_for_leader"] >= EVIDENCE_STOP
+                            or next_q is None or abs(next_q["margin_delta"]) < EPS):
+            break
+        if next_q is None:
+            break
+        functor = next_q["order"].split("(")[0]
+        asked.add(functor)
+        print(f"  ? order {functor:30s}  (would shift the margin by "
+              f"{next_q['margin_delta']:+.3f} — most decision-relevant)")
+        ans = ask_finding(functor, case["oracle"], interactive)
+        if ans is None:
+            print("      → unavailable; noted, moving on")
+            continue
+        # Closed-vocabulary gate: only a recognized functor(value) reaches the engine.
+        if functor not in domains or ans not in domains[functor]:
+            print(f"      → '{ans}' is not a recognized value for {functor}; ignored")
+            continue
+        observed.append(f"{functor}({ans})")
+        dialogue.append({"functor": functor, "value": ans, "voi": next_q["margin_delta"]})
+        nr = decide_mod.decide("session", "".join(f"observe {t}\n" for t in observed), cli)
+        print(f"      → {functor} = {ans}   (leader now {nr['leader']}, "
+              f"P={max(nr['posteriors'].values()):.3f})")
+
+    leader = res["leader"]
+    dtype = res["decision"].get("type")
+    print("\n[3] DIAGNOSIS  (0 answer-time model calls — engine over the grounded rulebook)")
+    for hyp, p in sorted(res["posteriors"].items(), key=lambda kv: -kv[1]):
+        print(f"    {hyp:24s} P = {p:.4f}{'   <- leading' if hyp == leader else ''}")
+    print(f"    decision: {dtype}  | corroborating findings for the leader: "
+          f"{res['n_evidence_for_leader']}  | questions asked: {len(dialogue)}")
+
+    if leader != "bacterial_meningitis" or dtype == "insufficient_evidence":
+        print("\n[4] THERAPY: no empiric antibacterial therapy indicated by the leading "
+              f"diagnosis ({leader}); reassess / await data. (Abstains, never fabricates.)")
+        print("\n" + bar + "\nPHYSICIAN REVIEW — grounded + overridable; you make the call.")
+        return {"leader": leader, "dialogue": dialogue, "regimen": None}
+
+    organisms = reg.SCENARIOS[case["organisms"]]
+    print(f"\n[4] THERAPY  (minimum-cost cover; 0 model calls)\n    likely organisms: {organisms}")
+    empiric = abx.solve(cli, organisms, set())
+    _show_regimen("    EMPIRIC regimen", empiric, organisms, set())
+
+    sens = [tuple(s) for s in case.get("sensitivities", [])]
+    final = empiric
+    if sens:
+        print(f"\n    CULTURE BACK — sensitivities (resistant): {sens}")
+        final = abx.solve(cli, organisms, set(), defeated=set(sens))
+        _show_regimen("    CULTURE-DIRECTED regimen (coverage re-derived)", final, organisms, set(sens))
+
+    print("\n" + bar)
+    print("PHYSICIAN REVIEW — every question, finding, and drug above is grounded + "
+          "overridable; you make the call.")
+    print("answer-time model calls across the whole consultation: 0")
+    return {"leader": leader, "dialogue": dialogue, "regimen": final.get("regimen"),
+            "empiric": empiric.get("regimen")}
+
+
+def _show_regimen(label: str, res: dict, organisms: list[str], defeated: set) -> None:
+    if res.get("regimen") is None:
+        print(f"{label}: NO regimen covers {organisms} "
+              + (f"given resistance {sorted(defeated)} " if defeated else "")
+              + f"-> escalate / specialist [{res.get('outcome')}].")
+        return
+    print(f"{label}: {' + '.join(res['regimen'])}  (cost {res.get('cost'):.0f})")
+    for d in res["regimen"]:
+        covered = sorted(o for o in organisms
+                         if o in reg.DRUGS.get(d, {}).get("covers", []) and (d, o) not in defeated)
+        why = f"covers {covered}" if covered else "combination partner"
+        print(f"      - {d:13s} {why}")
+
+
+def main(argv: list[str]) -> int:
+    interactive = "--ask" in argv
+    names = [a for a in argv if not a.startswith("--")]
+    case_name = names[0] if names else "adult_bacterial"
+    if case_name not in CASES:
+        print(f"unknown case {case_name!r}; choices: {list(CASES)}", file=sys.stderr)
+        return 2
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("mycin_consult: adj-lang-cli not built", file=sys.stderr)
+        return 3
+    consult(cli, CASES[case_name], interactive=interactive)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/code/specs/data/mycin-2026/test_mycin_consult.py
+++ b/code/specs/data/mycin-2026/test_mycin_consult.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""test_mycin_consult.py — guard the end-to-end interactive MYCIN consultation.
+
+Pure check: a culture sensitivity drops the defeated coverage edge from the emitted
+program (no engine needed). Full check (skipped if adj-lang-cli isn't built): the
+scripted consultation asks VOI-ranked questions, converges to bacterial meningitis,
+derives an empiric regimen, and RE-DERIVES it culture-directed when an isolate is
+resistant. 0 answer-time model calls.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+MYCIN = Path(__file__).resolve().parent
+sys.path.insert(0, str(MYCIN))
+sys.path.insert(0, str(MYCIN / "warm"))
+sys.path.insert(0, str(MYCIN / "treatment" / "antibiotics"))
+import decide as decide_mod  # noqa: E402
+import mycin_consult as mc  # noqa: E402
+import native_setcover as abx  # noqa: E402
+
+
+def test_sensitivity_defeases_coverage_edge() -> None:
+    """A resistant (drug, organism) edge is dropped from the cover (no engine)."""
+    organisms = ["listeria"]
+    base, _, _ = abx.emit_program(organisms, set())
+    line = next(ln for ln in base.splitlines() if "% cover listeria" in ln)
+    assert "x_ampicillin" in line, f"ampicillin should cover listeria by default: {line}"
+    # With the isolate ampicillin-resistant, that edge is gone.
+    deft, _, _ = abx.emit_program(organisms, set(), defeated={("ampicillin", "listeria")})
+    line2 = next(ln for ln in deft.splitlines() if "% cover listeria" in ln)
+    assert "x_ampicillin" not in line2, f"defeated edge must be dropped: {line2}"
+
+
+def test_defeated_combination_member_drops_the_combination() -> None:
+    """A combination is voided for an organism if a member is resistant to it."""
+    organisms = ["s_pneumoniae_resistant"]
+    base, _, _ = abx.emit_program(organisms, set())
+    assert any("y_vancomycin_ceftriaxone" in ln for ln in base.splitlines())
+    deft, _, _ = abx.emit_program(organisms, set(),
+                                  defeated={("ceftriaxone", "s_pneumoniae_resistant")})
+    # The vanc+ceftriaxone combo no longer contributes its aux to the cover line.
+    cover = next((ln for ln in deft.splitlines() if "% cover s_pneumoniae_resistant" in ln), "")
+    assert "y_vancomycin_ceftriaxone" not in cover, f"defeated combo dropped: {cover}"
+
+
+def main() -> int:
+    test_sensitivity_defeases_coverage_edge()
+    test_defeated_combination_member_drops_the_combination()
+
+    cli = decide_mod.find_cli()
+    if cli is None:
+        print("test_mycin_consult: PASS (sensitivity defeasance); CLI checks SKIPPED "
+              "(adj-lang-cli not built)")
+        return 0
+
+    res = mc.consult(cli, mc.CASES["adult_bacterial"], interactive=False)
+    assert res["leader"] == "bacterial_meningitis", res
+    assert len(res["dialogue"]) >= 1, "the consultation must ask at least one question"
+    # Empiric covers Listeria with ampicillin; the culture-directed regimen does not.
+    assert "ampicillin" in (res["empiric"] or []), res["empiric"]
+    assert "vancomycin" in (res["empiric"] or []), res["empiric"]
+    assert "ampicillin" not in (res["regimen"] or []), res["regimen"]
+    assert res["regimen"], "a culture-directed regimen must still be derivable"
+
+    print("test_mycin_consult: PASS (VOI-driven dialogue converges to bacterial "
+          "meningitis; empiric → culture-directed re-derivation drops the resistant "
+          "ampicillin; 0 answer-time model calls)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
+++ b/code/specs/data/mycin-2026/treatment/antibiotics/native_setcover.py
@@ -53,10 +53,18 @@ def _sym(prefix: str, *parts: str) -> str:
     return name
 
 
-def emit_program(organisms: list[str], exclusions: set[str]) -> tuple[str, dict, bool]:
+def emit_program(organisms: list[str], exclusions: set[str],
+                 defeated: set[tuple[str, str]] = frozenset()) -> tuple[str, dict, bool]:
     """Emit the adj-lang integer program for this cover. Returns (program text,
     {x_var → drug}, feasible?) — feasible is False if some organism has no coverer
-    (the program is then trivially infeasible and the engine will say so)."""
+    (the program is then trivially infeasible and the engine will say so).
+
+    `defeated` is the set of (drug, organism) coverage edges VOIDED by an observed
+    culture sensitivity — an in-vitro result that the isolate is resistant to that
+    drug. A defeated edge is dropped before the cover is built, so the regimen
+    re-derives around it (MYCIN's "culture-directed" refinement of empiric therapy).
+    A combination is defeated for an organism if any of its members is resistant to
+    that organism (the synergy rationale is undercut)."""
     cands = reg.candidates(exclusions)  # CSF-penetrant, not contraindicated
     lines: list[str] = []
     xvar = {d: _sym("x", d) for d in cands}
@@ -70,6 +78,8 @@ def emit_program(organisms: list[str], exclusions: set[str]) -> tuple[str, dict,
         ds = rule["drugs"]
         if not all(d in xvar for d in ds):
             continue  # a member is excluded → the combination is unavailable
+        if any((d, rule["covers"]) in defeated for d in ds):
+            continue  # a resistant member breaks the combination's coverage
         y = _sym("y", *ds)
         lines.append(f"symbol {y} : bool")
         for d in ds:  # y ≤ x_d  for each member
@@ -86,7 +96,9 @@ def emit_program(organisms: list[str], exclusions: set[str]) -> tuple[str, dict,
         # field from the formulary unvalidated, even across the CAS trust boundary.
         if not TOKEN_RE.match(org):
             raise ValueError(f"unsafe organism token {org!r} (must match {TOKEN_RE.pattern})")
-        terms = [xvar[d] for d in cands if org in reg.DRUGS[d]["covers"]]
+        # A drug covers `org` unless a culture sensitivity defeated that edge.
+        terms = [xvar[d] for d in cands
+                 if org in reg.DRUGS[d]["covers"] and (d, org) not in defeated]
         terms += combo_cover.get(org, [])
         if terms:
             lines.append(f"constrain {' + '.join(terms)} >= 1   % cover {org}")
@@ -104,9 +116,11 @@ def emit_program(organisms: list[str], exclusions: set[str]) -> tuple[str, dict,
     return "\n".join(lines) + "\n", var_to_drug, feasible
 
 
-def solve(cli: Path, organisms: list[str], exclusions: set[str]) -> dict:
-    """Run the emitted program through the engine; return the engine's regimen."""
-    program, var_to_drug, _ = emit_program(organisms, exclusions)
+def solve(cli: Path, organisms: list[str], exclusions: set[str],
+          defeated: set[tuple[str, str]] = frozenset()) -> dict:
+    """Run the emitted program through the engine; return the engine's regimen.
+    `defeated` carries culture-sensitivity results (resistant drug→organism edges)."""
+    program, var_to_drug, _ = emit_program(organisms, exclusions, defeated)
     fd, name = tempfile.mkstemp(suffix=".adj", prefix="_tmp_native_", dir=HERE)
     p = Path(name)
     try:


### PR DESCRIPTION
The program that runs MYCIN-2026 the way the **1976 MYCIN actually ran**, closing the last two parity gaps in one flow. `mycin_consult.py`:

```
[1] PRESENT ILLNESS: fever, neck stiffness            (sparse intake)
[2] CONSULTATION  (value-of-information drives the questions; 0 model calls)
  ? csf_culture      Δmargin −0.875  → unavailable; noted
  ? csf_gram_stain   Δmargin −0.729  → positive
  ? csf_protein      Δmargin −0.192  → high
  ? csf_lactate      Δmargin +0.024  → high
[3] DIAGNOSIS: bacterial_meningitis P=0.9986  (determinate; 3 corroborating findings)
[4] THERAPY
    EMPIRIC: ampicillin + ceftriaxone + vancomycin (cost 3)
    CULTURE BACK — ampicillin-resistant Listeria:
    CULTURE-DIRECTED: ceftriaxone + meropenem + vancomycin (cost 5)   # ampicillin dropped, re-derived
answer-time model calls across the whole consultation: 0
```

## Closes the two genuine 1976 gaps
1. **Interactive consultation loop.** We already had the VOI *ranking* (`warm/voi.py`); this drives the **Q&A dialogue** on top of it — ask the highest-VOI unobserved finding, take the answer (interactive prompt *or* a scripted oracle, so it's CI-testable), re-derive, and stop once determinate with enough evidence or no remaining question would change the call. Each question carries its VOI justification (WHY); the diagnosis reports its corroborating findings (HOW).
2. **Live sensitivity ingestion.** `native_setcover.py` `emit_program`/`solve` now take a `defeated` set of `(drug, organism)` edges — an in-vitro **resistant** result voids that coverage edge (and any combination whose member is resistant), so empiric therapy refines to **culture-directed** therapy. Backward compatible (`defeated` defaults empty; existing tests unchanged).

## Verification
- `python3 mycin_consult.py` reproduces the session above; `--ask` runs it interactively.
- `python3 test_mycin_consult.py` → PASS: the dialogue converges to bacterial meningitis, asks ≥1 question, empiric includes ampicillin+vancomycin, culture-directed **drops** ampicillin and still derives a regimen; plus a pure (no-engine) check that a defeated edge / defeated combination-member is removed from the emitted program. Existing `test_native_setcover.py` still passes. ruff clean.
- Security review: **one MEDIUM fixed** — an interactive/oracle answer reached the observe line without the closed-vocabulary gate the decompose path enforces; now every `functor(value)` is validated against the dictionary domains before it can reach the engine (out-of-vocabulary answers ignored). The `defeated` change verified safe (set-membership only, never interpolated; organism `TOKEN_RE` intact).

## Parity verdict (`MYCIN-1976-PARITY.md`)
Mechanistic parity **reached and exceeded** across both MYCIN domains (bacteremia + meningitis): rule-based diagnosis with calibrated uncertainty, organism identification, interactive Q&A, WHY/HOW explanation, minimum-drug culture-directed dosed therapy. Beyond 1976: byte-grounded provenance + adversarial gate, a correctable CAS, local-model decomposition of messy/spoken input, FHIR ingestion, dose-UNSAT, 0 answer-time model calls. **Remaining is breadth** (more organisms/sites/sub-populations), not capability.

Decision-support only — every question, finding, and drug is grounded + overridable; the physician decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)